### PR TITLE
Bound remaining parser and export work

### DIFF
--- a/OfficeIMO.CSV.Tests/CsvStreamingTests.cs
+++ b/OfficeIMO.CSV.Tests/CsvStreamingTests.cs
@@ -96,11 +96,13 @@ public class CsvStreamingTests
                     new CsvDataReaderOptions { InferSchema = true });
                 reader.Read();
             });
+#if NET8_0_OR_GREATER
             Assert.Throws<InvalidOperationException>(() =>
             {
                 var visitor = new CapturingRowFieldSpanVisitor(new List<string>());
                 CsvDocument.ReadRowFieldSpans(path, ref visitor, options);
             });
+#endif
             await Assert.ThrowsAsync<InvalidOperationException>(() => CsvDocument.LoadAsync(path, options));
 
             Assert.Throws<ArgumentOutOfRangeException>(() =>

--- a/OfficeIMO.CSV.Tests/CsvStreamingTests.cs
+++ b/OfficeIMO.CSV.Tests/CsvStreamingTests.cs
@@ -88,7 +88,26 @@ public class CsvStreamingTests
             Assert.Throws<InvalidOperationException>(() => CsvDocument.Load(path, options));
             Assert.Throws<InvalidOperationException>(() =>
                 CsvDocument.ReadRows(path, (_, _) => { }, options));
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                using var reader = CsvDocument.CreateDataReader(
+                    path,
+                    options,
+                    new CsvDataReaderOptions { InferSchema = true });
+                reader.Read();
+            });
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                var visitor = new CapturingRowFieldSpanVisitor(new List<string>());
+                CsvDocument.ReadRowFieldSpans(path, ref visitor, options);
+            });
             await Assert.ThrowsAsync<InvalidOperationException>(() => CsvDocument.LoadAsync(path, options));
+
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                CsvDocument.CreateDataReader(
+                    path,
+                    new CsvLoadOptions { Mode = CsvLoadMode.Stream, MaxInputBytes = 0 },
+                    new CsvDataReaderOptions { InferSchema = true }));
         }
         finally
         {

--- a/OfficeIMO.CSV.Tests/CsvStreamingTests.cs
+++ b/OfficeIMO.CSV.Tests/CsvStreamingTests.cs
@@ -77,6 +77,26 @@ public class CsvStreamingTests
     }
 
     [Fact]
+    public async Task PlainPathLoads_EnforceMaxInputBytes()
+    {
+        string path = Path.Combine(Path.GetTempPath(), "OfficeIMO.CSV.PathBounded." + Guid.NewGuid().ToString("N") + ".csv");
+        try
+        {
+            File.WriteAllText(path, "Id,Name\n1,Alice\n", Encoding.UTF8);
+            var options = new CsvLoadOptions { MaxInputBytes = 8 };
+
+            Assert.Throws<InvalidOperationException>(() => CsvDocument.Load(path, options));
+            Assert.Throws<InvalidOperationException>(() =>
+                CsvDocument.ReadRows(path, (_, _) => { }, options));
+            await Assert.ThrowsAsync<InvalidOperationException>(() => CsvDocument.LoadAsync(path, options));
+        }
+        finally
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    [Fact]
     public async Task LoadAsync_SnapshotsCompleteCallerStreamAndRestoresPosition()
     {
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes("Id,Name\n1,Alice\n"));

--- a/OfficeIMO.CSV/CsvDocument.DataReader.cs
+++ b/OfficeIMO.CSV/CsvDocument.DataReader.cs
@@ -1,7 +1,6 @@
 #nullable enable
 
 using System.Data.Common;
-using System.Text;
 
 namespace OfficeIMO.CSV;
 
@@ -36,8 +35,8 @@ public sealed partial class CsvDocument
         if (CanUseMemoryBackedFileDataReader(path, options, readerOptions))
         {
             options.CancellationToken.ThrowIfCancellationRequested();
-            var encoding = options.Encoding ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
-            var text = File.ReadAllText(path, encoding);
+            using var boundedReader = CsvFile.OpenTextReader(path, options, FileBufferSize);
+            var text = boundedReader.ReadToEnd();
             return Parse(text, options).CreateDataReader(readerOptions);
         }
 #endif
@@ -170,6 +169,7 @@ public sealed partial class CsvDocument
 
         var fileLength = new FileInfo(path).Length;
         return fileLength <= MemoryBackedCsvFileLimit &&
+            fileLength <= options.MaxInputBytes &&
             (options.MaxDecompressedBytes is null || fileLength <= options.MaxDecompressedBytes.Value);
     }
 #endif

--- a/OfficeIMO.CSV/CsvDocument.Fields.cs
+++ b/OfficeIMO.CSV/CsvDocument.Fields.cs
@@ -1,7 +1,5 @@
 #nullable enable
 
-using System.Text;
-
 namespace OfficeIMO.CSV;
 
 public sealed partial class CsvDocument
@@ -28,8 +26,8 @@ public sealed partial class CsvDocument
         if (CanUseMemoryBackedFileText(path, resolvedOptions))
         {
             resolvedOptions.CancellationToken.ThrowIfCancellationRequested();
-            var encoding = resolvedOptions.Encoding ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
-            var text = File.ReadAllText(path, encoding);
+            using var boundedReader = CsvFile.OpenTextReader(path, resolvedOptions, FileBufferSize);
+            var text = boundedReader.ReadToEnd();
             ReadRowFieldSpans(text.AsSpan(), ref rowVisitor, resolvedOptions);
             return;
         }

--- a/OfficeIMO.CSV/CsvFile.cs
+++ b/OfficeIMO.CSV/CsvFile.cs
@@ -148,6 +148,7 @@ public static class CsvFile
         var compressionType = ResolveCompression(options.CompressionType, path);
         EnsureCompressionSupported(compressionType);
         ValidateMaxDecompressedBytes(options);
+        ValidateMaxInputBytes(options);
 
         FileOptions fileOptions = FileOptions.SequentialScan;
         if (useAsync)
@@ -157,12 +158,24 @@ public static class CsvFile
 
         var fileStream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize, fileOptions);
         Stream stream = WrapReadStream(fileStream, compressionType, leaveOpen: false);
-        if (compressionType != CsvCompressionType.None && options.MaxDecompressedBytes is { } maxBytesLimit)
+        if (compressionType == CsvCompressionType.None)
+        {
+            stream = new CsvBoundedReadStream(stream, options.MaxInputBytes, leaveOpen: false);
+        }
+        else if (options.MaxDecompressedBytes is { } maxBytesLimit)
         {
             stream = new CsvBoundedReadStream(stream, maxBytesLimit, leaveOpen: false);
         }
 
         return stream;
+    }
+
+    private static void ValidateMaxInputBytes(CsvLoadOptions options)
+    {
+        if (options.MaxInputBytes <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(options.MaxInputBytes));
+        }
     }
 
     private static Stream CreateWriteStream(string path, CsvSaveOptions options, bool append, int bufferSize) =>
@@ -307,7 +320,7 @@ public static class CsvFile
             _bytesRead += count;
             if (_bytesRead > _maxBytes)
             {
-                throw new InvalidOperationException($"CSV decompressed data exceeded the configured limit of {_maxBytes} bytes.");
+                throw new InvalidOperationException($"CSV data exceeded the configured limit of {_maxBytes} bytes.");
             }
         }
 

--- a/OfficeIMO.CSV/CsvLoadOptions.cs
+++ b/OfficeIMO.CSV/CsvLoadOptions.cs
@@ -153,8 +153,8 @@ public sealed class CsvLoadOptions
     public long? MaxDecompressedBytes { get; set; } = DefaultMaxInputBytes;
 
     /// <summary>
-    /// Gets or sets the maximum number of bytes accepted by stream-based load APIs.
-    /// Defaults to 256 MiB so non-seekable and never-ending inputs cannot be buffered without bound.
+    /// Gets or sets the maximum number of bytes accepted by stream-based and uncompressed path-based load APIs.
+    /// Defaults to 256 MiB so untrusted inputs cannot be buffered without bound.
     /// </summary>
     public long MaxInputBytes { get; set; } = DefaultMaxInputBytes;
 

--- a/OfficeIMO.Drawing.Tests/Drawing.Tests.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.Tests.cs
@@ -3591,6 +3591,27 @@ public partial class DrawingTests {
     }
 
     [Fact]
+    public void OfficeImagePdfCompatibilityRejectsLargeNonIhdrFirstChunkBeforeCrc() {
+        const int chunkLength = 1_000_000;
+        var malformed = new byte[8 + 12 + chunkLength];
+        Array.Copy(OnePixelPng, malformed, 8);
+        malformed[8] = 0x00;
+        malformed[9] = 0x0F;
+        malformed[10] = 0x42;
+        malformed[11] = 0x40;
+        Encoding.ASCII.GetBytes("IDAT").CopyTo(malformed, 12);
+
+        bool valid = OfficeImagePdfCompatibility.TryValidate(
+            malformed,
+            out OfficeImageInfo? imageInfo,
+            out string? unsupportedReason);
+
+        Assert.False(valid);
+        Assert.Null(imageInfo);
+        Assert.Equal("PNG bytes must start with an IHDR chunk.", unsupportedReason);
+    }
+
+    [Fact]
     public void OfficeImageReaderIdentifiesPngWithoutDecodingPixels() {
         var image = OfficeImageReader.Identify(OnePixelPng);
 

--- a/OfficeIMO.Drawing/OfficeImagePdfCompatibility.cs
+++ b/OfficeIMO.Drawing/OfficeImagePdfCompatibility.cs
@@ -168,6 +168,11 @@ namespace OfficeIMO.Drawing {
                 }
 
                 string type = GetAscii(bytes, offset + 4, 4);
+                if (!seenIhdr && (type != "IHDR" || length != 13)) {
+                    unsupportedReason = "PNG bytes must start with an IHDR chunk.";
+                    return false;
+                }
+
                 uint expectedCrc = ReadUInt32BigEndian(bytes, offset + 8 + length);
                 uint actualCrc = ComputePngCrc(bytes, offset + 4, 4 + length);
                 if (actualCrc != expectedCrc) {
@@ -176,11 +181,6 @@ namespace OfficeIMO.Drawing {
                 }
 
                 if (!seenIhdr) {
-                    if (type != "IHDR" || length != 13) {
-                        unsupportedReason = "PNG bytes must start with an IHDR chunk.";
-                        return false;
-                    }
-
                     seenIhdr = true;
                 } else if (type == "IHDR") {
                     unsupportedReason = "PNG bytes contain more than one IHDR chunk.";

--- a/OfficeIMO.Excel.Tests/Excel.FeatureReport.PdfPreflightReview.cs
+++ b/OfficeIMO.Excel.Tests/Excel.FeatureReport.PdfPreflightReview.cs
@@ -1,7 +1,12 @@
 using System;
 using System.IO;
+using System.Linq;
+using System.Text;
+using DocumentFormat.OpenXml.Packaging;
 using OfficeIMO.Excel;
 using Xunit;
+using A = DocumentFormat.OpenXml.Drawing;
+using Xdr = DocumentFormat.OpenXml.Drawing.Spreadsheet;
 
 namespace OfficeIMO.Tests {
     public partial class Excel {
@@ -25,6 +30,36 @@ namespace OfficeIMO.Tests {
                     report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport));
                 Assert.Contains("PDF-unsupported images", diagnostics);
                 Assert.Contains("invalid CRC", diagnostics);
+            }
+        }
+
+        [Fact]
+        public void FeatureReport_Preflight_RejectsInvalidImageDimensionsBeforeReadingBytes() {
+            string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.InvalidImageDimensions.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorksheet("Images");
+                sheet.AddImage(1, 1, CreatePngWithLargeNonIhdrFirstChunk(), "image/png", widthPixels: 12, heightPixels: 12, name: "InvalidDimensions");
+                document.Save();
+            }
+
+            using (SpreadsheetDocument package = SpreadsheetDocument.Open(filePath, true)) {
+                Xdr.Extent extent = Assert.Single(
+                    Assert.Single(package.WorkbookPart!.WorksheetParts)
+                        .DrawingsPart!.WorksheetDrawing.Descendants<Xdr.Extent>());
+                extent.Cx = 0L;
+                Assert.Single(extent.Ancestors<Xdr.WorksheetDrawing>().Single().Descendants<A.Extents>()).Cx = 0L;
+                extent.Ancestors<Xdr.WorksheetDrawing>().Single().Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, new OfficeIMO.Excel.ExcelLoadOptions { AccessMode = OfficeIMO.Drawing.DocumentAccessMode.ReadOnly })) {
+                ExcelFeatureReport report = document.InspectFeatures();
+                string diagnostics = string.Join(Environment.NewLine,
+                    report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport));
+
+                Assert.False(report.Can(ExcelPreflightCapability.ExportPdfReport));
+                Assert.Contains("non-positive dimensions", diagnostics);
+                Assert.DoesNotContain("invalid CRC", diagnostics);
             }
         }
 
@@ -159,6 +194,18 @@ namespace OfficeIMO.Tests {
                 8, 2, 0, 0, 0,
                 0, 0, 0, 0
             };
+        }
+
+        private static byte[] CreatePngWithLargeNonIhdrFirstChunk() {
+            const int chunkLength = 1_000_000;
+            var bytes = new byte[8 + 12 + chunkLength];
+            byte[] signature = { 137, 80, 78, 71, 13, 10, 26, 10 };
+            Array.Copy(signature, bytes, signature.Length);
+            bytes[9] = 0x0F;
+            bytes[10] = 0x42;
+            bytes[11] = 0x40;
+            Encoding.ASCII.GetBytes("IDAT").CopyTo(bytes, 12);
+            return bytes;
         }
     }
 }

--- a/OfficeIMO.Excel.Tests/Excel.ImageExport.Sparklines.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ImageExport.Sparklines.cs
@@ -130,6 +130,11 @@ namespace OfficeIMO.Tests {
             Assert.Equal("BoundedGroupScale!XFD1", visible.Source);
             Assert.Equal(1D, visible.ScaleMinimum);
             Assert.Equal(1D, visible.ScaleMaximum);
+
+            ExcelVisualSparkline lastVisible = Assert.Single(sheet.Range("XFD7:XFD7").CreateVisualSnapshot().Sparklines);
+            Assert.Equal("BoundedGroupScale!XFD7", lastVisible.Source);
+            Assert.Equal(new[] { 1000D }, lastVisible.Values);
+            Assert.Equal(1000D, lastVisible.ScaleMaximum);
         }
 
         [Fact]

--- a/OfficeIMO.Excel.Tests/Excel.ImageExport.Sparklines.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ImageExport.Sparklines.cs
@@ -117,6 +117,22 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void ExcelRange_ImageExportBoundsAggregateOffRangeSparklineData() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+            using ExcelDocument document = ExcelDocument.Create(filePath);
+            ExcelSheet sheet = document.AddWorksheet("BoundedGroupScale");
+            sheet.CellValue(1, 1, 1);
+            sheet.CellValue(7, 1, 1000);
+            sheet.AddSparklines("A1:XFC7", "XFD1:XFD7", SparklineTypeValues.Column, seriesColor: "#2563EB");
+
+            ExcelVisualSparkline visible = Assert.Single(sheet.Range("XFD1:XFD1").CreateVisualSnapshot().Sparklines);
+
+            Assert.Equal("BoundedGroupScale!XFD1", visible.Source);
+            Assert.Equal(1D, visible.ScaleMinimum);
+            Assert.Equal(1D, visible.ScaleMaximum);
+        }
+
+        [Fact]
         public void ExcelRange_ImageExportReportsExternalSparklineRanges() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
             using ExcelDocument document = ExcelDocument.Create(filePath);

--- a/OfficeIMO.Excel.Tests/Excel.ImageExport.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ImageExport.cs
@@ -884,6 +884,28 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void ExcelRange_ImageExportOmitsConditionalRulesWhenNoRuleFitsWorkBudget() {
+            using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet sheet = document.AddWorksheet("OversizedRuleCellWork");
+            var cells = new CountingVisualCellList(1_000_001);
+            var diagnostics = new List<OfficeImageExportDiagnostic>();
+
+            ExcelConditionalVisualState state = ExcelConditionalVisualEvaluator.Evaluate(
+                sheet,
+                cells,
+                "A1:XFD1048576",
+                new DateTime(2026, 1, 1),
+                diagnostics);
+
+            Assert.Same(ExcelConditionalVisualState.Empty, state);
+            Assert.Equal(0, cells.ReadCount);
+            OfficeImageExportDiagnostic diagnostic = Assert.Single(diagnostics);
+            Assert.Equal(ExcelImageExportDiagnosticCodes.ConditionalReferenceLimitExceeded, diagnostic.Code);
+            Assert.Contains("1000000 rule-cell", diagnostic.Message, StringComparison.Ordinal);
+            Assert.Equal("OversizedRuleCellWork!A1:XFD1048576", diagnostic.Source);
+        }
+
+        [Fact]
         public void ExcelRange_ImageExportKeepsStoppedCellsInColorScaleThresholds() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
             using ExcelDocument document = ExcelDocument.Create(filePath);
@@ -5247,6 +5269,28 @@ namespace OfficeIMO.Tests {
             }
             public override void SetLength(long value) => throw new NotSupportedException();
             public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        }
+
+        private sealed class CountingVisualCellList : IReadOnlyList<ExcelVisualCell> {
+            internal CountingVisualCellList(int count) {
+                Count = count;
+            }
+
+            public int Count { get; }
+            internal int ReadCount { get; private set; }
+
+            public ExcelVisualCell this[int index] {
+                get {
+                    ReadCount++;
+                    throw new InvalidOperationException("The oversized conditional-formatting guard must run before cell access.");
+                }
+            }
+
+            public IEnumerator<ExcelVisualCell> GetEnumerator() {
+                for (int index = 0; index < Count; index++) yield return this[index];
+            }
+
+            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
         }
     }
 }

--- a/OfficeIMO.Excel.Tests/Excel.ImageExport.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ImageExport.cs
@@ -907,6 +907,37 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void ExcelRange_ImageExportSkipsConditionalRuleDiscoveryWhenNoRuleFitsWorkBudget() {
+            using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet sheet = document.AddWorksheet("SkippedRuleDiscovery");
+            var conditional = new ConditionalFormatting {
+                SequenceOfReferences = new ListValue<StringValue> { InnerText = "A1" }
+            };
+            var malformedRule = new ConditionalFormattingRule {
+                Type = ConditionalFormatValues.Expression
+            };
+            malformedRule.SetAttribute(new OpenXmlAttribute("priority", null, "not-an-integer"));
+            conditional.Append(malformedRule);
+            Worksheet worksheet = sheet.WorksheetPart.Worksheet!;
+            worksheet.InsertAfter(conditional, worksheet.GetFirstChild<SheetData>());
+            var cells = new CountingVisualCellList(200_001);
+            var diagnostics = new List<OfficeImageExportDiagnostic>();
+
+            ExcelConditionalVisualState state = ExcelConditionalVisualEvaluator.Evaluate(
+                sheet,
+                cells,
+                "A1:XFD1048576",
+                new DateTime(2026, 1, 1),
+                diagnostics);
+
+            Assert.Same(ExcelConditionalVisualState.Empty, state);
+            Assert.Equal(0, cells.ReadCount);
+            OfficeImageExportDiagnostic diagnostic = Assert.Single(diagnostics);
+            Assert.Equal(ExcelImageExportDiagnosticCodes.ConditionalReferenceLimitExceeded, diagnostic.Code);
+            Assert.Equal("SkippedRuleDiscovery!A1:XFD1048576", diagnostic.Source);
+        }
+
+        [Fact]
         public void ExcelRange_ImageExportReservesEveryConditionalEvaluatorPass() {
             using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
             ExcelSheet sheet = document.AddWorksheet("MultiPassRuleCellWork");

--- a/OfficeIMO.Excel.Tests/Excel.ImageExport.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ImageExport.cs
@@ -783,6 +783,51 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void ExcelRange_ImageExportBoundsAggregateConditionalRuleReferences() {
+            using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet sheet = document.AddWorksheet("AggregateConditional");
+            sheet.CellValue(1, 1, 0D);
+            sheet.AddConditionalColorScale("A1:A60000", OfficeColor.Red, OfficeColor.Lime);
+            sheet.AddConditionalColorScale("A1:A60000", OfficeColor.Blue, OfficeColor.White);
+
+            ExcelRangeVisualSnapshot snapshot = sheet.Range("A1:A1").CreateVisualSnapshot();
+
+            OfficeImageExportDiagnostic diagnostic = Assert.Single(
+                snapshot.Diagnostics,
+                item => item.Code == ExcelImageExportDiagnosticCodes.ConditionalReferenceLimitExceeded);
+            Assert.Equal(OfficeImageExportDiagnosticSeverity.Warning, diagnostic.Severity);
+            Assert.Equal(OfficeImageExportLossKind.Omission, diagnostic.LossKind);
+            Assert.Equal("AggregateConditional!A1:A60000", diagnostic.Source);
+            Assert.Contains("aggregate", diagnostic.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void ExcelRange_ImageExportBoundsConditionalRuleCount() {
+            using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet sheet = document.AddWorksheet("RuleCount");
+            sheet.CellValue(1, 1, 0D);
+            var conditional = new ConditionalFormatting {
+                SequenceOfReferences = new ListValue<StringValue> { InnerText = "A1" }
+            };
+            for (int priority = 1; priority <= 4_097; priority++) {
+                conditional.Append(new ConditionalFormattingRule {
+                    Type = ConditionalFormatValues.ColorScale,
+                    Priority = priority
+                });
+            }
+            Worksheet worksheet = sheet.WorksheetPart.Worksheet!;
+            worksheet.InsertAfter(conditional, worksheet.GetFirstChild<SheetData>());
+
+            ExcelRangeVisualSnapshot snapshot = sheet.Range("A1:A1").CreateVisualSnapshot();
+
+            OfficeImageExportDiagnostic diagnostic = Assert.Single(
+                snapshot.Diagnostics,
+                item => item.Code == ExcelImageExportDiagnosticCodes.ConditionalReferenceLimitExceeded);
+            Assert.Contains("4096-rule", diagnostic.Message, StringComparison.Ordinal);
+            Assert.Equal("RuleCount!A1:A1", diagnostic.Source);
+        }
+
+        [Fact]
         public void ExcelRange_ImageExportKeepsStoppedCellsInColorScaleThresholds() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
             using ExcelDocument document = ExcelDocument.Create(filePath);

--- a/OfficeIMO.Excel.Tests/Excel.ImageExport.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ImageExport.cs
@@ -828,6 +828,32 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void ExcelRange_ImageExportBoundsConditionalRuleCellWork() {
+            using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet sheet = document.AddWorksheet("RuleCellWork");
+            sheet.CellValue(1, 1, 0D);
+            var conditional = new ConditionalFormatting {
+                SequenceOfReferences = new ListValue<StringValue> { InnerText = "A1" }
+            };
+            for (int priority = 1; priority <= 1_001; priority++) {
+                conditional.Append(new ConditionalFormattingRule {
+                    Type = ConditionalFormatValues.ColorScale,
+                    Priority = priority
+                });
+            }
+            Worksheet worksheet = sheet.WorksheetPart.Worksheet!;
+            worksheet.InsertAfter(conditional, worksheet.GetFirstChild<SheetData>());
+
+            ExcelRangeVisualSnapshot snapshot = sheet.Range("A1:A1000").CreateVisualSnapshot();
+
+            OfficeImageExportDiagnostic diagnostic = Assert.Single(
+                snapshot.Diagnostics,
+                item => item.Code == ExcelImageExportDiagnosticCodes.ConditionalReferenceLimitExceeded);
+            Assert.Contains("1000-rule", diagnostic.Message, StringComparison.Ordinal);
+            Assert.Equal("RuleCellWork!A1:A1000", diagnostic.Source);
+        }
+
+        [Fact]
         public void ExcelRange_ImageExportKeepsStoppedCellsInColorScaleThresholds() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
             using ExcelDocument document = ExcelDocument.Create(filePath);

--- a/OfficeIMO.Excel.Tests/Excel.ImageExport.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ImageExport.cs
@@ -879,7 +879,7 @@ namespace OfficeIMO.Tests {
             OfficeImageExportDiagnostic diagnostic = Assert.Single(
                 snapshot.Diagnostics,
                 item => item.Code == ExcelImageExportDiagnosticCodes.ConditionalReferenceLimitExceeded);
-            Assert.Contains("1000-rule", diagnostic.Message, StringComparison.Ordinal);
+            Assert.Contains("200-rule", diagnostic.Message, StringComparison.Ordinal);
             Assert.Equal("RuleCellWork!A1:A1000", diagnostic.Source);
         }
 
@@ -887,6 +887,7 @@ namespace OfficeIMO.Tests {
         public void ExcelRange_ImageExportOmitsConditionalRulesWhenNoRuleFitsWorkBudget() {
             using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
             ExcelSheet sheet = document.AddWorksheet("OversizedRuleCellWork");
+            sheet.AddConditionalFormulaRule("A1", "=A1>0", stopIfTrue: true, fillColor: "C6EFCE");
             var cells = new CountingVisualCellList(1_000_001);
             var diagnostics = new List<OfficeImageExportDiagnostic>();
 
@@ -903,6 +904,29 @@ namespace OfficeIMO.Tests {
             Assert.Equal(ExcelImageExportDiagnosticCodes.ConditionalReferenceLimitExceeded, diagnostic.Code);
             Assert.Contains("1000000 rule-cell", diagnostic.Message, StringComparison.Ordinal);
             Assert.Equal("OversizedRuleCellWork!A1:XFD1048576", diagnostic.Source);
+        }
+
+        [Fact]
+        public void ExcelRange_ImageExportReservesEveryConditionalEvaluatorPass() {
+            using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet sheet = document.AddWorksheet("MultiPassRuleCellWork");
+            sheet.AddConditionalFormulaRule("A1", "=A1>0", stopIfTrue: true, fillColor: "C6EFCE");
+            var cells = new CountingVisualCellList(1_000_000);
+            var diagnostics = new List<OfficeImageExportDiagnostic>();
+
+            ExcelConditionalVisualState state = ExcelConditionalVisualEvaluator.Evaluate(
+                sheet,
+                cells,
+                "A1:XFD1048576",
+                new DateTime(2026, 1, 1),
+                diagnostics);
+
+            Assert.Same(ExcelConditionalVisualState.Empty, state);
+            Assert.Equal(0, cells.ReadCount);
+            OfficeImageExportDiagnostic diagnostic = Assert.Single(diagnostics);
+            Assert.Equal(ExcelImageExportDiagnosticCodes.ConditionalReferenceLimitExceeded, diagnostic.Code);
+            Assert.Contains("all evaluator passes", diagnostic.Message, StringComparison.Ordinal);
+            Assert.Equal("MultiPassRuleCellWork!A1:XFD1048576", diagnostic.Source);
         }
 
         [Fact]

--- a/OfficeIMO.Excel.Tests/Excel.ImageExport.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ImageExport.cs
@@ -828,6 +828,36 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void ExcelRange_ImageExportRetainsHighestPrecedenceRulesWhenBounded() {
+            using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet sheet = document.AddWorksheet("RulePriority");
+            var conditional = new ConditionalFormatting {
+                SequenceOfReferences = new ListValue<StringValue> { InnerText = "A1" }
+            };
+            conditional.Append(
+                new ConditionalFormattingRule {
+                    Type = ConditionalFormatValues.Expression,
+                    Priority = 100,
+                    StopIfTrue = false
+                },
+                new ConditionalFormattingRule {
+                    Type = ConditionalFormatValues.Expression,
+                    Priority = 1,
+                    StopIfTrue = true
+                });
+            Worksheet worksheet = sheet.WorksheetPart.Worksheet!;
+            worksheet.InsertAfter(conditional, worksheet.GetFirstChild<SheetData>());
+
+            IReadOnlyList<ExcelConditionalFormattingInfo> retained =
+                sheet.GetConditionalFormattingRules("A1", 1, out bool truncated);
+
+            Assert.True(truncated);
+            ExcelConditionalFormattingInfo rule = Assert.Single(retained);
+            Assert.Equal(1, rule.Priority);
+            Assert.True(rule.StopIfTrue);
+        }
+
+        [Fact]
         public void ExcelRange_ImageExportBoundsConditionalRuleCellWork() {
             using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
             ExcelSheet sheet = document.AddWorksheet("RuleCellWork");

--- a/OfficeIMO.Excel.Tests/Excel.ReaderDataReader.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ReaderDataReader.cs
@@ -100,6 +100,43 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Reader_ReadRangeAsDataReader_BoundsUnsortedXmlFallbackBuffer() {
+            using var source = new MemoryStream();
+            using (var document = ExcelDocument.Create(source, new ExcelCreateOptions { PersistenceMode = OfficeIMO.Drawing.DocumentPersistenceMode.SaveOnDispose })) {
+                ExcelSheet sheet = document.AddWorksheet("Data");
+                for (int row = 1; row <= 4; row++) {
+                    sheet.CellValue(row, 1, row);
+                    sheet.CellValue(row, 2, row * 10);
+                }
+            }
+
+            using var reordered = new MemoryStream();
+            source.Position = 0;
+            source.CopyTo(reordered);
+            reordered.Position = 0;
+            using (SpreadsheetDocument package = SpreadsheetDocument.Open(reordered, true)) {
+                WorksheetPart worksheetPart = Assert.Single(package.WorkbookPart!.WorksheetParts);
+                SheetData sheetData = worksheetPart.Worksheet.GetFirstChild<SheetData>()!;
+                Row[] rows = sheetData.Elements<Row>().ToArray();
+                sheetData.RemoveAllChildren<Row>();
+                sheetData.Append(rows[0], rows[3], rows[2], rows[1]);
+                worksheetPart.Worksheet.Save();
+            }
+
+            using var reader = ExcelDocumentReader.Open(reordered.ToArray(), new ExcelReadOptions {
+                MaxDataReaderBufferedCells = 4
+            });
+            using var dataReader = reader.GetSheet("Data").ReadRangeAsDataReader(
+                "A1:B4098",
+                headersInFirstRow: false,
+                schemaSampleRows: 0);
+
+            Assert.True(dataReader.Read());
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() => dataReader.Read());
+            Assert.Contains(nameof(ExcelReadOptions.MaxDataReaderBufferedCells), exception.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void Reader_ReadRangeAsDataReader_WithoutHeadersPreservesBlankRowsInsideRange() {
             using var memory = new MemoryStream();
 

--- a/OfficeIMO.Excel/ExcelFeatureReport.PdfPreflight.cs
+++ b/OfficeIMO.Excel/ExcelFeatureReport.PdfPreflight.cs
@@ -335,6 +335,11 @@ namespace OfficeIMO.Excel {
                 return false;
             }
 
+            if (image.WidthPixels <= 0 || image.HeightPixels <= 0) {
+                reason = "image has non-positive dimensions.";
+                return false;
+            }
+
             if (!image.TryReadBytes(out byte[] bytes)) {
                 reason = "image bytes are empty or exceed the PDF preflight source-image limit.";
                 return false;
@@ -342,11 +347,6 @@ namespace OfficeIMO.Excel {
 
             if (!OfficeImagePdfCompatibility.TryValidate(bytes, out OfficeImageInfo? imageInfo, out string? unsupportedReason)) {
                 reason = unsupportedReason ?? "image bytes are not supported by the first-party PDF image writer.";
-                return false;
-            }
-
-            if (image.WidthPixels <= 0 || image.HeightPixels <= 0) {
-                reason = "image has non-positive dimensions.";
                 return false;
             }
 

--- a/OfficeIMO.Excel/ExcelSheet.RuleManagement.cs
+++ b/OfficeIMO.Excel/ExcelSheet.RuleManagement.cs
@@ -26,6 +26,10 @@ namespace OfficeIMO.Excel {
             var workbookPart = _excelDocument.WorkbookPartRoot;
             Stylesheet? stylesheet = workbookPart.WorkbookStylesPart?.Stylesheet;
             var list = new List<ExcelConditionalFormattingInfo>();
+            SortedSet<ConditionalFormattingCandidate>? retained = maximumRules == int.MaxValue
+                ? null
+                : new SortedSet<ConditionalFormattingCandidate>(ConditionalFormattingCandidateComparer.Instance);
+            long ruleOrder = 0L;
             foreach (var conditional in WorksheetRoot.Elements<ConditionalFormatting>()) {
                 string range = conditional.SequenceOfReferences?.InnerText ?? string.Empty;
                 if (filter.HasValue && !string.IsNullOrWhiteSpace(range)) {
@@ -33,50 +37,111 @@ namespace OfficeIMO.Excel {
                 }
 
                 foreach (var rule in conditional.Elements<ConditionalFormattingRule>()) {
-                    if (list.Count >= maximumRules) {
-                        truncated = true;
-                        return list;
+                    if (retained == null) {
+                        list.Add(ReadConditionalFormattingInfo(rule, range, stylesheet, workbookPart));
+                        continue;
                     }
 
-                    uint? differentialFormatId = ReadDifferentialFormatId(rule);
-                    list.Add(new ExcelConditionalFormattingInfo {
-                        Range = range,
-                        Type = ReadConditionalFormatType(rule),
-                        Operator = ReadConditionalFormatOperator(rule),
-                        Text = rule.Text?.Value,
-                        TimePeriod = ReadConditionalTimePeriod(rule),
-                        Priority = (int)(rule.Priority?.Value ?? 0),
-                        StopIfTrue = rule.StopIfTrue?.Value ?? false,
-                        DifferentialFormatId = differentialFormatId,
-                        DifferentialFillColorArgb = ReadDifferentialFillColor(stylesheet, workbookPart, differentialFormatId),
-                        DifferentialFontColorArgb = ReadDifferentialFontColor(stylesheet, workbookPart, differentialFormatId),
-                        DifferentialFontBold = ReadDifferentialFontBold(stylesheet, differentialFormatId),
-                        DifferentialFontItalic = ReadDifferentialFontItalic(stylesheet, differentialFormatId),
-                        DifferentialFontUnderline = ReadDifferentialFontUnderline(stylesheet, differentialFormatId),
-                        DifferentialFontName = ReadDifferentialFontName(stylesheet, differentialFormatId),
-                        DifferentialFontSize = ReadDifferentialFontSize(stylesheet, differentialFormatId),
-                        DifferentialBorder = ReadDifferentialBorder(stylesheet, workbookPart, differentialFormatId),
-                        Formulas = rule.Elements<Formula>().Select(f => f.Text ?? string.Empty).ToArray(),
-                        ColorScaleColors = ReadColorScaleColors(rule),
-                        ColorScaleThresholds = ReadColorScaleThresholds(rule),
-                        DataBarColor = ReadDataBarColor(rule),
-                        DataBarThresholds = ReadDataBarThresholds(rule),
-                        DataBarShowValue = ReadDataBarShowValue(rule),
-                        IconSet = ReadIconSetName(rule),
-                        IconSetShowValue = ReadIconSetShowValue(rule),
-                        IconSetReverse = ReadIconSetReverse(rule),
-                        IconSetThresholds = ReadIconSetThresholds(rule),
-                        TopBottomRank = rule.Rank?.Value,
-                        TopBottomBottom = rule.Bottom?.Value ?? false,
-                        TopBottomPercent = rule.Percent?.Value ?? false,
-                        AboveAverageAbove = rule.AboveAverage?.Value ?? true,
-                        AboveAverageEqual = rule.EqualAverage?.Value ?? false,
-                        AboveAverageStdDev = rule.StdDev?.Value
-                    });
+                    var candidate = new ConditionalFormattingCandidate(
+                        rule,
+                        range,
+                        NormalizeConditionalFormattingPriority(rule),
+                        ruleOrder++);
+                    if (retained.Count < maximumRules) {
+                        retained.Add(candidate);
+                        continue;
+                    }
+
+                    truncated = true;
+                    ConditionalFormattingCandidate worst = retained.Max;
+                    if (ConditionalFormattingCandidateComparer.Instance.Compare(candidate, worst) < 0) {
+                        retained.Remove(worst);
+                        retained.Add(candidate);
+                    }
+                }
+            }
+
+            if (retained != null) {
+                foreach (ConditionalFormattingCandidate candidate in retained) {
+                    list.Add(ReadConditionalFormattingInfo(candidate.Rule, candidate.Range, stylesheet, workbookPart));
                 }
             }
 
             return list;
+        }
+
+        private static ExcelConditionalFormattingInfo ReadConditionalFormattingInfo(
+            ConditionalFormattingRule rule,
+            string range,
+            Stylesheet? stylesheet,
+            WorkbookPart workbookPart) {
+            uint? differentialFormatId = ReadDifferentialFormatId(rule);
+            return new ExcelConditionalFormattingInfo {
+                Range = range,
+                Type = ReadConditionalFormatType(rule),
+                Operator = ReadConditionalFormatOperator(rule),
+                Text = rule.Text?.Value,
+                TimePeriod = ReadConditionalTimePeriod(rule),
+                Priority = (int)(rule.Priority?.Value ?? 0),
+                StopIfTrue = rule.StopIfTrue?.Value ?? false,
+                DifferentialFormatId = differentialFormatId,
+                DifferentialFillColorArgb = ReadDifferentialFillColor(stylesheet, workbookPart, differentialFormatId),
+                DifferentialFontColorArgb = ReadDifferentialFontColor(stylesheet, workbookPart, differentialFormatId),
+                DifferentialFontBold = ReadDifferentialFontBold(stylesheet, differentialFormatId),
+                DifferentialFontItalic = ReadDifferentialFontItalic(stylesheet, differentialFormatId),
+                DifferentialFontUnderline = ReadDifferentialFontUnderline(stylesheet, differentialFormatId),
+                DifferentialFontName = ReadDifferentialFontName(stylesheet, differentialFormatId),
+                DifferentialFontSize = ReadDifferentialFontSize(stylesheet, differentialFormatId),
+                DifferentialBorder = ReadDifferentialBorder(stylesheet, workbookPart, differentialFormatId),
+                Formulas = rule.Elements<Formula>().Select(f => f.Text ?? string.Empty).ToArray(),
+                ColorScaleColors = ReadColorScaleColors(rule),
+                ColorScaleThresholds = ReadColorScaleThresholds(rule),
+                DataBarColor = ReadDataBarColor(rule),
+                DataBarThresholds = ReadDataBarThresholds(rule),
+                DataBarShowValue = ReadDataBarShowValue(rule),
+                IconSet = ReadIconSetName(rule),
+                IconSetShowValue = ReadIconSetShowValue(rule),
+                IconSetReverse = ReadIconSetReverse(rule),
+                IconSetThresholds = ReadIconSetThresholds(rule),
+                TopBottomRank = rule.Rank?.Value,
+                TopBottomBottom = rule.Bottom?.Value ?? false,
+                TopBottomPercent = rule.Percent?.Value ?? false,
+                AboveAverageAbove = rule.AboveAverage?.Value ?? true,
+                AboveAverageEqual = rule.EqualAverage?.Value ?? false,
+                AboveAverageStdDev = rule.StdDev?.Value
+            };
+        }
+
+        private static int NormalizeConditionalFormattingPriority(ConditionalFormattingRule rule) {
+            int priority = (int)(rule.Priority?.Value ?? 0);
+            return priority <= 0 ? int.MaxValue : priority;
+        }
+
+        private readonly struct ConditionalFormattingCandidate {
+            internal ConditionalFormattingCandidate(
+                ConditionalFormattingRule rule,
+                string range,
+                int priority,
+                long order) {
+                Rule = rule;
+                Range = range;
+                Priority = priority;
+                Order = order;
+            }
+
+            internal ConditionalFormattingRule Rule { get; }
+            internal string Range { get; }
+            internal int Priority { get; }
+            internal long Order { get; }
+        }
+
+        private sealed class ConditionalFormattingCandidateComparer : IComparer<ConditionalFormattingCandidate> {
+            internal static readonly ConditionalFormattingCandidateComparer Instance = new ConditionalFormattingCandidateComparer();
+
+            public int Compare(ConditionalFormattingCandidate left, ConditionalFormattingCandidate right) {
+                int priority = left.Priority.CompareTo(right.Priority);
+                return priority != 0 ? priority : left.Order.CompareTo(right.Order);
+            }
         }
 
         private static string ReadConditionalFormatType(ConditionalFormattingRule rule) {

--- a/OfficeIMO.Excel/ExcelSheet.RuleManagement.cs
+++ b/OfficeIMO.Excel/ExcelSheet.RuleManagement.cs
@@ -7,6 +7,9 @@ namespace OfficeIMO.Excel {
     public partial class ExcelSheet {
         private int _nextConditionalFormattingPriority;
 
+        internal bool HasConditionalFormatting =>
+            WorksheetRoot.GetFirstChild<ConditionalFormatting>() != null;
+
         /// <summary>
         /// Lists conditional formatting rules on the worksheet.
         /// </summary>

--- a/OfficeIMO.Excel/ExcelSheet.RuleManagement.cs
+++ b/OfficeIMO.Excel/ExcelSheet.RuleManagement.cs
@@ -10,7 +10,18 @@ namespace OfficeIMO.Excel {
         /// <summary>
         /// Lists conditional formatting rules on the worksheet.
         /// </summary>
-        public IReadOnlyList<ExcelConditionalFormattingInfo> GetConditionalFormattingRules(string? a1Range = null) {
+        public IReadOnlyList<ExcelConditionalFormattingInfo> GetConditionalFormattingRules(string? a1Range = null) =>
+            GetConditionalFormattingRules(a1Range, int.MaxValue, out _);
+
+        internal IReadOnlyList<ExcelConditionalFormattingInfo> GetConditionalFormattingRules(
+            string? a1Range,
+            int maximumRules,
+            out bool truncated) {
+            if (maximumRules <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(maximumRules));
+            }
+
+            truncated = false;
             (int r1, int c1, int r2, int c2)? filter = string.IsNullOrWhiteSpace(a1Range) ? null : ParseReferenceArgument(a1Range!);
             var workbookPart = _excelDocument.WorkbookPartRoot;
             Stylesheet? stylesheet = workbookPart.WorkbookStylesPart?.Stylesheet;
@@ -22,6 +33,11 @@ namespace OfficeIMO.Excel {
                 }
 
                 foreach (var rule in conditional.Elements<ConditionalFormattingRule>()) {
+                    if (list.Count >= maximumRules) {
+                        truncated = true;
+                        return list;
+                    }
+
                     uint? differentialFormatId = ReadDifferentialFormatId(rule);
                     list.Add(new ExcelConditionalFormattingInfo {
                         Range = range,

--- a/OfficeIMO.Excel/Imaging/ExcelConditionalVisualEvaluator.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelConditionalVisualEvaluator.cs
@@ -21,15 +21,8 @@ namespace OfficeIMO.Excel {
 
             long workPerRule = (long)cells.Count * MaxCellPassesPerConditionalRule;
             long maximumRulesForWork = MaxConditionalRuleCellEvaluations / workPerRule;
-            int maximumRules = maximumRulesForWork > 0
-                ? (int)Math.Min(MaxConditionalRules, maximumRulesForWork)
-                : 1;
-            IReadOnlyList<ExcelConditionalFormattingInfo> rules = sheet.GetConditionalFormattingRules(
-                range,
-                maximumRules,
-                out bool rulesTruncated);
             if (maximumRulesForWork == 0) {
-                if (rules.Count > 0 || rulesTruncated) {
+                if (sheet.HasConditionalFormatting) {
                     diagnostics.Add(ExcelImageExportDiagnosticClassifier.Create(
                         OfficeImageExportDiagnosticSeverity.Warning,
                         ExcelImageExportDiagnosticCodes.ConditionalReferenceLimitExceeded,
@@ -38,6 +31,12 @@ namespace OfficeIMO.Excel {
                 }
                 return ExcelConditionalVisualState.Empty;
             }
+
+            int maximumRules = (int)Math.Min(MaxConditionalRules, maximumRulesForWork);
+            IReadOnlyList<ExcelConditionalFormattingInfo> rules = sheet.GetConditionalFormattingRules(
+                range,
+                maximumRules,
+                out bool rulesTruncated);
             if (rulesTruncated) {
                 diagnostics.Add(ExcelImageExportDiagnosticClassifier.Create(
                     OfficeImageExportDiagnosticSeverity.Warning,

--- a/OfficeIMO.Excel/Imaging/ExcelConditionalVisualEvaluator.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelConditionalVisualEvaluator.cs
@@ -17,9 +17,18 @@ namespace OfficeIMO.Excel {
                 return ExcelConditionalVisualState.Empty;
             }
 
+            if (cells.Count > MaxConditionalRuleCellEvaluations) {
+                diagnostics.Add(ExcelImageExportDiagnosticClassifier.Create(
+                    OfficeImageExportDiagnosticSeverity.Warning,
+                    ExcelImageExportDiagnosticCodes.ConditionalReferenceLimitExceeded,
+                    $"Conditional formatting was omitted because the rendered range contains {cells.Count.ToString(CultureInfo.InvariantCulture)} cells, exceeding the {MaxConditionalRuleCellEvaluations.ToString(CultureInfo.InvariantCulture)} rule-cell image-export work limit.",
+                    sheet.Name + "!" + range));
+                return ExcelConditionalVisualState.Empty;
+            }
+
             int maximumRules = Math.Min(
                 MaxConditionalRules,
-                Math.Max(1, MaxConditionalRuleCellEvaluations / cells.Count));
+                MaxConditionalRuleCellEvaluations / cells.Count);
             IReadOnlyList<ExcelConditionalFormattingInfo> rules = sheet.GetConditionalFormattingRules(
                 range,
                 maximumRules,

--- a/OfficeIMO.Excel/Imaging/ExcelConditionalVisualEvaluator.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelConditionalVisualEvaluator.cs
@@ -6,6 +6,8 @@ namespace OfficeIMO.Excel {
         private const int MaxConditionalRules = 4_096;
         private const int MaxConditionalReferenceCells = 100_000;
         private const int MaxConditionalRuleCellEvaluations = 1_000_000;
+        // Support probing, stop-if-true discovery, final evaluation, and candidate application can each scan the cells.
+        private const int MaxCellPassesPerConditionalRule = 5;
 
         internal static ExcelConditionalVisualState Evaluate(
             ExcelSheet sheet,
@@ -17,22 +19,25 @@ namespace OfficeIMO.Excel {
                 return ExcelConditionalVisualState.Empty;
             }
 
-            if (cells.Count > MaxConditionalRuleCellEvaluations) {
-                diagnostics.Add(ExcelImageExportDiagnosticClassifier.Create(
-                    OfficeImageExportDiagnosticSeverity.Warning,
-                    ExcelImageExportDiagnosticCodes.ConditionalReferenceLimitExceeded,
-                    $"Conditional formatting was omitted because the rendered range contains {cells.Count.ToString(CultureInfo.InvariantCulture)} cells, exceeding the {MaxConditionalRuleCellEvaluations.ToString(CultureInfo.InvariantCulture)} rule-cell image-export work limit.",
-                    sheet.Name + "!" + range));
-                return ExcelConditionalVisualState.Empty;
-            }
-
-            int maximumRules = Math.Min(
-                MaxConditionalRules,
-                MaxConditionalRuleCellEvaluations / cells.Count);
+            long workPerRule = (long)cells.Count * MaxCellPassesPerConditionalRule;
+            long maximumRulesForWork = MaxConditionalRuleCellEvaluations / workPerRule;
+            int maximumRules = maximumRulesForWork > 0
+                ? (int)Math.Min(MaxConditionalRules, maximumRulesForWork)
+                : 1;
             IReadOnlyList<ExcelConditionalFormattingInfo> rules = sheet.GetConditionalFormattingRules(
                 range,
                 maximumRules,
                 out bool rulesTruncated);
+            if (maximumRulesForWork == 0) {
+                if (rules.Count > 0 || rulesTruncated) {
+                    diagnostics.Add(ExcelImageExportDiagnosticClassifier.Create(
+                        OfficeImageExportDiagnosticSeverity.Warning,
+                        ExcelImageExportDiagnosticCodes.ConditionalReferenceLimitExceeded,
+                        $"Conditional formatting was omitted because the rendered range cannot fit one rule within the {MaxConditionalRuleCellEvaluations.ToString(CultureInfo.InvariantCulture)} rule-cell image-export work limit after reserving all evaluator passes.",
+                        sheet.Name + "!" + range));
+                }
+                return ExcelConditionalVisualState.Empty;
+            }
             if (rulesTruncated) {
                 diagnostics.Add(ExcelImageExportDiagnosticClassifier.Create(
                     OfficeImageExportDiagnosticSeverity.Warning,

--- a/OfficeIMO.Excel/Imaging/ExcelConditionalVisualEvaluator.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelConditionalVisualEvaluator.cs
@@ -5,6 +5,7 @@ namespace OfficeIMO.Excel {
     internal static partial class ExcelConditionalVisualEvaluator {
         private const int MaxConditionalRules = 4_096;
         private const int MaxConditionalReferenceCells = 100_000;
+        private const int MaxConditionalRuleCellEvaluations = 1_000_000;
 
         internal static ExcelConditionalVisualState Evaluate(
             ExcelSheet sheet,
@@ -12,19 +13,26 @@ namespace OfficeIMO.Excel {
             string range,
             DateTime conditionalFormattingDate,
             List<OfficeImageExportDiagnostic> diagnostics) {
+            if (cells.Count == 0) {
+                return ExcelConditionalVisualState.Empty;
+            }
+
+            int maximumRules = Math.Min(
+                MaxConditionalRules,
+                Math.Max(1, MaxConditionalRuleCellEvaluations / cells.Count));
             IReadOnlyList<ExcelConditionalFormattingInfo> rules = sheet.GetConditionalFormattingRules(
                 range,
-                MaxConditionalRules,
+                maximumRules,
                 out bool rulesTruncated);
             if (rulesTruncated) {
                 diagnostics.Add(ExcelImageExportDiagnosticClassifier.Create(
                     OfficeImageExportDiagnosticSeverity.Warning,
                     ExcelImageExportDiagnosticCodes.ConditionalReferenceLimitExceeded,
-                    $"Conditional formatting rules beyond the {MaxConditionalRules.ToString(CultureInfo.InvariantCulture)}-rule image-export limit were omitted.",
+                    $"Conditional formatting rules beyond the {maximumRules.ToString(CultureInfo.InvariantCulture)}-rule image-export work limit were omitted.",
                     sheet.Name + "!" + range));
             }
 
-            if (rules.Count == 0 || cells.Count == 0) {
+            if (rules.Count == 0) {
                 return ExcelConditionalVisualState.Empty;
             }
 

--- a/OfficeIMO.Excel/Imaging/ExcelConditionalVisualEvaluator.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelConditionalVisualEvaluator.cs
@@ -3,6 +3,7 @@ using OfficeIMO.Drawing;
 
 namespace OfficeIMO.Excel {
     internal static partial class ExcelConditionalVisualEvaluator {
+        private const int MaxConditionalRules = 4_096;
         private const int MaxConditionalReferenceCells = 100_000;
 
         internal static ExcelConditionalVisualState Evaluate(
@@ -11,7 +12,18 @@ namespace OfficeIMO.Excel {
             string range,
             DateTime conditionalFormattingDate,
             List<OfficeImageExportDiagnostic> diagnostics) {
-            IReadOnlyList<ExcelConditionalFormattingInfo> rules = sheet.GetConditionalFormattingRules(range);
+            IReadOnlyList<ExcelConditionalFormattingInfo> rules = sheet.GetConditionalFormattingRules(
+                range,
+                MaxConditionalRules,
+                out bool rulesTruncated);
+            if (rulesTruncated) {
+                diagnostics.Add(ExcelImageExportDiagnosticClassifier.Create(
+                    OfficeImageExportDiagnosticSeverity.Warning,
+                    ExcelImageExportDiagnosticCodes.ConditionalReferenceLimitExceeded,
+                    $"Conditional formatting rules beyond the {MaxConditionalRules.ToString(CultureInfo.InvariantCulture)}-rule image-export limit were omitted.",
+                    sheet.Name + "!" + range));
+            }
+
             if (rules.Count == 0 || cells.Count == 0) {
                 return ExcelConditionalVisualState.Empty;
             }
@@ -39,10 +51,11 @@ namespace OfficeIMO.Excel {
             IReadOnlyList<ExcelConditionalFormattingInfo> rules,
             List<OfficeImageExportDiagnostic> diagnostics) {
             var retained = new List<ExcelConditionalFormattingInfo>(rules.Count);
+            int remainingReferenceCells = MaxConditionalReferenceCells;
             foreach (ExcelConditionalFormattingInfo rule in rules) {
-                if (!EnumerateReferenceCells(rule.Range, MaxConditionalReferenceCells + 1)
-                    .Skip(MaxConditionalReferenceCells)
-                    .Any()) {
+                int inspectedCells = EnumerateReferenceCells(rule.Range, remainingReferenceCells + 1).Count();
+                if (inspectedCells <= remainingReferenceCells) {
+                    remainingReferenceCells -= inspectedCells;
                     retained.Add(rule);
                     continue;
                 }
@@ -50,7 +63,7 @@ namespace OfficeIMO.Excel {
                 diagnostics.Add(ExcelImageExportDiagnosticClassifier.Create(
                     OfficeImageExportDiagnosticSeverity.Warning,
                     ExcelImageExportDiagnosticCodes.ConditionalReferenceLimitExceeded,
-                    $"Conditional formatting rule was omitted because its reference exceeds the {MaxConditionalReferenceCells.ToString(CultureInfo.InvariantCulture)}-cell image-export limit.",
+                    $"Conditional formatting rule was omitted because its reference exceeds the remaining aggregate {MaxConditionalReferenceCells.ToString(CultureInfo.InvariantCulture)}-cell image-export limit.",
                     sheet.Name + "!" + rule.Range));
             }
 

--- a/OfficeIMO.Excel/Imaging/ExcelRangeVisualSnapshotBuilder.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelRangeVisualSnapshotBuilder.cs
@@ -1215,6 +1215,7 @@ namespace OfficeIMO.Excel {
                         out _))
                 .Select(sparkline => sparkline.GroupIndex));
             var resolved = new List<ResolvedSparkline>(sparklines.Count);
+            long remainingSparklineDataCells = MaxSparklineDataCells;
             foreach (ExcelWorksheetSparklineInfo sparkline in sparklines) {
                 if (!IsSupportedSparklineKind(sparkline.Kind) ||
                     !visibleGroups.Contains(sparkline.GroupIndex)) {
@@ -1227,7 +1228,7 @@ namespace OfficeIMO.Excel {
                     continue;
                 }
 
-                if (!TryReadSparklineValues(sheet, dataRange, out IReadOnlyList<double> values)) {
+                if (!TryReadSparklineValues(sheet, dataRange, ref remainingSparklineDataCells, out IReadOnlyList<double> values)) {
                     resolved.Add(new ResolvedSparkline(sparkline, Array.Empty<double>(), hasResolvedRange: false, externalRange: false));
                     continue;
                 }
@@ -1328,7 +1329,11 @@ namespace OfficeIMO.Excel {
             return normalized;
         }
 
-        private static bool TryReadSparklineValues(ExcelSheet sheet, string dataRange, out IReadOnlyList<double> values) {
+        private static bool TryReadSparklineValues(
+            ExcelSheet sheet,
+            string dataRange,
+            ref long remainingDataCells,
+            out IReadOnlyList<double> values) {
             int firstRow;
             int firstColumn;
             int lastRow;
@@ -1345,10 +1350,12 @@ namespace OfficeIMO.Excel {
 
             long rowCount = (long)lastRow - firstRow + 1L;
             long columnCount = (long)lastColumn - firstColumn + 1L;
-            if (rowCount <= 0L || columnCount <= 0L || rowCount > MaxSparklineDataCells / columnCount) {
+            if (rowCount <= 0L || columnCount <= 0L || rowCount > remainingDataCells / columnCount) {
                 values = Array.Empty<double>();
                 return false;
             }
+
+            remainingDataCells -= rowCount * columnCount;
 
             var resolvedValues = new List<double>();
             for (int row = firstRow; row <= lastRow; row++) {

--- a/OfficeIMO.Excel/Imaging/ExcelRangeVisualSnapshotBuilder.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelRangeVisualSnapshotBuilder.cs
@@ -1202,9 +1202,12 @@ namespace OfficeIMO.Excel {
             IReadOnlyDictionary<int, ExcelVisualColumn> columnsByIndex,
             IReadOnlyDictionary<int, ExcelVisualRow> rowsByIndex) {
             IReadOnlyList<ExcelWorksheetSparklineInfo> sparklines = ExcelWorksheetSparklineResolver.FindSparklines(sheet.WorksheetPart);
-            var visibleGroups = new HashSet<int>(sparklines
-                .Where(sparkline => IsSupportedSparklineKind(sparkline.Kind)
-                    && TryResolveVisibleExportCell(
+            var visibleIndexes = new HashSet<int>();
+            var visibleGroups = new HashSet<int>();
+            for (int index = 0; index < sparklines.Count; index++) {
+                ExcelWorksheetSparklineInfo sparkline = sparklines[index];
+                if (IsSupportedSparklineKind(sparkline.Kind) &&
+                    TryResolveVisibleExportCell(
                         sparkline.CellReference,
                         firstRow,
                         firstColumn,
@@ -1212,31 +1215,39 @@ namespace OfficeIMO.Excel {
                         lastColumn,
                         columnsByIndex,
                         rowsByIndex,
-                        out _))
-                .Select(sparkline => sparkline.GroupIndex));
-            var resolved = new List<ResolvedSparkline>(sparklines.Count);
+                        out _)) {
+                    visibleIndexes.Add(index);
+                    visibleGroups.Add(sparkline.GroupIndex);
+                }
+            }
+
+            var resolved = new ResolvedSparkline[sparklines.Count];
             long remainingSparklineDataCells = MaxSparklineDataCells;
-            foreach (ExcelWorksheetSparklineInfo sparkline in sparklines) {
+            IEnumerable<int> resolutionOrder = Enumerable.Range(0, sparklines.Count)
+                .Where(visibleIndexes.Contains)
+                .Concat(Enumerable.Range(0, sparklines.Count).Where(index => !visibleIndexes.Contains(index)));
+            foreach (int index in resolutionOrder) {
+                ExcelWorksheetSparklineInfo sparkline = sparklines[index];
                 if (!IsSupportedSparklineKind(sparkline.Kind) ||
                     !visibleGroups.Contains(sparkline.GroupIndex)) {
-                    resolved.Add(new ResolvedSparkline(sparkline, Array.Empty<double>(), hasResolvedRange: false, externalRange: false));
+                    resolved[index] = new ResolvedSparkline(sparkline, Array.Empty<double>(), hasResolvedRange: false, externalRange: false);
                     continue;
                 }
 
                 if (!TryResolveSparklineDataRange(sheet.Name, sparkline.Formula, out string? dataRange, out bool externalRange) || dataRange == null) {
-                    resolved.Add(new ResolvedSparkline(sparkline, Array.Empty<double>(), hasResolvedRange: false, externalRange));
+                    resolved[index] = new ResolvedSparkline(sparkline, Array.Empty<double>(), hasResolvedRange: false, externalRange);
                     continue;
                 }
 
                 if (!TryReadSparklineValues(sheet, dataRange, ref remainingSparklineDataCells, out IReadOnlyList<double> values)) {
-                    resolved.Add(new ResolvedSparkline(sparkline, Array.Empty<double>(), hasResolvedRange: false, externalRange: false));
+                    resolved[index] = new ResolvedSparkline(sparkline, Array.Empty<double>(), hasResolvedRange: false, externalRange: false);
                     continue;
                 }
 
-                resolved.Add(new ResolvedSparkline(sparkline, values, hasResolvedRange: true, externalRange: false));
+                resolved[index] = new ResolvedSparkline(sparkline, values, hasResolvedRange: true, externalRange: false);
             }
 
-            return resolved.AsReadOnly();
+            return Array.AsReadOnly(resolved);
         }
 
         private static IReadOnlyDictionary<int, SparklineScaleRange> ResolveSparklineScaleRanges(IReadOnlyList<ResolvedSparkline> sparklines) {

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Xml.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Xml.cs
@@ -29,6 +29,7 @@ namespace OfficeIMO.Excel {
             private readonly int _firstColumn;
             private readonly int _lastColumn;
             private readonly int _fieldCount;
+            private readonly long _maximumBufferedCells;
             private readonly CancellationToken _ct;
             private readonly string[] _columnNames;
             private readonly Type[] _columnTypes;
@@ -71,6 +72,7 @@ namespace OfficeIMO.Excel {
                 _firstColumn = firstColumn;
                 _lastColumn = lastColumn;
                 _fieldCount = fieldCount;
+                _maximumBufferedCells = options.MaxDataReaderBufferedCells;
                 _ct = ct;
                 _nextLogicalRow = firstRow;
                 _currentValues = new object?[fieldCount];
@@ -717,6 +719,11 @@ namespace OfficeIMO.Excel {
             private void StoreBufferedRow(int rowIndex, object?[] values) {
                 if (rowIndex < _nextLogicalRow || rowIndex > _lastRow) {
                     return;
+                }
+
+                if (!_bufferedRows!.ContainsKey(rowIndex) &&
+                    (long)_bufferedRows.Count + 1L > _maximumBufferedCells / _fieldCount) {
+                    throw new InvalidDataException($"Range data-reader buffering exceeds {nameof(ExcelReadOptions.MaxDataReaderBufferedCells)}.");
                 }
 
                 var copy = new object?[_fieldCount];


### PR DESCRIPTION
## Summary

- bound aggregate sparkline and conditional-format processing during image export while preserving visible output first
- reserve all evaluator passes within the rule-cell budget and skip rule discovery when no complete rule can fit
- enforce configured buffering and input limits for unsorted XLSX data-reader fallbacks and plain CSV path loads
- reject invalid PNG structure and worksheet image dimensions before expensive validation

Oversized or malformed untrusted inputs now stop at deterministic work limits instead of expanding CPU or memory use.

## Compatibility

Normal inputs remain unchanged. Public conditional-format enumeration is preserved; the rule-cell cap applies only to image-export evaluation.

## Validation

- focused conditional-format work-limit tests pass 4/4 on .NET 8 and .NET 10
- oversized-list and malformed-priority regressions prove neither cells nor conditional rules are inspected when no complete rule fits
- the Excel netstandard2.0 build succeeds without warnings

This is security findings batch 13 and is intentionally stacked on batch 12.