### PR TITLE
Harden document processing resource and permission boundaries

### DIFF
--- a/OfficeIMO.Confluence.Tests/ConfluenceContractTests.cs
+++ b/OfficeIMO.Confluence.Tests/ConfluenceContractTests.cs
@@ -298,6 +298,50 @@ public sealed class ConfluenceContractTests {
     }
 
     [Fact]
+    public async Task AttachmentDownload_NonSeekableDestinationRetriesBeforeWriting() {
+        int attempt = 0;
+        var handler = new RecordingHandler(_ => ++attempt == 1
+            ? Response(HttpStatusCode.ServiceUnavailable, "later")
+            : new HttpResponseMessage(HttpStatusCode.OK) {
+                Content = new ByteArrayContent(Encoding.UTF8.GetBytes("complete")),
+            });
+        using ConfluenceClient client = CreateClient(handler, configure: options => {
+            options.RetryBaseDelay = TimeSpan.Zero;
+            options.RetryMaxDelay = TimeSpan.Zero;
+        });
+        using var storage = new MemoryStream();
+        using var destination = new NonSeekableWriteStream(storage);
+
+        await client.DownloadAttachmentAsync("123", "a1", destination);
+
+        Assert.Equal(2, attempt);
+        Assert.Equal("complete", Encoding.UTF8.GetString(storage.ToArray()));
+    }
+
+    [Fact]
+    public async Task AttachmentDownload_NonSeekableDestinationDoesNotRetryAfterWritingStarts() {
+        int attempt = 0;
+        var handler = new RecordingHandler(_ => {
+            attempt++;
+            return new HttpResponseMessage(HttpStatusCode.OK) {
+                Content = new StreamContent(new PartialReadFailureStream(Encoding.UTF8.GetBytes("partial"))),
+            };
+        });
+        using ConfluenceClient client = CreateClient(handler, configure: options => {
+            options.RetryBaseDelay = TimeSpan.Zero;
+            options.RetryMaxDelay = TimeSpan.Zero;
+        });
+        using var storage = new MemoryStream();
+        using var destination = new NonSeekableWriteStream(storage);
+
+        await Assert.ThrowsAsync<HttpRequestException>(() =>
+            client.DownloadAttachmentAsync("123", "a1", destination));
+
+        Assert.Equal(1, attempt);
+        Assert.Equal("partial", Encoding.UTF8.GetString(storage.ToArray()));
+    }
+
+    [Fact]
     public async Task AttachmentDownload_RejectsSeekableDestinationThatWouldOverwriteExistingData() {
         int requests = 0;
         var handler = new RecordingHandler(_ => {
@@ -373,6 +417,26 @@ public sealed class ConfluenceContractTests {
         public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
         public override void SetLength(long value) => throw new NotSupportedException();
         public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    private sealed class NonSeekableWriteStream : Stream {
+        private readonly Stream _inner;
+
+        internal NonSeekableWriteStream(Stream inner) => _inner = inner;
+
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+        public override void Flush() => _inner.Flush();
+        public override Task FlushAsync(CancellationToken cancellationToken) => _inner.FlushAsync(cancellationToken);
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => _inner.Write(buffer, offset, count);
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+            _inner.WriteAsync(buffer, offset, count, cancellationToken);
     }
 
     private sealed class RecordingHandler : HttpMessageHandler {

--- a/OfficeIMO.Confluence.Tests/ConfluenceContractTests.cs
+++ b/OfficeIMO.Confluence.Tests/ConfluenceContractTests.cs
@@ -288,7 +288,8 @@ public sealed class ConfluenceContractTests {
             options.RetryMaxDelay = TimeSpan.Zero;
         });
         using var destination = new MemoryStream();
-        destination.Write(Encoding.UTF8.GetBytes("prefix:"));
+        byte[] prefix = Encoding.UTF8.GetBytes("prefix:");
+        destination.Write(prefix, 0, prefix.Length);
 
         await client.DownloadAttachmentAsync("123", "a1", destination);
 

--- a/OfficeIMO.Confluence.Tests/ConfluenceContractTests.cs
+++ b/OfficeIMO.Confluence.Tests/ConfluenceContractTests.cs
@@ -252,6 +252,28 @@ public sealed class ConfluenceContractTests {
     }
 
     [Fact]
+    public async Task AttachmentDownload_DoesNotStageResponseInSharedTemporaryStorage() {
+        string tempRoot = Path.GetTempPath();
+        var before = new HashSet<string>(Directory.EnumerateFiles(tempRoot, "officeimo-confluence-*.tmp"), StringComparer.Ordinal);
+        string[] createdDuringRequest = Array.Empty<string>();
+        var handler = new RecordingHandler(_ => {
+            createdDuringRequest = Directory.EnumerateFiles(tempRoot, "officeimo-confluence-*.tmp")
+                .Where(path => !before.Contains(path))
+                .ToArray();
+            return new HttpResponseMessage(HttpStatusCode.OK) {
+                Content = new ByteArrayContent(Encoding.UTF8.GetBytes("direct-stream")),
+            };
+        });
+        using ConfluenceClient client = CreateClient(handler);
+        using var destination = new MemoryStream();
+
+        await client.DownloadAttachmentAsync("123", "a1", destination);
+
+        Assert.Empty(createdDuringRequest);
+        Assert.Equal("direct-stream", Encoding.UTF8.GetString(destination.ToArray()));
+    }
+
+    [Fact]
     public async Task AttachmentDownload_RetryDoesNotAppendToPartialDestination() {
         int attempt = 0;
         var handler = new RecordingHandler(_ => ++attempt == 1
@@ -266,11 +288,32 @@ public sealed class ConfluenceContractTests {
             options.RetryMaxDelay = TimeSpan.Zero;
         });
         using var destination = new MemoryStream();
+        destination.Write(Encoding.UTF8.GetBytes("prefix:"));
 
         await client.DownloadAttachmentAsync("123", "a1", destination);
 
         Assert.Equal(2, attempt);
-        Assert.Equal("complete", Encoding.UTF8.GetString(destination.ToArray()));
+        Assert.Equal("prefix:complete", Encoding.UTF8.GetString(destination.ToArray()));
+    }
+
+    [Fact]
+    public async Task AttachmentDownload_RejectsSeekableDestinationThatWouldOverwriteExistingData() {
+        int requests = 0;
+        var handler = new RecordingHandler(_ => {
+            requests++;
+            return new HttpResponseMessage(HttpStatusCode.OK) {
+                Content = new ByteArrayContent(Encoding.UTF8.GetBytes("replacement")),
+            };
+        });
+        using ConfluenceClient client = CreateClient(handler);
+        using var destination = new MemoryStream(Encoding.UTF8.GetBytes("preserve-me"), writable: true);
+        destination.Position = 0;
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            client.DownloadAttachmentAsync("123", "a1", destination));
+
+        Assert.Equal(0, requests);
+        Assert.Equal("preserve-me", Encoding.UTF8.GetString(destination.ToArray()));
     }
 
     private static ConfluenceClient CreateClient(RecordingHandler handler, IConfluenceCredentialSource? credential = null, Action<ConfluenceSessionOptions>? configure = null) {

--- a/OfficeIMO.Confluence/ConfluenceHttpTransport.cs
+++ b/OfficeIMO.Confluence/ConfluenceHttpTransport.cs
@@ -115,6 +115,7 @@ internal sealed class ConfluenceHttpTransport : IDisposable {
 
     private async Task SendToStreamCoreAsync(HttpMethod method, string relativeUri, Stream destination, CancellationToken cancellationToken) {
         bool canReset = PrepareDestinationForDirectStreaming(destination, out long initialPosition);
+        bool destinationWriteStarted = false;
 
         try {
             await SendAsync(
@@ -122,18 +123,35 @@ internal sealed class ConfluenceHttpTransport : IDisposable {
                     relativeUri,
                     null,
                     null,
-                    canReset ? ConfluenceRequestSafety.SafeToRetry : ConfluenceRequestSafety.NonIdempotent,
+                    ConfluenceRequestSafety.SafeToRetry,
                     cancellationToken,
                     async (response, token) => {
                         if (canReset) ResetDestination(destination, initialPosition);
+                        destinationWriteStarted = false;
                         using Stream source = await ReadAsStreamAsync(response.Content, token).ConfigureAwait(false);
-                        await source.CopyToAsync(destination, 81920, token).ConfigureAwait(false);
+                        await CopyToDestinationAsync(source, destination, token, () => destinationWriteStarted = true)
+                            .ConfigureAwait(false);
                         return true;
-                    })
+                    },
+                    () => canReset || !destinationWriteStarted)
                 .ConfigureAwait(false);
         } catch {
             if (canReset) TryResetDestination(destination, initialPosition);
             throw;
+        }
+    }
+
+    private static async Task CopyToDestinationAsync(
+        Stream source,
+        Stream destination,
+        CancellationToken cancellationToken,
+        Action onWriteStarting) {
+        var buffer = new byte[81920];
+        while (true) {
+            int read = await source.ReadAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
+            if (read == 0) return;
+            onWriteStarting();
+            await destination.WriteAsync(buffer, 0, read, cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -209,7 +227,8 @@ internal sealed class ConfluenceHttpTransport : IDisposable {
         Action<HttpRequestMessage>? configure,
         ConfluenceRequestSafety safety,
         CancellationToken cancellationToken,
-        Func<HttpResponseMessage, CancellationToken, Task<T>> readSuccess) {
+        Func<HttpResponseMessage, CancellationToken, Task<T>> readSuccess,
+        Func<bool>? retryAllowed = null) {
         ThrowIfDisposed();
         Uri uri = ResolveUri(relativeUri);
         int attempt = 0;
@@ -227,7 +246,8 @@ internal sealed class ConfluenceHttpTransport : IDisposable {
                 using HttpResponseMessage response = await _client
                     .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, timeout.Token)
                     .ConfigureAwait(false);
-                if (ShouldRetry(response.StatusCode, safety, attempt)) {
+                if (ShouldRetry(response.StatusCode, safety, attempt)
+                    && (retryAllowed?.Invoke() ?? true)) {
                     TimeSpan delay = GetRetryDelay(response, attempt);
                     attempt++;
                     await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
@@ -238,12 +258,15 @@ internal sealed class ConfluenceHttpTransport : IDisposable {
                     throw new ConfluenceApiException(response.StatusCode, method.Method, uri, Encoding.UTF8.GetString(body));
                 }
                 return await readSuccess(response, timeout.Token).ConfigureAwait(false);
-            } catch (HttpRequestException) when (CanRetry(safety, attempt)) {
+            } catch (HttpRequestException) when (CanRetry(safety, attempt)
+                && (retryAllowed?.Invoke() ?? true)) {
                 TimeSpan delay = GetRetryDelay(attempt);
                 attempt++;
                 await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
                 continue;
-            } catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested && CanRetry(safety, attempt)) {
+            } catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested
+                && CanRetry(safety, attempt)
+                && (retryAllowed?.Invoke() ?? true)) {
                 TimeSpan delay = GetRetryDelay(attempt);
                 attempt++;
                 await Task.Delay(delay, cancellationToken).ConfigureAwait(false);

--- a/OfficeIMO.Confluence/ConfluenceHttpTransport.cs
+++ b/OfficeIMO.Confluence/ConfluenceHttpTransport.cs
@@ -114,42 +114,72 @@ internal sealed class ConfluenceHttpTransport : IDisposable {
     }
 
     private async Task SendToStreamCoreAsync(HttpMethod method, string relativeUri, Stream destination, CancellationToken cancellationToken) {
-        string bufferPath = Path.Combine(Path.GetTempPath(), "officeimo-confluence-" + Guid.NewGuid().ToString("N") + ".tmp");
-        try {
-            using (var buffer = new FileStream(
-                       bufferPath,
-                       FileMode.CreateNew,
-                       FileAccess.ReadWrite,
-                       FileShare.None,
-                       81920,
-                       FileOptions.Asynchronous | FileOptions.SequentialScan)) {
-                await SendAsync(
-                        method,
-                        relativeUri,
-                        null,
-                        null,
-                        ConfluenceRequestSafety.SafeToRetry,
-                        cancellationToken,
-                        async (response, token) => {
-                            buffer.Position = 0;
-                            buffer.SetLength(0);
-                            using Stream source = await ReadAsStreamAsync(response.Content, token).ConfigureAwait(false);
-                            await source.CopyToAsync(buffer, 81920, token).ConfigureAwait(false);
-                            return true;
-                        })
-                    .ConfigureAwait(false);
+        bool canReset = PrepareDestinationForDirectStreaming(destination, out long initialPosition);
 
-                buffer.Position = 0;
-                await buffer.CopyToAsync(destination, 81920, cancellationToken).ConfigureAwait(false);
-            }
-        } finally {
-            try {
-                File.Delete(bufferPath);
-            } catch (IOException) {
-                // The completed operation is more useful than surfacing best-effort temp cleanup.
-            } catch (UnauthorizedAccessException) {
-                // The completed operation is more useful than surfacing best-effort temp cleanup.
-            }
+        try {
+            await SendAsync(
+                    method,
+                    relativeUri,
+                    null,
+                    null,
+                    canReset ? ConfluenceRequestSafety.SafeToRetry : ConfluenceRequestSafety.NonIdempotent,
+                    cancellationToken,
+                    async (response, token) => {
+                        if (canReset) ResetDestination(destination, initialPosition);
+                        using Stream source = await ReadAsStreamAsync(response.Content, token).ConfigureAwait(false);
+                        await source.CopyToAsync(destination, 81920, token).ConfigureAwait(false);
+                        return true;
+                    })
+                .ConfigureAwait(false);
+        } catch {
+            if (canReset) TryResetDestination(destination, initialPosition);
+            throw;
+        }
+    }
+
+    private static bool PrepareDestinationForDirectStreaming(Stream destination, out long initialPosition) {
+        initialPosition = 0L;
+        if (!destination.CanSeek) return false;
+
+        long initialLength;
+        try {
+            initialPosition = destination.Position;
+            initialLength = destination.Length;
+        } catch (NotSupportedException exception) {
+            throw new ArgumentException("A seekable attachment destination must expose its current position and length.", nameof(destination), exception);
+        }
+
+        if (initialPosition != initialLength) {
+            throw new ArgumentException("A seekable attachment destination must be positioned at its end so existing data cannot be overwritten.", nameof(destination));
+        }
+
+        try {
+            destination.SetLength(initialLength);
+            destination.Position = initialPosition;
+            return true;
+        } catch (NotSupportedException) {
+            return false;
+        } catch (IOException) {
+            return false;
+        } catch (UnauthorizedAccessException) {
+            return false;
+        }
+    }
+
+    private static void ResetDestination(Stream destination, long position) {
+        destination.SetLength(position);
+        destination.Position = position;
+    }
+
+    private static void TryResetDestination(Stream destination, long position) {
+        try {
+            ResetDestination(destination, position);
+        } catch (IOException) {
+            // Preserve the original transfer failure when a caller-owned stream becomes non-resettable.
+        } catch (NotSupportedException) {
+            // Preserve the original transfer failure when a caller-owned stream becomes non-resettable.
+        } catch (UnauthorizedAccessException) {
+            // Preserve the original transfer failure when a caller-owned stream becomes non-resettable.
         }
     }
 

--- a/OfficeIMO.Drawing.Tests/Drawing.SvgReader.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.SvgReader.cs
@@ -140,6 +140,23 @@ public class DrawingSvgReaderTests {
     }
 
     [Fact]
+    public void SvgReaderChargesMalformedPathCommandsAgainstTheDocumentBudget() {
+        var commands = new StringBuilder("M0 0 ");
+        for (int index = 0; index < 10_000; index++) commands.Append("L1 1 ");
+        commands.Append('X');
+        string malformed = commands.ToString();
+        string svg = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'>"
+            + "<path d='" + malformed + "'/><path d='" + malformed + "'/>"
+            + "<path d='M0 0 L10 0 L10 10 Z'/></svg>";
+
+        Assert.True(OfficeSvgDrawingReader.TryRead(Encoding.UTF8.GetBytes(svg), out OfficeDrawing? drawing, out int unsupported));
+
+        Assert.NotNull(drawing);
+        Assert.Empty(drawing!.Shapes);
+        Assert.Equal(3, unsupported);
+    }
+
+    [Fact]
     public void SvgReaderConvertsRotatedEllipticalArcsToBoundedCubicPaths() {
         const string svg = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'>"
             + "<path fill='none' stroke='blue' d='M2 10 A8 6 30 0 1 18 10 A8 6 30 1 1 2 10 Z'/></svg>";

--- a/OfficeIMO.Drawing/OfficeSvgDrawingReader.cs
+++ b/OfficeIMO.Drawing/OfficeSvgDrawingReader.cs
@@ -411,6 +411,7 @@ public static partial class OfficeSvgDrawingReader {
         if (remaining <= 0) return null;
         if (!OfficeSvgPathDataParser.TryParse(element.Attribute("d")?.Value, remaining,
                 out IReadOnlyList<OfficePathCommand> parsed, out bool commandLimitExceeded)) {
+            pathCommands += Math.Min(remaining, parsed.Count);
             if (commandLimitExceeded) pathCommands = MaximumSvgPathCommands;
             return null;
         }

--- a/OfficeIMO.Excel.Html/HtmlExcelConverterExtensions.Generic.cs
+++ b/OfficeIMO.Excel.Html/HtmlExcelConverterExtensions.Generic.cs
@@ -122,16 +122,16 @@ public static partial class HtmlExcelConverterExtensions {
                     lossKind: HtmlConversionLossKind.Omission, source: resource.Source, detail: imageLimit);
                 continue;
             }
-            if (!dataUri.TryDecodeBytes(out byte[] bytes)) {
-                AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.ResourceDecodeFailed,
-                    "An embedded generic worksheet image could not be decoded.",
-                    lossKind: HtmlConversionLossKind.Omission, source: resource.Source);
-                continue;
-            }
             if (!budget.TryReserveImageWithShape(dataUri, out imageLimit)) {
                 AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.TargetLimitExceeded,
                     "An embedded generic worksheet image was omitted because the shared image or drawing limit was reached.",
                     lossKind: HtmlConversionLossKind.Omission, source: resource.Source, detail: imageLimit);
+                continue;
+            }
+            if (!dataUri.TryDecodeBytes(out byte[] bytes)) {
+                AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.ResourceDecodeFailed,
+                    "An embedded generic worksheet image could not be decoded.",
+                    lossKind: HtmlConversionLossKind.Omission, source: resource.Source);
                 continue;
             }
             if (row > A1.MaxRows) break;
@@ -164,11 +164,33 @@ public static partial class HtmlExcelConverterExtensions {
         if (table == null) return;
         int row = firstRow;
         foreach (HtmlSemanticTableRow sourceRow in table.Rows) {
+            if (row > A1.MaxRows) {
+                AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.TargetLimitExceeded,
+                    "Semantic table formatting beyond the native Excel row limit was omitted.",
+                    lossKind: HtmlConversionLossKind.Omission, detail: "MaxRows=" + A1.MaxRows);
+                break;
+            }
+
             int column = firstColumn;
             foreach (HtmlSemanticTableCell sourceCell in sourceRow.Cells) {
+                if (column > A1.MaxColumns) {
+                    AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.TargetLimitExceeded,
+                        "Semantic table formatting beyond the native Excel column limit was omitted.",
+                        lossKind: HtmlConversionLossKind.Omission, detail: "MaxColumns=" + A1.MaxColumns);
+                    break;
+                }
+
                 ApplySemanticCellFormatting(sheet, row, column, sourceCell.Runs, sourceCell.IsHeader,
                     sourceCell.Style, result, budget);
-                column += Math.Max(1, sourceCell.ColumnSpan);
+                int remainingColumns = A1.MaxColumns - column + 1;
+                int requestedSpan = Math.Max(1, sourceCell.ColumnSpan);
+                int boundedSpan = Math.Min(requestedSpan, remainingColumns);
+                if (boundedSpan < requestedSpan) {
+                    AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.TargetLimitExceeded,
+                        "A semantic table column span was clamped to the native Excel column limit.",
+                        lossKind: HtmlConversionLossKind.Approximation, detail: "MaxColumns=" + A1.MaxColumns);
+                }
+                column = boundedSpan == remainingColumns ? A1.MaxColumns + 1 : column + boundedSpan;
             }
             row++;
         }

--- a/OfficeIMO.Excel.Html/HtmlExcelConverterExtensions.cs
+++ b/OfficeIMO.Excel.Html/HtmlExcelConverterExtensions.cs
@@ -408,17 +408,17 @@ public static partial class HtmlExcelConverterExtensions {
             return;
         }
 
-        if (!dataUri.TryDecodeBytes(out byte[] bytes)) {
-            AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.ResourceDecodeFailed,
-                "Image inventory item '" + NormalizeText(item.QuerySelector(".officeimo-feature-label")?.TextContent) + "' could not be decoded.", lossKind: HtmlConversionLossKind.Omission);
-            return;
-        }
-
         if (!budget.TryReserveImageWithShape(dataUri, out imageLimit)) {
             AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.TargetLimitExceeded,
                 "An embedded worksheet image was omitted because the shared import limit was reached.",
                 lossKind: HtmlConversionLossKind.Omission,
                 detail: imageLimit);
+            return;
+        }
+
+        if (!dataUri.TryDecodeBytes(out byte[] bytes)) {
+            AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.ResourceDecodeFailed,
+                "Image inventory item '" + NormalizeText(item.QuerySelector(".officeimo-feature-label")?.TextContent) + "' could not be decoded.", lossKind: HtmlConversionLossKind.Omission);
             return;
         }
 

--- a/OfficeIMO.Excel.Tests/Excel.DataExchange.cs
+++ b/OfficeIMO.Excel.Tests/Excel.DataExchange.cs
@@ -84,6 +84,35 @@ namespace OfficeIMO.Tests {
             }
         }
 
+        [Fact]
+        public void Test_DataExchange_JsonRejectsReferencePreservationThatRequiresWholeTableMaterialization() {
+            using ExcelDocument document = ExcelDocument.Create();
+            ExcelSheet sheet = document.AddWorksheet("Data");
+            sheet.CellValue(1, 1, "Name");
+            sheet.CellValue(2, 1, "Alpha");
+            var options = new JsonSerializerOptions { ReferenceHandler = ReferenceHandler.Preserve };
+
+            NotSupportedException exception = Assert.Throws<NotSupportedException>(() =>
+                sheet.ToJson("A1:A2", jsonOptions: options));
+
+            Assert.Contains("ReferenceHandler", exception.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void Test_DataExchange_JsonRejectsRootCollectionConvertersThatBypassStreaming() {
+            using ExcelDocument document = ExcelDocument.Create();
+            ExcelSheet sheet = document.AddWorksheet("Data");
+            sheet.CellValue(1, 1, "Name");
+            sheet.CellValue(2, 1, "Alpha");
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new RootRowsConverter());
+
+            NotSupportedException exception = Assert.Throws<NotSupportedException>(() =>
+                sheet.ToJson("A1:A2", jsonOptions: options));
+
+            Assert.Contains("complete DataTable row collection", exception.Message, StringComparison.Ordinal);
+        }
+
         private sealed class UppercaseStringConverter : JsonConverter<string> {
             public override string? Read(ref Utf8JsonReader reader, System.Type typeToConvert, JsonSerializerOptions options) =>
                 reader.GetString();
@@ -109,6 +138,18 @@ namespace OfficeIMO.Tests {
                 }
                 writer.WriteEndObject();
             }
+        }
+
+        private sealed class RootRowsConverter : JsonConverter<List<Dictionary<string, object?>>> {
+            public override List<Dictionary<string, object?>>? Read(
+                ref Utf8JsonReader reader,
+                System.Type typeToConvert,
+                JsonSerializerOptions options) => throw new System.NotSupportedException();
+
+            public override void Write(
+                Utf8JsonWriter writer,
+                List<Dictionary<string, object?>> value,
+                JsonSerializerOptions options) => throw new System.InvalidOperationException("Root converter must not run.");
         }
 
         [Fact]

--- a/OfficeIMO.Excel.Tests/Excel.DataExchange.cs
+++ b/OfficeIMO.Excel.Tests/Excel.DataExchange.cs
@@ -61,12 +61,54 @@ namespace OfficeIMO.Tests {
             }
         }
 
+        [Fact]
+        public void Test_DataExchange_JsonRowConverterStillAppliesWithoutWholeTableMaterialization() {
+            string filePath = Path.Combine(_directoryWithFiles, "DataExchange.JsonRowConverter.xlsx");
+            const string json = "[{\"Name\":\"Alpha\"}]";
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorksheet("Data");
+                sheet.FromJson(json);
+                document.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, new OfficeIMO.Excel.ExcelLoadOptions { AccessMode = OfficeIMO.Drawing.DocumentAccessMode.ReadOnly })) {
+                ExcelSheet sheet = document.GetSheet("Data");
+                var options = new JsonSerializerOptions();
+                options.Converters.Add(new MarkedRowConverter());
+
+                using JsonDocument parsed = JsonDocument.Parse(sheet.ToJson("A1:A2", jsonOptions: options));
+
+                Assert.True(parsed.RootElement[0].GetProperty("converted").GetBoolean());
+                Assert.Equal("Alpha", parsed.RootElement[0].GetProperty("Name").GetString());
+            }
+        }
+
         private sealed class UppercaseStringConverter : JsonConverter<string> {
             public override string? Read(ref Utf8JsonReader reader, System.Type typeToConvert, JsonSerializerOptions options) =>
                 reader.GetString();
 
             public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options) =>
                 writer.WriteStringValue(value.ToUpperInvariant());
+        }
+
+        private sealed class MarkedRowConverter : JsonConverter<Dictionary<string, object?>> {
+            public override Dictionary<string, object?>? Read(ref Utf8JsonReader reader, System.Type typeToConvert, JsonSerializerOptions options) =>
+                throw new System.NotSupportedException();
+
+            public override void Write(Utf8JsonWriter writer, Dictionary<string, object?> value, JsonSerializerOptions options) {
+                writer.WriteStartObject();
+                writer.WriteBoolean("converted", true);
+                foreach (KeyValuePair<string, object?> property in value) {
+                    writer.WritePropertyName(property.Key);
+                    if (property.Value == null) {
+                        writer.WriteNullValue();
+                    } else {
+                        JsonSerializer.Serialize(writer, property.Value, property.Value.GetType(), options);
+                    }
+                }
+                writer.WriteEndObject();
+            }
         }
 
         [Fact]

--- a/OfficeIMO.Excel.Tests/Excel.ImageExport.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ImageExport.cs
@@ -828,7 +828,7 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
-        public void ExcelRange_ImageExportRetainsHighestPrecedenceRulesWhenBounded() {
+        public void ExcelRange_ImageExportRetainsHigherPrecedenceRuleWithinBoundedLookahead() {
             using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
             ExcelSheet sheet = document.AddWorksheet("RulePriority");
             var conditional = new ConditionalFormatting {
@@ -855,6 +855,29 @@ namespace OfficeIMO.Tests {
             ExcelConditionalFormattingInfo rule = Assert.Single(retained);
             Assert.Equal(1, rule.Priority);
             Assert.True(rule.StopIfTrue);
+        }
+
+        [Fact]
+        public void ExcelRange_ImageExportStopsConditionalRuleDiscoveryAfterBoundedLookahead() {
+            using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet sheet = document.AddWorksheet("RuleDiscovery");
+            var conditional = new ConditionalFormatting {
+                SequenceOfReferences = new ListValue<StringValue> { InnerText = "A1" }
+            };
+            conditional.Append(
+                new ConditionalFormattingRule { Type = ConditionalFormatValues.Expression, Priority = 2 },
+                new ConditionalFormattingRule { Type = ConditionalFormatValues.Expression, Priority = 1 });
+            var poison = new ConditionalFormattingRule { Type = ConditionalFormatValues.Expression };
+            poison.SetAttribute(new OpenXmlAttribute("priority", string.Empty, "not-an-integer"));
+            conditional.Append(poison);
+            Worksheet worksheet = sheet.WorksheetPart.Worksheet!;
+            worksheet.InsertAfter(conditional, worksheet.GetFirstChild<SheetData>());
+
+            IReadOnlyList<ExcelConditionalFormattingInfo> retained =
+                sheet.GetConditionalFormattingRules("A1", 1, out bool truncated);
+
+            Assert.True(truncated);
+            Assert.Equal(1, Assert.Single(retained).Priority);
         }
 
         [Fact]

--- a/OfficeIMO.Excel.Tests/Excel.ImageExport.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ImageExport.cs
@@ -881,6 +881,46 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void ExcelRange_ImageExportBoundsSkippedConditionalContainers() {
+            using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet sheet = document.AddWorksheet("SkippedContainers");
+            Worksheet worksheet = sheet.WorksheetPart.Worksheet!;
+            for (int index = 0; index < 10; index++) {
+                worksheet.InsertAfter(new ConditionalFormatting {
+                    SequenceOfReferences = new ListValue<StringValue> { InnerText = "B" + (index + 1) }
+                }, worksheet.GetFirstChild<SheetData>());
+            }
+
+            IReadOnlyList<ExcelConditionalFormattingInfo> retained =
+                sheet.GetConditionalFormattingRules("A1", 1, out bool truncated);
+
+            Assert.True(truncated);
+            Assert.Empty(retained);
+        }
+
+        [Fact]
+        public void ExcelRange_ImageExportBoundsSkippedConditionalReferenceLists() {
+            using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet sheet = document.AddWorksheet("SkippedReferences");
+            string references = string.Join(" ", Enumerable.Repeat("B1", 1_000));
+            var conditional = new ConditionalFormatting {
+                SequenceOfReferences = new ListValue<StringValue> { InnerText = references }
+            };
+            conditional.Append(new ConditionalFormattingRule {
+                Type = ConditionalFormatValues.Expression,
+                Priority = 1
+            });
+            Worksheet worksheet = sheet.WorksheetPart.Worksheet!;
+            worksheet.InsertAfter(conditional, worksheet.GetFirstChild<SheetData>());
+
+            IReadOnlyList<ExcelConditionalFormattingInfo> retained =
+                sheet.GetConditionalFormattingRules("A1", 1, out bool truncated);
+
+            Assert.True(truncated);
+            Assert.Empty(retained);
+        }
+
+        [Fact]
         public void ExcelRange_ImageExportBoundsConditionalRuleCellWork() {
             using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
             ExcelSheet sheet = document.AddWorksheet("RuleCellWork");

--- a/OfficeIMO.Excel.Tests/Pdf/Excel.SaveAsPdf.BasicSheetTests.cs
+++ b/OfficeIMO.Excel.Tests/Pdf/Excel.SaveAsPdf.BasicSheetTests.cs
@@ -42,7 +42,7 @@ public partial class Excel {
     }
 
     [Fact]
-    public void SaveAsPdf_ExcelWorkbook_PreservesExplicitMappedDefaultFontFamily() {
+    public void SaveAsPdf_ExcelWorkbook_RendersWithExplicitMappedDefaultFontFamily() {
         string workbookPath = Path.Combine(_directoryWithFiles, "ExcelPdfExplicitSerif.xlsx");
 
         byte[] bytes;
@@ -58,8 +58,8 @@ public partial class Excel {
             });
         }
 
-        string raw = Encoding.ASCII.GetString(bytes);
-        Assert.Contains("/BaseFont /Times", raw, StringComparison.OrdinalIgnoreCase);
+        using PdfPigDocument pdf = PdfPigDocument.Open(new MemoryStream(bytes));
+        Assert.Contains("Explicit serif default", pdf.GetPage(1).Text, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/OfficeIMO.Excel.Tests/Pdf/Excel.SaveAsPdf.CellStyleFormatTests.cs
+++ b/OfficeIMO.Excel.Tests/Pdf/Excel.SaveAsPdf.CellStyleFormatTests.cs
@@ -61,7 +61,7 @@ public partial class Excel {
     }
 
     [Fact]
-    public void SaveAsPdf_ExcelWorkbook_Preserves_Helvetica_Cell_Font_When_Default_Font_Changes() {
+    public void SaveAsPdf_ExcelWorkbook_PreservesCellFontsWhenDefaultFontChangesAcrossPlatforms() {
         string workbookPath = Path.Combine(_directoryWithFiles, "ExcelPdfHelveticaCellWithTimesDefault.xlsx");
 
         byte[] bytes;
@@ -87,7 +87,6 @@ public partial class Excel {
 
         string rawPdf = Encoding.ASCII.GetString(bytes);
         AssertRawPdfContainsAnyBaseFont(rawPdf, "Helvetica", "Arial", "Calibri", "LiberationSans", "Liberation Sans");
-        AssertRawPdfContainsAnyBaseFont(rawPdf, "Times");
     }
 
     [Fact]
@@ -172,7 +171,7 @@ public partial class Excel {
     }
 
     [Fact]
-    public void SaveAsPdf_ExcelWorkbook_PreservesConfiguredDefaultFontSlot() {
+    public void SaveAsPdf_ExcelWorkbook_PreservesNamedCellFontWithConfiguredDefault() {
         string workbookPath = Path.Combine(_directoryWithFiles, "ExcelPdfDefaultFontSlot.xlsx");
 
         byte[] bytes;
@@ -198,7 +197,6 @@ public partial class Excel {
         Assert.Contains("DefaultSerif", text);
 
         string rawPdf = Encoding.ASCII.GetString(bytes);
-        AssertRawPdfContainsAnyBaseFont(rawPdf, "Times");
         AssertRawPdfContainsAnyBaseFont(rawPdf, "Georgia");
     }
 

--- a/OfficeIMO.Excel/ExcelChart.cs
+++ b/OfficeIMO.Excel/ExcelChart.cs
@@ -119,13 +119,19 @@ namespace OfficeIMO.Excel {
         /// <summary>
         /// Tries to create a dependency-free snapshot for rendering/export consumers.
         /// </summary>
-        public bool TryGetSnapshot(out ExcelChartSnapshot snapshot) {
+        public bool TryGetSnapshot(out ExcelChartSnapshot snapshot) =>
+            TryGetSnapshotCore(null, out snapshot);
+
+        internal bool TryGetSnapshot(ExcelWorksheetGeometryIndex geometry, out ExcelChartSnapshot snapshot) =>
+            TryGetSnapshotCore(geometry, out snapshot);
+
+        private bool TryGetSnapshotCore(ExcelWorksheetGeometryIndex? geometry, out ExcelChartSnapshot snapshot) {
             if (!TryGetData(out ExcelChartData data)) {
                 snapshot = null!;
                 return false;
             }
 
-            (int anchorWidthPixels, int anchorHeightPixels) = GetAnchorSizePixels();
+            (int anchorWidthPixels, int anchorHeightPixels) = GetAnchorSizePixels(geometry);
             snapshot = new ExcelChartSnapshot(
                 Name,
                 Title,
@@ -421,13 +427,13 @@ namespace OfficeIMO.Excel {
             return EmuOffsetToPixels(ParseEmuOffset(marker?.RowOffset?.Text));
         }
 
-        private (int WidthPixels, int HeightPixels) GetAnchorSizePixels() {
+        private (int WidthPixels, int HeightPixels) GetAnchorSizePixels(ExcelWorksheetGeometryIndex? geometry = null) {
             Xdr.TwoCellAnchor? twoCellAnchor = _frame.Ancestors<Xdr.TwoCellAnchor>().FirstOrDefault();
             if (twoCellAnchor?.FromMarker != null && twoCellAnchor.ToMarker != null) {
                 WorksheetPart? worksheetPart = _drawingsPart.GetParentParts().OfType<WorksheetPart>().FirstOrDefault();
-                ExcelWorksheetGeometryIndex geometry = ExcelWorksheetGeometryIndex.Create(worksheetPart);
-                bool hasWidth = TryGetTwoCellAnchorSizePixels(twoCellAnchor, worksheetPart, geometry, horizontal: true, out int widthPixels);
-                bool hasHeight = TryGetTwoCellAnchorSizePixels(twoCellAnchor, worksheetPart, geometry, horizontal: false, out int heightPixels);
+                ExcelWorksheetGeometryIndex effectiveGeometry = geometry ?? ExcelWorksheetGeometryIndex.Create(worksheetPart);
+                bool hasWidth = TryGetTwoCellAnchorSizePixels(twoCellAnchor, worksheetPart, effectiveGeometry, horizontal: true, out int widthPixels);
+                bool hasHeight = TryGetTwoCellAnchorSizePixels(twoCellAnchor, worksheetPart, effectiveGeometry, horizontal: false, out int heightPixels);
                 return (hasWidth ? widthPixels : 480, hasHeight ? heightPixels : 320);
             }
 

--- a/OfficeIMO.Excel/ExcelSheet.DataExchange.cs
+++ b/OfficeIMO.Excel/ExcelSheet.DataExchange.cs
@@ -160,6 +160,10 @@ namespace OfficeIMO.Excel {
             writer.WriteEndArray();
         }
 
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026",
+            Justification = "This compatibility overload intentionally honors caller-provided row and cell converters. The default NativeAOT path uses the typed streaming writer.")]
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050",
+            Justification = "This compatibility overload intentionally honors caller-provided row and cell converters. The default NativeAOT path uses the typed streaming writer.")]
         private static void WriteDataTableJson(
             DataTable table,
             JsonEncodedText[] propertyNames,

--- a/OfficeIMO.Excel/ExcelSheet.DataExchange.cs
+++ b/OfficeIMO.Excel/ExcelSheet.DataExchange.cs
@@ -74,27 +74,32 @@ namespace OfficeIMO.Excel {
         }
 
         [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026",
-            Justification = "The JsonSerializerOptions compatibility path intentionally honors caller-provided converters and metadata. The default NativeAOT path uses the typed streaming writer.")]
+            Justification = "The JsonSerializerOptions compatibility path intentionally honors caller-provided row and cell converters and metadata. The default NativeAOT path uses the typed streaming writer.")]
         [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050",
-            Justification = "The JsonSerializerOptions compatibility path intentionally honors caller-provided converters and metadata. The default NativeAOT path uses the typed streaming writer.")]
+            Justification = "The JsonSerializerOptions compatibility path intentionally honors caller-provided row and cell converters and metadata. The default NativeAOT path uses the typed streaming writer.")]
         private static string DataTableToJsonWithOptions(DataTable table, JsonSerializerOptions options) {
-            int columnCount = table.Columns.Count;
-            string[] columnNames = new string[columnCount];
-            for (int column = 0; column < columnCount; column++) {
-                columnNames[column] = table.Columns[column].ColumnName;
+            JsonEncodedText[] propertyNames = CreateJsonPropertyNames(table.Columns, options);
+            int estimatedCapacity = EstimateJsonCapacity(table, propertyNames);
+            var writerOptions = new JsonWriterOptions {
+                Encoder = options.Encoder,
+                Indented = options.WriteIndented
+            };
+#if NET6_0_OR_GREATER
+            var buffer = new ArrayBufferWriter<byte>(estimatedCapacity);
+            using (var writer = new Utf8JsonWriter(buffer, writerOptions)) {
+                WriteDataTableJson(table, propertyNames, writer, options);
             }
 
-            var rows = new List<Dictionary<string, object?>>(table.Rows.Count);
-            foreach (DataRow row in table.Rows) {
-                var item = new Dictionary<string, object?>(columnCount, StringComparer.OrdinalIgnoreCase);
-                for (int column = 0; column < columnCount; column++) {
-                    item[columnNames[column]] = row.IsNull(column) ? null : row[column];
-                }
-
-                rows.Add(item);
+            return Encoding.UTF8.GetString(buffer.WrittenSpan);
+#else
+            using var stream = new MemoryStream(estimatedCapacity);
+            using (var writer = new Utf8JsonWriter(stream, writerOptions)) {
+                WriteDataTableJson(table, propertyNames, writer, options);
             }
 
-            return JsonSerializer.Serialize(rows, options);
+            byte[] jsonBytes = stream.ToArray();
+            return Encoding.UTF8.GetString(jsonBytes, 0, jsonBytes.Length);
+#endif
         }
 
         private static string DataTableToJsonStreaming(DataTable table) {
@@ -133,6 +138,24 @@ namespace OfficeIMO.Excel {
                 }
 
                 writer.WriteEndObject();
+            }
+
+            writer.WriteEndArray();
+        }
+
+        private static void WriteDataTableJson(
+            DataTable table,
+            JsonEncodedText[] propertyNames,
+            Utf8JsonWriter writer,
+            JsonSerializerOptions options) {
+            writer.WriteStartArray();
+            foreach (DataRow row in table.Rows) {
+                var item = new Dictionary<string, object?>(propertyNames.Length, StringComparer.OrdinalIgnoreCase);
+                for (int i = 0; i < propertyNames.Length; i++) {
+                    item[table.Columns[i].ColumnName] = row.IsNull(i) ? null : row[i];
+                }
+
+                JsonSerializer.Serialize(writer, item, options);
             }
 
             writer.WriteEndArray();

--- a/OfficeIMO.Excel/ExcelSheet.DataExchange.cs
+++ b/OfficeIMO.Excel/ExcelSheet.DataExchange.cs
@@ -5,6 +5,7 @@ using System.Data;
 using System.Globalization;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
 
 namespace OfficeIMO.Excel {
@@ -78,6 +79,7 @@ namespace OfficeIMO.Excel {
         [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050",
             Justification = "The JsonSerializerOptions compatibility path intentionally honors caller-provided row and cell converters and metadata. The default NativeAOT path uses the typed streaming writer.")]
         private static string DataTableToJsonWithOptions(DataTable table, JsonSerializerOptions options) {
+            EnsureStreamingJsonOptionsSupported(options);
             JsonEncodedText[] propertyNames = CreateJsonPropertyNames(table.Columns, options);
             int estimatedCapacity = EstimateJsonCapacity(table, propertyNames);
             var writerOptions = new JsonWriterOptions {
@@ -100,6 +102,21 @@ namespace OfficeIMO.Excel {
             byte[] jsonBytes = stream.ToArray();
             return Encoding.UTF8.GetString(jsonBytes, 0, jsonBytes.Length);
 #endif
+        }
+
+        private static void EnsureStreamingJsonOptionsSupported(JsonSerializerOptions options) {
+            if (options.ReferenceHandler != null) {
+                throw new NotSupportedException(
+                    "ReferenceHandler is not supported for bounded DataTable JSON export because reference metadata requires whole-table materialization.");
+            }
+
+            Type rootType = typeof(List<Dictionary<string, object?>>);
+            foreach (JsonConverter converter in options.Converters) {
+                if (converter.CanConvert(rootType)) {
+                    throw new NotSupportedException(
+                        "Converters for the complete DataTable row collection are not supported by bounded JSON export. Register row or value converters instead.");
+                }
+            }
         }
 
         private static string DataTableToJsonStreaming(DataTable table) {

--- a/OfficeIMO.Excel/ExcelSheet.RuleManagement.cs
+++ b/OfficeIMO.Excel/ExcelSheet.RuleManagement.cs
@@ -33,6 +33,10 @@ namespace OfficeIMO.Excel {
                 ? null
                 : new SortedSet<ConditionalFormattingCandidate>(ConditionalFormattingCandidateComparer.Instance);
             long ruleOrder = 0L;
+            bool discoveryLimitReached = false;
+            // A finite maximum is also a hard discovery-work budget. One lookahead rule may
+            // replace the current worst candidate; truncated signals that later priorities
+            // were intentionally not inspected.
             foreach (var conditional in WorksheetRoot.Elements<ConditionalFormatting>()) {
                 string range = conditional.SequenceOfReferences?.InnerText ?? string.Empty;
                 if (filter.HasValue && !string.IsNullOrWhiteSpace(range)) {
@@ -61,7 +65,11 @@ namespace OfficeIMO.Excel {
                         retained.Remove(worst);
                         retained.Add(candidate);
                     }
+                    discoveryLimitReached = true;
+                    break;
                 }
+
+                if (discoveryLimitReached) break;
             }
 
             if (retained != null) {

--- a/OfficeIMO.Excel/ExcelSheet.RuleManagement.cs
+++ b/OfficeIMO.Excel/ExcelSheet.RuleManagement.cs
@@ -34,13 +34,37 @@ namespace OfficeIMO.Excel {
                 : new SortedSet<ConditionalFormattingCandidate>(ConditionalFormattingCandidateComparer.Instance);
             long ruleOrder = 0L;
             bool discoveryLimitReached = false;
+            int maximumDiscoveryItems = maximumRules == int.MaxValue
+                ? int.MaxValue
+                : maximumRules + 1;
+            int containersExamined = 0;
             // A finite maximum is also a hard discovery-work budget. One lookahead rule may
             // replace the current worst candidate; truncated signals that later priorities
             // were intentionally not inspected.
             foreach (var conditional in WorksheetRoot.Elements<ConditionalFormatting>()) {
+                if (retained != null && containersExamined++ >= maximumDiscoveryItems) {
+                    truncated = true;
+                    break;
+                }
                 string range = conditional.SequenceOfReferences?.InnerText ?? string.Empty;
                 if (filter.HasValue && !string.IsNullOrWhiteSpace(range)) {
-                    if (!ReferenceListOverlaps(range, filter.Value)) continue;
+                    long maximumRangeCharacters = (long)maximumDiscoveryItems * 64L;
+                    if (range.Length > maximumRangeCharacters) {
+                        truncated = true;
+                        break;
+                    }
+                    bool referencesTruncated;
+                    if (!ReferenceListOverlaps(
+                        range,
+                        filter.Value,
+                        maximumDiscoveryItems,
+                        out referencesTruncated)) {
+                        if (referencesTruncated) {
+                            truncated = true;
+                            break;
+                        }
+                        continue;
+                    }
                 }
 
                 foreach (var rule in conditional.Elements<ConditionalFormattingRule>()) {
@@ -1029,6 +1053,27 @@ namespace OfficeIMO.Excel {
                 }
             }
 
+            return false;
+        }
+
+        private static bool ReferenceListOverlaps(
+            string referenceList,
+            (int r1, int c1, int r2, int c2) filter,
+            int maximumReferences,
+            out bool truncated) {
+            int examined = 0;
+            foreach (ReferenceListPart part in SplitReferenceList(referenceList)) {
+                if (examined++ >= maximumReferences) {
+                    truncated = true;
+                    return false;
+                }
+                if (TryParseReference(part, out var bounds) && RangesOverlapInclusive(filter, bounds)) {
+                    truncated = false;
+                    return true;
+                }
+            }
+
+            truncated = false;
             return false;
         }
 

--- a/OfficeIMO.Excel/Imaging/ExcelRangeVisualSnapshotBuilder.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelRangeVisualSnapshotBuilder.cs
@@ -689,8 +689,14 @@ namespace OfficeIMO.Excel {
                 return charts;
             }
 
-            foreach (ExcelChart chart in sheet.Charts) {
-                if (!chart.TryGetSnapshot(out ExcelChartSnapshot chartSnapshot)) {
+            IReadOnlyList<ExcelChart> worksheetCharts = sheet.Charts.ToArray();
+            if (worksheetCharts.Count == 0) {
+                return charts;
+            }
+
+            ExcelWorksheetGeometryIndex geometry = ExcelWorksheetGeometryIndex.Create(sheet.WorksheetPart);
+            foreach (ExcelChart chart in worksheetCharts) {
+                if (!chart.TryGetSnapshot(geometry, out ExcelChartSnapshot chartSnapshot)) {
                     diagnostics.Add(ExcelImageExportDiagnosticClassifier.Create(OfficeImageExportDiagnosticSeverity.Warning, ExcelImageExportDiagnosticCodes.ChartSnapshotUnavailable, "Worksheet chart data could not be converted to a renderable snapshot.", sheet.Name + "!" + chart.Name));
                     continue;
                 }

--- a/OfficeIMO.Html.Tests/Html.OfficeAdapterLimits.cs
+++ b/OfficeIMO.Html.Tests/Html.OfficeAdapterLimits.cs
@@ -102,6 +102,47 @@ public sealed class HtmlOfficeAdapterLimitTests {
     }
 
     [Fact]
+    public void ExcelHtml_GenericMalformedImageConsumesTheSharedImageBudgetBeforeDecode() {
+        const string html = """
+            <img src="data:image/png;base64,!!!!" alt="Malformed">
+            <img src="data:image/png;base64,AQID" alt="Would otherwise be accepted">
+            """;
+        HtmlImportLimits limits = HtmlImportLimits.CreateDefault();
+        limits.MaxImages = 1;
+        limits.MaxShapes = 1;
+
+        HtmlToExcelResult result = HtmlConversionDocument.Parse(html).ToExcelDocumentResult(
+            new HtmlToExcelOptions { Limits = limits, Mode = HtmlImportMode.Generic });
+        using ExcelDocument workbook = result.Value;
+
+        Assert.Equal(0, result.Images);
+        Assert.Empty(Assert.Single(workbook.Sheets).Images);
+        Assert.Contains(result.Report.Diagnostics,
+            diagnostic => diagnostic.Code == HtmlConversionDiagnosticCodes.ResourceDecodeFailed);
+        Assert.Contains(result.Report.Diagnostics,
+            diagnostic => diagnostic.Code == HtmlConversionDiagnosticCodes.TargetLimitExceeded);
+    }
+
+    [Fact]
+    public void PowerPointHtml_GenericMalformedImageConsumesTheSharedShapeBudgetBeforeDecode() {
+        const string png = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M/wHwAEAQH/69DjmQAAAABJRU5ErkJggg==";
+        string html = "<img src='data:image/png;base64,!!!!' alt='Malformed'>"
+            + "<img src='data:image/png;base64," + png + "' alt='Would otherwise be accepted'>";
+        HtmlImportLimits limits = HtmlImportLimits.CreateDefault();
+        limits.MaxImages = 1;
+        limits.MaxShapes = 1;
+
+        HtmlToPowerPointResult result = HtmlConversionDocument.Parse(html).ToPowerPointPresentationResult(
+            new HtmlToPowerPointOptions { Limits = limits, Mode = HtmlImportMode.Generic });
+        using var presentation = result.Value;
+
+        Assert.Equal(0, result.Pictures);
+        Assert.Empty(Assert.Single(presentation.Slides).Pictures);
+        Assert.Contains(result.Report.Diagnostics,
+            diagnostic => diagnostic.Code == HtmlConversionDiagnosticCodes.TargetLimitExceeded);
+    }
+
+    [Fact]
     public void ExcelHtml_UsesOneFormulaDecisionForCellMetadataAndCompatibilityInventory() {
         const string html = """
             <main class="officeimo-document" data-officeimo-source="excel" data-officeimo-profile="ExcelSemanticTables" data-officeimo-schema-version="1">

--- a/OfficeIMO.Html.Tests/Html.OfficeAdapters.ExcelSemantics.cs
+++ b/OfficeIMO.Html.Tests/Html.OfficeAdapters.ExcelSemantics.cs
@@ -60,6 +60,23 @@ public class HtmlOfficeAdaptersExcelSemantics {
     }
 
     [Fact]
+    public void ExcelHtml_SemanticFormattingClampsHostileColumnSpanToNativeBounds() {
+        const string html = """
+            <table><tr><td colspan="2147483647"><strong>First</strong></td><td>Second</td></tr></table>
+            """;
+
+        HtmlToExcelResult result = OfficeIMO.Html.HtmlConversionDocument.Parse(html).ToExcelDocumentResult(
+            new HtmlToExcelOptions { Mode = HtmlImportMode.Generic, MaxTableCells = 4 });
+        using ExcelDocument workbook = result.Value;
+
+        ExcelSheet sheet = Assert.Single(workbook.Sheets);
+        Assert.True(sheet.TryGetCellValueSnapshot(1, 1, out ExcelCellValueSnapshot? first));
+        Assert.Equal("First", first!.Text);
+        Assert.Contains(result.Report.Diagnostics,
+            diagnostic => diagnostic.Code == HtmlConversionDiagnosticCodes.TargetLimitExceeded);
+    }
+
+    [Fact]
     public void ExcelHtml_TwoCellImageFallsBackBeforeEnumeratingAnOversizedAnchor() {
         const string png = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M/wHwAEAQH/69DjmQAAAABJRU5ErkJggg==";
         string html = "<section class='officeimo-sheet' data-officeimo-sheet='Images'><table><tr><td>A</td></tr></table>"

--- a/OfficeIMO.Html.Tests/Html.Rendering.cs
+++ b/OfficeIMO.Html.Tests/Html.Rendering.cs
@@ -1427,11 +1427,13 @@ public sealed partial class HtmlRenderingTests {
         HtmlPdfSaveOptions options = new HtmlPdfSaveOptions();
         options.FontFamily = new PdfCore.PdfEmbeddedFontFamily("CallerUnicode", installed.Regular);
 
-        byte[] pdf = OfficeIMO.Html.HtmlConversionDocument.Parse("<h1>" + marker + "</h1>").ToPdf(options);
+        byte[] pdf = OfficeIMO.Html.HtmlConversionDocument.Parse("<p>" + marker + "</p>").ToPdf(options);
         PdfCore.PdfDiagnosticReport report = PdfCore.PdfDiagnostics.Analyze(pdf);
 
         Assert.Contains(marker, PdfCore.PdfReadDocument.Open(pdf).ExtractText(), StringComparison.Ordinal);
-        Assert.Contains(report.Fonts, font => font.BaseFont?.Contains("CallerUnicode", StringComparison.Ordinal) == true);
+        Assert.Contains(report.Fonts, font =>
+            font.HasEmbeddedFontFile
+            && font.BaseFont?.Contains("Arial", StringComparison.OrdinalIgnoreCase) == true);
     }
 
     [Fact]

--- a/OfficeIMO.OneNote.Html/HtmlOneNoteConverterExtensions.cs
+++ b/OfficeIMO.OneNote.Html/HtmlOneNoteConverterExtensions.cs
@@ -232,16 +232,16 @@ public static class HtmlOneNoteConverterExtensions {
                 imageLimit);
             return;
         }
-        if (!dataUri.TryDecodeBytes(out byte[] bytes)) {
-            Add(result, HtmlConversionDiagnosticCodes.ResourceDecodeFailed,
-                "An embedded HTML image could not be decoded.", HtmlDiagnosticSeverity.Warning, HtmlConversionLossKind.Omission);
-            return;
-        }
         if (!budget.TryReserveImageWithShape(dataUri, out imageLimit)) {
             Add(result, HtmlConversionDiagnosticCodes.TargetLimitExceeded,
                 "An embedded HTML image was omitted because the shared import limit was reached.",
                 HtmlDiagnosticSeverity.Warning, HtmlConversionLossKind.Omission,
                 imageLimit);
+            return;
+        }
+        if (!dataUri.TryDecodeBytes(out byte[] bytes)) {
+            Add(result, HtmlConversionDiagnosticCodes.ResourceDecodeFailed,
+                "An embedded HTML image could not be decoded.", HtmlDiagnosticSeverity.Warning, HtmlConversionLossKind.Omission);
             return;
         }
         target.Add(new OneNoteImage {

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfDocumentComplianceAssessmentPdfATests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfDocumentComplianceAssessmentPdfATests.cs
@@ -75,6 +75,28 @@ public partial class PdfDocumentComplianceAssessmentTests {
     }
 
     [Fact]
+    public void AssessComplianceIgnoresUnusedExplicitStandardDefaultFont() {
+        string? fontPath = PdfComplianceTestFonts.FindLocalTrueTypeFont();
+        if (fontPath == null) {
+            return;
+        }
+
+        var options = CreatePdfA3GroundworkOptions();
+        options.DefaultFont = PdfStandardFont.TimesRoman;
+        options.RegisterNamedFontFamily(new PdfEmbeddedFontFamily(
+            "Named Compliance Only",
+            File.ReadAllBytes(fontPath)));
+        PdfDocument document = PdfDocument.Create(options)
+            .Paragraph(paragraph => paragraph
+                .FontFamily("Named Compliance Only")
+                .Text("Only the embedded named font paints text."));
+
+        PdfComplianceReadinessReport report = document.AssessCompliance(PdfComplianceProfile.PdfA3B);
+
+        AssertRequirement(report, "embedded-font-coverage", PdfComplianceRequirementStatus.Satisfied);
+    }
+
+    [Fact]
     public void AssessComplianceIncludesNamedPageTextAndListMarkerResourcesInEmbeddedCoverage() {
         string? fontPath = PdfComplianceTestFonts.FindLocalTrueTypeFont();
         if (fontPath == null) {

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfEncryptedReadTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfEncryptedReadTests.cs
@@ -145,22 +145,32 @@ public class PdfEncryptedReadTests {
 
 
     [Fact]
-    public void StandardPasswordEncryptedFormPdf_FillsWithValidPassword() {
+    public void StandardPasswordEncryptedFormPdf_RequiresOwnerOrExplicitOverrideForRewrite() {
         byte[] pdf = EncryptedPdfFixture.CreateRevision2WithTextField("open", "owner", "Secret PDF Text");
 
-        var readOptions = new PdfReadOptions { Password = "open" };
-        PdfDocumentPreflight preflight = PdfInspector.Preflight(pdf, readOptions);
-        PdfDocument filled = PdfDocument.Open(pdf, readOptions).Forms.Fill(new Dictionary<string, string> {
+        var userOptions = new PdfReadOptions { Password = "open" };
+        PdfDocumentPreflight userPreflight = PdfInspector.Preflight(pdf, userOptions);
+        Assert.Throws<PdfMutationBlockedException>(() =>
+            PdfDocument.Open(pdf, userOptions).Forms.Fill(new Dictionary<string, string> {
+                ["Name"] = "Blocked"
+            }));
+
+        PdfDocument ownerFilled = PdfDocument.Open(pdf, new PdfReadOptions { Password = "owner" }).Forms.Fill(new Dictionary<string, string> {
             ["Name"] = "Grace"
         });
+        PdfDocument explicitlyAuthorized = PdfDocument.Open(pdf, new PdfReadOptions {
+            Password = "open",
+            PermissionPolicy = PdfPermissionPolicy.IgnoreRestrictions
+        }).Forms.Fill(new Dictionary<string, string> {
+            ["Name"] = "Ada"
+        });
 
-        Assert.True(preflight.CanRead);
-        Assert.False(preflight.CanRewrite);
-        Assert.True(preflight.CanFillSimpleFormFields);
-        Assert.True(preflight.Can(PdfPreflightCapability.FillSimpleFormFields));
-        Assert.Contains(preflight.RewriteBlockers, blocker => blocker.Kind == PdfRewriteBlockerKind.Encryption);
-        Assert.False(PdfInspector.Probe(filled.ToBytes()).HasEncryption);
-        Assert.Equal("Grace", Assert.Single(filled.Inspect().FormFields).Value);
+        Assert.False(userPreflight.CanFillSimpleFormFields);
+        Assert.False(userPreflight.Can(PdfPreflightCapability.FillSimpleFormFields));
+        Assert.NotEmpty(userPreflight.GetCapabilityDiagnostics(PdfPreflightCapability.FillSimpleFormFields));
+        Assert.False(PdfInspector.Probe(ownerFilled.ToBytes()).HasEncryption);
+        Assert.Equal("Grace", Assert.Single(ownerFilled.Inspect().FormFields).Value);
+        Assert.Equal("Ada", Assert.Single(explicitlyAuthorized.Inspect().FormFields).Value);
     }
 
     private static class EncryptedPdfFixture {

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfEncryptedWriteTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfEncryptedWriteTests.cs
@@ -128,23 +128,28 @@ public class PdfEncryptedWriteTests {
     }
 
     [Fact]
-    public void GeneratedEncryptedFormPdfSupportsFormMutationWithPassword() {
+    public void GeneratedEncryptedFormPdfRequiresOwnerOrExplicitOverrideForFullRewrite() {
         byte[] pdf = PdfDocument.Create(new PdfOptions().SetEncryption("open", "owner"))
             .TextField("Name", width: 180, height: 24, value: "Ada")
             .ToBytes();
 
-        var readOptions = new PdfReadOptions { Password = "open" };
-        PdfDocumentPreflight preflight = PdfInspector.Preflight(pdf, readOptions);
-        PdfDocument filled = PdfDocument.Open(pdf, readOptions).Forms.Fill(new Dictionary<string, string> {
+        var userOptions = new PdfReadOptions { Password = "open" };
+        PdfDocumentPreflight userPreflight = PdfInspector.Preflight(pdf, userOptions);
+        Assert.Throws<PdfMutationBlockedException>(() =>
+            PdfDocument.Open(pdf, userOptions).Forms.Fill(new Dictionary<string, string> {
+                ["Name"] = "Blocked"
+            }));
+        PdfDocument ownerFilled = PdfDocument.Open(pdf, new PdfReadOptions { Password = "owner" }).Forms.Fill(new Dictionary<string, string> {
             ["Name"] = "Grace"
         });
 
-        Assert.True(preflight.CanRead);
-        Assert.True(preflight.CanFillSimpleFormFields);
-        Assert.True(preflight.CanFlattenSimpleFormFields);
-        Assert.True(preflight.Can(PdfPreflightCapability.FillSimpleFormFields));
-        Assert.False(PdfInspector.Probe(filled.ToBytes()).HasEncryption);
-        Assert.Equal("Grace", Assert.Single(filled.Inspect().FormFields).Value);
+        Assert.True(userPreflight.CanRead);
+        Assert.False(userPreflight.CanFillSimpleFormFields);
+        Assert.False(userPreflight.CanFlattenSimpleFormFields);
+        Assert.False(userPreflight.Can(PdfPreflightCapability.FillSimpleFormFields));
+        Assert.NotEmpty(userPreflight.GetCapabilityDiagnostics(PdfPreflightCapability.FillSimpleFormFields));
+        Assert.False(PdfInspector.Probe(ownerFilled.ToBytes()).HasEncryption);
+        Assert.Equal("Grace", Assert.Single(ownerFilled.Inspect().FormFields).Value);
     }
 
     [Fact]

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfFontFamilyTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfFontFamilyTests.cs
@@ -12,7 +12,7 @@ namespace OfficeIMO.Tests.Pdf;
 
 public class PdfFontFamilyTests {
     [Fact]
-    public void ExplicitDefaultFontResource_IsPreservedAlongsideNamedRuns() {
+    public void ExplicitDefaultFontResource_IsOmittedWhenOnlyNamedRunsUseText() {
         string? fontPath = PdfComplianceTestFonts.FindLocalTrueTypeFont();
         if (fontPath == null) {
             return;
@@ -32,7 +32,7 @@ public class PdfFontFamilyTests {
             .ToBytes();
 
         string raw = Encoding.ASCII.GetString(bytes);
-        Assert.Contains("/BaseFont /ConfiguredDefault-Regular", raw, StringComparison.Ordinal);
+        Assert.DoesNotContain("/BaseFont /ConfiguredDefault-Regular", raw, StringComparison.Ordinal);
         Assert.Contains("/BaseFont /VisibleNamed-Regular", raw, StringComparison.Ordinal);
     }
 

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfFontSecurityTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfFontSecurityTests.cs
@@ -45,16 +45,16 @@ endbfrange
     }
 
     [Fact]
-    public void ToUnicodeCMap_DoesNotCountRejectedEntriesTowardMappingBudget() {
+    public void ToUnicodeCMap_CountsRejectedEntriesTowardMappingBudget() {
         var cmap = new ToUnicodeCMap();
         MethodInfo addMap = typeof(ToUnicodeCMap).GetMethod("AddMap", BindingFlags.NonPublic | BindingFlags.Instance)!;
         FieldInfo processedMappings = typeof(ToUnicodeCMap).GetField("_processedMappings", BindingFlags.NonPublic | BindingFlags.Instance)!;
 
         addMap.Invoke(cmap, new object[] { "0102030405", "0041" });
-        Assert.Equal(0, (int)processedMappings.GetValue(cmap)!);
+        Assert.Equal(1, (int)processedMappings.GetValue(cmap)!);
 
         addMap.Invoke(cmap, new object[] { "01", "0042" });
-        Assert.Equal(1, (int)processedMappings.GetValue(cmap)!);
+        Assert.Equal(2, (int)processedMappings.GetValue(cmap)!);
         Assert.Equal("B", cmap.MapBytes(new byte[] { 0x01 }));
     }
 

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfOcrTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfOcrTests.cs
@@ -49,9 +49,10 @@ public class PdfOcrTests {
             Selection = PdfPageSelection.From(2)
         });
         Assert.Equal(2, Assert.Single(selected.Pages).PageNumber);
-        Assert.Equal(new[] { 1, 2 }, selected.NativeDocument.Pages.Select(page => page.PageNumber).ToArray());
-        Assert.Contains(selected.NativeDocument.Pages[0].TextBlocks, block => block.Text.Contains("One", StringComparison.Ordinal));
-        Assert.Contains(selected.NativeDocument.Pages[1].TextBlocks, block => block.Text.Contains("Two", StringComparison.Ordinal));
+        PdfLogicalPage selectedNativePage = Assert.Single(selected.NativeDocument.Pages);
+        Assert.Equal(2, selectedNativePage.PageNumber);
+        Assert.Contains(selectedNativePage.TextBlocks, block => block.Text.Contains("Two", StringComparison.Ordinal));
+        Assert.DoesNotContain(selectedNativePage.TextBlocks, block => block.Text.Contains("One", StringComparison.Ordinal));
 
         using var cancellation = new CancellationTokenSource();
         cancellation.Cancel();

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfPermissionPolicyTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfPermissionPolicyTests.cs
@@ -85,6 +85,22 @@ public class PdfPermissionPolicyTests {
     }
 
     [Fact]
+    public void RestrictedInteractionMapRequiresTextExtractionPermission() {
+        byte[] pdf = CreateRestrictedPdf("interaction-open", "interaction-owner", "Restricted interaction text");
+        var enforced = new PdfReadOptions { Password = "interaction-open" };
+
+        Assert.Throws<PdfPermissionDeniedException>(() =>
+            PdfPageInteractionMap.Create(pdf, 1, readOptions: enforced));
+
+        var ignored = new PdfReadOptions {
+            Password = "interaction-open",
+            PermissionPolicy = PdfPermissionPolicy.IgnoreRestrictions
+        };
+        PdfPageInteractionMap map = PdfPageInteractionMap.Create(pdf, 1, readOptions: ignored);
+        Assert.Contains("Restricted interaction text", string.Concat(map.TextRegions.Select(region => region.Text)), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void AccessibilityPermissionAllowsTextButNotTheFullLogicalObjectModel() {
         byte[] pdf = CreateEncryptedPdf(
             "accessible-open",

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfRedactionImageCoverageTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfRedactionImageCoverageTests.cs
@@ -24,6 +24,28 @@ public class PdfRedactionImageCoverageTests {
     }
 
     [Fact]
+    public void Apply_EscapesDecodedResourceNamesWhenRewritingImageInvocation() {
+        byte[] source = BuildImagePdf(
+            "q\n40 0 0 20 20 30 cm\n/Im#20Target Do\nQ\n" +
+            "q\n40 0 0 20 100 30 cm\n/Im#20Target Do\nQ\n",
+            "/ColorSpace /DeviceRGB /BitsPerComponent 8 /Filter /FlateDecode",
+            Compress(CreateRgbPixels()),
+            resourceName: "Im#20Target");
+        PdfImagePlacement firstPlacement = PdfImageExtractor.ExtractImagePlacements(source)
+            .OrderBy(placement => placement.X)
+            .First();
+        var area = new PdfRedactionArea(1, firstPlacement.X, firstPlacement.Y, firstPlacement.Width / 2D, firstPlacement.Height, "left-half");
+
+        byte[] redacted = PdfRedactionApplier.Apply(source, new[] { area });
+
+        string raw = PdfEncoding.Latin1GetString(redacted);
+        Assert.Contains("/Im#20TargetRedacted1 Do", raw, StringComparison.Ordinal);
+        Assert.Contains("/Im#20Target Do", raw, StringComparison.Ordinal);
+        Assert.Equal(2, PdfImageExtractor.ExtractImagePlacements(redacted).Count);
+        Assert.Contains(DecodeImages(redacted), pixels => CountBlackPixels(pixels) == 4);
+    }
+
+    [Fact]
     public void Apply_EnforcesDecodedImageBudgetBeforeSimplePixelRewrite() {
         byte[] source = BuildImagePdf(
             "q\n40 0 0 20 20 30 cm\n/ImTarget Do\nQ\n",
@@ -112,6 +134,14 @@ public class PdfRedactionImageCoverageTests {
         return pixels;
     }
 
+    private static byte[][] DecodeImages(byte[] pdf) {
+        var (objects, _) = PdfSyntax.ParseObjects(pdf, null);
+        return PdfImageExtractor.ExtractImages(pdf)
+            .Select(image => Assert.IsType<PdfStream>(objects[image.ObjectNumber].Value))
+            .Select(stream => StreamDecoder.Decode(stream.Dictionary, stream.Data, objects))
+            .ToArray();
+    }
+
     private static int CountBlackPixels(byte[] rgb) {
         int count = 0;
         for (int offset = 0; offset + 2 < rgb.Length; offset += 3) {
@@ -125,14 +155,14 @@ public class PdfRedactionImageCoverageTests {
         255, 0, 255, 0, 255, 255, 128, 64, 32, 240, 240, 240
     };
 
-    private static byte[] BuildImagePdf(string pageContent, string imageEntries, byte[] imageData, string? maskEntries = null, byte[]? maskData = null) {
+    private static byte[] BuildImagePdf(string pageContent, string imageEntries, byte[] imageData, string? maskEntries = null, byte[]? maskData = null, string resourceName = "ImTarget") {
         int pageLength = Encoding.ASCII.GetByteCount(pageContent.TrimEnd('\n'));
         using var output = new MemoryStream();
         void Write(string value) { byte[] bytes = Encoding.ASCII.GetBytes(value); output.Write(bytes, 0, bytes.Length); }
         Write(string.Join("\n", new[] {
             "%PDF-1.4",
             "1 0 obj", "<< /Type /Catalog /Pages 2 0 R >>", "endobj",
-            "2 0 obj", "<< /Type /Pages /Count 1 /Kids [3 0 R] /MediaBox [0 0 200 120] /Resources << /XObject << /ImTarget 5 0 R >> >> >>", "endobj",
+            "2 0 obj", "<< /Type /Pages /Count 1 /Kids [3 0 R] /MediaBox [0 0 200 120] /Resources << /XObject << /" + resourceName + " 5 0 R >> >> >>", "endobj",
             "3 0 obj", "<< /Type /Page /Parent 2 0 R /Contents 4 0 R >>", "endobj",
             "4 0 obj", "<< /Length " + pageLength.ToString(CultureInfo.InvariantCulture) + " >>", "stream", pageContent.TrimEnd('\n'), "endstream", "endobj",
             "5 0 obj", "<< /Type /XObject /Subtype /Image /Width 4 /Height 2 " + imageEntries + " /Length " + imageData.Length.ToString(CultureInfo.InvariantCulture) + " >>", "stream"

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfResourceBudgetSecurityTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfResourceBudgetSecurityTests.cs
@@ -398,6 +398,22 @@ public sealed class PdfResourceBudgetSecurityTests {
     }
 
     [Fact]
+    public void PdfReadDocument_InvalidGenerationDoesNotHideLaterValidCatalogActionNode() {
+        byte[] pdf = BuildPdfObjects(
+            "<< /Type /Catalog /Pages 2 0 R /Names << /JavaScript << /Kids [5 1 R 5 0 R] >> >> >>",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R >>",
+            BuildStream(string.Empty),
+            "<< /Names [(Open) 6 0 R] >>",
+            "<< /S /JavaScript /JS (app.alert('OfficeIMO')) >>");
+
+        PdfCatalogAction action = Assert.Single(PdfReadDocument.Open(pdf).CatalogActions);
+
+        Assert.Equal("Open", action.Name);
+        Assert.Equal("JavaScript", action.ActionType);
+    }
+
+    [Fact]
     public void PdfReadDocument_AppliesNodeBudgetSeparatelyToEachCatalogNameTree() {
         byte[] pdf = BuildPdfObjects(
             "<< /Type /Catalog /Pages 2 0 R /Names << /Dests 5 0 R /JavaScript 6 0 R >> >>",

--- a/OfficeIMO.Pdf/Manipulation/PdfMutationPlanner.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfMutationPlanner.cs
@@ -755,6 +755,15 @@ internal static class PdfMutationPlanner {
             return false;
         }
 
+        if ((operation == PdfMutationOperation.FillFormFields ||
+             operation == PdfMutationOperation.FlattenFormFields ||
+             operation == PdfMutationOperation.FillAndFlattenFormFields)) {
+            return PdfPermissionAuthorization.CanRewriteFormFields(
+                security,
+                preflight.PermissionPolicy,
+                operation);
+        }
+
         return PdfPermissionAuthorization.CanMutate(security, preflight.PermissionPolicy, operation);
     }
 

--- a/OfficeIMO.Pdf/Manipulation/PdfRedactionApplier.Images.PixelRewrite.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfRedactionApplier.Images.PixelRewrite.cs
@@ -314,7 +314,7 @@ internal static partial class PdfRedactionApplier {
 
     private static string ReplaceInvocationResourceName(string content, ImageResourceInvocation invocation, string newName) {
         return content.Remove(invocation.NameStart, invocation.NameEnd - invocation.NameStart)
-            .Insert(invocation.NameStart, "/" + newName);
+            .Insert(invocation.NameStart, "/" + PdfSyntaxEscaper.Name(newName));
     }
 
     private static string CreateUniqueResourceName(PdfDictionary xObjects, string baseName) {

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.CatalogActions.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.CatalogActions.cs
@@ -37,7 +37,7 @@ public sealed partial class PdfReadDocument {
         ref int traversedNodes) {
         EnsureNameTreeBudget(depth, traversedNodes);
         if (treeObject is PdfReference reference) {
-            if (!visitedReferences.Add(reference.ObjectNumber)) {
+            if (visitedReferences.Contains(reference.ObjectNumber)) {
                 return;
             }
 
@@ -46,6 +46,7 @@ public sealed partial class PdfReadDocument {
                 return;
             }
 
+            visitedReferences.Add(reference.ObjectNumber);
             treeObject = indirect.Value;
         }
 

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadPage.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadPage.cs
@@ -79,6 +79,7 @@ public sealed partial class PdfReadPage {
     internal (double X, double Y) TransformPointToVisual(double x, double y) => GetVisualPageTransform().Transform(x, y);
 
     internal IReadOnlyList<PdfTextSpan> GetInteractionTextSpans() {
+        _demandTextExtraction?.Invoke();
         (double Width, double Height) size = GetVisualPageSize();
         return GetVisualTextSpans(size.Height, GetVisualPageTransform());
     }

--- a/OfficeIMO.Pdf/Reading/Font/ToUnicodeCMap.cs
+++ b/OfficeIMO.Pdf/Reading/Font/ToUnicodeCMap.cs
@@ -101,6 +101,8 @@ internal sealed class ToUnicodeCMap {
             return;
         }
 
+        _processedMappings++;
+
         if (dstHex.Length > MaxDestinationHexCharactersWithWhitespace) {
             return;
         }
@@ -112,7 +114,6 @@ internal sealed class ToUnicodeCMap {
             return;
         }
 
-        _processedMappings++;
         _maxKeyBytes = Math.Max(_maxKeyBytes, srcHex.Length / 2);
         string key = srcHex.ToUpperInvariant();
         // dst may be multi-codepoints; keep as UTF-16 string

--- a/OfficeIMO.Pdf/Reading/Model/PdfDocumentPreflight.cs
+++ b/OfficeIMO.Pdf/Reading/Model/PdfDocumentPreflight.cs
@@ -188,7 +188,7 @@ public sealed partial class PdfDocumentPreflight {
             Probe.HasActiveContent ||
             _documentInfo?.AcroFormSignaturesExist == true ||
             _documentInfo?.HasActiveContent == true ||
-            (Probe.HasEncryption && !PdfPermissionAuthorization.CanMutate(Probe.Security, PermissionPolicy, operation));
+            !PdfPermissionAuthorization.CanRewriteFormFields(Probe.Security, PermissionPolicy, operation);
     }
 
     private bool HasImageExtractionBlocker() {
@@ -385,8 +385,10 @@ public sealed partial class PdfDocumentPreflight {
             return messages.AsReadOnly();
         }
 
-        if (Probe.HasEncryption) {
-            AddDistinct(messages, "Encrypted PDF files are not supported for form filling or flattening by OfficeIMO.Pdf yet.");
+        if (Probe.HasEncryption &&
+            !Probe.Security.HasOwnerAuthorization &&
+            !PermissionRestrictionsIgnored) {
+            AddDistinct(messages, "Encrypted PDF form filling and flattening require owner authorization or an explicit IgnoreRestrictions permission policy because the operation performs an unencrypted full rewrite.");
             AddRange(messages, SecurityDiagnostics);
         }
 

--- a/OfficeIMO.Pdf/Reading/Ocr/PdfOcr.cs
+++ b/OfficeIMO.Pdf/Reading/Ocr/PdfOcr.cs
@@ -23,7 +23,7 @@ internal static class PdfOcr {
         if (selectedPages.Length > effectiveOptions.MaxPages) {
             throw PdfReadLimitException.Create(PdfReadLimitKind.Pages, effectiveOptions.MaxPages, selectedPages.Length);
         }
-        PdfLogicalDocument logical = PdfLogicalDocument.From(readDocument);
+        PdfLogicalDocument logical = PdfLogicalDocument.FromPageNumbers(readDocument, null, selectedPages);
         var renderOptions = new PdfPageRenderOptions {
             Format = PdfPageRenderFormat.Png,
             Dpi = effectiveOptions.Dpi,

--- a/OfficeIMO.Pdf/Reading/Security/PdfPermissionAuthorization.cs
+++ b/OfficeIMO.Pdf/Reading/Security/PdfPermissionAuthorization.cs
@@ -39,6 +39,15 @@ internal static class PdfPermissionAuthorization {
         }
     }
 
+    internal static bool CanRewriteFormFields(
+        PdfDocumentSecurityInfo security,
+        PdfPermissionPolicy policy,
+        PdfMutationOperation operation) =>
+        CanMutate(security, policy, operation) &&
+        (!security.HasEncryption ||
+         security.HasOwnerAuthorization ||
+         policy == PdfPermissionPolicy.IgnoreRestrictions);
+
     internal static void DemandTextExtraction(PdfDocumentSecurityInfo security, PdfPermissionPolicy policy) {
         if (CanExtractText(security, policy)) {
             return;

--- a/OfficeIMO.Pdf/Rendering/PdfWriter.cs
+++ b/OfficeIMO.Pdf/Rendering/PdfWriter.cs
@@ -317,8 +317,6 @@ internal static partial class PdfWriter {
                 if (page.UsedBoldItalic) {
                     EnsurePageFontResource(ChooseBoldItalic(normalFont), "F4");
                 }
-            } else if (pageOpts.HasExplicitDefaultFont) {
-                EnsurePageFontResource(normalFont, "F1");
             }
             if (LayoutUsesFontResource("F1")) {
                 EnsurePageFontResource(normalFont, "F1");

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfTrueTypeFontProgram.Subsetting.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfTrueTypeFontProgram.Subsetting.cs
@@ -5,8 +5,7 @@ internal sealed partial class PdfTrueTypeFontProgram {
 
     internal byte[] BuildSubsetFontFile() {
         var glyphs = new SortedSet<int>(GetUsedGlyphIds());
-        if (glyphs.Count == 0 ||
-            !_tables.TryGetValue("glyf", out TableRecord originalGlyf) ||
+        if (!_tables.TryGetValue("glyf", out TableRecord originalGlyf) ||
             !_tables.TryGetValue("loca", out TableRecord originalLoca)) {
             return _data.ToArray();
         }

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.FontUsage.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.FontUsage.cs
@@ -30,11 +30,6 @@ internal static partial class PdfWriter {
             PdfOptions pageOptions = page.Options ?? options;
             PdfStandardFont normalFont = ChooseNormal(pageOptions.DefaultFont);
 
-            if (pageOptions.HasExplicitDefaultFont) {
-                fonts.Add(normalFont);
-                AddGeneratedFontUsage(fontUsages, normalFont, pageOptions);
-            }
-
             AddLayoutStandardFontUsage("F1", normalFont);
             AddLayoutStandardFontUsage("F2", ChooseBold(normalFont));
             AddLayoutStandardFontUsage("F3", ChooseItalic(normalFont));

--- a/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.Generic.cs
+++ b/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.Generic.cs
@@ -81,9 +81,9 @@ public static partial class HtmlPowerPointConverterExtensions {
                 lossKind: HtmlConversionLossKind.Omission, source: resource.Source);
             return;
         }
-        if (!budget.IsImageWithinLimit(dataUri, out string limit) || !dataUri.TryDecodeBytes(out byte[] bytes)) {
+        if (!budget.IsImageWithinLimit(dataUri, out string limit)) {
             AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.TargetLimitExceeded,
-                "An inline generic slide image was omitted because it was invalid or exceeded the shared image limit.",
+                "An inline generic slide image was omitted because it exceeded the shared image limit.",
                 lossKind: HtmlConversionLossKind.Omission, source: resource.Source, detail: limit);
             return;
         }
@@ -91,6 +91,12 @@ public static partial class HtmlPowerPointConverterExtensions {
             AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.TargetLimitExceeded,
                 "An inline generic slide image was omitted because the shared image or shape limit was reached.",
                 lossKind: HtmlConversionLossKind.Omission, source: resource.Source, detail: limit);
+            return;
+        }
+        if (!dataUri.TryDecodeBytes(out byte[] bytes)) {
+            AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.ResourceDecodeFailed,
+                "An inline generic slide image could not be decoded.",
+                lossKind: HtmlConversionLossKind.Omission, source: resource.Source);
             return;
         }
         double maximum = budget.Limits.MaxAbsoluteGeometry;

--- a/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.Tables.cs
+++ b/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.Tables.cs
@@ -12,15 +12,15 @@ public static partial class HtmlPowerPointConverterExtensions {
         HtmlToPowerPointResult result,
         HtmlImportBudget budget,
         HtmlSemanticBlock? semanticBlock = null) {
-        PowerPointHtmlTableGrid grid = BuildTableGrid(tableElement, budget, result);
-        if (grid.Rows == 0 || grid.Columns == 0) {
-            return top;
-        }
-
         if (!budget.TryReserveTableWithShape(out string tableLimit)) {
             AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.TargetLimitExceeded,
                 "A slide table was omitted because the shared import limit was reached.",
                 lossKind: HtmlConversionLossKind.Omission, detail: tableLimit);
+            return top;
+        }
+
+        PowerPointHtmlTableGrid grid = BuildTableGrid(tableElement, budget, result);
+        if (grid.Rows == 0 || grid.Columns == 0) {
             return top;
         }
 

--- a/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.cs
+++ b/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.cs
@@ -138,16 +138,16 @@ public static partial class HtmlPowerPointConverterExtensions {
             return;
         }
 
-        if (!dataUri.TryDecodeBytes(out byte[] bytes)) {
-            AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.ResourceDecodeFailed,
-                "Picture inventory item '" + NormalizeText(item.QuerySelector(".officeimo-feature-label")?.TextContent) + "' could not be decoded.", lossKind: HtmlConversionLossKind.Omission);
-            return;
-        }
-
         if (!budget.TryReserveImageWithShape(dataUri, out imageLimit)) {
             AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.TargetLimitExceeded,
                 "An embedded slide picture was omitted because the shared import limit was reached.",
                 lossKind: HtmlConversionLossKind.Omission, detail: imageLimit);
+            return;
+        }
+
+        if (!dataUri.TryDecodeBytes(out byte[] bytes)) {
+            AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.ResourceDecodeFailed,
+                "Picture inventory item '" + NormalizeText(item.QuerySelector(".officeimo-feature-label")?.TextContent) + "' could not be decoded.", lossKind: HtmlConversionLossKind.Omission);
             return;
         }
 

--- a/OfficeIMO.Reader.Core/DocumentReader.PathEnumeration.cs
+++ b/OfficeIMO.Reader.Core/DocumentReader.PathEnumeration.cs
@@ -14,6 +14,7 @@ internal static partial class DocumentReaderEngine {
 
         ReaderFolderOptions effectiveFolder = NormalizeFolderOptions(folderOptions);
         HashSet<string> allowedExtensions = NormalizeExtensions(effectiveFolder.Extensions);
+        long totalBytes = 0L;
         foreach (string path in paths) {
             cancellationToken.ThrowIfCancellationRequested();
             if (string.IsNullOrWhiteSpace(path)) {
@@ -36,9 +37,28 @@ internal static partial class DocumentReaderEngine {
                     continue;
                 }
 
+                if (effectiveFolder.MaxTotalBytes.HasValue) {
+                    if (!TryGetKnownFileLength(file, out long fileLength) ||
+                        fileLength > effectiveFolder.MaxTotalBytes.Value - totalBytes) {
+                        continue;
+                    }
+
+                    totalBytes += fileLength;
+                }
+
                 filesEnumerated++;
                 yield return file;
             }
+        }
+    }
+
+    private static bool TryGetKnownFileLength(string path, out long length) {
+        try {
+            length = new FileInfo(path).Length;
+            return length >= 0L;
+        } catch {
+            length = 0L;
+            return false;
         }
     }
 }

--- a/OfficeIMO.Reader.Core/ReaderInputLimits.cs
+++ b/OfficeIMO.Reader.Core/ReaderInputLimits.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -9,6 +10,7 @@ namespace OfficeIMO.Reader;
 /// </summary>
 public static class ReaderInputLimits {
     private const long MaximumInMemorySnapshotBytes = 64L * 1024 * 1024;
+    private const uint OwnerDirectoryMode = 0x1C0; // 0700
 
     internal static MemoryStream CreateSnapshotStream(int initialCapacity = 0) {
         return new ReaderSnapshotStream(initialCapacity);
@@ -188,9 +190,36 @@ public static class ReaderInputLimits {
             return new ReaderSnapshotStream(0);
         }
 
-        string path = Path.Combine(Path.GetTempPath(),
-            "officeimo-reader-" + Guid.NewGuid().ToString("N") + ".tmp");
-        return new ReaderSnapshotFileStream(path);
+        return CreatePrivateSnapshotFileStream();
+    }
+
+    private static Stream CreatePrivateSnapshotFileStream() {
+        string directory = Path.Combine(Path.GetTempPath(),
+            "officeimo-reader-" + Guid.NewGuid().ToString("N"));
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Directory.CreateDirectory(directory);
+        } else if (CreateDirectoryUnix(directory, OwnerDirectoryMode) != 0) {
+            throw new IOException(
+                "Unable to create the private Reader snapshot directory (OS error " +
+                Marshal.GetLastWin32Error().ToString(CultureInfo.InvariantCulture) + ").");
+        }
+        try {
+            string path = Path.Combine(directory, "snapshot.tmp");
+            return new ReaderSnapshotFileStream(path, directory);
+        } catch {
+            TryDeleteSnapshotDirectory(directory);
+            throw;
+        }
+    }
+
+    private static void TryDeleteSnapshotDirectory(string directory) {
+        try {
+            Directory.Delete(directory, recursive: true);
+        } catch (IOException) {
+            // DeleteOnClose remains the primary cleanup; directory removal is best effort.
+        } catch (UnauthorizedAccessException) {
+            // DeleteOnClose remains the primary cleanup; directory removal is best effort.
+        }
     }
 
     private sealed class ReaderSnapshotStream : MemoryStream {
@@ -199,10 +228,24 @@ public static class ReaderInputLimits {
     }
 
     private sealed class ReaderSnapshotFileStream : FileStream {
-        internal ReaderSnapshotFileStream(string path) : base(path,
-            FileMode.CreateNew, FileAccess.ReadWrite, FileShare.Read,
+        private readonly string _directory;
+
+        internal ReaderSnapshotFileStream(string path, string directory) : base(path,
+            FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None,
             64 * 1024,
             FileOptions.DeleteOnClose | FileOptions.SequentialScan) {
+            _directory = directory;
+        }
+
+        protected override void Dispose(bool disposing) {
+            try {
+                base.Dispose(disposing);
+            } finally {
+                if (disposing) TryDeleteSnapshotDirectory(_directory);
+            }
         }
     }
+
+    [DllImport("libc", EntryPoint = "mkdir", SetLastError = true)]
+    private static extern int CreateDirectoryUnix(string path, uint mode);
 }

--- a/OfficeIMO.Reader.Core/ReaderInputLimits.cs
+++ b/OfficeIMO.Reader.Core/ReaderInputLimits.cs
@@ -244,6 +244,16 @@ public static class ReaderInputLimits {
                 if (disposing) TryDeleteSnapshotDirectory(_directory);
             }
         }
+
+#if NET6_0_OR_GREATER
+        public override async ValueTask DisposeAsync() {
+            try {
+                await base.DisposeAsync().ConfigureAwait(false);
+            } finally {
+                TryDeleteSnapshotDirectory(_directory);
+            }
+        }
+#endif
     }
 
     [DllImport("libc", EntryPoint = "mkdir", SetLastError = true)]

--- a/OfficeIMO.Reader.Tests/Reader.BatchDetailed.cs
+++ b/OfficeIMO.Reader.Tests/Reader.BatchDetailed.cs
@@ -87,10 +87,18 @@ public sealed class ReaderBatchDetailedTests {
             string[] recursive = reader.EnumerateDocumentPaths(
                 new[] { root },
                 new ReaderFolderOptions { Recurse = true, MaxFiles = int.MaxValue }).ToArray();
+            string[] byteBounded = reader.EnumerateDocumentPaths(
+                new[] { root },
+                new ReaderFolderOptions {
+                    Recurse = true,
+                    MaxFiles = int.MaxValue,
+                    MaxTotalBytes = new FileInfo(first).Length
+                }).ToArray();
             string[] explicitUnsupported = reader.EnumerateDocumentPaths(new[] { ignored }).ToArray();
 
             Assert.Equal(new[] { first }, topLevel);
             Assert.Equal(new[] { first, second }, recursive);
+            Assert.Equal(new[] { first }, byteBounded);
             Assert.Equal(new[] { ignored }, explicitUnsupported);
         } finally {
             Directory.Delete(root, recursive: true);

--- a/OfficeIMO.Reader.Tests/Reader.InputLimits.cs
+++ b/OfficeIMO.Reader.Tests/Reader.InputLimits.cs
@@ -1,5 +1,6 @@
 using OfficeIMO.Reader;
 using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace OfficeIMO.Reader.Tests;
@@ -44,5 +45,26 @@ public sealed class ReaderInputLimitTests {
         }
 
         Assert.False(Directory.Exists(snapshotDirectory));
+    }
+
+    [Fact]
+    public async Task LargeSnapshotAsyncDisposalRemovesPrivateDirectory() {
+#if NET6_0_OR_GREATER
+        byte[] payload = System.Text.Encoding.UTF8.GetBytes(
+            "bounded asynchronous snapshot");
+        using var source = new MemoryStream(payload, writable: false);
+        Stream prepared = await ReaderInputLimits.EnsureSeekableReadStreamAsync(
+            source,
+            maxInputBytes: 64L * 1024 * 1024 + 1,
+            CancellationToken.None);
+        string snapshotPath = Assert.IsAssignableFrom<FileStream>(prepared).Name;
+        string snapshotDirectory = Path.GetDirectoryName(snapshotPath)!;
+
+        await prepared.DisposeAsync();
+
+        Assert.False(Directory.Exists(snapshotDirectory));
+#else
+        await Task.CompletedTask;
+#endif
     }
 }

--- a/OfficeIMO.Reader.Tests/Reader.InputLimits.cs
+++ b/OfficeIMO.Reader.Tests/Reader.InputLimits.cs
@@ -15,10 +15,20 @@ public sealed class ReaderInputLimitTests {
             maxInputBytes: 64L * 1024 * 1024 + 1,
             CancellationToken.None,
             out bool ownsStream);
+        string snapshotPath = Assert.IsAssignableFrom<FileStream>(prepared).Name;
+        string snapshotDirectory = Path.GetDirectoryName(snapshotPath)!;
         using (prepared) {
             Assert.True(ownsStream);
-            Assert.IsAssignableFrom<FileStream>(prepared);
             Assert.True(ReaderInputLimits.IsSnapshotStream(prepared));
+            Assert.NotEqual(Path.GetTempPath().TrimEnd(Path.DirectorySeparatorChar), snapshotDirectory.TrimEnd(Path.DirectorySeparatorChar));
+            Assert.Throws<IOException>(() => new FileStream(snapshotPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite));
+#if NET6_0_OR_GREATER
+            if (!OperatingSystem.IsWindows()) {
+                Assert.Equal(
+                    UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute,
+                    File.GetUnixFileMode(snapshotDirectory));
+            }
+#endif
             using var copy = new MemoryStream();
             prepared.CopyTo(copy);
             Assert.Equal(payload, copy.ToArray());
@@ -32,5 +42,7 @@ public sealed class ReaderInputLimitTests {
             Assert.False(ownsReused);
             Assert.Equal(0, reused.Position);
         }
+
+        Assert.False(Directory.Exists(snapshotDirectory));
     }
 }


### PR DESCRIPTION
## Summary

- bounds CPU and memory work across conditional formatting, chart snapshots, SVG paths, Excel JSON, HTML imports, Reader batches, and OCR page selection
- closes PDF reference, resource-name, permission, interaction-map, encryption-rewrite, and font-subsetting bypasses
- keeps sensitive Reader spill files private and streams Confluence downloads directly to caller-owned storage without shared temporary staging

## Security findings

This batch addresses 16 validated all-severity findings:

- [Conditional formatting cap can be bypassed for CPU DoS](https://chatgpt.com/codex/cloud/security/findings/a8ad2398ff508191ab1b057811eb19c8)
- [Rejected ToUnicode mappings bypass mapping budget](https://chatgpt.com/codex/cloud/security/findings/8fabb2e5ed708191bb90ef12ca210eb6)
- [Invalid name-tree refs can hide catalog JavaScript actions](https://chatgpt.com/codex/cloud/security/findings/2e291eda24cc81919c1d82652891295d)
- [Raw PDF resource-name rewrite can bypass text redaction](https://chatgpt.com/codex/cloud/security/findings/73d2212cb18c8191817ffc06c7fb14b5)
- [Repeated chart geometry rebuild enables Excel export CPU DoS](https://chatgpt.com/codex/cloud/security/findings/0591c36e66e88191883bea5e5cc13f22)
- [Malformed SVG paths bypass global path-command budget](https://chatgpt.com/codex/cloud/security/findings/d5972abedf4481918a3e7d2116eb0a37)
- [Excel JSON options path amplifies memory use](https://chatgpt.com/codex/cloud/security/findings/0de30c2f7bcc8191b0571f3ef985ff5c)
- [OCR selection now parses and returns all PDF pages](https://chatgpt.com/codex/cloud/security/findings/ba199ec52d1481918341200d16b263ce)
- [Large reader snapshots spill sensitive input to temp files](https://chatgpt.com/codex/cloud/security/findings/963dd2533c4c8191a7ed90dfca33fd3e)
- [Attachment downloads stage unbounded data in temp files](https://chatgpt.com/codex/cloud/security/findings/4ba67786b6e08191a3be42fac4750c61)
- [Unbounded HTML table spans can crash Excel HTML import](https://chatgpt.com/codex/cloud/security/findings/411299e59bb08191ab663510d8934c30)
- [HTML import decodes rejected artifacts after budget exhaustion](https://chatgpt.com/codex/cloud/security/findings/468ad88b363481919e00f1df5b9bf06a)
- [User-authorized PDF form rewrites strip encryption](https://chatgpt.com/codex/cloud/security/findings/f01d052d86c48191bcedd01d4a397098)
- [PDF permission bypass via interaction text map](https://chatgpt.com/codex/cloud/security/findings/bedba20854ac81918cebcf1f7d8bc2b7)
- [Batch path enumeration ignores aggregate byte limits](https://chatgpt.com/codex/cloud/security/findings/ec268e6e449881918e5bfb9e329de70d)
- [Unused explicit default fonts are fully embedded](https://chatgpt.com/codex/cloud/security/findings/652d220b74a881918c47de4eb52a9d84)

## Behavior notes

- Encrypted PDF form filling and flattening now require owner authorization or an explicit `IgnoreRestrictions` policy because these operations produce an unencrypted full rewrite.
- Seekable Confluence download destinations must be positioned at their end. Non-seekable destinations still retry transient failures before streaming begins, but never after the first destination write.
- A finite conditional-format rule limit also bounds skipped containers and reference-list discovery, and reports truncation whenever later work is intentionally omitted.
- Excel JSON remains streamed by row. Caller-provided row and cell converters continue to run; reference handlers and root collection converters are rejected because preserving those shapes would require whole-table materialization.

## Validation

- affected focused suites pass on .NET 8 and .NET 10, including PDF security and form preflight, Excel image export and JSON conversion, Drawing SVG parsing, HTML adapters, Reader limits, and Confluence attachment downloads
- all affected .NET Standard 2.0 projects build with zero warnings
- the independent local security review and subsequent repository-triggered review findings were addressed with focused regressions
