### PR TITLE
Bound raster, SVG, reader, and presentation processing

### DIFF
--- a/OfficeIMO.Drawing.CodeGlyphX.Tests/CodeGlyphDrawingIntegrationTests.cs
+++ b/OfficeIMO.Drawing.CodeGlyphX.Tests/CodeGlyphDrawingIntegrationTests.cs
@@ -144,14 +144,10 @@ public sealed class CodeGlyphDrawingIntegrationTests {
     }
 
     [Fact]
-    public void AdapterImportsTrustedBarcodeViewportBeyondDefaultAreaLimit() {
+    public void AdapterRejectsBarcodeViewportBeyondDefaultAreaLimit() {
         Barcode1D barcode = new Barcode1D(Enumerable.Range(0, 5_000).Select(index => new BarSegment(index % 2 == 0, 1)));
         var options = new BarcodeSvgRenderOptions { HeightModules = 5_000 };
 
-        OfficeDrawing drawing = barcode.ToOfficeDrawing(out int unsupported, options);
-
-        Assert.Equal(0, unsupported);
-        Assert.True(drawing.Width * drawing.Height > OfficeSvgDrawingReaderOptions.DefaultMaximumViewportPixels);
-        Assert.True(drawing.Width * drawing.Height <= OfficeSvgDrawingReaderOptions.MaximumAllowedViewportPixels);
+        Assert.Throws<InvalidOperationException>(() => barcode.ToOfficeDrawing(out _, options));
     }
 }

--- a/OfficeIMO.Drawing.CodeGlyphX/CodeGlyphDrawingExtensions.cs
+++ b/OfficeIMO.Drawing.CodeGlyphX/CodeGlyphDrawingExtensions.cs
@@ -74,8 +74,7 @@ public static class CodeGlyphDrawingExtensions {
         byte[] bytes = Encoding.UTF8.GetBytes(svg);
         var readerOptions = new OfficeSvgDrawingReaderOptions {
             MaximumElements = maximumElements,
-            MaximumViewportDimension = OfficeSvgDrawingReaderOptions.MaximumAllowedViewportDimension,
-            MaximumViewportPixels = OfficeSvgDrawingReaderOptions.MaximumAllowedViewportPixels
+            MaximumViewportDimension = OfficeSvgDrawingReaderOptions.MaximumAllowedViewportDimension
         };
         if (!OfficeSvgDrawingReader.TryRead(bytes, readerOptions, out OfficeDrawing? drawing, out unsupportedFeatureCount) || drawing is null) {
             throw new InvalidOperationException("CodeGlyphX produced SVG that OfficeIMO.Drawing could not read.");

--- a/OfficeIMO.Drawing.Tests/Drawing.Raster.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.Raster.cs
@@ -1544,6 +1544,20 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void OfficeRasterCanvas_RejectsNonFiniteDashedLineLengths() {
+            OfficeRasterImage image = new OfficeRasterImage(32, 8, OfficeColor.Transparent);
+            OfficeRasterCanvas canvas = new OfficeRasterCanvas(image);
+            var points = new[] { new OfficePoint(0D, 3D), new OfficePoint(31D, 3D) };
+
+            canvas.DrawDashedLine(0D, 3D, 31D, 3D, OfficeColor.Black, dashLength: double.PositiveInfinity);
+            canvas.DrawDashedLine(0D, 3D, 31D, 3D, OfficeColor.Black, gapLength: double.NaN);
+            canvas.DrawDashedPolyline(points, OfficeColor.Black, dashLength: double.PositiveInfinity);
+            canvas.DrawDashedPolyline(points, OfficeColor.Black, gapLength: double.PositiveInfinity);
+
+            Assert.All(image.GetPixels(), value => Assert.Equal(0, value));
+        }
+
+        [Fact]
         public void OfficeRasterCanvas_OddDashPatternsPreserveAlternatingParityAcrossWrap() {
             OfficeRasterImage odd = new OfficeRasterImage(32, 8, OfficeColor.Transparent);
             OfficeRasterImage duplicated = new OfficeRasterImage(32, 8, OfficeColor.Transparent);

--- a/OfficeIMO.Drawing.Tests/Drawing.SvgReader.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.SvgReader.cs
@@ -460,6 +460,23 @@ public class DrawingSvgReaderTests {
     }
 
     [Fact]
+    public void SvgReaderChargesRepeatedMalformedUsePolylinesToOneCommandBudget() {
+        var points = new StringBuilder("0");
+        for (int index = 1; index < 9_999; index++) points.Append(' ').Append(index % 10);
+        var svg = new StringBuilder("<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 10'><defs><polyline id='p' points='")
+            .Append(points).Append("' stroke='black'/></defs>");
+        for (int index = 0; index < 10; index++) svg.Append("<use href='#p'/>");
+        svg.Append("<path d='M10 0 L20 10' stroke='lime'/></svg>");
+
+        Assert.True(OfficeSvgDrawingReader.TryRead(Encoding.UTF8.GetBytes(svg.ToString()),
+            out OfficeDrawing? drawing, out int unsupported));
+
+        Assert.NotNull(drawing);
+        Assert.Empty(drawing!.Shapes);
+        Assert.True(unsupported > 0);
+    }
+
+    [Fact]
     public void SvgReaderRejectsTransformArgumentsBeyondSupportedArity() {
         var arguments = new StringBuilder("0");
         for (int index = 1; index < 1000; index++) arguments.Append(" 0");

--- a/OfficeIMO.Drawing.Tests/Drawing.SvgReader.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.SvgReader.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text;
 using OfficeIMO.Drawing;
 using Xunit;
@@ -474,6 +475,25 @@ public class DrawingSvgReaderTests {
         Assert.NotNull(drawing);
         Assert.Empty(drawing!.Shapes);
         Assert.True(unsupported > 0);
+    }
+
+    [Fact]
+    public void SvgReaderExhaustsPathBudgetAfterOverlongReferencedPointToken() {
+        var svg = new StringBuilder("<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 10'><defs><polyline id='p' points='0 ")
+            .Append('9', 512 * 1024)
+            .Append("' stroke='black'/></defs>");
+        for (int index = 0; index < 1_000; index++) svg.Append("<use href='#p'/>");
+        svg.Append("<path d='M10 0 L20 10' stroke='lime'/></svg>");
+        var timer = Stopwatch.StartNew();
+
+        Assert.True(OfficeSvgDrawingReader.TryRead(Encoding.UTF8.GetBytes(svg.ToString()),
+            out OfficeDrawing? drawing, out int unsupported));
+
+        timer.Stop();
+        Assert.NotNull(drawing);
+        Assert.Empty(drawing!.Shapes);
+        Assert.True(unsupported > 0);
+        Assert.True(timer.Elapsed < TimeSpan.FromSeconds(5), "Malformed referenced points exceeded the bounded parse time.");
     }
 
     [Fact]

--- a/OfficeIMO.Drawing.Tests/Drawing.SvgReader.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.SvgReader.cs
@@ -497,6 +497,25 @@ public class DrawingSvgReaderTests {
     }
 
     [Fact]
+    public void SvgReaderExhaustsPathBudgetAfterOverlongReferencedPointSeparator() {
+        var svg = new StringBuilder("<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 10'><defs><polyline id='p' points='0")
+            .Append(' ', 512 * 1024)
+            .Append("x' stroke='black'/></defs>");
+        for (int index = 0; index < 1_000; index++) svg.Append("<use href='#p'/>");
+        svg.Append("<path d='M10 0 L20 10' stroke='lime'/></svg>");
+        var timer = Stopwatch.StartNew();
+
+        Assert.True(OfficeSvgDrawingReader.TryRead(Encoding.UTF8.GetBytes(svg.ToString()),
+            out OfficeDrawing? drawing, out int unsupported));
+
+        timer.Stop();
+        Assert.NotNull(drawing);
+        Assert.Empty(drawing!.Shapes);
+        Assert.True(unsupported > 0);
+        Assert.True(timer.Elapsed < TimeSpan.FromSeconds(5), "Whitespace-padded malformed points exceeded the bounded parse time.");
+    }
+
+    [Fact]
     public void SvgReaderRejectsTransformArgumentsBeyondSupportedArity() {
         var arguments = new StringBuilder("0");
         for (int index = 1; index < 1000; index++) arguments.Append(" 0");

--- a/OfficeIMO.Drawing/OfficeSvgDrawingReader.cs
+++ b/OfficeIMO.Drawing/OfficeSvgDrawingReader.cs
@@ -739,7 +739,14 @@ public static partial class OfficeSvgDrawingReader {
         if (maximumValues <= 0 || string.IsNullOrWhiteSpace(value)) return false;
         int index = 0;
         while (index < value!.Length) {
-            while (index < value.Length && (char.IsWhiteSpace(value[index]) || value[index] == ',')) index++;
+            int separatorStart = index;
+            while (index < value.Length && (char.IsWhiteSpace(value[index]) || value[index] == ',')) {
+                index++;
+                if (index - separatorStart > 128) {
+                    limitExceeded = true;
+                    return false;
+                }
+            }
             if (index >= value.Length) break;
             if (result.Count >= maximumValues) {
                 limitExceeded = true;

--- a/OfficeIMO.Drawing/OfficeSvgDrawingReader.cs
+++ b/OfficeIMO.Drawing/OfficeSvgDrawingReader.cs
@@ -366,7 +366,12 @@ public static partial class OfficeSvgDrawingReader {
         bool parsed = TryParseNumberList(element.Attribute("points")?.Value, remainingCommands * 2,
             out IReadOnlyList<double> values, out bool limitExceeded);
         if (!parsed || values.Count < 4 || values.Count % 2 != 0) {
-            if (limitExceeded) pathCommands = MaximumSvgPathCommands;
+            if (limitExceeded) {
+                pathCommands = MaximumSvgPathCommands;
+            } else if (values.Count > 0) {
+                int parsedCommands = Math.Max(1, (values.Count + 1) / 2);
+                pathCommands += Math.Min(remainingCommands, parsedCommands);
+            }
             return null;
         }
         int commandCount = values.Count / 2;

--- a/OfficeIMO.Drawing/OfficeSvgDrawingReader.cs
+++ b/OfficeIMO.Drawing/OfficeSvgDrawingReader.cs
@@ -746,9 +746,15 @@ public static partial class OfficeSvgDrawingReader {
                 return false;
             }
             int start = index;
-            while (index < value.Length && !char.IsWhiteSpace(value[index]) && value[index] != ',') index++;
+            while (index < value.Length && !char.IsWhiteSpace(value[index]) && value[index] != ',') {
+                index++;
+                if (index - start > 128) {
+                    limitExceeded = true;
+                    return false;
+                }
+            }
             int length = index - start;
-            if (length <= 0 || length > 128
+            if (length <= 0
                 || !double.TryParse(value.Substring(start, length), NumberStyles.Float,
                     CultureInfo.InvariantCulture, out double number)
                 || double.IsNaN(number)

--- a/OfficeIMO.Drawing/Raster/OfficeRasterCanvas.DashedShapes.cs
+++ b/OfficeIMO.Drawing/Raster/OfficeRasterCanvas.DashedShapes.cs
@@ -183,6 +183,9 @@ public sealed partial class OfficeRasterCanvas {
         }
 
         double cycle = SaturatingDashCycle(dashLength, gapLength);
+        if (cycle <= 0D) {
+            return;
+        }
 
         OfficePoint clippedStart = start;
         OfficePoint clippedEnd = end;

--- a/OfficeIMO.Drawing/Raster/OfficeRasterCanvas.Polylines.cs
+++ b/OfficeIMO.Drawing/Raster/OfficeRasterCanvas.Polylines.cs
@@ -93,7 +93,8 @@ public sealed partial class OfficeRasterCanvas {
         double dashLength = 6D,
         double gapLength = 4D,
         bool resetDashPatternForEachSegment = false) {
-        if (color.A == 0 || points == null || points.Count < 2 || thickness <= 0D || dashLength <= 0D || gapLength < 0D) {
+        if (color.A == 0 || points == null || points.Count < 2 || thickness <= 0D || dashLength <= 0D || gapLength < 0D
+            || !IsFinite(dashLength) || !IsFinite(gapLength)) {
             return;
         }
 

--- a/OfficeIMO.Drawing/Raster/OfficeRasterCanvas.cs
+++ b/OfficeIMO.Drawing/Raster/OfficeRasterCanvas.cs
@@ -322,7 +322,8 @@ public sealed partial class OfficeRasterCanvas {
 
     /// <summary>Draws a dashed line segment.</summary>
     public void DrawDashedLine(double x1, double y1, double x2, double y2, OfficeColor color, double thickness = 1D, double dashLength = 6D, double gapLength = 4D) {
-        if (color.A == 0 || thickness <= 0D || dashLength <= 0D || gapLength < 0D) {
+        if (color.A == 0 || thickness <= 0D || dashLength <= 0D || gapLength < 0D
+            || !IsFinite(dashLength) || !IsFinite(gapLength)) {
             return;
         }
 

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.Accessibility.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.Accessibility.cs
@@ -257,6 +257,14 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void PackageFingerprintRejectsOversizedXmlStreamsBeforeParsing() {
+            using var stream = new MemoryStream(new byte[17]);
+
+            Assert.ThrowsAny<IOException>(() =>
+                PowerPointPackageFingerprint.EnsureStreamWithinLimit(stream, maximumBytes: 16));
+        }
+
+        [Fact]
         public void AccessibilityReportIsStableForGeneratedAndReloadedDecks() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
             string reportPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".json");

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.Accessibility.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.Accessibility.cs
@@ -265,6 +265,41 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void PackageFingerprintChecksApplicationPropertiesSizeBeforeLoadingSignatureMetadata() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            try {
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                    presentation.AddSlide();
+                    presentation.Save();
+                }
+
+                using (PresentationDocument document = PresentationDocument.Open(filePath, true)) {
+                    ExtendedFilePropertiesPart propertiesPart = document.ExtendedFilePropertiesPart
+                        ?? document.AddExtendedFilePropertiesPart();
+                    propertiesPart.Properties ??= new DocumentFormat.OpenXml.ExtendedProperties.Properties();
+                    propertiesPart.Properties.DigitalSignature = new DocumentFormat.OpenXml.ExtendedProperties.DigitalSignature();
+                    propertiesPart.Properties.Save();
+                }
+
+                using PresentationDocument reopened = PresentationDocument.Open(filePath, false);
+                ExtendedFilePropertiesPart reopenedProperties = reopened.ExtendedFilePropertiesPart!;
+                Assert.False(reopenedProperties.IsRootElementLoaded);
+                long serializedLength;
+                using (Stream source = reopenedProperties.GetStream(FileMode.Open, FileAccess.Read)) {
+                    serializedLength = source.Length;
+                }
+
+                Assert.ThrowsAny<IOException>(() =>
+                    PowerPointPackageFingerprint.HasApplicationSignatureFlag(reopened, serializedLength - 1));
+                Assert.False(reopenedProperties.IsRootElementLoaded);
+                Assert.True(PowerPointPackageFingerprint.HasApplicationSignatureFlag(reopened, serializedLength));
+                Assert.True(reopenedProperties.IsRootElementLoaded);
+            } finally {
+                if (File.Exists(filePath)) File.Delete(filePath);
+            }
+        }
+
+        [Fact]
         public void AccessibilityReportIsStableForGeneratedAndReloadedDecks() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
             string reportPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".json");

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.Accessibility.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.Accessibility.cs
@@ -325,8 +325,7 @@ namespace OfficeIMO.Tests {
                     }
                     xml = xml.Replace(
                         "</p:presentation>",
-                        "<!--" + new string('x', 4096) + "--></p:presentation>",
-                        StringComparison.Ordinal);
+                        "<!--" + new string('x', 4096) + "--></p:presentation>");
                     using (var writer = new StreamWriter(
                                presentationPart.GetStream(FileMode.Create, FileAccess.Write),
                                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false))) {

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.Accessibility.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.Accessibility.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Text;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Presentation;
 using DocumentFormat.OpenXml.Validation;
@@ -294,6 +295,63 @@ namespace OfficeIMO.Tests {
                 Assert.False(reopenedProperties.IsRootElementLoaded);
                 Assert.True(PowerPointPackageFingerprint.HasApplicationSignatureFlag(reopened, serializedLength));
                 Assert.True(reopenedProperties.IsRootElementLoaded);
+            } finally {
+                if (File.Exists(filePath)) File.Delete(filePath);
+            }
+        }
+
+        [Fact]
+        public void SignedPackageXmlIsBoundedBeforePresentationRootsAreLoaded() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            try {
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                    presentation.AddSlide();
+                    presentation.Save();
+                }
+
+                using (PresentationDocument document = PresentationDocument.Open(filePath, true)) {
+                    ExtendedFilePropertiesPart propertiesPart = document.ExtendedFilePropertiesPart
+                        ?? document.AddExtendedFilePropertiesPart();
+                    propertiesPart.Properties ??= new DocumentFormat.OpenXml.ExtendedProperties.Properties();
+                    propertiesPart.Properties.DigitalSignature = new DocumentFormat.OpenXml.ExtendedProperties.DigitalSignature();
+                    propertiesPart.Properties.Save();
+
+                    PresentationPart presentationPart = document.PresentationPart!;
+                    string xml;
+                    using (var reader = new StreamReader(
+                               presentationPart.GetStream(FileMode.Open, FileAccess.Read),
+                               Encoding.UTF8, detectEncodingFromByteOrderMarks: true)) {
+                        xml = reader.ReadToEnd();
+                    }
+                    xml = xml.Replace(
+                        "</p:presentation>",
+                        "<!--" + new string('x', 4096) + "--></p:presentation>",
+                        StringComparison.Ordinal);
+                    using (var writer = new StreamWriter(
+                               presentationPart.GetStream(FileMode.Create, FileAccess.Write),
+                               new UTF8Encoding(encoderShouldEmitUTF8Identifier: false))) {
+                        writer.Write(xml);
+                    }
+                }
+
+                using PresentationDocument reopened = PresentationDocument.Open(filePath, false);
+                PresentationPart reopenedPresentation = reopened.PresentationPart!;
+                Assert.False(reopenedPresentation.IsRootElementLoaded);
+                long applicationPropertiesLength;
+                using (Stream source = reopened.ExtendedFilePropertiesPart!
+                           .GetStream(FileMode.Open, FileAccess.Read)) {
+                    applicationPropertiesLength = source.Length;
+                }
+                long presentationLength;
+                using (Stream source = reopenedPresentation.GetStream(FileMode.Open, FileAccess.Read)) {
+                    presentationLength = source.Length;
+                }
+                Assert.True(presentationLength > applicationPropertiesLength);
+
+                Assert.ThrowsAny<IOException>(() =>
+                    PowerPointPackageFingerprint.HasSignatureAndEnsurePackageXmlWithinLimit(
+                        reopened, presentationLength - 1));
+                Assert.False(reopenedPresentation.IsRootElementLoaded);
             } finally {
                 if (File.Exists(filePath)) File.Delete(filePath);
             }

--- a/OfficeIMO.PowerPoint/Internal/PowerPointPackageFingerprint.cs
+++ b/OfficeIMO.PowerPoint/Internal/PowerPointPackageFingerprint.cs
@@ -169,6 +169,20 @@ namespace OfficeIMO.PowerPoint {
             (contentType!.EndsWith("+xml", StringComparison.OrdinalIgnoreCase) ||
              contentType.IndexOf("/xml", StringComparison.OrdinalIgnoreCase) >= 0);
 
+        internal static bool HasApplicationSignatureFlag(
+            PresentationDocument document,
+            long maximumXmlBytes = MaximumNormalizedXmlBytes) {
+            if (document == null) throw new ArgumentNullException(nameof(document));
+            ExtendedFilePropertiesPart? propertiesPart = document.ExtendedFilePropertiesPart;
+            if (propertiesPart == null) return false;
+
+            using (Stream source = propertiesPart.GetStream(FileMode.Open, FileAccess.Read)) {
+                EnsureStreamWithinLimit(source, maximumXmlBytes);
+            }
+
+            return propertiesPart.Properties?.DigitalSignature != null;
+        }
+
         internal static void EnsureStreamWithinLimit(Stream stream, long maximumBytes) {
             if (stream == null) throw new ArgumentNullException(nameof(stream));
             if (maximumBytes <= 0L) throw new ArgumentOutOfRangeException(nameof(maximumBytes));

--- a/OfficeIMO.PowerPoint/Internal/PowerPointPackageFingerprint.cs
+++ b/OfficeIMO.PowerPoint/Internal/PowerPointPackageFingerprint.cs
@@ -32,6 +32,10 @@ namespace OfficeIMO.PowerPoint {
                 content.Append(part.Uri.ToString());
                 content.Append(part.ContentType);
                 try {
+                    if (IsXmlContentType(part.ContentType) && !part.IsRootElementLoaded) {
+                        using Stream source = part.GetStream(FileMode.Open, FileAccess.Read);
+                        EnsureStreamWithinLimit(source, MaximumNormalizedXmlBytes);
+                    }
                     OpenXmlPartRootElement? root = part.RootElement;
                     if (root != null) {
                         if (normalizeRoot != null) {
@@ -158,6 +162,35 @@ namespace OfficeIMO.PowerPoint {
         private static void AppendPackageProperty(FingerprintWriter content, string name, string? value) {
             content.Append(name);
             content.Append(value ?? string.Empty);
+        }
+
+        private static bool IsXmlContentType(string? contentType) =>
+            !string.IsNullOrWhiteSpace(contentType) &&
+            (contentType!.EndsWith("+xml", StringComparison.OrdinalIgnoreCase) ||
+             contentType.IndexOf("/xml", StringComparison.OrdinalIgnoreCase) >= 0);
+
+        internal static void EnsureStreamWithinLimit(Stream stream, long maximumBytes) {
+            if (stream == null) throw new ArgumentNullException(nameof(stream));
+            if (maximumBytes <= 0L) throw new ArgumentOutOfRangeException(nameof(maximumBytes));
+            if (stream.CanSeek) {
+                long remaining = stream.Length - stream.Position;
+                if (remaining > maximumBytes) {
+                    throw new FingerprintLimitExceededException(
+                        "A presentation XML part exceeds the fingerprint normalization limit.");
+                }
+                return;
+            }
+
+            var buffer = new byte[81920];
+            long inspected = 0L;
+            int read;
+            while ((read = stream.Read(buffer, 0, buffer.Length)) > 0) {
+                if (read > maximumBytes - inspected) {
+                    throw new FingerprintLimitExceededException(
+                        "A presentation XML part exceeds the fingerprint normalization limit.");
+                }
+                inspected += read;
+            }
         }
 
         private sealed class FingerprintWriter : IDisposable {

--- a/OfficeIMO.PowerPoint/Internal/PowerPointPackageFingerprint.cs
+++ b/OfficeIMO.PowerPoint/Internal/PowerPointPackageFingerprint.cs
@@ -183,6 +183,25 @@ namespace OfficeIMO.PowerPoint {
             return propertiesPart.Properties?.DigitalSignature != null;
         }
 
+        internal static bool HasSignatureAndEnsurePackageXmlWithinLimit(
+            PresentationDocument document,
+            long maximumXmlBytes = MaximumNormalizedXmlBytes) {
+            if (document == null) throw new ArgumentNullException(nameof(document));
+            bool hasSignature = document.DigitalSignatureOriginPart != null ||
+                HasApplicationSignatureFlag(document, maximumXmlBytes);
+            if (!hasSignature) return false;
+
+            HashSet<OpenXmlPart> parts = CollectParts(
+                document, MaximumPartCount, MaximumPartDepth, MaximumRelationshipCount);
+            foreach (OpenXmlPart part in parts) {
+                if (!IsXmlContentType(part.ContentType)) continue;
+                using Stream source = part.GetStream(FileMode.Open, FileAccess.Read);
+                EnsureStreamWithinLimit(source, maximumXmlBytes);
+            }
+
+            return true;
+        }
+
         internal static void EnsureStreamWithinLimit(Stream stream, long maximumBytes) {
             if (stream == null) throw new ArgumentNullException(nameof(stream));
             if (maximumBytes <= 0L) throw new ArgumentOutOfRangeException(nameof(maximumBytes));

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.Lifecycle.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.Lifecycle.cs
@@ -443,7 +443,7 @@ namespace OfficeIMO.PowerPoint {
                     _persistenceMode = options.PersistenceMode
                 };
                 if (document.DigitalSignatureOriginPart != null ||
-                    document.ExtendedFilePropertiesPart?.Properties?.DigitalSignature != null) {
+                    PowerPointPackageFingerprint.HasApplicationSignatureFlag(document)) {
                     presentation._signedPackageOpenFingerprint = CreatePackageFingerprint(document);
                 }
                 presentation.MarkLoadedFromOpenXml(bytes);

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.Lifecycle.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.Lifecycle.cs
@@ -437,13 +437,14 @@ namespace OfficeIMO.PowerPoint {
             try {
                 PresentationDocument document = PresentationDocument.Open(
                     packageStream, editable, CreateOpenSettings(options.OpenSettings));
+                bool hasSignature = PowerPointPackageFingerprint
+                    .HasSignatureAndEnsurePackageXmlWithinLimit(document);
                 var presentation = new PowerPointPresentation(document, filePath ?? string.Empty, isNewPresentation: false) {
                     _packageStream = packageStream,
                     _sourceStream = associatedStream,
                     _persistenceMode = options.PersistenceMode
                 };
-                if (document.DigitalSignatureOriginPart != null ||
-                    PowerPointPackageFingerprint.HasApplicationSignatureFlag(document)) {
+                if (hasSignature) {
                     presentation._signedPackageOpenFingerprint = CreatePackageFingerprint(document);
                 }
                 presentation.MarkLoadedFromOpenXml(bytes);

--- a/OfficeIMO.Reader.Core/ReaderHierarchicalChunker.cs
+++ b/OfficeIMO.Reader.Core/ReaderHierarchicalChunker.cs
@@ -222,19 +222,24 @@ public static partial class ReaderHierarchicalChunker {
             yield break;
         }
 
-        int inspectedPageBlocks = 0;
+        int inspectedPageEntries = 0;
         for (int pageIndexValue = 0; pageIndexValue < pages.Count; pageIndexValue++) {
+            if (inspectedPageEntries >= maximumInspections) {
+                yield return FallbackBlock.LimitMarker;
+                yield break;
+            }
             cancellationToken.ThrowIfCancellationRequested();
+            inspectedPageEntries++;
             OfficeDocumentPage page = pages[pageIndexValue];
             if (page?.Blocks == null) continue;
             IReadOnlyList<OfficeDocumentBlock> pageBlocks = page.Blocks;
             for (int blockIndex = 0; blockIndex < pageBlocks.Count; blockIndex++) {
-                if (inspectedPageBlocks >= maximumInspections) {
+                if (inspectedPageEntries >= maximumInspections) {
                     yield return FallbackBlock.LimitMarker;
                     yield break;
                 }
                 cancellationToken.ThrowIfCancellationRequested();
-                inspectedPageBlocks++;
+                inspectedPageEntries++;
                 OfficeDocumentBlock block = pageBlocks[blockIndex];
                 if (!TryRegisterFallbackBlock(block, seen, seenIds)) continue;
                 if (emittedBlocks >= maximumInputChunks) {
@@ -274,18 +279,22 @@ public static partial class ReaderHierarchicalChunker {
             }
         }
 
-        int inspectedBlocks = 0;
+        int inspections = 0;
         for (int pageIndex = 0; pageIndex < pages.Count; pageIndex++) {
+            if (inspections >= maximumInspections) {
+                return new PageBlockIndex(byReference, byId);
+            }
             cancellationToken.ThrowIfCancellationRequested();
+            inspections++;
             OfficeDocumentPage page = pages[pageIndex];
             if (page?.Blocks == null) continue;
             IReadOnlyList<OfficeDocumentBlock> pageBlocks = page.Blocks;
             for (int blockIndex = 0;
-                 blockIndex < pageBlocks.Count && inspectedBlocks < maximumInspections;
+                 blockIndex < pageBlocks.Count && inspections < maximumInspections;
                  blockIndex++) {
                 cancellationToken.ThrowIfCancellationRequested();
                 OfficeDocumentBlock block = pageBlocks[blockIndex];
-                inspectedBlocks++;
+                inspections++;
                 if (block == null) continue;
                 if (remaining.Contains(block)) {
                     byReference[block] = page;
@@ -298,7 +307,7 @@ public static partial class ReaderHierarchicalChunker {
                 }
                 if (remaining.Count == 0) return new PageBlockIndex(byReference, byId);
             }
-            if (inspectedBlocks >= maximumInspections) {
+            if (inspections >= maximumInspections) {
                 return new PageBlockIndex(byReference, byId);
             }
         }

--- a/OfficeIMO.Reader.Core/ReaderHierarchicalChunker.cs
+++ b/OfficeIMO.Reader.Core/ReaderHierarchicalChunker.cs
@@ -9,6 +9,7 @@ namespace OfficeIMO.Reader;
 
 /// <summary>Creates bounded token-aware chunks and a document/container/heading hierarchy.</summary>
 public static partial class ReaderHierarchicalChunker {
+    private const int PageIndexInspectionMultiplier = 16;
     private static readonly ConditionalWeakTable<ReaderChunk, FallbackHeadingIdentityPath> FallbackHeadingIdentities =
         new ConditionalWeakTable<ReaderChunk, FallbackHeadingIdentityPath>();
     private static readonly ReaderChunk FallbackInputLimitMarker = new ReaderChunk();
@@ -201,7 +202,14 @@ public static partial class ReaderHierarchicalChunker {
             emittedBlocks++;
         }
 
-        PageBlockIndex pageIndex = IndexPageBlocks(pages, retainedDocumentBlocks, cancellationToken);
+        int maximumPageIndexInspections = (int)Math.Min(
+            int.MaxValue,
+            (long)maximumInputChunks * PageIndexInspectionMultiplier);
+        PageBlockIndex pageIndex = IndexPageBlocks(
+            pages,
+            retainedDocumentBlocks,
+            maximumPageIndexInspections,
+            cancellationToken);
         for (int blockIndex = 0; blockIndex < retainedDocumentBlocks.Count; blockIndex++) {
             OfficeDocumentBlock block = retainedDocumentBlocks[blockIndex];
             if (!pageIndex.ByReference.TryGetValue(block, out OfficeDocumentPage? page) && !string.IsNullOrWhiteSpace(block.Id)) {
@@ -250,6 +258,7 @@ public static partial class ReaderHierarchicalChunker {
     private static PageBlockIndex IndexPageBlocks(
         IReadOnlyList<OfficeDocumentPage> pages,
         IReadOnlyList<OfficeDocumentBlock> targetBlocks,
+        int maximumInspections,
         CancellationToken cancellationToken) {
         var byReference = new Dictionary<OfficeDocumentBlock, OfficeDocumentPage>(
             ReferenceIdentityComparer<OfficeDocumentBlock>.Instance);
@@ -265,12 +274,18 @@ public static partial class ReaderHierarchicalChunker {
             }
         }
 
+        int inspectedBlocks = 0;
         for (int pageIndex = 0; pageIndex < pages.Count; pageIndex++) {
             cancellationToken.ThrowIfCancellationRequested();
             OfficeDocumentPage page = pages[pageIndex];
             if (page?.Blocks == null) continue;
-            foreach (OfficeDocumentBlock block in page.Blocks) {
+            IReadOnlyList<OfficeDocumentBlock> pageBlocks = page.Blocks;
+            for (int blockIndex = 0;
+                 blockIndex < pageBlocks.Count && inspectedBlocks < maximumInspections;
+                 blockIndex++) {
                 cancellationToken.ThrowIfCancellationRequested();
+                OfficeDocumentBlock block = pageBlocks[blockIndex];
+                inspectedBlocks++;
                 if (block == null) continue;
                 if (remaining.Contains(block)) {
                     byReference[block] = page;
@@ -282,6 +297,9 @@ public static partial class ReaderHierarchicalChunker {
                     remaining.Remove(target);
                 }
                 if (remaining.Count == 0) return new PageBlockIndex(byReference, byId);
+            }
+            if (inspectedBlocks >= maximumInspections) {
+                return new PageBlockIndex(byReference, byId);
             }
         }
         return new PageBlockIndex(byReference, byId);

--- a/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
+++ b/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
@@ -502,7 +502,62 @@ public sealed class ReaderHierarchicalChunkingTests {
             });
 
         Assert.Single(result.Chunks);
-        Assert.Equal(16, pageBlocks.ReadCount);
+        Assert.Equal(15, pageBlocks.ReadCount);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "hierarchical-input-chunk-limit");
+    }
+
+    [Fact]
+    public void Chunk_BoundsPageIndexInspectionAcrossEmptyPages() {
+        var retained = new OfficeDocumentBlock { Id = "retained", Text = "body" };
+        var pages = new CountingPageList(
+            new OfficeDocumentPage { Number = 1, Blocks = Array.Empty<OfficeDocumentBlock>() },
+            1_000);
+        var document = new OfficeDocumentReadResult {
+            Kind = ReaderInputKind.Text,
+            Blocks = new[] {
+                retained,
+                new OfficeDocumentBlock { Id = "truncated", Text = "later" }
+            },
+            Pages = pages
+        };
+
+        ReaderChunkHierarchyResult result = ReaderHierarchicalChunker.Chunk(document,
+            new ReaderHierarchicalChunkingOptions {
+                MaxTokens = 10,
+                OverlapTokens = 0,
+                MaxInputChunks = 1,
+                IncludeContextInText = false,
+                TokenCounter = WordCounter
+            });
+
+        Assert.Single(result.Chunks);
+        Assert.Equal(16, pages.ReadCount);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "hierarchical-input-chunk-limit");
+    }
+
+    [Fact]
+    public void Chunk_BoundsFallbackInspectionAcrossEmptyPages() {
+        var retained = new OfficeDocumentBlock { Id = "retained", Text = "body" };
+        var pages = new CountingPageList(
+            new OfficeDocumentPage { Number = 1, Blocks = Array.Empty<OfficeDocumentBlock>() },
+            1_000);
+        var document = new OfficeDocumentReadResult {
+            Kind = ReaderInputKind.Text,
+            Blocks = new[] { retained },
+            Pages = pages
+        };
+
+        ReaderChunkHierarchyResult result = ReaderHierarchicalChunker.Chunk(document,
+            new ReaderHierarchicalChunkingOptions {
+                MaxTokens = 10,
+                OverlapTokens = 0,
+                MaxInputChunks = 1,
+                IncludeContextInText = false,
+                TokenCounter = WordCounter
+            });
+
+        Assert.Single(result.Chunks);
+        Assert.Equal(20, pages.ReadCount);
         Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "hierarchical-input-chunk-limit");
     }
 
@@ -1205,6 +1260,32 @@ public sealed class ReaderHierarchicalChunkingTests {
         }
 
         public IEnumerator<OfficeDocumentBlock> GetEnumerator() {
+            for (int index = 0; index < Count; index++) yield return this[index];
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    private sealed class CountingPageList : IReadOnlyList<OfficeDocumentPage> {
+        private readonly OfficeDocumentPage _page;
+
+        internal CountingPageList(OfficeDocumentPage page, int count) {
+            _page = page;
+            Count = count;
+        }
+
+        public int Count { get; }
+        internal int ReadCount { get; private set; }
+
+        public OfficeDocumentPage this[int index] {
+            get {
+                if (index < 0 || index >= Count) throw new ArgumentOutOfRangeException(nameof(index));
+                ReadCount++;
+                return _page;
+            }
+        }
+
+        public IEnumerator<OfficeDocumentPage> GetEnumerator() {
             for (int index = 0; index < Count; index++) yield return this[index];
         }
 

--- a/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
+++ b/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
@@ -479,6 +479,34 @@ public sealed class ReaderHierarchicalChunkingTests {
     }
 
     [Fact]
+    public void Chunk_BoundsPageIndexInspectionWhenRetainedBlocksAreMissing() {
+        var retained = new OfficeDocumentBlock { Id = "retained", Text = "body" };
+        var unrelated = new OfficeDocumentBlock { Id = "unrelated", Text = "other" };
+        var pageBlocks = new CountingBlockList(unrelated, 1_000);
+        var document = new OfficeDocumentReadResult {
+            Kind = ReaderInputKind.Text,
+            Blocks = new[] {
+                retained,
+                new OfficeDocumentBlock { Id = "truncated", Text = "later" }
+            },
+            Pages = new[] { new OfficeDocumentPage { Number = 7, Blocks = pageBlocks } }
+        };
+
+        ReaderChunkHierarchyResult result = ReaderHierarchicalChunker.Chunk(document,
+            new ReaderHierarchicalChunkingOptions {
+                MaxTokens = 10,
+                OverlapTokens = 0,
+                MaxInputChunks = 1,
+                IncludeContextInText = false,
+                TokenCounter = WordCounter
+            });
+
+        Assert.Single(result.Chunks);
+        Assert.Equal(16, pageBlocks.ReadCount);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "hierarchical-input-chunk-limit");
+    }
+
+    [Fact]
     public void Chunk_BoundsLeafTitlesAndPathsWithoutChangingLeafIdentity() {
         ReaderChunk source = CreateChunk("stable-id", "body");
         source.Location.Page = null;


### PR DESCRIPTION
## Summary

- reject non-finite raster dash cycles and charge malformed SVG point lists against the shared path budget
- stop overlong SVG point tokens and separator runs after 128 characters, exhausting the shared path budget before referenced definitions can be replayed
- keep CodeGlyph SVG imports within the standard viewport-area limit
- count empty-page visits in both hierarchical page indexing and fallback enumeration
- preflight every raw XML part in signed PowerPoint packages before presentation or slide roots can be materialized
- preserve unsaved loaded roots when later fingerprints are created

## Validation

- malformed and repeatedly referenced SVG point-list regressions pass on .NET 8 and .NET 10
- PowerPoint package-fingerprint regressions pass on .NET 8 and .NET 10
- Reader hierarchical chunking tests pass on .NET 8 and .NET 10, including bounded empty-page lists
- Drawing, CodeGlyphX, Reader.Core, and PowerPoint build cleanly for netstandard2.0

This is security findings batch 12.