### PR TITLE
Bound PDF and Excel resource expansion

### DIFF
--- a/OfficeIMO.Excel.Tests/Excel.ResourceBudgetSecurity.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ResourceBudgetSecurity.cs
@@ -76,6 +76,22 @@ public sealed class ExcelResourceBudgetSecurityTests {
     }
 
     [Fact]
+    public void ReadObjectsOfT_RejectsDenseRangesBeyondConfiguredCellBudget() {
+        string path = CreateWorkbookWithRows(2);
+        try {
+            var options = new ExcelReadOptions { MaxRangeCells = 100 };
+            using var reader = ExcelDocumentReader.Open(path, options);
+
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+                reader.GetSheet("Data").ReadObjects<BudgetRow>("A1:Z100").ToList());
+
+            Assert.Contains("2600", exception.Message, StringComparison.Ordinal);
+        } finally {
+            DeleteIfExists(path);
+        }
+    }
+
+    [Fact]
     public void ReadUsedRange_RejectsOversizedTableBackedDimensionBeforeAllocation() {
         string path = GetTemporaryWorkbookPath();
         try {

--- a/OfficeIMO.Excel.Tests/Excel.ResourceBudgetSecurity.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ResourceBudgetSecurity.cs
@@ -44,6 +44,22 @@ public sealed class ExcelResourceBudgetSecurityTests {
     }
 
     [Fact]
+    public void ReadRangeAsDataTable_RejectsDenseRangesBeyondConfiguredCellBudget() {
+        string path = CreateWorkbookWithRows(2);
+        try {
+            var options = new ExcelReadOptions { MaxRangeCells = 100 };
+            using var reader = ExcelDocumentReader.Open(path, options);
+
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+                reader.GetSheet("Data").ReadRangeAsDataTable("A1:XFD1048576"));
+
+            Assert.Contains("17179869184", exception.Message, StringComparison.Ordinal);
+        } finally {
+            DeleteIfExists(path);
+        }
+    }
+
+    [Fact]
     public void ReadUsedRange_RejectsOversizedTableBackedDimensionBeforeAllocation() {
         string path = GetTemporaryWorkbookPath();
         try {

--- a/OfficeIMO.Excel.Tests/Excel.ResourceBudgetSecurity.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ResourceBudgetSecurity.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class ExcelResourceBudgetSecurityTests {
+    [Fact]
+    public void AddSparklines_RejectsOversizedRangeExpansionBeforeAllocation() {
+        string path = GetTemporaryWorkbookPath();
+        try {
+            using var document = ExcelDocument.Create(path);
+            ExcelSheet sheet = document.AddWorksheet("Data");
+
+            ArgumentOutOfRangeException exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
+                sheet.AddSparklines("A1:B10001", "C1:C10001"));
+
+            Assert.Equal("locationRange", exception.ParamName);
+        } finally {
+            DeleteIfExists(path);
+        }
+    }
+
+    [Fact]
+    public void ReadRange_RejectsDenseRangesBeyondConfiguredCellBudget() {
+        string path = CreateWorkbookWithRows(2);
+        try {
+            var options = new ExcelReadOptions { MaxRangeCells = 100 };
+            using var reader = ExcelDocumentReader.Open(path, options);
+
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+                reader.GetSheet("Data").ReadRange("A1:Z100"));
+
+            Assert.Contains("2600", exception.Message, StringComparison.Ordinal);
+        } finally {
+            DeleteIfExists(path);
+        }
+    }
+
+    [Fact]
+    public void ReadUsedRange_RejectsOversizedTableBackedDimensionBeforeAllocation() {
+        string path = GetTemporaryWorkbookPath();
+        try {
+            using (var document = ExcelDocument.Create(path)) {
+                ExcelSheet sheet = document.AddWorksheet("Data");
+                sheet.CellValue(1, 1, "A");
+                sheet.CellValue(1, 2, "B");
+                sheet.CellValue(2, 1, 1);
+                sheet.CellValue(2, 2, 2);
+                sheet.AddTable("A1:B2", hasHeader: true, name: "BudgetTable", style: OfficeIMO.Excel.TableStyle.TableStyleMedium2);
+                document.Save();
+            }
+
+            using (SpreadsheetDocument package = SpreadsheetDocument.Open(path, true)) {
+                WorksheetPart worksheetPart = package.WorkbookPart!.WorksheetParts.Single();
+                worksheetPart.Worksheet.SheetDimension!.Reference = "A1:XFD1048576";
+                worksheetPart.Worksheet.Save();
+                TableDefinitionPart tablePart = worksheetPart.TableDefinitionParts.Single();
+                tablePart.Table.Reference = "A1:XFD1048576";
+                tablePart.Table.Save();
+            }
+
+            var options = new ExcelReadOptions { MaxRangeCells = 100 };
+            using var reader = ExcelDocumentReader.Open(path, options);
+
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+                reader.GetSheet("Data").ReadUsedRange());
+
+            Assert.Contains("17179869184", exception.Message, StringComparison.Ordinal);
+        } finally {
+            DeleteIfExists(path);
+        }
+    }
+
+    [Fact]
+    public void ReadObjectsStream_RejectsExcessiveOutOfOrderRowBuffering() {
+        string path = CreateWorkbookWithRows(4);
+        try {
+            using (SpreadsheetDocument package = SpreadsheetDocument.Open(path, true)) {
+                WorksheetPart worksheetPart = package.WorkbookPart!.WorksheetParts.First();
+                SheetData data = worksheetPart.Worksheet.GetFirstChild<SheetData>()!;
+                Row[] rows = data.Elements<Row>().OrderByDescending(row => row.RowIndex!.Value).ToArray();
+                data.RemoveAllChildren<Row>();
+                data.Append(rows);
+                worksheetPart.Worksheet.Save();
+            }
+
+            var options = new ExcelReadOptions { MaxPendingTypedRows = 1 };
+            using var reader = ExcelDocumentReader.Open(path, options);
+
+            Assert.Throws<InvalidDataException>(() =>
+                reader.GetSheet("Data").ReadObjectsStream<BudgetRow>("A1:A4").ToList());
+        } finally {
+            DeleteIfExists(path);
+        }
+    }
+
+    [Fact]
+    public void TypedHeaderBindings_DoNotCacheOversizedAttackerControlledHeaders() {
+        string path = GetTemporaryWorkbookPath();
+        try {
+            string header = new string('H', 25_000);
+            using (var document = ExcelDocument.Create(path)) {
+                ExcelSheet sheet = document.AddWorksheet("Data");
+                sheet.CellValue(1, 1, header + "1");
+                sheet.CellValue(1, 2, header + "2");
+                sheet.CellValue(1, 3, header + "3");
+                sheet.CellValue(2, 1, "value");
+                document.Save();
+            }
+
+            int before = GetHeaderBindingCacheCount();
+            using (var reader = ExcelDocumentReader.Open(path)) {
+                _ = reader.GetSheet("Data").ReadObjectsStream<BudgetRow>("A1:C2").Single();
+            }
+
+            Assert.Equal(before, GetHeaderBindingCacheCount());
+        } finally {
+            DeleteIfExists(path);
+        }
+    }
+
+    private static int GetHeaderBindingCacheCount() {
+        Type cacheDefinition = typeof(ExcelSheetReader).GetNestedType("TypedObjectBindingCache`1", BindingFlags.NonPublic)!;
+        Type cache = cacheDefinition.MakeGenericType(typeof(BudgetRow));
+        object dictionary = cache.GetField("HeaderBindings", BindingFlags.NonPublic | BindingFlags.Static)!.GetValue(null)!;
+        return (int)dictionary.GetType().GetProperty("Count")!.GetValue(dictionary)!;
+    }
+
+    private static string CreateWorkbookWithRows(int rowCount) {
+        string path = GetTemporaryWorkbookPath();
+        using var document = ExcelDocument.Create(path);
+        ExcelSheet sheet = document.AddWorksheet("Data");
+        sheet.CellValue(1, 1, "Name");
+        for (int row = 2; row <= rowCount; row++) {
+            sheet.CellValue(row, 1, "Row" + row.ToString(CultureInfo.InvariantCulture));
+        }
+
+        document.Save();
+        return path;
+    }
+
+    private static string GetTemporaryWorkbookPath() =>
+        Path.Combine(Path.GetTempPath(), "OfficeIMO-" + Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture) + ".xlsx");
+
+    private static void DeleteIfExists(string path) {
+        if (File.Exists(path)) {
+            File.Delete(path);
+        }
+    }
+
+    private sealed class BudgetRow {
+        public string? Name { get; set; }
+    }
+}

--- a/OfficeIMO.Excel.Tests/Excel.ResourceBudgetSecurity.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ResourceBudgetSecurity.cs
@@ -60,6 +60,22 @@ public sealed class ExcelResourceBudgetSecurityTests {
     }
 
     [Fact]
+    public void ReadObjects_RejectsDenseRangesBeyondConfiguredCellBudget() {
+        string path = CreateWorkbookWithRows(2);
+        try {
+            var options = new ExcelReadOptions { MaxRangeCells = 100 };
+            using var reader = ExcelDocumentReader.Open(path, options);
+
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+                reader.GetSheet("Data").ReadObjects("A1:XFD1048576"));
+
+            Assert.Contains("17179869184", exception.Message, StringComparison.Ordinal);
+        } finally {
+            DeleteIfExists(path);
+        }
+    }
+
+    [Fact]
     public void ReadUsedRange_RejectsOversizedTableBackedDimensionBeforeAllocation() {
         string path = GetTemporaryWorkbookPath();
         try {

--- a/OfficeIMO.Excel/ExcelSheet.Sparklines.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Sparklines.cs
@@ -11,6 +11,8 @@ namespace OfficeIMO.Excel {
     /// Helpers for adding sparklines to worksheets.
     /// </summary>
     public partial class ExcelSheet {
+        private const int MaximumExpandedSparklines = 10_000;
+
         /// <summary>
         /// Adds sparklines to the worksheet.
         /// </summary>
@@ -189,6 +191,7 @@ namespace OfficeIMO.Excel {
 
             var references = new List<SparklineReference>();
             if (locationAddress.ColumnCount == 1 && dataAddress.RowCount == locationAddress.RowCount) {
+                EnsureSparklineExpansionWithinLimit(locationAddress.RowCount, nameof(locationRange));
                 for (int offset = 0; offset < locationAddress.RowCount; offset++) {
                     int dataRow = dataAddress.Row1 + offset;
                     int locationRow = locationAddress.Row1 + offset;
@@ -201,6 +204,7 @@ namespace OfficeIMO.Excel {
             }
 
             if (locationAddress.RowCount == 1 && dataAddress.ColumnCount == locationAddress.ColumnCount) {
+                EnsureSparklineExpansionWithinLimit(locationAddress.ColumnCount, nameof(locationRange));
                 for (int offset = 0; offset < locationAddress.ColumnCount; offset++) {
                     int dataColumn = dataAddress.Column1 + offset;
                     int locationColumn = locationAddress.Column1 + offset;
@@ -216,6 +220,15 @@ namespace OfficeIMO.Excel {
                 "LocationRange spans multiple cells, but DataRange does not match by row or by column. " +
                 "Use a single destination cell, one data row per destination row, or one data column per destination column.",
                 nameof(locationRange));
+        }
+
+        private static void EnsureSparklineExpansionWithinLimit(int count, string parameterName) {
+            if (count > MaximumExpandedSparklines) {
+                throw new ArgumentOutOfRangeException(
+                    parameterName,
+                    count,
+                    $"A sparkline range may expand to at most {MaximumExpandedSparklines.ToString(CultureInfo.InvariantCulture)} entries.");
+            }
         }
 
         private static bool TryParseSparklineRange(string text, out SparklineRange range) {

--- a/OfficeIMO.Excel/Read/ExcelReadOptions.cs
+++ b/OfficeIMO.Excel/Read/ExcelReadOptions.cs
@@ -21,6 +21,12 @@ namespace OfficeIMO.Excel {
         /// <summary>Maximum cells materialized by a data-reader chunk or schema sample.</summary>
         public long MaxDataReaderBufferedCells { get; set; } = 1_000_000L;
 
+        /// <summary>Maximum cells materialized by one dense range read. Default: 1,000,000.</summary>
+        public long MaxRangeCells { get; set; } = 1_000_000L;
+
+        /// <summary>Maximum out-of-order rows retained by one typed streaming read. Default: 8,192.</summary>
+        public int MaxPendingTypedRows { get; set; } = 8_192;
+
         /// <summary>
         /// Execution policy used to decide Sequential vs Parallel conversion.
         /// Reuses the writer-side policy for symmetry.

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Objects.Bindings.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Objects.Bindings.cs
@@ -115,6 +115,7 @@ namespace OfficeIMO.Excel {
 
         private static class TypedObjectBindingCache<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] TTarget> where TTarget : new() {
             private const int HeaderBindingCacheLimit = 64;
+            private const int HeaderBindingCacheCharacterLimit = 65_536;
 
             internal static readonly PropertyInfo[] WritableProperties = typeof(TTarget)
                 .GetProperties(BindingFlags.Instance | BindingFlags.Public)
@@ -134,6 +135,10 @@ namespace OfficeIMO.Excel {
                     return WritablePropertyOrderBindings;
                 }
 
+                if (!CanCacheHeaders(headers)) {
+                    return CreateHeaderBindings(headers);
+                }
+
                 string key = CreateHeaderBindingKey(headers);
                 if (HeaderBindings.TryGetValue(key, out var cached)) {
                     return cached;
@@ -145,6 +150,18 @@ namespace OfficeIMO.Excel {
                 }
 
                 return created;
+            }
+
+            private static bool CanCacheHeaders(string[] headers) {
+                long characters = 0;
+                for (int index = 0; index < headers.Length; index++) {
+                    characters += headers[index]?.Length ?? 0;
+                    if (characters > HeaderBindingCacheCharacterLimit) {
+                        return false;
+                    }
+                }
+
+                return true;
             }
 
             private static Dictionary<PropertyInfo, TypedPropertyBinding<TTarget>> CreateBindings() {

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Objects.Sequential.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Objects.Sequential.cs
@@ -65,7 +65,7 @@ namespace OfficeIMO.Excel {
                     }
 
                     pendingRows ??= new Dictionary<int, Row>();
-                    pendingRows[rowIndex] = row;
+                    AddPendingTypedRow(pendingRows, rowIndex, row);
                     continue;
                 }
 
@@ -79,7 +79,7 @@ namespace OfficeIMO.Excel {
 
                 if (rowIndex > nextDataRow) {
                     pendingRows ??= new Dictionary<int, Row>();
-                    pendingRows[rowIndex] = row;
+                    AddPendingTypedRow(pendingRows, rowIndex, row);
                     continue;
                 }
 

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Objects.Stream.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Objects.Stream.cs
@@ -147,7 +147,7 @@ namespace OfficeIMO.Excel {
                     }
 
                     pendingRows ??= new Dictionary<int, T>();
-                    pendingRows[rowIndex] = target;
+                    AddPendingTypedRow(pendingRows, rowIndex, target);
                 }
             }
 
@@ -175,6 +175,19 @@ namespace OfficeIMO.Excel {
 
             pending = default!;
             return false;
+        }
+
+        private void AddPendingTypedRow<T>(Dictionary<int, T> pendingRows, int rowIndex, T row) {
+            if (_opt.MaxPendingTypedRows <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(_opt.MaxPendingTypedRows), "Maximum pending typed rows must be positive.");
+            }
+
+            if (!pendingRows.ContainsKey(rowIndex) && pendingRows.Count >= _opt.MaxPendingTypedRows) {
+                throw new InvalidDataException(
+                    $"Typed row streaming exceeded the configured out-of-order row buffer limit of {_opt.MaxPendingTypedRows.ToString(CultureInfo.InvariantCulture)}.");
+            }
+
+            pendingRows[rowIndex] = row;
         }
 
         private bool TryReadObjectsStreamOrderedXmlFast<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Objects.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Objects.cs
@@ -27,6 +27,16 @@ namespace OfficeIMO.Excel {
 
             int rows = r2 - r1 + 1;
             int cols = c2 - c1 + 1;
+            long cellCount = (long)rows * cols;
+            if (_opt.MaxRangeCells <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(_opt.MaxRangeCells), "Maximum dense range cell count must be positive.");
+            }
+
+            if (cellCount > _opt.MaxRangeCells) {
+                throw new InvalidDataException(
+                    $"Range '{a1Range}' contains {cellCount.ToString(CultureInfo.InvariantCulture)} cells, exceeding the configured limit of {_opt.MaxRangeCells.ToString(CultureInfo.InvariantCulture)}.");
+            }
+
             if (rows <= 1 || cols == 0) return Array.Empty<T>();
 
             var policy = _opt.Execution;

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataTableBuffer.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataTableBuffer.cs
@@ -21,12 +21,22 @@ namespace OfficeIMO.Excel {
             var (r1, c1, r2, c2) = A1.ParseRange(a1Range);
             if (r1 > r2 || c1 > c2) throw new ArgumentException($"Invalid range '{a1Range}'.");
 
-            var dt = new DataTable(_sheetName);
             int rows = r2 - r1 + 1;
             int cols = c2 - c1 + 1;
+            long cellCount = (long)rows * cols;
+            if (_opt.MaxRangeCells <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(_opt.MaxRangeCells), "Maximum dense range cell count must be positive.");
+            }
+
+            if (cellCount > _opt.MaxRangeCells) {
+                throw new InvalidDataException(
+                    $"Range '{a1Range}' contains {cellCount.ToString(CultureInfo.InvariantCulture)} cells, exceeding the configured limit of {_opt.MaxRangeCells.ToString(CultureInfo.InvariantCulture)}.");
+            }
+
+            var dt = new DataTable(_sheetName);
             var policy = _opt.Execution;
             var decided = mode ?? policy.Mode;
-            int workload = rows * cols;
+            int workload = checked((int)cellCount);
             if (decided == OfficeIMO.Excel.ExecutionMode.Automatic) {
                 if (CanUseAutomaticXmlReadFastPath(policy)) {
                     if (TryFillDataTableXmlBufferedSinglePass(dt, r1, c1, r2, c2, rows, cols, headersInFirstRow, workload, ct)) {

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataTableXml.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataTableXml.cs
@@ -375,6 +375,16 @@ namespace OfficeIMO.Excel {
 
             int rows = r2 - r1 + 1;
             int cols = c2 - c1 + 1;
+            long cellCount = (long)rows * cols;
+            if (_opt.MaxRangeCells <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(_opt.MaxRangeCells), "Maximum dense range cell count must be positive.");
+            }
+
+            if (cellCount > _opt.MaxRangeCells) {
+                throw new InvalidDataException(
+                    $"Range '{a1Range}' contains {cellCount.ToString(CultureInfo.InvariantCulture)} cells, exceeding the configured limit of {_opt.MaxRangeCells.ToString(CultureInfo.InvariantCulture)}.");
+            }
+
             if (rows <= 1 || cols == 0) {
                 return Array.Empty<Dictionary<string, object?>>();
             }

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.Used.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.Used.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Globalization;
 using System.Threading;
 using System.Xml;
 
@@ -36,6 +37,16 @@ namespace OfficeIMO.Excel {
             int width = lastColumn - firstColumn + 1;
             if (height <= 0 || width <= 0) {
                 return false;
+            }
+
+            if (_opt.MaxRangeCells <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(_opt.MaxRangeCells), "Maximum dense range cell count must be positive.");
+            }
+
+            long cellCount = (long)height * width;
+            if (cellCount > _opt.MaxRangeCells) {
+                throw new InvalidDataException(
+                    $"Range '{tableBackedReference}' contains {cellCount.ToString(CultureInfo.InvariantCulture)} cells, exceeding the configured limit of {_opt.MaxRangeCells.ToString(CultureInfo.InvariantCulture)}.");
             }
 
             var result = new object?[height, width];

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.cs
@@ -410,11 +410,21 @@ namespace OfficeIMO.Excel {
 
             var height = r2 - r1 + 1;
             var width = c2 - c1 + 1;
+            long cellCount = (long)height * width;
+            if (_opt.MaxRangeCells <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(_opt.MaxRangeCells), "Maximum dense range cell count must be positive.");
+            }
+
+            if (cellCount > _opt.MaxRangeCells) {
+                throw new InvalidDataException(
+                    $"Range '{a1Range}' contains {cellCount.ToString(CultureInfo.InvariantCulture)} cells, exceeding the configured limit of {_opt.MaxRangeCells.ToString(CultureInfo.InvariantCulture)}.");
+            }
+
             var result = new object?[height, width];
 
             var policy = _opt.Execution;
             var decided = mode ?? policy.Mode;
-            int workload = height * width;
+            int workload = checked((int)cellCount);
             if (decided == OfficeIMO.Excel.ExecutionMode.Automatic) {
                 if (CanUseAutomaticXmlReadFastPath(policy)) {
                     if ((ShouldAttemptUtf8Range(r1, r2) && RangeReachesDeclaredWorksheetEnd(r2) && TryFillRangeUtf8Fast(result, r1, c1, r2, c2, ct))

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfAttachmentExtractorTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfAttachmentExtractorTests.cs
@@ -156,6 +156,24 @@ public class PdfAttachmentExtractorTests {
     }
 
     [Fact]
+    public void PdfReadDocument_BoundsMalformedPredictorFallbackAttachmentBytes() {
+        var payload = new byte[64];
+        for (int index = 0; index < payload.Length; index++) {
+            payload[index] = (byte)index;
+        }
+        byte[] pdf = BuildFlateEmbeddedFilePdf(payload, malformedPredictor: true);
+
+        PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() =>
+            PdfReadDocument.Open(pdf, new PdfReadOptions {
+                Limits = new PdfReadLimits { MaxTotalAttachmentBytes = 64 }
+            }));
+
+        Assert.Equal(PdfReadLimitKind.AttachmentBytes, exception.Kind);
+        Assert.Equal(64, exception.Limit);
+        Assert.True(exception.Actual > exception.Limit);
+    }
+
+    [Fact]
     public void PdfReadDocument_RejectsAttachmentCountBeforeDecodingNextPayload() {
         byte[] pdf = PdfDocument.Create()
             .AttachFile("first.bin", new byte[] { 1, 2, 3 })
@@ -255,7 +273,7 @@ public class PdfAttachmentExtractorTests {
         return Encoding.ASCII.GetBytes(pdf);
     }
 
-    private static byte[] BuildFlateEmbeddedFilePdf(byte[] payload) {
+    private static byte[] BuildFlateEmbeddedFilePdf(byte[] payload, bool malformedPredictor = false) {
         byte[] compressed = DeflateZlib(payload);
         string header = string.Join("\n", new[] {
             "%PDF-1.4",
@@ -278,7 +296,8 @@ public class PdfAttachmentExtractorTests {
             "<< /Type /Filespec /F (data.bin) /UF (data.bin) /Desc (Payload) /AFRelationship /Data /EF << /F 6 0 R /UF 6 0 R >> >>",
             "endobj",
             "6 0 obj",
-            "<< /Type /EmbeddedFile /Subtype /application#2Foctet-stream /Length " + compressed.Length.ToString(System.Globalization.CultureInfo.InvariantCulture) + " /Filter /FlateDecode >>",
+            "<< /Type /EmbeddedFile /Subtype /application#2Foctet-stream /Length " + compressed.Length.ToString(System.Globalization.CultureInfo.InvariantCulture) + " /Filter /FlateDecode" +
+                (malformedPredictor ? " /DecodeParms << /Predictor 12 /Columns 4 >>" : string.Empty) + " >>",
             "stream"
         });
         string footer = string.Join("\n", new[] {

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfAttachmentExtractorTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfAttachmentExtractorTests.cs
@@ -21,9 +21,12 @@ public class PdfAttachmentExtractorTests {
 
         IReadOnlyList<PdfExtractedAttachment> attachments = PdfAttachmentExtractor.ExtractAttachments(pdf);
         IReadOnlyList<PdfExtractedAttachment> documentAttachments = PdfReadDocument.Open(pdf).ExtractAttachments();
+        IReadOnlyList<PdfAttachmentInfo> documentAttachmentInfos = PdfReadDocument.Open(pdf).Attachments;
 
         Assert.Equal(2, attachments.Count);
         Assert.Equal(2, documentAttachments.Count);
+        Assert.Equal(invoiceXml.Length, documentAttachmentInfos[0].SizeBytes);
+        Assert.Equal(sourceBytes.Length, documentAttachmentInfos[1].SizeBytes);
 
         PdfExtractedAttachment invoice = attachments[0];
         Assert.Equal("invoice.xml", invoice.Name);
@@ -118,6 +121,38 @@ public class PdfAttachmentExtractorTests {
         Assert.Equal("alias-999.txt", attachments[999].FileName);
         Assert.All(attachments, attachment => Assert.Equal("payload", Encoding.ASCII.GetString(attachment.Bytes)));
         Assert.Single(PdfAttachmentExtractor.ExtractAttachmentsByFileName(pdf, "alias-999.txt"));
+    }
+
+    [Fact]
+    public void PdfReadDocument_BoundsAttachmentAliasCount() {
+        byte[] pdf = BuildRepeatedFileAttachmentAnnotationPdf(annotationCount: 3);
+
+        PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() =>
+            PdfReadDocument.Open(pdf, new PdfReadOptions {
+                Limits = new PdfReadLimits { MaxAttachments = 2 }
+            }));
+
+        Assert.Equal(PdfReadLimitKind.Attachments, exception.Kind);
+        Assert.Equal(2, exception.Limit);
+        Assert.Equal(3, exception.Actual);
+    }
+
+    [Fact]
+    public void PdfReadDocument_BoundsAggregateUniqueAttachmentBytes() {
+        byte[] pdf = PdfDocument.Create()
+            .AttachFile("first.bin", new byte[] { 1, 2, 3 })
+            .AttachFile("second.bin", new byte[] { 4, 5, 6 })
+            .Paragraph(p => p.Text("Aggregate attachment budget."))
+            .ToBytes();
+
+        PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() =>
+            PdfReadDocument.Open(pdf, new PdfReadOptions {
+                Limits = new PdfReadLimits { MaxTotalAttachmentBytes = 5 }
+            }));
+
+        Assert.Equal(PdfReadLimitKind.AttachmentBytes, exception.Kind);
+        Assert.Equal(5, exception.Limit);
+        Assert.True(exception.Actual > exception.Limit);
     }
 
     [Fact]

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfAttachmentExtractorTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfAttachmentExtractorTests.cs
@@ -156,6 +156,27 @@ public class PdfAttachmentExtractorTests {
     }
 
     [Fact]
+    public void PdfReadDocument_RejectsAttachmentCountBeforeDecodingNextPayload() {
+        byte[] pdf = PdfDocument.Create()
+            .AttachFile("first.bin", new byte[] { 1, 2, 3 })
+            .AttachFile("second.bin", new byte[] { 4, 5, 6 })
+            .Paragraph(p => p.Text("Attachment count ordering."))
+            .ToBytes();
+
+        PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() =>
+            PdfReadDocument.Open(pdf, new PdfReadOptions {
+                Limits = new PdfReadLimits {
+                    MaxAttachments = 1,
+                    MaxTotalAttachmentBytes = 3
+                }
+            }));
+
+        Assert.Equal(PdfReadLimitKind.Attachments, exception.Kind);
+        Assert.Equal(1, exception.Limit);
+        Assert.Equal(2, exception.Actual);
+    }
+
+    [Fact]
     public void ExtractAttachments_SupportsPathStreamAndDirectoryOutputs() {
         byte[] payload = Encoding.UTF8.GetBytes("directory payload");
         byte[] pdf = PdfDocument.Create()

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfFontSecurityTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfFontSecurityTests.cs
@@ -45,6 +45,20 @@ endbfrange
     }
 
     [Fact]
+    public void ToUnicodeCMap_DoesNotCountRejectedEntriesTowardMappingBudget() {
+        var cmap = new ToUnicodeCMap();
+        MethodInfo addMap = typeof(ToUnicodeCMap).GetMethod("AddMap", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        FieldInfo processedMappings = typeof(ToUnicodeCMap).GetField("_processedMappings", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        addMap.Invoke(cmap, new object[] { "0102030405", "0041" });
+        Assert.Equal(0, (int)processedMappings.GetValue(cmap)!);
+
+        addMap.Invoke(cmap, new object[] { "01", "0042" });
+        Assert.Equal(1, (int)processedMappings.GetValue(cmap)!);
+        Assert.Equal("B", cmap.MapBytes(new byte[] { 0x01 }));
+    }
+
+    [Fact]
     public void ResourceResolver_CapsCidWidthRangeExpansion() {
         var page = new PdfDictionary();
         var resources = new PdfDictionary();

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfInspectorDestinationPreflightTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfInspectorDestinationPreflightTests.cs
@@ -65,6 +65,23 @@ public partial class PdfInspectorTests {
     }
 
     [Fact]
+    public void Preflight_HonorsConfiguredNamedDestinationRewriteTraversalLimits() {
+        byte[] pdf = BuildDeepNamedDestinationNameTreePdf();
+        var nodeLimitedOptions = new PdfReadOptions {
+            Limits = new PdfReadLimits { MaxNameTreeNodes = 2 }
+        };
+        var depthLimitedOptions = new PdfReadOptions {
+            Limits = new PdfReadLimits { MaxNameTreeDepth = 1 }
+        };
+
+        PdfDocumentPreflight nodeLimited = PdfInspector.Preflight(pdf, nodeLimitedOptions);
+        PdfDocumentPreflight depthLimited = PdfInspector.Preflight(pdf, depthLimitedOptions);
+
+        Assert.True(nodeLimited.HasRewriteBlocker(PdfRewriteBlockerKind.NamedDestinations));
+        Assert.True(depthLimited.HasRewriteBlocker(PdfRewriteBlockerKind.NamedDestinations));
+    }
+
+    [Fact]
     public void Preflight_AllowsUnsupportedNamedDestinationNameTreeReadButBlocksRewrite() {
         PdfDocumentPreflight report = PdfInspector.Preflight(BuildComplexNamedDestinationNameTreePdf());
 

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfInspectorSupport.Destinations.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfInspectorSupport.Destinations.cs
@@ -127,6 +127,41 @@ public partial class PdfInspectorTests {
         return System.Text.Encoding.ASCII.GetBytes(pdf);
     }
 
+    private static byte[] BuildDeepNamedDestinationNameTreePdf() {
+        string pdf = string.Join("\n", new[] {
+            "%PDF-1.4",
+            "1 0 obj",
+            "<< /Type /Catalog /Pages 2 0 R /Names << /Dests 5 0 R >> >>",
+            "endobj",
+            "2 0 obj",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "endobj",
+            "3 0 obj",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R >>",
+            "endobj",
+            "4 0 obj",
+            "<< /Length 0 >>",
+            "stream",
+            "",
+            "endstream",
+            "endobj",
+            "5 0 obj",
+            "<< /Kids [6 0 R] >>",
+            "endobj",
+            "6 0 obj",
+            "<< /Kids [7 0 R] >>",
+            "endobj",
+            "7 0 obj",
+            "<< /Names [(Chapter1) [3 0 R /XYZ 0 200 0]] >>",
+            "endobj",
+            "trailer",
+            "<< /Root 1 0 R /Size 8 >>",
+            "%%EOF"
+        });
+
+        return System.Text.Encoding.ASCII.GetBytes(pdf);
+    }
+
     private static byte[] BuildComplexNamedDestinationNameTreePdf() {
         string pdf = string.Join("\n", new[] {
             "%PDF-1.4",

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfReadLimitTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfReadLimitTests.cs
@@ -565,8 +565,16 @@ public class PdfReadLimitTests {
         var options = new PdfReadOptions {
             Limits = new PdfReadLimits { MaxIndirectObjects = 0 }
         };
+        var attachmentCountOptions = new PdfReadOptions {
+            Limits = new PdfReadLimits { MaxAttachments = 0 }
+        };
+        var attachmentBytesOptions = new PdfReadOptions {
+            Limits = new PdfReadLimits { MaxTotalAttachmentBytes = 0 }
+        };
 
         Assert.Throws<ArgumentOutOfRangeException>(() => PdfReadDocument.Open(pdf, options));
+        Assert.Throws<ArgumentOutOfRangeException>(() => PdfReadDocument.Open(pdf, attachmentCountOptions));
+        Assert.Throws<ArgumentOutOfRangeException>(() => PdfReadDocument.Open(pdf, attachmentBytesOptions));
     }
 
     [Fact]

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfReadStreamNamedDestinationTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfReadStreamNamedDestinationTests.cs
@@ -7,6 +7,37 @@ namespace OfficeIMO.Tests.Pdf;
 
 public partial class PdfReadStreamTests {
     [Fact]
+    public void NameTreeBudgetCountsAnIndirectDictionaryOnce() {
+        var page = new PdfDictionary();
+        page.Items["Type"] = new PdfName("Page");
+
+        var destination = new PdfArray();
+        destination.Items.Add(new PdfReference(3, 0));
+        destination.Items.Add(new PdfName("Fit"));
+
+        var names = new PdfArray();
+        names.Items.Add(new PdfStringObj("Chapter1"));
+        names.Items.Add(destination);
+
+        var tree = new PdfDictionary();
+        tree.Items["Names"] = names;
+        var objects = new Dictionary<int, PdfIndirectObject> {
+            [3] = new PdfIndirectObject(3, 0, page),
+            [5] = new PdfIndirectObject(5, 0, tree)
+        };
+
+        bool supported = PdfPageExtractor.TryBuildFlattenedNamedDestinationNameTree(
+            objects,
+            new PdfReference(5, 0),
+            copiedPageObjectIds: null,
+            out PdfDictionary flattened,
+            maximumNodes: 1);
+
+        Assert.True(supported);
+        Assert.True(flattened.Items.ContainsKey("Names"));
+    }
+
+    [Fact]
     public void RewriteApis_PreserveDirectNamedDestinationsForCopiedPages() {
         byte[] namedDestinationPdf = BuildNamedDestinationPdf();
         byte[] twoPageNamedDestinationPdf = BuildTwoPageNamedDestinationPdf();

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfReadStreamNamedDestinationTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfReadStreamNamedDestinationTests.cs
@@ -38,6 +38,41 @@ public partial class PdfReadStreamTests {
     }
 
     [Fact]
+    public void NameTreeBudgetDoesNotCountADirectRootDictionary() {
+        var page = new PdfDictionary();
+        page.Items["Type"] = new PdfName("Page");
+
+        var destination = new PdfArray();
+        destination.Items.Add(new PdfReference(3, 0));
+        destination.Items.Add(new PdfName("Fit"));
+
+        var names = new PdfArray();
+        names.Items.Add(new PdfStringObj("Chapter1"));
+        names.Items.Add(destination);
+
+        var leaf = new PdfDictionary();
+        leaf.Items["Names"] = names;
+        var kids = new PdfArray();
+        kids.Items.Add(new PdfReference(5, 0));
+        var root = new PdfDictionary();
+        root.Items["Kids"] = kids;
+        var objects = new Dictionary<int, PdfIndirectObject> {
+            [3] = new PdfIndirectObject(3, 0, page),
+            [5] = new PdfIndirectObject(5, 0, leaf)
+        };
+
+        bool supported = PdfPageExtractor.TryBuildFlattenedNamedDestinationNameTree(
+            objects,
+            root,
+            copiedPageObjectIds: null,
+            out PdfDictionary flattened,
+            maximumNodes: 1);
+
+        Assert.True(supported);
+        Assert.True(flattened.Items.ContainsKey("Names"));
+    }
+
+    [Fact]
     public void RewriteApis_PreserveDirectNamedDestinationsForCopiedPages() {
         byte[] namedDestinationPdf = BuildNamedDestinationPdf();
         byte[] twoPageNamedDestinationPdf = BuildTwoPageNamedDestinationPdf();

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfResourceBudgetSecurityTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfResourceBudgetSecurityTests.cs
@@ -253,6 +253,26 @@ public sealed class PdfResourceBudgetSecurityTests {
     }
 
     [Fact]
+    public void PdfReadDocument_AppliesNodeBudgetSeparatelyToEachCatalogNameTree() {
+        byte[] pdf = BuildPdfObjects(
+            "<< /Type /Catalog /Pages 2 0 R /Names << /Dests 5 0 R /JavaScript 6 0 R >> >>",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R >>",
+            BuildStream(string.Empty),
+            "<< /Names [(Target) [3 0 R /Fit]] >>",
+            "<< /Names [(Open) 7 0 R] >>",
+            "<< /S /JavaScript /JS (app.alert('OfficeIMO')) >>");
+        var options = new PdfReadOptions {
+            Limits = new PdfReadLimits { MaxNameTreeNodes = 1 }
+        };
+
+        PdfReadDocument document = PdfReadDocument.Open(pdf, options);
+
+        Assert.Equal("Target", Assert.Single(document.NamedDestinations).Name);
+        Assert.Equal("Open", Assert.Single(document.CatalogActions).Name);
+    }
+
+    [Fact]
     public void PdfReadDocument_BoundsEmbeddedFileNameTreeDepth() {
         byte[] pdf = BuildPdfObjects(
             "<< /Type /Catalog /Pages 2 0 R /Names << /EmbeddedFiles 5 0 R >> >>",

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfResourceBudgetSecurityTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfResourceBudgetSecurityTests.cs
@@ -91,6 +91,23 @@ public sealed class PdfResourceBudgetSecurityTests {
     }
 
     [Fact]
+    public void PdfReadPage_ChargesRepeatedContentStreamReferencesPerOccurrence() {
+        byte[] pdf = BuildPdfObjects(
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents [4 0 R 4 0 R] >>",
+            BuildStream("BT ET"));
+        var options = new PdfReadOptions {
+            Limits = new PdfReadLimits { MaxPageContentBytes = 9 }
+        };
+
+        PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() =>
+            PdfReadDocument.Open(pdf, options).Pages[0].ExtractText());
+
+        Assert.Equal(PdfReadLimitKind.PageContentBytes, exception.Kind);
+    }
+
+    [Fact]
     public void PdfReadPage_BoundsNestedFormContentAgainstPageBudget() {
         const string pageContent = "/Fx Do";
         const string formContent = "BT (Nested) Tj ET";
@@ -289,6 +306,22 @@ public sealed class PdfResourceBudgetSecurityTests {
             PdfAttachmentExtractor.ExtractAttachments(objects, trailer, limits));
 
         Assert.Equal(PdfReadLimitKind.NameTreeDepth, exception.Kind);
+    }
+
+    [Fact]
+    public void PdfAttachmentExtractor_CountsOnlyIndirectNameTreeNodes() {
+        byte[] pdf = BuildPdfObjects(
+            "<< /Type /Catalog /Pages 2 0 R /Names << /EmbeddedFiles << /Kids [5 0 R] >> >> >>",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R >>",
+            BuildStream(string.Empty),
+            "<< /Names [] >>");
+        (System.Collections.Generic.Dictionary<int, PdfIndirectObject> objects, string trailer) = PdfSyntax.ParseObjects(pdf);
+        var limits = new PdfReadLimits { MaxNameTreeNodes = 1 };
+
+        IReadOnlyList<PdfExtractedAttachment> attachments = PdfAttachmentExtractor.ExtractAttachments(objects, trailer, limits);
+
+        Assert.Empty(attachments);
     }
 
     [Fact]

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfResourceBudgetSecurityTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfResourceBudgetSecurityTests.cs
@@ -250,9 +250,46 @@ public sealed class PdfResourceBudgetSecurityTests {
     }
 
     [Fact]
+    public void PdfReadDocument_CountsOnlyUniqueIndirectNameTreeNodes() {
+        byte[] pdf = BuildPdfObjects(
+            "<< /Type /Catalog /Pages 2 0 R /Names << /Dests << /Kids [5 0 R 5 0 R] >> >> >>",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R >>",
+            BuildStream(string.Empty),
+            "<< /Names [(Target) [3 0 R /Fit]] >>");
+        var options = new PdfReadOptions {
+            Limits = new PdfReadLimits { MaxNameTreeNodes = 1 }
+        };
+
+        PdfReadDocument document = PdfReadDocument.Open(pdf, options);
+
+        Assert.Equal("Target", Assert.Single(document.NamedDestinations).Name);
+    }
+
+    [Fact]
     public void PdfReadDocument_CountsReferencedCatalogActionNameTreeNodeOnce() {
         byte[] pdf = BuildPdfObjects(
             "<< /Type /Catalog /Pages 2 0 R /Names << /JavaScript 5 0 R >> >>",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R >>",
+            BuildStream(string.Empty),
+            "<< /Names [(Open) 6 0 R] >>",
+            "<< /S /JavaScript /JS (app.alert('OfficeIMO')) >>");
+        var options = new PdfReadOptions {
+            Limits = new PdfReadLimits { MaxNameTreeNodes = 1 }
+        };
+
+        PdfReadDocument document = PdfReadDocument.Open(pdf, options);
+
+        PdfCatalogAction action = Assert.Single(document.CatalogActions);
+        Assert.Equal("Open", action.Name);
+        Assert.Equal("JavaScript", action.ActionType);
+    }
+
+    [Fact]
+    public void PdfReadDocument_CountsOnlyUniqueIndirectCatalogActionNameTreeNodes() {
+        byte[] pdf = BuildPdfObjects(
+            "<< /Type /Catalog /Pages 2 0 R /Names << /JavaScript << /Kids [5 0 R 5 0 R] >> >> >>",
             "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
             "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R >>",
             BuildStream(string.Empty),

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfResourceBudgetSecurityTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfResourceBudgetSecurityTests.cs
@@ -101,6 +101,17 @@ public sealed class PdfResourceBudgetSecurityTests {
     }
 
     [Fact]
+    public void TextContentParser_BoundsTextRunBufferBeforeDecoding() {
+        var budget = new TextContentParser.TextOutputBudget(
+            maxActualTextCharacters: 1,
+            maxDecodedTextCharacters: 1);
+
+        Assert.Equal(1, budget.GetDecodedTextBufferCapacity(int.MaxValue));
+        budget.ChargeDecodedText(1);
+        Assert.Equal(0, budget.GetDecodedTextBufferCapacity(int.MaxValue));
+    }
+
+    [Fact]
     public void PdfReadPage_BoundsAggregateContentStreamBytes() {
         byte[] pdf = BuildPdfObjects(
             "<< /Type /Catalog /Pages 2 0 R >>",

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfResourceBudgetSecurityTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfResourceBudgetSecurityTests.cs
@@ -233,6 +233,26 @@ public sealed class PdfResourceBudgetSecurityTests {
     }
 
     [Fact]
+    public void PdfReadDocument_CountsReferencedCatalogActionNameTreeNodeOnce() {
+        byte[] pdf = BuildPdfObjects(
+            "<< /Type /Catalog /Pages 2 0 R /Names << /JavaScript 5 0 R >> >>",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R >>",
+            BuildStream(string.Empty),
+            "<< /Names [(Open) 6 0 R] >>",
+            "<< /S /JavaScript /JS (app.alert('OfficeIMO')) >>");
+        var options = new PdfReadOptions {
+            Limits = new PdfReadLimits { MaxNameTreeNodes = 1 }
+        };
+
+        PdfReadDocument document = PdfReadDocument.Open(pdf, options);
+
+        PdfCatalogAction action = Assert.Single(document.CatalogActions);
+        Assert.Equal("Open", action.Name);
+        Assert.Equal("JavaScript", action.ActionType);
+    }
+
+    [Fact]
     public void PdfReadDocument_BoundsEmbeddedFileNameTreeDepth() {
         byte[] pdf = BuildPdfObjects(
             "<< /Type /Catalog /Pages 2 0 R /Names << /EmbeddedFiles 5 0 R >> >>",

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfResourceBudgetSecurityTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfResourceBudgetSecurityTests.cs
@@ -52,6 +52,27 @@ public sealed class PdfResourceBudgetSecurityTests {
     }
 
     [Fact]
+    public void TextContentParser_BoundsInlineActualTextBeforeDecoding() {
+        const string oversized = "/Span << /ActualText (AB) >> BDC BT /F1 12 Tf (X) Tj ET EMC";
+        const string boundedUtf16 = "/Span << /ActualText <FEFF00410042> >> BDC BT /F1 12 Tf (X) Tj ET EMC";
+
+        PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() =>
+            TextContentParser.Parse(
+                oversized,
+                static (_, bytes) => Encoding.ASCII.GetString(bytes),
+                static (_, bytes) => bytes.Length * 500D,
+                maxActualTextCharacters: 1));
+        IReadOnlyList<PdfTextSpan> spans = TextContentParser.Parse(
+            boundedUtf16,
+            static (_, bytes) => Encoding.ASCII.GetString(bytes),
+            static (_, bytes) => bytes.Length * 500D,
+            maxActualTextCharacters: 2);
+
+        Assert.Equal(PdfReadLimitKind.ActualTextCharacters, exception.Kind);
+        Assert.Equal("AB", Assert.Single(spans).Text);
+    }
+
+    [Fact]
     public void PdfReadPage_BoundsAggregateContentStreamBytes() {
         byte[] pdf = BuildPdfObjects(
             "<< /Type /Catalog /Pages 2 0 R >>",
@@ -192,6 +213,23 @@ public sealed class PdfResourceBudgetSecurityTests {
         PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() => PdfReadDocument.Open(pdf, options));
 
         Assert.Equal(PdfReadLimitKind.NameTreeDepth, exception.Kind);
+    }
+
+    [Fact]
+    public void PdfReadDocument_CountsReferencedNameTreeNodeOnce() {
+        byte[] pdf = BuildPdfObjects(
+            "<< /Type /Catalog /Pages 2 0 R /Names << /Dests 5 0 R >> >>",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R >>",
+            BuildStream(string.Empty),
+            "<< /Names [(Target) [3 0 R /Fit]] >>");
+        var options = new PdfReadOptions {
+            Limits = new PdfReadLimits { MaxNameTreeNodes = 1 }
+        };
+
+        PdfReadDocument document = PdfReadDocument.Open(pdf, options);
+
+        Assert.Equal("Target", Assert.Single(document.NamedDestinations).Name);
     }
 
     [Fact]

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfResourceBudgetSecurityTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfResourceBudgetSecurityTests.cs
@@ -87,6 +87,20 @@ public sealed class PdfResourceBudgetSecurityTests {
     }
 
     [Fact]
+    public void TextContentParser_ChargesFontDecodedTextReplacedByActualText() {
+        const string content = "/Span << /ActualText (X) >> BDC BT /F1 12 Tf (AB) Tj ET EMC";
+
+        PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() =>
+            TextContentParser.Parse(
+                content,
+                static (_, bytes) => Encoding.ASCII.GetString(bytes),
+                static (_, bytes) => bytes.Length * 500D,
+                maxDecodedTextCharacters: 1));
+
+        Assert.Equal(PdfReadLimitKind.DecodedTextCharacters, exception.Kind);
+    }
+
+    [Fact]
     public void PdfReadPage_BoundsAggregateContentStreamBytes() {
         byte[] pdf = BuildPdfObjects(
             "<< /Type /Catalog /Pages 2 0 R >>",

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfResourceBudgetSecurityTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfResourceBudgetSecurityTests.cs
@@ -70,6 +70,46 @@ public sealed class PdfResourceBudgetSecurityTests {
     }
 
     [Fact]
+    public void PdfReadPage_BoundsNestedFormContentAgainstPageBudget() {
+        const string pageContent = "/Fx Do";
+        const string formContent = "BT (Nested) Tj ET";
+        byte[] pdf = BuildPdfObjects(
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Resources << /XObject << /Fx 5 0 R >> >> /Contents 4 0 R >>",
+            BuildStream(pageContent),
+            BuildStream(formContent, "/Type /XObject /Subtype /Form /BBox [0 0 100 100]"));
+        var options = new PdfReadOptions {
+            Limits = new PdfReadLimits { MaxPageContentBytes = pageContent.Length + formContent.Length - 1 }
+        };
+
+        PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() =>
+            PdfReadDocument.Open(pdf, options).Pages[0].ExtractText());
+
+        Assert.Equal(PdfReadLimitKind.PageContentBytes, exception.Kind);
+    }
+
+    [Fact]
+    public void PdfReadPage_ToDrawingChargesAnnotationAppearancesToPageBudget() {
+        const string appearanceContent = "BT (Annotation) Tj ET";
+        byte[] pdf = BuildPdfObjects(
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Annots [5 0 R] /Contents 4 0 R >>",
+            BuildStream(string.Empty),
+            "<< /Type /Annot /Subtype /FreeText /Rect [0 0 10 10] /AP << /N 6 0 R >> >>",
+            BuildStream(appearanceContent, "/Type /XObject /Subtype /Form /BBox [0 0 10 10]"));
+        var options = new PdfReadOptions {
+            Limits = new PdfReadLimits { MaxPageContentBytes = appearanceContent.Length - 1 }
+        };
+
+        PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() =>
+            PdfReadDocument.Open(pdf, options).Pages[0].ToDrawing());
+
+        Assert.Equal(PdfReadLimitKind.PageContentBytes, exception.Kind);
+    }
+
+    [Fact]
     public void PdfReadPage_SharesActualTextBudgetAcrossRepeatedForms() {
         const string pageContent = "/Fx Do /Fx Do";
         const string formContent = "/Span << /ActualText (123456) >> BDC BT (A) Tj ET EMC";
@@ -152,6 +192,59 @@ public sealed class PdfResourceBudgetSecurityTests {
         PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() => PdfReadDocument.Open(pdf, options));
 
         Assert.Equal(PdfReadLimitKind.NameTreeDepth, exception.Kind);
+    }
+
+    [Fact]
+    public void PdfReadDocument_BoundsEmbeddedFileNameTreeDepth() {
+        byte[] pdf = BuildPdfObjects(
+            "<< /Type /Catalog /Pages 2 0 R /Names << /EmbeddedFiles 5 0 R >> >>",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R >>",
+            BuildStream(string.Empty),
+            "<< /Kids [6 0 R] >>",
+            "<< /Kids [7 0 R] >>",
+            "<< /Names [] >>");
+        (System.Collections.Generic.Dictionary<int, PdfIndirectObject> objects, string trailer) = PdfSyntax.ParseObjects(pdf);
+        var limits = new PdfReadLimits { MaxNameTreeDepth = 1 };
+
+        PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() =>
+            PdfAttachmentExtractor.ExtractAttachments(objects, trailer, limits));
+
+        Assert.Equal(PdfReadLimitKind.NameTreeDepth, exception.Kind);
+    }
+
+    [Fact]
+    public void PdfReadPage_BoundsBaseAndFallbackFontDecodingBeforeAllocation() {
+        byte[] baseFontPdf = BuildPdfObjects(
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>",
+            BuildStream("BT /F1 12 Tf (AB) Tj ET"),
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>");
+        byte[] fallbackFontPdf = BuildPdfObjects(
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R >>",
+            BuildStream("BT /Missing 12 Tf (AB) Tj ET"));
+        var options = new PdfReadOptions {
+            Limits = new PdfReadLimits { MaxDecodedTextCharacters = 1 }
+        };
+
+        PdfReadLimitException baseException = Assert.Throws<PdfReadLimitException>(() =>
+            PdfReadDocument.Open(baseFontPdf, options).Pages[0].ExtractText());
+        PdfReadLimitException fallbackException = Assert.Throws<PdfReadLimitException>(() =>
+            PdfReadDocument.Open(fallbackFontPdf, options).Pages[0].ExtractText());
+
+        Assert.Equal(PdfReadLimitKind.DecodedTextCharacters, baseException.Kind);
+        Assert.Equal(PdfReadLimitKind.DecodedTextCharacters, fallbackException.Kind);
+    }
+
+    [Fact]
+    public void StandardEncoding_BoundsLigatureExpansionBeforeBuildingOutput() {
+        PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() =>
+            PdfStandardEncoding.Decode(new byte[] { 174 }, maxOutputCharacters: 1));
+
+        Assert.Equal(PdfReadLimitKind.DecodedTextCharacters, exception.Kind);
     }
 
     [Fact]

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfResourceBudgetSecurityTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfResourceBudgetSecurityTests.cs
@@ -1,0 +1,194 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using OfficeIMO.Pdf;
+using OfficeIMO.Pdf.Filters;
+using Xunit;
+
+namespace OfficeIMO.Tests.Pdf;
+
+public sealed class PdfResourceBudgetSecurityTests {
+    [Fact]
+    public void ToUnicodeCMap_IgnoresSourceCodesLongerThanPdfLimit() {
+        const string source = "1 beginbfchar\n<0102030405> <0041>\nendbfchar";
+
+        Assert.True(ToUnicodeCMap.TryParse(Encoding.ASCII.GetBytes(source), out ToUnicodeCMap? cmap));
+
+        Assert.Equal("\u0001\u0002\u0003\u0004\u0005", cmap!.MapBytes(new byte[] { 1, 2, 3, 4, 5 }));
+    }
+
+    [Fact]
+    public void ToUnicodeCMap_RejectsOversizedDestinationAndOutputExpansion() {
+        string oversizedDestination = string.Concat(Enumerable.Repeat("0041", 4097));
+        string source = "2 beginbfchar\n<01> <" + oversizedDestination + ">\n<02> <0041004200430044>\nendbfchar";
+
+        Assert.True(ToUnicodeCMap.TryParse(Encoding.ASCII.GetBytes(source), out ToUnicodeCMap? cmap));
+        Assert.Equal("\u0001", cmap!.MapBytes(new byte[] { 1 }));
+
+        PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() =>
+            cmap.MapBytes(new byte[] { 2, 2, 2 }, maxOutputCharacters: 10));
+
+        Assert.Equal(PdfReadLimitKind.DecodedTextCharacters, exception.Kind);
+    }
+
+    [Fact]
+    public void TextContentParser_BoundsRepeatedActualTextExpansion() {
+        const string content =
+            "/Span /Shared BDC BT /F1 12 Tf (A) Tj ET EMC " +
+            "/Span /Shared BDC BT /F1 12 Tf (B) Tj ET EMC";
+
+        PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() =>
+            TextContentParser.Parse(
+                content,
+                static (_, bytes) => Encoding.ASCII.GetString(bytes),
+                static (_, bytes) => bytes.Length * 500D,
+                actualTextForProperty: static _ => "123456",
+                maxActualTextCharacters: 10));
+
+        Assert.Equal(PdfReadLimitKind.ActualTextCharacters, exception.Kind);
+    }
+
+    [Fact]
+    public void PdfReadPage_BoundsAggregateContentStreamBytes() {
+        byte[] pdf = BuildPdfObjects(
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents [4 0 R 5 0 R] >>",
+            "<< /Length 5 >>\nstream\nBT ET\nendstream",
+            "<< /Length 5 >>\nstream\nBT ET\nendstream");
+        var options = new PdfReadOptions {
+            Limits = new PdfReadLimits { MaxPageContentBytes = 9 }
+        };
+
+        PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() =>
+            PdfReadDocument.Open(pdf, options).Pages[0].ExtractText());
+
+        Assert.Equal(PdfReadLimitKind.PageContentBytes, exception.Kind);
+    }
+
+    [Fact]
+    public void PdfReadPage_SharesActualTextBudgetAcrossRepeatedForms() {
+        const string pageContent = "/Fx Do /Fx Do";
+        const string formContent = "/Span << /ActualText (123456) >> BDC BT (A) Tj ET EMC";
+        byte[] pdf = BuildPdfObjects(
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Resources << /XObject << /Fx 5 0 R >> >> /Contents 4 0 R >>",
+            BuildStream(pageContent),
+            BuildStream(formContent, "/Type /XObject /Subtype /Form /BBox [0 0 100 100]"));
+        var options = new PdfReadOptions {
+            Limits = new PdfReadLimits { MaxActualTextCharacters = 10 }
+        };
+
+        PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() =>
+            PdfReadDocument.Open(pdf, options).Pages[0].ExtractText());
+
+        Assert.Equal(PdfReadLimitKind.ActualTextCharacters, exception.Kind);
+    }
+
+    [Fact]
+    public void PdfReadPage_ToDrawingSharesDecodedTextBudgetAcrossAnnotationAppearances() {
+        const string appearanceContent = "BT /F1 12 Tf (123456) Tj ET";
+        byte[] pdf = BuildPdfObjects(
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Resources << /Font << /F1 8 0 R >> >> /Annots [5 0 R 6 0 R] /Contents 4 0 R >>",
+            BuildStream(string.Empty),
+            "<< /Type /Annot /Subtype /FreeText /Rect [0 0 10 10] /Contents (First) /AP << /N 7 0 R >> >>",
+            "<< /Type /Annot /Subtype /FreeText /Rect [20 0 30 10] /Contents (Second) /AP << /N 7 0 R >> >>",
+            BuildStream(appearanceContent, "/Type /XObject /Subtype /Form /BBox [0 0 10 10] /Resources << /Font << /F1 8 0 R >> >>"),
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>");
+        var options = new PdfReadOptions {
+            Limits = new PdfReadLimits { MaxDecodedTextCharacters = 10 }
+        };
+
+        PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() =>
+            PdfReadDocument.Open(pdf, options).Pages[0].ToDrawing());
+
+        Assert.Equal(PdfReadLimitKind.DecodedTextCharacters, exception.Kind);
+    }
+
+    [Fact]
+    public void StreamDecoder_RejectsOversizedPredictorRowBeforeAllocation() {
+        var dictionary = new PdfDictionary();
+        dictionary.Items["Filter"] = new PdfName("FlateDecode");
+        var decodeParameters = new PdfDictionary();
+        decodeParameters.Items["Predictor"] = new PdfNumber(12);
+        decodeParameters.Items["Columns"] = new PdfNumber(100_000_000);
+        dictionary.Items["DecodeParms"] = decodeParameters;
+
+        byte[] encoded;
+        using (var buffer = new MemoryStream()) {
+            using (var compressor = new DeflateStream(buffer, CompressionLevel.Optimal, leaveOpen: true)) {
+                compressor.WriteByte(0);
+            }
+            encoded = buffer.ToArray();
+        }
+
+        PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() =>
+            StreamDecoder.Decode(dictionary, encoded, maxOutputBytes: 64));
+
+        Assert.Equal(PdfReadLimitKind.DecodedStreamBytes, exception.Kind);
+        Assert.Equal(64, exception.Limit);
+    }
+
+    [Fact]
+    public void PdfReadDocument_BoundsNamedDestinationTreeDepth() {
+        byte[] pdf = BuildPdfObjects(
+            "<< /Type /Catalog /Pages 2 0 R /Names << /Dests 5 0 R >> >>",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R >>",
+            "<< /Length 0 >>\nstream\n\nendstream",
+            "<< /Kids [6 0 R] >>",
+            "<< /Kids [7 0 R] >>",
+            "<< /Names [(Target) [3 0 R /Fit]] >>");
+        var options = new PdfReadOptions {
+            Limits = new PdfReadLimits { MaxNameTreeDepth = 1 }
+        };
+
+        PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() => PdfReadDocument.Open(pdf, options));
+
+        Assert.Equal(PdfReadLimitKind.NameTreeDepth, exception.Kind);
+    }
+
+    [Fact]
+    public void ContentStructureExtractor_RejectsHostileLeaderTextInLinearTime() {
+        string hostile = "Label" + new string('-', 200_000) + "!";
+        var spans = new[] { new PdfTextSpan(hostile, "F1", 12, 0, 100, hostile.Length) };
+        var timer = Stopwatch.StartNew();
+
+        StructuredPage page = ContentStructureExtractor.Extract(spans, new TextLayoutEngine.Options());
+
+        timer.Stop();
+        Assert.Empty(page.LeaderRows);
+        Assert.True(timer.Elapsed < TimeSpan.FromSeconds(5), "Leader parsing exceeded the linear-time test budget: " + timer.Elapsed + ".");
+    }
+
+    [Fact]
+    public void ContentStructureExtractor_DoesNotTreatUnicodeDigitsAsAsciiPageNumbers() {
+        const string text = "Contents.... ９";
+        var spans = new[] { new PdfTextSpan(text, "F1", 12, 0, 100, text.Length) };
+
+        StructuredPage page = ContentStructureExtractor.Extract(spans, new TextLayoutEngine.Options());
+
+        Assert.Empty(page.Toc);
+    }
+
+    private static string BuildStream(string content, string dictionaryEntries = "") =>
+        "<< " + dictionaryEntries + " /Length " + Encoding.ASCII.GetByteCount(content) + " >>\nstream\n" + content + "\nendstream";
+
+    private static byte[] BuildPdfObjects(params string[] bodies) {
+        var builder = new StringBuilder("%PDF-1.7\n");
+        for (int index = 0; index < bodies.Length; index++) {
+            builder.Append(index + 1).Append(" 0 obj\n").Append(bodies[index]).Append("\nendobj\n");
+        }
+
+        builder.Append("trailer\n<< /Root 1 0 R /Size ")
+            .Append(bodies.Length + 1)
+            .Append(" >>\nstartxref\n0\n%%EOF\n");
+        return Encoding.ASCII.GetBytes(builder.ToString());
+    }
+}

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfResourceBudgetSecurityTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfResourceBudgetSecurityTests.cs
@@ -45,7 +45,7 @@ public sealed class PdfResourceBudgetSecurityTests {
                 content,
                 static (_, bytes) => Encoding.ASCII.GetString(bytes),
                 static (_, bytes) => bytes.Length * 500D,
-                actualTextForProperty: static _ => "123456",
+                actualTextForProperty: static _ => Encoding.ASCII.GetBytes("123456"),
                 maxActualTextCharacters: 10));
 
         Assert.Equal(PdfReadLimitKind.ActualTextCharacters, exception.Kind);
@@ -70,6 +70,20 @@ public sealed class PdfResourceBudgetSecurityTests {
 
         Assert.Equal(PdfReadLimitKind.ActualTextCharacters, exception.Kind);
         Assert.Equal("AB", Assert.Single(spans).Text);
+    }
+
+    [Fact]
+    public void TextContentParser_ChargesDiscardedArtifactTextToDecodedBudget() {
+        const string content = "/Artifact BMC BT /F1 12 Tf (AB) Tj ET EMC";
+
+        PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() =>
+            TextContentParser.Parse(
+                content,
+                static (_, bytes) => Encoding.ASCII.GetString(bytes),
+                static (_, bytes) => bytes.Length * 500D,
+                maxDecodedTextCharacters: 1));
+
+        Assert.Equal(PdfReadLimitKind.DecodedTextCharacters, exception.Kind);
     }
 
     [Fact]
@@ -159,6 +173,24 @@ public sealed class PdfResourceBudgetSecurityTests {
             BuildStream(formContent, "/Type /XObject /Subtype /Form /BBox [0 0 100 100]"));
         var options = new PdfReadOptions {
             Limits = new PdfReadLimits { MaxActualTextCharacters = 10 }
+        };
+
+        PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() =>
+            PdfReadDocument.Open(pdf, options).Pages[0].ExtractText());
+
+        Assert.Equal(PdfReadLimitKind.ActualTextCharacters, exception.Kind);
+    }
+
+    [Fact]
+    public void PdfReadPage_BoundsNamedActualTextFromRawBytes() {
+        const string pageContent = "/Span /MC0 BDC BT /F1 12 Tf (X) Tj ET EMC";
+        byte[] pdf = BuildPdfObjects(
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Resources << /Properties << /MC0 << /ActualText <FEFF00410042> >> >> >> /Contents 4 0 R >>",
+            BuildStream(pageContent));
+        var options = new PdfReadOptions {
+            Limits = new PdfReadLimits { MaxActualTextCharacters = 1 }
         };
 
         PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() =>

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfResourceBudgetSecurityTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfResourceBudgetSecurityTests.cs
@@ -112,6 +112,26 @@ public sealed class PdfResourceBudgetSecurityTests {
     }
 
     [Fact]
+    public void TextContentParser_PassesRemainingBudgetToEachTextRunDecoder() {
+        var decoderLimits = new List<int>();
+        const string content = "BT /F1 12 Tf (123456789) Tj (abcdefghij) Tj ET";
+
+        PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() =>
+            TextContentParser.Parse(
+                content,
+                static (_, _) => throw new InvalidOperationException("The bounded decoder must be used."),
+                static (_, bytes) => bytes.Length * 500D,
+                maxDecodedTextCharacters: 10,
+                decodeWithFontWithinLimit: (_, bytes, maximumCharacters) => {
+                    decoderLimits.Add(maximumCharacters);
+                    return PdfWinAnsiEncoding.Decode(bytes, maximumCharacters);
+                }));
+
+        Assert.Equal(PdfReadLimitKind.DecodedTextCharacters, exception.Kind);
+        Assert.Contains(1, decoderLimits);
+    }
+
+    [Fact]
     public void PdfReadPage_BoundsAggregateContentStreamBytes() {
         byte[] pdf = BuildPdfObjects(
             "<< /Type /Catalog /Pages 2 0 R >>",

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfResourceBudgetSecurityTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfResourceBudgetSecurityTests.cs
@@ -101,6 +101,20 @@ public sealed class PdfResourceBudgetSecurityTests {
     }
 
     [Fact]
+    public void TextContentParser_ChargesDecodedGlyphsDroppedByThinSpacingFilter() {
+        PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() =>
+            TextContentParser.Parse(
+                "BT /F1 12 Tf (AB) Tj ET",
+                static (_, bytes) => bytes.Length == 1 && bytes[0] == (byte)'B'
+                    ? "BBBBBB"
+                    : Encoding.ASCII.GetString(bytes),
+                static (_, bytes) => bytes[0] == (byte)'B' ? 0D : bytes.Length * 500D,
+                maxDecodedTextCharacters: 6));
+
+        Assert.Equal(PdfReadLimitKind.DecodedTextCharacters, exception.Kind);
+    }
+
+    [Fact]
     public void TextContentParser_BoundsTextRunBufferBeforeDecoding() {
         var budget = new TextContentParser.TextOutputBudget(
             maxActualTextCharacters: 1,

--- a/OfficeIMO.Pdf/Manipulation/PdfPageExtractor.CatalogNameTrees.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageExtractor.CatalogNameTrees.cs
@@ -52,7 +52,8 @@ internal static partial class PdfPageExtractor {
         out PdfDictionary result) {
         result = new PdfDictionary();
         var entries = new List<NamedDestinationNameTreeEntry>();
-        if (!TryCollectNamedDestinationNameTreeEntries(sourceObjects, namedDestinationNameTree, entries, new HashSet<int>())) {
+        int traversedNodes = 0;
+        if (!TryCollectNamedDestinationNameTreeEntries(sourceObjects, namedDestinationNameTree, entries, new HashSet<int>(), 0, ref traversedNodes)) {
             return false;
         }
     
@@ -90,14 +91,21 @@ internal static partial class PdfPageExtractor {
         Dictionary<int, PdfIndirectObject> sourceObjects,
         PdfObject? value,
         List<NamedDestinationNameTreeEntry> entries,
-        HashSet<int> visitedReferences) {
+        HashSet<int> visitedReferences,
+        int depth,
+        ref int traversedNodes) {
+        if (depth > PdfReadLimits.DefaultMaxNameTreeDepth ||
+            ++traversedNodes > PdfReadLimits.DefaultMaxNameTreeNodes) {
+            return false;
+        }
+
         if (value is PdfReference reference) {
             if (!visitedReferences.Add(reference.ObjectNumber) ||
                 !PdfObjectLookup.TryGet(sourceObjects, reference, out var indirect)) {
                 return false;
             }
     
-            return TryCollectNamedDestinationNameTreeEntries(sourceObjects, indirect.Value, entries, visitedReferences);
+            return TryCollectNamedDestinationNameTreeEntries(sourceObjects, indirect.Value, entries, visitedReferences, depth, ref traversedNodes);
         }
     
         if (value is not PdfDictionary tree) {
@@ -133,7 +141,7 @@ internal static partial class PdfPageExtractor {
                     return false;
                 }
     
-                if (!TryCollectNamedDestinationNameTreeEntries(sourceObjects, kid, entries, visitedReferences)) {
+                if (!TryCollectNamedDestinationNameTreeEntries(sourceObjects, kid, entries, visitedReferences, depth + 1, ref traversedNodes)) {
                     return false;
                 }
             }

--- a/OfficeIMO.Pdf/Manipulation/PdfPageExtractor.CatalogNameTrees.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageExtractor.CatalogNameTrees.cs
@@ -45,15 +45,16 @@ internal static partial class PdfPageExtractor {
         return TryBuildFlattenedNamedDestinationNameTree(sourceObjects, namedDestinations, null, out _);
     }
     
-    private static bool TryBuildFlattenedNamedDestinationNameTree(
+    internal static bool TryBuildFlattenedNamedDestinationNameTree(
         Dictionary<int, PdfIndirectObject> sourceObjects,
         PdfObject? namedDestinationNameTree,
         HashSet<int>? copiedPageObjectIds,
-        out PdfDictionary result) {
+        out PdfDictionary result,
+        int maximumNodes = PdfReadLimits.DefaultMaxNameTreeNodes) {
         result = new PdfDictionary();
         var entries = new List<NamedDestinationNameTreeEntry>();
         int traversedNodes = 0;
-        if (!TryCollectNamedDestinationNameTreeEntries(sourceObjects, namedDestinationNameTree, entries, new HashSet<int>(), 0, ref traversedNodes)) {
+        if (!TryCollectNamedDestinationNameTreeEntries(sourceObjects, namedDestinationNameTree, entries, new HashSet<int>(), 0, maximumNodes, ref traversedNodes)) {
             return false;
         }
     
@@ -93,9 +94,9 @@ internal static partial class PdfPageExtractor {
         List<NamedDestinationNameTreeEntry> entries,
         HashSet<int> visitedReferences,
         int depth,
+        int maximumNodes,
         ref int traversedNodes) {
-        if (depth > PdfReadLimits.DefaultMaxNameTreeDepth ||
-            ++traversedNodes > PdfReadLimits.DefaultMaxNameTreeNodes) {
+        if (depth > PdfReadLimits.DefaultMaxNameTreeDepth) {
             return false;
         }
 
@@ -105,10 +106,11 @@ internal static partial class PdfPageExtractor {
                 return false;
             }
     
-            return TryCollectNamedDestinationNameTreeEntries(sourceObjects, indirect.Value, entries, visitedReferences, depth, ref traversedNodes);
+            return TryCollectNamedDestinationNameTreeEntries(sourceObjects, indirect.Value, entries, visitedReferences, depth, maximumNodes, ref traversedNodes);
         }
-    
-        if (value is not PdfDictionary tree) {
+
+        if (value is not PdfDictionary tree ||
+            ++traversedNodes > maximumNodes) {
             return false;
         }
     
@@ -141,7 +143,7 @@ internal static partial class PdfPageExtractor {
                     return false;
                 }
     
-                if (!TryCollectNamedDestinationNameTreeEntries(sourceObjects, kid, entries, visitedReferences, depth + 1, ref traversedNodes)) {
+                if (!TryCollectNamedDestinationNameTreeEntries(sourceObjects, kid, entries, visitedReferences, depth + 1, maximumNodes, ref traversedNodes)) {
                     return false;
                 }
             }

--- a/OfficeIMO.Pdf/Manipulation/PdfPageExtractor.CatalogNameTrees.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageExtractor.CatalogNameTrees.cs
@@ -105,12 +105,15 @@ internal static partial class PdfPageExtractor {
                 !PdfObjectLookup.TryGet(sourceObjects, reference, out var indirect)) {
                 return false;
             }
-    
-            return TryCollectNamedDestinationNameTreeEntries(sourceObjects, indirect.Value, entries, visitedReferences, depth, maximumNodes, ref traversedNodes);
+
+            if (++traversedNodes > maximumNodes) {
+                return false;
+            }
+
+            value = indirect.Value;
         }
 
-        if (value is not PdfDictionary tree ||
-            ++traversedNodes > maximumNodes) {
+        if (value is not PdfDictionary tree) {
             return false;
         }
     

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.Attachments.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.Attachments.cs
@@ -24,7 +24,7 @@ public sealed partial class PdfReadDocument {
                 attachment.Filter,
                 attachment.FileSpecObjectNumber,
                 attachment.EmbeddedFileObjectNumber,
-                attachment.Bytes.Length,
+                attachment.ByteLength,
                 attachment.Source,
                 attachment.CreationDate,
                 attachment.ModificationDate));

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.CatalogActions.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.CatalogActions.cs
@@ -35,19 +35,20 @@ public sealed partial class PdfReadDocument {
         HashSet<int> visitedReferences,
         int depth,
         ref int traversedNodes) {
-        HashSet<int> pathReferences = visitedReferences;
+        EnsureNameTreeBudget(depth, traversedNodes);
         if (treeObject is PdfReference reference) {
-            if (visitedReferences.Contains(reference.ObjectNumber) ||
-                !PdfObjectLookup.TryGet(_objects, reference, out var indirect)) {
+            if (!visitedReferences.Add(reference.ObjectNumber)) {
                 return;
             }
 
-            pathReferences = new HashSet<int>(visitedReferences) { reference.ObjectNumber };
-            AddCatalogActionsFromNameTree(indirect.Value, result, pathReferences, depth, ref traversedNodes);
-            return;
+            EnsureNameTreeBudget(depth, ++traversedNodes);
+            if (!PdfObjectLookup.TryGet(_objects, reference, out var indirect)) {
+                return;
+            }
+
+            treeObject = indirect.Value;
         }
 
-        EnsureNameTreeBudget(depth, ++traversedNodes);
         if (treeObject is not PdfDictionary tree) {
             return;
         }
@@ -64,7 +65,7 @@ public sealed partial class PdfReadDocument {
         if (tree.Items.TryGetValue("Kids", out var kidsObject) &&
             ResolveArray(kidsObject) is PdfArray kids) {
             foreach (var kid in kids.Items) {
-                AddCatalogActionsFromNameTree(kid, result, new HashSet<int>(pathReferences), depth + 1, ref traversedNodes);
+                AddCatalogActionsFromNameTree(kid, result, visitedReferences, depth + 1, ref traversedNodes);
             }
         }
     }

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.CatalogActions.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.CatalogActions.cs
@@ -35,7 +35,6 @@ public sealed partial class PdfReadDocument {
         HashSet<int> visitedReferences,
         int depth,
         ref int traversedNodes) {
-        EnsureNameTreeBudget(depth, ++traversedNodes);
         HashSet<int> pathReferences = visitedReferences;
         if (treeObject is PdfReference reference) {
             if (visitedReferences.Contains(reference.ObjectNumber) ||
@@ -48,6 +47,7 @@ public sealed partial class PdfReadDocument {
             return;
         }
 
+        EnsureNameTreeBudget(depth, ++traversedNodes);
         if (treeObject is not PdfDictionary tree) {
             return;
         }

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.CatalogActions.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.CatalogActions.cs
@@ -11,7 +11,8 @@ public sealed partial class PdfReadDocument {
         if (catalog.Items.TryGetValue("Names", out var namesObject) &&
             ResolveDict(namesObject) is PdfDictionary namesDictionary &&
             namesDictionary.Items.TryGetValue("JavaScript", out var javaScriptNameTree)) {
-            AddCatalogActionsFromNameTree(javaScriptNameTree, result, new HashSet<int>());
+            int traversedNameTreeNodes = 0;
+            AddCatalogActionsFromNameTree(javaScriptNameTree, result, new HashSet<int>(), 0, ref traversedNameTreeNodes);
         }
 
         if (catalog.Items.TryGetValue("OpenAction", out var openAction)) {
@@ -31,7 +32,10 @@ public sealed partial class PdfReadDocument {
     private void AddCatalogActionsFromNameTree(
         PdfObject treeObject,
         List<PdfCatalogAction> result,
-        HashSet<int> visitedReferences) {
+        HashSet<int> visitedReferences,
+        int depth,
+        ref int traversedNodes) {
+        EnsureNameTreeBudget(depth, ++traversedNodes);
         HashSet<int> pathReferences = visitedReferences;
         if (treeObject is PdfReference reference) {
             if (visitedReferences.Contains(reference.ObjectNumber) ||
@@ -40,7 +44,7 @@ public sealed partial class PdfReadDocument {
             }
 
             pathReferences = new HashSet<int>(visitedReferences) { reference.ObjectNumber };
-            AddCatalogActionsFromNameTree(indirect.Value, result, pathReferences);
+            AddCatalogActionsFromNameTree(indirect.Value, result, pathReferences, depth, ref traversedNodes);
             return;
         }
 
@@ -60,7 +64,7 @@ public sealed partial class PdfReadDocument {
         if (tree.Items.TryGetValue("Kids", out var kidsObject) &&
             ResolveArray(kidsObject) is PdfArray kids) {
             foreach (var kid in kids.Items) {
-                AddCatalogActionsFromNameTree(kid, result, new HashSet<int>(pathReferences));
+                AddCatalogActionsFromNameTree(kid, result, new HashSet<int>(pathReferences), depth + 1, ref traversedNodes);
             }
         }
     }

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.Destinations.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.Destinations.cs
@@ -37,7 +37,8 @@ public sealed partial class PdfReadDocument {
         if (catalog.Items.TryGetValue("Names", out var namesObject) &&
             ResolveDict(namesObject) is PdfDictionary namesDictionary &&
             namesDictionary.Items.TryGetValue("Dests", out var namedDestinationTree)) {
-            AddNamedDestinationsFromNameTree(namedDestinationTree, result, new HashSet<int>());
+            int traversedNameTreeNodes = 0;
+            AddNamedDestinationsFromNameTree(namedDestinationTree, result, new HashSet<int>(), 0, ref traversedNameTreeNodes);
         }
 
         return result.Count == 0 ? Array.Empty<PdfNamedDestination>() : result.AsReadOnly();
@@ -46,14 +47,17 @@ public sealed partial class PdfReadDocument {
     private void AddNamedDestinationsFromNameTree(
         PdfObject treeObject,
         List<PdfNamedDestination> result,
-        HashSet<int> visitedReferences) {
+        HashSet<int> visitedReferences,
+        int depth,
+        ref int traversedNodes) {
+        EnsureNameTreeBudget(depth, ++traversedNodes);
         if (treeObject is PdfReference reference) {
             if (!visitedReferences.Add(reference.ObjectNumber) ||
                 !PdfObjectLookup.TryGet(_objects, reference, out var indirect)) {
                 return;
             }
 
-            AddNamedDestinationsFromNameTree(indirect.Value, result, visitedReferences);
+            AddNamedDestinationsFromNameTree(indirect.Value, result, visitedReferences, depth, ref traversedNodes);
             return;
         }
 
@@ -74,8 +78,18 @@ public sealed partial class PdfReadDocument {
         if (tree.Items.TryGetValue("Kids", out var kidsObject) &&
             ResolveArray(kidsObject) is PdfArray kids) {
             foreach (var kid in kids.Items) {
-                AddNamedDestinationsFromNameTree(kid, result, visitedReferences);
+                AddNamedDestinationsFromNameTree(kid, result, visitedReferences, depth + 1, ref traversedNodes);
             }
+        }
+    }
+
+    private void EnsureNameTreeBudget(int depth, int traversedNodes) {
+        if (depth > _options.Limits.MaxNameTreeDepth) {
+            throw PdfReadLimitException.Create(PdfReadLimitKind.NameTreeDepth, _options.Limits.MaxNameTreeDepth, depth);
+        }
+
+        if (traversedNodes > _options.Limits.MaxNameTreeNodes) {
+            throw PdfReadLimitException.Create(PdfReadLimitKind.NameTreeNodes, _options.Limits.MaxNameTreeNodes, traversedNodes);
         }
     }
 

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.Destinations.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.Destinations.cs
@@ -50,17 +50,20 @@ public sealed partial class PdfReadDocument {
         HashSet<int> visitedReferences,
         int depth,
         ref int traversedNodes) {
+        EnsureNameTreeBudget(depth, traversedNodes);
         if (treeObject is PdfReference reference) {
-            if (!visitedReferences.Add(reference.ObjectNumber) ||
-                !PdfObjectLookup.TryGet(_objects, reference, out var indirect)) {
+            if (!visitedReferences.Add(reference.ObjectNumber)) {
                 return;
             }
 
-            AddNamedDestinationsFromNameTree(indirect.Value, result, visitedReferences, depth, ref traversedNodes);
-            return;
+            EnsureNameTreeBudget(depth, ++traversedNodes);
+            if (!PdfObjectLookup.TryGet(_objects, reference, out var indirect)) {
+                return;
+            }
+
+            treeObject = indirect.Value;
         }
 
-        EnsureNameTreeBudget(depth, ++traversedNodes);
         if (treeObject is not PdfDictionary tree) {
             return;
         }

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.Destinations.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.Destinations.cs
@@ -50,7 +50,6 @@ public sealed partial class PdfReadDocument {
         HashSet<int> visitedReferences,
         int depth,
         ref int traversedNodes) {
-        EnsureNameTreeBudget(depth, ++traversedNodes);
         if (treeObject is PdfReference reference) {
             if (!visitedReferences.Add(reference.ObjectNumber) ||
                 !PdfObjectLookup.TryGet(_objects, reference, out var indirect)) {
@@ -61,6 +60,7 @@ public sealed partial class PdfReadDocument {
             return;
         }
 
+        EnsureNameTreeBudget(depth, ++traversedNodes);
         if (treeObject is not PdfDictionary tree) {
             return;
         }

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadPage.RenderDiagnostics.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadPage.RenderDiagnostics.cs
@@ -5,8 +5,9 @@ public sealed partial class PdfReadPage {
         var diagnostics = new List<PdfRenderCapabilityDiagnostic>();
         var seen = new HashSet<string>(StringComparer.Ordinal);
         var activeForms = new HashSet<PdfStream>();
+        var pageContentBudget = new PageContentBudget(this);
         PdfDictionary? resources = ResolveDictionary(GetInheritedValue("Resources"));
-        CollectRenderCapabilityDiagnostics(GetContentStreamContent(), resources, diagnostics, seen, activeForms, 0);
+        CollectRenderCapabilityDiagnostics(GetContentStreamContent(pageContentBudget), resources, diagnostics, seen, activeForms, pageContentBudget, 0);
         CollectAnnotationCapabilityDiagnostics(diagnostics, seen);
         return diagnostics.Count == 0 ? Array.Empty<PdfRenderCapabilityDiagnostic>() : diagnostics.AsReadOnly();
     }
@@ -17,6 +18,7 @@ public sealed partial class PdfReadPage {
         List<PdfRenderCapabilityDiagnostic> diagnostics,
         HashSet<string> seen,
         HashSet<PdfStream> activeForms,
+        PageContentBudget pageContentBudget,
         int depth) {
         EnsureContentNestingBudget(depth);
         HashSet<string> unsupportedColorSpaces = GetUnsupportedColorSpaceResourceNames(resources);
@@ -51,7 +53,7 @@ public sealed partial class PdfReadPage {
         CollectFontCapabilityDiagnostics(resources, diagnostics, seen);
         CollectPatternCapabilityDiagnostics(resources, diagnostics, seen);
         CollectGraphicsStateCapabilityDiagnostics(resources, diagnostics, seen);
-        CollectXObjectCapabilityDiagnostics(resources, invokedXObjects, diagnostics, seen, activeForms, depth);
+        CollectXObjectCapabilityDiagnostics(resources, invokedXObjects, diagnostics, seen, activeForms, pageContentBudget, depth);
     }
 
     private static string? GetOperatorCapabilityId(string op) {
@@ -146,6 +148,7 @@ public sealed partial class PdfReadPage {
         List<PdfRenderCapabilityDiagnostic> diagnostics,
         HashSet<string> seen,
         HashSet<PdfStream> activeForms,
+        PageContentBudget pageContentBudget,
         int depth) {
         PdfDictionary? xObjects = ResolveDictionary(resources.Items.TryGetValue("XObject", out PdfObject? value) ? value : null);
         if (xObjects == null) return;
@@ -180,7 +183,7 @@ public sealed partial class PdfReadPage {
             if (!activeForms.Add(stream)) continue;
             try {
                 PdfDictionary? formResources = ResolveDictionary(stream.Dictionary.Items.TryGetValue("Resources", out PdfObject? formResourceObject) ? formResourceObject : null) ?? resources;
-                CollectRenderCapabilityDiagnostics(PdfEncoding.Latin1GetString(DecodeIfNeeded(stream)), formResources, diagnostics, seen, activeForms, depth + 1);
+                CollectRenderCapabilityDiagnostics(PdfEncoding.Latin1GetString(pageContentBudget.Decode(stream)), formResources, diagnostics, seen, activeForms, pageContentBudget, depth + 1);
             } finally {
                 activeForms.Remove(stream);
             }

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadPage.Visual.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadPage.Visual.cs
@@ -6,6 +6,7 @@ public sealed partial class PdfReadPage {
     internal int GetVisibleVisualPrimitiveCount() {
         (double Width, double Height) size = GetVisualPageSize();
         int count = 0;
+        var textOutputBudget = CreateTextOutputBudget();
         var visibilityBudget = new VisualGeometryBudget();
         var patternPaintCache = new Dictionary<PdfPageTilingPatternResource, bool>();
         var tilingPatternResourceCache =
@@ -32,7 +33,8 @@ public sealed partial class PdfReadPage {
                 },
                 activeForms,
                 retainPrimitiveData: false,
-                tilingPatternResourceCache: tilingPatternResourceCache);
+                tilingPatternResourceCache: tilingPatternResourceCache,
+                textOutputBudget: textOutputBudget);
         }
 
         return count;
@@ -46,17 +48,18 @@ public sealed partial class PdfReadPage {
         (double Width, double Height) size = GetVisualPageSize();
         Matrix2D pageTransform = GetVisualPageTransform();
         var drawing = new OfficeDrawing(size.Width, size.Height);
+        var textOutputBudget = CreateTextOutputBudget();
         RegisterEmbeddedFonts(drawing, ResolveDictionary(GetInheritedValue("Resources")), new HashSet<PdfStream>(), 0);
 
-        List<PdfPageDrawingElement> pageElements = GetOrderedPageDrawingElements(size.Width, size.Height, pageTransform);
+        List<PdfPageDrawingElement> pageElements = GetOrderedPageDrawingElements(size.Width, size.Height, pageTransform, textOutputBudget);
         IReadOnlyList<PdfPageDrawingEffectTransition> effects = GetGraphicsEffectTransitions(pageTransform, size.Height);
         var softMasks = new Dictionary<PdfPageSoftMaskResource, OfficeDrawingSoftMask>();
         for (int i = 0; i < pageElements.Count; i++) {
             PdfPageDrawingElement element = pageElements[i].WithEffect(ResolveDrawingEffect(effects, pageElements[i].PaintOrder));
-            AddDrawingElement(drawing, size.Height, pageTransform, element, softMasks);
+            AddDrawingElement(drawing, size.Height, pageTransform, element, softMasks, textOutputBudget);
         }
 
-        AddAnnotationAppearances(drawing, size.Height, pageTransform);
+        AddAnnotationAppearances(drawing, size.Height, pageTransform, textOutputBudget);
 
         return drawing;
     }
@@ -86,14 +89,18 @@ public sealed partial class PdfReadPage {
         }
     }
 
-    private List<PdfPageDrawingElement> GetOrderedPageDrawingElements(double pageWidth, double pageHeight, Matrix2D pageTransform) {
+    private List<PdfPageDrawingElement> GetOrderedPageDrawingElements(
+        double pageWidth,
+        double pageHeight,
+        Matrix2D pageTransform,
+        TextContentParser.TextOutputBudget textOutputBudget) {
         var elements = new List<PdfPageDrawingElement>();
-        IReadOnlyList<PdfPageVisualPrimitive> primitives = GetVisualPrimitives(pageWidth, pageHeight, pageTransform);
+        IReadOnlyList<PdfPageVisualPrimitive> primitives = GetVisualPrimitives(pageWidth, pageHeight, pageTransform, textOutputBudget);
         for (int i = 0; i < primitives.Count; i++) {
             elements.Add(PdfPageDrawingElement.FromPrimitive(primitives[i], elements.Count));
         }
 
-        IReadOnlyList<PdfTextSpan> spans = GetVisualTextSpans(pageHeight, pageTransform);
+        IReadOnlyList<PdfTextSpan> spans = GetVisualTextSpans(pageHeight, pageTransform, textOutputBudget);
         for (int i = 0; i < spans.Count; i++) {
             elements.Add(PdfPageDrawingElement.FromText(spans[i], elements.Count));
         }
@@ -126,7 +133,8 @@ public sealed partial class PdfReadPage {
         double pageHeight,
         Matrix2D pageTransform,
         PdfPageDrawingElement element,
-        Dictionary<PdfPageSoftMaskResource, OfficeDrawingSoftMask> softMasks) {
+        Dictionary<PdfPageSoftMaskResource, OfficeDrawingSoftMask> softMasks,
+        TextContentParser.TextOutputBudget textOutputBudget) {
         if (element.Effect.IsDefault) {
             AddDrawingElementCore(drawing, pageHeight, element);
             return;
@@ -137,7 +145,7 @@ public sealed partial class PdfReadPage {
         if (isolated.Elements.Count == 0) return;
         OfficeDrawingSoftMask? softMask = element.Effect.SoftMask == null
             ? null
-            : GetOrCreateSoftMask(element.Effect.SoftMask, drawing.Width, drawing.Height, pageTransform, softMasks);
+            : GetOrCreateSoftMask(element.Effect.SoftMask, drawing.Width, drawing.Height, pageTransform, softMasks, textOutputBudget);
         drawing.AddEffectDrawing(isolated, OfficeTransform.Identity, element.Effect.BlendMode, softMask);
     }
 
@@ -361,7 +369,12 @@ public sealed partial class PdfReadPage {
         return true;
     }
 
-    private IReadOnlyList<PdfPageVisualPrimitive> GetVisualPrimitives(double pageWidth, double pageHeight, Matrix2D pageTransform) {
+    private IReadOnlyList<PdfPageVisualPrimitive> GetVisualPrimitives(
+        double pageWidth,
+        double pageHeight,
+        Matrix2D pageTransform,
+        TextContentParser.TextOutputBudget? textOutputBudget = null) {
+        textOutputBudget ??= CreateTextOutputBudget();
         var primitives = new List<PdfPageVisualPrimitive>();
         PdfDictionary? pageResources = ResolveDictionary(GetInheritedValue("Resources"));
         var activeForms = new HashSet<PdfStream>();
@@ -377,7 +390,8 @@ public sealed partial class PdfReadPage {
                 pageHeight,
                 primitives.Add,
                 activeForms,
-                tilingPatternResourceCache: tilingPatternResourceCache);
+                tilingPatternResourceCache: tilingPatternResourceCache,
+                textOutputBudget: textOutputBudget);
         }
 
         return primitives.Count == 0 ? Array.Empty<PdfPageVisualPrimitive>() : primitives.AsReadOnly();
@@ -408,7 +422,8 @@ public sealed partial class PdfReadPage {
         int contentNestingDepth = 0,
         bool includeTilingPatterns = true,
         bool retainPrimitiveData = true,
-        Dictionary<(PdfStream Stream, PdfDictionary Resources), PdfPageTilingPatternResource?>? tilingPatternResourceCache = null) {
+        Dictionary<(PdfStream Stream, PdfDictionary Resources), PdfPageTilingPatternResource?>? tilingPatternResourceCache = null,
+        TextContentParser.TextOutputBudget? textOutputBudget = null) {
         EnsureContentNestingBudget(contentNestingDepth);
         string transformedContent = WrapContentWithTransform(content, baseTransform, out int transformedContentOffset);
         _ = PdfPageContentVisualParser.Parse(
@@ -420,7 +435,7 @@ public sealed partial class PdfReadPage {
             GetShadingResources(resources),
             GetShadingPatternResources(resources),
             includeTilingPatterns
-                ? GetTilingPatternResources(resources, tilingPatternResourceCache)
+                ? GetTilingPatternResources(resources, tilingPatternResourceCache, textOutputBudget)
                 : null,
             GetOptionalContentVisibility(resources),
             paintOrderBase,
@@ -505,7 +520,8 @@ public sealed partial class PdfReadPage {
                     contentNestingDepth: contentNestingDepth + 1,
                     includeTilingPatterns: includeTilingPatterns,
                     retainPrimitiveData: retainPrimitiveData,
-                    tilingPatternResourceCache: tilingPatternResourceCache);
+                    tilingPatternResourceCache: tilingPatternResourceCache,
+                    textOutputBudget: textOutputBudget);
             } finally {
                 activeForms.Remove(formStream);
             }
@@ -1009,7 +1025,11 @@ public sealed partial class PdfReadPage {
         }
     }
 
-    private void AddAnnotationAppearances(OfficeDrawing drawing, double pageHeight, Matrix2D pageTransform) {
+    private void AddAnnotationAppearances(
+        OfficeDrawing drawing,
+        double pageHeight,
+        Matrix2D pageTransform,
+        TextContentParser.TextOutputBudget textOutputBudget) {
         if (!_pageDict.Items.TryGetValue("Annots", out PdfObject? annotationsObject)) {
             return;
         }
@@ -1021,7 +1041,7 @@ public sealed partial class PdfReadPage {
         EnsureAnnotationBudget(annotations);
 
         PdfDictionary? pageResources = ResolveDictionary(GetInheritedValue("Resources"));
-        Dictionary<string, Func<byte[], string>> pageDecoders = ResourceResolver.GetFontDecoders(_pageDict, _objects);
+        Dictionary<string, Func<byte[], string>> pageDecoders = ResourceResolver.GetFontDecoders(_pageDict, _objects, _limits.MaxDecodedTextCharacters);
         Dictionary<string, Func<byte[], double>> pageWidthProviders = ResourceResolver.GetFontWidthProviders(_pageDict, _objects);
         Dictionary<string, PdfFontResource> pageFonts = ResourceResolver.GetFontsForResources(pageResources, _objects);
         var activeForms = new HashSet<PdfStream>();
@@ -1043,13 +1063,23 @@ public sealed partial class PdfReadPage {
             Matrix2D appearanceTransform = Matrix2D.Multiply(pageTransform, CreateAnnotationAppearanceTransform(rectangle, appearanceStream.Dictionary));
             var elements = new List<PdfPageDrawingElement>();
             var primitives = new List<PdfPageVisualPrimitive>();
-            CollectVisualPrimitivesAndForms(appearanceContent, appearanceResources, appearanceTransform, drawing.Width, pageHeight, primitives.Add, activeForms);
+            CollectVisualPrimitivesAndForms(
+                appearanceContent,
+                appearanceResources,
+                appearanceTransform,
+                drawing.Width,
+                pageHeight,
+                primitives.Add,
+                activeForms,
+                textOutputBudget: textOutputBudget);
             for (int primitiveIndex = 0; primitiveIndex < primitives.Count; primitiveIndex++) {
                 elements.Add(PdfPageDrawingElement.FromPrimitive(primitives[primitiveIndex], elements.Count));
             }
 
             var textSpans = new List<PdfTextSpan>();
-            Dictionary<string, Func<byte[], string>> appearanceDecoders = MergeDecoders(pageDecoders, ResourceResolver.GetFontDecodersForForm(appearanceStream.Dictionary, _objects));
+            Dictionary<string, Func<byte[], string>> appearanceDecoders = MergeDecoders(
+                pageDecoders,
+                ResourceResolver.GetFontDecodersForForm(appearanceStream.Dictionary, _objects, _limits.MaxDecodedTextCharacters));
             Dictionary<string, Func<byte[], double>> appearanceWidthProviders = MergeWidthProviders(pageWidthProviders, ResourceResolver.GetFontWidthProviders(appearanceStream.Dictionary, _objects));
             Dictionary<string, PdfFontResource> appearanceFonts = MergeFonts(pageFonts, ResourceResolver.GetFontsForResources(appearanceResources, _objects));
             string transformedAppearanceContent = WrapContentWithTransform(appearanceContent, appearanceTransform, out int transformedAppearanceContentOffset);
@@ -1063,7 +1093,8 @@ public sealed partial class PdfReadPage {
                 activeForms,
                 pageHeight,
                 paintOrderOffset: -transformedAppearanceContentOffset,
-                useLogicalTextFilters: false);
+                useLogicalTextFilters: false,
+                textOutputBudget: textOutputBudget);
             for (int textIndex = 0; textIndex < textSpans.Count; textIndex++) {
                 elements.Add(PdfPageDrawingElement.FromText(textSpans[textIndex], elements.Count));
             }
@@ -1222,10 +1253,14 @@ public sealed partial class PdfReadPage {
         }
     }
 
-    private IReadOnlyList<PdfTextSpan> GetVisualTextSpans(double pageHeight, Matrix2D pageTransform) {
+    private IReadOnlyList<PdfTextSpan> GetVisualTextSpans(
+        double pageHeight,
+        Matrix2D pageTransform,
+        TextContentParser.TextOutputBudget? textOutputBudget = null) {
+        textOutputBudget ??= CreateTextOutputBudget();
         var spans = new List<PdfTextSpan>();
         PdfDictionary? pageResources = ResolveDictionary(GetInheritedValue("Resources"));
-        Dictionary<string, Func<byte[], string>> pageDecoders = ResourceResolver.GetFontDecoders(_pageDict, _objects);
+        Dictionary<string, Func<byte[], string>> pageDecoders = ResourceResolver.GetFontDecoders(_pageDict, _objects, _limits.MaxDecodedTextCharacters);
         Dictionary<string, Func<byte[], double>> pageWidthProviders = ResourceResolver.GetFontWidthProviders(_pageDict, _objects);
         Dictionary<string, PdfFontResource> pageFonts = ResourceResolver.GetFontsForResources(pageResources, _objects);
         var activeForms = new HashSet<PdfStream>();
@@ -1243,11 +1278,15 @@ public sealed partial class PdfReadPage {
                 activeForms,
                 pageHeight,
                 paintOrderOffset: -transformedContentOffset,
-                useLogicalTextFilters: false);
+                useLogicalTextFilters: false,
+                textOutputBudget: textOutputBudget);
         }
 
         return spans.Count == 0 ? Array.Empty<PdfTextSpan>() : spans.AsReadOnly();
     }
+
+    private TextContentParser.TextOutputBudget CreateTextOutputBudget() =>
+        new(_limits.MaxActualTextCharacters, _limits.MaxDecodedTextCharacters);
 
     private static void AddTextSpan(OfficeDrawing drawing, double pageHeight, PdfTextSpan span) {
         if (string.IsNullOrEmpty(span.Text) || !span.IsVisible) {

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadPage.Visual.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadPage.Visual.cs
@@ -13,7 +13,8 @@ public sealed partial class PdfReadPage {
             new Dictionary<(PdfStream Stream, PdfDictionary Resources), PdfPageTilingPatternResource?>();
         PdfDictionary? pageResources = ResolveDictionary(GetInheritedValue("Resources"));
         var activeForms = new HashSet<PdfStream>();
-        string content = GetContentStreamContent();
+        var pageContentBudget = new PageContentBudget(this);
+        string content = GetContentStreamContent(pageContentBudget);
         if (content.Length > 0) {
             CollectVisualPrimitivesAndForms(
                 content,
@@ -34,7 +35,8 @@ public sealed partial class PdfReadPage {
                 activeForms,
                 retainPrimitiveData: false,
                 tilingPatternResourceCache: tilingPatternResourceCache,
-                textOutputBudget: textOutputBudget);
+                textOutputBudget: textOutputBudget,
+                pageContentBudget: pageContentBudget);
         }
 
         return count;
@@ -49,17 +51,18 @@ public sealed partial class PdfReadPage {
         Matrix2D pageTransform = GetVisualPageTransform();
         var drawing = new OfficeDrawing(size.Width, size.Height);
         var textOutputBudget = CreateTextOutputBudget();
+        var pageContentBudget = new PageContentBudget(this);
         RegisterEmbeddedFonts(drawing, ResolveDictionary(GetInheritedValue("Resources")), new HashSet<PdfStream>(), 0);
 
-        List<PdfPageDrawingElement> pageElements = GetOrderedPageDrawingElements(size.Width, size.Height, pageTransform, textOutputBudget);
-        IReadOnlyList<PdfPageDrawingEffectTransition> effects = GetGraphicsEffectTransitions(pageTransform, size.Height);
+        List<PdfPageDrawingElement> pageElements = GetOrderedPageDrawingElements(size.Width, size.Height, pageTransform, textOutputBudget, pageContentBudget);
+        IReadOnlyList<PdfPageDrawingEffectTransition> effects = GetGraphicsEffectTransitions(pageTransform, size.Height, pageContentBudget);
         var softMasks = new Dictionary<PdfPageSoftMaskResource, OfficeDrawingSoftMask>();
         for (int i = 0; i < pageElements.Count; i++) {
             PdfPageDrawingElement element = pageElements[i].WithEffect(ResolveDrawingEffect(effects, pageElements[i].PaintOrder));
-            AddDrawingElement(drawing, size.Height, pageTransform, element, softMasks, textOutputBudget);
+            AddDrawingElement(drawing, size.Height, pageTransform, element, softMasks, textOutputBudget, pageContentBudget);
         }
 
-        AddAnnotationAppearances(drawing, size.Height, pageTransform, textOutputBudget);
+        AddAnnotationAppearances(drawing, size.Height, pageTransform, textOutputBudget, pageContentBudget);
 
         return drawing;
     }
@@ -93,19 +96,20 @@ public sealed partial class PdfReadPage {
         double pageWidth,
         double pageHeight,
         Matrix2D pageTransform,
-        TextContentParser.TextOutputBudget textOutputBudget) {
+        TextContentParser.TextOutputBudget textOutputBudget,
+        PageContentBudget pageContentBudget) {
         var elements = new List<PdfPageDrawingElement>();
-        IReadOnlyList<PdfPageVisualPrimitive> primitives = GetVisualPrimitives(pageWidth, pageHeight, pageTransform, textOutputBudget);
+        IReadOnlyList<PdfPageVisualPrimitive> primitives = GetVisualPrimitives(pageWidth, pageHeight, pageTransform, textOutputBudget, pageContentBudget);
         for (int i = 0; i < primitives.Count; i++) {
             elements.Add(PdfPageDrawingElement.FromPrimitive(primitives[i], elements.Count));
         }
 
-        IReadOnlyList<PdfTextSpan> spans = GetVisualTextSpans(pageHeight, pageTransform, textOutputBudget);
+        IReadOnlyList<PdfTextSpan> spans = GetVisualTextSpans(pageHeight, pageTransform, textOutputBudget, pageContentBudget);
         for (int i = 0; i < spans.Count; i++) {
             elements.Add(PdfPageDrawingElement.FromText(spans[i], elements.Count));
         }
 
-        IReadOnlyList<PdfImagePlacement> placements = GetVisualImagePlacements(pageHeight, pageTransform);
+        IReadOnlyList<PdfImagePlacement> placements = GetVisualImagePlacements(pageHeight, pageTransform, pageContentBudget);
         if (placements.Count > 0) {
             IReadOnlyList<PdfExtractedImage> images = GetImages(0, placements, colorizeImageMasks: true);
             for (int i = 0; i < placements.Count; i++) {
@@ -134,7 +138,8 @@ public sealed partial class PdfReadPage {
         Matrix2D pageTransform,
         PdfPageDrawingElement element,
         Dictionary<PdfPageSoftMaskResource, OfficeDrawingSoftMask> softMasks,
-        TextContentParser.TextOutputBudget textOutputBudget) {
+        TextContentParser.TextOutputBudget textOutputBudget,
+        PageContentBudget pageContentBudget) {
         if (element.Effect.IsDefault) {
             AddDrawingElementCore(drawing, pageHeight, element);
             return;
@@ -145,7 +150,7 @@ public sealed partial class PdfReadPage {
         if (isolated.Elements.Count == 0) return;
         OfficeDrawingSoftMask? softMask = element.Effect.SoftMask == null
             ? null
-            : GetOrCreateSoftMask(element.Effect.SoftMask, drawing.Width, drawing.Height, pageTransform, softMasks, textOutputBudget);
+            : GetOrCreateSoftMask(element.Effect.SoftMask, drawing.Width, drawing.Height, pageTransform, softMasks, textOutputBudget, pageContentBudget);
         drawing.AddEffectDrawing(isolated, OfficeTransform.Identity, element.Effect.BlendMode, softMask);
     }
 
@@ -373,14 +378,16 @@ public sealed partial class PdfReadPage {
         double pageWidth,
         double pageHeight,
         Matrix2D pageTransform,
-        TextContentParser.TextOutputBudget? textOutputBudget = null) {
+        TextContentParser.TextOutputBudget? textOutputBudget = null,
+        PageContentBudget? pageContentBudget = null) {
         textOutputBudget ??= CreateTextOutputBudget();
+        pageContentBudget ??= new PageContentBudget(this);
         var primitives = new List<PdfPageVisualPrimitive>();
         PdfDictionary? pageResources = ResolveDictionary(GetInheritedValue("Resources"));
         var activeForms = new HashSet<PdfStream>();
         var tilingPatternResourceCache =
             new Dictionary<(PdfStream Stream, PdfDictionary Resources), PdfPageTilingPatternResource?>();
-        string content = GetContentStreamContent();
+        string content = GetContentStreamContent(pageContentBudget);
         if (content.Length > 0) {
             CollectVisualPrimitivesAndForms(
                 content,
@@ -391,7 +398,8 @@ public sealed partial class PdfReadPage {
                 primitives.Add,
                 activeForms,
                 tilingPatternResourceCache: tilingPatternResourceCache,
-                textOutputBudget: textOutputBudget);
+                textOutputBudget: textOutputBudget,
+                pageContentBudget: pageContentBudget);
         }
 
         return primitives.Count == 0 ? Array.Empty<PdfPageVisualPrimitive>() : primitives.AsReadOnly();
@@ -423,8 +431,10 @@ public sealed partial class PdfReadPage {
         bool includeTilingPatterns = true,
         bool retainPrimitiveData = true,
         Dictionary<(PdfStream Stream, PdfDictionary Resources), PdfPageTilingPatternResource?>? tilingPatternResourceCache = null,
-        TextContentParser.TextOutputBudget? textOutputBudget = null) {
+        TextContentParser.TextOutputBudget? textOutputBudget = null,
+        PageContentBudget? pageContentBudget = null) {
         EnsureContentNestingBudget(contentNestingDepth);
+        pageContentBudget ??= new PageContentBudget(this);
         string transformedContent = WrapContentWithTransform(content, baseTransform, out int transformedContentOffset);
         _ = PdfPageContentVisualParser.Parse(
             transformedContent,
@@ -435,7 +445,7 @@ public sealed partial class PdfReadPage {
             GetShadingResources(resources),
             GetShadingPatternResources(resources),
             includeTilingPatterns
-                ? GetTilingPatternResources(resources, tilingPatternResourceCache, textOutputBudget)
+                ? GetTilingPatternResources(resources, tilingPatternResourceCache, textOutputBudget, pageContentBudget)
                 : null,
             GetOptionalContentVisibility(resources),
             paintOrderBase,
@@ -495,7 +505,7 @@ public sealed partial class PdfReadPage {
                 PdfDictionary formDictionary = formStream.Dictionary;
                 PdfDictionary? formResources = ResolveDictionary(formDictionary.Items.TryGetValue("Resources", out PdfObject? resourcesObject) ? resourcesObject : null) ?? resources;
                 Matrix2D formTransform = ApplyFormMatrix(invocation.Transform, formDictionary);
-                string formContent = WrapFormContentWithBoundingBoxClip(PdfEncoding.Latin1GetString(DecodeIfNeeded(formStream)), formDictionary);
+                string formContent = WrapFormContentWithBoundingBoxClip(PdfEncoding.Latin1GetString(pageContentBudget.Decode(formStream)), formDictionary);
                 CollectVisualPrimitivesAndForms(
                     formContent,
                     formResources,
@@ -521,7 +531,8 @@ public sealed partial class PdfReadPage {
                     includeTilingPatterns: includeTilingPatterns,
                     retainPrimitiveData: retainPrimitiveData,
                     tilingPatternResourceCache: tilingPatternResourceCache,
-                    textOutputBudget: textOutputBudget);
+                    textOutputBudget: textOutputBudget,
+                    pageContentBudget: pageContentBudget);
             } finally {
                 activeForms.Remove(formStream);
             }
@@ -1029,7 +1040,8 @@ public sealed partial class PdfReadPage {
         OfficeDrawing drawing,
         double pageHeight,
         Matrix2D pageTransform,
-        TextContentParser.TextOutputBudget textOutputBudget) {
+        TextContentParser.TextOutputBudget textOutputBudget,
+        PageContentBudget pageContentBudget) {
         if (!_pageDict.Items.TryGetValue("Annots", out PdfObject? annotationsObject)) {
             return;
         }
@@ -1055,7 +1067,7 @@ public sealed partial class PdfReadPage {
             }
 
             PdfDictionary? appearanceResources = ResolveDictionary(appearanceStream.Dictionary.Items.TryGetValue("Resources", out PdfObject? resourcesObject) ? resourcesObject : null) ?? pageResources;
-            string appearanceContent = WrapFormContentWithBoundingBoxClip(PdfEncoding.Latin1GetString(DecodeIfNeeded(appearanceStream)), appearanceStream.Dictionary);
+            string appearanceContent = WrapFormContentWithBoundingBoxClip(PdfEncoding.Latin1GetString(pageContentBudget.Decode(appearanceStream)), appearanceStream.Dictionary);
             if (appearanceContent.Length == 0) {
                 continue;
             }
@@ -1071,7 +1083,8 @@ public sealed partial class PdfReadPage {
                 pageHeight,
                 primitives.Add,
                 activeForms,
-                textOutputBudget: textOutputBudget);
+                textOutputBudget: textOutputBudget,
+                pageContentBudget: pageContentBudget);
             for (int primitiveIndex = 0; primitiveIndex < primitives.Count; primitiveIndex++) {
                 elements.Add(PdfPageDrawingElement.FromPrimitive(primitives[primitiveIndex], elements.Count));
             }
@@ -1094,13 +1107,14 @@ public sealed partial class PdfReadPage {
                 pageHeight,
                 paintOrderOffset: -transformedAppearanceContentOffset,
                 useLogicalTextFilters: false,
-                textOutputBudget: textOutputBudget);
+                textOutputBudget: textOutputBudget,
+                pageContentBudget: pageContentBudget);
             for (int textIndex = 0; textIndex < textSpans.Count; textIndex++) {
                 elements.Add(PdfPageDrawingElement.FromText(textSpans[textIndex], elements.Count));
             }
 
             var imagePlacements = new List<PdfImagePlacement>();
-            CollectImagePlacementsAndForms(appearanceContent, appearanceResources, 0, appearanceTransform, pageHeight, imagePlacements, activeForms);
+            CollectImagePlacementsAndForms(appearanceContent, appearanceResources, 0, appearanceTransform, pageHeight, imagePlacements, activeForms, pageContentBudget: pageContentBudget);
             if (imagePlacements.Count > 0) {
                 IReadOnlyList<PdfExtractedImage> images = GetImagesForResources(appearanceResources, 0, imagePlacements, colorizeImageMasks: true);
                 for (int imageIndex = 0; imageIndex < imagePlacements.Count; imageIndex++) {
@@ -1256,8 +1270,10 @@ public sealed partial class PdfReadPage {
     private IReadOnlyList<PdfTextSpan> GetVisualTextSpans(
         double pageHeight,
         Matrix2D pageTransform,
-        TextContentParser.TextOutputBudget? textOutputBudget = null) {
+        TextContentParser.TextOutputBudget? textOutputBudget = null,
+        PageContentBudget? pageContentBudget = null) {
         textOutputBudget ??= CreateTextOutputBudget();
+        pageContentBudget ??= new PageContentBudget(this);
         var spans = new List<PdfTextSpan>();
         PdfDictionary? pageResources = ResolveDictionary(GetInheritedValue("Resources"));
         Dictionary<string, Func<byte[], string>> pageDecoders = ResourceResolver.GetFontDecoders(_pageDict, _objects, _limits.MaxDecodedTextCharacters);
@@ -1265,7 +1281,7 @@ public sealed partial class PdfReadPage {
         Dictionary<string, PdfFontResource> pageFonts = ResourceResolver.GetFontsForResources(pageResources, _objects);
         var activeForms = new HashSet<PdfStream>();
 
-        string content = GetContentStreamContent();
+        string content = GetContentStreamContent(pageContentBudget);
         if (content.Length > 0) {
             string transformedContent = WrapContentWithTransform(content, pageTransform, out int transformedContentOffset);
             CollectTextAndForms(
@@ -1279,7 +1295,8 @@ public sealed partial class PdfReadPage {
                 pageHeight,
                 paintOrderOffset: -transformedContentOffset,
                 useLogicalTextFilters: false,
-                textOutputBudget: textOutputBudget);
+                textOutputBudget: textOutputBudget,
+                pageContentBudget: pageContentBudget);
         }
 
         return spans.Count == 0 ? Array.Empty<PdfTextSpan>() : spans.AsReadOnly();
@@ -1501,12 +1518,13 @@ public sealed partial class PdfReadPage {
         AddImagePlacements(drawing, pageHeight, placements, images);
     }
 
-    private IReadOnlyList<PdfImagePlacement> GetVisualImagePlacements(double pageHeight, Matrix2D pageTransform) {
+    private IReadOnlyList<PdfImagePlacement> GetVisualImagePlacements(double pageHeight, Matrix2D pageTransform, PageContentBudget? pageContentBudget = null) {
+        pageContentBudget ??= new PageContentBudget(this);
         var placements = new List<PdfImagePlacement>();
         PdfDictionary? pageResources = ResolveDictionary(GetInheritedValue("Resources"));
         var activeForms = new HashSet<PdfStream>();
 
-        string content = GetContentStreamContent();
+        string content = GetContentStreamContent(pageContentBudget);
         if (content.Length > 0) {
             CollectImagePlacementsAndForms(
                 content,
@@ -1515,7 +1533,8 @@ public sealed partial class PdfReadPage {
                 pageTransform,
                 pageHeight,
                 placements,
-                activeForms);
+                activeForms,
+                pageContentBudget: pageContentBudget);
         }
 
         return placements.Count == 0 ? Array.Empty<PdfImagePlacement>() : placements.AsReadOnly();

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadPage.Visual.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadPage.Visual.cs
@@ -1053,7 +1053,7 @@ public sealed partial class PdfReadPage {
         EnsureAnnotationBudget(annotations);
 
         PdfDictionary? pageResources = ResolveDictionary(GetInheritedValue("Resources"));
-        Dictionary<string, Func<byte[], string>> pageDecoders = ResourceResolver.GetFontDecoders(_pageDict, _objects, _limits.MaxDecodedTextCharacters);
+        Dictionary<string, Func<byte[], int, string>> pageDecoders = ResourceResolver.GetBudgetedFontDecoders(_pageDict, _objects);
         Dictionary<string, Func<byte[], double>> pageWidthProviders = ResourceResolver.GetFontWidthProviders(_pageDict, _objects);
         Dictionary<string, PdfFontResource> pageFonts = ResourceResolver.GetFontsForResources(pageResources, _objects);
         var activeForms = new HashSet<PdfStream>();
@@ -1090,9 +1090,9 @@ public sealed partial class PdfReadPage {
             }
 
             var textSpans = new List<PdfTextSpan>();
-            Dictionary<string, Func<byte[], string>> appearanceDecoders = MergeDecoders(
+            Dictionary<string, Func<byte[], int, string>> appearanceDecoders = MergeDecoders(
                 pageDecoders,
-                ResourceResolver.GetFontDecodersForForm(appearanceStream.Dictionary, _objects, _limits.MaxDecodedTextCharacters));
+                ResourceResolver.GetBudgetedFontDecodersForForm(appearanceStream.Dictionary, _objects));
             Dictionary<string, Func<byte[], double>> appearanceWidthProviders = MergeWidthProviders(pageWidthProviders, ResourceResolver.GetFontWidthProviders(appearanceStream.Dictionary, _objects));
             Dictionary<string, PdfFontResource> appearanceFonts = MergeFonts(pageFonts, ResourceResolver.GetFontsForResources(appearanceResources, _objects));
             string transformedAppearanceContent = WrapContentWithTransform(appearanceContent, appearanceTransform, out int transformedAppearanceContentOffset);
@@ -1276,7 +1276,7 @@ public sealed partial class PdfReadPage {
         pageContentBudget ??= new PageContentBudget(this);
         var spans = new List<PdfTextSpan>();
         PdfDictionary? pageResources = ResolveDictionary(GetInheritedValue("Resources"));
-        Dictionary<string, Func<byte[], string>> pageDecoders = ResourceResolver.GetFontDecoders(_pageDict, _objects, _limits.MaxDecodedTextCharacters);
+        Dictionary<string, Func<byte[], int, string>> pageDecoders = ResourceResolver.GetBudgetedFontDecoders(_pageDict, _objects);
         Dictionary<string, Func<byte[], double>> pageWidthProviders = ResourceResolver.GetFontWidthProviders(_pageDict, _objects);
         Dictionary<string, PdfFontResource> pageFonts = ResourceResolver.GetFontsForResources(pageResources, _objects);
         var activeForms = new HashSet<PdfStream>();

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadPage.VisualEffects.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadPage.VisualEffects.cs
@@ -226,9 +226,9 @@ public sealed partial class PdfReadPage {
         for (int i = 0; i < primitives.Count; i++) elements.Add(PdfPageDrawingElement.FromPrimitive(primitives[i], elements.Count));
 
         var spans = new List<PdfTextSpan>();
-        Dictionary<string, Func<byte[], string>> decoders = MergeDecoders(
-            ResourceResolver.GetFontDecoders(_pageDict, _objects, _limits.MaxDecodedTextCharacters),
-            ResourceResolver.GetFontDecodersForForm(form.Dictionary, _objects, _limits.MaxDecodedTextCharacters));
+        Dictionary<string, Func<byte[], int, string>> decoders = MergeDecoders(
+            ResourceResolver.GetBudgetedFontDecoders(_pageDict, _objects),
+            ResourceResolver.GetBudgetedFontDecodersForForm(form.Dictionary, _objects));
         Dictionary<string, Func<byte[], double>> widthProviders = MergeWidthProviders(ResourceResolver.GetFontWidthProviders(_pageDict, _objects), ResourceResolver.GetFontWidthProviders(form.Dictionary, _objects));
         Dictionary<string, PdfFontResource> fonts = MergeFonts(ResourceResolver.GetFontsForResources(pageResources, _objects), ResourceResolver.GetFontsForResources(resources, _objects));
         string transformedContent = WrapContentWithTransform(content, transform, out int transformedOffset);

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadPage.VisualEffects.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadPage.VisualEffects.cs
@@ -57,13 +57,14 @@ public sealed partial class PdfReadPage {
         return new PdfPageSoftMaskResource(group, mode, backdrop);
     }
 
-    private IReadOnlyList<PdfPageDrawingEffectTransition> GetGraphicsEffectTransitions(Matrix2D pageTransform, double pageHeight) {
+    private IReadOnlyList<PdfPageDrawingEffectTransition> GetGraphicsEffectTransitions(Matrix2D pageTransform, double pageHeight, PageContentBudget? pageContentBudget = null) {
+        pageContentBudget ??= new PageContentBudget(this);
         var transitions = new List<PdfPageDrawingEffectTransition>();
         PdfDictionary? resources = ResolveDictionary(GetInheritedValue("Resources"));
-        string content = GetContentStreamContent();
+        string content = GetContentStreamContent(pageContentBudget);
         if (content.Length == 0) return Array.Empty<PdfPageDrawingEffectTransition>();
         var activeForms = new HashSet<PdfStream>();
-        CollectGraphicsEffectTransitions(content, resources, pageTransform, pageHeight, transitions, activeForms, PdfPageDrawingEffect.Default);
+        CollectGraphicsEffectTransitions(content, resources, pageTransform, pageHeight, transitions, activeForms, PdfPageDrawingEffect.Default, pageContentBudget: pageContentBudget);
         transitions.Sort(static (left, right) => left.PaintOrder.CompareTo(right.PaintOrder));
         return transitions.Count == 0 ? Array.Empty<PdfPageDrawingEffectTransition>() : transitions.AsReadOnly();
     }
@@ -90,8 +91,10 @@ public sealed partial class PdfReadPage {
         OfficeStrokeDashStyle? initialStrokeDashStyle = null,
         OfficeStrokeLineCap? initialStrokeLineCap = null,
         OfficeStrokeLineJoin? initialStrokeLineJoin = null,
-        int contentNestingDepth = 0) {
+        int contentNestingDepth = 0,
+        PageContentBudget? pageContentBudget = null) {
         EnsureContentNestingBudget(contentNestingDepth);
+        pageContentBudget ??= new PageContentBudget(this);
         Dictionary<string, PdfPageGraphicsStateResource> graphicsStates = GetGraphicsStateResources(resources);
         IReadOnlyList<PdfPageDrawingEffectTransition> local = PdfPageGraphicsEffectTimelineParser.Parse(
             content,
@@ -135,7 +138,7 @@ public sealed partial class PdfReadPage {
                 PdfDictionary dictionary = formStream.Dictionary;
                 PdfDictionary? formResources = ResolveDictionary(dictionary.Items.TryGetValue("Resources", out PdfObject? resourcesObject) ? resourcesObject : null) ?? resources;
                 Matrix2D formTransform = ApplyFormMatrix(invocation.Transform, dictionary);
-                string formContent = WrapFormContentWithBoundingBoxClip(PdfEncoding.Latin1GetString(DecodeIfNeeded(formStream)), dictionary);
+                string formContent = WrapFormContentWithBoundingBoxClip(PdfEncoding.Latin1GetString(pageContentBudget.Decode(formStream)), dictionary);
                 CollectGraphicsEffectTransitions(
                     formContent,
                     formResources,
@@ -157,7 +160,8 @@ public sealed partial class PdfReadPage {
                     initialStrokeDashStyle: invocation.StrokeDashStyle,
                     initialStrokeLineCap: invocation.StrokeLineCap,
                     initialStrokeLineJoin: invocation.StrokeLineJoin,
-                    contentNestingDepth: contentNestingDepth + 1);
+                    contentNestingDepth: contentNestingDepth + 1,
+                    pageContentBudget: pageContentBudget);
                 transitions.Add(new PdfPageDrawingEffectTransition(invocation.PaintOrder + (Math.Abs(paintOrderScale) * 0.25D), inherited));
             } finally {
                 activeForms.Remove(formStream);
@@ -183,9 +187,10 @@ public sealed partial class PdfReadPage {
         double height,
         Matrix2D pageTransform,
         Dictionary<PdfPageSoftMaskResource, OfficeDrawingSoftMask> cache,
-        TextContentParser.TextOutputBudget textOutputBudget) {
+        TextContentParser.TextOutputBudget textOutputBudget,
+        PageContentBudget pageContentBudget) {
         if (cache.TryGetValue(resource, out OfficeDrawingSoftMask? existing)) return existing;
-        OfficeDrawing drawing = CreateFormDrawing(resource.Group, width, height, pageTransform, textOutputBudget);
+        OfficeDrawing drawing = CreateFormDrawing(resource.Group, width, height, pageTransform, textOutputBudget, pageContentBudget);
         var mask = new OfficeDrawingSoftMask(drawing, resource.Mode, backdropColor: resource.BackdropColor);
         cache[resource] = mask;
         return mask;
@@ -196,12 +201,13 @@ public sealed partial class PdfReadPage {
         double width,
         double height,
         Matrix2D pageTransform,
-        TextContentParser.TextOutputBudget textOutputBudget) {
+        TextContentParser.TextOutputBudget textOutputBudget,
+        PageContentBudget pageContentBudget) {
         var drawing = new OfficeDrawing(width, height);
         PdfDictionary? pageResources = ResolveDictionary(GetInheritedValue("Resources"));
         PdfDictionary? resources = ResolveDictionary(form.Dictionary.Items.TryGetValue("Resources", out PdfObject? resourceObject) ? resourceObject : null) ?? pageResources;
         RegisterEmbeddedFonts(drawing, resources, new HashSet<PdfStream>(), 0);
-        string content = WrapFormContentWithBoundingBoxClip(PdfEncoding.Latin1GetString(DecodeIfNeeded(form)), form.Dictionary);
+        string content = WrapFormContentWithBoundingBoxClip(PdfEncoding.Latin1GetString(pageContentBudget.Decode(form)), form.Dictionary);
         if (content.Length == 0) return drawing;
         Matrix2D transform = ApplyFormMatrix(pageTransform, form.Dictionary);
         var activeForms = new HashSet<PdfStream>();
@@ -215,7 +221,8 @@ public sealed partial class PdfReadPage {
             height,
             primitives.Add,
             activeForms,
-            textOutputBudget: textOutputBudget);
+            textOutputBudget: textOutputBudget,
+            pageContentBudget: pageContentBudget);
         for (int i = 0; i < primitives.Count; i++) elements.Add(PdfPageDrawingElement.FromPrimitive(primitives[i], elements.Count));
 
         var spans = new List<PdfTextSpan>();
@@ -236,11 +243,12 @@ public sealed partial class PdfReadPage {
             height,
             paintOrderOffset: -transformedOffset,
             useLogicalTextFilters: false,
-            textOutputBudget: textOutputBudget);
+            textOutputBudget: textOutputBudget,
+            pageContentBudget: pageContentBudget);
         for (int i = 0; i < spans.Count; i++) elements.Add(PdfPageDrawingElement.FromText(spans[i], elements.Count));
 
         var placements = new List<PdfImagePlacement>();
-        CollectImagePlacementsAndForms(content, resources, 0, transform, height, placements, activeForms);
+        CollectImagePlacementsAndForms(content, resources, 0, transform, height, placements, activeForms, pageContentBudget: pageContentBudget);
         if (placements.Count > 0) {
             IReadOnlyList<PdfExtractedImage> images = GetImagesForResources(resources, 0, placements, colorizeImageMasks: true);
             for (int i = 0; i < placements.Count; i++) {

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadPage.VisualEffects.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadPage.VisualEffects.cs
@@ -182,15 +182,21 @@ public sealed partial class PdfReadPage {
         double width,
         double height,
         Matrix2D pageTransform,
-        Dictionary<PdfPageSoftMaskResource, OfficeDrawingSoftMask> cache) {
+        Dictionary<PdfPageSoftMaskResource, OfficeDrawingSoftMask> cache,
+        TextContentParser.TextOutputBudget textOutputBudget) {
         if (cache.TryGetValue(resource, out OfficeDrawingSoftMask? existing)) return existing;
-        OfficeDrawing drawing = CreateFormDrawing(resource.Group, width, height, pageTransform);
+        OfficeDrawing drawing = CreateFormDrawing(resource.Group, width, height, pageTransform, textOutputBudget);
         var mask = new OfficeDrawingSoftMask(drawing, resource.Mode, backdropColor: resource.BackdropColor);
         cache[resource] = mask;
         return mask;
     }
 
-    private OfficeDrawing CreateFormDrawing(PdfStream form, double width, double height, Matrix2D pageTransform) {
+    private OfficeDrawing CreateFormDrawing(
+        PdfStream form,
+        double width,
+        double height,
+        Matrix2D pageTransform,
+        TextContentParser.TextOutputBudget textOutputBudget) {
         var drawing = new OfficeDrawing(width, height);
         PdfDictionary? pageResources = ResolveDictionary(GetInheritedValue("Resources"));
         PdfDictionary? resources = ResolveDictionary(form.Dictionary.Items.TryGetValue("Resources", out PdfObject? resourceObject) ? resourceObject : null) ?? pageResources;
@@ -201,15 +207,36 @@ public sealed partial class PdfReadPage {
         var activeForms = new HashSet<PdfStream>();
         var elements = new List<PdfPageDrawingElement>();
         var primitives = new List<PdfPageVisualPrimitive>();
-        CollectVisualPrimitivesAndForms(content, resources, transform, width, height, primitives.Add, activeForms);
+        CollectVisualPrimitivesAndForms(
+            content,
+            resources,
+            transform,
+            width,
+            height,
+            primitives.Add,
+            activeForms,
+            textOutputBudget: textOutputBudget);
         for (int i = 0; i < primitives.Count; i++) elements.Add(PdfPageDrawingElement.FromPrimitive(primitives[i], elements.Count));
 
         var spans = new List<PdfTextSpan>();
-        Dictionary<string, Func<byte[], string>> decoders = MergeDecoders(ResourceResolver.GetFontDecoders(_pageDict, _objects), ResourceResolver.GetFontDecodersForForm(form.Dictionary, _objects));
+        Dictionary<string, Func<byte[], string>> decoders = MergeDecoders(
+            ResourceResolver.GetFontDecoders(_pageDict, _objects, _limits.MaxDecodedTextCharacters),
+            ResourceResolver.GetFontDecodersForForm(form.Dictionary, _objects, _limits.MaxDecodedTextCharacters));
         Dictionary<string, Func<byte[], double>> widthProviders = MergeWidthProviders(ResourceResolver.GetFontWidthProviders(_pageDict, _objects), ResourceResolver.GetFontWidthProviders(form.Dictionary, _objects));
         Dictionary<string, PdfFontResource> fonts = MergeFonts(ResourceResolver.GetFontsForResources(pageResources, _objects), ResourceResolver.GetFontsForResources(resources, _objects));
         string transformedContent = WrapContentWithTransform(content, transform, out int transformedOffset);
-        CollectTextAndForms(transformedContent, resources, decoders, widthProviders, fonts, spans, activeForms, height, paintOrderOffset: -transformedOffset, useLogicalTextFilters: false);
+        CollectTextAndForms(
+            transformedContent,
+            resources,
+            decoders,
+            widthProviders,
+            fonts,
+            spans,
+            activeForms,
+            height,
+            paintOrderOffset: -transformedOffset,
+            useLogicalTextFilters: false,
+            textOutputBudget: textOutputBudget);
         for (int i = 0; i < spans.Count; i++) elements.Add(PdfPageDrawingElement.FromText(spans[i], elements.Count));
 
         var placements = new List<PdfImagePlacement>();

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadPage.VisualPatterns.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadPage.VisualPatterns.cs
@@ -115,7 +115,8 @@ public sealed partial class PdfReadPage {
 
     private Dictionary<string, PdfPageTilingPatternResource> GetTilingPatternResources(
         PdfDictionary? resources,
-        Dictionary<(PdfStream Stream, PdfDictionary Resources), PdfPageTilingPatternResource?>? resourceCache = null) {
+        Dictionary<(PdfStream Stream, PdfDictionary Resources), PdfPageTilingPatternResource?>? resourceCache = null,
+        TextContentParser.TextOutputBudget? textOutputBudget = null) {
         var result = new Dictionary<string, PdfPageTilingPatternResource>(StringComparer.Ordinal);
         if (resources == null || !resources.Items.TryGetValue("Pattern", out PdfObject? patternObject)) return result;
         PdfDictionary? patterns = ResolveDictionary(patternObject);
@@ -137,6 +138,7 @@ public sealed partial class PdfReadPage {
             PdfPageTilingPatternResource? pattern = TryReadTilingPattern(
                 stream,
                 resources,
+                textOutputBudget,
                 out PdfPageTilingPatternResource? parsed)
                 ? parsed
                 : null;
@@ -150,7 +152,11 @@ public sealed partial class PdfReadPage {
         return result;
     }
 
-    private bool TryReadTilingPattern(PdfObject? value, PdfDictionary parentResources, out PdfPageTilingPatternResource pattern) {
+    private bool TryReadTilingPattern(
+        PdfObject? value,
+        PdfDictionary parentResources,
+        TextContentParser.TextOutputBudget? textOutputBudget,
+        out PdfPageTilingPatternResource pattern) {
         pattern = null!;
         int? paintType;
         int? tilingType;
@@ -167,7 +173,7 @@ public sealed partial class PdfReadPage {
         double height = box.Y2 - box.Y1;
         if (width <= 0D || height <= 0D) return false;
         PdfDictionary? resources = ResolveDictionary(stream.Dictionary.Items.TryGetValue("Resources", out PdfObject? resourceObject) ? resourceObject : null) ?? parentResources;
-        OfficeDrawing tile = CreatePatternTileDrawing(stream, resources, box, width, height);
+        OfficeDrawing tile = CreatePatternTileDrawing(stream, resources, box, width, height, textOutputBudget ?? CreateTextOutputBudget());
         Matrix2D matrix = stream.Dictionary.Items.TryGetValue("Matrix", out PdfObject? matrixObject)
             ? ReadPatternMatrix(matrixObject)
             : Matrix2D.Identity;
@@ -187,7 +193,8 @@ public sealed partial class PdfReadPage {
         PdfDictionary? resources,
         (double X1, double Y1, double X2, double Y2) box,
         double width,
-        double height) {
+        double height,
+        TextContentParser.TextOutputBudget textOutputBudget) {
         var drawing = new OfficeDrawing(width, height);
         RegisterEmbeddedFonts(drawing, resources, new HashSet<PdfStream>(), 0);
         string content = PdfEncoding.Latin1GetString(DecodeIfNeeded(stream));
@@ -196,15 +203,35 @@ public sealed partial class PdfReadPage {
         var activeForms = new HashSet<PdfStream>();
         var elements = new List<PdfPageDrawingElement>();
         var primitives = new List<PdfPageVisualPrimitive>();
-        CollectVisualPrimitivesAndForms(content, resources, transform, width, height, primitives.Add, activeForms, includeTilingPatterns: false);
+        CollectVisualPrimitivesAndForms(
+            content,
+            resources,
+            transform,
+            width,
+            height,
+            primitives.Add,
+            activeForms,
+            includeTilingPatterns: false,
+            textOutputBudget: textOutputBudget);
         for (int i = 0; i < primitives.Count; i++) elements.Add(PdfPageDrawingElement.FromPrimitive(primitives[i], elements.Count));
 
         var spans = new List<PdfTextSpan>();
-        Dictionary<string, Func<byte[], string>> decoders = ResourceResolver.GetFontDecodersForForm(stream.Dictionary, _objects);
+        Dictionary<string, Func<byte[], string>> decoders = ResourceResolver.GetFontDecodersForForm(stream.Dictionary, _objects, _limits.MaxDecodedTextCharacters);
         Dictionary<string, Func<byte[], double>> widthProviders = ResourceResolver.GetFontWidthProviders(stream.Dictionary, _objects);
         Dictionary<string, PdfFontResource> fonts = ResourceResolver.GetFontsForResources(resources, _objects);
         string transformedContent = WrapContentWithTransform(content, transform, out int transformedOffset);
-        CollectTextAndForms(transformedContent, resources, decoders, widthProviders, fonts, spans, activeForms, height, paintOrderOffset: -transformedOffset, useLogicalTextFilters: false);
+        CollectTextAndForms(
+            transformedContent,
+            resources,
+            decoders,
+            widthProviders,
+            fonts,
+            spans,
+            activeForms,
+            height,
+            paintOrderOffset: -transformedOffset,
+            useLogicalTextFilters: false,
+            textOutputBudget: textOutputBudget);
         for (int i = 0; i < spans.Count; i++) elements.Add(PdfPageDrawingElement.FromText(spans[i], elements.Count));
 
         var placements = new List<PdfImagePlacement>();

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadPage.VisualPatterns.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadPage.VisualPatterns.cs
@@ -116,7 +116,9 @@ public sealed partial class PdfReadPage {
     private Dictionary<string, PdfPageTilingPatternResource> GetTilingPatternResources(
         PdfDictionary? resources,
         Dictionary<(PdfStream Stream, PdfDictionary Resources), PdfPageTilingPatternResource?>? resourceCache = null,
-        TextContentParser.TextOutputBudget? textOutputBudget = null) {
+        TextContentParser.TextOutputBudget? textOutputBudget = null,
+        PageContentBudget? pageContentBudget = null) {
+        pageContentBudget ??= new PageContentBudget(this);
         var result = new Dictionary<string, PdfPageTilingPatternResource>(StringComparer.Ordinal);
         if (resources == null || !resources.Items.TryGetValue("Pattern", out PdfObject? patternObject)) return result;
         PdfDictionary? patterns = ResolveDictionary(patternObject);
@@ -139,6 +141,7 @@ public sealed partial class PdfReadPage {
                 stream,
                 resources,
                 textOutputBudget,
+                pageContentBudget,
                 out PdfPageTilingPatternResource? parsed)
                 ? parsed
                 : null;
@@ -156,6 +159,7 @@ public sealed partial class PdfReadPage {
         PdfObject? value,
         PdfDictionary parentResources,
         TextContentParser.TextOutputBudget? textOutputBudget,
+        PageContentBudget pageContentBudget,
         out PdfPageTilingPatternResource pattern) {
         pattern = null!;
         int? paintType;
@@ -173,7 +177,7 @@ public sealed partial class PdfReadPage {
         double height = box.Y2 - box.Y1;
         if (width <= 0D || height <= 0D) return false;
         PdfDictionary? resources = ResolveDictionary(stream.Dictionary.Items.TryGetValue("Resources", out PdfObject? resourceObject) ? resourceObject : null) ?? parentResources;
-        OfficeDrawing tile = CreatePatternTileDrawing(stream, resources, box, width, height, textOutputBudget ?? CreateTextOutputBudget());
+        OfficeDrawing tile = CreatePatternTileDrawing(stream, resources, box, width, height, textOutputBudget ?? CreateTextOutputBudget(), pageContentBudget);
         Matrix2D matrix = stream.Dictionary.Items.TryGetValue("Matrix", out PdfObject? matrixObject)
             ? ReadPatternMatrix(matrixObject)
             : Matrix2D.Identity;
@@ -194,10 +198,11 @@ public sealed partial class PdfReadPage {
         (double X1, double Y1, double X2, double Y2) box,
         double width,
         double height,
-        TextContentParser.TextOutputBudget textOutputBudget) {
+        TextContentParser.TextOutputBudget textOutputBudget,
+        PageContentBudget pageContentBudget) {
         var drawing = new OfficeDrawing(width, height);
         RegisterEmbeddedFonts(drawing, resources, new HashSet<PdfStream>(), 0);
-        string content = PdfEncoding.Latin1GetString(DecodeIfNeeded(stream));
+        string content = PdfEncoding.Latin1GetString(pageContentBudget.Decode(stream));
         if (content.Length == 0) return drawing;
         Matrix2D transform = Matrix2D.Translation(-box.X1, -box.Y1);
         var activeForms = new HashSet<PdfStream>();
@@ -212,7 +217,8 @@ public sealed partial class PdfReadPage {
             primitives.Add,
             activeForms,
             includeTilingPatterns: false,
-            textOutputBudget: textOutputBudget);
+            textOutputBudget: textOutputBudget,
+            pageContentBudget: pageContentBudget);
         for (int i = 0; i < primitives.Count; i++) elements.Add(PdfPageDrawingElement.FromPrimitive(primitives[i], elements.Count));
 
         var spans = new List<PdfTextSpan>();
@@ -231,11 +237,12 @@ public sealed partial class PdfReadPage {
             height,
             paintOrderOffset: -transformedOffset,
             useLogicalTextFilters: false,
-            textOutputBudget: textOutputBudget);
+            textOutputBudget: textOutputBudget,
+            pageContentBudget: pageContentBudget);
         for (int i = 0; i < spans.Count; i++) elements.Add(PdfPageDrawingElement.FromText(spans[i], elements.Count));
 
         var placements = new List<PdfImagePlacement>();
-        CollectImagePlacementsAndForms(content, resources, 0, transform, height, placements, activeForms);
+        CollectImagePlacementsAndForms(content, resources, 0, transform, height, placements, activeForms, pageContentBudget: pageContentBudget);
         if (placements.Count > 0) {
             IReadOnlyList<PdfExtractedImage> images = GetImagesForResources(resources, 0, placements, colorizeImageMasks: true);
             for (int i = 0; i < placements.Count; i++) {

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadPage.VisualPatterns.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadPage.VisualPatterns.cs
@@ -222,7 +222,7 @@ public sealed partial class PdfReadPage {
         for (int i = 0; i < primitives.Count; i++) elements.Add(PdfPageDrawingElement.FromPrimitive(primitives[i], elements.Count));
 
         var spans = new List<PdfTextSpan>();
-        Dictionary<string, Func<byte[], string>> decoders = ResourceResolver.GetFontDecodersForForm(stream.Dictionary, _objects, _limits.MaxDecodedTextCharacters);
+        Dictionary<string, Func<byte[], int, string>> decoders = ResourceResolver.GetBudgetedFontDecodersForForm(stream.Dictionary, _objects);
         Dictionary<string, Func<byte[], double>> widthProviders = ResourceResolver.GetFontWidthProviders(stream.Dictionary, _objects);
         Dictionary<string, PdfFontResource> fonts = ResourceResolver.GetFontsForResources(resources, _objects);
         string transformedContent = WrapContentWithTransform(content, transform, out int transformedOffset);

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadPage.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadPage.cs
@@ -115,7 +115,7 @@ public sealed partial class PdfReadPage {
         _demandTextExtraction?.Invoke();
         var spans = new List<PdfTextSpan>();
         var pageResources = ResolveDictionary(GetInheritedValue("Resources"));
-        var pageDecoders = ResourceResolver.GetFontDecoders(_pageDict, _objects, _limits.MaxDecodedTextCharacters);
+        var pageDecoders = ResourceResolver.GetBudgetedFontDecoders(_pageDict, _objects);
         var pageWidthProviders = ResourceResolver.GetFontWidthProviders(_pageDict, _objects);
         var pageFonts = ResourceResolver.GetFontsForResources(pageResources, _objects);
         var activeForms = new HashSet<PdfStream>();
@@ -464,7 +464,7 @@ public sealed partial class PdfReadPage {
     private void CollectTextAndForms(
         string content,
         PdfDictionary? resources,
-        Dictionary<string, Func<byte[], string>> decoders,
+        Dictionary<string, Func<byte[], int, string>> decoders,
         Dictionary<string, Func<byte[], double>> widthProviders,
         Dictionary<string, PdfFontResource> fonts,
         List<PdfTextSpan> spans,
@@ -490,8 +490,12 @@ public sealed partial class PdfReadPage {
         textOutputBudget ??= new TextContentParser.TextOutputBudget(
             _limits.MaxActualTextCharacters,
             _limits.MaxDecodedTextCharacters);
+        string DecodeWithFontWithinLimit(string fontRes, byte[] bytes, int maximumCharacters) =>
+            decoders.TryGetValue(fontRes, out var dec)
+                ? dec(bytes, maximumCharacters)
+                : PdfWinAnsiEncoding.Decode(bytes, maximumCharacters);
         string DecodeWithFont(string fontRes, byte[] bytes) =>
-            decoders.TryGetValue(fontRes, out var dec) ? dec(bytes) : PdfWinAnsiEncoding.Decode(bytes, _limits.MaxDecodedTextCharacters);
+            DecodeWithFontWithinLimit(fontRes, bytes, _limits.MaxDecodedTextCharacters);
         double SumWidth1000(string fontRes, byte[] bytes) =>
             widthProviders.TryGetValue(fontRes, out var wp) ? wp(bytes) : (bytes?.Length ?? 0) * 500.0;
         string? ResolveBaseFont(string fontRes) =>
@@ -529,7 +533,8 @@ public sealed partial class PdfReadPage {
             maxOperands: _limits.MaxContentOperands,
             maxActualTextCharacters: _limits.MaxActualTextCharacters,
             maxDecodedTextCharacters: _limits.MaxDecodedTextCharacters,
-            textOutputBudget: textOutputBudget));
+            textOutputBudget: textOutputBudget,
+            decodeWithFontWithinLimit: DecodeWithFontWithinLimit));
 
         foreach (var invocation in TextContentParser.ExtractFormInvocations(
                      content,
@@ -562,7 +567,7 @@ public sealed partial class PdfReadPage {
             try {
                 var formDict = formStream.Dictionary;
                 var formResources = ResolveDictionary(formDict.Items.TryGetValue("Resources", out var resObj) ? resObj : null) ?? resources;
-                var formDecoders = MergeDecoders(decoders, ResourceResolver.GetFontDecodersForForm(formDict, _objects, _limits.MaxDecodedTextCharacters));
+                var formDecoders = MergeDecoders(decoders, ResourceResolver.GetBudgetedFontDecodersForForm(formDict, _objects));
                 var formWidths = MergeWidthProviders(widthProviders, ResourceResolver.GetFontWidthProviders(formDict, _objects));
                 var formFonts = MergeFonts(fonts, ResourceResolver.GetFontsForResources(formResources, _objects));
                 var combinedTransform = ApplyFormMatrix(invocation.Transform, formDict);
@@ -825,6 +830,17 @@ public sealed partial class PdfReadPage {
 
     private PdfPageOptionalContentVisibility? GetOptionalContentVisibility(PdfDictionary? resources) =>
         PdfPageOptionalContentVisibility.Create(resources, _objects);
+
+    private static Dictionary<string, Func<byte[], int, string>> MergeDecoders(
+        Dictionary<string, Func<byte[], int, string>> parent,
+        Dictionary<string, Func<byte[], int, string>> local) {
+        var merged = new Dictionary<string, Func<byte[], int, string>>(parent, StringComparer.Ordinal);
+        foreach (var entry in local) {
+            merged[entry.Key] = entry.Value;
+        }
+
+        return merged;
+    }
 
     private static Dictionary<string, Func<byte[], string>> MergeDecoders(
         Dictionary<string, Func<byte[], string>> parent,

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadPage.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadPage.cs
@@ -120,8 +120,9 @@ public sealed partial class PdfReadPage {
         var pageFonts = ResourceResolver.GetFontsForResources(pageResources, _objects);
         var activeForms = new HashSet<PdfStream>();
         double pageHeight = GetPageSize().Height;
+        var pageContentBudget = new PageContentBudget(this);
 
-        string content = GetContentStreamContent();
+        string content = GetContentStreamContent(pageContentBudget);
         if (content.Length > 0) {
             CollectTextAndForms(
                 content,
@@ -131,7 +132,8 @@ public sealed partial class PdfReadPage {
                 pageFonts,
                 spans,
                 activeForms,
-                pageHeight);
+                pageHeight,
+                pageContentBudget: pageContentBudget);
         }
 
         return spans;
@@ -374,8 +376,9 @@ public sealed partial class PdfReadPage {
         var pageResources = ResolveDictionary(GetInheritedValue("Resources"));
         var activeForms = new HashSet<PdfStream>();
         double pageHeight = GetPageSize().Height;
+        var pageContentBudget = new PageContentBudget(this);
 
-        string content = GetContentStreamContent();
+        string content = GetContentStreamContent(pageContentBudget);
         if (content.Length > 0) {
             CollectImagePlacementsAndForms(
                 content,
@@ -384,7 +387,8 @@ public sealed partial class PdfReadPage {
                 Matrix2D.Identity,
                 pageHeight,
                 placements,
-                activeForms);
+                activeForms,
+                pageContentBudget: pageContentBudget);
         }
 
         return placements.Count == 0 ? Array.Empty<PdfImagePlacement>() : placements.AsReadOnly();
@@ -394,6 +398,7 @@ public sealed partial class PdfReadPage {
         var unsupported = new List<string>();
         var pageResources = ResolveDictionary(GetInheritedValue("Resources"));
         var activeForms = new HashSet<PdfStream>();
+        var pageContentBudget = new PageContentBudget(this);
         var content = new System.Text.StringBuilder();
         bool canInspectFormInvocations = true;
         foreach (var stream in GetContentStreamObjects()) {
@@ -403,11 +408,11 @@ public sealed partial class PdfReadPage {
                 continue;
             }
 
-            content.Append(PdfEncoding.Latin1GetString(DecodeIfNeeded(stream)));
+            content.Append(PdfEncoding.Latin1GetString(pageContentBudget.Decode(stream)));
         }
 
         if (canInspectFormInvocations && content.Length > 0) {
-            CollectUnsupportedFormFilters(content.ToString(), pageResources, unsupported, activeForms);
+            CollectUnsupportedFormFilters(content.ToString(), pageResources, unsupported, activeForms, pageContentBudget);
         }
 
         return unsupported;
@@ -418,6 +423,7 @@ public sealed partial class PdfReadPage {
         PdfDictionary? resources,
         List<string> unsupported,
         HashSet<PdfStream> activeForms,
+        PageContentBudget pageContentBudget,
         int contentNestingDepth = 0) {
         EnsureContentNestingBudget(contentNestingDepth);
         foreach (var invocation in TextContentParser.ExtractFormInvocations(
@@ -440,7 +446,7 @@ public sealed partial class PdfReadPage {
                 }
 
                 var formResources = ResolveDictionary(formStream.Dictionary.Items.TryGetValue("Resources", out var resObj) ? resObj : null) ?? resources;
-                CollectUnsupportedFormFilters(PdfEncoding.Latin1GetString(DecodeIfNeeded(formStream)), formResources, unsupported, activeForms, contentNestingDepth + 1);
+                CollectUnsupportedFormFilters(PdfEncoding.Latin1GetString(pageContentBudget.Decode(formStream)), formResources, unsupported, activeForms, pageContentBudget, contentNestingDepth + 1);
             } finally {
                 activeForms.Remove(formStream);
             }
@@ -477,13 +483,15 @@ public sealed partial class PdfReadPage {
         PdfPageClipPath? initialClipPath = null,
         bool useLogicalTextFilters = true,
         int contentNestingDepth = 0,
-        TextContentParser.TextOutputBudget? textOutputBudget = null) {
+        TextContentParser.TextOutputBudget? textOutputBudget = null,
+        PageContentBudget? pageContentBudget = null) {
         EnsureContentNestingBudget(contentNestingDepth);
+        pageContentBudget ??= new PageContentBudget(this);
         textOutputBudget ??= new TextContentParser.TextOutputBudget(
             _limits.MaxActualTextCharacters,
             _limits.MaxDecodedTextCharacters);
         string DecodeWithFont(string fontRes, byte[] bytes) =>
-            decoders.TryGetValue(fontRes, out var dec) ? dec(bytes) : PdfWinAnsiEncoding.Decode(bytes);
+            decoders.TryGetValue(fontRes, out var dec) ? dec(bytes) : PdfWinAnsiEncoding.Decode(bytes, _limits.MaxDecodedTextCharacters);
         double SumWidth1000(string fontRes, byte[] bytes) =>
             widthProviders.TryGetValue(fontRes, out var wp) ? wp(bytes) : (bytes?.Length ?? 0) * 500.0;
         string? ResolveBaseFont(string fontRes) =>
@@ -558,7 +566,7 @@ public sealed partial class PdfReadPage {
                 var formWidths = MergeWidthProviders(widthProviders, ResourceResolver.GetFontWidthProviders(formDict, _objects));
                 var formFonts = MergeFonts(fonts, ResourceResolver.GetFontsForResources(formResources, _objects));
                 var combinedTransform = ApplyFormMatrix(invocation.Transform, formDict);
-                var formContent = WrapContentWithTransform(WrapFormContentWithBoundingBoxClip(PdfEncoding.Latin1GetString(DecodeIfNeeded(formStream)), formDict), combinedTransform, out int formContentOffset);
+                var formContent = WrapContentWithTransform(WrapFormContentWithBoundingBoxClip(PdfEncoding.Latin1GetString(pageContentBudget.Decode(formStream)), formDict), combinedTransform, out int formContentOffset);
 
                 CollectTextAndForms(
                     formContent,
@@ -582,7 +590,8 @@ public sealed partial class PdfReadPage {
                     invocation.ClipPath,
                     useLogicalTextFilters,
                     contentNestingDepth + 1,
-                    textOutputBudget);
+                    textOutputBudget,
+                    pageContentBudget);
             } finally {
                 activeForms.Remove(formStream);
             }
@@ -604,8 +613,10 @@ public sealed partial class PdfReadPage {
         double paintOrderScale = 1D,
         double paintOrderOffset = 0D,
         PdfPageClipPath? initialClipPath = null,
-        int contentNestingDepth = 0) {
+        int contentNestingDepth = 0,
+        PageContentBudget? pageContentBudget = null) {
         EnsureContentNestingBudget(contentNestingDepth);
+        pageContentBudget ??= new PageContentBudget(this);
         foreach (var invocation in PdfPageXObjectInvocationParser.Parse(
                      content,
                      baseTransform,
@@ -657,7 +668,7 @@ public sealed partial class PdfReadPage {
                 var formDict = formStream.Dictionary;
                 var formResources = ResolveDictionary(formDict.Items.TryGetValue("Resources", out var resObj) ? resObj : null) ?? resources;
                 Matrix2D formTransform = ApplyFormMatrix(invocationTransform, formDict);
-                string formContent = WrapFormContentWithBoundingBoxClip(PdfEncoding.Latin1GetString(DecodeIfNeeded(formStream)), formDict);
+                string formContent = WrapFormContentWithBoundingBoxClip(PdfEncoding.Latin1GetString(pageContentBudget.Decode(formStream)), formDict);
                 CollectImagePlacementsAndForms(
                     formContent,
                     formResources,
@@ -672,7 +683,8 @@ public sealed partial class PdfReadPage {
                     invocation.PaintOrder,
                     paintOrderScale * 0.000000001D,
                     initialClipPath: invocation.ClipPath,
-                    contentNestingDepth: contentNestingDepth + 1);
+                    contentNestingDepth: contentNestingDepth + 1,
+                    pageContentBudget: pageContentBudget);
             } finally {
                 activeForms.Remove(formStream);
             }
@@ -1370,40 +1382,11 @@ public sealed partial class PdfReadPage {
     /// <summary>
     /// Returns decoded page content with stream arrays concatenated in PDF processing order.
     /// </summary>
-    private string GetContentStreamContent() {
+    private string GetContentStreamContent(PageContentBudget? pageContentBudget = null) {
+        pageContentBudget ??= new PageContentBudget(this);
         var builder = new System.Text.StringBuilder();
-        long decodedBytes = 0;
         foreach (var stream in GetContentStreamObjects()) {
-            long remainingPageBytes = (long)_limits.MaxPageContentBytes - decodedBytes;
-            if (remainingPageBytes <= 0) {
-                throw PdfReadLimitException.Create(
-                    PdfReadLimitKind.PageContentBytes,
-                    _limits.MaxPageContentBytes,
-                    (long)_limits.MaxPageContentBytes + 1L);
-            }
-
-            int streamDecodeLimit = (int)Math.Min(_maxDecodedStreamBytes, remainingPageBytes);
-            byte[] decoded;
-            try {
-                decoded = DecodeIfNeeded(stream, streamDecodeLimit);
-            } catch (PdfReadLimitException exception) when (
-                exception.Kind == PdfReadLimitKind.DecodedStreamBytes &&
-                remainingPageBytes <= _maxDecodedStreamBytes) {
-                throw PdfReadLimitException.Create(
-                    PdfReadLimitKind.PageContentBytes,
-                    _limits.MaxPageContentBytes,
-                    (long)_limits.MaxPageContentBytes + 1L);
-            }
-
-            decodedBytes += decoded.LongLength;
-            if (decodedBytes > _limits.MaxPageContentBytes) {
-                throw PdfReadLimitException.Create(
-                    PdfReadLimitKind.PageContentBytes,
-                    _limits.MaxPageContentBytes,
-                    decodedBytes);
-            }
-
-            builder.Append(PdfEncoding.Latin1GetString(decoded));
+            builder.Append(PdfEncoding.Latin1GetString(pageContentBudget.Decode(stream)));
         }
 
         return builder.ToString();
@@ -1447,11 +1430,55 @@ public sealed partial class PdfReadPage {
         return false;
     }
 
-    private byte[] DecodeIfNeeded(PdfStream s) {
-        return Filters.StreamDecoder.Decode(s.Dictionary, s.Data, _objects, _maxDecodedStreamBytes);
-    }
-
     private byte[] DecodeIfNeeded(PdfStream s, int maxDecodedBytes) {
         return Filters.StreamDecoder.Decode(s.Dictionary, s.Data, _objects, maxDecodedBytes);
+    }
+
+    private sealed class PageContentBudget {
+        private readonly PdfReadPage _page;
+        private readonly Dictionary<PdfStream, byte[]> _decodedStreams = new();
+        private long _decodedBytes;
+
+        internal PageContentBudget(PdfReadPage page) {
+            _page = page;
+        }
+
+        internal byte[] Decode(PdfStream stream) {
+            if (_decodedStreams.TryGetValue(stream, out byte[]? cached)) {
+                return cached;
+            }
+
+            long remainingPageBytes = (long)_page._limits.MaxPageContentBytes - _decodedBytes;
+            if (remainingPageBytes <= 0L) {
+                throw PdfReadLimitException.Create(
+                    PdfReadLimitKind.PageContentBytes,
+                    _page._limits.MaxPageContentBytes,
+                    (long)_page._limits.MaxPageContentBytes + 1L);
+            }
+
+            int streamDecodeLimit = (int)Math.Min(_page._maxDecodedStreamBytes, remainingPageBytes);
+            byte[] decoded;
+            try {
+                decoded = _page.DecodeIfNeeded(stream, streamDecodeLimit);
+            } catch (PdfReadLimitException exception) when (
+                exception.Kind == PdfReadLimitKind.DecodedStreamBytes &&
+                remainingPageBytes <= _page._maxDecodedStreamBytes) {
+                throw PdfReadLimitException.Create(
+                    PdfReadLimitKind.PageContentBytes,
+                    _page._limits.MaxPageContentBytes,
+                    (long)_page._limits.MaxPageContentBytes + 1L);
+            }
+
+            _decodedBytes += decoded.LongLength;
+            if (_decodedBytes > _page._limits.MaxPageContentBytes) {
+                throw PdfReadLimitException.Create(
+                    PdfReadLimitKind.PageContentBytes,
+                    _page._limits.MaxPageContentBytes,
+                    _decodedBytes);
+            }
+
+            _decodedStreams[stream] = decoded;
+            return decoded;
+        }
     }
 }

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadPage.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadPage.cs
@@ -115,7 +115,7 @@ public sealed partial class PdfReadPage {
         _demandTextExtraction?.Invoke();
         var spans = new List<PdfTextSpan>();
         var pageResources = ResolveDictionary(GetInheritedValue("Resources"));
-        var pageDecoders = ResourceResolver.GetFontDecoders(_pageDict, _objects);
+        var pageDecoders = ResourceResolver.GetFontDecoders(_pageDict, _objects, _limits.MaxDecodedTextCharacters);
         var pageWidthProviders = ResourceResolver.GetFontWidthProviders(_pageDict, _objects);
         var pageFonts = ResourceResolver.GetFontsForResources(pageResources, _objects);
         var activeForms = new HashSet<PdfStream>();
@@ -476,8 +476,12 @@ public sealed partial class PdfReadPage {
         int initialTextRenderingMode = 0,
         PdfPageClipPath? initialClipPath = null,
         bool useLogicalTextFilters = true,
-        int contentNestingDepth = 0) {
+        int contentNestingDepth = 0,
+        TextContentParser.TextOutputBudget? textOutputBudget = null) {
         EnsureContentNestingBudget(contentNestingDepth);
+        textOutputBudget ??= new TextContentParser.TextOutputBudget(
+            _limits.MaxActualTextCharacters,
+            _limits.MaxDecodedTextCharacters);
         string DecodeWithFont(string fontRes, byte[] bytes) =>
             decoders.TryGetValue(fontRes, out var dec) ? dec(bytes) : PdfWinAnsiEncoding.Decode(bytes);
         double SumWidth1000(string fontRes, byte[] bytes) =>
@@ -514,7 +518,10 @@ public sealed partial class PdfReadPage {
             useLogicalTextFilters: useLogicalTextFilters,
             maxOperations: _limits.MaxContentOperations,
             maxNestingDepth: _limits.MaxContentNestingDepth,
-            maxOperands: _limits.MaxContentOperands));
+            maxOperands: _limits.MaxContentOperands,
+            maxActualTextCharacters: _limits.MaxActualTextCharacters,
+            maxDecodedTextCharacters: _limits.MaxDecodedTextCharacters,
+            textOutputBudget: textOutputBudget));
 
         foreach (var invocation in TextContentParser.ExtractFormInvocations(
                      content,
@@ -547,7 +554,7 @@ public sealed partial class PdfReadPage {
             try {
                 var formDict = formStream.Dictionary;
                 var formResources = ResolveDictionary(formDict.Items.TryGetValue("Resources", out var resObj) ? resObj : null) ?? resources;
-                var formDecoders = MergeDecoders(decoders, ResourceResolver.GetFontDecodersForForm(formDict, _objects));
+                var formDecoders = MergeDecoders(decoders, ResourceResolver.GetFontDecodersForForm(formDict, _objects, _limits.MaxDecodedTextCharacters));
                 var formWidths = MergeWidthProviders(widthProviders, ResourceResolver.GetFontWidthProviders(formDict, _objects));
                 var formFonts = MergeFonts(fonts, ResourceResolver.GetFontsForResources(formResources, _objects));
                 var combinedTransform = ApplyFormMatrix(invocation.Transform, formDict);
@@ -574,7 +581,8 @@ public sealed partial class PdfReadPage {
                     invocation.TextRenderingMode,
                     invocation.ClipPath,
                     useLogicalTextFilters,
-                    contentNestingDepth + 1);
+                    contentNestingDepth + 1,
+                    textOutputBudget);
             } finally {
                 activeForms.Remove(formStream);
             }
@@ -1364,8 +1372,38 @@ public sealed partial class PdfReadPage {
     /// </summary>
     private string GetContentStreamContent() {
         var builder = new System.Text.StringBuilder();
+        long decodedBytes = 0;
         foreach (var stream in GetContentStreamObjects()) {
-            builder.Append(PdfEncoding.Latin1GetString(DecodeIfNeeded(stream)));
+            long remainingPageBytes = (long)_limits.MaxPageContentBytes - decodedBytes;
+            if (remainingPageBytes <= 0) {
+                throw PdfReadLimitException.Create(
+                    PdfReadLimitKind.PageContentBytes,
+                    _limits.MaxPageContentBytes,
+                    (long)_limits.MaxPageContentBytes + 1L);
+            }
+
+            int streamDecodeLimit = (int)Math.Min(_maxDecodedStreamBytes, remainingPageBytes);
+            byte[] decoded;
+            try {
+                decoded = DecodeIfNeeded(stream, streamDecodeLimit);
+            } catch (PdfReadLimitException exception) when (
+                exception.Kind == PdfReadLimitKind.DecodedStreamBytes &&
+                remainingPageBytes <= _maxDecodedStreamBytes) {
+                throw PdfReadLimitException.Create(
+                    PdfReadLimitKind.PageContentBytes,
+                    _limits.MaxPageContentBytes,
+                    (long)_limits.MaxPageContentBytes + 1L);
+            }
+
+            decodedBytes += decoded.LongLength;
+            if (decodedBytes > _limits.MaxPageContentBytes) {
+                throw PdfReadLimitException.Create(
+                    PdfReadLimitKind.PageContentBytes,
+                    _limits.MaxPageContentBytes,
+                    decodedBytes);
+            }
+
+            builder.Append(PdfEncoding.Latin1GetString(decoded));
         }
 
         return builder.ToString();
@@ -1411,5 +1449,9 @@ public sealed partial class PdfReadPage {
 
     private byte[] DecodeIfNeeded(PdfStream s) {
         return Filters.StreamDecoder.Decode(s.Dictionary, s.Data, _objects, _maxDecodedStreamBytes);
+    }
+
+    private byte[] DecodeIfNeeded(PdfStream s, int maxDecodedBytes) {
+        return Filters.StreamDecoder.Decode(s.Dictionary, s.Data, _objects, maxDecodedBytes);
     }
 }

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadPage.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadPage.cs
@@ -498,8 +498,8 @@ public sealed partial class PdfReadPage {
             fonts.TryGetValue(fontRes, out PdfFontResource? font) ? font.BaseFont : null;
         string? ResolveDrawingFontFamily(string fontRes) =>
             fonts.TryGetValue(fontRes, out PdfFontResource? font) ? font.DrawingFontFamily : null;
-        string? ResolveActualTextProperty(string propertyName) =>
-            GetMarkedContentActualText(resources, propertyName);
+        byte[]? ResolveActualTextProperty(string propertyName) =>
+            GetMarkedContentActualTextBytes(resources, propertyName);
 
         spans.AddRange(TextContentParser.Parse(
             content,
@@ -801,7 +801,7 @@ public sealed partial class PdfReadPage {
             paintOrder);
     }
 
-    private string? GetMarkedContentActualText(PdfDictionary? resources, string propertyName) {
+    private byte[]? GetMarkedContentActualTextBytes(PdfDictionary? resources, string propertyName) {
         if (resources is null ||
             !resources.Items.TryGetValue("Properties", out var propertiesObj)) {
             return null;
@@ -820,7 +820,7 @@ public sealed partial class PdfReadPage {
             return null;
         }
 
-        return actualText.Value;
+        return actualText.RawBytes;
     }
 
     private PdfPageOptionalContentVisibility? GetOptionalContentVisibility(PdfDictionary? resources) =>

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadPage.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadPage.cs
@@ -1445,6 +1445,7 @@ public sealed partial class PdfReadPage {
 
         internal byte[] Decode(PdfStream stream) {
             if (_decodedStreams.TryGetValue(stream, out byte[]? cached)) {
+                Charge(cached.LongLength);
                 return cached;
             }
 
@@ -1469,16 +1470,19 @@ public sealed partial class PdfReadPage {
                     (long)_page._limits.MaxPageContentBytes + 1L);
             }
 
-            _decodedBytes += decoded.LongLength;
+            Charge(decoded.LongLength);
+            _decodedStreams[stream] = decoded;
+            return decoded;
+        }
+
+        private void Charge(long decodedBytes) {
+            _decodedBytes += decodedBytes;
             if (_decodedBytes > _page._limits.MaxPageContentBytes) {
                 throw PdfReadLimitException.Create(
                     PdfReadLimitKind.PageContentBytes,
                     _page._limits.MaxPageContentBytes,
                     _decodedBytes);
             }
-
-            _decodedStreams[stream] = decoded;
-            return decoded;
         }
     }
 }

--- a/OfficeIMO.Pdf/Reading/Core/PdfSyntax.Catalog.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfSyntax.Catalog.cs
@@ -378,8 +378,7 @@ internal static partial class PdfSyntax {
         HashSet<int> visitedReferences,
         int depth,
         ref int traversedNodes) {
-        if (depth > PdfReadLimits.DefaultMaxNameTreeDepth ||
-            ++traversedNodes > PdfReadLimits.DefaultMaxNameTreeNodes) {
+        if (depth > PdfReadLimits.DefaultMaxNameTreeDepth) {
             return false;
         }
 
@@ -389,7 +388,11 @@ internal static partial class PdfSyntax {
                 return false;
             }
 
-            return TryCollectNamedDestinationNameTreeEntries(map, indirect.Value, visitedReferences, depth, ref traversedNodes);
+            if (++traversedNodes > PdfReadLimits.DefaultMaxNameTreeNodes) {
+                return false;
+            }
+
+            value = indirect.Value;
         }
 
         if (value is not PdfDictionary tree) {

--- a/OfficeIMO.Pdf/Reading/Core/PdfSyntax.Catalog.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfSyntax.Catalog.cs
@@ -367,9 +367,10 @@ internal static partial class PdfSyntax {
 
     private static bool IsSupportedNamedDestinationNameTree(
         Dictionary<int, PdfIndirectObject> map,
-        PdfObject namedDestinations) {
+        PdfObject namedDestinations,
+        PdfReadLimits limits) {
         int traversedNodes = 0;
-        return TryCollectNamedDestinationNameTreeEntries(map, namedDestinations, new HashSet<int>(), 0, ref traversedNodes);
+        return TryCollectNamedDestinationNameTreeEntries(map, namedDestinations, new HashSet<int>(), 0, limits, ref traversedNodes);
     }
 
     private static bool TryCollectNamedDestinationNameTreeEntries(
@@ -377,8 +378,9 @@ internal static partial class PdfSyntax {
         PdfObject value,
         HashSet<int> visitedReferences,
         int depth,
+        PdfReadLimits limits,
         ref int traversedNodes) {
-        if (depth > PdfReadLimits.DefaultMaxNameTreeDepth) {
+        if (depth > limits.MaxNameTreeDepth) {
             return false;
         }
 
@@ -388,7 +390,7 @@ internal static partial class PdfSyntax {
                 return false;
             }
 
-            if (++traversedNodes > PdfReadLimits.DefaultMaxNameTreeNodes) {
+            if (++traversedNodes > limits.MaxNameTreeNodes) {
                 return false;
             }
 
@@ -433,7 +435,7 @@ internal static partial class PdfSyntax {
                     return false;
                 }
 
-                if (!TryCollectNamedDestinationNameTreeEntries(map, kid, visitedReferences, depth + 1, ref traversedNodes)) {
+                if (!TryCollectNamedDestinationNameTreeEntries(map, kid, visitedReferences, depth + 1, limits, ref traversedNodes)) {
                     return false;
                 }
             }

--- a/OfficeIMO.Pdf/Reading/Core/PdfSyntax.Catalog.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfSyntax.Catalog.cs
@@ -368,20 +368,28 @@ internal static partial class PdfSyntax {
     private static bool IsSupportedNamedDestinationNameTree(
         Dictionary<int, PdfIndirectObject> map,
         PdfObject namedDestinations) {
-        return TryCollectNamedDestinationNameTreeEntries(map, namedDestinations, new HashSet<int>());
+        int traversedNodes = 0;
+        return TryCollectNamedDestinationNameTreeEntries(map, namedDestinations, new HashSet<int>(), 0, ref traversedNodes);
     }
 
     private static bool TryCollectNamedDestinationNameTreeEntries(
         Dictionary<int, PdfIndirectObject> map,
         PdfObject value,
-        HashSet<int> visitedReferences) {
+        HashSet<int> visitedReferences,
+        int depth,
+        ref int traversedNodes) {
+        if (depth > PdfReadLimits.DefaultMaxNameTreeDepth ||
+            ++traversedNodes > PdfReadLimits.DefaultMaxNameTreeNodes) {
+            return false;
+        }
+
         if (value is PdfReference reference) {
             if (!visitedReferences.Add(reference.ObjectNumber) ||
                 !PdfObjectLookup.TryGet(map, reference, out var indirect)) {
                 return false;
             }
 
-            return TryCollectNamedDestinationNameTreeEntries(map, indirect.Value, visitedReferences);
+            return TryCollectNamedDestinationNameTreeEntries(map, indirect.Value, visitedReferences, depth, ref traversedNodes);
         }
 
         if (value is not PdfDictionary tree) {
@@ -422,7 +430,7 @@ internal static partial class PdfSyntax {
                     return false;
                 }
 
-                if (!TryCollectNamedDestinationNameTreeEntries(map, kid, visitedReferences)) {
+                if (!TryCollectNamedDestinationNameTreeEntries(map, kid, visitedReferences, depth + 1, ref traversedNodes)) {
                     return false;
                 }
             }

--- a/OfficeIMO.Pdf/Reading/Core/PdfSyntax.Markers.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfSyntax.Markers.cs
@@ -257,6 +257,7 @@ internal static partial class PdfSyntax {
 
         try {
             var (objects, trailerRaw) = ParseObjects(pdf, options);
+            PdfReadLimits limits = options?.Limits ?? PdfReadOptions.Default.Limits;
             PdfDictionary? catalog = FindCatalog(objects, trailerRaw);
             if (catalog is null) {
                 return true;
@@ -274,7 +275,7 @@ internal static partial class PdfSyntax {
 
                 if (namesDictionary.Items.ContainsKey("Dests")) {
                     return !TryGetNamedDestinationNameTree(objects, names, out var namedDestinationTree) ||
-                        !IsSupportedNamedDestinationNameTree(objects, namedDestinationTree);
+                        !IsSupportedNamedDestinationNameTree(objects, namedDestinationTree, limits);
                 }
             }
 

--- a/OfficeIMO.Pdf/Reading/Core/ResourceResolver.cs
+++ b/OfficeIMO.Pdf/Reading/Core/ResourceResolver.cs
@@ -38,6 +38,16 @@ internal static partial class ResourceResolver {
         return map;
     }
 
+    public static Dictionary<string, System.Func<byte[], int, string>> GetBudgetedFontDecoders(
+        PdfDictionary page,
+        Dictionary<int, PdfIndirectObject> objects) {
+        var map = new Dictionary<string, System.Func<byte[], int, string>>(System.StringComparer.Ordinal);
+        foreach (var kv in GetFontsForPage(page, objects)) {
+            map[kv.Key] = BuildBudgetedDecoderForFont(kv.Value);
+        }
+        return map;
+    }
+
     public static Dictionary<string, System.Func<byte[], double>> GetFontWidthProviders(PdfDictionary page, Dictionary<int, PdfIndirectObject> objects) {
         var map = new Dictionary<string, System.Func<byte[], double>>(System.StringComparer.Ordinal);
         var dict = GetInheritedDictionary(page, "Resources", objects);
@@ -161,6 +171,20 @@ internal static partial class ResourceResolver {
         if (res is null) return map;
         foreach (var kv in GetFontsForResources(res, objects)) {
             map[kv.Key] = BuildDecoderForFont(kv.Value, maxDecodedTextCharacters);
+        }
+
+        return map;
+    }
+
+    public static Dictionary<string, System.Func<byte[], int, string>> GetBudgetedFontDecodersForForm(
+        PdfDictionary formDict,
+        Dictionary<int, PdfIndirectObject> objects) {
+        var map = new Dictionary<string, System.Func<byte[], int, string>>(System.StringComparer.Ordinal);
+        if (!formDict.Items.TryGetValue("Resources", out var resObj)) return map;
+        var res = ResolveDict(resObj, objects);
+        if (res is null) return map;
+        foreach (var kv in GetFontsForResources(res, objects)) {
+            map[kv.Key] = BuildBudgetedDecoderForFont(kv.Value);
         }
 
         return map;
@@ -363,6 +387,35 @@ internal static partial class ResourceResolver {
         }
 
         return baseDecoder;
+    }
+
+    private static System.Func<byte[], int, string> BuildBudgetedDecoderForFont(PdfFontResource font) {
+        if (font.HasToUnicode && font.CMap is not null) {
+            return (bytes, maximumCharacters) => font.CMap.MapBytes(bytes, maximumCharacters);
+        }
+
+        if (font.Differences is not null && font.Differences.Count > 0) {
+            var differences = font.Differences;
+            return (bytes, maximumCharacters) => DecodeWithDifferences(
+                bytes,
+                differences,
+                BuildBaseEncodingDecoder(font.Encoding, maximumCharacters),
+                maximumCharacters);
+        }
+
+        return BuildBudgetedBaseEncodingDecoder(font.Encoding);
+    }
+
+    private static System.Func<byte[], int, string> BuildBudgetedBaseEncodingDecoder(string encoding) {
+        if (string.Equals(encoding, "StandardEncoding", System.StringComparison.Ordinal)) {
+            return static (bytes, maximumCharacters) => PdfStandardEncoding.Decode(bytes, maximumCharacters);
+        }
+
+        if (string.Equals(encoding, "MacRomanEncoding", System.StringComparison.Ordinal)) {
+            return static (bytes, maximumCharacters) => PdfMacRomanEncoding.Decode(bytes, maximumCharacters);
+        }
+
+        return static (bytes, maximumCharacters) => PdfWinAnsiEncoding.Decode(bytes, maximumCharacters);
     }
 
     private static System.Func<byte[], string> BuildBaseEncodingDecoder(string encoding, int maxDecodedTextCharacters) {

--- a/OfficeIMO.Pdf/Reading/Core/ResourceResolver.cs
+++ b/OfficeIMO.Pdf/Reading/Core/ResourceResolver.cs
@@ -25,11 +25,14 @@ internal static partial class ResourceResolver {
         return fonts;
     }
 
-    public static Dictionary<string, System.Func<byte[], string>> GetFontDecoders(PdfDictionary page, Dictionary<int, PdfIndirectObject> objects) {
+    public static Dictionary<string, System.Func<byte[], string>> GetFontDecoders(
+        PdfDictionary page,
+        Dictionary<int, PdfIndirectObject> objects,
+        int maxDecodedTextCharacters = PdfReadLimits.DefaultMaxDecodedTextCharacters) {
         var map = new Dictionary<string, System.Func<byte[], string>>(System.StringComparer.Ordinal);
         var fonts = GetFontsForPage(page, objects);
         foreach (var kv in fonts) {
-            var dec = BuildDecoderForFont(kv.Value);
+            var dec = BuildDecoderForFont(kv.Value, maxDecodedTextCharacters);
             map[kv.Key] = dec;
         }
         return map;
@@ -59,7 +62,7 @@ internal static partial class ResourceResolver {
                 var widths = ResolveArray(fontVal.Items.TryGetValue("Widths", out var wobj) ? wobj : null, objects);
                 if (widths is null) {
                     if (PdfWriter.TryGetStandardFontByBaseFontName(fontResource.BaseFont, out var standardFont)) {
-                        var decoder = BuildDecoderForFont(fontResource);
+                        var decoder = BuildDecoderForFont(fontResource, PdfReadLimits.DefaultMaxDecodedTextCharacters);
                         map[kv.Key] = bytes => PdfWriter.EstimateSimpleTextWidth1000(decoder(bytes), standardFont);
                     } else {
                         map[kv.Key] = bytes => (bytes?.Length ?? 0) * 500.0;
@@ -148,13 +151,16 @@ internal static partial class ResourceResolver {
         return sum;
     }
 
-    public static Dictionary<string, System.Func<byte[], string>> GetFontDecodersForForm(PdfDictionary formDict, Dictionary<int, PdfIndirectObject> objects) {
+    public static Dictionary<string, System.Func<byte[], string>> GetFontDecodersForForm(
+        PdfDictionary formDict,
+        Dictionary<int, PdfIndirectObject> objects,
+        int maxDecodedTextCharacters = PdfReadLimits.DefaultMaxDecodedTextCharacters) {
         var map = new Dictionary<string, System.Func<byte[], string>>(System.StringComparer.Ordinal);
         if (!formDict.Items.TryGetValue("Resources", out var resObj)) return map;
         var res = ResolveDict(resObj, objects);
         if (res is null) return map;
         foreach (var kv in GetFontsForResources(res, objects)) {
-            map[kv.Key] = BuildDecoderForFont(kv.Value);
+            map[kv.Key] = BuildDecoderForFont(kv.Value, maxDecodedTextCharacters);
         }
 
         return map;
@@ -347,13 +353,13 @@ internal static partial class ResourceResolver {
         "," +
         imageMaskColor.A.ToString(System.Globalization.CultureInfo.InvariantCulture);
 
-    private static System.Func<byte[], string> BuildDecoderForFont(PdfFontResource font) {
+    private static System.Func<byte[], string> BuildDecoderForFont(PdfFontResource font, int maxDecodedTextCharacters) {
         // Prefer font-specific ToUnicode map when present
-        if (font.HasToUnicode && font.CMap is not null) return font.CMap.MapBytes;
+        if (font.HasToUnicode && font.CMap is not null) return bytes => font.CMap.MapBytes(bytes, maxDecodedTextCharacters);
         var baseDecoder = BuildBaseEncodingDecoder(font.Encoding);
         if (font.Differences is not null && font.Differences.Count > 0) {
             var differences = font.Differences;
-            return bytes => DecodeWithDifferences(bytes, differences, baseDecoder);
+            return bytes => DecodeWithDifferences(bytes, differences, baseDecoder, maxDecodedTextCharacters);
         }
 
         return baseDecoder;
@@ -502,16 +508,24 @@ internal static partial class ResourceResolver {
         return map.Count == 0 ? null : map;
     }
 
-    private static string DecodeWithDifferences(byte[] bytes, IReadOnlyDictionary<int, string> differences, System.Func<byte[], string> baseDecoder) {
+    private static string DecodeWithDifferences(
+        byte[] bytes,
+        IReadOnlyDictionary<int, string> differences,
+        System.Func<byte[], string> baseDecoder,
+        int maxDecodedTextCharacters) {
         if (bytes is null || bytes.Length == 0) return string.Empty;
         var builder = new System.Text.StringBuilder(bytes.Length);
         for (int i = 0; i < bytes.Length; i++) {
             int code = bytes[i];
-            if (differences.TryGetValue(code, out string? value)) {
-                builder.Append(value);
-            } else {
-                builder.Append(baseDecoder(new[] { bytes[i] }));
+            string value = differences.TryGetValue(code, out string? difference)
+                ? difference!
+                : baseDecoder(new[] { bytes[i] });
+            long nextLength = (long)builder.Length + value.Length;
+            if (nextLength > maxDecodedTextCharacters) {
+                throw PdfReadLimitException.Create(PdfReadLimitKind.DecodedTextCharacters, maxDecodedTextCharacters, nextLength);
             }
+
+            builder.Append(value);
         }
 
         return builder.ToString();

--- a/OfficeIMO.Pdf/Reading/Core/ResourceResolver.cs
+++ b/OfficeIMO.Pdf/Reading/Core/ResourceResolver.cs
@@ -356,7 +356,7 @@ internal static partial class ResourceResolver {
     private static System.Func<byte[], string> BuildDecoderForFont(PdfFontResource font, int maxDecodedTextCharacters) {
         // Prefer font-specific ToUnicode map when present
         if (font.HasToUnicode && font.CMap is not null) return bytes => font.CMap.MapBytes(bytes, maxDecodedTextCharacters);
-        var baseDecoder = BuildBaseEncodingDecoder(font.Encoding);
+        var baseDecoder = BuildBaseEncodingDecoder(font.Encoding, maxDecodedTextCharacters);
         if (font.Differences is not null && font.Differences.Count > 0) {
             var differences = font.Differences;
             return bytes => DecodeWithDifferences(bytes, differences, baseDecoder, maxDecodedTextCharacters);
@@ -365,16 +365,16 @@ internal static partial class ResourceResolver {
         return baseDecoder;
     }
 
-    private static System.Func<byte[], string> BuildBaseEncodingDecoder(string encoding) {
+    private static System.Func<byte[], string> BuildBaseEncodingDecoder(string encoding, int maxDecodedTextCharacters) {
         if (string.Equals(encoding, "StandardEncoding", System.StringComparison.Ordinal)) {
-            return PdfStandardEncoding.Decode;
+            return bytes => PdfStandardEncoding.Decode(bytes, maxDecodedTextCharacters);
         }
 
         if (string.Equals(encoding, "MacRomanEncoding", System.StringComparison.Ordinal)) {
-            return PdfMacRomanEncoding.Decode;
+            return bytes => PdfMacRomanEncoding.Decode(bytes, maxDecodedTextCharacters);
         }
 
-        return PdfWinAnsiEncoding.Decode;
+        return bytes => PdfWinAnsiEncoding.Decode(bytes, maxDecodedTextCharacters);
     }
 
     private static PdfFontResource CreateFontResource(string resourceName, PdfDictionary fontVal, Dictionary<int, PdfIndirectObject> objects) {
@@ -514,6 +514,9 @@ internal static partial class ResourceResolver {
         System.Func<byte[], string> baseDecoder,
         int maxDecodedTextCharacters) {
         if (bytes is null || bytes.Length == 0) return string.Empty;
+        if (bytes.LongLength > maxDecodedTextCharacters) {
+            throw PdfReadLimitException.Create(PdfReadLimitKind.DecodedTextCharacters, maxDecodedTextCharacters, bytes.LongLength);
+        }
         var builder = new System.Text.StringBuilder(bytes.Length);
         for (int i = 0; i < bytes.Length; i++) {
             int code = bytes[i];

--- a/OfficeIMO.Pdf/Reading/Core/TextContentParser.cs
+++ b/OfficeIMO.Pdf/Reading/Core/TextContentParser.cs
@@ -44,26 +44,47 @@ internal static class TextContentParser {
     }
 
     private readonly struct ActualTextValue {
-        public string Text { get; }
+        private readonly string? _text;
+        private readonly byte[]? _bytes;
 
         public ActualTextValue(string text) {
-            Text = text;
+            _text = text;
+            _bytes = null;
+        }
+
+        public ActualTextValue(byte[] bytes) {
+            _text = null;
+            _bytes = bytes;
+        }
+
+        public string Decode(TextOutputBudget budget) {
+            if (_bytes != null) {
+                budget.EnsureActualTextMayFit(PdfTextString.GetDecodedCharacterCount(_bytes));
+                return PdfTextString.Decode(_bytes);
+            }
+
+            string text = _text ?? string.Empty;
+            budget.EnsureActualTextMayFit(text.Length);
+            return text;
         }
     }
 
     private sealed class MarkedContentState {
-        public string ActualText { get; }
+        private readonly ActualTextValue? _actualText;
         public bool HasActualText { get; }
         public bool IsArtifact { get; }
         public bool IsHidden { get; }
         public bool ActualTextEmitted { get; set; }
 
         public MarkedContentState(ActualTextValue? actualText, bool isArtifact, bool isHidden) {
-            ActualText = actualText?.Text ?? string.Empty;
+            _actualText = actualText;
             HasActualText = actualText.HasValue;
             IsArtifact = isArtifact;
             IsHidden = isHidden;
         }
+
+        public string DecodeActualText(TextOutputBudget budget) =>
+            _actualText?.Decode(budget) ?? string.Empty;
     }
 
     internal sealed class TextOutputBudget {
@@ -91,6 +112,13 @@ internal static class TextContentParser {
             }
 
             _actualTextCharacters = next;
+        }
+
+        internal void EnsureActualTextMayFit(int characters) {
+            long next = _actualTextCharacters + characters;
+            if (next > _maxActualTextCharacters) {
+                throw PdfReadLimitException.Create(PdfReadLimitKind.ActualTextCharacters, _maxActualTextCharacters, next);
+            }
         }
 
         internal void ChargeDecodedText(int characters) {
@@ -602,7 +630,7 @@ internal static class TextContentParser {
             } else if (isArtifact) {
                 // Artifact content is visual decoration, not logical page text.
             } else if (actualTextState is not null && !actualTextState.ActualTextEmitted) {
-                textOut = actualTextState.ActualText;
+                textOut = actualTextState.DecodeActualText(textOutputBudget);
                 textOutputBudget.ChargeActualText(textOut.Length);
                 actualTextState.ActualTextEmitted = true;
                 if (textOut.Length > 0) {
@@ -706,7 +734,7 @@ internal static class TextContentParser {
             if (propertyObject is PdfContentDictionary dictionary &&
                 dictionary.Items.TryGetValue("ActualText", out var value) &&
                 value is byte[] bytes) {
-                return new ActualTextValue(PdfTextString.Decode(bytes));
+                return new ActualTextValue(bytes);
             }
 
             return null;

--- a/OfficeIMO.Pdf/Reading/Core/TextContentParser.cs
+++ b/OfficeIMO.Pdf/Reading/Core/TextContentParser.cs
@@ -129,6 +129,11 @@ internal static class TextContentParser {
 
             _decodedTextCharacters = next;
         }
+
+        internal int GetDecodedTextBufferCapacity(int requestedCapacity) {
+            long remaining = _maxDecodedTextCharacters - _decodedTextCharacters;
+            return (int)Math.Min(Math.Max(0L, remaining), Math.Max(0, requestedCapacity));
+        }
     }
 
     internal readonly struct FormInvocation {
@@ -577,7 +582,7 @@ internal static class TextContentParser {
                 twoByte = (IsNullOrEmptyDecodedGlyph(one) && !IsNullOrEmptyDecodedGlyph(two)) ||
                     (firstByteWidth <= 0 && secondByteWidth <= 0 && pairWidth > 0);
             }
-            var sbOut = new StringBuilder(bytes.Length);
+            var sbOut = new StringBuilder(textOutputBudget.GetDecodedTextBufferCapacity(bytes.Length));
             double advTotal = 0;
             char prevChar = '\0';
             string wholeDecoded = NormalizeDecodedGlyphText(decodeWithFont(font, bytes) ?? string.Empty);

--- a/OfficeIMO.Pdf/Reading/Core/TextContentParser.cs
+++ b/OfficeIMO.Pdf/Reading/Core/TextContentParser.cs
@@ -175,7 +175,7 @@ internal static class TextContentParser {
         System.Func<string, byte[], string> decodeWithFont,
         System.Func<string, byte[], double> sumWidth1000ForFont,
         bool adjustKerningFromTJ = true,
-        System.Func<string, string?>? actualTextForProperty = null,
+        System.Func<string, byte[]?>? actualTextForProperty = null,
         IReadOnlyDictionary<string, PdfPageGraphicsStateResource>? graphicsStates = null,
         IReadOnlyDictionary<string, PdfPageColorSpace>? colorSpaces = null,
         System.Func<string, string?>? baseFontForResource = null,
@@ -625,6 +625,10 @@ internal static class TextContentParser {
             OfficeColor paintColor = ResolveTextPaintColor(textRenderingMode, fillColor, strokeColor);
             OfficeColor visibleColor = ApplyTextOpacity(paintColor, textRenderingMode);
             PdfPageClipPath? spanClipPath = clipPath;
+            if ((isHidden || isArtifact) && textOut.Length > 0) {
+                textOutputBudget.ChargeDecodedText(textOut.Length);
+            }
+
             if (isHidden) {
                 // Hidden optional-content still advances text state but should not emit visible/logical spans.
             } else if (isArtifact) {
@@ -727,8 +731,8 @@ internal static class TextContentParser {
 
         ActualTextValue? GetActualText(object? propertyObject) {
             if (propertyObject is string propertyName) {
-                string? text = actualTextForProperty?.Invoke(propertyName);
-                return text is null ? (ActualTextValue?)null : new ActualTextValue(text);
+                byte[]? propertyBytes = actualTextForProperty?.Invoke(propertyName);
+                return propertyBytes is null ? (ActualTextValue?)null : new ActualTextValue(propertyBytes);
             }
 
             if (propertyObject is PdfContentDictionary dictionary &&

--- a/OfficeIMO.Pdf/Reading/Core/TextContentParser.cs
+++ b/OfficeIMO.Pdf/Reading/Core/TextContentParser.cs
@@ -130,6 +130,12 @@ internal static class TextContentParser {
             _decodedTextCharacters = next;
         }
 
+        internal void ThrowDecodedTextLimitExceeded() =>
+            throw PdfReadLimitException.Create(
+                PdfReadLimitKind.DecodedTextCharacters,
+                _maxDecodedTextCharacters,
+                (long)_maxDecodedTextCharacters + 1L);
+
         internal int GetDecodedTextBufferCapacity(int requestedCapacity) {
             return Math.Min(GetRemainingDecodedTextCharacters(), Math.Max(0, requestedCapacity));
         }
@@ -575,10 +581,10 @@ internal static class TextContentParser {
         void ShowTextRun(byte[] bytes, double paintOrder) {
             if (!inText || bytes == null || bytes.Length == 0) return;
             MaybeInsertSpaceBeforeRun();
-            string DecodeRun(byte[] value) {
-                int remaining = textOutputBudget.GetRemainingDecodedTextCharacters();
+            string DecodeRun(byte[] value, int? maximumCharacters = null) {
+                int remaining = maximumCharacters ?? textOutputBudget.GetRemainingDecodedTextCharacters();
                 if (remaining == 0) {
-                    textOutputBudget.ChargeDecodedText(1);
+                    textOutputBudget.ThrowDecodedTextLimitExceeded();
                 }
                 return decodeWithFontWithinLimit != null
                     ? decodeWithFontWithinLimit(font, value, remaining)
@@ -599,10 +605,19 @@ internal static class TextContentParser {
             double advTotal = 0;
             char prevChar = '\0';
             string wholeDecoded = NormalizeDecodedGlyphText(DecodeRun(bytes) ?? string.Empty);
+            int decodedGlyphCharacters = 0;
             for (int idx = 0; idx < bytes.Length;) {
                 int step = twoByte ? (idx + 1 < bytes.Length ? 2 : 1) : 1;
                 byte[] g = step == 1 ? new byte[] { bytes[idx] } : new byte[] { bytes[idx], bytes[idx + 1] };
-                string t = NormalizeDecodedGlyphText(DecodeRun(g) ?? string.Empty);
+                int remainingGlyphCharacters = textOutputBudget.GetRemainingDecodedTextCharacters() - decodedGlyphCharacters;
+                if (remainingGlyphCharacters <= 0) {
+                    textOutputBudget.ThrowDecodedTextLimitExceeded();
+                }
+                string t = NormalizeDecodedGlyphText(DecodeRun(g, remainingGlyphCharacters) ?? string.Empty);
+                if (t.Length > remainingGlyphCharacters) {
+                    textOutputBudget.ThrowDecodedTextLimitExceeded();
+                }
+                decodedGlyphCharacters += t.Length;
                 char ch = (t.Length > 0) ? t[0] : '\0';
                 double w1000 = sumWidth1000ForFont(font, g);
                 double advGlyph = ((w1000 / 1000.0) * size + charSpacing + (ch == ' ' ? wordSpacing : 0)) * hScale;
@@ -624,6 +639,7 @@ internal static class TextContentParser {
                 advTotal += advGlyph;
                 idx += step;
             }
+            textOutputBudget.ChargeDecodedText(Math.Max(wholeDecoded.Length, decodedGlyphCharacters));
             if (ShouldUseWholeDecodedText(sbOut.ToString(), wholeDecoded)) {
                 sbOut.Clear();
                 sbOut.Append(wholeDecoded);
@@ -643,10 +659,6 @@ internal static class TextContentParser {
             OfficeColor paintColor = ResolveTextPaintColor(textRenderingMode, fillColor, strokeColor);
             OfficeColor visibleColor = ApplyTextOpacity(paintColor, textRenderingMode);
             PdfPageClipPath? spanClipPath = clipPath;
-            if (textOut.Length > 0) {
-                textOutputBudget.ChargeDecodedText(textOut.Length);
-            }
-
             if (isHidden) {
                 // Hidden optional-content still advances text state but should not emit visible/logical spans.
             } else if (isArtifact) {

--- a/OfficeIMO.Pdf/Reading/Core/TextContentParser.cs
+++ b/OfficeIMO.Pdf/Reading/Core/TextContentParser.cs
@@ -66,6 +66,43 @@ internal static class TextContentParser {
         }
     }
 
+    internal sealed class TextOutputBudget {
+        private readonly int _maxActualTextCharacters;
+        private readonly int _maxDecodedTextCharacters;
+        private long _actualTextCharacters;
+        private long _decodedTextCharacters;
+
+        internal TextOutputBudget(int maxActualTextCharacters, int maxDecodedTextCharacters) {
+#if NET8_0_OR_GREATER
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxActualTextCharacters);
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxDecodedTextCharacters);
+#else
+            if (maxActualTextCharacters <= 0) throw new ArgumentOutOfRangeException(nameof(maxActualTextCharacters));
+            if (maxDecodedTextCharacters <= 0) throw new ArgumentOutOfRangeException(nameof(maxDecodedTextCharacters));
+#endif
+            _maxActualTextCharacters = maxActualTextCharacters;
+            _maxDecodedTextCharacters = maxDecodedTextCharacters;
+        }
+
+        internal void ChargeActualText(int characters) {
+            long next = _actualTextCharacters + characters;
+            if (next > _maxActualTextCharacters) {
+                throw PdfReadLimitException.Create(PdfReadLimitKind.ActualTextCharacters, _maxActualTextCharacters, next);
+            }
+
+            _actualTextCharacters = next;
+        }
+
+        internal void ChargeDecodedText(int characters) {
+            long next = _decodedTextCharacters + characters;
+            if (next > _maxDecodedTextCharacters) {
+                throw PdfReadLimitException.Create(PdfReadLimitKind.DecodedTextCharacters, _maxDecodedTextCharacters, next);
+            }
+
+            _decodedTextCharacters = next;
+        }
+    }
+
     internal readonly struct FormInvocation {
         public string Name { get; }
         public Matrix2D Transform { get; }
@@ -131,7 +168,24 @@ internal static class TextContentParser {
         bool useLogicalTextFilters = true,
         int maxOperations = PdfReadLimits.DefaultMaxContentOperations,
         int maxNestingDepth = PdfReadLimits.DefaultMaxContentNestingDepth,
-        int maxOperands = PdfReadLimits.DefaultMaxContentOperands) {
+        int maxOperands = PdfReadLimits.DefaultMaxContentOperands,
+        int maxActualTextCharacters = PdfReadLimits.DefaultMaxActualTextCharacters,
+        int maxDecodedTextCharacters = PdfReadLimits.DefaultMaxDecodedTextCharacters,
+        TextOutputBudget? textOutputBudget = null) {
+#if NET8_0_OR_GREATER
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxActualTextCharacters);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxDecodedTextCharacters);
+#else
+        if (maxActualTextCharacters <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(maxActualTextCharacters));
+        }
+        if (maxDecodedTextCharacters <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(maxDecodedTextCharacters));
+        }
+#endif
+
+        textOutputBudget ??= new TextOutputBudget(maxActualTextCharacters, maxDecodedTextCharacters);
+
         var spans = new List<PdfTextSpan>();
         // Text state
         bool inText = false;
@@ -549,11 +603,13 @@ internal static class TextContentParser {
                 // Artifact content is visual decoration, not logical page text.
             } else if (actualTextState is not null && !actualTextState.ActualTextEmitted) {
                 textOut = actualTextState.ActualText;
+                textOutputBudget.ChargeActualText(textOut.Length);
                 actualTextState.ActualTextEmitted = true;
                 if (textOut.Length > 0) {
                     AddTextSpan(textOut);
                 }
             } else if (actualTextState is null && textOut.Length > 0) {
+                textOutputBudget.ChargeDecodedText(textOut.Length);
                 AddTextSpan(textOut);
             }
 

--- a/OfficeIMO.Pdf/Reading/Core/TextContentParser.cs
+++ b/OfficeIMO.Pdf/Reading/Core/TextContentParser.cs
@@ -625,7 +625,7 @@ internal static class TextContentParser {
             OfficeColor paintColor = ResolveTextPaintColor(textRenderingMode, fillColor, strokeColor);
             OfficeColor visibleColor = ApplyTextOpacity(paintColor, textRenderingMode);
             PdfPageClipPath? spanClipPath = clipPath;
-            if ((isHidden || isArtifact) && textOut.Length > 0) {
+            if (textOut.Length > 0) {
                 textOutputBudget.ChargeDecodedText(textOut.Length);
             }
 
@@ -641,7 +641,6 @@ internal static class TextContentParser {
                     AddTextSpan(textOut);
                 }
             } else if (actualTextState is null && textOut.Length > 0) {
-                textOutputBudget.ChargeDecodedText(textOut.Length);
                 AddTextSpan(textOut);
             }
 

--- a/OfficeIMO.Pdf/Reading/Core/TextContentParser.cs
+++ b/OfficeIMO.Pdf/Reading/Core/TextContentParser.cs
@@ -131,8 +131,11 @@ internal static class TextContentParser {
         }
 
         internal int GetDecodedTextBufferCapacity(int requestedCapacity) {
-            long remaining = _maxDecodedTextCharacters - _decodedTextCharacters;
-            return (int)Math.Min(Math.Max(0L, remaining), Math.Max(0, requestedCapacity));
+            return Math.Min(GetRemainingDecodedTextCharacters(), Math.Max(0, requestedCapacity));
+        }
+
+        internal int GetRemainingDecodedTextCharacters() {
+            return (int)Math.Max(0L, _maxDecodedTextCharacters - _decodedTextCharacters);
         }
     }
 
@@ -204,7 +207,8 @@ internal static class TextContentParser {
         int maxOperands = PdfReadLimits.DefaultMaxContentOperands,
         int maxActualTextCharacters = PdfReadLimits.DefaultMaxActualTextCharacters,
         int maxDecodedTextCharacters = PdfReadLimits.DefaultMaxDecodedTextCharacters,
-        TextOutputBudget? textOutputBudget = null) {
+        TextOutputBudget? textOutputBudget = null,
+        System.Func<string, byte[], int, string>? decodeWithFontWithinLimit = null) {
 #if NET8_0_OR_GREATER
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxActualTextCharacters);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxDecodedTextCharacters);
@@ -571,11 +575,20 @@ internal static class TextContentParser {
         void ShowTextRun(byte[] bytes, double paintOrder) {
             if (!inText || bytes == null || bytes.Length == 0) return;
             MaybeInsertSpaceBeforeRun();
+            string DecodeRun(byte[] value) {
+                int remaining = textOutputBudget.GetRemainingDecodedTextCharacters();
+                if (remaining == 0) {
+                    textOutputBudget.ChargeDecodedText(1);
+                }
+                return decodeWithFontWithinLimit != null
+                    ? decodeWithFontWithinLimit(font, value, remaining)
+                    : decodeWithFont(font, value);
+            }
             // Detect 2-byte CIDs (Identity-H) vs single-byte
             bool twoByte = false;
             if (bytes.Length >= 2) {
-                string one = decodeWithFont(font, new byte[] { bytes[0] });
-                string two = decodeWithFont(font, new byte[] { bytes[0], bytes[1] });
+                string one = DecodeRun(new byte[] { bytes[0] });
+                string two = DecodeRun(new byte[] { bytes[0], bytes[1] });
                 double firstByteWidth = sumWidth1000ForFont(font, new byte[] { bytes[0] });
                 double secondByteWidth = sumWidth1000ForFont(font, new byte[] { bytes[1] });
                 double pairWidth = sumWidth1000ForFont(font, new byte[] { bytes[0], bytes[1] });
@@ -585,11 +598,11 @@ internal static class TextContentParser {
             var sbOut = new StringBuilder(textOutputBudget.GetDecodedTextBufferCapacity(bytes.Length));
             double advTotal = 0;
             char prevChar = '\0';
-            string wholeDecoded = NormalizeDecodedGlyphText(decodeWithFont(font, bytes) ?? string.Empty);
+            string wholeDecoded = NormalizeDecodedGlyphText(DecodeRun(bytes) ?? string.Empty);
             for (int idx = 0; idx < bytes.Length;) {
                 int step = twoByte ? (idx + 1 < bytes.Length ? 2 : 1) : 1;
                 byte[] g = step == 1 ? new byte[] { bytes[idx] } : new byte[] { bytes[idx], bytes[idx + 1] };
-                string t = NormalizeDecodedGlyphText(decodeWithFont(font, g) ?? string.Empty);
+                string t = NormalizeDecodedGlyphText(DecodeRun(g) ?? string.Empty);
                 char ch = (t.Length > 0) ? t[0] : '\0';
                 double w1000 = sumWidth1000ForFont(font, g);
                 double advGlyph = ((w1000 / 1000.0) * size + charSpacing + (ch == ' ' ? wordSpacing : 0)) * hScale;

--- a/OfficeIMO.Pdf/Reading/Diagnostics/PdfSemanticRepairDiagnostics.cs
+++ b/OfficeIMO.Pdf/Reading/Diagnostics/PdfSemanticRepairDiagnostics.cs
@@ -91,8 +91,12 @@ internal static class PdfSemanticRepairDiagnostics {
         List<PdfRepairDiagnostic> diagnostics,
         int depth,
         ref int traversedNodes) {
-        EnsureNameTreeBudget(options.Limits, depth, ++traversedNodes);
-        if (nodeObject is PdfReference reference && !visited.Add(reference.ObjectNumber)) return;
+        EnsureNameTreeBudget(options.Limits, depth, traversedNodes);
+        if (nodeObject is PdfReference reference) {
+            if (!visited.Add(reference.ObjectNumber)) return;
+            EnsureNameTreeBudget(options.Limits, depth, ++traversedNodes);
+        }
+
         PdfDictionary? node = ResolveDictionary(objects, nodeObject);
         if (node is null) { AddDefect(options, diagnostics, "InvalidNameTreeNode", "The " + treeName + " name tree contains a node that does not resolve to a dictionary.", nodeObject is PdfReference missing ? missing.ObjectNumber : null, recovered: false); return; }
         PdfArray? pairs = ResolveArray(objects, node.Items.TryGetValue("Names", out PdfObject? namesObject) ? namesObject : null);
@@ -113,8 +117,12 @@ internal static class PdfSemanticRepairDiagnostics {
         List<PdfRepairDiagnostic> diagnostics,
         int depth,
         ref int traversedNodes) {
-        EnsureNameTreeBudget(options.Limits, depth, ++traversedNodes);
-        if (nodeObject is PdfReference reference && !visited.Add(reference.ObjectNumber)) return;
+        EnsureNameTreeBudget(options.Limits, depth, traversedNodes);
+        if (nodeObject is PdfReference reference) {
+            if (!visited.Add(reference.ObjectNumber)) return;
+            EnsureNameTreeBudget(options.Limits, depth, ++traversedNodes);
+        }
+
         PdfDictionary? node = ResolveDictionary(objects, nodeObject); if (node is null) return;
         if (ResolveArray(objects, node.Items.TryGetValue("Names", out PdfObject? namesObject) ? namesObject : null) is PdfArray pairs) {
             for (int i = 1; i < pairs.Items.Count; i += 2) if (!IsValidDestination(objects, pairs.Items[i], pageObjectNumbers)) AddDefect(options, diagnostics, "BrokenNamedDestination", "A named destination does not resolve to a reachable page and was left unchanged for caller review.", FindObjectNumber(objects, node), recovered: false);

--- a/OfficeIMO.Pdf/Reading/Diagnostics/PdfSemanticRepairDiagnostics.cs
+++ b/OfficeIMO.Pdf/Reading/Diagnostics/PdfSemanticRepairDiagnostics.cs
@@ -63,14 +63,35 @@ internal static class PdfSemanticRepairDiagnostics {
     private static void ValidateNameTrees(Dictionary<int, PdfIndirectObject> objects, PdfDictionary catalog, IReadOnlyList<PdfReadPage> pages, PdfReadOptions options, List<PdfRepairDiagnostic> diagnostics) {
         PdfDictionary? names = ResolveDictionary(objects, catalog.Items.TryGetValue("Names", out PdfObject? namesObject) ? namesObject : null);
         if (names is null) return;
+        int traversedNameTreeNodes = 0;
         foreach (KeyValuePair<string, PdfObject> entry in names.Items) {
-            ValidateNameTreeNode(objects, entry.Value, entry.Key, new HashSet<int>(), options, diagnostics);
+            ValidateNameTreeNode(objects, entry.Value, entry.Key, new HashSet<int>(), options, diagnostics, 0, ref traversedNameTreeNodes);
         }
 
-        if (names.Items.TryGetValue("Dests", out PdfObject? destinations)) ValidateDestinationTree(objects, destinations, new HashSet<int>(), new HashSet<int>(pages.Select(static page => page.ObjectNumber)), options, diagnostics);
+        if (names.Items.TryGetValue("Dests", out PdfObject? destinations)) {
+            int traversedDestinationTreeNodes = 0;
+            ValidateDestinationTree(
+                objects,
+                destinations,
+                new HashSet<int>(),
+                new HashSet<int>(pages.Select(static page => page.ObjectNumber)),
+                options,
+                diagnostics,
+                0,
+                ref traversedDestinationTreeNodes);
+        }
     }
 
-    private static void ValidateNameTreeNode(Dictionary<int, PdfIndirectObject> objects, PdfObject nodeObject, string treeName, HashSet<int> visited, PdfReadOptions options, List<PdfRepairDiagnostic> diagnostics) {
+    private static void ValidateNameTreeNode(
+        Dictionary<int, PdfIndirectObject> objects,
+        PdfObject nodeObject,
+        string treeName,
+        HashSet<int> visited,
+        PdfReadOptions options,
+        List<PdfRepairDiagnostic> diagnostics,
+        int depth,
+        ref int traversedNodes) {
+        EnsureNameTreeBudget(options.Limits, depth, ++traversedNodes);
         if (nodeObject is PdfReference reference && !visited.Add(reference.ObjectNumber)) return;
         PdfDictionary? node = ResolveDictionary(objects, nodeObject);
         if (node is null) { AddDefect(options, diagnostics, "InvalidNameTreeNode", "The " + treeName + " name tree contains a node that does not resolve to a dictionary.", nodeObject is PdfReference missing ? missing.ObjectNumber : null, recovered: false); return; }
@@ -80,16 +101,35 @@ internal static class PdfSemanticRepairDiagnostics {
         bool hasKids = kids is not null;
         if (hasNames && hasKids) AddDefect(options, diagnostics, "MixedNameTreeNode", "The " + treeName + " name-tree node contains both /Names and /Kids and was left unchanged to avoid changing lookup semantics.", FindObjectNumber(objects, node), recovered: false);
         if (hasNames && pairs!.Items.Count % 2 != 0) AddDefect(options, diagnostics, "OddNameTreePairs", "The " + treeName + " name-tree /Names array has an unmatched key or value and was left unchanged.", FindObjectNumber(objects, node), recovered: false);
-        if (hasKids) foreach (PdfObject kid in kids!.Items) ValidateNameTreeNode(objects, kid, treeName, visited, options, diagnostics);
+        if (hasKids) foreach (PdfObject kid in kids!.Items) ValidateNameTreeNode(objects, kid, treeName, visited, options, diagnostics, depth + 1, ref traversedNodes);
     }
 
-    private static void ValidateDestinationTree(Dictionary<int, PdfIndirectObject> objects, PdfObject nodeObject, HashSet<int> visited, HashSet<int> pageObjectNumbers, PdfReadOptions options, List<PdfRepairDiagnostic> diagnostics) {
+    private static void ValidateDestinationTree(
+        Dictionary<int, PdfIndirectObject> objects,
+        PdfObject nodeObject,
+        HashSet<int> visited,
+        HashSet<int> pageObjectNumbers,
+        PdfReadOptions options,
+        List<PdfRepairDiagnostic> diagnostics,
+        int depth,
+        ref int traversedNodes) {
+        EnsureNameTreeBudget(options.Limits, depth, ++traversedNodes);
         if (nodeObject is PdfReference reference && !visited.Add(reference.ObjectNumber)) return;
         PdfDictionary? node = ResolveDictionary(objects, nodeObject); if (node is null) return;
         if (ResolveArray(objects, node.Items.TryGetValue("Names", out PdfObject? namesObject) ? namesObject : null) is PdfArray pairs) {
             for (int i = 1; i < pairs.Items.Count; i += 2) if (!IsValidDestination(objects, pairs.Items[i], pageObjectNumbers)) AddDefect(options, diagnostics, "BrokenNamedDestination", "A named destination does not resolve to a reachable page and was left unchanged for caller review.", FindObjectNumber(objects, node), recovered: false);
         }
-        if (ResolveArray(objects, node.Items.TryGetValue("Kids", out PdfObject? kidsObject) ? kidsObject : null) is PdfArray kids) foreach (PdfObject kid in kids.Items) ValidateDestinationTree(objects, kid, visited, pageObjectNumbers, options, diagnostics);
+        if (ResolveArray(objects, node.Items.TryGetValue("Kids", out PdfObject? kidsObject) ? kidsObject : null) is PdfArray kids) foreach (PdfObject kid in kids.Items) ValidateDestinationTree(objects, kid, visited, pageObjectNumbers, options, diagnostics, depth + 1, ref traversedNodes);
+    }
+
+    private static void EnsureNameTreeBudget(PdfReadLimits limits, int depth, int traversedNodes) {
+        if (depth > limits.MaxNameTreeDepth) {
+            throw PdfReadLimitException.Create(PdfReadLimitKind.NameTreeDepth, limits.MaxNameTreeDepth, depth);
+        }
+
+        if (traversedNodes > limits.MaxNameTreeNodes) {
+            throw PdfReadLimitException.Create(PdfReadLimitKind.NameTreeNodes, limits.MaxNameTreeNodes, traversedNodes);
+        }
     }
 
     private static bool IsValidDestination(Dictionary<int, PdfIndirectObject> objects, PdfObject destinationObject, HashSet<int> pageObjectNumbers) {

--- a/OfficeIMO.Pdf/Reading/Diagnostics/PdfSemanticRepairDiagnostics.cs
+++ b/OfficeIMO.Pdf/Reading/Diagnostics/PdfSemanticRepairDiagnostics.cs
@@ -63,8 +63,8 @@ internal static class PdfSemanticRepairDiagnostics {
     private static void ValidateNameTrees(Dictionary<int, PdfIndirectObject> objects, PdfDictionary catalog, IReadOnlyList<PdfReadPage> pages, PdfReadOptions options, List<PdfRepairDiagnostic> diagnostics) {
         PdfDictionary? names = ResolveDictionary(objects, catalog.Items.TryGetValue("Names", out PdfObject? namesObject) ? namesObject : null);
         if (names is null) return;
-        int traversedNameTreeNodes = 0;
         foreach (KeyValuePair<string, PdfObject> entry in names.Items) {
+            int traversedNameTreeNodes = 0;
             ValidateNameTreeNode(objects, entry.Value, entry.Key, new HashSet<int>(), options, diagnostics, 0, ref traversedNameTreeNodes);
         }
 

--- a/OfficeIMO.Pdf/Reading/Filters/PngPredictorDecoder.cs
+++ b/OfficeIMO.Pdf/Reading/Filters/PngPredictorDecoder.cs
@@ -1,7 +1,11 @@
 namespace OfficeIMO.Pdf.Filters;
 
 internal static class PngPredictorDecoder {
-    public static byte[] Decode(byte[] data, int columns, int colors = 1, int bitsPerComponent = 8) {
+    public static byte[] Decode(byte[] data, int columns, int colors, int bitsPerComponent, int maxOutputBytes) {
+        if (maxOutputBytes <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(maxOutputBytes), maxOutputBytes, "Maximum decoded stream bytes must be positive.");
+        }
+
         if (data == null || data.Length == 0) {
             return Array.Empty<byte>();
         }
@@ -10,13 +14,32 @@ internal static class PngPredictorDecoder {
         bitsPerComponent = Math.Max(1, bitsPerComponent);
         columns = Math.Max(1, columns);
 
-        int bytesPerPixel = Math.Max(1, (colors * bitsPerComponent + 7) / 8);
-        int rowLength = (columns * colors * bitsPerComponent + 7) / 8;
-        if (rowLength <= 0) {
-            return data;
+        long bitsPerPixel = ((long)colors * bitsPerComponent) + 7L;
+        long rowBits;
+        try {
+            rowBits = checked((long)columns * colors * bitsPerComponent);
+        } catch (OverflowException) {
+            throw CreateDecodedLimitException(maxOutputBytes, (long)maxOutputBytes + 1L);
         }
 
-        var output = new byte[(data.Length / (rowLength + 1) + 1) * rowLength];
+        long rowLengthValue = (rowBits + 7L) / 8L;
+        if (rowLengthValue <= 0L || rowLengthValue > maxOutputBytes) {
+            throw CreateDecodedLimitException(maxOutputBytes, Math.Max(rowLengthValue, (long)maxOutputBytes + 1L));
+        }
+
+        int rowLength = (int)rowLengthValue;
+        int bytesPerPixel = (int)Math.Max(1L, bitsPerPixel / 8L);
+        long encodedRowLength = rowLengthValue + 1L;
+        if (data.LongLength % encodedRowLength != 0L) {
+            throw new FormatException("PNG predictor row exceeds decoded stream length.");
+        }
+
+        long outputLength = (data.LongLength / encodedRowLength) * rowLengthValue;
+        if (outputLength > maxOutputBytes) {
+            throw CreateDecodedLimitException(maxOutputBytes, outputLength);
+        }
+
+        var output = new byte[(int)outputLength];
         int outputOffset = 0;
         int inputOffset = 0;
         var previousRow = new byte[rowLength];
@@ -77,6 +100,9 @@ internal static class PngPredictorDecoder {
         Buffer.BlockCopy(output, 0, trimmed, 0, outputOffset);
         return trimmed;
     }
+
+    private static PdfReadLimitException CreateDecodedLimitException(int maximum, long actual) =>
+        PdfReadLimitException.Create(PdfReadLimitKind.DecodedStreamBytes, maximum, actual);
 
     private static int PaethPredictor(int left, int up, int upLeft) {
         int prediction = left + up - upLeft;

--- a/OfficeIMO.Pdf/Reading/Filters/StreamDecoder.cs
+++ b/OfficeIMO.Pdf/Reading/Filters/StreamDecoder.cs
@@ -42,7 +42,7 @@ internal static class StreamDecoder {
                             return original;
                         }
 
-                        current = ApplyDecodeParms(dict, filterIndex, current, objects);
+                        current = ApplyDecodeParms(dict, filterIndex, current, objects, maxOutputBytes);
                         break;
                     case DecodeFilterKind.AsciiHex:
                         if (!AsciiHexDecoder.TryDecode(current, maxOutputBytes, out current)) {
@@ -67,7 +67,7 @@ internal static class StreamDecoder {
                             throw CreateDecodedLimitException(maxOutputBytes, (long)maxOutputBytes + 1L);
                         }
 
-                        current = ApplyDecodeParms(dict, filterIndex, current, objects);
+                        current = ApplyDecodeParms(dict, filterIndex, current, objects, maxOutputBytes);
                         break;
                     default:
                         return original;
@@ -240,7 +240,12 @@ internal static class StreamDecoder {
         return predictor > 1;
     }
 
-    private static byte[] ApplyDecodeParms(PdfDictionary dict, int filterIndex, byte[] data, Dictionary<int, PdfIndirectObject>? objects) {
+    private static byte[] ApplyDecodeParms(
+        PdfDictionary dict,
+        int filterIndex,
+        byte[] data,
+        Dictionary<int, PdfIndirectObject>? objects,
+        int maxOutputBytes) {
         var decodeParms = GetDecodeParms(dict, filterIndex, objects);
         if (decodeParms is null) {
             return data;
@@ -255,14 +260,14 @@ internal static class StreamDecoder {
         int colors = (int)(decodeParms.Get<PdfNumber>("Colors")?.Value ?? 1);
         int bitsPerComponent = (int)(decodeParms.Get<PdfNumber>("BitsPerComponent")?.Value ?? 8);
         if (predictor == 2) {
-            return TiffPredictorDecoder.Decode(data, columns, colors, bitsPerComponent);
+            return TiffPredictorDecoder.Decode(data, columns, colors, bitsPerComponent, maxOutputBytes);
         }
 
         if (predictor < 10) {
             return data;
         }
 
-        return PngPredictorDecoder.Decode(data, columns, colors, bitsPerComponent);
+        return PngPredictorDecoder.Decode(data, columns, colors, bitsPerComponent, maxOutputBytes);
     }
 
     private static int GetEarlyChange(PdfDictionary dict, int filterIndex, Dictionary<int, PdfIndirectObject>? objects) {

--- a/OfficeIMO.Pdf/Reading/Filters/StreamDecoder.cs
+++ b/OfficeIMO.Pdf/Reading/Filters/StreamDecoder.cs
@@ -39,7 +39,7 @@ internal static class StreamDecoder {
                                 throw CreateDecodedLimitException(maxOutputBytes, (long)maxOutputBytes + 1L);
                             }
 
-                            return original;
+                            return ReturnWithinDecodedLimit(original, maxOutputBytes);
                         }
 
                         current = ApplyDecodeParms(dict, filterIndex, current, objects, maxOutputBytes);
@@ -70,19 +70,19 @@ internal static class StreamDecoder {
                         current = ApplyDecodeParms(dict, filterIndex, current, objects, maxOutputBytes);
                         break;
                     default:
-                        return original;
+                        return ReturnWithinDecodedLimit(original, maxOutputBytes);
                 }
                 ThrowIfDecodedLimitExceeded(current.LongLength, maxOutputBytes);
             } catch (PdfReadLimitException) {
                 throw;
             } catch {
-                return original;
+                return ReturnWithinDecodedLimit(original, maxOutputBytes);
             }
 
             filterIndex++;
         }
 
-        return current;
+        return ReturnWithinDecodedLimit(current, maxOutputBytes);
     }
 
     public static bool TryDecode(PdfDictionary dict, byte[] data, int maxOutputBytes, out byte[] decoded, Dictionary<int, PdfIndirectObject>? objects = null) {
@@ -229,6 +229,11 @@ internal static class StreamDecoder {
 
     private static PdfReadLimitException CreateDecodedLimitException(int maximum, long actual) =>
         PdfReadLimitException.Create(PdfReadLimitKind.DecodedStreamBytes, maximum, actual);
+
+    private static byte[] ReturnWithinDecodedLimit(byte[] data, int maximum) {
+        ThrowIfDecodedLimitExceeded(data.LongLength, maximum);
+        return data;
+    }
 
     private static bool HasActiveDecodeParms(PdfDictionary dict, int filterIndex, Dictionary<int, PdfIndirectObject>? objects) {
         var decodeParms = GetDecodeParms(dict, filterIndex, objects);

--- a/OfficeIMO.Pdf/Reading/Filters/TiffPredictorDecoder.cs
+++ b/OfficeIMO.Pdf/Reading/Filters/TiffPredictorDecoder.cs
@@ -1,9 +1,16 @@
 namespace OfficeIMO.Pdf.Filters;
 
 internal static class TiffPredictorDecoder {
-    public static byte[] Decode(byte[] data, int columns, int colors = 1, int bitsPerComponent = 8) {
+    public static byte[] Decode(byte[] data, int columns, int colors, int bitsPerComponent, int maxOutputBytes) {
+        if (maxOutputBytes <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(maxOutputBytes), maxOutputBytes, "Maximum decoded stream bytes must be positive.");
+        }
+
         if (data == null || data.Length == 0) {
             return Array.Empty<byte>();
+        }
+        if (data.LongLength > maxOutputBytes) {
+            throw CreateDecodedLimitException(maxOutputBytes, data.LongLength);
         }
 
         colors = Math.Max(1, colors);
@@ -14,8 +21,13 @@ internal static class TiffPredictorDecoder {
             return data;
         }
 
-        int rowLength = columns * colors;
-        if (rowLength <= 0 || data.Length % rowLength != 0) {
+        long rowLengthValue = (long)columns * colors;
+        if (rowLengthValue <= 0L || rowLengthValue > maxOutputBytes) {
+            throw CreateDecodedLimitException(maxOutputBytes, Math.Max(rowLengthValue, (long)maxOutputBytes + 1L));
+        }
+
+        int rowLength = (int)rowLengthValue;
+        if (data.Length % rowLength != 0) {
             return data;
         }
 
@@ -29,4 +41,7 @@ internal static class TiffPredictorDecoder {
 
         return output;
     }
+
+    private static PdfReadLimitException CreateDecodedLimitException(int maximum, long actual) =>
+        PdfReadLimitException.Create(PdfReadLimitKind.DecodedStreamBytes, maximum, actual);
 }

--- a/OfficeIMO.Pdf/Reading/Font/PdfMacRomanEncoding.cs
+++ b/OfficeIMO.Pdf/Reading/Font/PdfMacRomanEncoding.cs
@@ -21,6 +21,13 @@ internal static class PdfMacRomanEncoding {
     };
 
     public static string Decode(byte[] bytes) {
+        return Decode(bytes, int.MaxValue);
+    }
+
+    public static string Decode(byte[] bytes, int maxOutputCharacters) {
+        if (bytes.LongLength > maxOutputCharacters) {
+            throw PdfReadLimitException.Create(PdfReadLimitKind.DecodedTextCharacters, maxOutputCharacters, bytes.LongLength);
+        }
         var chars = new char[bytes.Length];
         for (int i = 0; i < bytes.Length; i++) chars[i] = Map[bytes[i]];
         return new string(chars);

--- a/OfficeIMO.Pdf/Reading/Font/PdfStandardEncoding.cs
+++ b/OfficeIMO.Pdf/Reading/Font/PdfStandardEncoding.cs
@@ -4,8 +4,20 @@ internal static class PdfStandardEncoding {
     private static readonly string[] Map = BuildMap();
 
     public static string Decode(byte[] bytes) {
+        return Decode(bytes, int.MaxValue);
+    }
+
+    public static string Decode(byte[] bytes, int maxOutputCharacters) {
         if (bytes is null || bytes.Length == 0) return string.Empty;
-        var builder = new System.Text.StringBuilder(bytes.Length);
+        long decodedLength = 0L;
+        for (int i = 0; i < bytes.Length; i++) {
+            decodedLength += Map[bytes[i]].Length;
+            if (decodedLength > maxOutputCharacters) {
+                throw PdfReadLimitException.Create(PdfReadLimitKind.DecodedTextCharacters, maxOutputCharacters, decodedLength);
+            }
+        }
+
+        var builder = new System.Text.StringBuilder((int)decodedLength);
         for (int i = 0; i < bytes.Length; i++) {
             builder.Append(Map[bytes[i]]);
         }

--- a/OfficeIMO.Pdf/Reading/Font/PdfWinAnsiEncoding.cs
+++ b/OfficeIMO.Pdf/Reading/Font/PdfWinAnsiEncoding.cs
@@ -26,6 +26,13 @@ internal static class PdfWinAnsiEncoding {
     private static readonly System.Collections.Generic.Dictionary<char, byte> ReverseMap = BuildReverse();
 
     public static string Decode(byte[] bytes) {
+        return Decode(bytes, int.MaxValue);
+    }
+
+    public static string Decode(byte[] bytes, int maxOutputCharacters) {
+        if (bytes.LongLength > maxOutputCharacters) {
+            throw PdfReadLimitException.Create(PdfReadLimitKind.DecodedTextCharacters, maxOutputCharacters, bytes.LongLength);
+        }
         var chars = new char[bytes.Length];
         for (int i = 0; i < bytes.Length; i++) chars[i] = Map[bytes[i]];
         return new string(chars);

--- a/OfficeIMO.Pdf/Reading/Font/ToUnicodeCMap.cs
+++ b/OfficeIMO.Pdf/Reading/Font/ToUnicodeCMap.cs
@@ -5,6 +5,9 @@ namespace OfficeIMO.Pdf;
 internal sealed class ToUnicodeCMap {
     private const int MaxMappings = 65536;
     private const int MaxRangeMappings = 4096;
+    private const int MaxSourceCodeBytes = 4;
+    private const int MaxDestinationTextCharacters = 4096;
+    private const int MaxDestinationHexCharactersWithWhitespace = MaxDestinationTextCharacters * 8;
 
     private readonly Dictionary<string, string> _map = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, string> _reverseMap = new(StringComparer.Ordinal);
@@ -99,9 +102,17 @@ internal sealed class ToUnicodeCMap {
         }
 
         _processedMappings++;
+        if (dstHex.Length > MaxDestinationHexCharactersWithWhitespace) {
+            return;
+        }
+
         srcHex = RemoveHexWhitespace(srcHex);
         dstHex = RemoveHexWhitespace(dstHex);
         if (srcHex.Length % 2 != 0) srcHex = "0" + srcHex;
+        if (srcHex.Length == 0 || srcHex.Length / 2 > MaxSourceCodeBytes || dstHex.Length > MaxDestinationTextCharacters * 4) {
+            return;
+        }
+
         _maxKeyBytes = Math.Max(_maxKeyBytes, srcHex.Length / 2);
         string key = srcHex.ToUpperInvariant();
         // dst may be multi-codepoints; keep as UTF-16 string
@@ -170,7 +181,13 @@ internal sealed class ToUnicodeCMap {
         return new string(chars.ToArray());
     }
 
-    public string MapBytes(byte[] bytes) {
+    public string MapBytes(byte[] bytes) => MapBytes(bytes, PdfReadLimits.DefaultMaxDecodedTextCharacters);
+
+    internal string MapBytes(byte[] bytes, int maxOutputCharacters) {
+        if (maxOutputCharacters <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(maxOutputCharacters), maxOutputCharacters, "Maximum decoded text characters must be positive.");
+        }
+
         var sb = new System.Text.StringBuilder();
         for (int i = 0; i < bytes.Length;) {
             // Greedy match up to _maxKeyBytes (1-2 bytes typical)
@@ -180,6 +197,12 @@ internal sealed class ToUnicodeCMap {
                 string key = ByteSliceToHex(bytes, i, len);
                 if (_map.TryGetValue(key, out var s)) { mapped = s; used = len; break; }
             }
+            int appendLength = mapped?.Length ?? 1;
+            long nextLength = (long)sb.Length + appendLength;
+            if (nextLength > maxOutputCharacters) {
+                throw PdfReadLimitException.Create(PdfReadLimitKind.DecodedTextCharacters, maxOutputCharacters, nextLength);
+            }
+
             if (mapped is null) { sb.Append((char)bytes[i]); i++; } else { sb.Append(mapped); i += used; }
         }
         return sb.ToString();

--- a/OfficeIMO.Pdf/Reading/Font/ToUnicodeCMap.cs
+++ b/OfficeIMO.Pdf/Reading/Font/ToUnicodeCMap.cs
@@ -101,7 +101,6 @@ internal sealed class ToUnicodeCMap {
             return;
         }
 
-        _processedMappings++;
         if (dstHex.Length > MaxDestinationHexCharactersWithWhitespace) {
             return;
         }
@@ -113,6 +112,7 @@ internal sealed class ToUnicodeCMap {
             return;
         }
 
+        _processedMappings++;
         _maxKeyBytes = Math.Max(_maxKeyBytes, srcHex.Length / 2);
         string key = srcHex.ToUpperInvariant();
         // dst may be multi-codepoints; keep as UTF-16 string

--- a/OfficeIMO.Pdf/Reading/Layout/ContentStructureExtractor.cs
+++ b/OfficeIMO.Pdf/Reading/Layout/ContentStructureExtractor.cs
@@ -568,8 +568,10 @@ internal static class ContentStructureExtractor {
     private static bool TryParseTocRow(string text, out string label, out int pageNumber) {
         label = string.Empty;
         pageNumber = 0;
-        bool[] whitespaceSuffix = BuildWhitespaceSuffix(text);
-        int[] nextNonWhitespace = BuildNextNonWhitespace(text);
+        int trailingContentEnd = text.Length;
+        while (trailingContentEnd > 0 && char.IsWhiteSpace(text[trailingContentEnd - 1])) {
+            trailingContentEnd--;
+        }
 
         for (int index = 1; index < text.Length;) {
             if (text[index] != '.') {
@@ -586,14 +588,14 @@ internal static class ContentStructureExtractor {
                 continue;
             }
 
-            int digitStart = nextNonWhitespace[index];
+            int digitStart = SkipWhitespace(text, index);
             int digitEnd = digitStart;
-            while (digitEnd < text.Length && digitEnd - digitStart < 6 && text[digitEnd] is >= '0' and <= '9') {
+            while (digitEnd < trailingContentEnd && digitEnd - digitStart < 6 && text[digitEnd] is >= '0' and <= '9') {
                 digitEnd++;
             }
 
             int digitCount = digitEnd - digitStart;
-            if (digitCount is < 1 or > 5 || !whitespaceSuffix[digitEnd]) {
+            if (digitCount is < 1 or > 5 || digitEnd != trailingContentEnd) {
                 continue;
             }
 
@@ -611,8 +613,7 @@ internal static class ContentStructureExtractor {
     private static bool TryParseLeaderRow(string text, out string label, out string value) {
         label = string.Empty;
         value = string.Empty;
-        bool[] validValueSuffix = BuildLeaderValueSuffix(text);
-        int[] nextNonWhitespace = BuildNextNonWhitespace(text);
+        int validValueSuffixStart = FindValidLeaderValueSuffixStart(text);
 
         for (int index = 1; index < text.Length;) {
             char leader = text[index];
@@ -630,14 +631,14 @@ internal static class ContentStructureExtractor {
                 continue;
             }
 
-            int valueStart = nextNonWhitespace[index];
+            int valueStart = SkipWhitespace(text, index);
             if (valueStart < text.Length && IsLeaderCurrency(text[valueStart])) {
-                valueStart = nextNonWhitespace[valueStart + 1];
+                valueStart = SkipWhitespace(text, valueStart + 1);
             }
 
             if (valueStart >= text.Length ||
                 !char.IsLetterOrDigit(text[valueStart]) ||
-                !validValueSuffix[valueStart]) {
+                valueStart < validValueSuffixStart) {
                 continue;
             }
 
@@ -649,38 +650,26 @@ internal static class ContentStructureExtractor {
         return false;
     }
 
-    private static bool[] BuildWhitespaceSuffix(string text) {
-        var result = new bool[text.Length + 1];
-        result[text.Length] = true;
-        for (int index = text.Length - 1; index >= 0; index--) {
-            result[index] = char.IsWhiteSpace(text[index]) && result[index + 1];
-        }
-
-        return result;
-    }
-
-    private static bool[] BuildLeaderValueSuffix(string text) {
-        var result = new bool[text.Length + 1];
-        result[text.Length] = true;
+    private static int FindValidLeaderValueSuffixStart(string text) {
         for (int index = text.Length - 1; index >= 0; index--) {
             char character = text[index];
             bool allowed = char.IsLetterOrDigit(character) ||
                            char.IsWhiteSpace(character) ||
                            character is '.' or ',' or '\'' or '/' or '%' or '+' or '-' or '(' or ')';
-            result[index] = allowed && result[index + 1];
+            if (!allowed) {
+                return index + 1;
+            }
         }
 
-        return result;
+        return 0;
     }
 
-    private static int[] BuildNextNonWhitespace(string text) {
-        var result = new int[text.Length + 1];
-        result[text.Length] = text.Length;
-        for (int index = text.Length - 1; index >= 0; index--) {
-            result[index] = char.IsWhiteSpace(text[index]) ? result[index + 1] : index;
+    private static int SkipWhitespace(string text, int index) {
+        while (index < text.Length && char.IsWhiteSpace(text[index])) {
+            index++;
         }
 
-        return result;
+        return index;
     }
 
     private static bool IsLeaderCurrency(char value) => value is '$' or '€' or '£';

--- a/OfficeIMO.Pdf/Reading/Layout/ContentStructureExtractor.cs
+++ b/OfficeIMO.Pdf/Reading/Layout/ContentStructureExtractor.cs
@@ -205,8 +205,6 @@ public sealed class StructuredLine {
 }
 
 internal static class ContentStructureExtractor {
-    private static readonly Regex TocRegex = new Regex(@"^(?<label>.+?)\s*\.{3,}\s+(?<num>\d{1,5})\s*$", RegexOptions.Compiled);
-    private static readonly Regex LeaderRowRegex = new Regex(@"^(?<label>.+?)(?:\.{3,}|-{3,}|_{3,})\s*(?<value>[$€£]?\s*[A-Za-z0-9][A-Za-z0-9\s.,'/%+\-()]*)\s*$", RegexOptions.Compiled);
     private static readonly Regex ListRegex = new Regex(@"^\s*(?:[\u2022\u25CF]\s*|[\-\*]\s+|\d+(?:\.\d+)*[\.)]\s*|\([A-Za-z0-9]+\)\s*).+", RegexOptions.Compiled);
     private static readonly Regex NumberListRegex = new Regex(@"^\s*(?<mark>\d+(?:\.\d+)*)[\.)]\s*(?<text>.+)$", RegexOptions.Compiled);
     private static readonly Regex BulletRegex = new Regex(@"^\s*(?:(?<mark>[\u2022\u25CF])\s*|(?<mark>[\-\*])\s+)(?<text>.+)$", RegexOptions.Compiled);
@@ -233,9 +231,8 @@ internal static class ContentStructureExtractor {
             string t = ln.Text.Trim();
             if (t.Length == 0) continue;
             page.Lines.Add(t);
-            var mToc = TocRegex.Match(t);
-            if (mToc.Success && int.TryParse(mToc.Groups["num"].Value, out int num)) {
-                var label = NormalizeShattered(mToc.Groups["label"].Value.TrimEnd('.').Trim());
+            if (TryParseTocRow(t, out string tocLabel, out int num)) {
+                var label = NormalizeShattered(tocLabel.TrimEnd('.').Trim());
                 page.Toc.Add((label, num));
                 AddLeaderRow(page, label, num.ToString(System.Globalization.CultureInfo.InvariantCulture));
                 continue;
@@ -257,11 +254,10 @@ internal static class ContentStructureExtractor {
                 }
             }
             else {
-                var mLeader = LeaderRowRegex.Match(t);
-                if (mLeader.Success) {
-                    var value = NormalizeLeaderValue(mLeader.Groups["value"].Value);
+                if (TryParseLeaderRow(t, out string leaderLabel, out string leaderValue)) {
+                    var value = NormalizeLeaderValue(leaderValue);
                     if (value.Length > 0) {
-                        var left = NormalizeShattered(mLeader.Groups["label"].Value.TrimEnd('.', '-', '_', ' ').Trim());
+                        var left = NormalizeShattered(leaderLabel.TrimEnd('.', '-', '_', ' ').Trim());
                         AddLeaderRow(page, left, value);
                     }
                 }
@@ -568,6 +564,126 @@ internal static class ContentStructureExtractor {
 
         page.LeaderRows.Add(new[] { label, value });
     }
+
+    private static bool TryParseTocRow(string text, out string label, out int pageNumber) {
+        label = string.Empty;
+        pageNumber = 0;
+        bool[] whitespaceSuffix = BuildWhitespaceSuffix(text);
+        int[] nextNonWhitespace = BuildNextNonWhitespace(text);
+
+        for (int index = 1; index < text.Length;) {
+            if (text[index] != '.') {
+                index++;
+                continue;
+            }
+
+            int runStart = index;
+            while (index < text.Length && text[index] == '.') {
+                index++;
+            }
+
+            if (index - runStart < 3 || index >= text.Length || !char.IsWhiteSpace(text[index])) {
+                continue;
+            }
+
+            int digitStart = nextNonWhitespace[index];
+            int digitEnd = digitStart;
+            while (digitEnd < text.Length && digitEnd - digitStart < 6 && text[digitEnd] is >= '0' and <= '9') {
+                digitEnd++;
+            }
+
+            int digitCount = digitEnd - digitStart;
+            if (digitCount is < 1 or > 5 || !whitespaceSuffix[digitEnd]) {
+                continue;
+            }
+
+            label = text.Substring(0, runStart);
+            for (int digitIndex = digitStart; digitIndex < digitEnd; digitIndex++) {
+                pageNumber = checked((pageNumber * 10) + (text[digitIndex] - '0'));
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryParseLeaderRow(string text, out string label, out string value) {
+        label = string.Empty;
+        value = string.Empty;
+        bool[] validValueSuffix = BuildLeaderValueSuffix(text);
+        int[] nextNonWhitespace = BuildNextNonWhitespace(text);
+
+        for (int index = 1; index < text.Length;) {
+            char leader = text[index];
+            if (leader != '.' && leader != '-' && leader != '_') {
+                index++;
+                continue;
+            }
+
+            int runStart = index;
+            while (index < text.Length && text[index] == leader) {
+                index++;
+            }
+
+            if (index - runStart < 3) {
+                continue;
+            }
+
+            int valueStart = nextNonWhitespace[index];
+            if (valueStart < text.Length && IsLeaderCurrency(text[valueStart])) {
+                valueStart = nextNonWhitespace[valueStart + 1];
+            }
+
+            if (valueStart >= text.Length ||
+                !char.IsLetterOrDigit(text[valueStart]) ||
+                !validValueSuffix[valueStart]) {
+                continue;
+            }
+
+            label = text.Substring(0, runStart);
+            value = text.Substring(index);
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool[] BuildWhitespaceSuffix(string text) {
+        var result = new bool[text.Length + 1];
+        result[text.Length] = true;
+        for (int index = text.Length - 1; index >= 0; index--) {
+            result[index] = char.IsWhiteSpace(text[index]) && result[index + 1];
+        }
+
+        return result;
+    }
+
+    private static bool[] BuildLeaderValueSuffix(string text) {
+        var result = new bool[text.Length + 1];
+        result[text.Length] = true;
+        for (int index = text.Length - 1; index >= 0; index--) {
+            char character = text[index];
+            bool allowed = char.IsLetterOrDigit(character) ||
+                           char.IsWhiteSpace(character) ||
+                           character is '.' or ',' or '\'' or '/' or '%' or '+' or '-' or '(' or ')';
+            result[index] = allowed && result[index + 1];
+        }
+
+        return result;
+    }
+
+    private static int[] BuildNextNonWhitespace(string text) {
+        var result = new int[text.Length + 1];
+        result[text.Length] = text.Length;
+        for (int index = text.Length - 1; index >= 0; index--) {
+            result[index] = char.IsWhiteSpace(text[index]) ? result[index + 1] : index;
+        }
+
+        return result;
+    }
+
+    private static bool IsLeaderCurrency(char value) => value is '$' or '€' or '£';
 
     private static bool IsWordish(char c) => char.IsLetter(c) || c == '\'' || c == '-' || c == '/';
     private static bool IsAllLetters(string s) { for (int i = 0; i < s.Length; i++) if (!IsWordish(s[i])) return false; return s.Length > 0; }

--- a/OfficeIMO.Pdf/Reading/Model/PdfExtractedAttachment.cs
+++ b/OfficeIMO.Pdf/Reading/Model/PdfExtractedAttachment.cs
@@ -72,4 +72,7 @@ public sealed class PdfExtractedAttachment {
 
     /// <summary>Decoded embedded file bytes. The returned array is a defensive copy.</summary>
     public byte[] Bytes => (byte[])_bytes.Clone();
+
+    /// <summary>Decoded payload size without allocating the defensive public copy.</summary>
+    internal int ByteLength => _bytes.Length;
 }

--- a/OfficeIMO.Pdf/Reading/Options/PdfReadLimitKind.cs
+++ b/OfficeIMO.Pdf/Reading/Options/PdfReadLimitKind.cs
@@ -90,5 +90,11 @@ public enum PdfReadLimitKind {
     NameTreeDepth = 28,
 
     /// <summary>Font-decoded text characters emitted while extracting one page.</summary>
-    DecodedTextCharacters = 29
+    DecodedTextCharacters = 29,
+
+    /// <summary>Attachment records discovered across the document catalog and annotations.</summary>
+    Attachments = 30,
+
+    /// <summary>Aggregate decoded bytes retained for unique embedded attachment streams.</summary>
+    AttachmentBytes = 31
 }

--- a/OfficeIMO.Pdf/Reading/Options/PdfReadLimitKind.cs
+++ b/OfficeIMO.Pdf/Reading/Options/PdfReadLimitKind.cs
@@ -75,5 +75,20 @@ public enum PdfReadLimitKind {
     RenderBytes = 23,
 
     /// <summary>Named appearance states declared for one AcroForm widget.</summary>
-    FormAppearanceStates = 24
+    FormAppearanceStates = 24,
+
+    /// <summary>Aggregate decoded content-stream bytes materialized for one page.</summary>
+    PageContentBytes = 25,
+
+    /// <summary>Characters emitted from marked-content ActualText replacements.</summary>
+    ActualTextCharacters = 26,
+
+    /// <summary>Indirect nodes traversed in a PDF name tree.</summary>
+    NameTreeNodes = 27,
+
+    /// <summary>Nested PDF name-tree depth.</summary>
+    NameTreeDepth = 28,
+
+    /// <summary>Font-decoded text characters emitted while extracting one page.</summary>
+    DecodedTextCharacters = 29
 }

--- a/OfficeIMO.Pdf/Reading/Options/PdfReadLimits.cs
+++ b/OfficeIMO.Pdf/Reading/Options/PdfReadLimits.cs
@@ -11,6 +11,8 @@ public sealed class PdfReadLimits {
     internal const int DefaultMaxDecodedTextCharacters = 10_000_000;
     internal const int DefaultMaxNameTreeNodes = 100_000;
     internal const int DefaultMaxNameTreeDepth = 128;
+    internal const int DefaultMaxAttachments = 100_000;
+    internal const long DefaultMaxTotalAttachmentBytes = 256L * 1024L * 1024L;
 
     /// <summary>Creates default parser budgets that callers can customize without changing another options instance.</summary>
     public static PdfReadLimits Default => new PdfReadLimits();
@@ -72,6 +74,12 @@ public sealed class PdfReadLimits {
     /// <summary>Maximum nested PDF name-tree depth. Default: 128.</summary>
     public int MaxNameTreeDepth { get; init; } = DefaultMaxNameTreeDepth;
 
+    /// <summary>Maximum attachment records discovered across name trees, associated files, and annotations. Default: 100,000.</summary>
+    public int MaxAttachments { get; init; } = DefaultMaxAttachments;
+
+    /// <summary>Maximum aggregate decoded bytes retained for unique embedded attachment streams. Default: 256 MiB.</summary>
+    public long MaxTotalAttachmentBytes { get; init; } = DefaultMaxTotalAttachmentBytes;
+
     /// <summary>Maximum named appearance states declared for one AcroForm widget. Default: 4,096.</summary>
     public int MaxFormFieldAppearanceStates { get; init; } = 4_096;
 
@@ -108,6 +116,8 @@ public sealed class PdfReadLimits {
             MaxFormFieldDepth = MaxFormFieldDepth,
             MaxNameTreeNodes = MaxNameTreeNodes,
             MaxNameTreeDepth = MaxNameTreeDepth,
+            MaxAttachments = MaxAttachments,
+            MaxTotalAttachmentBytes = MaxTotalAttachmentBytes,
             MaxFormFieldAppearanceStates = MaxFormFieldAppearanceStates,
             MaxAnnotationsPerPage = MaxAnnotationsPerPage,
             MaxContentOperations = MaxContentOperations,
@@ -161,6 +171,10 @@ public sealed class PdfReadLimits {
         ValidatePositive(MaxFormFieldDepth, nameof(MaxFormFieldDepth), "Maximum form-field depth must be positive.");
         ValidatePositive(MaxNameTreeNodes, nameof(MaxNameTreeNodes), "Maximum name-tree nodes must be positive.");
         ValidatePositive(MaxNameTreeDepth, nameof(MaxNameTreeDepth), "Maximum name-tree depth must be positive.");
+        ValidatePositive(MaxAttachments, nameof(MaxAttachments), "Maximum attachments must be positive.");
+        if (MaxTotalAttachmentBytes <= 0L) {
+            throw new ArgumentOutOfRangeException(nameof(MaxTotalAttachmentBytes), MaxTotalAttachmentBytes, "Maximum aggregate attachment bytes must be positive.");
+        }
         ValidatePositive(MaxFormFieldAppearanceStates, nameof(MaxFormFieldAppearanceStates), "Maximum form-field appearance states must be positive.");
         ValidatePositive(MaxAnnotationsPerPage, nameof(MaxAnnotationsPerPage), "Maximum annotations per page must be positive.");
         ValidatePositive(MaxContentOperations, nameof(MaxContentOperations), "Maximum content operations must be positive.");

--- a/OfficeIMO.Pdf/Reading/Options/PdfReadLimits.cs
+++ b/OfficeIMO.Pdf/Reading/Options/PdfReadLimits.cs
@@ -6,6 +6,11 @@ public sealed class PdfReadLimits {
     internal const int DefaultMaxContentOperations = 1_000_000;
     internal const int DefaultMaxContentOperands = 1_000_000;
     internal const int DefaultMaxContentNestingDepth = 128;
+    internal const int DefaultMaxPageContentBytes = 256 * 1024 * 1024;
+    internal const int DefaultMaxActualTextCharacters = 1_000_000;
+    internal const int DefaultMaxDecodedTextCharacters = 10_000_000;
+    internal const int DefaultMaxNameTreeNodes = 100_000;
+    internal const int DefaultMaxNameTreeDepth = 128;
 
     /// <summary>Creates default parser budgets that callers can customize without changing another options instance.</summary>
     public static PdfReadLimits Default => new PdfReadLimits();
@@ -21,6 +26,15 @@ public sealed class PdfReadLimits {
 
     /// <summary>Maximum decoded byte count produced from one filtered stream. Default: 256 MiB.</summary>
     public int MaxDecodedStreamBytes { get; init; } = DefaultMaxDecodedStreamBytes;
+
+    /// <summary>Maximum aggregate decoded content-stream bytes materialized for one page. Default: 256 MiB.</summary>
+    public int MaxPageContentBytes { get; init; } = DefaultMaxPageContentBytes;
+
+    /// <summary>Maximum characters emitted from marked-content ActualText replacements on one page, including nested Form XObjects. Default: 1,000,000.</summary>
+    public int MaxActualTextCharacters { get; init; } = DefaultMaxActualTextCharacters;
+
+    /// <summary>Maximum font-decoded text characters emitted on one page, including nested Form XObjects. Default: 10,000,000.</summary>
+    public int MaxDecodedTextCharacters { get; init; } = DefaultMaxDecodedTextCharacters;
 
     /// <summary>Maximum characters tokenized from one object or dictionary. Default: 1,000,000.</summary>
     public int MaxObjectCharacters { get; init; } = 1_000_000;
@@ -52,6 +66,12 @@ public sealed class PdfReadLimits {
     /// <summary>Maximum nested AcroForm field-tree depth. Default: 256.</summary>
     public int MaxFormFieldDepth { get; init; } = 256;
 
+    /// <summary>Maximum indirect nodes traversed in one PDF name tree. Default: 100,000.</summary>
+    public int MaxNameTreeNodes { get; init; } = DefaultMaxNameTreeNodes;
+
+    /// <summary>Maximum nested PDF name-tree depth. Default: 128.</summary>
+    public int MaxNameTreeDepth { get; init; } = DefaultMaxNameTreeDepth;
+
     /// <summary>Maximum named appearance states declared for one AcroForm widget. Default: 4,096.</summary>
     public int MaxFormFieldAppearanceStates { get; init; } = 4_096;
 
@@ -73,6 +93,9 @@ public sealed class PdfReadLimits {
             MaxIndirectObjects = MaxIndirectObjects,
             MaxRawStreamBytes = MaxRawStreamBytes,
             MaxDecodedStreamBytes = MaxDecodedStreamBytes,
+            MaxPageContentBytes = MaxPageContentBytes,
+            MaxActualTextCharacters = MaxActualTextCharacters,
+            MaxDecodedTextCharacters = MaxDecodedTextCharacters,
             MaxObjectCharacters = MaxObjectCharacters,
             MaxTokensPerObject = MaxTokensPerObject,
             MaxObjectNestingDepth = MaxObjectNestingDepth,
@@ -83,6 +106,8 @@ public sealed class PdfReadLimits {
             MaxPages = MaxPages,
             MaxFormFields = MaxFormFields,
             MaxFormFieldDepth = MaxFormFieldDepth,
+            MaxNameTreeNodes = MaxNameTreeNodes,
+            MaxNameTreeDepth = MaxNameTreeDepth,
             MaxFormFieldAppearanceStates = MaxFormFieldAppearanceStates,
             MaxAnnotationsPerPage = MaxAnnotationsPerPage,
             MaxContentOperations = MaxContentOperations,
@@ -108,6 +133,10 @@ public sealed class PdfReadLimits {
             throw new ArgumentOutOfRangeException(nameof(MaxDecodedStreamBytes), MaxDecodedStreamBytes, "Maximum decoded stream bytes must be positive.");
         }
 
+        ValidatePositive(MaxPageContentBytes, nameof(MaxPageContentBytes), "Maximum aggregate page content bytes must be positive.");
+        ValidatePositive(MaxActualTextCharacters, nameof(MaxActualTextCharacters), "Maximum ActualText characters must be positive.");
+        ValidatePositive(MaxDecodedTextCharacters, nameof(MaxDecodedTextCharacters), "Maximum decoded text characters must be positive.");
+
         if (MaxObjectCharacters <= 0) {
             throw new ArgumentOutOfRangeException(nameof(MaxObjectCharacters), MaxObjectCharacters, "Maximum object characters must be positive.");
         }
@@ -130,6 +159,8 @@ public sealed class PdfReadLimits {
         ValidatePositive(MaxPages, nameof(MaxPages), "Maximum pages must be positive.");
         ValidatePositive(MaxFormFields, nameof(MaxFormFields), "Maximum form fields must be positive.");
         ValidatePositive(MaxFormFieldDepth, nameof(MaxFormFieldDepth), "Maximum form-field depth must be positive.");
+        ValidatePositive(MaxNameTreeNodes, nameof(MaxNameTreeNodes), "Maximum name-tree nodes must be positive.");
+        ValidatePositive(MaxNameTreeDepth, nameof(MaxNameTreeDepth), "Maximum name-tree depth must be positive.");
         ValidatePositive(MaxFormFieldAppearanceStates, nameof(MaxFormFieldAppearanceStates), "Maximum form-field appearance states must be positive.");
         ValidatePositive(MaxAnnotationsPerPage, nameof(MaxAnnotationsPerPage), "Maximum annotations per page must be positive.");
         ValidatePositive(MaxContentOperations, nameof(MaxContentOperations), "Maximum content operations must be positive.");

--- a/OfficeIMO.Pdf/Reading/PdfAttachmentExtractor.cs
+++ b/OfficeIMO.Pdf/Reading/PdfAttachmentExtractor.cs
@@ -87,20 +87,20 @@ internal static class PdfAttachmentExtractor {
         }
 
         var attachments = new List<PdfExtractedAttachment>();
-        var decodedEmbeddedStreams = new Dictionary<PdfStream, byte[]>();
+        var budget = new AttachmentExtractionBudget(effectiveLimits);
         if (catalog.Items.TryGetValue("Names", out var namesObject) &&
             ResolveDictionary(objects, namesObject) is PdfDictionary namesDictionary &&
             namesDictionary.Items.TryGetValue("EmbeddedFiles", out var embeddedFilesTreeObject)) {
             var visitedTrees = new HashSet<int>();
             int traversedNameTreeNodes = 0;
-            ReadEmbeddedFilesNameTree(objects, embeddedFilesTreeObject, attachments, visitedTrees, decodedEmbeddedStreams, effectiveLimits, 0, ref traversedNameTreeNodes);
+            ReadEmbeddedFilesNameTree(objects, embeddedFilesTreeObject, attachments, visitedTrees, budget, effectiveLimits, 0, ref traversedNameTreeNodes);
         }
 
         foreach (PdfArray associatedFiles in PdfAssociatedFileGraph.FindAssociatedFileArrays(objects)) {
-            ReadAssociatedFiles(objects, associatedFiles, attachments, decodedEmbeddedStreams, effectiveLimits.MaxDecodedStreamBytes);
+            ReadAssociatedFiles(objects, associatedFiles, attachments, budget);
         }
 
-        ReadFileAttachmentAnnotations(objects, attachments, decodedEmbeddedStreams, effectiveLimits.MaxDecodedStreamBytes);
+        ReadFileAttachmentAnnotations(objects, attachments, budget);
 
         return attachments.Count == 0 ? Array.Empty<PdfExtractedAttachment>() : attachments.AsReadOnly();
     }
@@ -108,11 +108,14 @@ internal static class PdfAttachmentExtractor {
     private static void ReadFileAttachmentAnnotations(
         Dictionary<int, PdfIndirectObject> objects,
         List<PdfExtractedAttachment> attachments,
-        Dictionary<PdfStream, byte[]> decodedEmbeddedStreams,
-        int maximumDecodedStreamBytes) {
+        AttachmentExtractionBudget budget) {
         var visited = new HashSet<PdfObject>();
+        var existingFileSpecs = new HashSet<int>(
+            attachments
+                .Where(attachment => attachment.FileSpecObjectNumber > 0)
+                .Select(attachment => attachment.FileSpecObjectNumber));
         foreach (PdfIndirectObject indirect in objects.Values) {
-            ReadFileAttachmentAnnotations(objects, indirect.Value, attachments, visited, decodedEmbeddedStreams, maximumDecodedStreamBytes);
+            ReadFileAttachmentAnnotations(objects, indirect.Value, attachments, visited, existingFileSpecs, budget);
         }
     }
 
@@ -121,11 +124,11 @@ internal static class PdfAttachmentExtractor {
         PdfObject value,
         List<PdfExtractedAttachment> attachments,
         ISet<PdfObject> visited,
-        Dictionary<PdfStream, byte[]> decodedEmbeddedStreams,
-        int maximumDecodedStreamBytes) {
+        ISet<int> existingFileSpecs,
+        AttachmentExtractionBudget budget) {
         if (!visited.Add(value)) return;
         if (value is PdfStream stream) {
-            ReadFileAttachmentAnnotations(objects, stream.Dictionary, attachments, visited, decodedEmbeddedStreams, maximumDecodedStreamBytes);
+            ReadFileAttachmentAnnotations(objects, stream.Dictionary, attachments, visited, existingFileSpecs, budget);
             return;
         }
         if (value is PdfDictionary dictionary) {
@@ -135,7 +138,7 @@ internal static class PdfAttachmentExtractor {
                     ? fileSpecReference.ObjectNumber
                     : 0;
                 bool alreadyDecoded = referencedFileSpecObjectNumber > 0 &&
-                    attachments.Any(attachment => attachment.FileSpecObjectNumber == referencedFileSpecObjectNumber);
+                    existingFileSpecs.Contains(referencedFileSpecObjectNumber);
                 if (!alreadyDecoded) {
                     string name = TryReadFileSpecName(objects, fileSpecObject) ?? "FileAttachment";
                     PdfExtractedAttachment? attachment = TryBuildAttachment(
@@ -143,17 +146,19 @@ internal static class PdfAttachmentExtractor {
                         name,
                         fileSpecObject,
                         "FileAttachment",
-                        decodedEmbeddedStreams,
-                        maximumDecodedStreamBytes);
+                        budget);
                     if (attachment != null) {
-                        attachments.Add(attachment);
+                        budget.Add(attachments, attachment);
+                        if (attachment.FileSpecObjectNumber > 0) {
+                            existingFileSpecs.Add(attachment.FileSpecObjectNumber);
+                        }
                     }
                 }
             }
 
             foreach (PdfObject child in dictionary.Items.Values) {
                 if (child is not PdfReference) {
-                    ReadFileAttachmentAnnotations(objects, child, attachments, visited, decodedEmbeddedStreams, maximumDecodedStreamBytes);
+                    ReadFileAttachmentAnnotations(objects, child, attachments, visited, existingFileSpecs, budget);
                 }
             }
             return;
@@ -161,7 +166,7 @@ internal static class PdfAttachmentExtractor {
         if (value is PdfArray array) {
             foreach (PdfObject child in array.Items) {
                 if (child is not PdfReference) {
-                    ReadFileAttachmentAnnotations(objects, child, attachments, visited, decodedEmbeddedStreams, maximumDecodedStreamBytes);
+                    ReadFileAttachmentAnnotations(objects, child, attachments, visited, existingFileSpecs, budget);
                 }
             }
         }
@@ -172,7 +177,7 @@ internal static class PdfAttachmentExtractor {
         PdfObject treeObject,
         List<PdfExtractedAttachment> attachments,
         HashSet<int> visitedTrees,
-        Dictionary<PdfStream, byte[]> decodedEmbeddedStreams,
+        AttachmentExtractionBudget budget,
         PdfReadLimits limits,
         int depth,
         ref int traversedNodes) {
@@ -202,16 +207,16 @@ internal static class PdfAttachmentExtractor {
                 }
 
                 PdfObject fileSpecObject = names.Items[i + 1];
-                PdfExtractedAttachment? attachment = TryBuildAttachment(objects, name.Value, fileSpecObject, "Names/EmbeddedFiles", decodedEmbeddedStreams, limits.MaxDecodedStreamBytes);
+                PdfExtractedAttachment? attachment = TryBuildAttachment(objects, name.Value, fileSpecObject, "Names/EmbeddedFiles", budget);
                 if (attachment != null) {
-                    attachments.Add(attachment);
+                    budget.Add(attachments, attachment);
                 }
             }
         }
 
         if (ResolveObject(objects, tree.Items.TryGetValue("Kids", out var kidsObject) ? kidsObject : null) is PdfArray kids) {
             foreach (PdfObject kid in kids.Items) {
-                ReadEmbeddedFilesNameTree(objects, kid, attachments, visitedTrees, decodedEmbeddedStreams, limits, depth + 1, ref traversedNodes);
+                ReadEmbeddedFilesNameTree(objects, kid, attachments, visitedTrees, budget, limits, depth + 1, ref traversedNodes);
             }
         }
     }
@@ -220,8 +225,7 @@ internal static class PdfAttachmentExtractor {
         Dictionary<int, PdfIndirectObject> objects,
         PdfArray associatedFiles,
         List<PdfExtractedAttachment> attachments,
-        Dictionary<PdfStream, byte[]> decodedEmbeddedStreams,
-        int maximumDecodedStreamBytes) {
+        AttachmentExtractionBudget budget) {
         var existingFileSpecs = new HashSet<int>();
         foreach (PdfExtractedAttachment attachment in attachments) {
             if (attachment.FileSpecObjectNumber > 0) {
@@ -237,9 +241,9 @@ internal static class PdfAttachmentExtractor {
             }
 
             string name = TryReadFileSpecName(objects, fileSpecObject) ?? "AF." + i.ToString(CultureInfo.InvariantCulture);
-            PdfExtractedAttachment? attachment = TryBuildAttachment(objects, name, fileSpecObject, "AF", decodedEmbeddedStreams, maximumDecodedStreamBytes);
+            PdfExtractedAttachment? attachment = TryBuildAttachment(objects, name, fileSpecObject, "AF", budget);
             if (attachment != null) {
-                attachments.Add(attachment);
+                budget.Add(attachments, attachment);
                 if (attachment.FileSpecObjectNumber > 0) {
                     existingFileSpecs.Add(attachment.FileSpecObjectNumber);
                 }
@@ -252,8 +256,7 @@ internal static class PdfAttachmentExtractor {
         string name,
         PdfObject fileSpecObject,
         string source,
-        Dictionary<PdfStream, byte[]> decodedEmbeddedStreams,
-        int maximumDecodedStreamBytes) {
+        AttachmentExtractionBudget budget) {
         int fileSpecObjectNumber = fileSpecObject is PdfReference fileSpecReference ? fileSpecReference.ObjectNumber : 0;
         if (ResolveDictionary(objects, fileSpecObject) is not PdfDictionary fileSpec ||
             ResolveDictionary(objects, fileSpec.Items.TryGetValue("EF", out var embeddedFilesObject) ? embeddedFilesObject : null) is not PdfDictionary embeddedFiles) {
@@ -277,13 +280,7 @@ internal static class PdfAttachmentExtractor {
         string? mimeType = TryReadStreamSubtype(objects, stream.Dictionary);
         PdfAssociatedFileRelationship relationship = TryReadRelationship(objects, fileSpec);
         string filter = GetFilterName(objects, stream.Dictionary.Items.TryGetValue("Filter", out var filterObject) ? filterObject : null);
-        byte[] bytes;
-        if (decodedEmbeddedStreams.TryGetValue(stream, out byte[]? cachedBytes) && cachedBytes is not null) {
-            bytes = cachedBytes;
-        } else {
-            bytes = StreamDecoder.Decode(stream.Dictionary, stream.Data, objects, maximumDecodedStreamBytes);
-            decodedEmbeddedStreams[stream] = bytes;
-        }
+        byte[] bytes = budget.GetDecodedBytes(stream, objects);
 
         PdfDictionary? parameters = ResolveDictionary(objects, stream.Dictionary.Items.TryGetValue("Params", out PdfObject? parametersObject) ? parametersObject : null);
         DateTimeOffset? creationDate = TryReadPdfDate(objects, parameters, "CreationDate");
@@ -304,6 +301,58 @@ internal static class PdfAttachmentExtractor {
             creationDate,
             modificationDate,
             copyBytes: false);
+    }
+
+    private sealed class AttachmentExtractionBudget {
+        private readonly PdfReadLimits _limits;
+        private readonly Dictionary<PdfStream, byte[]> _decodedEmbeddedStreams = new();
+        private int _attachmentCount;
+        private long _decodedAttachmentBytes;
+
+        internal AttachmentExtractionBudget(PdfReadLimits limits) {
+            _limits = limits;
+        }
+
+        internal void Add(List<PdfExtractedAttachment> attachments, PdfExtractedAttachment attachment) {
+            int nextCount = _attachmentCount + 1;
+            if (nextCount > _limits.MaxAttachments) {
+                throw PdfReadLimitException.Create(PdfReadLimitKind.Attachments, _limits.MaxAttachments, nextCount);
+            }
+
+            _attachmentCount = nextCount;
+            attachments.Add(attachment);
+        }
+
+        internal byte[] GetDecodedBytes(PdfStream stream, Dictionary<int, PdfIndirectObject> objects) {
+            if (_decodedEmbeddedStreams.TryGetValue(stream, out byte[]? cachedBytes) && cachedBytes is not null) {
+                return cachedBytes;
+            }
+
+            long remainingBytes = _limits.MaxTotalAttachmentBytes - _decodedAttachmentBytes;
+            if (remainingBytes <= 0L) {
+                throw PdfReadLimitException.Create(
+                    PdfReadLimitKind.AttachmentBytes,
+                    _limits.MaxTotalAttachmentBytes,
+                    _limits.MaxTotalAttachmentBytes + 1L);
+            }
+
+            int decodeLimit = (int)Math.Min(_limits.MaxDecodedStreamBytes, remainingBytes);
+            byte[] bytes;
+            try {
+                bytes = StreamDecoder.Decode(stream.Dictionary, stream.Data, objects, decodeLimit);
+            } catch (PdfReadLimitException exception) when (
+                exception.Kind == PdfReadLimitKind.DecodedStreamBytes &&
+                remainingBytes < _limits.MaxDecodedStreamBytes) {
+                throw PdfReadLimitException.Create(
+                    PdfReadLimitKind.AttachmentBytes,
+                    _limits.MaxTotalAttachmentBytes,
+                    _decodedAttachmentBytes + exception.Actual);
+            }
+
+            _decodedAttachmentBytes += bytes.LongLength;
+            _decodedEmbeddedStreams[stream] = bytes;
+            return bytes;
+        }
     }
 
     private static DateTimeOffset? TryReadPdfDate(Dictionary<int, PdfIndirectObject> objects, PdfDictionary? dictionary, string key) {

--- a/OfficeIMO.Pdf/Reading/PdfAttachmentExtractor.cs
+++ b/OfficeIMO.Pdf/Reading/PdfAttachmentExtractor.cs
@@ -148,7 +148,7 @@ internal static class PdfAttachmentExtractor {
                         "FileAttachment",
                         budget);
                     if (attachment != null) {
-                        budget.Add(attachments, attachment);
+                        attachments.Add(attachment);
                         if (attachment.FileSpecObjectNumber > 0) {
                             existingFileSpecs.Add(attachment.FileSpecObjectNumber);
                         }
@@ -209,7 +209,7 @@ internal static class PdfAttachmentExtractor {
                 PdfObject fileSpecObject = names.Items[i + 1];
                 PdfExtractedAttachment? attachment = TryBuildAttachment(objects, name.Value, fileSpecObject, "Names/EmbeddedFiles", budget);
                 if (attachment != null) {
-                    budget.Add(attachments, attachment);
+                    attachments.Add(attachment);
                 }
             }
         }
@@ -243,7 +243,7 @@ internal static class PdfAttachmentExtractor {
             string name = TryReadFileSpecName(objects, fileSpecObject) ?? "AF." + i.ToString(CultureInfo.InvariantCulture);
             PdfExtractedAttachment? attachment = TryBuildAttachment(objects, name, fileSpecObject, "AF", budget);
             if (attachment != null) {
-                budget.Add(attachments, attachment);
+                attachments.Add(attachment);
                 if (attachment.FileSpecObjectNumber > 0) {
                     existingFileSpecs.Add(attachment.FileSpecObjectNumber);
                 }
@@ -273,6 +273,7 @@ internal static class PdfAttachmentExtractor {
         if (ResolveObject(objects, embeddedFileObject) is not PdfStream stream) {
             return null;
         }
+        budget.ReserveAttachment();
 
         string fileName = TryReadText(objects, fileSpec, "F") ?? name;
         string? unicodeFileName = TryReadText(objects, fileSpec, "UF");
@@ -313,14 +314,13 @@ internal static class PdfAttachmentExtractor {
             _limits = limits;
         }
 
-        internal void Add(List<PdfExtractedAttachment> attachments, PdfExtractedAttachment attachment) {
+        internal void ReserveAttachment() {
             int nextCount = _attachmentCount + 1;
             if (nextCount > _limits.MaxAttachments) {
                 throw PdfReadLimitException.Create(PdfReadLimitKind.Attachments, _limits.MaxAttachments, nextCount);
             }
 
             _attachmentCount = nextCount;
-            attachments.Add(attachment);
         }
 
         internal byte[] GetDecodedBytes(PdfStream stream, Dictionary<int, PdfIndirectObject> objects) {

--- a/OfficeIMO.Pdf/Reading/PdfAttachmentExtractor.cs
+++ b/OfficeIMO.Pdf/Reading/PdfAttachmentExtractor.cs
@@ -92,7 +92,8 @@ internal static class PdfAttachmentExtractor {
             ResolveDictionary(objects, namesObject) is PdfDictionary namesDictionary &&
             namesDictionary.Items.TryGetValue("EmbeddedFiles", out var embeddedFilesTreeObject)) {
             var visitedTrees = new HashSet<int>();
-            ReadEmbeddedFilesNameTree(objects, embeddedFilesTreeObject, attachments, visitedTrees, decodedEmbeddedStreams, effectiveLimits.MaxDecodedStreamBytes);
+            int traversedNameTreeNodes = 0;
+            ReadEmbeddedFilesNameTree(objects, embeddedFilesTreeObject, attachments, visitedTrees, decodedEmbeddedStreams, effectiveLimits, 0, ref traversedNameTreeNodes);
         }
 
         foreach (PdfArray associatedFiles in PdfAssociatedFileGraph.FindAssociatedFileArrays(objects)) {
@@ -172,10 +173,20 @@ internal static class PdfAttachmentExtractor {
         List<PdfExtractedAttachment> attachments,
         HashSet<int> visitedTrees,
         Dictionary<PdfStream, byte[]> decodedEmbeddedStreams,
-        int maximumDecodedStreamBytes) {
+        PdfReadLimits limits,
+        int depth,
+        ref int traversedNodes) {
         int treeObjectNumber = treeObject is PdfReference treeReference ? treeReference.ObjectNumber : 0;
         if (treeObjectNumber > 0 && !visitedTrees.Add(treeObjectNumber)) {
             return;
+        }
+
+        if (depth > limits.MaxNameTreeDepth) {
+            throw PdfReadLimitException.Create(PdfReadLimitKind.NameTreeDepth, limits.MaxNameTreeDepth, depth);
+        }
+        traversedNodes++;
+        if (traversedNodes > limits.MaxNameTreeNodes) {
+            throw PdfReadLimitException.Create(PdfReadLimitKind.NameTreeNodes, limits.MaxNameTreeNodes, traversedNodes);
         }
 
         if (ResolveDictionary(objects, treeObject) is not PdfDictionary tree) {
@@ -189,7 +200,7 @@ internal static class PdfAttachmentExtractor {
                 }
 
                 PdfObject fileSpecObject = names.Items[i + 1];
-                PdfExtractedAttachment? attachment = TryBuildAttachment(objects, name.Value, fileSpecObject, "Names/EmbeddedFiles", decodedEmbeddedStreams, maximumDecodedStreamBytes);
+                PdfExtractedAttachment? attachment = TryBuildAttachment(objects, name.Value, fileSpecObject, "Names/EmbeddedFiles", decodedEmbeddedStreams, limits.MaxDecodedStreamBytes);
                 if (attachment != null) {
                     attachments.Add(attachment);
                 }
@@ -198,7 +209,7 @@ internal static class PdfAttachmentExtractor {
 
         if (ResolveObject(objects, tree.Items.TryGetValue("Kids", out var kidsObject) ? kidsObject : null) is PdfArray kids) {
             foreach (PdfObject kid in kids.Items) {
-                ReadEmbeddedFilesNameTree(objects, kid, attachments, visitedTrees, decodedEmbeddedStreams, maximumDecodedStreamBytes);
+                ReadEmbeddedFilesNameTree(objects, kid, attachments, visitedTrees, decodedEmbeddedStreams, limits, depth + 1, ref traversedNodes);
             }
         }
     }

--- a/OfficeIMO.Pdf/Reading/PdfAttachmentExtractor.cs
+++ b/OfficeIMO.Pdf/Reading/PdfAttachmentExtractor.cs
@@ -176,17 +176,19 @@ internal static class PdfAttachmentExtractor {
         PdfReadLimits limits,
         int depth,
         ref int traversedNodes) {
-        int treeObjectNumber = treeObject is PdfReference treeReference ? treeReference.ObjectNumber : 0;
-        if (treeObjectNumber > 0 && !visitedTrees.Add(treeObjectNumber)) {
-            return;
+        if (treeObject is PdfReference treeReference) {
+            if (!visitedTrees.Add(treeReference.ObjectNumber)) {
+                return;
+            }
+
+            traversedNodes++;
+            if (traversedNodes > limits.MaxNameTreeNodes) {
+                throw PdfReadLimitException.Create(PdfReadLimitKind.NameTreeNodes, limits.MaxNameTreeNodes, traversedNodes);
+            }
         }
 
         if (depth > limits.MaxNameTreeDepth) {
             throw PdfReadLimitException.Create(PdfReadLimitKind.NameTreeDepth, limits.MaxNameTreeDepth, depth);
-        }
-        traversedNodes++;
-        if (traversedNodes > limits.MaxNameTreeNodes) {
-            throw PdfReadLimitException.Create(PdfReadLimitKind.NameTreeNodes, limits.MaxNameTreeNodes, traversedNodes);
         }
 
         if (ResolveDictionary(objects, treeObject) is not PdfDictionary tree) {

--- a/OfficeIMO.Pdf/Reading/Util/PdfTextString.cs
+++ b/OfficeIMO.Pdf/Reading/Util/PdfTextString.cs
@@ -3,6 +3,23 @@ using System.Text;
 namespace OfficeIMO.Pdf;
 
 internal static class PdfTextString {
+    internal static int GetDecodedCharacterCount(byte[] bytes) {
+        if (bytes == null || bytes.Length == 0) {
+            return 0;
+        }
+
+        if (bytes.Length >= 2 &&
+            (bytes[0] == 0xFE && bytes[1] == 0xFF || bytes[0] == 0xFF && bytes[1] == 0xFE)) {
+            return (bytes.Length - 2) / 2;
+        }
+
+        if (bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF) {
+            return Encoding.UTF8.GetCharCount(bytes, 3, bytes.Length - 3);
+        }
+
+        return bytes.Length;
+    }
+
     public static string Decode(byte[] bytes) {
         if (bytes == null || bytes.Length == 0) {
             return string.Empty;


### PR DESCRIPTION
## Summary\n\n- bound PDF text decoding, ActualText expansion, page content aggregation, name-tree traversal, predictor buffers, and structural text parsing\n- share PDF rendering budgets across nested forms, patterns, masks, and annotation appearances\n- apply caller-configured name-tree limits during named-destination rewrite preflight\n- cap text-run buffers before decoding, charge filtered glyph decodes, and parse TOC/leader suffixes without per-character index buffers\n- bound attachment aliases and aggregate unique decoded payload bytes, reserve count slots before decoding, avoid metadata payload copies, keep annotation file-spec lookup linear, and enforce decode limits when malformed or unsupported filters fall back to encoded bytes\n- bound Excel dense-range reads, including dictionary and typed projections, sparkline expansion, typed-row buffering, and oversized header caching\n\n## Validation\n\n- PDF read-limit and attachment tests pass 54/54 on .NET 8 and .NET 10\n- named-destination preflight limit regression passes on .NET 8 and .NET 10\n- Excel resource-budget tests pass 8/8 on .NET 8 and .NET 10\n- structured leader and attachment pre-decode regressions pass on both target frameworks\n- PDF and Excel netstandard2.0 builds succeed without warnings\n\nThis is security findings batch 11 and is based on master.\n