### PR TITLE
Bound PDF catalog name-tree diagnostics

### DIFF
--- a/OfficeIMO.Pdf.Tests/Pdf/PdfResourceBudgetSecurityTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfResourceBudgetSecurityTests.cs
@@ -418,6 +418,28 @@ public sealed class PdfResourceBudgetSecurityTests {
     }
 
     [Fact]
+    public void PdfReadDocument_IgnoresUnknownCatalogNameTreeAliasesBeforeTraversal() {
+        string aliases = string.Join(
+            " ",
+            Enumerable.Range(0, 256).Select(static index => "/Unknown" + index + " 6 0 R"));
+        byte[] pdf = BuildPdfObjects(
+            "<< /Type /Catalog /Pages 2 0 R /Names << /Dests 5 0 R " + aliases + " >> >>",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R >>",
+            BuildStream(string.Empty),
+            "<< /Names [(Target) [3 0 R /Fit]] >>",
+            "<< /Kids [7 0 R] >>",
+            "<< /Names [(Ignored) [3 0 R /Fit]] >>");
+        var options = new PdfReadOptions {
+            Limits = new PdfReadLimits { MaxNameTreeNodes = 1 }
+        };
+
+        PdfReadDocument document = PdfReadDocument.Open(pdf, options);
+
+        Assert.Equal("Target", Assert.Single(document.NamedDestinations).Name);
+    }
+
+    [Fact]
     public void PdfReadDocument_BoundsEmbeddedFileNameTreeDepth() {
         byte[] pdf = BuildPdfObjects(
             "<< /Type /Catalog /Pages 2 0 R /Names << /EmbeddedFiles 5 0 R >> >>",

--- a/OfficeIMO.Pdf/Reading/Diagnostics/PdfSemanticRepairDiagnostics.cs
+++ b/OfficeIMO.Pdf/Reading/Diagnostics/PdfSemanticRepairDiagnostics.cs
@@ -64,6 +64,7 @@ internal static class PdfSemanticRepairDiagnostics {
         PdfDictionary? names = ResolveDictionary(objects, catalog.Items.TryGetValue("Names", out PdfObject? namesObject) ? namesObject : null);
         if (names is null) return;
         foreach (KeyValuePair<string, PdfObject> entry in names.Items) {
+            if (!IsStandardCatalogNameTree(entry.Key)) continue;
             int traversedNameTreeNodes = 0;
             ValidateNameTreeNode(objects, entry.Value, entry.Key, new HashSet<int>(), options, diagnostics, 0, ref traversedNameTreeNodes);
         }
@@ -80,6 +81,11 @@ internal static class PdfSemanticRepairDiagnostics {
                 0,
                 ref traversedDestinationTreeNodes);
         }
+    }
+
+    private static bool IsStandardCatalogNameTree(string name) {
+        return name is "Dests" or "AP" or "JavaScript" or "Pages" or "Templates" or
+            "IDS" or "URLS" or "EmbeddedFiles" or "AlternatePresentations" or "Renditions";
     }
 
     private static void ValidateNameTreeNode(


### PR DESCRIPTION
## Summary

- Limit semantic name-tree traversal to the standard PDF catalog name-tree slots.
- Ignore unknown and extension aliases before allocating an independent traversal budget.
- Add a regression with 256 attacker-controlled aliases while preserving a supported Dests tree.

## Why

The catalog Names dictionary is attacker-controlled. Unknown keys could point to the same large tree, and each key received a fresh MaxNameTreeNodes budget. That made total diagnostic work scale with the number of aliases during normal PDF open operations.

## Compatibility

Standard catalog name trees keep their intended independent budgets. Unknown entries remain parsed and preserved, but generic semantic diagnostics no longer traverse them.

## Validation

- The regression fails against the merged parent with NameTreeNodes observed 2, maximum 1, and passes after the fix.
- Focused regression passes on .NET 8 and .NET 10.
- PDF resource-budget tests pass 30/30 on both frameworks.
- OfficeIMO.Pdf builds for netstandard2.0 with zero warnings.
- Independent read-only security review found no actionable issues.