### PR TITLE
Preserve responsive image aspect ratios across the website

### DIFF
--- a/Website/scripts/Test-DocumentationContracts.ps1
+++ b/Website/scripts/Test-DocumentationContracts.ps1
@@ -7,6 +7,13 @@ $failures = [System.Collections.Generic.List[string]]::new()
 
 function Add-Failure([string] $Message) { $failures.Add($Message) }
 
+function Test-ResponsiveImageRule([string] $Path, [string] $Label) {
+    $css = Get-Content -LiteralPath $Path -Raw
+    if ($css -notmatch '(?s)(?:^|})\s*img\s*\{[^}]*\bheight\s*:\s*auto\s*;?[^}]*\}') {
+        Add-Failure "$Label must preserve intrinsic image aspect ratios with an img { height: auto; } rule."
+    }
+}
+
 function Get-PngDimensions([string] $Path) {
     [byte[]] $bytes = [System.IO.File]::ReadAllBytes($Path)
     if ($bytes.Length -lt 24 -or
@@ -29,6 +36,11 @@ function Get-PngDimensions([string] $Path) {
 $docsRoot = Join-Path $SiteRoot 'content\docs'
 $tocPath = Join-Path $docsRoot 'toc.json'
 $toc = Get-Content -LiteralPath $tocPath -Raw | ConvertFrom-Json
+$criticalCssPath = Join-Path $SiteRoot 'themes\officeimo\critical.css'
+$appCssPath = Join-Path $SiteRoot 'themes\officeimo\assets\app.css'
+Test-ResponsiveImageRule -Path $criticalCssPath -Label 'Critical site CSS'
+Test-ResponsiveImageRule -Path $appCssPath -Label 'Full site CSS'
+
 $tocEntries = @($toc | ForEach-Object {
     if ($_.path) { $_ }
     @($_.items)

--- a/Website/themes/officeimo/assets/app.css
+++ b/Website/themes/officeimo/assets/app.css
@@ -7,6 +7,7 @@ html{-webkit-text-size-adjust:100%;scroll-behavior:smooth;background:var(--imo-b
 html[data-theme="light"]{color-scheme:light}
 body{font-family:var(--imo-font);font-size:16px;line-height:var(--imo-leading);color:var(--imo-text);background:var(--imo-bg);-webkit-font-smoothing:antialiased;min-height:100vh;overflow-x:hidden}
 img,svg,video{display:block;max-width:100%}
+img{height:auto}
 a{color:var(--imo-text-secondary);text-decoration:none;transition:color var(--imo-duration)}
 a:hover{color:var(--imo-accent)}
 .imo-prose a,.imo-docs__link,.imo-footer__links a{color:var(--imo-accent);opacity:0.8}

--- a/Website/themes/officeimo/critical.css
+++ b/Website/themes/officeimo/critical.css
@@ -30,6 +30,9 @@ svg {
   display: block;
   max-width: 100%;
 }
+img {
+  height: auto;
+}
 .skip-link,
 .imo-skip-link {
   position: absolute;


### PR DESCRIPTION
## What changed

- Preserve intrinsic image aspect ratios when responsive layouts constrain image width.
- Apply the rule in both critical CSS and the full site stylesheet so images are correct before and after deferred assets load.
- Add a documentation contract that prevents either stylesheet path from dropping the responsive height rule.

## Why

Generated documentation images include accurate width and height metadata for layout stability. The shared CSS constrained wide images to the content column but left their declared height fixed, so a 1600 x 900 slide could render at roughly 770 x 900. Images now scale proportionally while component-specific `cover` and `contain` previews keep their intended behavior.

## Validation

- Full CI-mode website, API docs, converter, SEO, and 3,704-page audit pipeline passed.
- Checked every image-bearing generated route and all 21 emitted image tags.
- Verified desktop and mobile layouts in light and dark themes with no distorted images or horizontal overflow.