### PR TITLE
Harden cross-format document processing limits

### DIFF
--- a/OfficeIMO.Drawing.Tests/Drawing.Ink.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.Ink.cs
@@ -214,6 +214,20 @@ public class DrawingInkTests {
     }
 
     [Fact]
+    public void InkRendererSkipsNumericallyDegenerateSegmentsAfterTransform() {
+        var stroke = new OfficeInkStroke {
+            Transform = OfficeTransform.Scale(0.00000000000001D, 0.00000000000001D)
+        }
+            .AddPoint(10D, 10D)
+            .AddPoint(11D, 11D);
+
+        OfficeDrawing drawing = OfficeInkRenderer.Render(
+            new OfficeInkDocument().Add(stroke), 100D, 100D);
+
+        Assert.Empty(drawing.Shapes);
+    }
+
+    [Fact]
     public void InkPointsValidatePressureAndCoordinates() {
         Assert.Throws<ArgumentOutOfRangeException>(() => new OfficeInkPoint(double.NaN, 0));
         Assert.Throws<ArgumentOutOfRangeException>(() => new OfficeInkPoint(0, 0, 1.01));

--- a/OfficeIMO.Drawing/Ink/OfficeInkRenderer.cs
+++ b/OfficeIMO.Drawing/Ink/OfficeInkRenderer.cs
@@ -126,7 +126,7 @@ public static class OfficeInkRenderer {
             double y1 = from.Y;
             double x2 = to.X;
             double y2 = to.Y;
-            if (x1.Equals(x2) && y1.Equals(y2)) continue;
+            if (IsDegenerateSegment(x1, y1, x2, y2)) continue;
             if (affineTipGeometry) {
                 AddAffineTipSegment(drawing, stroke, renderColor, from, to, opacity, options, transformedTipWidth, transformedTipHeight);
                 AddTransformedTip(drawing, stroke, renderColor, to, opacity, ResolvePointPressure(stroke, to, options));
@@ -141,7 +141,7 @@ public static class OfficeInkRenderer {
             double clipHalfWidth = transformedTipWidth * pressure / 2D;
             double clipHalfHeight = transformedTipHeight * pressure / 2D;
             if (!TryClipLine(-clipHalfWidth, -clipHalfHeight, drawing.Width + clipHalfWidth, drawing.Height + clipHalfHeight, ref x1, ref y1, ref x2, ref y2)) continue;
-            if (x1.Equals(x2) && y1.Equals(y2)) continue;
+            if (IsDegenerateSegment(x1, y1, x2, y2)) continue;
 
             OfficeShape shape = OfficeShape.Line(x1, y1, x2, y2);
             shape.StrokeColor = renderColor;
@@ -180,7 +180,7 @@ public static class OfficeInkRenderer {
         double clipHalfWidth = transformedTipWidth * maximumPressure / 2D;
         double clipHalfHeight = transformedTipHeight * maximumPressure / 2D;
         if (!TryClipLine(-clipHalfWidth, -clipHalfHeight, drawing.Width + clipHalfWidth, drawing.Height + clipHalfHeight, ref x1, ref y1, ref x2, ref y2)) return;
-        if (x1.Equals(x2) && y1.Equals(y2)) return;
+        if (IsDegenerateSegment(x1, y1, x2, y2)) return;
 
         OfficePoint support = stroke.GetTransformedTipSupport(-deltaY, deltaX);
         OfficePoint fromSupport = new OfficePoint(support.X * fromPressure, support.Y * fromPressure);
@@ -284,6 +284,9 @@ public static class OfficeInkRenderer {
         }
         return true;
     }
+
+    private static bool IsDegenerateSegment(double x1, double y1, double x2, double y2) =>
+        Math.Abs(x2 - x1) <= 0.000000000001D && Math.Abs(y2 - y1) <= 0.000000000001D;
 
     private static double ResolvePointPressure(OfficeInkStroke stroke, OfficeInkPoint point, OfficeInkRenderOptions options) =>
         options.UsePressure && !stroke.IgnorePressure

--- a/OfficeIMO.Email.Tests/AddressBook/OfflineAddressBookSessionTests.cs
+++ b/OfficeIMO.Email.Tests/AddressBook/OfflineAddressBookSessionTests.cs
@@ -51,6 +51,23 @@ public sealed class OfflineAddressBookSessionTests {
     }
 
     [Fact]
+    public void DirectoryDiscoveryAcceptsAnEmptyDirectoryAtTheExactEntryBudget() {
+        string root = Path.Combine(Path.GetTempPath(),
+            "officeimo-oab-empty-entry-budget-" + Guid.NewGuid().ToString("N"));
+        try {
+            Directory.CreateDirectory(Path.Combine(root, "empty"));
+
+            OfflineAddressBookDiscoveryReport report = OfflineAddressBookInspector.Inspect(
+                root,
+                new OfflineAddressBookReaderOptions(maxDirectoryEntries: 1));
+
+            Assert.Empty(report.Files);
+        } finally {
+            if (Directory.Exists(root)) Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public void OpensStreamFromCurrentPositionAndRestoresIt() {
         byte[] oab = new OabV4Fixture().Build();
         using (var stream = new MemoryStream()) {

--- a/OfficeIMO.Email.Tests/AddressBook/OfflineAddressBookSessionTests.cs
+++ b/OfficeIMO.Email.Tests/AddressBook/OfflineAddressBookSessionTests.cs
@@ -2,6 +2,35 @@ namespace OfficeIMO.Email.AddressBook.Tests;
 
 public sealed class OfflineAddressBookSessionTests {
     [Fact]
+    public void ReaderOptionsRetainTheOriginalConstructorSignature() {
+        Type[] parameterTypes = {
+            typeof(long), typeof(int), typeof(int), typeof(int),
+            typeof(int), typeof(int), typeof(int), typeof(int),
+            typeof(int), typeof(long), typeof(int), typeof(bool)
+        };
+
+        System.Reflection.ConstructorInfo? constructor =
+            typeof(OfflineAddressBookReaderOptions).GetConstructor(parameterTypes);
+
+        Assert.NotNull(constructor);
+        var options = Assert.IsType<OfflineAddressBookReaderOptions>(constructor!.Invoke(new object[] {
+            64L * 1024 * 1024 * 1024,
+            4096,
+            16,
+            8 * 1024 * 1024,
+            4096,
+            16 * 1024 * 1024,
+            4 * 1024 * 1024,
+            16 * 1024 * 1024,
+            100_000,
+            100_000_000L,
+            1252,
+            true
+        }));
+        Assert.Equal(100_000, options.MaxDirectoryEntries);
+    }
+
+    [Fact]
     public void DirectoryDiscoveryEnforcesAggregateEntryBudgetBeforeMaterialization() {
         string root = Path.Combine(Path.GetTempPath(),
             "officeimo-oab-entry-budget-" + Guid.NewGuid().ToString("N"));

--- a/OfficeIMO.Email.Tests/AddressBook/OfflineAddressBookSessionTests.cs
+++ b/OfficeIMO.Email.Tests/AddressBook/OfflineAddressBookSessionTests.cs
@@ -2,6 +2,26 @@ namespace OfficeIMO.Email.AddressBook.Tests;
 
 public sealed class OfflineAddressBookSessionTests {
     [Fact]
+    public void DirectoryDiscoveryEnforcesAggregateEntryBudgetBeforeMaterialization() {
+        string root = Path.Combine(Path.GetTempPath(),
+            "officeimo-oab-entry-budget-" + Guid.NewGuid().ToString("N"));
+        try {
+            Directory.CreateDirectory(root);
+            for (int index = 0; index < 4; index++) {
+                File.WriteAllText(Path.Combine(root, "entry" + index + ".txt"), "x");
+            }
+
+            OfflineAddressBookLimitExceededException exception = Assert.Throws<OfflineAddressBookLimitExceededException>(
+                () => OfflineAddressBookInspector.Inspect(root,
+                    new OfflineAddressBookReaderOptions(maxDirectoryEntries: 3)));
+
+            Assert.Equal(nameof(OfflineAddressBookReaderOptions.MaxDirectoryEntries), exception.LimitName);
+        } finally {
+            if (Directory.Exists(root)) Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public void OpensStreamFromCurrentPositionAndRestoresIt() {
         byte[] oab = new OabV4Fixture().Build();
         using (var stream = new MemoryStream()) {

--- a/OfficeIMO.Email.Tests/Data/EmailDataArtifactTests.cs
+++ b/OfficeIMO.Email.Tests/Data/EmailDataArtifactTests.cs
@@ -46,6 +46,20 @@ public sealed class EmailDataArtifactTests {
     }
 
     [Fact]
+    public void DirectoryWithOnlyUnsupportedOabComponentsPreservesTheFormatError() {
+        string directory = TemporaryDirectory();
+        try {
+            File.WriteAllBytes(
+                Path.Combine(directory, "unsupported.oab"),
+                new byte[] { 7, 0, 0, 0 });
+
+            Assert.Throws<NotSupportedException>(() => EmailDataArtifact.Open(directory));
+        } finally {
+            TryDeleteDirectory(directory);
+        }
+    }
+
+    [Fact]
     public void Opens_individual_email_calendar_and_contact_through_existing_owners() {
         string directory = TemporaryDirectory();
         try {

--- a/OfficeIMO.Email.Tests/Data/EmailDataArtifactTests.cs
+++ b/OfficeIMO.Email.Tests/Data/EmailDataArtifactTests.cs
@@ -1,3 +1,4 @@
+using OfficeIMO.Email.AddressBook;
 using OfficeIMO.Email.AddressBook.Tests;
 using OfficeIMO.Email.Data;
 using OfficeIMO.Email.Store;
@@ -5,6 +6,28 @@ using OfficeIMO.Email.Store;
 namespace OfficeIMO.Email.Data.Tests;
 
 public sealed class EmailDataArtifactTests {
+    [Fact]
+    public void MailboxDispatchUsesTheMailboxBudgetWhenTheOabProbeLimitIsReached() {
+        string directory = TemporaryDirectory();
+        try {
+            for (int index = 0; index < 4; index++) {
+                File.WriteAllText(
+                    Path.Combine(directory, $"message-{index}.eml"),
+                    $"From: sender@example.test\r\nSubject: message {index}\r\n\r\nBody\r\n");
+            }
+            var options = new EmailDataOpenOptions(
+                addressBook: new OfflineAddressBookReaderOptions(maxDirectoryEntries: 3),
+                store: new EmailStoreReaderOptions(maxDirectoryFileCount: 10));
+
+            using EmailDataOpenResult result = EmailDataArtifact.Open(directory, options);
+
+            Assert.Equal(EmailDataArtifactKind.Store, result.Kind);
+            Assert.Equal(4, result.Store!.EnumerateItems().Count());
+        } finally {
+            TryDeleteDirectory(directory);
+        }
+    }
+
     [Fact]
     public void DirectoryWithUnsupportedOabComponentFallsBackToMailboxStore() {
         string directory = TemporaryDirectory();

--- a/OfficeIMO.Email.Tests/Data/EmailDataArtifactTests.cs
+++ b/OfficeIMO.Email.Tests/Data/EmailDataArtifactTests.cs
@@ -6,6 +6,23 @@ namespace OfficeIMO.Email.Data.Tests;
 
 public sealed class EmailDataArtifactTests {
     [Fact]
+    public void DirectoryWithUnsupportedOabComponentFallsBackToMailboxStore() {
+        string directory = TemporaryDirectory();
+        try {
+            File.WriteAllBytes(Path.Combine(directory, "unsupported.oab"), new byte[] { 7, 0, 0, 0 });
+            File.WriteAllText(Path.Combine(directory, "message.eml"),
+                "From: sender@example.test\r\nSubject: mailbox fallback\r\n\r\nBody\r\n");
+
+            using EmailDataOpenResult result = EmailDataArtifact.Open(directory);
+
+            Assert.Equal(EmailDataArtifactKind.Store, result.Kind);
+            Assert.Single(result.Store!.EnumerateItems());
+        } finally {
+            TryDeleteDirectory(directory);
+        }
+    }
+
+    [Fact]
     public void Opens_individual_email_calendar_and_contact_through_existing_owners() {
         string directory = TemporaryDirectory();
         try {

--- a/OfficeIMO.Email.Tests/Reading/EmailStreamingSafetyTests.cs
+++ b/OfficeIMO.Email.Tests/Reading/EmailStreamingSafetyTests.cs
@@ -4,6 +4,25 @@ using Xunit;
 namespace OfficeIMO.Email.Tests;
 
 public sealed class EmailStreamingSafetyTests {
+#if NET8_0_OR_GREATER
+    [Fact]
+    public void EmailTemporaryStorageCreatesOwnerOnlyUnixDirectories() {
+        if (OperatingSystem.IsWindows()) return;
+        string path = Path.Combine(Path.GetTempPath(),
+            "officeimo-email-private-" + Guid.NewGuid().ToString("N"));
+        try {
+            EmailTemporaryStorage.CreatePrivateDirectory(path);
+
+            UnixFileMode permissions = File.GetUnixFileMode(path);
+            Assert.Equal(UnixFileMode.None, permissions &
+                (UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
+                 UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute));
+        } finally {
+            if (Directory.Exists(path)) Directory.Delete(path, recursive: true);
+        }
+    }
+#endif
+
     [Fact]
     public void InvalidBase64AttachmentIsPreservedAndDiagnosed() {
         byte[] artifact = Encoding.ASCII.GetBytes(

--- a/OfficeIMO.Email.Tests/Store/MailboxDirectory/MailboxDirectorySessionTests.cs
+++ b/OfficeIMO.Email.Tests/Store/MailboxDirectory/MailboxDirectorySessionTests.cs
@@ -8,6 +8,88 @@ namespace OfficeIMO.Email.Store.Tests;
 
 public sealed class MailboxDirectorySessionTests {
     [Fact]
+    public void FilesystemCaseDetectionUsesExistingNamedAncestorsForNumericDirectories() {
+        string root = Path.Combine(Path.GetTempPath(),
+            "officeimo-case-ancestor-" + Guid.NewGuid().ToString("N"));
+        string numeric = Path.Combine(root, "123456");
+        try {
+            Directory.CreateDirectory(numeric);
+
+            Assert.Equal(
+                EmailStorePathIdentity.IsCaseInsensitiveFileSystem(root),
+                EmailStorePathIdentity.IsCaseInsensitiveFileSystem(numeric));
+        } finally {
+            if (Directory.Exists(root)) Directory.Delete(root, recursive: true);
+        }
+    }
+
+#if NET8_0_OR_GREATER
+    [Fact]
+    public void MailboxDirectorySkipsNamedPipeCandidatesWithoutBlocking() {
+        if (OperatingSystem.IsWindows()) return;
+        string root = Path.Combine(Path.GetTempPath(),
+            "officeimo-mailbox-fifo-" + Guid.NewGuid().ToString("N"));
+        try {
+            Directory.CreateDirectory(root);
+            string fifo = Path.Combine(root, "blocking.emlx");
+            Assert.Equal(0, CreateNamedPipe(fifo, 0x180));
+
+            var stopwatch = Stopwatch.StartNew();
+            using EmailStoreSession session = EmailStoreSession.Open(root);
+            stopwatch.Stop();
+
+            Assert.Empty(session.EnumerateItems());
+            Assert.Contains(session.Diagnostics, diagnostic =>
+                diagnostic.Code == "EMAIL_STORE_DIRECTORY_SPECIAL_FILE_SKIPPED");
+            Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(2), stopwatch.Elapsed.ToString());
+        } finally {
+            if (Directory.Exists(root)) Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task MailboxDirectoryReadRejectsFileReplacedWithNamedPipeWithoutBlocking() {
+        if (OperatingSystem.IsWindows()) return;
+        string root = Path.Combine(Path.GetTempPath(),
+            "officeimo-mailbox-fifo-swap-" + Guid.NewGuid().ToString("N"));
+        try {
+            Directory.CreateDirectory(root);
+            string path = Path.Combine(root, "message.eml");
+            File.WriteAllText(path, "Subject: Safe\r\n\r\nBody");
+            using EmailStoreSession session = EmailStoreSession.Open(root);
+            EmailStoreItemReference reference = Assert.Single(session.EnumerateItems());
+            File.Delete(path);
+            Assert.Equal(0, CreateNamedPipe(path, 0x180));
+
+            Task<Exception> read = Task.Run(() => Record.Exception(() => session.ReadItem(reference)));
+            bool completedWithoutWriter = ReferenceEquals(
+                await Task.WhenAny(read, Task.Delay(TimeSpan.FromMilliseconds(500))),
+                read);
+            if (!completedWithoutWriter) {
+                int nonBlocking = OperatingSystem.IsMacOS() ? 0x0004 : 0x0800;
+                int descriptor = OpenNamedPipe(path, 0x0002 | nonBlocking);
+                if (descriptor >= 0) CloseDescriptor(descriptor);
+                Assert.Same(read, await Task.WhenAny(read, Task.Delay(TimeSpan.FromSeconds(2))));
+            }
+
+            Assert.True(completedWithoutWriter, "Reading a swapped FIFO waited for a writer.");
+            Assert.IsType<IOException>(await read);
+        } finally {
+            if (Directory.Exists(root)) Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [DllImport("libc", EntryPoint = "mkfifo", SetLastError = true, CharSet = CharSet.Ansi)]
+    private static extern int CreateNamedPipe(string path, uint mode);
+
+    [DllImport("libc", EntryPoint = "open", SetLastError = true, CharSet = CharSet.Ansi)]
+    private static extern int OpenNamedPipe(string path, int flags);
+
+    [DllImport("libc", EntryPoint = "close", SetLastError = true)]
+    private static extern int CloseDescriptor(int descriptor);
+#endif
+
+    [Fact]
     public void Opens_apple_mail_and_maildir_trees_as_one_lazy_store() {
         string root = CreateMailboxDirectory();
         try {

--- a/OfficeIMO.Email.Tests/Store/MailboxDirectory/MailboxDirectorySessionTests.cs
+++ b/OfficeIMO.Email.Tests/Store/MailboxDirectory/MailboxDirectorySessionTests.cs
@@ -48,6 +48,19 @@ public sealed class MailboxDirectorySessionTests {
     }
 
     [Fact]
+    public void MailboxRegularFileCheckRejectsSeekableDeviceDescriptors() {
+        if (OperatingSystem.IsWindows()) return;
+        Type backend = typeof(EmailStoreSession).Assembly.GetType(
+            "OfficeIMO.Email.Store.MailboxDirectoryStoreSessionBackend",
+            throwOnError: true)!;
+        System.Reflection.MethodInfo method = backend.GetMethod(
+            "IsRegularMailboxFile",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
+
+        Assert.False(Assert.IsType<bool>(method.Invoke(null, new object[] { "/dev/null" })));
+    }
+
+    [Fact]
     public async Task MailboxDirectoryReadRejectsFileReplacedWithNamedPipeWithoutBlocking() {
         if (OperatingSystem.IsWindows()) return;
         string root = Path.Combine(Path.GetTempPath(),

--- a/OfficeIMO.Email/AddressBook/Discovery/OabFileDiscovery.cs
+++ b/OfficeIMO.Email/AddressBook/Discovery/OabFileDiscovery.cs
@@ -27,13 +27,23 @@ internal static class OabFileDiscovery {
         var diagnostics = new List<EmailDiagnostic>();
         var paths = new List<string>();
         var pending = new Stack<DirectoryNode>();
+        int inspectedEntries = 0;
         pending.Push(new DirectoryNode(fullPath, 0));
         while (pending.Count > 0) {
             cancellationToken.ThrowIfCancellationRequested();
             DirectoryNode node = pending.Pop();
             FileSystemInfo[] entries;
             try {
-                entries = new DirectoryInfo(node.Path).GetFileSystemInfos();
+                int remainingEntries = options.MaxDirectoryEntries - inspectedEntries;
+                if (remainingEntries <= 0) {
+                    throw new OfflineAddressBookLimitExceededException(
+                        nameof(options.MaxDirectoryEntries), inspectedEntries + 1L,
+                        options.MaxDirectoryEntries, fullPath);
+                }
+                entries = new DirectoryInfo(node.Path)
+                    .EnumerateFileSystemInfos()
+                    .Take(remainingEntries == int.MaxValue ? int.MaxValue : remainingEntries + 1)
+                    .ToArray();
             } catch (Exception exception) when (exception is IOException || exception is UnauthorizedAccessException) {
                 diagnostics.Add(new EmailDiagnostic(
                     "OAB_DIRECTORY_SKIPPED",
@@ -42,6 +52,12 @@ internal static class OabFileDiscovery {
                     node.Path));
                 continue;
             }
+            if (entries.Length > options.MaxDirectoryEntries - inspectedEntries) {
+                throw new OfflineAddressBookLimitExceededException(
+                    nameof(options.MaxDirectoryEntries), inspectedEntries + entries.Length,
+                    options.MaxDirectoryEntries, fullPath);
+            }
+            inspectedEntries += entries.Length;
 
             foreach (FileSystemInfo entry in entries.OrderBy(item => item.Name, StringComparer.OrdinalIgnoreCase)) {
                 cancellationToken.ThrowIfCancellationRequested();

--- a/OfficeIMO.Email/AddressBook/Discovery/OabFileDiscovery.cs
+++ b/OfficeIMO.Email/AddressBook/Discovery/OabFileDiscovery.cs
@@ -35,14 +35,14 @@ internal static class OabFileDiscovery {
             FileSystemInfo[] entries;
             try {
                 int remainingEntries = options.MaxDirectoryEntries - inspectedEntries;
-                if (remainingEntries <= 0) {
-                    throw new OfflineAddressBookLimitExceededException(
-                        nameof(options.MaxDirectoryEntries), inspectedEntries + 1L,
-                        options.MaxDirectoryEntries, fullPath);
-                }
+                int probeEntries = remainingEntries <= 0
+                    ? 1
+                    : remainingEntries == int.MaxValue
+                        ? int.MaxValue
+                        : remainingEntries + 1;
                 entries = new DirectoryInfo(node.Path)
                     .EnumerateFileSystemInfos()
-                    .Take(remainingEntries == int.MaxValue ? int.MaxValue : remainingEntries + 1)
+                    .Take(probeEntries)
                     .ToArray();
             } catch (Exception exception) when (exception is IOException || exception is UnauthorizedAccessException) {
                 diagnostics.Add(new EmailDiagnostic(

--- a/OfficeIMO.Email/AddressBook/Reading/OfflineAddressBookReaderOptions.cs
+++ b/OfficeIMO.Email/AddressBook/Reading/OfflineAddressBookReaderOptions.cs
@@ -18,7 +18,8 @@ public sealed class OfflineAddressBookReaderOptions {
         int maxValuesPerProperty = 100_000,
         long maxDeclaredEntries = 100_000_000,
         int string8CodePage = 1252,
-        bool retainRawPropertyBytes = true) {
+        bool retainRawPropertyBytes = true,
+        int maxDirectoryEntries = 100_000) {
         if (maxInputBytes <= 0) throw new ArgumentOutOfRangeException(nameof(maxInputBytes));
         if (maxDiscoveredFiles <= 0) throw new ArgumentOutOfRangeException(nameof(maxDiscoveredFiles));
         if (maxDirectoryDepth < 0) throw new ArgumentOutOfRangeException(nameof(maxDirectoryDepth));
@@ -30,6 +31,7 @@ public sealed class OfflineAddressBookReaderOptions {
         if (maxValuesPerProperty <= 0) throw new ArgumentOutOfRangeException(nameof(maxValuesPerProperty));
         if (maxDeclaredEntries <= 0) throw new ArgumentOutOfRangeException(nameof(maxDeclaredEntries));
         if (string8CodePage <= 0) throw new ArgumentOutOfRangeException(nameof(string8CodePage));
+        if (maxDirectoryEntries <= 0) throw new ArgumentOutOfRangeException(nameof(maxDirectoryEntries));
 
         MaxInputBytes = maxInputBytes;
         MaxDiscoveredFiles = maxDiscoveredFiles;
@@ -43,6 +45,7 @@ public sealed class OfflineAddressBookReaderOptions {
         MaxDeclaredEntries = maxDeclaredEntries;
         String8CodePage = string8CodePage;
         RetainRawPropertyBytes = retainRawPropertyBytes;
+        MaxDirectoryEntries = maxDirectoryEntries;
     }
 
     /// <summary>Maximum bytes in one OAB component.</summary>
@@ -69,4 +72,6 @@ public sealed class OfflineAddressBookReaderOptions {
     public int String8CodePage { get; }
     /// <summary>Whether decoded MAPI properties retain their original OAB value encoding.</summary>
     public bool RetainRawPropertyBytes { get; }
+    /// <summary>Maximum total filesystem entries inspected during directory discovery, including non-OAB entries.</summary>
+    public int MaxDirectoryEntries { get; }
 }

--- a/OfficeIMO.Email/AddressBook/Reading/OfflineAddressBookReaderOptions.cs
+++ b/OfficeIMO.Email/AddressBook/Reading/OfflineAddressBookReaderOptions.cs
@@ -48,6 +48,40 @@ public sealed class OfflineAddressBookReaderOptions {
         MaxDirectoryEntries = maxDirectoryEntries;
     }
 
+    /// <summary>
+    /// Creates the reader profile exposed before directory-entry discovery was bounded.
+    /// Retained so already-compiled callers continue to bind to the original constructor signature.
+    /// </summary>
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public OfflineAddressBookReaderOptions(
+        long maxInputBytes,
+        int maxDiscoveredFiles,
+        int maxDirectoryDepth,
+        int maxMetadataBytes,
+        int maxPropertiesPerTable,
+        int maxRecordBytes,
+        int maxStringBytes,
+        int maxBinaryBytes,
+        int maxValuesPerProperty,
+        long maxDeclaredEntries,
+        int string8CodePage,
+        bool retainRawPropertyBytes)
+        : this(
+            maxInputBytes,
+            maxDiscoveredFiles,
+            maxDirectoryDepth,
+            maxMetadataBytes,
+            maxPropertiesPerTable,
+            maxRecordBytes,
+            maxStringBytes,
+            maxBinaryBytes,
+            maxValuesPerProperty,
+            maxDeclaredEntries,
+            string8CodePage,
+            retainRawPropertyBytes,
+            maxDirectoryEntries: 100_000) {
+    }
+
     /// <summary>Maximum bytes in one OAB component.</summary>
     public long MaxInputBytes { get; }
     /// <summary>Maximum .oab files discovered below a directory root.</summary>

--- a/OfficeIMO.Email/Data/EmailDataArtifact.cs
+++ b/OfficeIMO.Email/Data/EmailDataArtifact.cs
@@ -57,11 +57,20 @@ public static class EmailDataArtifact {
                 exception.LimitName,
                 nameof(OfflineAddressBookReaderOptions.MaxDirectoryEntries),
                 StringComparison.Ordinal)) {
-            return OpenStore(path, options, cancellationToken);
+            EmailDataOpenResult boundedStore = OpenStore(path, options, cancellationToken);
+            if (boundedStore.Store!.EnumerateItems().Any()) return boundedStore;
+            boundedStore.Dispose();
+            throw;
         }
         if (discovery.ReadableFullDetailsCount > 0)
             return OpenAddressBook(path, options, cancellationToken);
-        return OpenStore(path, options, cancellationToken);
+        EmailDataOpenResult store = OpenStore(path, options, cancellationToken);
+        if (discovery.Files.Count == 0 || store.Store!.EnumerateItems().Any()) {
+            return store;
+        }
+        store.Dispose();
+        throw new NotSupportedException(
+            "The directory contains OAB components, but none is a supported version 4 Full Details file.");
     }
 
     private static EmailDataOpenResult OpenExpected(string path, EmailDataArtifactKind kind,

--- a/OfficeIMO.Email/Data/EmailDataArtifact.cs
+++ b/OfficeIMO.Email/Data/EmailDataArtifact.cs
@@ -48,8 +48,17 @@ public static class EmailDataArtifact {
 
     private static EmailDataOpenResult OpenDirectory(string path, EmailDataOpenOptions options,
         CancellationToken cancellationToken) {
-        OfflineAddressBookDiscoveryReport discovery = OfflineAddressBookInspector.Inspect(
-            path, options.AddressBook, cancellationToken);
+        OfflineAddressBookDiscoveryReport discovery;
+        try {
+            discovery = OfflineAddressBookInspector.Inspect(
+                path, options.AddressBook, cancellationToken);
+        } catch (OfflineAddressBookLimitExceededException exception) when (
+            string.Equals(
+                exception.LimitName,
+                nameof(OfflineAddressBookReaderOptions.MaxDirectoryEntries),
+                StringComparison.Ordinal)) {
+            return OpenStore(path, options, cancellationToken);
+        }
         if (discovery.ReadableFullDetailsCount > 0)
             return OpenAddressBook(path, options, cancellationToken);
         return OpenStore(path, options, cancellationToken);

--- a/OfficeIMO.Email/Data/EmailDataArtifact.cs
+++ b/OfficeIMO.Email/Data/EmailDataArtifact.cs
@@ -52,10 +52,6 @@ public static class EmailDataArtifact {
             path, options.AddressBook, cancellationToken);
         if (discovery.ReadableFullDetailsCount > 0)
             return OpenAddressBook(path, options, cancellationToken);
-        if (discovery.Files.Count > 0) {
-            throw new NotSupportedException(
-                "OAB components were discovered, but none is a readable version 4 Full Details component.");
-        }
         return OpenStore(path, options, cancellationToken);
     }
 

--- a/OfficeIMO.Email/Internal/EmailTemporaryStorage.cs
+++ b/OfficeIMO.Email/Internal/EmailTemporaryStorage.cs
@@ -1,0 +1,19 @@
+using System.Runtime.InteropServices;
+
+namespace OfficeIMO.Email;
+
+internal static class EmailTemporaryStorage {
+    internal static void CreatePrivateDirectory(string path) {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Directory.CreateDirectory(path);
+            return;
+        }
+
+        if (CreateDirectory(path, 0x1C0) == 0) return;
+        int error = Marshal.GetLastWin32Error();
+        throw new IOException($"Unable to create a private email temporary directory (error {error}).");
+    }
+
+    [DllImport("libc", EntryPoint = "mkdir", SetLastError = true, CharSet = CharSet.Ansi)]
+    private static extern int CreateDirectory(string path, uint mode);
+}

--- a/OfficeIMO.Email/Reading/EmailReadWorkspace.cs
+++ b/OfficeIMO.Email/Reading/EmailReadWorkspace.cs
@@ -10,7 +10,7 @@ internal sealed class EmailReadWorkspace : IDisposable {
     internal EmailReadWorkspace() {
         _directoryPath = Path.Combine(Path.GetTempPath(),
             string.Concat("OfficeIMO.Email.Read.", Guid.NewGuid().ToString("N")));
-        Directory.CreateDirectory(_directoryPath);
+        EmailTemporaryStorage.CreatePrivateDirectory(_directoryPath);
     }
 
     internal Stream OpenExternalDestination(string logicalPath, long length) {

--- a/OfficeIMO.Email/Store/MailboxDirectory/MailboxDirectoryStoreSessionBackend.cs
+++ b/OfficeIMO.Email/Store/MailboxDirectory/MailboxDirectoryStoreSessionBackend.cs
@@ -323,6 +323,11 @@ internal sealed class MailboxDirectoryStoreSessionBackend : IEmailStoreSessionBa
         int noFollow = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? 0x00000100 : 0x00020000;
         int descriptor = OpenUnix(path, nonBlocking | closeOnExec | noFollow);
         if (descriptor < 0) return false;
+        if (GetUnixFileStatus(new IntPtr(descriptor), out UnixFileStatus status) != 0 ||
+            (status.Mode & 0xF000) != 0x8000) {
+            CloseUnix(descriptor);
+            return false;
+        }
         if (SeekUnix(descriptor, 0L, 1) < 0L) {
             CloseUnix(descriptor);
             return false;
@@ -344,8 +349,33 @@ internal sealed class MailboxDirectoryStoreSessionBackend : IEmailStoreSessionBa
     [DllImport("libc", EntryPoint = "lseek", SetLastError = true)]
     private static extern long SeekUnix(int descriptor, long offset, int origin);
 
+    [DllImport("System.Native", EntryPoint = "SystemNative_FStat", SetLastError = true)]
+    private static extern int GetUnixFileStatus(IntPtr descriptor, out UnixFileStatus status);
+
     [DllImport("libc", EntryPoint = "close", SetLastError = true)]
     private static extern int CloseUnix(int descriptor);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct UnixFileStatus {
+        internal int Flags;
+        internal int Mode;
+        internal uint Uid;
+        internal uint Gid;
+        internal long Size;
+        internal long AccessTime;
+        internal long AccessTimeNanoseconds;
+        internal long ModificationTime;
+        internal long ModificationTimeNanoseconds;
+        internal long ChangeTime;
+        internal long ChangeTimeNanoseconds;
+        internal long BirthTime;
+        internal long BirthTimeNanoseconds;
+        internal long Device;
+        internal long RawDevice;
+        internal long Inode;
+        internal uint UserFlags;
+        internal int HardLinkCount;
+    }
 
     internal static string? ParseMaildirFlags(string name, string? parentDirectoryName) {
         if (name == null) throw new ArgumentNullException(nameof(name));

--- a/OfficeIMO.Email/Store/MailboxDirectory/MailboxDirectoryStoreSessionBackend.cs
+++ b/OfficeIMO.Email/Store/MailboxDirectory/MailboxDirectoryStoreSessionBackend.cs
@@ -1,4 +1,6 @@
 using OfficeIMO.Email;
+using Microsoft.Win32.SafeHandles;
+using System.Runtime.InteropServices;
 
 namespace OfficeIMO.Email.Store;
 
@@ -61,8 +63,7 @@ internal sealed class MailboxDirectoryStoreSessionBackend : IEmailStoreSessionBa
                 "The item reference does not belong to this mailbox-directory session.");
         }
         bool includeAttachmentContent = options.Includes(EmailStoreItemReadParts.AttachmentContent);
-        using (var stream = new FileStream(
-            file.Path, FileMode.Open, FileAccess.Read, FileShare.Read, 64 * 1024, FileOptions.SequentialScan)) {
+        using (FileStream stream = OpenRegularMailboxFile(file.Path)) {
             EmailDocument document;
             if (file.IsEmlx) {
                 EmailStoreReadResult result = new EmlxStoreReader(_options, includeAttachmentContent)
@@ -131,6 +132,14 @@ internal sealed class MailboxDirectoryStoreSessionBackend : IEmailStoreSessionBa
                     continue;
                 }
                 if (!(entry is FileInfo file) || !IsMailboxFile(file)) continue;
+                if (!IsRegularMailboxFile(file.FullName)) {
+                    _diagnostics.Add(new EmailStoreDiagnostic(
+                        "EMAIL_STORE_DIRECTORY_SPECIAL_FILE_SKIPPED",
+                        "A non-regular mailbox candidate was skipped without opening it as a blocking stream.",
+                        EmailStoreDiagnosticSeverity.Warning,
+                        ToRelativePath(file.FullName)));
+                    continue;
+                }
                 if (candidates.Count >= _options.MaxDirectoryFileCount) {
                     throw new EmailStoreLimitExceededException(
                         nameof(EmailStoreReaderOptions.MaxDirectoryFileCount),
@@ -270,15 +279,73 @@ internal sealed class MailboxDirectoryStoreSessionBackend : IEmailStoreSessionBa
         if (!string.Equals(parent, "cur", StringComparison.OrdinalIgnoreCase) &&
             !string.Equals(parent, "new", StringComparison.OrdinalIgnoreCase)) return true;
         try {
-            using (var stream = new FileStream(
-                file.FullName, FileMode.Open, FileAccess.Read, FileShare.Read, 4 * 1024,
-                FileOptions.SequentialScan)) {
+            if (!TryOpenRegularMailboxFile(file.FullName, 4 * 1024, out FileStream stream)) {
+                return false;
+            }
+            using (stream) {
                 return EmlxStoreReader.HasEnvelopePrefix(stream);
             }
         } catch (Exception exception) when (exception is IOException || exception is UnauthorizedAccessException) {
             return false;
         }
     }
+
+    private static bool IsRegularMailboxFile(string path) {
+        if (!TryOpenRegularMailboxFile(path, 4 * 1024, out FileStream stream)) return false;
+        stream.Dispose();
+        return true;
+    }
+
+    private static FileStream OpenRegularMailboxFile(string path) {
+        if (TryOpenRegularMailboxFile(path, 64 * 1024, out FileStream stream)) return stream;
+        throw new IOException("The mailbox item is no longer a regular readable file.");
+    }
+
+    private static bool TryOpenRegularMailboxFile(
+        string path,
+        int bufferSize,
+        out FileStream stream) {
+        stream = null!;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            try {
+                stream = new FileStream(
+                    path, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize,
+                    FileOptions.SequentialScan);
+                return true;
+            } catch (Exception exception) when (
+                exception is IOException || exception is UnauthorizedAccessException) {
+                return false;
+            }
+        }
+
+        int nonBlocking = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? 0x0004 : 0x0800;
+        int closeOnExec = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? 0x01000000 : 0x00080000;
+        int noFollow = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? 0x00000100 : 0x00020000;
+        int descriptor = OpenUnix(path, nonBlocking | closeOnExec | noFollow);
+        if (descriptor < 0) return false;
+        if (SeekUnix(descriptor, 0L, 1) < 0L) {
+            CloseUnix(descriptor);
+            return false;
+        }
+
+        var handle = new SafeFileHandle(new IntPtr(descriptor), ownsHandle: true);
+        try {
+            stream = new FileStream(handle, FileAccess.Read, bufferSize, isAsync: false);
+            return true;
+        } catch {
+            handle.Dispose();
+            throw;
+        }
+    }
+
+    [DllImport("libc", EntryPoint = "open", SetLastError = true, CharSet = CharSet.Ansi)]
+    private static extern int OpenUnix(string path, int flags);
+
+    [DllImport("libc", EntryPoint = "lseek", SetLastError = true)]
+    private static extern long SeekUnix(int descriptor, long offset, int origin);
+
+    [DllImport("libc", EntryPoint = "close", SetLastError = true)]
+    private static extern int CloseUnix(int descriptor);
 
     internal static string? ParseMaildirFlags(string name, string? parentDirectoryName) {
         if (name == null) throw new ArgumentNullException(nameof(name));

--- a/OfficeIMO.Email/Store/Reading/EmailStorePathIdentity.cs
+++ b/OfficeIMO.Email/Store/Reading/EmailStorePathIdentity.cs
@@ -86,6 +86,14 @@ internal static partial class EmailStorePathIdentity {
             } catch (IOException) {
             } catch (UnauthorizedAccessException) {
             }
+
+            string? ancestor = Path.GetDirectoryName(TrimEndingDirectorySeparators(directory));
+            while (!string.IsNullOrEmpty(ancestor)) {
+                if (TryDetectFromExistingName(ancestor, out caseInsensitive)) return caseInsensitive;
+                string? parent = Path.GetDirectoryName(TrimEndingDirectorySeparators(ancestor));
+                if (string.Equals(parent, ancestor, StringComparison.Ordinal)) break;
+                ancestor = parent;
+            }
         }
         return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
     }

--- a/OfficeIMO.Email/Writing/EmailAttachmentStaging.cs
+++ b/OfficeIMO.Email/Writing/EmailAttachmentStaging.cs
@@ -79,7 +79,7 @@ internal sealed class EmailAttachmentStaging : IDisposable {
         if (_directoryPath != null) return _directoryPath;
         _directoryPath = Path.Combine(Path.GetTempPath(),
             string.Concat("OfficeIMO.Email.Write.", Guid.NewGuid().ToString("N")));
-        Directory.CreateDirectory(_directoryPath);
+        EmailTemporaryStorage.CreatePrivateDirectory(_directoryPath);
         return _directoryPath;
     }
 

--- a/OfficeIMO.Excel.Tests/Excel.CellAndRange.cs
+++ b/OfficeIMO.Excel.Tests/Excel.CellAndRange.cs
@@ -124,8 +124,8 @@ namespace OfficeIMO.Tests {
             Assert.Equal((0, 0), A1.ParseCellRef("A0"));
             Assert.Equal((0, 0), A1.ParseCellRef("A1:B2"));
             Assert.Equal((A1.MaxRows, A1.MaxColumns), A1.ParseCellRef("XFD1048576"));
-            Assert.Equal((1, A1.MaxColumns + 1), A1.ParseCellRef("XFE1"));
-            Assert.Equal((A1.MaxRows + 1, A1.MaxColumns), A1.ParseCellRef("XFD1048577"));
+            Assert.Equal((0, 0), A1.ParseCellRef("XFE1"));
+            Assert.Equal((0, 0), A1.ParseCellRef("XFD1048577"));
             Assert.Equal((0, 0), A1.ParseCellRef("ZZZZZZZ1"));
             Assert.Equal((0, 0), A1.ParseCellRef("A2147483648"));
 
@@ -133,8 +133,7 @@ namespace OfficeIMO.Tests {
             Assert.Equal((2, 1, 10, 3), (r1, c1, r2, c2));
 
             Assert.False(A1.TryParseRange("A1", out _, out _, out _, out _));
-            Assert.True(A1.TryParseRange("A1:XFE1", out r1, out c1, out r2, out c2));
-            Assert.Equal((1, 1, 1, A1.MaxColumns + 1), (r1, c1, r2, c2));
+            Assert.False(A1.TryParseRange("A1:XFE1", out r1, out c1, out r2, out c2));
             Assert.False(A1.TryParseRange("A1:ZZZZZZZ1", out _, out _, out _, out _));
             Assert.False(A1.TryParseRange("A1:A2147483648", out _, out _, out _, out _));
             Assert.Equal(28, A1.ColumnLettersToIndex("a-b1"));
@@ -166,6 +165,9 @@ namespace OfficeIMO.Tests {
             Assert.False(A1.TryParseCellReferenceFast("A0", out _, out _));
             Assert.False(A1.TryParseCellReferenceFast("AB12X", out _, out _));
             Assert.False(A1.TryParseCellReferenceFast("A2147483648", out _, out _));
+            Assert.True(A1.TryParseCellReferenceFast("XFD1048576", out _, out _));
+            Assert.False(A1.TryParseCellReferenceFast("XFE1", out _, out _));
+            Assert.False(A1.TryParseCellReferenceFast("XFD1048577", out _, out _));
             Assert.Equal("A", A1.ColumnIndexToLetters(0));
             Assert.Equal("A", A1.ColumnIndexToLetters(1));
             Assert.Equal("Z", A1.ColumnIndexToLetters(26));

--- a/OfficeIMO.Excel.Tests/Excel.FormulaDepth.cs
+++ b/OfficeIMO.Excel.Tests/Excel.FormulaDepth.cs
@@ -1128,6 +1128,64 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_FormulaInspection_DoesNotExpandOversizedSharedFormulaFollowers() {
+            using ExcelDocument document = ExcelDocument.Create();
+            ExcelSheet sheet = document.AddWorksheet("Shared");
+            Worksheet worksheet = sheet.WorksheetPart.Worksheet;
+            SheetData sheetData = worksheet.GetFirstChild<SheetData>()!;
+            const int followerCount = 1_000;
+            string masterFormula = new string('A', 8_193);
+            sheetData.RemoveAllChildren<Row>();
+            for (int rowIndex = 1; rowIndex <= followerCount; rowIndex++) {
+                var cell = new Cell { CellReference = "A" + rowIndex };
+                cell.CellFormula = rowIndex == 1
+                    ? new CellFormula(masterFormula) {
+                        FormulaType = CellFormulaValues.Shared,
+                        SharedIndex = 19U,
+                        Reference = "A1:A" + followerCount
+                    }
+                    : new CellFormula {
+                        FormulaType = CellFormulaValues.Shared,
+                        SharedIndex = 19U
+                    };
+                sheetData.Append(new Row(cell) { RowIndex = (uint)rowIndex });
+            }
+            worksheet.Save();
+
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+            Assert.Equal(string.Empty, sheet.GetFormulaText(followerCount, 1));
+            ExcelFormulaInspection inspection = document.InspectFormulas();
+            stopwatch.Stop();
+
+            Assert.Equal(followerCount, inspection.Formulas.Count);
+            Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(5), stopwatch.Elapsed.ToString());
+        }
+
+        [Fact]
+        public void Test_FormulaInspection_IgnoresDefinedNamesScopedToMalformedSheets() {
+            using ExcelDocument document = ExcelDocument.Create();
+            ExcelSheet valid = document.AddWorksheet("Valid");
+            valid.CellFormula(1, 1, "Broken!ScopedValue");
+
+            uint malformedSheetIndex = (uint)document.WorkbookRoot.Sheets!.Elements<Sheet>().Count();
+            document.WorkbookRoot.Sheets.Append(new Sheet {
+                Name = "Broken",
+                SheetId = malformedSheetIndex + 1U
+            });
+            document.WorkbookRoot.DefinedNames ??= new DefinedNames();
+            document.WorkbookRoot.DefinedNames.Append(new DefinedName("Valid!$B$1") {
+                Name = "ScopedValue",
+                LocalSheetId = malformedSheetIndex
+            });
+            document.WorkbookRoot.Save();
+
+            ExcelFormulaInspection inspection = document.InspectFormulas();
+            ExcelFormulaCellInfo formula = Assert.Single(inspection.Formulas);
+            Assert.Equal("A1", formula.CellReference);
+            Assert.Empty(formula.Dependencies);
+        }
+
+        [Fact]
         public void Test_FormulaDependencyGraph_IgnoresDefinedNamesInsideErrorLiterals() {
             using ExcelDocument document = ExcelDocument.Create();
             ExcelSheet sheet = document.AddWorksheet("Errors");

--- a/OfficeIMO.Excel.Tests/Excel.ModernChartRecipes.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ModernChartRecipes.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
 using OfficeIMO.Excel;
 using Xunit;
 using A = DocumentFormat.OpenXml.Drawing;
@@ -171,6 +172,33 @@ namespace OfficeIMO.Tests {
                 includeTotal: false);
             Assert.True(noTotalWaterfall.TryGetData(out ExcelChartData noTotalData));
             Assert.Equal(3, noTotalData.Series.Count);
+        }
+
+        [Fact]
+        public void Test_WaterfallChart_BatchesLargePointLabelSets() {
+            string filePath = Path.Combine(_directoryWithFiles, "Excel.ModernChartRecipes.LargeWaterfall.xlsx");
+            const int pointCount = 2_000;
+            string[] categories = Enumerable.Range(0, pointCount).Select(index => "P" + index).ToArray();
+            double[] changes = Enumerable.Range(0, pointCount).Select(index => index % 2 == 0 ? 1D : -1D).ToArray();
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorksheet("Waterfall");
+                var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+                sheet.AddWaterfallChart(categories, changes, 1, 1);
+                stopwatch.Stop();
+                Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(10), stopwatch.Elapsed.ToString());
+                document.Save();
+            }
+
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false);
+            C.BarChart chart = spreadsheet.WorkbookPart!.WorksheetParts
+                .Single(part => part.DrawingsPart != null).DrawingsPart!.ChartParts.Single()
+                .ChartSpace.Descendants<C.BarChart>()
+                .Single(candidate => candidate.Elements<C.BarChartSeries>().Count() == 4);
+            Assert.Equal(1_000, chart.Elements<C.BarChartSeries>().ElementAt(1)
+                .GetFirstChild<C.DataLabels>()!.Elements<C.DataLabel>().Count());
+            Assert.Equal(1_000, chart.Elements<C.BarChartSeries>().ElementAt(2)
+                .GetFirstChild<C.DataLabels>()!.Elements<C.DataLabel>().Count());
         }
 
         [Fact]

--- a/OfficeIMO.Excel.Tests/Excel.PivotInteractions.cs
+++ b/OfficeIMO.Excel.Tests/Excel.PivotInteractions.cs
@@ -132,7 +132,49 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
-        public void Test_PivotTimelineCache_ValidatesRetargetedLiveSourceBeforeStaleCacheMetadata() {
+        public void Test_PivotInteractionCaches_BoundDefaultNameSearchToExistingCaches() {
+            using ExcelDocument document = ExcelDocument.Create();
+            ExcelSheet sheet = document.AddWorksheet("Sales");
+            sheet.CellValue(1, 1, "Region");
+            sheet.CellValue(1, 2, "Sales");
+            sheet.CellValue(2, 1, "East");
+            sheet.CellValue(2, 2, 10d);
+            sheet.AddPivotTable(
+                sourceRange: "A1:B2",
+                destinationCell: "D2",
+                name: "SalesPivot",
+                rowFields: new[] { "Region" },
+                dataFields: new[] { new ExcelPivotDataField("Sales", DataConsolidateFunctionValues.Sum) });
+
+            WorkbookPart workbookPart = document._spreadSheetDocument.WorkbookPart!;
+            const int existingCount = 512;
+            for (int suffix = 1; suffix <= existingCount; suffix++) {
+                string name = suffix == 1 ? "Slicer_Region" : "Slicer_Region_" + suffix;
+                WriteExtendedPart(
+                    workbookPart.AddExtendedPart(
+                        "http://schemas.microsoft.com/office/2007/relationships/slicerCache",
+                        "application/vnd.ms-excel.slicerCache+xml",
+                        "xml"),
+                    "<slicerCacheDefinition xmlns=\"http://schemas.microsoft.com/office/spreadsheetml/2009/9/main\" name=\""
+                    + name + "\" sourceName=\"Region\" pivotTableName=\"SalesPivot\"/>");
+            }
+
+            IReadOnlyList<ExcelPivotInteractionCacheInfo> existing = document.GetWorkbookSlicerCaches();
+            Assert.True(existing.Count > 50, existing.Count.ToString());
+            var existingNames = new HashSet<string>(existing.Select(cache => cache.Name), StringComparer.OrdinalIgnoreCase);
+            int expectedSuffix = Enumerable.Range(2, existing.Count + 1)
+                .First(suffix => !existingNames.Contains("Slicer_Region_" + suffix));
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+            document.AddPivotSlicerCache("SalesPivot", "Region");
+            stopwatch.Stop();
+
+            Assert.Contains(document.GetWorkbookSlicerCaches(), cache =>
+                cache.Name == "Slicer_Region_" + expectedSuffix);
+            Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(5), stopwatch.Elapsed.ToString());
+        }
+
+        [Fact]
+        public void Test_PivotTimelineCache_UsesDecisiveCacheBeforeUntrustedSourceRange() {
             using ExcelDocument document = ExcelDocument.Create();
             ExcelSheet original = document.AddWorksheet("Original");
             original.CellValue(1, 1, "Region");
@@ -148,17 +190,22 @@ namespace OfficeIMO.Tests {
                 rowFields: new[] { "Region" },
                 dataFields: new[] { new ExcelPivotDataField("Sales", DataConsolidateFunctionValues.Sum) });
 
-            ExcelSheet replacement = document.AddWorksheet("Replacement");
-            replacement.CellValue(1, 1, "Region");
-            replacement.CellValue(1, 2, "OrderDate");
-            replacement.CellValue(1, 3, "Sales");
-            replacement.CellValue(2, 1, "West");
-            replacement.CellValue(2, 2, "not a date");
-            replacement.CellValue(2, 3, 20d);
+            PivotTablePart pivotPart = original.WorksheetPart.PivotTableParts.Single();
+            PivotCacheDefinition cache = pivotPart.PivotTableCacheDefinitionPart!.PivotCacheDefinition!;
+            CacheField orderDate = cache.CacheFields!.Elements<CacheField>()
+                .Single(field => field.Name?.Value == "OrderDate");
+            orderDate.SharedItems = new SharedItems(
+                new DateTimeItem { Val = new DateTime(2026, 1, 2) }) {
+                ContainsDate = true,
+                ContainsString = false,
+                ContainsNumber = false,
+                Count = 1U
+            };
+            cache.CacheSource!.WorksheetSource!.Reference = "A1:A2147483647";
+            cache.Save();
 
-            original.UpdatePivotTableSource("SalesPivot", replacement, "A1:C2");
-
-            Assert.Throws<ArgumentException>(() => document.AddPivotTimelineCache("SalesPivot", "OrderDate"));
+            document.AddPivotTimelineCache("SalesPivot", "OrderDate");
+            Assert.Equal("OrderDate", Assert.Single(document.GetWorkbookTimelineCaches()).SourceName);
         }
 
         [Fact]

--- a/OfficeIMO.Excel/ExcelChart.DataLabels.cs
+++ b/OfficeIMO.Excel/ExcelChart.DataLabels.cs
@@ -531,6 +531,62 @@ namespace OfficeIMO.Excel {
             return this;
         }
 
+        internal ExcelChart SetSeriesDataLabelsForPoints(int seriesIndex, IReadOnlyList<int> pointIndices,
+            bool? showValue = null, bool? showCategoryName = null, bool? showSeriesName = null,
+            bool? showLegendKey = null, bool? showPercent = null, bool? showBubbleSize = null,
+            C.DataLabelPositionValues? position = null, string? numberFormat = null, bool sourceLinked = false) {
+            if (seriesIndex < 0) {
+                throw new ArgumentOutOfRangeException(nameof(seriesIndex));
+            }
+            if (pointIndices == null) {
+                throw new ArgumentNullException(nameof(pointIndices));
+            }
+            if (numberFormat != null && string.IsNullOrWhiteSpace(numberFormat)) {
+                throw new ArgumentException("Number format cannot be empty.", nameof(numberFormat));
+            }
+
+            bool applied = ApplySeriesByIndex(seriesIndex, series => {
+                C.DataLabels labels = EnsureDataLabels(series);
+                var labelsByIndex = new Dictionary<uint, C.DataLabel>();
+                foreach (C.DataLabel existing in labels.Elements<C.DataLabel>()) {
+                    uint? existingIndex = existing.GetFirstChild<C.Index>()?.Val?.Value;
+                    if (existingIndex.HasValue && !labelsByIndex.ContainsKey(existingIndex.Value)) {
+                        labelsByIndex.Add(existingIndex.Value, existing);
+                    }
+                }
+
+                var requested = new HashSet<uint>();
+                foreach (int pointIndex in pointIndices) {
+                    if (pointIndex < 0) {
+                        throw new ArgumentOutOfRangeException(nameof(pointIndices), "Point indices cannot be negative.");
+                    }
+
+                    uint index = (uint)pointIndex;
+                    if (!requested.Add(index)) continue;
+                    if (!labelsByIndex.TryGetValue(index, out C.DataLabel? label)) {
+                        label = new C.DataLabel(new C.Index { Val = index });
+                        OpenXmlElement? insertBefore = labels.ChildElements.FirstOrDefault(child => child is not C.DataLabel);
+                        if (insertBefore != null) {
+                            labels.InsertBefore(label, insertBefore);
+                        } else {
+                            labels.Append(label);
+                        }
+                        labelsByIndex.Add(index, label);
+                    }
+
+                    ApplyDataLabelOverrides(label, showLegendKey, showValue, showCategoryName, showSeriesName,
+                        showPercent, showBubbleSize, position, numberFormat, sourceLinked);
+                }
+            });
+
+            if (!applied) {
+                throw new InvalidOperationException($"Series index {seriesIndex} was not found.");
+            }
+
+            Save();
+            return this;
+        }
+
         /// <summary>
         /// Configures a single data label point by series name and point index.
         /// </summary>

--- a/OfficeIMO.Excel/ExcelDocument.NamedRanges.cs
+++ b/OfficeIMO.Excel/ExcelDocument.NamedRanges.cs
@@ -396,17 +396,18 @@ namespace OfficeIMO.Excel {
             a1 = a1.Replace("$", string.Empty);
 
             int r1, c1, r2, c2;
-            if (!A1.TryParseRange(a1, out r1, out c1, out r2, out c2)) {
+            if (!A1.TryParseRangeCoordinates(a1,
+                    out r1, out c1, out r2, out c2)) {
                 bool containsColon = a1.IndexOf(':') >= 0;
-                var cell = A1.ParseCellRef(a1);
-                if (cell.Row <= 0 || cell.Col <= 0) {
+                if (!A1.TryParseCellReferenceCoordinates(a1,
+                        out int cellRow, out int cellColumn)) {
                     string message = containsColon
                         ? "Range must be a valid A1 reference such as 'A1:B2'."
                         : "Range must be a valid A1 reference such as 'A1' or 'A1:B2'.";
                     throw new ArgumentException(message, nameof(range));
                 }
-                r1 = r2 = cell.Row;
-                c1 = c2 = cell.Col;
+                r1 = r2 = cellRow;
+                c1 = c2 = cellColumn;
             }
 
             // Bounds check: Excel supports 1..1,048,576 rows and 1..16,384 columns (XFD)

--- a/OfficeIMO.Excel/ExcelDocument.PivotInteractions.cs
+++ b/OfficeIMO.Excel/ExcelDocument.PivotInteractions.cs
@@ -93,11 +93,6 @@ namespace OfficeIMO.Excel {
 
         private bool IsDateOnlyPivotSourceField(ExcelPivotTableInfo pivot, string sourceField) {
             PivotTablePart? pivotPart = FindPivotTablePart(pivot);
-            bool? currentSourceResult = TryIsDateOnlyPivotSourceFieldFromCurrentSource(pivot, sourceField, pivotPart);
-            if (currentSourceResult.HasValue) {
-                return currentSourceResult.Value;
-            }
-
             CacheField? cacheField = pivotPart?
                 .PivotTableCacheDefinitionPart?
                 .PivotCacheDefinition?
@@ -116,7 +111,8 @@ namespace OfficeIMO.Excel {
                 }
             }
 
-            return false;
+            return TryIsDateOnlyPivotSourceFieldFromCurrentSource(
+                pivot, sourceField, pivotPart) == true;
         }
 
         private PivotTablePart? FindPivotTablePart(ExcelPivotTableInfo pivot) {
@@ -311,15 +307,19 @@ namespace OfficeIMO.Excel {
             string sourceField,
             IReadOnlyList<ExcelPivotInteractionCacheInfo> existingCaches) {
             string baseName = CreatePivotInteractionCacheName(prefix, sourceField);
-            if (!existingCaches.Any(cache => string.Equals(cache.Name, baseName, StringComparison.OrdinalIgnoreCase))) {
+            var existingNames = new HashSet<string>(
+                existingCaches.Select(cache => cache.Name),
+                StringComparer.OrdinalIgnoreCase);
+            if (!existingNames.Contains(baseName)) {
                 return baseName;
             }
 
-            for (int suffix = 2; suffix < int.MaxValue; suffix++) {
+            long maximumSuffix = (long)existingNames.Count + 1L;
+            for (long suffix = 2; suffix <= maximumSuffix; suffix++) {
                 string suffixText = "_" + suffix.ToString(System.Globalization.CultureInfo.InvariantCulture);
                 int baseLength = Math.Min(baseName.Length, 255 - suffixText.Length);
                 string candidate = baseName.Substring(0, baseLength) + suffixText;
-                if (!existingCaches.Any(cache => string.Equals(cache.Name, candidate, StringComparison.OrdinalIgnoreCase))) {
+                if (!existingNames.Contains(candidate)) {
                     return candidate;
                 }
             }

--- a/OfficeIMO.Excel/ExcelSheet.Formulas.DefinedNames.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Formulas.DefinedNames.cs
@@ -13,13 +13,16 @@ namespace OfficeIMO.Excel {
 
             internal FormulaDefinedNameResolutionCatalog(ExcelSheet owner) {
                 _sheets = owner.WorkbookRoot.Sheets?.Elements<Sheet>().ToList() ?? new List<Sheet>();
+                var worksheetRelationshipIds = new HashSet<string>(
+                    owner.WorkbookPartRoot.Parts
+                        .Where(pair => pair.OpenXmlPart is DocumentFormat.OpenXml.Packaging.WorksheetPart)
+                        .Select(pair => pair.RelationshipId),
+                    StringComparer.Ordinal);
                 for (int index = 0; index < _sheets.Count; index++) {
                     string? sheetName = _sheets[index].Name?.Value;
                     string? relationshipId = _sheets[index].Id?.Value;
                     bool validWorksheet = !string.IsNullOrWhiteSpace(relationshipId)
-                        && owner.WorkbookPartRoot.Parts.Any(pair =>
-                            string.Equals(pair.RelationshipId, relationshipId, StringComparison.Ordinal)
-                            && pair.OpenXmlPart is DocumentFormat.OpenXml.Packaging.WorksheetPart);
+                        && worksheetRelationshipIds.Contains(relationshipId!);
                     if (validWorksheet) _validSheetIndexes.Add(index);
                     if (validWorksheet && !string.IsNullOrWhiteSpace(sheetName) && !_sheetIndexes.ContainsKey(sheetName!)) {
                         _sheetIndexes.Add(sheetName!, index);

--- a/OfficeIMO.Excel/ExcelSheet.Formulas.DefinedNames.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Formulas.DefinedNames.cs
@@ -7,6 +7,7 @@ namespace OfficeIMO.Excel {
 
         private sealed class FormulaDefinedNameResolutionCatalog {
             private readonly List<Sheet> _sheets;
+            private readonly HashSet<int> _validSheetIndexes = new HashSet<int>();
             private readonly Dictionary<string, int> _sheetIndexes = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
             private readonly Dictionary<string, DefinedName> _definedNames = new Dictionary<string, DefinedName>(StringComparer.OrdinalIgnoreCase);
 
@@ -14,7 +15,13 @@ namespace OfficeIMO.Excel {
                 _sheets = owner.WorkbookRoot.Sheets?.Elements<Sheet>().ToList() ?? new List<Sheet>();
                 for (int index = 0; index < _sheets.Count; index++) {
                     string? sheetName = _sheets[index].Name?.Value;
-                    if (!string.IsNullOrWhiteSpace(sheetName) && !_sheetIndexes.ContainsKey(sheetName!)) {
+                    string? relationshipId = _sheets[index].Id?.Value;
+                    bool validWorksheet = !string.IsNullOrWhiteSpace(relationshipId)
+                        && owner.WorkbookPartRoot.Parts.Any(pair =>
+                            string.Equals(pair.RelationshipId, relationshipId, StringComparison.Ordinal)
+                            && pair.OpenXmlPart is DocumentFormat.OpenXml.Packaging.WorksheetPart);
+                    if (validWorksheet) _validSheetIndexes.Add(index);
+                    if (validWorksheet && !string.IsNullOrWhiteSpace(sheetName) && !_sheetIndexes.ContainsKey(sheetName!)) {
                         _sheetIndexes.Add(sheetName!, index);
                     }
                 }
@@ -43,7 +50,7 @@ namespace OfficeIMO.Excel {
             }
 
             internal bool TryGetSheet(uint index, out Sheet sheet) {
-                if (index < (uint)_sheets.Count) {
+                if (index < (uint)_sheets.Count && _validSheetIndexes.Contains((int)index)) {
                     sheet = _sheets[(int)index];
                     return true;
                 }

--- a/OfficeIMO.Excel/ExcelSheet.Formulas.Shared.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Formulas.Shared.cs
@@ -30,6 +30,7 @@ namespace OfficeIMO.Excel {
                 if (cellFormula?.FormulaType?.Value != CellFormulaValues.Shared
                     || cellFormula.SharedIndex?.Value is not uint sharedIndex
                     || string.IsNullOrWhiteSpace(cellFormula.Text)
+                    || cellFormula.Text.Length > MaxSupportedFormulaLength
                     || !A1.TryParseCellReferenceFast(cell.CellReference?.Value, out int row, out int column)) {
                     continue;
                 }
@@ -121,7 +122,8 @@ namespace OfficeIMO.Excel {
         }
 
         private string TranslateSharedFormula(string formula, int rowOffset, int columnOffset) {
-            if (formula.Length == 0 || (rowOffset == 0 && columnOffset == 0)) {
+            if (formula.Length == 0 || formula.Length > MaxSupportedFormulaLength
+                || (rowOffset == 0 && columnOffset == 0)) {
                 return formula;
             }
 

--- a/OfficeIMO.Excel/ExcelSheet.ModernChartRecipes.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ModernChartRecipes.cs
@@ -265,18 +265,27 @@ namespace OfficeIMO.Excel {
                 .SetValueAxisGridlines(showMajor: true, showMinor: false, lineColor: "E5E7EB", lineWidthPoints: 0.5)
                 .SetValueAxisNumberFormat(waterfallNumberFormat, sourceLinked: false);
 
+            var increasePoints = new List<int>();
+            var decreasePoints = new List<int>();
             for (int index = 0; index < points.Count; index++) {
                 if (points[index].Value > 0) {
-                    chart.SetSeriesDataLabelForPoint(1, index, showValue: true,
-                        position: C.DataLabelPositionValues.OutsideEnd, numberFormat: "+" + waterfallNumberFormat);
+                    increasePoints.Add(index);
                 } else if (points[index].Value < 0) {
-                    chart.SetSeriesDataLabelForPoint(2, index, showValue: true,
-                        position: C.DataLabelPositionValues.OutsideEnd, numberFormat: "-" + waterfallNumberFormat);
+                    decreasePoints.Add(index);
                 }
             }
 
+            if (increasePoints.Count > 0) {
+                chart.SetSeriesDataLabelsForPoints(1, increasePoints, showValue: true,
+                    position: C.DataLabelPositionValues.OutsideEnd, numberFormat: "+" + waterfallNumberFormat);
+            }
+            if (decreasePoints.Count > 0) {
+                chart.SetSeriesDataLabelsForPoints(2, decreasePoints, showValue: true,
+                    position: C.DataLabelPositionValues.OutsideEnd, numberFormat: "-" + waterfallNumberFormat);
+            }
+
             if (includeTotal) {
-                chart.SetSeriesDataLabelForPoint(3, count - 1, showValue: true,
+                chart.SetSeriesDataLabelsForPoints(3, new[] { count - 1 }, showValue: true,
                     position: C.DataLabelPositionValues.OutsideEnd, numberFormat: waterfallNumberFormat);
             }
 

--- a/OfficeIMO.Excel/LegacyXls/Write/LegacyXlsConditionalFormattingWriter.cs
+++ b/OfficeIMO.Excel/LegacyXls/Write/LegacyXlsConditionalFormattingWriter.cs
@@ -431,8 +431,11 @@ namespace OfficeIMO.Excel.LegacyXls.Write {
             var parsed = new List<CellRange>(parts.Length);
             foreach (string part in parts) {
                 string rangeText = part.Replace("$", string.Empty);
-                if (!A1.TryParseRange(rangeText, out int firstRow, out int firstColumn, out int lastRow, out int lastColumn)) {
-                    if (!A1.TryParseCellReferenceFast(rangeText, out firstRow, out firstColumn)) {
+                if (!A1.TryParseRangeCoordinates(rangeText,
+                        out int firstRow, out int firstColumn,
+                        out int lastRow, out int lastColumn)) {
+                    if (!A1.TryParseCellReferenceCoordinates(rangeText,
+                            out firstRow, out firstColumn)) {
                         reason = "conditional formatting ranges";
                         return false;
                     }

--- a/OfficeIMO.Excel/LegacyXls/Write/LegacyXlsDataValidationWriter.cs
+++ b/OfficeIMO.Excel/LegacyXls/Write/LegacyXlsDataValidationWriter.cs
@@ -354,8 +354,11 @@ namespace OfficeIMO.Excel.LegacyXls.Write {
             var parsed = new List<CellRange>(parts.Length);
             foreach (string part in parts) {
                 string rangeText = part.Replace("$", string.Empty);
-                if (!A1.TryParseRange(rangeText, out int firstRow, out int firstColumn, out int lastRow, out int lastColumn)) {
-                    if (!A1.TryParseCellReferenceFast(rangeText, out firstRow, out firstColumn)) {
+                if (!A1.TryParseRangeCoordinates(rangeText,
+                        out int firstRow, out int firstColumn,
+                        out int lastRow, out int lastColumn)) {
+                    if (!A1.TryParseCellReferenceCoordinates(rangeText,
+                            out firstRow, out firstColumn)) {
                         reason = "data validation ranges";
                         return false;
                     }

--- a/OfficeIMO.Excel/Read/Helpers/A1.cs
+++ b/OfficeIMO.Excel/Read/Helpers/A1.cs
@@ -354,7 +354,7 @@ namespace OfficeIMO.Excel {
                     row = (row * 10) + digit;
                 }
 
-                if (row <= 0 || col <= 0) {
+                if (row <= 0 || row > MaxRows || col <= 0 || col > MaxColumns) {
                     row = 0;
                     col = 0;
                     return false;
@@ -656,7 +656,7 @@ namespace OfficeIMO.Excel {
                 row = row * 10 + digit;
             }
 
-            if (row <= 0 || col <= 0) {
+            if (row <= 0 || row > MaxRows || col <= 0 || col > MaxColumns) {
                 row = 0;
                 col = 0;
                 return false;

--- a/OfficeIMO.Excel/Read/Helpers/A1.cs
+++ b/OfficeIMO.Excel/Read/Helpers/A1.cs
@@ -48,6 +48,40 @@ namespace OfficeIMO.Excel {
             return true;
         }
 
+        internal static bool TryParseRangeCoordinates(string a1Range,
+            out int r1, out int c1, out int r2, out int c2) {
+            r1 = c1 = r2 = c2 = 0;
+            if (string.IsNullOrWhiteSpace(a1Range)) return false;
+            int start = 0;
+            int length = a1Range.Length;
+            TrimBounds(a1Range, ref start, ref length);
+
+            int separator = a1Range.IndexOf(':', start, length);
+            if (separator < 0
+                || separator != a1Range.LastIndexOf(':', start + length - 1,
+                    length)) {
+                return false;
+            }
+
+            if (!TryParseCellRef(a1Range, start, separator - start,
+                    out r1, out c1, enforceWorksheetBounds: false)
+                || !TryParseCellRef(a1Range, separator + 1,
+                    start + length - separator - 1, out r2, out c2,
+                    enforceWorksheetBounds: false)) {
+                r1 = c1 = r2 = c2 = 0;
+                return false;
+            }
+
+            if (c1 > c2) (c1, c2) = (c2, c1);
+            if (r1 > r2) (r1, r2) = (r2, r1);
+            return true;
+        }
+
+        internal static bool TryParseCellReferenceCoordinates(string? cellRef,
+            out int row, out int column) => TryParseCellRef(cellRef, 0,
+            cellRef?.Length ?? 0, out row, out column,
+            enforceWorksheetBounds: false);
+
         internal static bool TryParseWholeColumnRange(string reference, out int c1, out int c2) {
             c1 = c2 = 0;
             if (!TrySplitWholeRange(reference, out string start, out string end)
@@ -597,7 +631,8 @@ namespace OfficeIMO.Excel {
             return BuildCellReference(row, column, absolute: true);
         }
 
-        private static bool TryParseCellRef(string? text, int start, int length, out int row, out int col) {
+        private static bool TryParseCellRef(string? text, int start, int length,
+            out int row, out int col, bool enforceWorksheetBounds = true) {
             row = 0;
             col = 0;
             if (string.IsNullOrEmpty(text) || length <= 0) {
@@ -656,7 +691,9 @@ namespace OfficeIMO.Excel {
                 row = row * 10 + digit;
             }
 
-            if (row <= 0 || row > MaxRows || col <= 0 || col > MaxColumns) {
+            if (row <= 0 || col <= 0
+                || (enforceWorksheetBounds
+                    && (row > MaxRows || col > MaxColumns))) {
                 row = 0;
                 col = 0;
                 return false;

--- a/OfficeIMO.Html.Pdf/HtmlPdfSaveOptions.cs
+++ b/OfficeIMO.Html.Pdf/HtmlPdfSaveOptions.cs
@@ -30,15 +30,13 @@ public sealed class HtmlPdfSaveOptions : HtmlRenderOptions {
 
     /// <summary>
     /// Creates PDF-capable options from shared HTML rendering settings without changing their layout mode.
-    /// PDF conversion enforces paged layout on its own conversion snapshot and applies PDF-safe hyperlink defaults.
+    /// PDF conversion enforces paged layout on its own conversion snapshot.
     /// </summary>
     /// <param name="renderOptions">Shared settings used by PNG, SVG, and PDF rendering.</param>
-    /// <remarks>Set <see cref="HtmlRenderOptions.UrlPolicy"/> on the returned options to explicitly use a different hyperlink policy.</remarks>
+    /// <remarks>The supplied URL policy is preserved. The parameterless constructor provides the PDF hyperlink default.</remarks>
     public HtmlPdfSaveOptions(HtmlRenderOptions renderOptions) : base(renderOptions) {
         if (renderOptions is HtmlPdfSaveOptions pdfOptions) {
             CopyPdfSettingsFrom(pdfOptions);
-        } else {
-            UrlPolicy = HtmlUrlPolicy.CreateHyperlinkProfile();
         }
     }
 

--- a/OfficeIMO.Html.Tests/Html.ApiConsistency.cs
+++ b/OfficeIMO.Html.Tests/Html.ApiConsistency.cs
@@ -149,6 +149,19 @@ public sealed class HtmlApiConsistencyTests {
     }
 
     [Fact]
+    public void HtmlPdfOptions_FromRenderOptionsPreserveCallerUrlPolicy() {
+        var source = new HtmlRenderOptions {
+            UrlPolicy = HtmlUrlPolicy.CreateOfficeIMOProfile()
+        };
+
+        var copied = new HtmlPdfSaveOptions(source);
+
+        Assert.False(copied.UrlPolicy.RestrictUrlSchemes);
+        Assert.False(copied.UrlPolicy.DisallowFileUrls);
+        Assert.True(copied.UrlPolicy.AllowDataUrls);
+    }
+
+    [Fact]
     public void HtmlPdf_ByteSerializationHonorsCancellation() {
         PdfCore.PdfDocumentConversionResult result = OfficeIMO.Html.HtmlConversionDocument.Parse("<p>Cancellation contract</p>").ToPdfDocumentResult();
         using var cancellation = new CancellationTokenSource();

--- a/OfficeIMO.OneNote.Tests/OneNoteRenderingTests.cs
+++ b/OfficeIMO.OneNote.Tests/OneNoteRenderingTests.cs
@@ -689,6 +689,36 @@ public sealed class OneNoteRenderingTests {
     }
 
     [Fact]
+    public void AutomaticCanvasCapsUntrustedImageDimensionsInsideParagraphs() {
+        var page = new OneNotePage { PageSize = OneNotePageSize.Automatic };
+        var paragraph = new OneNoteParagraph();
+        paragraph.Children.Add(new OneNoteImage {
+            FileName = "paragraph-oversized.png",
+            Layout = new OneNoteLayout {
+                Width = double.MaxValue,
+                Height = double.MaxValue
+            },
+            Payload = OneNoteBinaryPayload.FromBytes(OfficePngWriter.Encode(
+                new OfficeRasterImage(1, 1, OfficeColor.CornflowerBlue)))
+        });
+        page.DirectContent.Add(paragraph);
+        var options = new OneNotePageRenderingOptions {
+            IncludeTitle = false,
+            MaximumImageDimensionPoints = 100D,
+            AutomaticPagePaddingPoints = 10D
+        };
+
+        OfficeDrawing drawing = page.ToDrawing(options);
+        OfficeDrawingImage image = Assert.Single(drawing.Elements
+            .OfType<OfficeDrawingImage>());
+
+        Assert.InRange(image.Projection.Width, 1D, 100D);
+        Assert.InRange(image.Projection.Height, 1D, 100D);
+        Assert.InRange(drawing.Width, 1D, 800D);
+        Assert.InRange(drawing.Height, 1D, 800D);
+    }
+
+    [Fact]
     public void AutomaticCanvasDoesNotRematerializeImagesBetweenMeasurementPasses() {
         byte[] payload = OfficePngWriter.Encode(new OfficeRasterImage(10, 1600, OfficeColor.CornflowerBlue));
         int opens = 0;

--- a/OfficeIMO.OneNote.Tests/OneNoteRenderingTests.cs
+++ b/OfficeIMO.OneNote.Tests/OneNoteRenderingTests.cs
@@ -661,6 +661,34 @@ public sealed class OneNoteRenderingTests {
     }
 
     [Fact]
+    public void AutomaticCanvasCapsUntrustedImageDimensionsInsideOutlines() {
+        var page = new OneNotePage { PageSize = OneNotePageSize.Automatic };
+        var outline = new OneNoteOutline {
+            Layout = new OneNoteLayout { Width = 2D }
+        };
+        outline.Children.Add(new OneNoteImage {
+            FileName = "nested-oversized.png",
+            Layout = new OneNoteLayout { Width = double.MaxValue, Height = double.MaxValue },
+            Payload = OneNoteBinaryPayload.FromBytes(OfficePngWriter.Encode(
+                new OfficeRasterImage(1, 1, OfficeColor.CornflowerBlue)))
+        });
+        page.Outlines.Add(outline);
+        var options = new OneNotePageRenderingOptions {
+            IncludeTitle = false,
+            MaximumImageDimensionPoints = 100D,
+            AutomaticPagePaddingPoints = 10D
+        };
+
+        OfficeDrawing drawing = page.ToDrawing(options);
+        OfficeDrawingImage image = Assert.Single(drawing.Elements.OfType<OfficeDrawingImage>());
+
+        Assert.InRange(image.Projection.Width, 1D, 100D);
+        Assert.InRange(image.Projection.Height, 1D, 100D);
+        Assert.InRange(drawing.Width, 1D, 800D);
+        Assert.InRange(drawing.Height, 1D, 800D);
+    }
+
+    [Fact]
     public void AutomaticCanvasDoesNotRematerializeImagesBetweenMeasurementPasses() {
         byte[] payload = OfficePngWriter.Encode(new OfficeRasterImage(10, 1600, OfficeColor.CornflowerBlue));
         int opens = 0;

--- a/OfficeIMO.OneNote.Tests/OneNoteRenderingTests.cs
+++ b/OfficeIMO.OneNote.Tests/OneNoteRenderingTests.cs
@@ -637,6 +637,30 @@ public sealed class OneNoteRenderingTests {
     }
 
     [Fact]
+    public void AutomaticCanvasCapsUntrustedImageLayoutDimensions() {
+        var page = new OneNotePage { PageSize = OneNotePageSize.Automatic };
+        page.DirectContent.Add(new OneNoteImage {
+            FileName = "oversized.png",
+            Layout = new OneNoteLayout { Width = double.MaxValue, Height = double.MaxValue },
+            Payload = OneNoteBinaryPayload.FromBytes(OfficePngWriter.Encode(
+                new OfficeRasterImage(1, 1, OfficeColor.CornflowerBlue)))
+        });
+        var options = new OneNotePageRenderingOptions {
+            IncludeTitle = false,
+            MaximumImageDimensionPoints = 100D,
+            AutomaticPagePaddingPoints = 10D
+        };
+
+        OfficeDrawing drawing = page.ToDrawing(options);
+        OfficeDrawingImage image = Assert.Single(drawing.Elements.OfType<OfficeDrawingImage>());
+
+        Assert.InRange(image.Projection.Width, 1D, 100D);
+        Assert.InRange(image.Projection.Height, 1D, 100D);
+        Assert.InRange(drawing.Width, 1D, 800D);
+        Assert.InRange(drawing.Height, 1D, 800D);
+    }
+
+    [Fact]
     public void AutomaticCanvasDoesNotRematerializeImagesBetweenMeasurementPasses() {
         byte[] payload = OfficePngWriter.Encode(new OfficeRasterImage(10, 1600, OfficeColor.CornflowerBlue));
         int opens = 0;

--- a/OfficeIMO.OneNote/Rendering/OneNotePageRenderer.Elements.cs
+++ b/OfficeIMO.OneNote/Rendering/OneNotePageRenderer.Elements.cs
@@ -287,9 +287,7 @@ public static partial class OneNotePageRenderer {
                     ? element.Layout.Y.Value * PointsPerHalfInch
                     : cursor + Math.Max(pendingSpace, ParagraphSpaceBefore(element));
                 double remainingWidth = Math.Max(1D, width - Math.Max(0D, elementX));
-                double elementWidth = element.Layout?.Width.HasValue == true
-                    ? Math.Max(1D, element.Layout.Width.Value * PointsPerHalfInch)
-                    : remainingWidth;
+                double elementWidth = ResolveEstimatedWidth(element, remainingWidth, _options);
                 double elementHeight = MeasureElementHeight(element, elementWidth);
                 double extentWidth = MeasureElementWidthExtent(element, elementWidth);
                 right = Math.Max(right, elementX + extentWidth);
@@ -335,9 +333,10 @@ public static partial class OneNotePageRenderer {
                 double childY = child.Layout?.Y.HasValue == true
                     ? child.Layout.Y.Value * PointsPerHalfInch
                     : cursor + Math.Max(pendingSpace, ParagraphSpaceBefore(child));
-                double childWidth = child.Layout?.Width.HasValue == true
-                    ? Math.Max(1D, child.Layout.Width.Value * PointsPerHalfInch)
-                    : Math.Max(1D, width - Math.Max(0D, childX));
+                double childWidth = ResolveEstimatedWidth(
+                    child,
+                    Math.Max(1D, width - Math.Max(0D, childX)),
+                    _options);
                 double childHeight = child.Layout?.Height.HasValue == true
                     ? Math.Max(1D, child.Layout.Height.Value * PointsPerHalfInch)
                     : MeasureElementHeight(child, childWidth);

--- a/OfficeIMO.OneNote/Rendering/OneNotePageRenderer.Elements.cs
+++ b/OfficeIMO.OneNote/Rendering/OneNotePageRenderer.Elements.cs
@@ -68,7 +68,8 @@ public static partial class OneNotePageRenderer {
             }
             availableWidth = Math.Min(availableWidth, _drawing.Width - x);
             if (availableWidth <= 0D) return 0D;
-            double explicitHeight = element.Layout?.Height.HasValue == true
+            double explicitHeight = element is not OneNoteImage
+                && element.Layout?.Height.HasValue == true
                 ? Math.Max(0D, element.Layout.Height.Value * PointsPerHalfInch)
                 : 0D;
             if (explicitHeight > 0D) availableHeight = explicitHeight;
@@ -337,9 +338,7 @@ public static partial class OneNotePageRenderer {
                     child,
                     Math.Max(1D, width - Math.Max(0D, childX)),
                     _options);
-                double childHeight = child.Layout?.Height.HasValue == true
-                    ? Math.Max(1D, child.Layout.Height.Value * PointsPerHalfInch)
-                    : MeasureElementHeight(child, childWidth);
+                double childHeight = MeasureElementHeight(child, childWidth);
                 bottom = Math.Max(bottom, childY + childHeight);
                 if (participatesInFlow) {
                     cursor = Math.Max(cursor, childY + childHeight);

--- a/OfficeIMO.OneNote/Rendering/OneNotePageRenderer.Elements.cs
+++ b/OfficeIMO.OneNote/Rendering/OneNotePageRenderer.Elements.cs
@@ -244,19 +244,18 @@ public static partial class OneNotePageRenderer {
             Math.Max(fontSize * 1.25D, ParagraphDistance(paragraph.Style.ExactLineSpacing));
 
         internal double MeasureElementHeight(OneNoteElement element, double width) {
-            if (element.Layout?.Height.HasValue == true) return Math.Max(1D, element.Layout.Height.Value * PointsPerHalfInch);
-            if (element is OneNoteParagraph paragraph) return MeasureParagraphHeight(paragraph, width);
-            if (element is OneNoteOutline outline) return MeasureElementsBounds(outline.Children, width).Bottom;
-            if (element is OneNoteTable table) return MeasureTableHeight(table, width);
             if (element is OneNoteImage image) {
                 if (!_options.IncludeImages) return 0D;
-                if (image.HeightHalfInches.HasValue) return Math.Max(1D, image.HeightHalfInches.Value * PointsPerHalfInch);
                 if (TryIdentifyImage(image, out OfficeImageInfo? info)) {
                     double renderWidth = ResolveImageWidth(image, info, width);
                     return Math.Max(1D, ResolveImageHeight(image, info, renderWidth));
                 }
-                return Math.Max(80D, Math.Min(240D, width) * 0.6D);
+                return ResolveImageHeight(image, null, width);
             }
+            if (element.Layout?.Height.HasValue == true) return Math.Max(1D, element.Layout.Height.Value * PointsPerHalfInch);
+            if (element is OneNoteParagraph paragraph) return MeasureParagraphHeight(paragraph, width);
+            if (element is OneNoteOutline outline) return MeasureElementsBounds(outline.Children, width).Bottom;
+            if (element is OneNoteTable table) return MeasureTableHeight(table, width);
             if (element is OneNoteInk ink) {
                 OfficeInkBounds bounds = ink.Ink.GetBounds();
                 if (bounds.IsEmpty) return DefaultParagraphHeight;
@@ -705,18 +704,34 @@ public static partial class OneNotePageRenderer {
         }
 
         private double ResolveImageWidth(OneNoteImage image, OfficeImageInfo? info, double fallback) {
-            if (image.Layout?.Width.HasValue == true) return image.Layout.Width.Value * PointsPerHalfInch;
-            if (image.WidthHalfInches.HasValue) return image.WidthHalfInches.Value * PointsPerHalfInch;
-            if (info != null && info.Width > 0) return info.Width / info.DpiX * 72D;
-            return Math.Min(240D, fallback);
+            double resolved;
+            if (image.Layout?.Width.HasValue == true) resolved = image.Layout.Width.Value * PointsPerHalfInch;
+            else if (image.WidthHalfInches.HasValue) resolved = image.WidthHalfInches.Value * PointsPerHalfInch;
+            else if (info != null && info.Width > 0 && IsFinitePositive(info.DpiX)) resolved = info.Width / info.DpiX * 72D;
+            else resolved = Math.Min(240D, fallback);
+            return ClampImageDimension(resolved, Math.Min(240D, fallback));
         }
 
-        private static double ResolveImageHeight(OneNoteImage image, OfficeImageInfo? info, double width) {
-            if (image.Layout?.Height.HasValue == true) return image.Layout.Height.Value * PointsPerHalfInch;
-            if (image.HeightHalfInches.HasValue) return image.HeightHalfInches.Value * PointsPerHalfInch;
-            if (info?.AspectRatio.HasValue == true) return width / info.AspectRatio.Value;
-            return Math.Max(80D, width * 0.6D);
+        private double ResolveImageHeight(OneNoteImage image, OfficeImageInfo? info, double width) {
+            double fallback = Math.Max(80D, Math.Min(width, _options.MaximumImageDimensionPoints) * 0.6D);
+            double resolved;
+            if (image.Layout?.Height.HasValue == true) resolved = image.Layout.Height.Value * PointsPerHalfInch;
+            else if (image.HeightHalfInches.HasValue) resolved = image.HeightHalfInches.Value * PointsPerHalfInch;
+            else if (info?.AspectRatio.HasValue == true && IsFinitePositive(info.AspectRatio.Value)) {
+                resolved = width / info.AspectRatio.Value;
+            } else {
+                resolved = fallback;
+            }
+            return ClampImageDimension(resolved, fallback);
         }
+
+        private double ClampImageDimension(double value, double fallback) {
+            double resolved = IsFinitePositive(value) ? value : Math.Max(1D, fallback);
+            return Math.Max(1D, Math.Min(resolved, _options.MaximumImageDimensionPoints));
+        }
+
+        private static bool IsFinitePositive(double value) =>
+            !double.IsNaN(value) && !double.IsInfinity(value) && value > 0D;
 
         private OfficeMathRenderOptions CreateMathOptions(OneNoteTextRun run) {
             OfficeMathRenderOptions options = _options.Math.Clone();

--- a/OfficeIMO.OneNote/Rendering/OneNotePageRenderer.cs
+++ b/OfficeIMO.OneNote/Rendering/OneNotePageRenderer.cs
@@ -161,10 +161,11 @@ public static partial class OneNotePageRenderer {
         OneNoteElement element,
         double fallback,
         OneNotePageRenderingOptions options) {
-        if (element.Layout?.Width.HasValue == true) return Math.Max(1D, element.Layout.Width.Value * PointsPerHalfInch);
-        if (element is OneNoteImage image && image.WidthHalfInches.HasValue) {
-            return Math.Max(1D, image.WidthHalfInches.Value * PointsPerHalfInch);
+        if (element is OneNoteImage image) {
+            double? requested = image.Layout?.Width ?? image.WidthHalfInches;
+            return ResolveBoundedImageDimension(requested, fallback, options.MaximumImageDimensionPoints);
         }
+        if (element.Layout?.Width.HasValue == true) return Math.Max(1D, element.Layout.Width.Value * PointsPerHalfInch);
         if (element is OneNoteInk ink) {
             OfficeInkBounds bounds = ink.Ink.GetBounds();
             if (!bounds.IsEmpty) return Math.Max(1D, (bounds.X + bounds.Width) * PointsPerHalfInch);
@@ -173,6 +174,16 @@ public static partial class OneNotePageRenderer {
             return Math.Max(1D, OfficeMathRenderer.Measure(math.GetExpression(), options.Math).Width);
         }
         return Math.Max(1D, fallback);
+    }
+
+    private static double ResolveBoundedImageDimension(double? halfInches, double fallback, double maximumPoints) {
+        if (!halfInches.HasValue || double.IsNaN(halfInches.Value) || halfInches.Value <= 0D) {
+            return Math.Max(1D, Math.Min(fallback, maximumPoints));
+        }
+        if (double.IsInfinity(halfInches.Value) || halfInches.Value >= maximumPoints / PointsPerHalfInch) {
+            return maximumPoints;
+        }
+        return Math.Max(1D, Math.Min(halfInches.Value * PointsPerHalfInch, maximumPoints));
     }
 
     private static double ResolveMargin(double? origin, double? margin, double fallback) => origin ?? margin ?? fallback;

--- a/OfficeIMO.OneNote/Rendering/OneNotePageRenderingOptions.cs
+++ b/OfficeIMO.OneNote/Rendering/OneNotePageRenderingOptions.cs
@@ -4,6 +4,9 @@ namespace OfficeIMO.OneNote;
 
 /// <summary>Controls dependency-free OneNote page layout, rendering, and image export.</summary>
 public class OneNotePageRenderingOptions : OfficeImageExportOptions {
+    /// <summary>Default maximum logical width or height contributed by one embedded image.</summary>
+    public const double DefaultMaximumImageDimensionPoints = 14_400D;
+
     /// <inheritdoc />
     public override double LogicalUnitsPerInch => 72D;
 
@@ -24,6 +27,9 @@ public class OneNotePageRenderingOptions : OfficeImageExportOptions {
 
     /// <summary>Maximum bytes materialized from any single lazy image payload.</summary>
     public long MaxImageBytes { get; set; } = 64L * 1024L * 1024L;
+
+    /// <summary>Maximum logical width or height inferred from an embedded image header, in points.</summary>
+    public double MaximumImageDimensionPoints { get; set; } = DefaultMaximumImageDimensionPoints;
 
     /// <summary>Minimum width used for automatically sized pages, in points.</summary>
     public double AutomaticPageWidthPoints { get; set; } = 612D;
@@ -54,6 +60,7 @@ public class OneNotePageRenderingOptions : OfficeImageExportOptions {
         clone.IncludeMath = IncludeMath;
         clone.IncludeAttachmentPlaceholders = IncludeAttachmentPlaceholders;
         clone.MaxImageBytes = MaxImageBytes;
+        clone.MaximumImageDimensionPoints = MaximumImageDimensionPoints;
         clone.AutomaticPageWidthPoints = AutomaticPageWidthPoints;
         clone.AutomaticPageHeightPoints = AutomaticPageHeightPoints;
         clone.AutomaticPagePaddingPoints = AutomaticPagePaddingPoints;
@@ -66,6 +73,7 @@ public class OneNotePageRenderingOptions : OfficeImageExportOptions {
     internal void Validate() {
         ValidateImageExportOptions();
         if (MaxImageBytes < 1) throw new ArgumentOutOfRangeException(nameof(MaxImageBytes));
+        ValidatePositive(MaximumImageDimensionPoints, nameof(MaximumImageDimensionPoints));
         ValidatePositive(AutomaticPageWidthPoints, nameof(AutomaticPageWidthPoints));
         ValidatePositive(AutomaticPageHeightPoints, nameof(AutomaticPageHeightPoints));
         if (double.IsNaN(AutomaticPagePaddingPoints) || double.IsInfinity(AutomaticPagePaddingPoints) || AutomaticPagePaddingPoints < 0D) {

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfConverterOptionsApiTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfConverterOptionsApiTests.cs
@@ -6,7 +6,7 @@ namespace OfficeIMO.Tests.Pdf;
 
 public sealed class PdfConverterOptionsApiTests {
     [Fact]
-    public void ConverterOptionsExposeUnifiedBalancedResourceDefaults() {
+    public void ConverterOptionsExposeExpectedResourceDefaults() {
         var markdown = new MarkdownPdfSaveOptions();
         var word = new OfficeIMO.Word.Pdf.PdfSaveOptions();
         var excel = new OfficeIMO.Excel.Pdf.ExcelPdfSaveOptions();
@@ -21,7 +21,7 @@ public sealed class PdfConverterOptionsApiTests {
         Assert.Equal(PdfTextFallbackFeatures.Default, excel.TextFallbacks);
         Assert.Equal(PdfTextFallbackFeatures.Default, powerPoint.TextFallbacks);
         AssertBalancedDefault(markdown.ResourcePolicy);
-        AssertBalancedDefault(word.ResourcePolicy);
+        AssertPortable(word.ResourcePolicy);
         AssertBalancedDefault(excel.ResourcePolicy);
         AssertBalancedDefault(powerPoint.ResourcePolicy);
         AssertBalancedDefault(html.ResourcePolicy);

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfFontFamilyTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfFontFamilyTests.cs
@@ -201,6 +201,34 @@ public class PdfFontFamilyTests {
     }
 
     [Fact]
+    public void NamedOfficeFontRegistrationHonorsInstalledCandidateOrderBeforeReuse() {
+        string[] candidates = {
+            "Arial", "Calibri", "Helvetica", "Times New Roman",
+            "DejaVu Sans", "Liberation Sans", "Noto Sans"
+        };
+        PdfEmbeddedFontFamily[] installed = candidates
+            .Select(candidate => PdfEmbeddedFontFamily.TryFromSystem(
+                candidate,
+                out PdfEmbeddedFontFamily? family)
+                ? family
+                : null)
+            .Where(family => family != null)
+            .Cast<PdfEmbeddedFontFamily>()
+            .GroupBy(family => family.FamilyName, StringComparer.OrdinalIgnoreCase)
+            .Select(group => group.First())
+            .Take(2)
+            .ToArray();
+        if (installed.Length < 2) return;
+        var options = new PdfOptions().RegisterNamedFontFamily(installed[1]);
+
+        Assert.True(options.TryRegisterNamedOfficeFontFamily(
+            installed[0].FamilyName + ", " + installed[1].FamilyName,
+            out string? registeredFamilyName));
+
+        Assert.Equal(installed[0].FamilyName, registeredFamilyName, ignoreCase: true);
+    }
+
+    [Fact]
     public void PdfOptions_UseOfficeFontFamilyFallsBackThroughFamilyListToStandardFont() {
         PdfOptions options = new PdfOptions()
             .UseOfficeFontFamily("OfficeIMO Missing Display, Consolas, monospace", embedSystemFont: false);

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfFontSecurityTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfFontSecurityTests.cs
@@ -9,6 +9,20 @@ namespace OfficeIMO.Tests.Pdf;
 
 public class PdfFontSecurityTests {
     [Fact]
+    public void NamedFontRegistrationRejectsUnboundedDistinctFamilies() {
+        var options = new PdfOptions();
+        for (int index = 0; index < PdfOptions.MaximumNamedFontFamilies; index++) {
+            options.RegisterNamedFontFamily(new PdfEmbeddedFontFamily(
+                "SecurityFont" + index.ToString(), new byte[] { 1 }));
+        }
+
+        Assert.Throws<InvalidOperationException>(() =>
+            options.RegisterNamedFontFamily(new PdfEmbeddedFontFamily("OverflowFont", new byte[] { 1 })));
+        options.RegisterNamedFontFamily(new PdfEmbeddedFontFamily("SecurityFont0", new byte[] { 2 }));
+        Assert.Equal(PdfOptions.MaximumNamedFontFamilies, options.NamedFontFamilies.Count);
+    }
+
+    [Fact]
     public void ToUnicodeCMap_SkipsOversizedSequentialRanges() {
         byte[] cmapBytes = Encoding.ASCII.GetBytes("""
 beginbfchar

--- a/OfficeIMO.Pdf/Options/PdfOptions.NamedFonts.cs
+++ b/OfficeIMO.Pdf/Options/PdfOptions.NamedFonts.cs
@@ -3,6 +3,8 @@ using System.Collections.ObjectModel;
 namespace OfficeIMO.Pdf;
 
 public sealed partial class PdfOptions {
+    internal const int MaximumNamedFontFamilies = 64;
+
     /// <summary>
     /// Embedded named font families available to run-level text without consuming a standard-font slot.
     /// </summary>
@@ -29,6 +31,11 @@ public sealed partial class PdfOptions {
     public PdfOptions RegisterNamedFontFamily(PdfEmbeddedFontFamily fontFamily) {
         Guard.NotNull(fontFamily, nameof(fontFamily));
         string key = NormalizeNamedFontFamilyKey(fontFamily.FamilyName);
+        if ((_namedFontFamilies?.Count ?? 0) >= MaximumNamedFontFamilies
+            && _namedFontFamilies?.ContainsKey(key) != true) {
+            throw new InvalidOperationException(
+                $"No more than {MaximumNamedFontFamilies} named font families can be registered.");
+        }
         (_namedFontFamilies ??= new Dictionary<string, PdfEmbeddedFontFamily>(StringComparer.Ordinal))[key] = fontFamily.Clone();
         RemoveNamedFontProgramCache(key);
         return this;
@@ -42,7 +49,13 @@ public sealed partial class PdfOptions {
     /// <returns>True when an installed embeddable family was found and registered.</returns>
     public bool TryRegisterNamedOfficeFontFamily(string? familyNames, out string? registeredFamilyName) {
         registeredFamilyName = null;
-        if (string.IsNullOrWhiteSpace(familyNames) ||
+        if (TryGetNamedFontFamily(familyNames, out PdfEmbeddedFontFamily? registered)
+            && registered != null) {
+            registeredFamilyName = registered.FamilyName;
+            return true;
+        }
+        if ((_namedFontFamilies?.Count ?? 0) >= MaximumNamedFontFamilies
+            || string.IsNullOrWhiteSpace(familyNames) ||
             !TryLoadOfficeFontFamily(familyNames!, out PdfEmbeddedFontFamily? family) ||
             family == null) {
             return false;

--- a/OfficeIMO.Pdf/Options/PdfOptions.NamedFonts.cs
+++ b/OfficeIMO.Pdf/Options/PdfOptions.NamedFonts.cs
@@ -49,15 +49,19 @@ public sealed partial class PdfOptions {
     /// <returns>True when an installed embeddable family was found and registered.</returns>
     public bool TryRegisterNamedOfficeFontFamily(string? familyNames, out string? registeredFamilyName) {
         registeredFamilyName = null;
-        if (TryGetNamedFontFamily(familyNames, out PdfEmbeddedFontFamily? registered)
-            && registered != null) {
+        if (string.IsNullOrWhiteSpace(familyNames) ||
+            !TryLoadOfficeFontFamily(familyNames!, out PdfEmbeddedFontFamily? family) ||
+            family == null) {
+            return false;
+        }
+
+        string key = NormalizeNamedFontFamilyKey(family.FamilyName);
+        if (_namedFontFamilies != null &&
+            _namedFontFamilies.TryGetValue(key, out PdfEmbeddedFontFamily? registered)) {
             registeredFamilyName = registered.FamilyName;
             return true;
         }
-        if ((_namedFontFamilies?.Count ?? 0) >= MaximumNamedFontFamilies
-            || string.IsNullOrWhiteSpace(familyNames) ||
-            !TryLoadOfficeFontFamily(familyNames!, out PdfEmbeddedFontFamily? family) ||
-            family == null) {
+        if ((_namedFontFamilies?.Count ?? 0) >= MaximumNamedFontFamilies) {
             return false;
         }
 

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.Safety.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.Safety.cs
@@ -2,6 +2,7 @@ using OfficeIMO.Drawing;
 using OfficeIMO.PowerPoint;
 using OfficeIMO.PowerPoint.LegacyPpt;
 using OfficeIMO.PowerPoint.LegacyPpt.Internal;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -310,10 +311,15 @@ namespace OfficeIMO.Tests {
                     .ToInt64();
             Assert.Equal(UnixFileMode.UserRead | UnixFileMode.UserWrite,
                 File.GetUnixFileMode(descriptorPath) & accessBits);
+            int descriptor = temporary.SafeFileHandle.DangerousGetHandle().ToInt32();
+            Assert.NotEqual(0, GetFileDescriptorFlags(descriptor) & 1);
             temporary.WriteByte(0x5A);
             temporary.Position = 0;
             Assert.Equal(0x5A, temporary.ReadByte());
         }
+
+        [DllImport("libc", EntryPoint = "fcntl", SetLastError = true)]
+        private static extern int GetFileDescriptorFlags(int descriptor, int command = 1);
 #endif
 
         [Fact]

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.PictureUpdate.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.PictureUpdate.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using PresentationDocument = DocumentFormat.OpenXml.Packaging.PresentationDocument;
 using OfficeIMO.Drawing;
 using OfficeIMO.PowerPoint;
 using Xunit;
@@ -52,6 +53,31 @@ namespace OfficeIMO.Tests {
         [Fact]
         public void PowerPointImagePartExtensionsRejectUnsupportedWebP() {
             Assert.Throws<NotSupportedException>(() => ImagePartTypeExtensions.FromOfficeImageFormat(OfficeImageFormat.Webp));
+        }
+
+        [Fact]
+        public void DanglingPictureRelationshipReturnsNoContentTypeInsteadOfThrowing() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string imagePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Images", "BackgroundImage.png");
+            try {
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                    presentation.AddSlide().AddPicture(imagePath);
+                    presentation.Save();
+                }
+                using (PresentationDocument package = PresentationDocument.Open(filePath, true)) {
+                    DocumentFormat.OpenXml.Presentation.Picture picture = package.PresentationPart!.SlideParts
+                        .Single().Slide.Descendants<DocumentFormat.OpenXml.Presentation.Picture>().Single();
+                    picture.BlipFill!.Blip!.Embed = "rIdMissingPreview";
+                    package.PresentationPart.SlideParts.Single().Slide.Save();
+                }
+
+                using PowerPointPresentation reopened = PowerPointPresentation.Load(filePath);
+                PowerPointPicture pictureModel = Assert.Single(reopened.Slides.Single().Pictures);
+                Assert.Null(pictureModel.ContentType);
+                Assert.Null(pictureModel.MimeType);
+            } finally {
+                if (File.Exists(filePath)) File.Delete(filePath);
+            }
         }
 
         [Theory]

--- a/OfficeIMO.PowerPoint/PowerPointPicture.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPicture.cs
@@ -54,7 +54,9 @@ namespace OfficeIMO.PowerPoint {
         private ImagePart? GetImagePart() {
             Picture picture = (Picture)Element;
             string? relationshipId = picture.BlipFill?.Blip?.Embed?.Value;
-            return relationshipId != null ? _ownerPart.GetPartById(relationshipId) as ImagePart : null;
+            return relationshipId != null && _ownerPart.TryGetPartById(relationshipId, out OpenXmlPart? part)
+                ? part as ImagePart
+                : null;
         }
 
         /// <summary>

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.Input.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.Input.cs
@@ -419,14 +419,33 @@ namespace OfficeIMO.PowerPoint {
             var template = new StringBuilder(Path.Combine(
                 Path.GetTempPath(), "officeimo-powerpoint-"
                 + Guid.NewGuid().ToString("N") + "-XXXXXX"));
-            int descriptor = CreateSecureTemporaryFile(template,
-                RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
-                    ? 0x01000000
-                    : 0x00080000);
+            bool isMacOS = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+            int descriptor = isMacOS
+                ? CreateSecureTemporaryFile(template)
+                : CreateSecureTemporaryFileWithFlags(template, 0x00080000);
             if (descriptor < 0) {
                 int error = Marshal.GetLastWin32Error();
                 throw new IOException(
                     $"Unable to create a secure temporary presentation file (error {error}).");
+            }
+            if (isMacOS) {
+                int originalDescriptor = descriptor;
+                descriptor = OpenExistingFileDescriptor(
+                    "/dev/fd/" + originalDescriptor,
+                    0x01000002);
+                if (descriptor < 0) {
+                    int error = Marshal.GetLastWin32Error();
+                    new SafeFileHandle(
+                        new IntPtr(originalDescriptor), ownsHandle: true)
+                        .Dispose();
+                    string failedPath = template.ToString();
+                    if (File.Exists(failedPath)) File.Delete(failedPath);
+                    throw new IOException(
+                        $"Unable to protect a temporary presentation descriptor from child processes (error {error}).");
+                }
+                new SafeFileHandle(
+                    new IntPtr(originalDescriptor), ownsHandle: true)
+                    .Dispose();
             }
             var handle = new SafeFileHandle(
                 new IntPtr(descriptor), ownsHandle: true);
@@ -442,9 +461,18 @@ namespace OfficeIMO.PowerPoint {
             }
         }
 
-        [DllImport("libc", EntryPoint = "mkostemp", SetLastError = true,
+        [DllImport("libc", EntryPoint = "mkstemp", SetLastError = true,
             CharSet = CharSet.Ansi)]
         private static extern int CreateSecureTemporaryFile(
+            StringBuilder template);
+
+        [DllImport("libc", EntryPoint = "mkostemp", SetLastError = true,
+            CharSet = CharSet.Ansi)]
+        private static extern int CreateSecureTemporaryFileWithFlags(
             StringBuilder template, int flags);
+
+        [DllImport("libc", EntryPoint = "open", SetLastError = true,
+            CharSet = CharSet.Ansi)]
+        private static extern int OpenExistingFileDescriptor(string path, int flags);
     }
 }

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.Input.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.Input.cs
@@ -419,7 +419,10 @@ namespace OfficeIMO.PowerPoint {
             var template = new StringBuilder(Path.Combine(
                 Path.GetTempPath(), "officeimo-powerpoint-"
                 + Guid.NewGuid().ToString("N") + "-XXXXXX"));
-            int descriptor = CreateSecureTemporaryFile(template);
+            int descriptor = CreateSecureTemporaryFile(template,
+                RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+                    ? 0x01000000
+                    : 0x00080000);
             if (descriptor < 0) {
                 int error = Marshal.GetLastWin32Error();
                 throw new IOException(
@@ -439,9 +442,9 @@ namespace OfficeIMO.PowerPoint {
             }
         }
 
-        [DllImport("libc", EntryPoint = "mkstemp", SetLastError = true,
+        [DllImport("libc", EntryPoint = "mkostemp", SetLastError = true,
             CharSet = CharSet.Ansi)]
         private static extern int CreateSecureTemporaryFile(
-            StringBuilder template);
+            StringBuilder template, int flags);
     }
 }

--- a/OfficeIMO.Reader.All/OfficeDocumentReaderBuilderAllExtensions.cs
+++ b/OfficeIMO.Reader.All/OfficeDocumentReaderBuilderAllExtensions.cs
@@ -41,6 +41,9 @@ public static class OfficeDocumentReaderBuilderAllExtensions {
         if (builder == null) throw new ArgumentNullException(nameof(builder));
 
         ReaderAllOptions configured = options ?? new ReaderAllOptions();
+        ReaderOneNoteOptions oneNoteOptions = configured.OneNote ?? new ReaderOneNoteOptions {
+            AllowTableOfContentsSiblingFileReads = false
+        };
         return builder
             .AddPlainTextHandlers()
             .AddAsciiDocHandler(configured.AsciiDoc)
@@ -54,7 +57,7 @@ public static class OfficeDocumentReaderBuilderAllExtensions {
             .AddLatexHandler(configured.Latex)
             .AddMarkdownHandler(configured.Markdown)
             .AddNotebookHandler(configured.Notebook)
-            .AddOneNoteHandler(configured.OneNote)
+            .AddOneNoteHandler(oneNoteOptions)
             .AddOpenDocumentHandler(configured.OpenDocument)
             .AddPdfHandler(configured.Pdf)
             .AddPowerPointHandler(configured.PowerPoint)

--- a/OfficeIMO.Reader.All/ReaderAllOptions.cs
+++ b/OfficeIMO.Reader.All/ReaderAllOptions.cs
@@ -41,7 +41,10 @@ public sealed class ReaderAllOptions {
     /// <summary>Gets or sets Jupyter Notebook adapter options.</summary>
     public Notebook.ReaderNotebookOptions? Notebook { get; set; }
 
-    /// <summary>Gets or sets offline OneNote adapter options.</summary>
+    /// <summary>
+    /// Gets or sets offline OneNote adapter options. When omitted, the all-formats preset does not follow sibling
+    /// files referenced by a <c>.onetoc2</c> path. Supply explicit options to opt into that compatibility behavior.
+    /// </summary>
     public OneNote.ReaderOneNoteOptions? OneNote { get; set; }
 
     /// <summary>Gets or sets OpenDocument adapter options.</summary>

--- a/OfficeIMO.Reader.Core/OfficeDocumentSearch.cs
+++ b/OfficeIMO.Reader.Core/OfficeDocumentSearch.cs
@@ -229,9 +229,16 @@ public static partial class OfficeDocumentReadResultExtensions {
             string query,
             StringComparison comparison,
             bool wholeWord,
-        IReadOnlyList<int> sourceOccurrenceIndexes,
-        out bool hasConflictingPageEvidence) {
+            IReadOnlyList<int> sourceOccurrenceIndexes,
+            out bool hasConflictingPageEvidence) {
         hasConflictingPageEvidence = false;
+        if (sourceText.Length > MaximumFallbackCorrelationCharacters) {
+            hasConflictingPageEvidence = true;
+            return null;
+        }
+        if (HasRepeatedCompleteBlockCopies(locations, blockId, sourceText)) {
+            return null;
+        }
         if (!TryGetCaseInsensitiveOccurrenceOrdinals(
                 sourceText,
                 query,
@@ -264,6 +271,11 @@ public static partial class OfficeDocumentReadResultExtensions {
         }
 
         string combinedText = combined.ToString();
+        if (CountCaseInsensitiveOccurrences(combinedText, query) !=
+            CountCaseInsensitiveOccurrences(sourceText, query)) {
+            hasConflictingPageEvidence = true;
+            return null;
+        }
         var fragmentOccurrenceIndexes = new List<int>(stableOrdinals.Count);
         bool foundSelectedOccurrences = CollectOccurrenceIndexesAtOrdinals(
             combinedText,
@@ -271,10 +283,7 @@ public static partial class OfficeDocumentReadResultExtensions {
             stableOrdinals,
             fragmentOccurrenceIndexes);
         if (!foundSelectedOccurrences) {
-            hasConflictingPageEvidence = !HasRepeatedCompleteBlockCopies(
-                locations,
-                blockId,
-                sourceText);
+            hasConflictingPageEvidence = true;
             return null;
         }
 
@@ -377,6 +386,18 @@ public static partial class OfficeDocumentReadResultExtensions {
             totalOccurrenceCount++;
         }
         return false;
+    }
+
+    private static int CountCaseInsensitiveOccurrences(string text, string query) {
+        int count = 0;
+        int searchFrom = 0;
+        while (searchFrom <= text.Length - query.Length) {
+            int index = text.IndexOf(query, searchFrom, StringComparison.OrdinalIgnoreCase);
+            if (index < 0) break;
+            count++;
+            searchFrom = index + Math.Max(1, query.Length);
+        }
+        return count;
     }
 
     private static IReadOnlyList<IReadOnlyList<OfficeDocumentPageLocation>>?

--- a/OfficeIMO.Reader.Core/OfficeDocumentSearch.cs
+++ b/OfficeIMO.Reader.Core/OfficeDocumentSearch.cs
@@ -86,6 +86,8 @@ public sealed class OfficeDocumentSearchResult {
 }
 
 public static partial class OfficeDocumentReadResultExtensions {
+    private const int MaximumFallbackCorrelationCharacters = 1024 * 1024;
+
     /// <summary>
     /// Searches normalized document blocks and attaches page-like locations to every occurrence.
     /// </summary>
@@ -227,15 +229,14 @@ public static partial class OfficeDocumentReadResultExtensions {
             string query,
             StringComparison comparison,
             bool wholeWord,
-            IReadOnlyList<int> sourceOccurrenceIndexes,
-            out bool hasConflictingPageEvidence) {
+        IReadOnlyList<int> sourceOccurrenceIndexes,
+        out bool hasConflictingPageEvidence) {
         hasConflictingPageEvidence = false;
-        IReadOnlyList<int>? stableOrdinals = FindStableOccurrenceOrdinals(
-            sourceText,
-            query,
-            sourceOccurrenceIndexes,
-            out int sourceStableOccurrenceCount);
-        if (stableOrdinals == null) {
+        if (!TryGetCaseInsensitiveOccurrenceOrdinals(
+                sourceText,
+                query,
+                sourceOccurrenceIndexes,
+                out IReadOnlyList<int> stableOrdinals)) {
             hasConflictingPageEvidence = true;
             return null;
         }
@@ -250,8 +251,13 @@ public static partial class OfficeDocumentReadResultExtensions {
                     continue;
                 }
 
+                string fragmentText = pageBlock.Text ?? string.Empty;
+                if (fragmentText.Length > MaximumFallbackCorrelationCharacters - combined.Length) {
+                    hasConflictingPageEvidence = true;
+                    return null;
+                }
                 fragmentStarts.Add(combined.Length);
-                combined.Append(pageBlock.Text ?? string.Empty);
+                combined.Append(fragmentText);
                 fragmentEnds.Add(combined.Length);
                 fragmentLocations.Add(location);
             }
@@ -259,13 +265,12 @@ public static partial class OfficeDocumentReadResultExtensions {
 
         string combinedText = combined.ToString();
         var fragmentOccurrenceIndexes = new List<int>(stableOrdinals.Count);
-        int fragmentStableOccurrenceCount = CollectOccurrenceIndexesAtOrdinals(
+        bool foundSelectedOccurrences = CollectOccurrenceIndexesAtOrdinals(
             combinedText,
             query,
             stableOrdinals,
             fragmentOccurrenceIndexes);
-        if (fragmentStableOccurrenceCount != sourceStableOccurrenceCount ||
-            fragmentOccurrenceIndexes.Count != stableOrdinals.Count) {
+        if (!foundSelectedOccurrences) {
             hasConflictingPageEvidence = !HasRepeatedCompleteBlockCopies(
                 locations,
                 blockId,
@@ -296,6 +301,38 @@ public static partial class OfficeDocumentReadResultExtensions {
             fragmentOccurrenceIndexes.Count);
     }
 
+    private static bool TryGetCaseInsensitiveOccurrenceOrdinals(
+        string text,
+        string query,
+        IReadOnlyList<int> selectedOccurrenceIndexes,
+        out IReadOnlyList<int> selectedOrdinals) {
+        var ordinals = new List<int>(selectedOccurrenceIndexes.Count);
+        int selectedIndex = 0;
+        int ordinal = 0;
+        int searchFrom = 0;
+        while (selectedIndex < selectedOccurrenceIndexes.Count &&
+               searchFrom <= text.Length - query.Length) {
+            int occurrenceIndex = text.IndexOf(query, searchFrom, StringComparison.OrdinalIgnoreCase);
+            if (occurrenceIndex < 0 || occurrenceIndex > selectedOccurrenceIndexes[selectedIndex]) {
+                selectedOrdinals = null!;
+                return false;
+            }
+            if (occurrenceIndex == selectedOccurrenceIndexes[selectedIndex]) {
+                ordinals.Add(ordinal);
+                selectedIndex++;
+            }
+            ordinal++;
+            searchFrom = occurrenceIndex + Math.Max(1, query.Length);
+        }
+
+        if (selectedIndex != selectedOccurrenceIndexes.Count) {
+            selectedOrdinals = null!;
+            return false;
+        }
+        selectedOrdinals = ordinals.AsReadOnly();
+        return true;
+    }
+
     private static bool HasRepeatedCompleteBlockCopies(
         IReadOnlyList<OfficeDocumentPageLocation> locations,
         string blockId,
@@ -313,40 +350,12 @@ public static partial class OfficeDocumentReadResultExtensions {
         return false;
     }
 
-    private static IReadOnlyList<int>? FindStableOccurrenceOrdinals(
-        string text,
-        string query,
-        IReadOnlyList<int> selectedOccurrenceIndexes,
-        out int totalOccurrenceCount) {
-        var selectedOrdinals = new List<int>(selectedOccurrenceIndexes.Count);
-        int selectedIndex = 0;
-        int searchFrom = 0;
-        totalOccurrenceCount = 0;
-        while (searchFrom <= text.Length - query.Length) {
-            int index = text.IndexOf(query, searchFrom, StringComparison.OrdinalIgnoreCase);
-            if (index < 0) {
-                break;
-            }
-
-            searchFrom = index + Math.Max(1, query.Length);
-            if (selectedIndex < selectedOccurrenceIndexes.Count &&
-                index == selectedOccurrenceIndexes[selectedIndex]) {
-                selectedOrdinals.Add(totalOccurrenceCount);
-                selectedIndex++;
-            }
-            totalOccurrenceCount++;
-        }
-
-        return selectedIndex == selectedOccurrenceIndexes.Count
-            ? selectedOrdinals.AsReadOnly()
-            : null;
-    }
-
-    private static int CollectOccurrenceIndexesAtOrdinals(
+    private static bool CollectOccurrenceIndexesAtOrdinals(
         string text,
         string query,
         IReadOnlyList<int> selectedOrdinals,
         List<int> selectedOccurrenceIndexes) {
+        if (selectedOrdinals.Count == 0) return true;
         int selectedOrdinalIndex = 0;
         int searchFrom = 0;
         int totalOccurrenceCount = 0;
@@ -361,10 +370,13 @@ public static partial class OfficeDocumentReadResultExtensions {
                 totalOccurrenceCount == selectedOrdinals[selectedOrdinalIndex]) {
                 selectedOccurrenceIndexes.Add(index);
                 selectedOrdinalIndex++;
+                if (selectedOrdinalIndex == selectedOrdinals.Count) {
+                    return true;
+                }
             }
             totalOccurrenceCount++;
         }
-        return totalOccurrenceCount;
+        return false;
     }
 
     private static IReadOnlyList<IReadOnlyList<OfficeDocumentPageLocation>>?
@@ -427,15 +439,20 @@ public static partial class OfficeDocumentReadResultExtensions {
             int occurrenceCount) {
         var mapped =
             new List<IReadOnlyList<OfficeDocumentPageLocation>>(occurrenceCount);
+        int firstPossibleFragment = 0;
         for (int occurrenceIndex = 0; occurrenceIndex < occurrenceCount; occurrenceIndex++) {
             int occurrenceStart = occurrenceIndexes[occurrenceIndex];
             int occurrenceEnd = occurrenceStart + queryLength;
+            while (firstPossibleFragment < fragmentLocations.Count
+                   && fragmentEnds[firstPossibleFragment] <= occurrenceStart) {
+                firstPossibleFragment++;
+            }
             var occurrenceLocations = new List<OfficeDocumentPageLocation>();
-            for (int fragmentIndex = 0; fragmentIndex < fragmentLocations.Count; fragmentIndex++) {
-                if (fragmentStarts[fragmentIndex] >= occurrenceEnd ||
-                    fragmentEnds[fragmentIndex] <= occurrenceStart) {
-                    continue;
-                }
+            for (int fragmentIndex = firstPossibleFragment;
+                 fragmentIndex < fragmentLocations.Count
+                 && fragmentStarts[fragmentIndex] < occurrenceEnd;
+                 fragmentIndex++) {
+                if (fragmentEnds[fragmentIndex] <= occurrenceStart) continue;
 
                 OfficeDocumentPageLocation location = fragmentLocations[fragmentIndex];
                 if (!occurrenceLocations.Contains(location)) {

--- a/OfficeIMO.Reader.Email/ReaderEmailAddressBookOptionsCloner.cs
+++ b/OfficeIMO.Reader.Email/ReaderEmailAddressBookOptionsCloner.cs
@@ -33,7 +33,8 @@ internal static class ReaderEmailAddressBookOptionsCloner {
             source.MaxValuesPerProperty,
             source.MaxDeclaredEntries,
             source.String8CodePage,
-            source.RetainRawPropertyBytes);
+            source.RetainRawPropertyBytes,
+            source.MaxDirectoryEntries);
     }
 
     internal static OfflineAddressBookSearchQuery CreateEffectiveQuery(

--- a/OfficeIMO.Reader.OneNote/OneNoteReaderAdapter.cs
+++ b/OfficeIMO.Reader.OneNote/OneNoteReaderAdapter.cs
@@ -104,6 +104,7 @@ internal static partial class OneNoteReaderAdapter {
             return CreateNotebookContext(package, source, reader, native, cancellationToken);
         }
         if (header.FileKind == OneNoteFileKind.TableOfContents) {
+            ApplyTableOfContentsFileReadPolicy(native);
             OneNoteNotebook notebook = OneNoteNotebookReader.Read(path, native.NotebookOptions);
             return CreateNotebookContext(notebook, source, reader, native, cancellationToken);
         }
@@ -139,6 +140,7 @@ internal static partial class OneNoteReaderAdapter {
                 return CreateNotebookContext(package, source, reader, native, cancellationToken);
             }
             if (header.FileKind == OneNoteFileKind.TableOfContents) {
+                ApplyTableOfContentsFileReadPolicy(native);
                 OneNoteNotebook notebook = OneNoteNotebookReader.Read(parseStream, logicalName, native.NotebookOptions);
                 return CreateNotebookContext(notebook, source, reader, native, cancellationToken);
             }
@@ -159,6 +161,12 @@ internal static partial class OneNoteReaderAdapter {
         clone.OneNoteOptions.MaxInputBytes = EffectiveLimit(reader.MaxInputBytes, clone.OneNoteOptions.MaxInputBytes);
         clone.NotebookOptions.OneNoteOptions = clone.OneNoteOptions;
         return clone;
+    }
+
+    private static void ApplyTableOfContentsFileReadPolicy(ReaderOneNoteOptions options) {
+        if (options.AllowTableOfContentsSiblingFileReads) return;
+        options.NotebookOptions.LoadSectionContent = false;
+        options.NotebookOptions.RecurseSectionGroups = false;
     }
 
     private static ReadContext CreateSectionContext(

--- a/OfficeIMO.Reader.OneNote/ReaderOneNoteOptions.cs
+++ b/OfficeIMO.Reader.OneNote/ReaderOneNoteOptions.cs
@@ -4,6 +4,12 @@ namespace OfficeIMO.Reader.OneNote;
 
 /// <summary>Options for offline OneNote ingestion.</summary>
 public sealed class ReaderOneNoteOptions {
+    /// <summary>
+    /// Allows a <c>.onetoc2</c> path to load sibling section and nested table-of-contents files.
+    /// Disable this for isolated-file ingestion. Direct OneNote registration retains the compatibility default.
+    /// </summary>
+    public bool AllowTableOfContentsSiblingFileReads { get; set; } = true;
+
     /// <summary>Native OneNote parser limits and compatibility settings.</summary>
     public OneNoteReaderOptions OneNoteOptions { get; set; } = new OneNoteReaderOptions();
 

--- a/OfficeIMO.Reader.OneNote/ReaderOneNoteOptionsCloner.cs
+++ b/OfficeIMO.Reader.OneNote/ReaderOneNoteOptionsCloner.cs
@@ -9,6 +9,7 @@ internal static class ReaderOneNoteOptionsCloner {
         OneNoteNotebookReaderOptions notebook = CloneNotebook(options.NotebookOptions ?? new OneNoteNotebookReaderOptions());
         notebook.OneNoteOptions = native;
         return new ReaderOneNoteOptions {
+            AllowTableOfContentsSiblingFileReads = options.AllowTableOfContentsSiblingFileReads,
             IncludeAssetPayloads = options.IncludeAssetPayloads,
             IncludeConflictPages = options.IncludeConflictPages,
             IncludeVersionHistory = options.IncludeVersionHistory,

--- a/OfficeIMO.Reader.Tests/Reader.AllPreset.cs
+++ b/OfficeIMO.Reader.Tests/Reader.AllPreset.cs
@@ -82,7 +82,23 @@ public sealed class ReaderAllPresetTests {
             OneNoteNotebookWriter.Write(notebook, root);
             OfficeDocumentReadResult notebookResult = reader.ReadDocument(
                 Path.Combine(root, "Open Notebook.onetoc2"));
-            AssertOneNotePresetResult(notebookResult);
+            Assert.Equal(ReaderInputKind.OneNote, notebookResult.Kind);
+            Assert.Contains("officeimo.reader.onenote", notebookResult.CapabilitiesUsed);
+            Assert.DoesNotContain(notebookResult.Chunks, chunk =>
+                chunk.Text.Contains("Reader All OneNote content", StringComparison.Ordinal));
+
+            OfficeDocumentReader siblingEnabled = new OfficeDocumentReaderBuilder()
+                .AddAllOfficeIMOHandlers(new ReaderAllOptions {
+                    OneNote = new OfficeIMO.Reader.OneNote.ReaderOneNoteOptions {
+                        AllowTableOfContentsSiblingFileReads = true
+                    }
+                })
+                .Build();
+            OfficeDocumentReadResult optedInResult = siblingEnabled.ReadDocument(
+                Path.Combine(root, "Open Notebook.onetoc2"));
+            AssertOneNotePresetResult(optedInResult);
+            Assert.Contains(optedInResult.Chunks, chunk =>
+                chunk.Text.Contains("Reader All OneNote content", StringComparison.Ordinal));
         } finally {
             if (Directory.Exists(root)) Directory.Delete(root, true);
         }

--- a/OfficeIMO.Reader.Tests/Reader.PageLocations.cs
+++ b/OfficeIMO.Reader.Tests/Reader.PageLocations.cs
@@ -382,7 +382,8 @@ public sealed class ReaderPageLocationTests {
 
         Assert.Equal(fragmentCount, result.Hits.Count);
         Assert.Equal(1, result.Hits[0].Pages.Single().Number);
-        Assert.Equal(fragmentCount, result.Hits[^1].Pages.Single().Number);
+        Assert.Equal(fragmentCount,
+            result.Hits[result.Hits.Count - 1].Pages.Single().Number);
         Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(5), stopwatch.Elapsed.ToString());
     }
 

--- a/OfficeIMO.Reader.Tests/Reader.PageLocations.cs
+++ b/OfficeIMO.Reader.Tests/Reader.PageLocations.cs
@@ -330,6 +330,63 @@ public sealed class ReaderPageLocationTests {
     }
 
     [Fact]
+    public void Search_LimitedFallbackCorrelationDoesNotCopyUnboundedFragmentText() {
+        const int fragmentCount = 256;
+        const int fragmentLength = 8192;
+        var sourceBlock = new OfficeDocumentBlock {
+            Id = "paragraph-bounded-correlation",
+            Kind = "paragraph",
+            Text = "needle"
+        };
+        string fragmentText = new string('x', fragmentLength);
+        var document = new OfficeDocumentReadResult {
+            Blocks = new[] { sourceBlock },
+            Pages = Enumerable.Range(1, fragmentCount)
+                .Select(page => Page(page, PageBlock(sourceBlock, page, fragmentText)))
+                .ToArray()
+        };
+
+#if NET8_0_OR_GREATER
+        long allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+#endif
+        OfficeDocumentSearchHit hit = Assert.Single(document.Search(
+            "needle",
+            new OfficeDocumentSearchOptions { MaximumResults = 1 }).Hits);
+#if NET8_0_OR_GREATER
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+        Assert.InRange(allocated, 0L, 8L * 1024L * 1024L);
+#endif
+
+        Assert.Empty(hit.Pages);
+    }
+
+    [Fact]
+    public void Search_PageMappingScalesAcrossManyFragments() {
+        const int fragmentCount = 10_000;
+        var sourceBlock = new OfficeDocumentBlock {
+            Id = "paragraph-many-fragments",
+            Kind = "paragraph",
+            Text = new string('x', fragmentCount)
+        };
+        var document = new OfficeDocumentReadResult {
+            Blocks = new[] { sourceBlock },
+            Pages = Enumerable.Range(1, fragmentCount)
+                .Select(page => Page(page, PageBlock(sourceBlock, page, "x")))
+                .ToArray()
+        };
+
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        OfficeDocumentSearchResult result = document.Search("x",
+            new OfficeDocumentSearchOptions { MaximumResults = fragmentCount });
+        stopwatch.Stop();
+
+        Assert.Equal(fragmentCount, result.Hits.Count);
+        Assert.Equal(1, result.Hits[0].Pages.Single().Number);
+        Assert.Equal(fragmentCount, result.Hits[^1].Pages.Single().Number);
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(5), stopwatch.Elapsed.ToString());
+    }
+
+    [Fact]
     public void PdfReader_ExposesNativePageSearchAndPageMarkedMarkdown() {
         byte[] pdf = PdfDocument.Create(new PdfOptions {
                 PageWidth = 420,

--- a/OfficeIMO.Word.Pdf/PdfSaveOptions.cs
+++ b/OfficeIMO.Word.Pdf/PdfSaveOptions.cs
@@ -6,7 +6,7 @@ namespace OfficeIMO.Word.Pdf {
     /// Options controlling first-party OfficeIMO PDF export.
     /// </summary>
     public class PdfSaveOptions {
-        private PdfCore.PdfResourcePolicy _resourcePolicy = PdfCore.PdfResourcePolicy.CreateDefault();
+        private PdfCore.PdfResourcePolicy _resourcePolicy = PdfCore.PdfResourcePolicy.CreatePortableDeterministic();
         /// <summary>
         /// PDF creation options passed to the first-party PDF engine. The options are cloned before export.
         /// </summary>
@@ -17,7 +17,7 @@ namespace OfficeIMO.Word.Pdf {
         /// </summary>
         public string? FontFamily { get; set; }
 
-        /// <summary>Host-resource policy. Defaults to balanced conversion: system fonts and bounded in-source resources are allowed, while local and remote reads are denied.</summary>
+        /// <summary>Host-resource policy. Defaults to portable deterministic conversion; callers must explicitly opt in before installed host fonts or external resources are read.</summary>
         public PdfCore.PdfResourcePolicy ResourcePolicy {
             get => _resourcePolicy;
             set => _resourcePolicy = value ?? throw new ArgumentNullException(nameof(value));

--- a/OfficeIMO.Word.Tests/Pdf/Word.SaveAsPdf.Defaults.cs
+++ b/OfficeIMO.Word.Tests/Pdf/Word.SaveAsPdf.Defaults.cs
@@ -10,6 +10,15 @@ using Xunit;
 namespace OfficeIMO.Tests {
     public partial class Word {
         [Fact]
+        public void SaveAsPdf_DefaultsDoNotReadInstalledHostFonts() {
+            var options = new PdfSaveOptions();
+
+            Assert.False(options.ResourcePolicy.AllowSystemFontEmbedding);
+            Assert.False(options.ResourcePolicy.AllowLocalFileAccess);
+            Assert.False(options.ResourcePolicy.AllowRemoteResourceResolution);
+        }
+
+        [Fact]
         public void SaveAsPdf_Uses_DefaultPageSettings() {
             string docPath = Path.Combine(_directoryWithFiles, "PdfDefaultSettings.docx");
             string pdfPath = Path.Combine(_directoryWithFiles, "PdfDefaultSettings.pdf");


### PR DESCRIPTION
## Summary

- bound cross-format resource work in PDF font registration, Reader page correlation, email/OAB discovery, OneNote layout, Excel pivots/formulas/charts, and PowerPoint input handling
- keep temporary email and presentation storage private, non-inheritable, and resistant to special-file replacement on Unix and macOS
- preserve caller URL policies and compatibility defaults while making aggregate Reader presets fail closed for OneNote notebook sibling reads
- reject malformed or oversized references, formula expansions, image geometry, and drawing segments before expensive processing or unsafe serialization

## Security behavior

- limits distinct named PDF font families while honoring installed candidate order and keeps Word-to-PDF defaults independent of host-installed fonts
- bounds Reader occurrence collection and fallback page correlation while preserving repeated-page ambiguity, case-sensitive, and whole-word identity
- enforces exact aggregate OAB directory budgets without applying the OAB probe ceiling to bounded mailbox dispatch
- verifies opened Unix mailbox descriptors are regular files before reading, including seekable device-file cases
- caps untrusted OneNote image dimensions for direct, outline, and paragraph content during both measurement and rendering, and disables sibling notebook reads in the aggregate Reader preset unless explicitly enabled
- indexes Excel worksheet relationships and bounds pivot-name allocation, timeline/source inspection, shared-formula expansion, defined-name resolution, public A1 ranges, and waterfall label writes
- preserves explicit HTML-to-PDF URL policies, skips degenerate ink geometry, and tolerates dangling image relationships

## Compatibility

- restores the original public OfflineAddressBookReaderOptions constructor signature for already-compiled callers
- uses mkstemp plus a close-on-exec descriptor on macOS and mkostemp on other Unix platforms
- mixed OAB/mailbox directories retain bounded mailbox fallback while unsupported OAB-only directories preserve their format error
- direct Reader.OneNote behavior remains compatible; only the aggregate Reader.All preset changes its default sibling-read policy
- syntactically valid out-of-grid A1 coordinates remain available only to explicit sanitize/strict and BIFF policy layers, while public A1 parsers stay bounded
- supported cell/row JSON, URL-policy, PDF font, and document conversion paths remain unchanged within the new safety limits

## Validation

- the original 24 focused security and compatibility regressions pass on both net8.0 and net10.0
- 35 follow-up compatibility, platform, page-correlation, formula, font, mailbox-dispatch, special-file, and nested-image cases pass on each target
- the four named-range/native-XLS CI compatibility regressions and the PDF resource-default contract pass on net8.0 and net10.0
- affected Email, PDF, PowerPoint, Reader.Core, Excel, and OneNote netstandard2.0 projects build with zero warnings and zero errors
- the secure temporary-stream and device-file tests pass on the actual macOS host
- independent and delayed repository review findings were addressed and their threads resolved

This is the second all-severity Codex Security batch and covers exported findings 21–40 (20 findings).
