### PR TITLE
Bound Word comparison work for untrusted documents

### DIFF
--- a/OfficeIMO.Word.Tests/Word.CompareDocuments.StructuredSecurity.cs
+++ b/OfficeIMO.Word.Tests/Word.CompareDocuments.StructuredSecurity.cs
@@ -1,0 +1,216 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void LcsMatchingUsesCachedHashesBeforeEquality() {
+            MethodInfo method = typeof(WordDocumentComparer)
+                .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
+                .Single(candidate => candidate.Name == "FindMatchingIndexes" && candidate.IsGenericMethodDefinition)
+                .MakeGenericMethod(typeof(FingerprintProbe));
+            List<FingerprintProbe> source = Enumerable.Range(0, 999).Select(index => new FingerprintProbe(index)).ToList();
+            List<FingerprintProbe> target = Enumerable.Range(1_000, 999).Select(index => new FingerprintProbe(index)).ToList();
+            var comparer = new ConstantHashFingerprintComparer();
+
+            _ = method.Invoke(null, new object[] { source, target, comparer });
+
+            Assert.Equal(1_998, comparer.HashCalls);
+            Assert.Equal(0, comparer.EqualsCalls);
+        }
+
+        [Fact]
+        public void BoundedTextSimilarityWorkDoesNotScaleWithInputLength() {
+            MethodInfo method = typeof(WordDocumentComparer).GetMethod(
+                "GetBoundedTextSimilarity",
+                BindingFlags.NonPublic | BindingFlags.Static,
+                null,
+                new[] { typeof(string), typeof(string) },
+                null)
+                ?? throw new InvalidOperationException("Bounded text similarity implementation was not found.");
+            var similarity = (Func<string, string, double>)method.CreateDelegate(typeof(Func<string, string, double>));
+
+            string shortSource = "A" + new string('x', 4_094) + "B";
+            string shortTarget = "C" + new string('y', 4_094) + "D";
+            string longSource = "A" + new string('x', 3_999_998) + "B";
+            string longTarget = "C" + new string('y', 3_999_998) + "D";
+
+            Assert.Equal(0D, similarity(shortSource, shortTarget));
+            Assert.Equal(0D, similarity(longSource, longTarget));
+
+            const int iterations = 128;
+            TimeSpan shortElapsed = MeasureSimilarity(similarity, shortSource, shortTarget, iterations);
+            TimeSpan longElapsed = MeasureSimilarity(similarity, longSource, longTarget, iterations);
+            TimeSpan maximumLongElapsed = TimeSpan.FromTicks((shortElapsed.Ticks * 50) + TimeSpan.FromMilliseconds(50).Ticks);
+
+            Assert.True(
+                longElapsed <= maximumLongElapsed,
+                $"Bounded similarity scaled with attacker-controlled input length: short={shortElapsed.TotalMilliseconds:F1} ms, long={longElapsed.TotalMilliseconds:F1} ms, limit={maximumLongElapsed.TotalMilliseconds:F1} ms.");
+        }
+
+        [Fact]
+        public void ContainmentAwareSimilarityUsesBoundedWorkForLargeText() {
+            MethodInfo method = typeof(WordDocumentComparer).GetMethod(
+                "GetContainmentAwareTextSimilarity",
+                BindingFlags.NonPublic | BindingFlags.Static,
+                null,
+                new[] { typeof(string), typeof(string) },
+                null)
+                ?? throw new InvalidOperationException("Containment-aware text similarity implementation was not found.");
+            var similarity = (Func<string, string, double>)method.CreateDelegate(typeof(Func<string, string, double>));
+
+            string shortSource = "A" + new string('x', 4_094) + "B";
+            string target = "C" + new string('y', 1_022) + "D";
+            string longSource = "A" + new string('x', 3_999_998) + "B";
+
+            const int iterations = 4_096;
+            TimeSpan shortElapsed = MeasureSimilarity(similarity, shortSource, target, iterations);
+            TimeSpan longElapsed = MeasureSimilarity(similarity, longSource, target, iterations);
+            TimeSpan maximumLongElapsed = TimeSpan.FromTicks((shortElapsed.Ticks * 50) + TimeSpan.FromMilliseconds(50).Ticks);
+
+            Assert.True(
+                longElapsed <= maximumLongElapsed,
+                $"Containment-aware similarity scaled with attacker-controlled input length: short={shortElapsed.TotalMilliseconds:F1} ms, long={longElapsed.TotalMilliseconds:F1} ms, limit={maximumLongElapsed.TotalMilliseconds:F1} ms.");
+        }
+
+        [Fact]
+        public void TextSimilarityChecksTheLargeInputLimitBeforeExactEquality() {
+            MethodInfo method = typeof(WordDocumentComparer).GetMethod(
+                "GetTextSimilarity",
+                BindingFlags.NonPublic | BindingFlags.Static,
+                null,
+                new[] { typeof(string), typeof(string) },
+                null)
+                ?? throw new InvalidOperationException("Text similarity implementation was not found.");
+            var similarity = (Func<string, string, double>)method.CreateDelegate(typeof(Func<string, string, double>));
+
+            string shortSource = new string('x', 4_095) + "A";
+            string shortTarget = new string('x', 4_095) + "B";
+            string longSource = new string('x', 3_999_999) + "A";
+            string longTarget = new string('x', 3_999_999) + "B";
+
+            const int iterations = 512;
+            TimeSpan shortElapsed = MeasureSimilarity(similarity, shortSource, shortTarget, iterations);
+            TimeSpan longElapsed = MeasureSimilarity(similarity, longSource, longTarget, iterations);
+            TimeSpan maximumLongElapsed = TimeSpan.FromTicks((shortElapsed.Ticks * 50) + TimeSpan.FromMilliseconds(50).Ticks);
+
+            Assert.True(
+                longElapsed <= maximumLongElapsed,
+                $"Large-input similarity performed attacker-length exact comparisons: short={shortElapsed.TotalMilliseconds:F1} ms, long={longElapsed.TotalMilliseconds:F1} ms, limit={maximumLongElapsed.TotalMilliseconds:F1} ms.");
+        }
+
+        [Fact]
+        public void CompareStructureRetainsModifiedParagraphWithTwentyCharacterShift() {
+            string sharedMiddle = new string(Enumerable.Range(0, 512).Select(index => (char)(0x0100 + index)).ToArray());
+            string sourceText = "S" + sharedMiddle + new string('U', 20);
+            string targetText = new string('T', 21) + sharedMiddle;
+            string sourcePath = Path.Combine(_directoryWithFiles, "compare_structure_source_twenty_character_shift.docx");
+            using (WordDocument doc = WordDocument.Create(sourcePath)) {
+                doc.AddParagraph(sourceText);
+                doc.AddParagraph("Closing");
+                doc.Save();
+            }
+
+            string targetPath = Path.Combine(_directoryWithFiles, "compare_structure_target_twenty_character_shift.docx");
+            using (WordDocument doc = WordDocument.Create(targetPath)) {
+                for (int index = 0; index < 260; index++) {
+                    doc.AddParagraph("Unrelated inserted candidate " + index);
+                }
+
+                doc.AddParagraph(targetText);
+                doc.AddParagraph("Closing");
+                doc.Save();
+            }
+
+            WordComparisonResult result = WordDocumentComparer.CompareStructure(sourcePath, targetPath);
+
+            Assert.Contains(result.Findings, finding =>
+                finding.Scope == WordComparisonScope.Paragraph &&
+                finding.ChangeKind == WordComparisonChangeKind.Modified &&
+                finding.SourceText == sourceText &&
+                finding.TargetText == targetText);
+        }
+
+        [Fact]
+        public void CompareStructureConsidersInteriorCandidateBeyondFourThousandParagraphs() {
+            const string sourceText = "Status pending for security review";
+            const string targetText = "Status approved for security review";
+            string sourcePath = Path.Combine(_directoryWithFiles, "compare_structure_source_interior_candidate.docx");
+            using (WordDocument doc = WordDocument.Create(sourcePath)) {
+                doc.AddParagraph(sourceText);
+                doc.AddParagraph("Closing");
+                doc.Save();
+            }
+
+            string targetPath = Path.Combine(_directoryWithFiles, "compare_structure_target_interior_candidate.docx");
+            using (WordDocument doc = WordDocument.Create(targetPath)) {
+                for (int index = 0; index < 4_096; index++) {
+                    doc.AddParagraph("Unrelated inserted candidate " + index.ToString("D4"));
+                }
+
+                doc.AddParagraph(targetText);
+                doc.AddParagraph("Unrelated trailing candidate");
+                doc.AddParagraph("Closing");
+                doc.Save();
+            }
+
+            WordComparisonResult result = WordDocumentComparer.CompareStructure(sourcePath, targetPath);
+
+            Assert.Contains(result.Findings, finding =>
+                finding.Scope == WordComparisonScope.Paragraph &&
+                finding.ChangeKind == WordComparisonChangeKind.Modified &&
+                finding.SourceText == sourceText &&
+                finding.TargetText == targetText);
+            Assert.DoesNotContain(result.Findings, finding =>
+                finding.Scope == WordComparisonScope.Paragraph &&
+                finding.ChangeKind == WordComparisonChangeKind.Modified &&
+                finding.SourceText == sourceText &&
+                finding.TargetText?.StartsWith("Unrelated", StringComparison.Ordinal) == true);
+        }
+
+        private static TimeSpan MeasureSimilarity(
+            Func<string, string, double> similarity,
+            string source,
+            string target,
+            int iterations) {
+            var stopwatch = Stopwatch.StartNew();
+            for (int iteration = 0; iteration < iterations; iteration++) {
+                _ = similarity(source, target);
+            }
+
+            stopwatch.Stop();
+            return stopwatch.Elapsed;
+        }
+
+        private sealed class FingerprintProbe : WordDocumentComparer.IComparisonFingerprint {
+            internal FingerprintProbe(int value) {
+                Value = value;
+            }
+
+            internal int Value { get; }
+
+            public ulong ComparisonFingerprint => unchecked((ulong)Value);
+        }
+
+        private sealed class ConstantHashFingerprintComparer : IEqualityComparer<FingerprintProbe> {
+            internal int EqualsCalls { get; private set; }
+            internal int HashCalls { get; private set; }
+
+            public bool Equals(FingerprintProbe? x, FingerprintProbe? y) {
+                EqualsCalls++;
+                return x?.Value == y?.Value;
+            }
+
+            public int GetHashCode(FingerprintProbe obj) {
+                HashCalls++;
+                return 1;
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word.Tests/Word.CompareDocuments.StructuredSecurity.cs
+++ b/OfficeIMO.Word.Tests/Word.CompareDocuments.StructuredSecurity.cs
@@ -174,6 +174,92 @@ namespace OfficeIMO.Tests {
                 finding.TargetText?.StartsWith("Unrelated", StringComparison.Ordinal) == true);
         }
 
+        [Fact]
+        public void CompareStructureTableSimilarityConsumesSharedComparisonWorkBudget() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "compare_structure_source_table_budget.docx");
+            using (WordDocument document = WordDocument.Create(sourcePath)) {
+                WordTable table = document.AddTable(1, 1);
+                table.Rows[0].Cells[0].Paragraphs[0].SetText(new string('A', 100));
+                document.Save();
+            }
+
+            string targetPath = Path.Combine(_directoryWithFiles, "compare_structure_target_table_budget.docx");
+            using (WordDocument document = WordDocument.Create(targetPath)) {
+                WordTable table = document.AddTable(1, 1);
+                table.Rows[0].Cells[0].Paragraphs[0].SetText(new string('B', 100));
+                document.Save();
+            }
+
+            var options = new WordComparisonOptions();
+            using WordDocument source = WordDocument.Load(sourcePath);
+            using WordDocument target = WordDocument.Load(targetPath);
+            MethodInfo getTableSnapshots = typeof(WordDocumentComparer).GetMethod(
+                "GetTableSnapshots",
+                BindingFlags.NonPublic | BindingFlags.Static)
+                ?? throw new InvalidOperationException("Table snapshot implementation was not found.");
+            object sourceSnapshots = getTableSnapshots.Invoke(null, new object[] { source, options })
+                ?? throw new InvalidOperationException("Source table snapshots were not created.");
+            object targetSnapshots = getTableSnapshots.Invoke(null, new object[] { target, options })
+                ?? throw new InvalidOperationException("Target table snapshots were not created.");
+            object sourceSnapshot = sourceSnapshots.GetType().GetProperty("Item")?.GetValue(sourceSnapshots, new object[] { 0 })
+                ?? throw new InvalidOperationException("Source table snapshot was not available.");
+            object targetSnapshot = targetSnapshots.GetType().GetProperty("Item")?.GetValue(targetSnapshots, new object[] { 0 })
+                ?? throw new InvalidOperationException("Target table snapshot was not available.");
+            object comparisonWorkBudget = CreateComparisonWorkBudget(1);
+            MethodInfo getTableSimilarity = typeof(WordDocumentComparer).GetMethod(
+                "GetTableSimilarity",
+                BindingFlags.NonPublic | BindingFlags.Static)
+                ?? throw new InvalidOperationException("Table similarity implementation was not found.");
+
+            getTableSimilarity.Invoke(null, new[] { sourceSnapshot, targetSnapshot, comparisonWorkBudget });
+
+            Assert.Equal(0, GetRemainingComparisonWorkUnits(comparisonWorkBudget));
+        }
+
+        [Fact]
+        public void CompareStructureTableCellAlignmentConsumesSharedComparisonWorkBudget() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "compare_structure_source_cell_budget.docx");
+            using (WordDocument document = WordDocument.Create(sourcePath)) {
+                WordTable table = document.AddTable(1, 1);
+                table.Rows[0].Cells[0].Paragraphs[0].SetText(new string('A', 100));
+                document.Save();
+            }
+
+            string targetPath = Path.Combine(_directoryWithFiles, "compare_structure_target_cell_budget.docx");
+            using (WordDocument document = WordDocument.Create(targetPath)) {
+                WordTable table = document.AddTable(1, 2);
+                table.Rows[0].Cells[0].Paragraphs[0].SetText(new string('B', 100));
+                table.Rows[0].Cells[1].Paragraphs[0].SetText(new string('C', 100));
+                document.Save();
+            }
+
+            var options = new WordComparisonOptions();
+            WordComparisonResult result = WordDocumentComparer.CompareStructure(sourcePath, targetPath, options);
+            using WordDocument source = WordDocument.Load(sourcePath);
+            using WordDocument target = WordDocument.Load(targetPath);
+            object comparisonWorkBudget = CreateComparisonWorkBudget(1);
+            MethodInfo analyzeTableRow = typeof(WordDocumentComparer).GetMethod(
+                "AnalyzeTableRow",
+                BindingFlags.NonPublic | BindingFlags.Static)
+                ?? throw new InvalidOperationException("Table row analysis implementation was not found.");
+
+            analyzeTableRow.Invoke(null, new object?[] {
+                source.Tables[0].Rows[0],
+                target.Tables[0].Rows[0],
+                null,
+                null,
+                0,
+                0,
+                0,
+                0,
+                result,
+                options,
+                comparisonWorkBudget
+            });
+
+            Assert.Equal(0, GetRemainingComparisonWorkUnits(comparisonWorkBudget));
+        }
+
         private static TimeSpan MeasureSimilarity(
             Func<string, string, double> similarity,
             string source,
@@ -186,6 +272,29 @@ namespace OfficeIMO.Tests {
 
             stopwatch.Stop();
             return stopwatch.Elapsed;
+        }
+
+        private static object CreateComparisonWorkBudget(long maximumWorkUnits) {
+            Type workBudgetType = typeof(WordDocumentComparer).GetNestedType(
+                "ComparisonWorkBudget",
+                BindingFlags.NonPublic)
+                ?? throw new InvalidOperationException("Comparison work budget implementation was not found.");
+            ConstructorInfo constructor = workBudgetType.GetConstructor(
+                BindingFlags.Instance | BindingFlags.NonPublic,
+                null,
+                new[] { typeof(long) },
+                null)
+                ?? throw new InvalidOperationException("Comparison work budget constructor was not found.");
+            return constructor.Invoke(new object[] { maximumWorkUnits });
+        }
+
+        private static long GetRemainingComparisonWorkUnits(object comparisonWorkBudget) {
+            FieldInfo remainingWorkUnits = comparisonWorkBudget.GetType().GetField(
+                "_remainingWorkUnits",
+                BindingFlags.Instance | BindingFlags.NonPublic)
+                ?? throw new InvalidOperationException("Comparison work budget state was not found.");
+            return (long)(remainingWorkUnits.GetValue(comparisonWorkBudget)
+                ?? throw new InvalidOperationException("Comparison work budget state was not available."));
         }
 
         private sealed class FingerprintProbe : WordDocumentComparer.IComparisonFingerprint {

--- a/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.Features.cs
+++ b/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.Features.cs
@@ -387,7 +387,7 @@ namespace OfficeIMO.Word {
             return string.Join("/", parts.Where(part => !string.IsNullOrWhiteSpace(part)).ToArray());
         }
 
-        private interface IFeatureSnapshot {
+        private interface IFeatureSnapshot : IComparisonFingerprint {
             int Index { get; }
 
             string MatchKey { get; }
@@ -425,6 +425,8 @@ namespace OfficeIMO.Word {
             public string DetailedLocation { get; }
 
             public int DocumentOrder { get; }
+
+            ulong IComparisonFingerprint.ComparisonFingerprint => GetOrdinalTextFingerprint(MatchKey);
         }
 
         private sealed class ContentControlSnapshot : IFeatureSnapshot {
@@ -451,6 +453,8 @@ namespace OfficeIMO.Word {
             public string DetailedLocation { get; }
 
             public int DocumentOrder { get; }
+
+            ulong IComparisonFingerprint.ComparisonFingerprint => GetOrdinalTextFingerprint(MatchKey);
         }
 
         private sealed class FeatureSnapshotKeyComparer<TSnapshot> : IEqualityComparer<TSnapshot>

--- a/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.Images.cs
+++ b/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.Images.cs
@@ -459,7 +459,7 @@ namespace OfficeIMO.Word {
             return new ImageFingerprint(length, Convert.ToBase64String(sha256.Hash ?? Array.Empty<byte>()));
         }
 
-        private sealed class ImageSnapshot {
+        private sealed class ImageSnapshot : IComparisonFingerprint {
             private ImageSnapshot(ImageFingerprint? embeddedFingerprint, string? externalUri, string visualSignature, string partKey, int documentOrder, string positionKey) {
                 EmbeddedFingerprint = embeddedFingerprint;
                 ExternalUri = externalUri;
@@ -482,6 +482,30 @@ namespace OfficeIMO.Word {
             internal string PositionKey { get; }
 
             internal string DisplayText => ExternalUri == null ? "[Image]" : "[Image: " + ExternalUri + "]";
+
+            public ulong ComparisonFingerprint {
+                get {
+                    ulong fingerprint = CombineComparisonFingerprints(
+                        GetOrdinalTextFingerprint(PartKey),
+                        GetOrdinalTextFingerprint(VisualSignature));
+                    if (ExternalUri != null) {
+                        return CombineComparisonFingerprints(
+                            fingerprint,
+                            CombineComparisonFingerprints(0x45585445524E414CUL, GetOrdinalTextFingerprint(ExternalUri)));
+                    }
+
+                    if (EmbeddedFingerprint != null) {
+                        ulong embedded = CombineComparisonFingerprints(
+                            unchecked((ulong)EmbeddedFingerprint.Value.Length),
+                            GetOrdinalTextFingerprint(EmbeddedFingerprint.Value.Sha256));
+                        return CombineComparisonFingerprints(
+                            fingerprint,
+                            CombineComparisonFingerprints(0x454D424544444544UL, embedded));
+                    }
+
+                    return fingerprint;
+                }
+            }
 
             internal static ImageSnapshot FromEmbedded(ImageFingerprint embeddedFingerprint, string visualSignature, string partKey, int documentOrder, string positionKey) {
                 return new ImageSnapshot(embeddedFingerprint, null, visualSignature, partKey, documentOrder, positionKey);

--- a/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.LinksLists.cs
+++ b/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.LinksLists.cs
@@ -464,6 +464,8 @@ namespace OfficeIMO.Word {
             public string DetailedLocation { get; }
 
             public int DocumentOrder { get; }
+
+            ulong IComparisonFingerprint.ComparisonFingerprint => GetOrdinalTextFingerprint(MatchKey);
         }
 
         private sealed class HyperlinkSnapshot : IFeatureSnapshot {
@@ -487,6 +489,8 @@ namespace OfficeIMO.Word {
             public string DetailedLocation { get; }
 
             public int DocumentOrder { get; }
+
+            ulong IComparisonFingerprint.ComparisonFingerprint => GetOrdinalTextFingerprint(MatchKey);
         }
 
         private sealed class ListSnapshot : IFeatureSnapshot {
@@ -510,6 +514,8 @@ namespace OfficeIMO.Word {
             public string DetailedLocation { get; }
 
             public int DocumentOrder { get; }
+
+            ulong IComparisonFingerprint.ComparisonFingerprint => GetOrdinalTextFingerprint(MatchKey);
         }
     }
 }

--- a/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.Paragraphs.cs
+++ b/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.Paragraphs.cs
@@ -6,7 +6,12 @@ using V = DocumentFormat.OpenXml.Vml;
 
 namespace OfficeIMO.Word {
     public static partial class WordDocumentComparer {
-        private static void AnalyzeParagraphs(WordDocument source, WordDocument target, WordComparisonResult result, WordComparisonOptions options) {
+        private static void AnalyzeParagraphs(
+            WordDocument source,
+            WordDocument target,
+            WordComparisonResult result,
+            WordComparisonOptions options,
+            ComparisonWorkBudget comparisonWorkBudget) {
             List<ParagraphSnapshot> sourceParagraphs = GetLogicalBodyParagraphs(source, options);
             List<ParagraphSnapshot> targetParagraphs = GetLogicalBodyParagraphs(target, options);
             IReadOnlyList<MatchedIndexPair> matchedParagraphs = FindMatchingIndexes(
@@ -18,7 +23,7 @@ namespace OfficeIMO.Word {
             int targetStart = 0;
 
             foreach (MatchedIndexPair match in matchedParagraphs) {
-                AddParagraphRangeFindings(sourceParagraphs, targetParagraphs, sourceStart, match.SourceIndex, targetStart, match.TargetIndex, result, options);
+                AddParagraphRangeFindings(sourceParagraphs, targetParagraphs, sourceStart, match.SourceIndex, targetStart, match.TargetIndex, result, options, comparisonWorkBudget);
                 AnalyzeParagraphStyle(sourceParagraphs[match.SourceIndex], targetParagraphs[match.TargetIndex], match.SourceIndex, match.TargetIndex, result, options);
                 AnalyzeParagraphEffectiveFormatting(sourceParagraphs[match.SourceIndex], targetParagraphs[match.TargetIndex], match.SourceIndex, match.TargetIndex, result, options);
                 AnalyzeParagraphRuns(sourceParagraphs[match.SourceIndex], targetParagraphs[match.TargetIndex], match.SourceIndex, match.TargetIndex, result, options);
@@ -26,7 +31,7 @@ namespace OfficeIMO.Word {
                 targetStart = match.TargetIndex + 1;
             }
 
-            AddParagraphRangeFindings(sourceParagraphs, targetParagraphs, sourceStart, sourceParagraphs.Count, targetStart, targetParagraphs.Count, result, options);
+            AddParagraphRangeFindings(sourceParagraphs, targetParagraphs, sourceStart, sourceParagraphs.Count, targetStart, targetParagraphs.Count, result, options, comparisonWorkBudget);
         }
 
         private static void AddParagraphRangeFindings(
@@ -37,12 +42,13 @@ namespace OfficeIMO.Word {
             int targetStart,
             int targetEnd,
             WordComparisonResult result,
-            WordComparisonOptions options) {
+            WordComparisonOptions options,
+            ComparisonWorkBudget comparisonWorkBudget) {
             int sourceIndex = sourceStart;
             int targetIndex = targetStart;
 
             while (sourceIndex < sourceEnd && targetIndex < targetEnd) {
-                int betterTargetIndex = FindBetterTargetAlignmentIndex(sourceParagraphs[sourceIndex], targetParagraphs, targetIndex, targetEnd);
+                int betterTargetIndex = FindBetterTargetAlignmentIndex(sourceParagraphs[sourceIndex], targetParagraphs, targetIndex, targetEnd, comparisonWorkBudget);
                 if (betterTargetIndex > targetIndex) {
                     while (targetIndex < betterTargetIndex) {
                         AddInsertedParagraphFinding(targetParagraphs, targetIndex, result);
@@ -52,7 +58,7 @@ namespace OfficeIMO.Word {
                     continue;
                 }
 
-                int betterSourceIndex = FindBetterSourceAlignmentIndex(sourceParagraphs, sourceIndex, sourceEnd, targetParagraphs[targetIndex]);
+                int betterSourceIndex = FindBetterSourceAlignmentIndex(sourceParagraphs, sourceIndex, sourceEnd, targetParagraphs[targetIndex], comparisonWorkBudget);
                 if (betterSourceIndex > sourceIndex) {
                     while (sourceIndex < betterSourceIndex) {
                         AddDeletedParagraphFinding(sourceParagraphs, sourceIndex, result);
@@ -211,18 +217,25 @@ namespace OfficeIMO.Word {
                 targetParagraph.DocumentOrder);
         }
 
-        private static int FindBetterTargetAlignmentIndex(ParagraphSnapshot sourceParagraph, IReadOnlyList<ParagraphSnapshot> targetParagraphs, int targetStart, int targetEnd) {
+        private static int FindBetterTargetAlignmentIndex(
+            ParagraphSnapshot sourceParagraph,
+            IReadOnlyList<ParagraphSnapshot> targetParagraphs,
+            int targetStart,
+            int targetEnd,
+            ComparisonWorkBudget comparisonWorkBudget) {
             int bestIndex = targetStart;
-            double currentVisibleSimilarity = GetParagraphVisibleTextSimilarity(sourceParagraph, targetParagraphs[targetStart]);
+            double currentVisibleSimilarity = GetParagraphVisibleTextSimilarity(sourceParagraph, targetParagraphs[targetStart], comparisonWorkBudget);
             double bestVisibleSimilarity = currentVisibleSimilarity;
-            double bestSimilarity = GetParagraphSimilarity(sourceParagraph, targetParagraphs[targetStart]);
+            double currentSimilarity = GetParagraphSimilarity(sourceParagraph, targetParagraphs[targetStart], comparisonWorkBudget);
+            double bestSimilarity = currentSimilarity;
 
             foreach (int index in SelectBoundedAlignmentCandidates(
                 targetStart + 1,
                 targetEnd,
-                index => GetParagraphAlignmentPrefilterSimilarity(sourceParagraph, targetParagraphs[index]))) {
-                double visibleSimilarity = GetParagraphVisibleTextSimilarity(sourceParagraph, targetParagraphs[index]);
-                double similarity = GetParagraphSimilarity(sourceParagraph, targetParagraphs[index]);
+                index => GetParagraphAlignmentPrefilterSimilarity(sourceParagraph, targetParagraphs[index], comparisonWorkBudget),
+                comparisonWorkBudget)) {
+                double visibleSimilarity = GetParagraphVisibleTextSimilarity(sourceParagraph, targetParagraphs[index], comparisonWorkBudget);
+                double similarity = GetParagraphSimilarity(sourceParagraph, targetParagraphs[index], comparisonWorkBudget);
                 if (visibleSimilarity < bestVisibleSimilarity ||
                     (visibleSimilarity == bestVisibleSimilarity && similarity <= bestSimilarity)) {
                     continue;
@@ -236,23 +249,30 @@ namespace OfficeIMO.Word {
                 }
             }
 
-            return bestVisibleSimilarity > currentVisibleSimilarity || bestSimilarity > GetParagraphSimilarity(sourceParagraph, targetParagraphs[targetStart])
+            return bestVisibleSimilarity > currentVisibleSimilarity || bestSimilarity > currentSimilarity
                 ? bestIndex
                 : targetStart;
         }
 
-        private static int FindBetterSourceAlignmentIndex(IReadOnlyList<ParagraphSnapshot> sourceParagraphs, int sourceStart, int sourceEnd, ParagraphSnapshot targetParagraph) {
+        private static int FindBetterSourceAlignmentIndex(
+            IReadOnlyList<ParagraphSnapshot> sourceParagraphs,
+            int sourceStart,
+            int sourceEnd,
+            ParagraphSnapshot targetParagraph,
+            ComparisonWorkBudget comparisonWorkBudget) {
             int bestIndex = sourceStart;
-            double currentVisibleSimilarity = GetParagraphVisibleTextSimilarity(sourceParagraphs[sourceStart], targetParagraph);
+            double currentVisibleSimilarity = GetParagraphVisibleTextSimilarity(sourceParagraphs[sourceStart], targetParagraph, comparisonWorkBudget);
             double bestVisibleSimilarity = currentVisibleSimilarity;
-            double bestSimilarity = GetParagraphSimilarity(sourceParagraphs[sourceStart], targetParagraph);
+            double currentSimilarity = GetParagraphSimilarity(sourceParagraphs[sourceStart], targetParagraph, comparisonWorkBudget);
+            double bestSimilarity = currentSimilarity;
 
             foreach (int index in SelectBoundedAlignmentCandidates(
                 sourceStart + 1,
                 sourceEnd,
-                index => GetParagraphAlignmentPrefilterSimilarity(sourceParagraphs[index], targetParagraph))) {
-                double visibleSimilarity = GetParagraphVisibleTextSimilarity(sourceParagraphs[index], targetParagraph);
-                double similarity = GetParagraphSimilarity(sourceParagraphs[index], targetParagraph);
+                index => GetParagraphAlignmentPrefilterSimilarity(sourceParagraphs[index], targetParagraph, comparisonWorkBudget),
+                comparisonWorkBudget)) {
+                double visibleSimilarity = GetParagraphVisibleTextSimilarity(sourceParagraphs[index], targetParagraph, comparisonWorkBudget);
+                double similarity = GetParagraphSimilarity(sourceParagraphs[index], targetParagraph, comparisonWorkBudget);
                 if (visibleSimilarity < bestVisibleSimilarity ||
                     (visibleSimilarity == bestVisibleSimilarity && similarity <= bestSimilarity)) {
                     continue;
@@ -266,34 +286,48 @@ namespace OfficeIMO.Word {
                 }
             }
 
-            return bestVisibleSimilarity > currentVisibleSimilarity || bestSimilarity > GetParagraphSimilarity(sourceParagraphs[sourceStart], targetParagraph)
+            return bestVisibleSimilarity > currentVisibleSimilarity || bestSimilarity > currentSimilarity
                 ? bestIndex
                 : sourceStart;
         }
 
-        private static double GetParagraphSimilarity(ParagraphSnapshot sourceParagraph, ParagraphSnapshot targetParagraph) {
+        private static double GetParagraphSimilarity(
+            ParagraphSnapshot sourceParagraph,
+            ParagraphSnapshot targetParagraph,
+            ComparisonWorkBudget comparisonWorkBudget) {
             if (!string.Equals(sourceParagraph.PartKind, targetParagraph.PartKind, StringComparison.Ordinal)) {
                 return 0;
             }
 
             return Math.Max(
-                GetTextSimilarity(sourceParagraph.MatchText, targetParagraph.MatchText),
-                GetTextSimilarity(sourceParagraph.ComparisonText, targetParagraph.ComparisonText));
+                GetTextSimilarity(sourceParagraph.MatchText, targetParagraph.MatchText, comparisonWorkBudget),
+                GetTextSimilarity(sourceParagraph.ComparisonText, targetParagraph.ComparisonText, comparisonWorkBudget));
         }
 
-        private static double GetParagraphAlignmentPrefilterSimilarity(ParagraphSnapshot sourceParagraph, ParagraphSnapshot targetParagraph) {
+        private static double GetParagraphAlignmentPrefilterSimilarity(
+            ParagraphSnapshot sourceParagraph,
+            ParagraphSnapshot targetParagraph,
+            ComparisonWorkBudget comparisonWorkBudget) {
             if (!string.Equals(sourceParagraph.PartKind, targetParagraph.PartKind, StringComparison.Ordinal)) {
                 return 0;
             }
 
             return Math.Max(
-                GetBoundedTextSimilarity(sourceParagraph.MatchText, targetParagraph.MatchText),
-                GetBoundedTextSimilarity(sourceParagraph.ComparisonText, targetParagraph.ComparisonText));
+                GetBoundedTextSimilarity(sourceParagraph.MatchText, targetParagraph.MatchText, comparisonWorkBudget),
+                GetBoundedTextSimilarity(sourceParagraph.ComparisonText, targetParagraph.ComparisonText, comparisonWorkBudget));
         }
 
-        private static IReadOnlyList<int> SelectBoundedAlignmentCandidates(int start, int end, Func<int, double> getPrefilterSimilarity) {
+        private static IReadOnlyList<int> SelectBoundedAlignmentCandidates(
+            int start,
+            int end,
+            Func<int, double> getPrefilterSimilarity,
+            ComparisonWorkBudget comparisonWorkBudget) {
             var candidates = new SortedSet<AlignmentCandidate>(AlignmentCandidateComparer.Instance);
             for (int index = start; index < end; index++) {
+                if (!comparisonWorkBudget.TryConsume(1)) {
+                    break;
+                }
+
                 var candidate = new AlignmentCandidate(index, getPrefilterSimilarity(index));
                 candidates.Add(candidate);
                 if (candidates.Count > MaxComparisonAlignmentWindow) {
@@ -327,19 +361,15 @@ namespace OfficeIMO.Word {
             }
         }
 
-        private static double GetParagraphVisibleTextSimilarity(ParagraphSnapshot sourceParagraph, ParagraphSnapshot targetParagraph) {
+        private static double GetParagraphVisibleTextSimilarity(
+            ParagraphSnapshot sourceParagraph,
+            ParagraphSnapshot targetParagraph,
+            ComparisonWorkBudget comparisonWorkBudget) {
             if (!string.Equals(sourceParagraph.PartKind, targetParagraph.PartKind, StringComparison.Ordinal)) {
                 return 0;
             }
 
-            if (sourceParagraph.ComparisonText.Length > 0 &&
-                targetParagraph.ComparisonText.Length > 0 &&
-                (sourceParagraph.ComparisonText.IndexOf(targetParagraph.ComparisonText, StringComparison.Ordinal) >= 0 ||
-                 targetParagraph.ComparisonText.IndexOf(sourceParagraph.ComparisonText, StringComparison.Ordinal) >= 0)) {
-                return GetContainmentAwareTextSimilarity(sourceParagraph.ComparisonText, targetParagraph.ComparisonText);
-            }
-
-            return GetTextSimilarity(sourceParagraph.ComparisonText, targetParagraph.ComparisonText);
+            return GetContainmentAwareTextSimilarity(sourceParagraph.ComparisonText, targetParagraph.ComparisonText, comparisonWorkBudget);
         }
 
         private static void AddInsertedParagraphFinding(IReadOnlyList<ParagraphSnapshot> targetParagraphs, int targetIndex, WordComparisonResult result) {
@@ -735,129 +765,11 @@ namespace OfficeIMO.Word {
                    paragraph.Descendants<V.ImageData>().Any();
         }
 
-        private static double GetContainmentAwareTextSimilarity(string source, string target) {
-            if (source.Length > 0 &&
-                target.Length > 0 &&
-                (source.IndexOf(target, StringComparison.Ordinal) >= 0 ||
-                 target.IndexOf(source, StringComparison.Ordinal) >= 0)) {
-                return 0.75 + (0.25 * Math.Min(source.Length, target.Length) / Math.Max(source.Length, target.Length));
-            }
-
-            return GetTextSimilarity(source, target);
-        }
-
-        private static double GetTextSimilarity(string source, string target) {
-            if (string.Equals(source, target, StringComparison.Ordinal)) {
-                return 1;
-            }
-
-            if (source.Length == 0 || target.Length == 0) {
-                return 0;
-            }
-
-            if ((long)(source.Length + 1) * (target.Length + 1) > LcsCellLimit) {
-                return GetBoundedTextSimilarity(source, target);
-            }
-
-            return (double)GetCommonSubsequenceLength(source, target) / Math.Max(source.Length, target.Length);
-        }
-
-        private static bool AreComparisonTextEqual(string? source, string? target, WordComparisonOptions options) =>
-            string.Equals(NormalizeComparisonText(source ?? string.Empty, options), NormalizeComparisonText(target ?? string.Empty, options), StringComparison.Ordinal);
-
-        private static string NormalizeComparisonText(string value, WordComparisonOptions options) {
-            string normalized = value ?? string.Empty;
-            if (options.IgnoreWhitespace) {
-                normalized = string.Join(" ", normalized.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
-            }
-
-            if (options.IgnoreCase) {
-                normalized = normalized.ToUpperInvariant();
-            }
-
-            return normalized;
-        }
-
-        private static double GetBoundedTextSimilarity(string source, string target) {
-            int prefixLength = 0;
-            int maxPrefixLength = Math.Min(source.Length, target.Length);
-            while (prefixLength < maxPrefixLength && source[prefixLength] == target[prefixLength]) {
-                prefixLength++;
-            }
-
-            int suffixLength = 0;
-            int sourceSuffixIndex = source.Length - 1;
-            int targetSuffixIndex = target.Length - 1;
-            while (sourceSuffixIndex >= prefixLength &&
-                   targetSuffixIndex >= prefixLength &&
-                   source[sourceSuffixIndex] == target[targetSuffixIndex]) {
-                suffixLength++;
-                sourceSuffixIndex--;
-                targetSuffixIndex--;
-            }
-
-            double edgeSimilarity = (double)(prefixLength + suffixLength) / Math.Max(source.Length, target.Length);
-            int sampleCount = Math.Min(MaxBoundedTextSimilaritySamples, Math.Min(source.Length, target.Length));
-            if (sampleCount <= 1) {
-                return edgeSimilarity;
-            }
-
-            int matchingSamples = 0;
-            for (int sample = 0; sample < sampleCount; sample++) {
-                int sourceIndex = (int)((long)sample * (source.Length - 1) / (sampleCount - 1));
-                int targetIndex = (int)((long)sample * (target.Length - 1) / (sampleCount - 1));
-                if (source[sourceIndex] == target[targetIndex]) {
-                    matchingSamples++;
-                }
-            }
-
-            double lengthRatio = (double)Math.Min(source.Length, target.Length) / Math.Max(source.Length, target.Length);
-            double sampledSimilarity = (double)matchingSamples / sampleCount * lengthRatio;
-            double anchorSimilarity = GetBoundedAnchorTextSimilarity(source, target, lengthRatio);
-            return Math.Max(edgeSimilarity, Math.Max(sampledSimilarity, anchorSimilarity));
-        }
-
-        private static double GetBoundedAnchorTextSimilarity(string source, string target, double lengthRatio) {
-            string anchors = source.Length <= target.Length ? source : target;
-            string searchable = source.Length <= target.Length ? target : source;
-            if (anchors.Length == 0) return 0D;
-
-            int anchorLength = Math.Min(BoundedTextSimilarityAnchorLength, anchors.Length);
-            int maximumStart = anchors.Length - anchorLength;
-            int sampleCount = Math.Min(MaxBoundedTextSimilarityAnchors, maximumStart + 1);
-            int matchingAnchors = 0;
-            for (int sample = 0; sample < sampleCount; sample++) {
-                int start = sampleCount == 1
-                    ? 0
-                    : (int)((long)sample * maximumStart / (sampleCount - 1));
-                string anchor = anchors.Substring(start, anchorLength);
-                if (searchable.IndexOf(anchor, StringComparison.Ordinal) >= 0) {
-                    matchingAnchors++;
-                }
-            }
-
-            return (double)matchingAnchors / sampleCount * lengthRatio;
-        }
-
-        private static int GetCommonSubsequenceLength(string source, string target) {
-            int[,] lengths = new int[source.Length + 1, target.Length + 1];
-
-            for (int sourceIndex = source.Length - 1; sourceIndex >= 0; sourceIndex--) {
-                for (int targetIndex = target.Length - 1; targetIndex >= 0; targetIndex--) {
-                    lengths[sourceIndex, targetIndex] = source[sourceIndex] == target[targetIndex]
-                        ? lengths[sourceIndex + 1, targetIndex + 1] + 1
-                        : Math.Max(lengths[sourceIndex + 1, targetIndex], lengths[sourceIndex, targetIndex + 1]);
-                }
-            }
-
-            return lengths[0, 0];
-        }
-
         private static string ParagraphLocation(int paragraphIndex) {
             return "paragraph[" + paragraphIndex.ToString(System.Globalization.CultureInfo.InvariantCulture) + "]";
         }
 
-        private sealed class ParagraphSnapshot {
+        private sealed class ParagraphSnapshot : IComparisonFingerprint {
             internal ParagraphSnapshot(string partKind, OpenXmlPart? part, Paragraph paragraph, string text, string comparisonText, string matchText, string styleId, string formatSignature, int documentOrder) {
                 PartKind = partKind;
                 Part = part;
@@ -868,6 +780,9 @@ namespace OfficeIMO.Word {
                 StyleId = styleId;
                 FormatSignature = formatSignature;
                 DocumentOrder = documentOrder;
+                ComparisonFingerprint = CombineComparisonFingerprints(
+                    GetOrdinalTextFingerprint(partKind),
+                    GetOrdinalTextFingerprint(matchText));
             }
 
             internal string PartKind { get; }
@@ -887,6 +802,8 @@ namespace OfficeIMO.Word {
             internal string FormatSignature { get; }
 
             internal int DocumentOrder { get; }
+
+            public ulong ComparisonFingerprint { get; }
         }
 
         private readonly struct ParagraphTextSnapshot {

--- a/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.Review.cs
+++ b/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.Review.cs
@@ -183,6 +183,8 @@ namespace OfficeIMO.Word {
             public string DetailedLocation { get; }
 
             public int DocumentOrder { get; }
+
+            ulong IComparisonFingerprint.ComparisonFingerprint => GetOrdinalTextFingerprint(MatchKey);
         }
 
         private sealed class RevisionSnapshot : IFeatureSnapshot {
@@ -206,6 +208,8 @@ namespace OfficeIMO.Word {
             public string DetailedLocation { get; }
 
             public int DocumentOrder { get; }
+
+            ulong IComparisonFingerprint.ComparisonFingerprint => GetOrdinalTextFingerprint(MatchKey);
         }
     }
 }

--- a/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.Runs.cs
+++ b/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.Runs.cs
@@ -320,7 +320,7 @@ namespace OfficeIMO.Word {
             return ParagraphLocation(paragraphIndex) + "/run[" + runIndex.ToString(System.Globalization.CultureInfo.InvariantCulture) + "]";
         }
 
-        private sealed class RunSnapshot {
+        private sealed class RunSnapshot : IComparisonFingerprint {
             internal RunSnapshot(int index, string text, string comparisonText, string matchKey, string formatSignature, int documentOrder) {
                 Index = index;
                 Text = text;
@@ -341,6 +341,8 @@ namespace OfficeIMO.Word {
             internal string FormatSignature { get; }
 
             internal int DocumentOrder { get; }
+
+            public ulong ComparisonFingerprint => GetOrdinalTextFingerprint(MatchKey);
         }
 
         private readonly struct RunTextSegment {

--- a/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.Similarity.cs
+++ b/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.Similarity.cs
@@ -1,0 +1,205 @@
+using System;
+
+namespace OfficeIMO.Word {
+    public static partial class WordDocumentComparer {
+        private static double GetContainmentAwareTextSimilarity(string source, string target) =>
+            GetContainmentAwareTextSimilarity(source, target, null);
+
+        private static double GetContainmentAwareTextSimilarity(
+            string source,
+            string target,
+            ComparisonWorkBudget? comparisonWorkBudget) {
+            long cellCount = ((long)source.Length + 1) * ((long)target.Length + 1);
+            if (source.Length > 0 &&
+                target.Length > 0 &&
+                cellCount <= LcsCellLimit &&
+                (comparisonWorkBudget == null || comparisonWorkBudget.TryConsume(Math.Max(source.Length, target.Length))) &&
+                (source.IndexOf(target, StringComparison.Ordinal) >= 0 ||
+                 target.IndexOf(source, StringComparison.Ordinal) >= 0)) {
+                return 0.75 + (0.25 * Math.Min(source.Length, target.Length) / Math.Max(source.Length, target.Length));
+            }
+
+            return GetTextSimilarity(source, target, comparisonWorkBudget);
+        }
+
+        private static double GetTextSimilarity(string source, string target) =>
+            GetTextSimilarity(source, target, null);
+
+        private static double GetTextSimilarity(
+            string source,
+            string target,
+            ComparisonWorkBudget? comparisonWorkBudget) {
+            if (source.Length == 0 || target.Length == 0) {
+                return source.Length == target.Length ? 1D : 0D;
+            }
+
+            long cellCount = ((long)source.Length + 1) * ((long)target.Length + 1);
+            if (cellCount > LcsCellLimit) {
+                return GetBoundedTextSimilarity(source, target, comparisonWorkBudget);
+            }
+
+            if (comparisonWorkBudget != null && !comparisonWorkBudget.TryConsume(cellCount)) {
+                return 0D;
+            }
+
+            if (string.Equals(source, target, StringComparison.Ordinal)) {
+                return 1D;
+            }
+
+            return (double)GetCommonSubsequenceLength(source, target) / Math.Max(source.Length, target.Length);
+        }
+
+        private static bool AreComparisonTextEqual(string? source, string? target, WordComparisonOptions options) =>
+            string.Equals(NormalizeComparisonText(source ?? string.Empty, options), NormalizeComparisonText(target ?? string.Empty, options), StringComparison.Ordinal);
+
+        private static string NormalizeComparisonText(string value, WordComparisonOptions options) {
+            string normalized = value ?? string.Empty;
+            if (options.IgnoreWhitespace) {
+                normalized = string.Join(" ", normalized.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+            }
+
+            if (options.IgnoreCase) {
+                normalized = normalized.ToUpperInvariant();
+            }
+
+            return normalized;
+        }
+
+        private static double GetBoundedTextSimilarity(string source, string target) =>
+            GetBoundedTextSimilarity(source, target, null);
+
+        private static double GetBoundedTextSimilarity(
+            string source,
+            string target,
+            ComparisonWorkBudget? comparisonWorkBudget) {
+            int prefixLength = 0;
+            int maxPrefixLength = Math.Min(source.Length, target.Length);
+            int maximumEdgeLength = Math.Min(MaxBoundedTextSimilaritySamples, maxPrefixLength);
+            long boundedWorkUnits = (maximumEdgeLength * 2L) + Math.Min(MaxBoundedTextSimilaritySamples, maxPrefixLength);
+            if (comparisonWorkBudget != null && !comparisonWorkBudget.TryConsume(boundedWorkUnits)) {
+                return 0D;
+            }
+
+            while (prefixLength < maximumEdgeLength && source[prefixLength] == target[prefixLength]) {
+                prefixLength++;
+            }
+
+            int suffixLength = 0;
+            int sourceSuffixIndex = source.Length - 1;
+            int targetSuffixIndex = target.Length - 1;
+            while (suffixLength < maximumEdgeLength &&
+                   sourceSuffixIndex >= prefixLength &&
+                   targetSuffixIndex >= prefixLength &&
+                   source[sourceSuffixIndex] == target[targetSuffixIndex]) {
+                suffixLength++;
+                sourceSuffixIndex--;
+                targetSuffixIndex--;
+            }
+
+            double edgeSimilarity = (double)(prefixLength + suffixLength) / Math.Max(source.Length, target.Length);
+            int sampleCount = Math.Min(MaxBoundedTextSimilaritySamples, Math.Min(source.Length, target.Length));
+            if (sampleCount <= 1) {
+                return edgeSimilarity;
+            }
+
+            int matchingSamples = 0;
+            for (int sample = 0; sample < sampleCount; sample++) {
+                int sourceIndex = (int)((long)sample * (source.Length - 1) / (sampleCount - 1));
+                int targetIndex = (int)((long)sample * (target.Length - 1) / (sampleCount - 1));
+                if (source[sourceIndex] == target[targetIndex]) {
+                    matchingSamples++;
+                }
+            }
+
+            double lengthRatio = (double)Math.Min(source.Length, target.Length) / Math.Max(source.Length, target.Length);
+            double sampledSimilarity = (double)matchingSamples / sampleCount * lengthRatio;
+            double anchorSimilarity = GetBoundedAnchorTextSimilarity(source, target, lengthRatio, comparisonWorkBudget);
+            return Math.Max(edgeSimilarity, Math.Max(sampledSimilarity, anchorSimilarity));
+        }
+
+        private static double GetBoundedAnchorTextSimilarity(
+            string source,
+            string target,
+            double lengthRatio,
+            ComparisonWorkBudget? comparisonWorkBudget) {
+            string anchors = source.Length <= target.Length ? source : target;
+            string searchable = source.Length <= target.Length ? target : source;
+            if (anchors.Length == 0) return 0D;
+
+            int anchorLength = Math.Min(BoundedTextSimilarityAnchorLength, anchors.Length);
+            int maximumStart = anchors.Length - anchorLength;
+            int maximumSearchStart = searchable.Length - anchorLength;
+            int sampleCount = Math.Min(MaxBoundedTextSimilarityAnchors, maximumStart + 1);
+            int matchingAnchors = 0;
+            for (int sample = 0; sample < sampleCount; sample++) {
+                int anchorStart = sampleCount == 1
+                    ? 0
+                    : (int)((long)sample * maximumStart / (sampleCount - 1));
+                bool matched;
+                if (comparisonWorkBudget != null) {
+                    if (!comparisonWorkBudget.TryConsume(Math.Max(searchable.Length, MaxBoundedTextSimilaritySamples))) {
+                        break;
+                    }
+
+                    string anchor = anchors.Substring(anchorStart, anchorLength);
+                    matched = searchable.IndexOf(anchor, StringComparison.Ordinal) >= 0;
+                } else {
+                    int searchCenter = maximumStart == 0
+                        ? 0
+                        : (int)((long)anchorStart * maximumSearchStart / maximumStart);
+                    matched = ContainsAnchorWithinBoundedOffset(
+                        anchors,
+                        anchorStart,
+                        searchable,
+                        searchCenter,
+                        anchorLength,
+                        maximumSearchStart);
+                }
+
+                if (matched) {
+                    matchingAnchors++;
+                }
+            }
+
+            return (double)matchingAnchors / sampleCount * lengthRatio;
+        }
+
+        private static bool ContainsAnchorWithinBoundedOffset(
+            string anchors,
+            int anchorStart,
+            string searchable,
+            int searchCenter,
+            int anchorLength,
+            int maximumSearchStart) {
+            int searchStart = Math.Max(0, searchCenter - MaxBoundedTextSimilaritySamples);
+            int searchEnd = Math.Min(maximumSearchStart, searchCenter + MaxBoundedTextSimilaritySamples);
+            for (int candidateStart = searchStart; candidateStart <= searchEnd; candidateStart++) {
+                int offset = 0;
+                while (offset < anchorLength &&
+                       anchors[anchorStart + offset] == searchable[candidateStart + offset]) {
+                    offset++;
+                }
+
+                if (offset == anchorLength) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static int GetCommonSubsequenceLength(string source, string target) {
+            int[,] lengths = new int[source.Length + 1, target.Length + 1];
+
+            for (int sourceIndex = source.Length - 1; sourceIndex >= 0; sourceIndex--) {
+                for (int targetIndex = target.Length - 1; targetIndex >= 0; targetIndex--) {
+                    lengths[sourceIndex, targetIndex] = source[sourceIndex] == target[targetIndex]
+                        ? lengths[sourceIndex + 1, targetIndex + 1] + 1
+                        : Math.Max(lengths[sourceIndex + 1, targetIndex], lengths[sourceIndex, targetIndex + 1]);
+                }
+            }
+
+            return lengths[0, 0];
+        }
+    }
+}

--- a/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.WorkLimits.cs
+++ b/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.WorkLimits.cs
@@ -1,0 +1,70 @@
+namespace OfficeIMO.Word {
+    public static partial class WordDocumentComparer {
+        private static ulong GetComparisonFingerprint<T>(T value) where T : notnull {
+            if (value is string text) {
+                return GetOrdinalTextFingerprint(text);
+            }
+
+            if (value is IComparisonFingerprint fingerprint) {
+                return fingerprint.ComparisonFingerprint;
+            }
+
+            throw new InvalidOperationException(
+                "Structured comparison values must expose an independent comparison fingerprint.");
+        }
+
+        private static ulong GetOrdinalTextFingerprint(string value) {
+            const ulong offsetBasis = 14695981039346656037UL;
+            const ulong prime = 1099511628211UL;
+            ulong fingerprint = offsetBasis;
+            unchecked {
+                for (int index = 0; index < value.Length; index++) {
+                    char character = value[index];
+                    fingerprint ^= (byte)character;
+                    fingerprint *= prime;
+                    fingerprint ^= (byte)(character >> 8);
+                    fingerprint *= prime;
+                }
+
+                fingerprint ^= (uint)value.Length;
+                fingerprint *= prime;
+            }
+
+            return fingerprint;
+        }
+
+        private static ulong CombineComparisonFingerprints(ulong first, ulong second) {
+            unchecked {
+                return (first * 11400714819323198485UL) ^ second;
+            }
+        }
+
+        private sealed class ComparisonWorkBudget {
+            private long _remainingWorkUnits;
+
+            internal ComparisonWorkBudget(long maximumWorkUnits) {
+                _remainingWorkUnits = Math.Max(0, maximumWorkUnits);
+            }
+
+            internal bool IsExhausted => _remainingWorkUnits <= 0;
+
+            internal bool TryConsume(long workUnits) {
+                if (workUnits <= 0) {
+                    return true;
+                }
+
+                if (workUnits > _remainingWorkUnits) {
+                    _remainingWorkUnits = 0;
+                    return false;
+                }
+
+                _remainingWorkUnits -= workUnits;
+                return true;
+            }
+        }
+
+        internal interface IComparisonFingerprint {
+            ulong ComparisonFingerprint { get; }
+        }
+    }
+}

--- a/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.cs
+++ b/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.cs
@@ -10,6 +10,7 @@ namespace OfficeIMO.Word {
     public static partial class WordDocumentComparer {
         private const int LcsCellLimit = 1_000_000;
         private const int MaxComparisonAlignmentWindow = 256;
+        private const long MaxComparisonTextWorkUnits = 64_000_000;
         private const int MaxBoundedTextSimilaritySamples = 64;
         private const int MaxBoundedTextSimilarityAnchors = 8;
         private const int BoundedTextSimilarityAnchorLength = 8;
@@ -53,7 +54,8 @@ namespace OfficeIMO.Word {
             using WordDocument target = WordDocument.Load(targetPath);
 
             WordComparisonResult result = new(sourcePath, targetPath);
-            AnalyzeParagraphs(source, target, result, options);
+            var comparisonWorkBudget = new ComparisonWorkBudget(MaxComparisonTextWorkUnits);
+            AnalyzeParagraphs(source, target, result, options, comparisonWorkBudget);
             if (options.CompareFields) {
                 AnalyzeFields(source, target, result, options);
             }
@@ -82,7 +84,7 @@ namespace OfficeIMO.Word {
                 AnalyzeRevisions(source, target, result, options);
             }
 
-            AnalyzeTables(source, target, result, options);
+            AnalyzeTables(source, target, result, options, comparisonWorkBudget);
             if (options.CompareImages) {
                 AnalyzeImages(source, target, result);
             }
@@ -108,7 +110,12 @@ namespace OfficeIMO.Word {
                 (hasExcludedScopes && options.ExcludedScopes!.Contains(finding.Scope)));
         }
 
-        private static void AnalyzeTables(WordDocument source, WordDocument target, WordComparisonResult result, WordComparisonOptions options) {
+        private static void AnalyzeTables(
+            WordDocument source,
+            WordDocument target,
+            WordComparisonResult result,
+            WordComparisonOptions options,
+            ComparisonWorkBudget comparisonWorkBudget) {
             List<TableSnapshot> sourceTables = GetTableSnapshots(source, options);
             List<TableSnapshot> targetTables = GetTableSnapshots(target, options);
             IReadOnlyList<MatchedIndexPair> matchedTables = FindMatchingIndexes(
@@ -120,12 +127,12 @@ namespace OfficeIMO.Word {
             int targetStart = 0;
 
             foreach (MatchedIndexPair match in matchedTables) {
-                AddTableRangeFindings(sourceTables, targetTables, sourceStart, match.SourceIndex, targetStart, match.TargetIndex, result, options);
+                AddTableRangeFindings(sourceTables, targetTables, sourceStart, match.SourceIndex, targetStart, match.TargetIndex, result, options, comparisonWorkBudget);
                 sourceStart = match.SourceIndex + 1;
                 targetStart = match.TargetIndex + 1;
             }
 
-            AddTableRangeFindings(sourceTables, targetTables, sourceStart, sourceTables.Count, targetStart, targetTables.Count, result, options);
+            AddTableRangeFindings(sourceTables, targetTables, sourceStart, sourceTables.Count, targetStart, targetTables.Count, result, options, comparisonWorkBudget);
         }
 
         private static void AddTableRangeFindings(
@@ -136,7 +143,8 @@ namespace OfficeIMO.Word {
             int targetStart,
             int targetEnd,
             WordComparisonResult result,
-            WordComparisonOptions options) {
+            WordComparisonOptions options,
+            ComparisonWorkBudget comparisonWorkBudget) {
             int sourceIndex = sourceStart;
             int targetIndex = targetStart;
 
@@ -167,7 +175,7 @@ namespace OfficeIMO.Word {
                     continue;
                 }
 
-                AnalyzeTable(sourceTables[sourceIndex], targetTables[targetIndex], targetIndex, targetTables[targetIndex].DocumentOrder, result, options);
+                AnalyzeTable(sourceTables[sourceIndex], targetTables[targetIndex], targetIndex, targetTables[targetIndex].DocumentOrder, result, options, comparisonWorkBudget);
                 sourceIndex++;
                 targetIndex++;
             }
@@ -209,9 +217,22 @@ namespace OfficeIMO.Word {
                 sourceTables[tableIndex].DocumentOrder);
         }
 
-        private static void AnalyzeTable(TableSnapshot source, TableSnapshot target, int tableIndex, int tableDocumentOrder, WordComparisonResult result, WordComparisonOptions options) {
+        private static void AnalyzeTable(
+            TableSnapshot source,
+            TableSnapshot target,
+            int tableIndex,
+            int tableDocumentOrder,
+            WordComparisonResult result,
+            WordComparisonOptions options,
+            ComparisonWorkBudget comparisonWorkBudget) {
             List<WordTableRow> sourceRows = source.Table.Rows.ToList();
             List<WordTableRow> targetRows = target.Table.Rows.ToList();
+            List<string> sourceRowComparisonTexts = sourceRows
+                .Select(row => NormalizeComparisonText(GetRowText(row), options))
+                .ToList();
+            List<string> targetRowComparisonTexts = targetRows
+                .Select(row => NormalizeComparisonText(GetRowText(row), options))
+                .ToList();
             IReadOnlyList<MatchedIndexPair> matchedRows = FindMatchingIndexes(
                 sourceRows.Select(row => GetRowMatchKey(row, source.Part, options)).ToList(),
                 targetRows.Select(row => GetRowMatchKey(row, target.Part, options)).ToList(),
@@ -221,17 +242,19 @@ namespace OfficeIMO.Word {
             int targetStart = 0;
 
             foreach (MatchedIndexPair match in matchedRows) {
-                AddTableRowRangeFindings(sourceRows, targetRows, source.Part, target.Part, tableIndex, tableDocumentOrder, sourceStart, match.SourceIndex, targetStart, match.TargetIndex, result, options);
+                AddTableRowRangeFindings(sourceRows, targetRows, sourceRowComparisonTexts, targetRowComparisonTexts, source.Part, target.Part, tableIndex, tableDocumentOrder, sourceStart, match.SourceIndex, targetStart, match.TargetIndex, result, options, comparisonWorkBudget);
                 sourceStart = match.SourceIndex + 1;
                 targetStart = match.TargetIndex + 1;
             }
 
-            AddTableRowRangeFindings(sourceRows, targetRows, source.Part, target.Part, tableIndex, tableDocumentOrder, sourceStart, sourceRows.Count, targetStart, targetRows.Count, result, options);
+            AddTableRowRangeFindings(sourceRows, targetRows, sourceRowComparisonTexts, targetRowComparisonTexts, source.Part, target.Part, tableIndex, tableDocumentOrder, sourceStart, sourceRows.Count, targetStart, targetRows.Count, result, options, comparisonWorkBudget);
         }
 
         private static void AddTableRowRangeFindings(
             IReadOnlyList<WordTableRow> sourceRows,
             IReadOnlyList<WordTableRow> targetRows,
+            IReadOnlyList<string> sourceRowComparisonTexts,
+            IReadOnlyList<string> targetRowComparisonTexts,
             OpenXmlPart? sourcePart,
             OpenXmlPart? targetPart,
             int tableIndex,
@@ -241,12 +264,20 @@ namespace OfficeIMO.Word {
             int targetStart,
             int targetEnd,
             WordComparisonResult result,
-            WordComparisonOptions options) {
+            WordComparisonOptions options,
+            ComparisonWorkBudget comparisonWorkBudget) {
             int sourceIndex = sourceStart;
             int targetIndex = targetStart;
 
             while (sourceIndex < sourceEnd && targetIndex < targetEnd) {
-                int betterTargetIndex = FindBetterTargetRowAlignmentIndex(sourceRows[sourceIndex], targetRows, targetIndex, targetEnd, options);
+                int betterTargetIndex = FindBetterTargetRowAlignmentIndex(
+                    sourceRows[sourceIndex],
+                    sourceRowComparisonTexts[sourceIndex],
+                    targetRows,
+                    targetRowComparisonTexts,
+                    targetIndex,
+                    targetEnd,
+                    comparisonWorkBudget);
                 if (betterTargetIndex > targetIndex) {
                     while (targetIndex < betterTargetIndex) {
                         AddInsertedTableRowFinding(targetRows, tableIndex, tableDocumentOrder, targetIndex, result);
@@ -256,7 +287,14 @@ namespace OfficeIMO.Word {
                     continue;
                 }
 
-                int betterSourceIndex = FindBetterSourceRowAlignmentIndex(sourceRows, sourceIndex, sourceEnd, targetRows[targetIndex], options);
+                int betterSourceIndex = FindBetterSourceRowAlignmentIndex(
+                    sourceRows,
+                    sourceRowComparisonTexts,
+                    sourceIndex,
+                    sourceEnd,
+                    targetRows[targetIndex],
+                    targetRowComparisonTexts[targetIndex],
+                    comparisonWorkBudget);
                 if (betterSourceIndex > sourceIndex) {
                     while (sourceIndex < betterSourceIndex) {
                         AddDeletedTableRowFinding(sourceRows, tableIndex, tableDocumentOrder, sourceIndex, result);
@@ -267,7 +305,7 @@ namespace OfficeIMO.Word {
                 }
 
                 if (sourceRows[sourceIndex].Cells.Count != targetRows[targetIndex].Cells.Count &&
-                    AreComparisonTextEqual(GetRowText(sourceRows[sourceIndex]), GetRowText(targetRows[targetIndex]), options)) {
+                    string.Equals(sourceRowComparisonTexts[sourceIndex], targetRowComparisonTexts[targetIndex], StringComparison.Ordinal)) {
                     AddDeletedTableRowFinding(sourceRows, tableIndex, tableDocumentOrder, sourceIndex, result);
                     AddInsertedTableRowFinding(targetRows, tableIndex, tableDocumentOrder, targetIndex, result);
                     sourceIndex++;
@@ -293,19 +331,22 @@ namespace OfficeIMO.Word {
 
         private static int FindBetterTargetRowAlignmentIndex(
             WordTableRow sourceRow,
+            string sourceComparisonText,
             IReadOnlyList<WordTableRow> targetRows,
+            IReadOnlyList<string> targetComparisonTexts,
             int targetStart,
             int targetEnd,
-            WordComparisonOptions options) {
-            double currentSimilarity = GetRowSimilarity(sourceRow, targetRows[targetStart], options);
+            ComparisonWorkBudget comparisonWorkBudget) {
+            double currentSimilarity = GetRowSimilarity(sourceRow, sourceComparisonText, targetRows[targetStart], targetComparisonTexts[targetStart], comparisonWorkBudget);
             int bestIndex = targetStart;
             double bestSimilarity = currentSimilarity;
 
             foreach (int index in SelectBoundedAlignmentCandidates(
                 targetStart + 1,
                 targetEnd,
-                index => GetRowAlignmentPrefilterSimilarity(sourceRow, targetRows[index], options))) {
-                double similarity = GetRowSimilarity(sourceRow, targetRows[index], options);
+                index => GetRowAlignmentPrefilterSimilarity(sourceRow, sourceComparisonText, targetRows[index], targetComparisonTexts[index], comparisonWorkBudget),
+                comparisonWorkBudget)) {
+                double similarity = GetRowSimilarity(sourceRow, sourceComparisonText, targetRows[index], targetComparisonTexts[index], comparisonWorkBudget);
                 if (similarity > bestSimilarity) {
                     bestSimilarity = similarity;
                     bestIndex = index;
@@ -317,19 +358,22 @@ namespace OfficeIMO.Word {
 
         private static int FindBetterSourceRowAlignmentIndex(
             IReadOnlyList<WordTableRow> sourceRows,
+            IReadOnlyList<string> sourceComparisonTexts,
             int sourceStart,
             int sourceEnd,
             WordTableRow targetRow,
-            WordComparisonOptions options) {
-            double currentSimilarity = GetRowSimilarity(sourceRows[sourceStart], targetRow, options);
+            string targetComparisonText,
+            ComparisonWorkBudget comparisonWorkBudget) {
+            double currentSimilarity = GetRowSimilarity(sourceRows[sourceStart], sourceComparisonTexts[sourceStart], targetRow, targetComparisonText, comparisonWorkBudget);
             int bestIndex = sourceStart;
             double bestSimilarity = currentSimilarity;
 
             foreach (int index in SelectBoundedAlignmentCandidates(
                 sourceStart + 1,
                 sourceEnd,
-                index => GetRowAlignmentPrefilterSimilarity(sourceRows[index], targetRow, options))) {
-                double similarity = GetRowSimilarity(sourceRows[index], targetRow, options);
+                index => GetRowAlignmentPrefilterSimilarity(sourceRows[index], sourceComparisonTexts[index], targetRow, targetComparisonText, comparisonWorkBudget),
+                comparisonWorkBudget)) {
+                double similarity = GetRowSimilarity(sourceRows[index], sourceComparisonTexts[index], targetRow, targetComparisonText, comparisonWorkBudget);
                 if (similarity > bestSimilarity) {
                     bestSimilarity = similarity;
                     bestIndex = index;
@@ -485,15 +529,31 @@ namespace OfficeIMO.Word {
         }
 
         private static IReadOnlyList<MatchedIndexPair> FindMatchingIndexes<T>(IReadOnlyList<T> source, IReadOnlyList<T> target, IEqualityComparer<T> comparer) where T : notnull {
-            if ((long)(source.Count + 1) * (target.Count + 1) > LcsCellLimit) {
+            if (((long)source.Count + 1) * ((long)target.Count + 1) > LcsCellLimit) {
                 return FindGreedyMatchingIndexes(source, target, comparer);
+            }
+
+            int[] sourceHashCodes = new int[source.Count];
+            ulong[] sourceFingerprints = new ulong[source.Count];
+            for (int sourceIndex = 0; sourceIndex < source.Count; sourceIndex++) {
+                sourceHashCodes[sourceIndex] = comparer.GetHashCode(source[sourceIndex]);
+                sourceFingerprints[sourceIndex] = GetComparisonFingerprint(source[sourceIndex]);
+            }
+
+            int[] targetHashCodes = new int[target.Count];
+            ulong[] targetFingerprints = new ulong[target.Count];
+            for (int targetIndex = 0; targetIndex < target.Count; targetIndex++) {
+                targetHashCodes[targetIndex] = comparer.GetHashCode(target[targetIndex]);
+                targetFingerprints[targetIndex] = GetComparisonFingerprint(target[targetIndex]);
             }
 
             int[,] lengths = new int[source.Count + 1, target.Count + 1];
 
             for (int sourceIndex = source.Count - 1; sourceIndex >= 0; sourceIndex--) {
                 for (int targetIndex = target.Count - 1; targetIndex >= 0; targetIndex--) {
-                    lengths[sourceIndex, targetIndex] = comparer.Equals(source[sourceIndex], target[targetIndex])
+                    lengths[sourceIndex, targetIndex] = sourceHashCodes[sourceIndex] == targetHashCodes[targetIndex] &&
+                        sourceFingerprints[sourceIndex] == targetFingerprints[targetIndex] &&
+                        comparer.Equals(source[sourceIndex], target[targetIndex])
                         ? lengths[sourceIndex + 1, targetIndex + 1] + 1
                         : Math.Max(lengths[sourceIndex + 1, targetIndex], lengths[sourceIndex, targetIndex + 1]);
                 }
@@ -504,7 +564,9 @@ namespace OfficeIMO.Word {
             int targetCursor = 0;
 
             while (sourceCursor < source.Count && targetCursor < target.Count) {
-                if (comparer.Equals(source[sourceCursor], target[targetCursor])) {
+                if (sourceHashCodes[sourceCursor] == targetHashCodes[targetCursor] &&
+                    sourceFingerprints[sourceCursor] == targetFingerprints[targetCursor] &&
+                    comparer.Equals(source[sourceCursor], target[targetCursor])) {
                     matches.Add(new MatchedIndexPair(sourceCursor, targetCursor));
                     sourceCursor++;
                     targetCursor++;
@@ -702,22 +764,30 @@ namespace OfficeIMO.Word {
             return value.Length.ToString(System.Globalization.CultureInfo.InvariantCulture) + ":" + value;
         }
 
-        private static double GetRowSimilarity(WordTableRow source, WordTableRow target, WordComparisonOptions options) {
+        private static double GetRowSimilarity(
+            WordTableRow source,
+            string sourceComparisonText,
+            WordTableRow target,
+            string targetComparisonText,
+            ComparisonWorkBudget comparisonWorkBudget) {
             if (source.Cells.Count != target.Cells.Count) {
                 return 0;
             }
 
-            return GetContainmentAwareTextSimilarity(NormalizeComparisonText(GetRowText(source), options), NormalizeComparisonText(GetRowText(target), options));
+            return GetContainmentAwareTextSimilarity(sourceComparisonText, targetComparisonText, comparisonWorkBudget);
         }
 
-        private static double GetRowAlignmentPrefilterSimilarity(WordTableRow source, WordTableRow target, WordComparisonOptions options) {
+        private static double GetRowAlignmentPrefilterSimilarity(
+            WordTableRow source,
+            string sourceComparisonText,
+            WordTableRow target,
+            string targetComparisonText,
+            ComparisonWorkBudget comparisonWorkBudget) {
             if (source.Cells.Count != target.Cells.Count) {
                 return 0;
             }
 
-            return GetBoundedTextSimilarity(
-                NormalizeComparisonText(GetRowText(source), options),
-                NormalizeComparisonText(GetRowText(target), options));
+            return GetBoundedTextSimilarity(sourceComparisonText, targetComparisonText, comparisonWorkBudget);
         }
 
         private static double GetTableSimilarity(TableSnapshot source, TableSnapshot target, WordComparisonOptions options) {

--- a/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.cs
+++ b/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.cs
@@ -151,8 +151,8 @@ namespace OfficeIMO.Word {
             while (sourceIndex < sourceEnd && targetIndex < targetEnd) {
                 if (targetEnd - targetIndex > sourceEnd - sourceIndex &&
                     targetIndex + 1 < targetEnd &&
-                    GetTableSimilarity(sourceTables[sourceIndex], targetTables[targetIndex + 1], options) >
-                    GetTableSimilarity(sourceTables[sourceIndex], targetTables[targetIndex], options)) {
+                    GetTableSimilarity(sourceTables[sourceIndex], targetTables[targetIndex + 1], comparisonWorkBudget) >
+                    GetTableSimilarity(sourceTables[sourceIndex], targetTables[targetIndex], comparisonWorkBudget)) {
                     AddInsertedTableFinding(targetTables, targetIndex, result);
                     targetIndex++;
                     continue;
@@ -160,8 +160,8 @@ namespace OfficeIMO.Word {
 
                 if (sourceEnd - sourceIndex > targetEnd - targetIndex &&
                     sourceIndex + 1 < sourceEnd &&
-                    GetTableSimilarity(sourceTables[sourceIndex + 1], targetTables[targetIndex], options) >
-                    GetTableSimilarity(sourceTables[sourceIndex], targetTables[targetIndex], options)) {
+                    GetTableSimilarity(sourceTables[sourceIndex + 1], targetTables[targetIndex], comparisonWorkBudget) >
+                    GetTableSimilarity(sourceTables[sourceIndex], targetTables[targetIndex], comparisonWorkBudget)) {
                     AddDeletedTableFinding(sourceTables, sourceIndex, result);
                     sourceIndex++;
                     continue;
@@ -313,7 +313,7 @@ namespace OfficeIMO.Word {
                     continue;
                 }
 
-                AnalyzeTableRow(sourceRows[sourceIndex], targetRows[targetIndex], sourcePart, targetPart, tableIndex, tableDocumentOrder, sourceIndex, targetIndex, result, options);
+                AnalyzeTableRow(sourceRows[sourceIndex], targetRows[targetIndex], sourcePart, targetPart, tableIndex, tableDocumentOrder, sourceIndex, targetIndex, result, options, comparisonWorkBudget);
                 sourceIndex++;
                 targetIndex++;
             }
@@ -409,9 +409,26 @@ namespace OfficeIMO.Word {
                 GetTableChildDocumentOrder(tableDocumentOrder, sourceRows[rowIndex]._tableRow));
         }
 
-        private static void AnalyzeTableRow(WordTableRow source, WordTableRow target, OpenXmlPart? sourcePart, OpenXmlPart? targetPart, int tableIndex, int tableDocumentOrder, int sourceRowIndex, int targetRowIndex, WordComparisonResult result, WordComparisonOptions options) {
+        private static void AnalyzeTableRow(
+            WordTableRow source,
+            WordTableRow target,
+            OpenXmlPart? sourcePart,
+            OpenXmlPart? targetPart,
+            int tableIndex,
+            int tableDocumentOrder,
+            int sourceRowIndex,
+            int targetRowIndex,
+            WordComparisonResult result,
+            WordComparisonOptions options,
+            ComparisonWorkBudget comparisonWorkBudget) {
             List<WordTableCell> sourceCells = source.Cells.ToList();
             List<WordTableCell> targetCells = target.Cells.ToList();
+            List<string> sourceCellComparisonTexts = sourceCells
+                .Select(cell => NormalizeComparisonText(GetCellText(cell), options))
+                .ToList();
+            List<string> targetCellComparisonTexts = targetCells
+                .Select(cell => NormalizeComparisonText(GetCellText(cell), options))
+                .ToList();
             IReadOnlyList<MatchedIndexPair> matchedCells = FindMatchingIndexes(
                 sourceCells.Select(cell => GetCellMatchKey(cell, sourcePart, options)).ToList(),
                 targetCells.Select(cell => GetCellMatchKey(cell, targetPart, options)).ToList(),
@@ -421,17 +438,19 @@ namespace OfficeIMO.Word {
             int targetStart = 0;
 
             foreach (MatchedIndexPair match in matchedCells) {
-                AddTableCellRangeFindings(sourceCells, targetCells, sourcePart, targetPart, tableIndex, tableDocumentOrder, sourceRowIndex, targetRowIndex, sourceStart, match.SourceIndex, targetStart, match.TargetIndex, result, options);
+                AddTableCellRangeFindings(sourceCells, targetCells, sourceCellComparisonTexts, targetCellComparisonTexts, sourcePart, targetPart, tableIndex, tableDocumentOrder, sourceRowIndex, targetRowIndex, sourceStart, match.SourceIndex, targetStart, match.TargetIndex, result, options, comparisonWorkBudget);
                 sourceStart = match.SourceIndex + 1;
                 targetStart = match.TargetIndex + 1;
             }
 
-            AddTableCellRangeFindings(sourceCells, targetCells, sourcePart, targetPart, tableIndex, tableDocumentOrder, sourceRowIndex, targetRowIndex, sourceStart, sourceCells.Count, targetStart, targetCells.Count, result, options);
+            AddTableCellRangeFindings(sourceCells, targetCells, sourceCellComparisonTexts, targetCellComparisonTexts, sourcePart, targetPart, tableIndex, tableDocumentOrder, sourceRowIndex, targetRowIndex, sourceStart, sourceCells.Count, targetStart, targetCells.Count, result, options, comparisonWorkBudget);
         }
 
         private static void AddTableCellRangeFindings(
             IReadOnlyList<WordTableCell> sourceCells,
             IReadOnlyList<WordTableCell> targetCells,
+            IReadOnlyList<string> sourceCellComparisonTexts,
+            IReadOnlyList<string> targetCellComparisonTexts,
             OpenXmlPart? sourcePart,
             OpenXmlPart? targetPart,
             int tableIndex,
@@ -443,15 +462,16 @@ namespace OfficeIMO.Word {
             int targetStart,
             int targetEnd,
             WordComparisonResult result,
-            WordComparisonOptions options) {
+            WordComparisonOptions options,
+            ComparisonWorkBudget comparisonWorkBudget) {
             int sourceIndex = sourceStart;
             int targetIndex = targetStart;
 
             while (sourceIndex < sourceEnd && targetIndex < targetEnd) {
                 if (targetEnd - targetIndex > sourceEnd - sourceIndex &&
                     targetIndex + 1 < targetEnd &&
-                    GetCellSimilarity(sourceCells[sourceIndex], targetCells[targetIndex + 1], options) >
-                    GetCellSimilarity(sourceCells[sourceIndex], targetCells[targetIndex], options)) {
+                    GetCellSimilarity(sourceCellComparisonTexts[sourceIndex], targetCellComparisonTexts[targetIndex + 1], comparisonWorkBudget) >
+                    GetCellSimilarity(sourceCellComparisonTexts[sourceIndex], targetCellComparisonTexts[targetIndex], comparisonWorkBudget)) {
                     AddInsertedTableCellFinding(targetCells, tableIndex, tableDocumentOrder, targetRowIndex, targetIndex, result);
                     targetIndex++;
                     continue;
@@ -459,8 +479,8 @@ namespace OfficeIMO.Word {
 
                 if (sourceEnd - sourceIndex > targetEnd - targetIndex &&
                     sourceIndex + 1 < sourceEnd &&
-                    GetCellSimilarity(sourceCells[sourceIndex + 1], targetCells[targetIndex], options) >
-                    GetCellSimilarity(sourceCells[sourceIndex], targetCells[targetIndex], options)) {
+                    GetCellSimilarity(sourceCellComparisonTexts[sourceIndex + 1], targetCellComparisonTexts[targetIndex], comparisonWorkBudget) >
+                    GetCellSimilarity(sourceCellComparisonTexts[sourceIndex], targetCellComparisonTexts[targetIndex], comparisonWorkBudget)) {
                     AddDeletedTableCellFinding(sourceCells, tableIndex, tableDocumentOrder, sourceRowIndex, sourceIndex, result);
                     sourceIndex++;
                     continue;
@@ -656,7 +676,7 @@ namespace OfficeIMO.Word {
                 var wordTable = new WordTable(document, table);
                 string text = GetTableText(wordTable);
                 string matchText = GetTableMatchText(wordTable, part, options);
-                snapshots.Add(new TableSnapshot(wordTable, part, text, matchText, GetTableMatchKey(partKey, wordTable, part, options), partKey, ordered.DocumentOrder));
+                snapshots.Add(new TableSnapshot(wordTable, part, text, NormalizeComparisonText(text, options), matchText, GetTableMatchKey(partKey, wordTable, part, options), partKey, ordered.DocumentOrder));
             }
         }
 
@@ -790,16 +810,16 @@ namespace OfficeIMO.Word {
             return GetBoundedTextSimilarity(sourceComparisonText, targetComparisonText, comparisonWorkBudget);
         }
 
-        private static double GetTableSimilarity(TableSnapshot source, TableSnapshot target, WordComparisonOptions options) {
+        private static double GetTableSimilarity(TableSnapshot source, TableSnapshot target, ComparisonWorkBudget comparisonWorkBudget) {
             if (!string.Equals(source.PartKey, target.PartKey, StringComparison.Ordinal)) {
                 return 0;
             }
 
-            return GetTextSimilarity(NormalizeComparisonText(source.Text, options), NormalizeComparisonText(target.Text, options));
+            return GetTextSimilarity(source.ComparisonText, target.ComparisonText, comparisonWorkBudget);
         }
 
-        private static double GetCellSimilarity(WordTableCell source, WordTableCell target, WordComparisonOptions options) {
-            return GetTextSimilarity(NormalizeComparisonText(GetCellText(source), options), NormalizeComparisonText(GetCellText(target), options));
+        private static double GetCellSimilarity(string sourceComparisonText, string targetComparisonText, ComparisonWorkBudget comparisonWorkBudget) {
+            return GetTextSimilarity(sourceComparisonText, targetComparisonText, comparisonWorkBudget);
         }
 
         private static string GetStableElementPath(OpenXmlElement element) {
@@ -926,10 +946,11 @@ namespace OfficeIMO.Word {
         }
 
         private sealed class TableSnapshot {
-            internal TableSnapshot(WordTable table, OpenXmlPart? part, string text, string matchText, string matchKey, string partKey, int documentOrder) {
+            internal TableSnapshot(WordTable table, OpenXmlPart? part, string text, string comparisonText, string matchText, string matchKey, string partKey, int documentOrder) {
                 Table = table;
                 Part = part;
                 Text = text;
+                ComparisonText = comparisonText;
                 MatchText = matchText;
                 MatchKey = matchKey;
                 PartKey = partKey;
@@ -941,6 +962,8 @@ namespace OfficeIMO.Word {
             internal OpenXmlPart? Part { get; }
 
             internal string Text { get; }
+
+            internal string ComparisonText { get; }
 
             internal string MatchText { get; }
 


### PR DESCRIPTION
## Summary

- cap aggregate paragraph, table, row, and cell similarity work while retaining full-range alignment
- precompute independent comparison fingerprints before dynamic-programming matching
- cache normalized row, table, and cell text so exhausted comparisons do not repeat attacker-sized allocations
- preserve shifted internal matches and candidates beyond the former sampling boundary

## Security impact

This prevents untrusted DOCX inputs from amplifying structure-comparison CPU or memory through repeated long-string scans, table/cell LCS matrices, colliding equality hashes, or unrestricted candidate evaluation.

## Validation

- focused table and cell budget regressions: 2/2 on .NET 8
- full `CompareStructure` suite: 225/225 on .NET 8 and 225/225 on .NET 10
- `OfficeIMO.Word` netstandard2.0 build: zero warnings and zero errors
