### PR TITLE
Harden legacy document and cloud import boundaries

### DIFF
--- a/OfficeIMO.Email.Tests/Store/MailboxDirectory/MailboxDirectorySessionTests.cs
+++ b/OfficeIMO.Email.Tests/Store/MailboxDirectory/MailboxDirectorySessionTests.cs
@@ -8,6 +8,36 @@ namespace OfficeIMO.Email.Store.Tests;
 
 public sealed class MailboxDirectorySessionTests {
     [Fact]
+    public void WindowsMailboxRootAliasUsesItsPhysicalIdentityForSafeReads() {
+        if (!OperatingSystem.IsWindows()) return;
+        string physicalRoot = CreateMailboxDirectory();
+        string aliasRoot = Path.Combine(Path.GetTempPath(),
+            "officeimo-mailbox-root-alias-" + Guid.NewGuid().ToString("N"));
+        try {
+            try {
+                Directory.CreateSymbolicLink(aliasRoot, physicalRoot);
+            } catch (Exception exception) when (
+                exception is IOException || exception is UnauthorizedAccessException
+                || exception is PlatformNotSupportedException) {
+                return;
+            }
+
+            using EmailStoreSession session = EmailStoreSession.Open(aliasRoot);
+            EmailStoreItemReference reference = Assert.Single(
+                session.EnumerateItems(), item =>
+                    session.ReadSummary(item).Subject == "Apple directory message");
+
+            Assert.Equal("Apple directory message",
+                session.ReadItem(reference).Document.Subject);
+        } finally {
+            if (Directory.Exists(aliasRoot)) Directory.Delete(aliasRoot);
+            if (Directory.Exists(physicalRoot)) {
+                Directory.Delete(physicalRoot, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
     public void FilesystemCaseDetectionUsesExistingNamedAncestorsForNumericDirectories() {
         string root = Path.Combine(Path.GetTempPath(),
             "officeimo-case-ancestor-" + Guid.NewGuid().ToString("N"));
@@ -50,14 +80,20 @@ public sealed class MailboxDirectorySessionTests {
     [Fact]
     public void MailboxRegularFileCheckRejectsSeekableDeviceDescriptors() {
         if (OperatingSystem.IsWindows()) return;
+        int descriptor = OpenNamedPipe("/dev/null", 0);
+        Assert.True(descriptor >= 0);
         Type backend = typeof(EmailStoreSession).Assembly.GetType(
             "OfficeIMO.Email.Store.MailboxDirectoryStoreSessionBackend",
             throwOnError: true)!;
         System.Reflection.MethodInfo method = backend.GetMethod(
-            "IsRegularMailboxFile",
+            "IsRegularUnixDescriptor",
             System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
-
-        Assert.False(Assert.IsType<bool>(method.Invoke(null, new object[] { "/dev/null" })));
+        try {
+            Assert.False(Assert.IsType<bool>(method.Invoke(null,
+                new object[] { descriptor })));
+        } finally {
+            CloseDescriptor(descriptor);
+        }
     }
 
     [Fact]
@@ -89,6 +125,33 @@ public sealed class MailboxDirectorySessionTests {
             Assert.IsType<IOException>(await read);
         } finally {
             if (Directory.Exists(root)) Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void MailboxDirectoryReadRejectsParentDirectoryReplacedWithSymlink() {
+        if (OperatingSystem.IsWindows()) return;
+        string root = Path.Combine(Path.GetTempPath(),
+            "officeimo-mailbox-parent-swap-" + Guid.NewGuid().ToString("N"));
+        string outside = Path.Combine(Path.GetTempPath(),
+            "officeimo-mailbox-parent-target-" + Guid.NewGuid().ToString("N"));
+        string indexedDirectory = Path.Combine(root, "Inbox");
+        try {
+            Directory.CreateDirectory(indexedDirectory);
+            Directory.CreateDirectory(outside);
+            File.WriteAllText(Path.Combine(indexedDirectory, "message.eml"),
+                "Subject: Indexed\r\n\r\nSafe");
+            File.WriteAllText(Path.Combine(outside, "message.eml"),
+                "Subject: Outside\r\n\r\nUnsafe");
+            using EmailStoreSession session = EmailStoreSession.Open(root);
+            EmailStoreItemReference reference = Assert.Single(session.EnumerateItems());
+            Directory.Delete(indexedDirectory, recursive: true);
+            Directory.CreateSymbolicLink(indexedDirectory, outside);
+
+            Assert.Throws<IOException>(() => session.ReadItem(reference));
+        } finally {
+            if (Directory.Exists(root)) Directory.Delete(root, recursive: true);
+            if (Directory.Exists(outside)) Directory.Delete(outside, recursive: true);
         }
     }
 

--- a/OfficeIMO.Email.Tests/Store/MailboxDirectory/MailboxDirectorySessionTests.cs
+++ b/OfficeIMO.Email.Tests/Store/MailboxDirectory/MailboxDirectorySessionTests.cs
@@ -18,6 +18,7 @@ public sealed class MailboxDirectorySessionTests {
             MailboxDirectoryStoreSessionBackend.TrimTrailingDirectorySeparators(nested));
     }
 
+#if NET8_0_OR_GREATER
     [Fact]
     public void WindowsMailboxRootAliasUsesItsPhysicalIdentityForSafeReads() {
         if (!OperatingSystem.IsWindows()) return;
@@ -47,6 +48,7 @@ public sealed class MailboxDirectorySessionTests {
             }
         }
     }
+#endif
 
     [Fact]
     public void FilesystemCaseDetectionUsesExistingNamedAncestorsForNumericDirectories() {

--- a/OfficeIMO.Email.Tests/Store/MailboxDirectory/MailboxDirectorySessionTests.cs
+++ b/OfficeIMO.Email.Tests/Store/MailboxDirectory/MailboxDirectorySessionTests.cs
@@ -8,6 +8,17 @@ namespace OfficeIMO.Email.Store.Tests;
 
 public sealed class MailboxDirectorySessionTests {
     [Fact]
+    public void TrailingSeparatorNormalizationPreservesFilesystemRoots() {
+        string root = Path.GetPathRoot(Path.GetFullPath(Path.GetTempPath()))!;
+        string nested = Path.Combine(root, "mailbox") + Path.DirectorySeparatorChar;
+
+        Assert.Equal(root,
+            MailboxDirectoryStoreSessionBackend.TrimTrailingDirectorySeparators(root));
+        Assert.Equal(Path.Combine(root, "mailbox"),
+            MailboxDirectoryStoreSessionBackend.TrimTrailingDirectorySeparators(nested));
+    }
+
+    [Fact]
     public void WindowsMailboxRootAliasUsesItsPhysicalIdentityForSafeReads() {
         if (!OperatingSystem.IsWindows()) return;
         string physicalRoot = CreateMailboxDirectory();

--- a/OfficeIMO.Email.Tests/Store/Pst/PstReaderTests.cs
+++ b/OfficeIMO.Email.Tests/Store/Pst/PstReaderTests.cs
@@ -43,6 +43,23 @@ public sealed class PstReaderTests {
     }
 
     [Fact]
+    public void SummaryProjectionCountsFilteredPstPropertyRecordsAgainstTheScanLimit() {
+        using var stream = new MemoryStream(PstTestFileBuilder.Create());
+        using EmailStoreSession session = EmailStoreSession.Open(
+            stream,
+            "mailbox.pst",
+            new EmailStoreReaderOptions(maxPropertiesPerItem: 2));
+
+        EmailStoreItemReference reference = Assert.Single(session.EnumerateItems());
+        EmailStoreLimitExceededException exception = Assert.Throws<EmailStoreLimitExceededException>(
+            () => session.ReadSummary(reference));
+
+        Assert.Equal(nameof(EmailStoreReaderOptions.MaxPropertiesPerItem), exception.LimitName);
+        Assert.Equal(3, exception.Actual);
+        Assert.Equal(2, exception.Maximum);
+    }
+
+    [Fact]
     public void ReadsAnsiPstHierarchyAndProjectsMessagesThroughOfficeImoEmail() {
         using var stream = new MemoryStream(PstTestFileBuilder.Create(ansi: true));
 

--- a/OfficeIMO.Email.Tests/Store/Pst/PstStructuralValidationTests.cs
+++ b/OfficeIMO.Email.Tests/Store/Pst/PstStructuralValidationTests.cs
@@ -74,4 +74,29 @@ public sealed class PstStructuralValidationTests {
         Assert.False(report.IsComplete);
         Assert.True(report.IsValid);
     }
+
+    [Fact]
+    public void ReportsUnsignedChildOffsetsOutsideTheSupportedStreamRange() {
+        const int nbtOffset = 1536;
+        const int pageDataLength = 496;
+        byte[] bytes = PstTestFileBuilder.Create();
+        using var source = new MemoryStream(bytes);
+        using EmailStoreSession session = EmailStoreSession.Open(source, "mailbox.pst");
+        bytes[nbtOffset + 491] = 1;
+        Buffer.BlockCopy(BitConverter.GetBytes(ulong.MaxValue), 0, bytes, nbtOffset + 16, 8);
+        Buffer.BlockCopy(BitConverter.GetBytes(PstCrc32.Compute(bytes, nbtOffset, pageDataLength)),
+            0, bytes, nbtOffset + 500, 4);
+
+        EmailStoreValidationReport report = session.Validate(
+            new EmailStoreValidationOptions(
+                mode: EmailStoreValidationMode.Shallow,
+                verifyStructuralIntegrity: true,
+                maxStructuralPages: 100,
+                maxStructuralBlocks: 100,
+                maxStructuralBytes: 1024 * 1024));
+
+        Assert.Contains(report.Diagnostics, diagnostic =>
+            diagnostic.Code == "EMAIL_STORE_PST_PAGE_CHILD_OFFSET");
+        Assert.False(report.IsValid);
+    }
 }

--- a/OfficeIMO.Email.Tests/Store/Pst/PstWriterTests.cs
+++ b/OfficeIMO.Email.Tests/Store/Pst/PstWriterTests.cs
@@ -179,6 +179,42 @@ public sealed class PstWriterTests {
     }
 
     [Fact]
+    public void LazySessionReadsShareTheConfiguredPstAttachmentAggregateBudget() {
+        string path = TemporaryPstPath();
+        try {
+            using (EmailStorePstWriter writer = EmailStorePstWriter.Create(path)) {
+                string folder = writer.AddFolder("Mailbox");
+                for (int index = 0; index < 2; index++) {
+                    var document = new EmailDocument { Subject = "Item " + index };
+                    document.Attachments.Add(new EmailAttachment {
+                        FileName = "payload.bin",
+                        Content = new byte[] { 1, 2, 3, 4, 5, 6 },
+                        Length = 6
+                    });
+                    writer.AddItem(folder, document);
+                }
+                writer.Complete();
+            }
+
+            using EmailStoreSession session = EmailStoreSession.Open(
+                path,
+                new EmailStoreReaderOptions(
+                    maxAttachmentBytes: 10,
+                    maxTotalAttachmentBytes: 10));
+            EmailStoreItemReference[] references = session.EnumerateItems().ToArray();
+
+            Assert.Single(session.ReadItem(references[0]).Document.Attachments);
+            EmailStoreLimitExceededException exception = Assert.Throws<EmailStoreLimitExceededException>(
+                () => session.ReadItem(references[1]));
+
+            Assert.Equal(nameof(EmailStoreReaderOptions.MaxTotalAttachmentBytes), exception.LimitName);
+            Assert.Equal(12, exception.Actual);
+        } finally {
+            TryDelete(path);
+        }
+    }
+
+    [Fact]
     public void Ost_session_converts_to_a_different_new_pst_without_mutating_source() {
         byte[] sourceBytes = PstTestFileBuilder.Create(ost: true,
             attachmentContent: new byte[] { 9, 8, 7 });

--- a/OfficeIMO.Email.Tests/Store/Reading/EmailStoreSessionTests.cs
+++ b/OfficeIMO.Email.Tests/Store/Reading/EmailStoreSessionTests.cs
@@ -123,8 +123,10 @@ public sealed class EmailStoreSessionTests {
 
     [Fact]
     public void Searches_selective_pst_summaries_without_decoding_message_bodies() {
-        using var source = new MemoryStream(PstTestFileBuilder.Create());
-        var options = new EmailStoreReaderOptions(maxPropertiesPerItem: 2);
+        using var source = new MemoryStream(PstTestFileBuilder.Create(attachmentContent: new byte[128]));
+        var options = new EmailStoreReaderOptions(
+            maxPropertiesPerItem: 3,
+            maxAttachmentBytes: 64);
         using EmailStoreSession session = EmailStoreSession.Open(source, "archive.pst", options);
 
         EmailStoreSearchResult result = Assert.Single(session.Search(new EmailStoreQuery(
@@ -174,8 +176,10 @@ public sealed class EmailStoreSessionTests {
 
     [Fact]
     public void Validates_summaries_and_reports_bounded_full_item_failures() {
-        using var source = new MemoryStream(PstTestFileBuilder.Create());
-        var readerOptions = new EmailStoreReaderOptions(maxPropertiesPerItem: 2);
+        using var source = new MemoryStream(PstTestFileBuilder.Create(attachmentContent: new byte[128]));
+        var readerOptions = new EmailStoreReaderOptions(
+            maxPropertiesPerItem: 3,
+            maxAttachmentBytes: 64);
         using EmailStoreSession session = EmailStoreSession.Open(source, "archive.pst", readerOptions);
 
         EmailStoreValidationReport summaries = session.Validate(

--- a/OfficeIMO.Email/Store/MailboxDirectory/MailboxDirectoryStoreSessionBackend.cs
+++ b/OfficeIMO.Email/Store/MailboxDirectory/MailboxDirectoryStoreSessionBackend.cs
@@ -23,7 +23,7 @@ internal sealed class MailboxDirectoryStoreSessionBackend : IEmailStoreSessionBa
     internal MailboxDirectoryStoreSessionBackend(string path, EmailStoreReaderOptions options,
         CancellationToken cancellationToken) {
         _root = AppendSeparator(Path.GetFullPath(path));
-        string rootWithoutSeparator = _root.TrimEnd(Path.DirectorySeparatorChar);
+        string rootWithoutSeparator = TrimTrailingDirectorySeparators(_root);
         string? rootParent = Path.GetDirectoryName(rootWithoutSeparator);
         _rootComparison = EmailStorePathIdentity.GetComparison(rootParent ?? rootWithoutSeparator);
         _unixOpenRoot = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
@@ -103,7 +103,7 @@ internal sealed class MailboxDirectoryStoreSessionBackend : IEmailStoreSessionBa
     private void Index(CancellationToken cancellationToken) {
         var candidates = new List<MailboxCandidate>();
         var pending = new Stack<DirectoryCandidate>();
-        pending.Push(new DirectoryCandidate(_root.TrimEnd(Path.DirectorySeparatorChar), 0));
+        pending.Push(new DirectoryCandidate(TrimTrailingDirectorySeparators(_root), 0));
         while (pending.Count > 0) {
             cancellationToken.ThrowIfCancellationRequested();
             DirectoryCandidate current = pending.Pop();
@@ -241,7 +241,7 @@ internal sealed class MailboxDirectoryStoreSessionBackend : IEmailStoreSessionBa
         if (normalized.StartsWith(_root, _rootComparison)) {
             return normalized.Substring(_root.Length).Replace('\\', '/');
         }
-        string rootWithoutSeparator = _root.TrimEnd(Path.DirectorySeparatorChar);
+        string rootWithoutSeparator = TrimTrailingDirectorySeparators(_root);
         return string.Equals(normalized, rootWithoutSeparator, _rootComparison)
             ? string.Empty
             : normalized;
@@ -418,7 +418,7 @@ internal sealed class MailboxDirectoryStoreSessionBackend : IEmailStoreSessionBa
         const int linuxNoFollow = 0x00020000;
         const int linuxDirectory = 0x00010000;
         int directory = OpenUnix(
-            _unixOpenRoot.TrimEnd(Path.DirectorySeparatorChar),
+            TrimTrailingDirectorySeparators(_unixOpenRoot),
             linuxCloseOnExec | linuxNoFollow | linuxDirectory);
         if (directory < 0) return -1;
         try {
@@ -435,6 +435,17 @@ internal sealed class MailboxDirectoryStoreSessionBackend : IEmailStoreSessionBa
         } finally {
             CloseUnix(directory);
         }
+    }
+
+    internal static string TrimTrailingDirectorySeparators(string path) {
+        string root = Path.GetPathRoot(path) ?? string.Empty;
+        int length = path.Length;
+        while (length > root.Length
+               && (path[length - 1] == Path.DirectorySeparatorChar
+                   || path[length - 1] == Path.AltDirectorySeparatorChar)) {
+            length--;
+        }
+        return length == path.Length ? path : path.Substring(0, length);
     }
 
     private static string? ResolveUnixRealPath(string path) {

--- a/OfficeIMO.Email/Store/MailboxDirectory/MailboxDirectoryStoreSessionBackend.cs
+++ b/OfficeIMO.Email/Store/MailboxDirectory/MailboxDirectoryStoreSessionBackend.cs
@@ -1,11 +1,14 @@
 using OfficeIMO.Email;
 using Microsoft.Win32.SafeHandles;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace OfficeIMO.Email.Store;
 
 internal sealed class MailboxDirectoryStoreSessionBackend : IEmailStoreSessionBackend {
     private readonly string _root;
+    private readonly string _unixOpenRoot;
+    private readonly string _windowsOpenRoot;
     private readonly StringComparison _rootComparison;
     private readonly EmailStoreReaderOptions _options;
     private readonly List<EmailStoreDiagnostic> _diagnostics = new List<EmailStoreDiagnostic>();
@@ -23,6 +26,13 @@ internal sealed class MailboxDirectoryStoreSessionBackend : IEmailStoreSessionBa
         string rootWithoutSeparator = _root.TrimEnd(Path.DirectorySeparatorChar);
         string? rootParent = Path.GetDirectoryName(rootWithoutSeparator);
         _rootComparison = EmailStorePathIdentity.GetComparison(rootParent ?? rootWithoutSeparator);
+        _unixOpenRoot = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? _root
+            : AppendSeparator(ResolveUnixRealPath(rootWithoutSeparator) ?? rootWithoutSeparator);
+        _windowsOpenRoot = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? AppendSeparator(EmailStorePathIdentity.ResolvePhysicalPath(
+                rootWithoutSeparator))
+            : _root;
         _options = options;
         DisplayName = new DirectoryInfo(path).Name;
         Index(cancellationToken);
@@ -273,7 +283,7 @@ internal sealed class MailboxDirectoryStoreSessionBackend : IEmailStoreSessionBa
         }
     }
 
-    private static bool IsEmlx(FileInfo file) {
+    private bool IsEmlx(FileInfo file) {
         if (!file.Name.EndsWith(".emlx", StringComparison.OrdinalIgnoreCase)) return false;
         string? parent = file.Directory?.Name;
         if (!string.Equals(parent, "cur", StringComparison.OrdinalIgnoreCase) &&
@@ -290,18 +300,18 @@ internal sealed class MailboxDirectoryStoreSessionBackend : IEmailStoreSessionBa
         }
     }
 
-    private static bool IsRegularMailboxFile(string path) {
+    private bool IsRegularMailboxFile(string path) {
         if (!TryOpenRegularMailboxFile(path, 4 * 1024, out FileStream stream)) return false;
         stream.Dispose();
         return true;
     }
 
-    private static FileStream OpenRegularMailboxFile(string path) {
+    private FileStream OpenRegularMailboxFile(string path) {
         if (TryOpenRegularMailboxFile(path, 64 * 1024, out FileStream stream)) return stream;
         throw new IOException("The mailbox item is no longer a regular readable file.");
     }
 
-    private static bool TryOpenRegularMailboxFile(
+    private bool TryOpenRegularMailboxFile(
         string path,
         int bufferSize,
         out FileStream stream) {
@@ -311,6 +321,11 @@ internal sealed class MailboxDirectoryStoreSessionBackend : IEmailStoreSessionBa
                 stream = new FileStream(
                     path, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize,
                     FileOptions.SequentialScan);
+                if (!OpenedPathRemainsInsideRoot(stream.SafeFileHandle, path)) {
+                    stream.Dispose();
+                    stream = null!;
+                    return false;
+                }
                 return true;
             } catch (Exception exception) when (
                 exception is IOException || exception is UnauthorizedAccessException) {
@@ -321,10 +336,9 @@ internal sealed class MailboxDirectoryStoreSessionBackend : IEmailStoreSessionBa
         int nonBlocking = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? 0x0004 : 0x0800;
         int closeOnExec = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? 0x01000000 : 0x00080000;
         int noFollow = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? 0x00000100 : 0x00020000;
-        int descriptor = OpenUnix(path, nonBlocking | closeOnExec | noFollow);
+        int descriptor = OpenUnixPathWithoutLinks(path, nonBlocking | closeOnExec | noFollow);
         if (descriptor < 0) return false;
-        if (GetUnixFileStatus(new IntPtr(descriptor), out UnixFileStatus status) != 0 ||
-            (status.Mode & 0xF000) != 0x8000) {
+        if (!IsRegularUnixDescriptor(descriptor)) {
             CloseUnix(descriptor);
             return false;
         }
@@ -343,8 +357,108 @@ internal sealed class MailboxDirectoryStoreSessionBackend : IEmailStoreSessionBa
         }
     }
 
+    private static bool IsRegularUnixDescriptor(int descriptor) =>
+        GetUnixFileStatus(new IntPtr(descriptor), out UnixFileStatus status) == 0
+        && (status.Mode & 0xF000) == 0x8000;
+
+    private bool OpenedPathRemainsInsideRoot(SafeFileHandle handle, string requestedPath) {
+        var buffer = new StringBuilder(1024);
+        uint length = GetFinalPathNameByHandle(handle, buffer, (uint)buffer.Capacity, 0);
+        if (length == 0) return false;
+        if (length >= buffer.Capacity) {
+            buffer = new StringBuilder(checked((int)length + 1));
+            length = GetFinalPathNameByHandle(handle, buffer, (uint)buffer.Capacity, 0);
+            if (length == 0 || length >= buffer.Capacity) return false;
+        }
+        return IsResolvedPathInsideRoot(NormalizeWindowsFinalPath(buffer.ToString()), requestedPath);
+    }
+
+    private bool IsResolvedPathInsideRoot(string resolvedPath, string requestedPath) {
+        string normalized;
+        try {
+            normalized = Path.GetFullPath(resolvedPath);
+        } catch (Exception exception) when (
+            exception is ArgumentException || exception is NotSupportedException || exception is PathTooLongException) {
+            return false;
+        }
+        string requested = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? EmailStorePathIdentity.ResolvePhysicalPath(requestedPath)
+            : Path.GetFullPath(requestedPath);
+        return normalized.StartsWith(_windowsOpenRoot, _rootComparison)
+            && string.Equals(normalized, requested, _rootComparison);
+    }
+
+    private static string NormalizeWindowsFinalPath(string path) {
+        const string uncPrefix = @"\\?\UNC\";
+        const string devicePrefix = @"\\?\";
+        if (path.StartsWith(uncPrefix, StringComparison.OrdinalIgnoreCase)) {
+            return @"\\" + path.Substring(uncPrefix.Length);
+        }
+        return path.StartsWith(devicePrefix, StringComparison.OrdinalIgnoreCase)
+            ? path.Substring(devicePrefix.Length)
+            : path;
+    }
+
+    private int OpenUnixPathWithoutLinks(string path, int fileFlags) {
+        string normalized = Path.GetFullPath(path);
+        if (!normalized.StartsWith(_root, _rootComparison)) return -1;
+        string relative = normalized.Substring(_root.Length);
+        string[] segments = relative.Split(
+            new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar },
+            StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length == 0 || segments.Any(segment => segment == "." || segment == "..")) return -1;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
+            const int noFollow = 0x00000100;
+            const int noFollowAny = 0x20000000;
+            string canonicalPath = Path.Combine(_unixOpenRoot, string.Join(Path.DirectorySeparatorChar.ToString(), segments));
+            return OpenUnix(canonicalPath, (fileFlags & ~noFollow) | noFollowAny);
+        }
+
+        const int linuxCloseOnExec = 0x00080000;
+        const int linuxNoFollow = 0x00020000;
+        const int linuxDirectory = 0x00010000;
+        int directory = OpenUnix(
+            _unixOpenRoot.TrimEnd(Path.DirectorySeparatorChar),
+            linuxCloseOnExec | linuxNoFollow | linuxDirectory);
+        if (directory < 0) return -1;
+        try {
+            for (int index = 0; index < segments.Length - 1; index++) {
+                int child = OpenAtUnix(
+                    directory,
+                    segments[index],
+                    linuxCloseOnExec | linuxNoFollow | linuxDirectory);
+                if (child < 0) return -1;
+                CloseUnix(directory);
+                directory = child;
+            }
+            return OpenAtUnix(directory, segments[segments.Length - 1], fileFlags);
+        } finally {
+            CloseUnix(directory);
+        }
+    }
+
+    private static string? ResolveUnixRealPath(string path) {
+        IntPtr resolved = RealPathUnix(path, IntPtr.Zero);
+        if (resolved == IntPtr.Zero) return null;
+        try {
+            return Marshal.PtrToStringAnsi(resolved);
+        } finally {
+            FreeUnix(resolved);
+        }
+    }
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern uint GetFinalPathNameByHandle(
+        SafeFileHandle file,
+        StringBuilder filePath,
+        uint filePathLength,
+        uint flags);
+
     [DllImport("libc", EntryPoint = "open", SetLastError = true, CharSet = CharSet.Ansi)]
     private static extern int OpenUnix(string path, int flags);
+
+    [DllImport("libc", EntryPoint = "openat", SetLastError = true, CharSet = CharSet.Ansi)]
+    private static extern int OpenAtUnix(int directoryDescriptor, string path, int flags);
 
     [DllImport("libc", EntryPoint = "lseek", SetLastError = true)]
     private static extern long SeekUnix(int descriptor, long offset, int origin);
@@ -376,6 +490,12 @@ internal sealed class MailboxDirectoryStoreSessionBackend : IEmailStoreSessionBa
         internal uint UserFlags;
         internal int HardLinkCount;
     }
+
+    [DllImport("libc", EntryPoint = "realpath", SetLastError = true, CharSet = CharSet.Ansi)]
+    private static extern IntPtr RealPathUnix(string path, IntPtr resolvedPath);
+
+    [DllImport("libc", EntryPoint = "free")]
+    private static extern void FreeUnix(IntPtr pointer);
 
     internal static string? ParseMaildirFlags(string name, string? parentDirectoryName) {
         if (name == null) throw new ArgumentNullException(nameof(name));

--- a/OfficeIMO.Email/Store/Pst/PstNdbReader.Validation.cs
+++ b/OfficeIMO.Email/Store/Pst/PstNdbReader.Validation.cs
@@ -126,9 +126,16 @@ internal sealed partial class PstNdbReader {
                     ulong childBid = _header.IsUnicode
                         ? PstBinary.UInt64(page, entryOffset + keySize)
                         : PstBinary.UInt32(page, entryOffset + keySize);
-                    long childOffset = _header.IsUnicode
-                        ? checked((long)PstBinary.UInt64(page, entryOffset + keySize + bidSize))
+                    ulong rawChildOffset = _header.IsUnicode
+                        ? PstBinary.UInt64(page, entryOffset + keySize + bidSize)
                         : PstBinary.UInt32(page, entryOffset + keySize + bidSize);
+                    if (rawChildOffset > long.MaxValue) {
+                        AddPageDiagnostic("EMAIL_STORE_PST_PAGE_CHILD_OFFSET",
+                            "A PST B-tree child offset is outside the supported stream range.", offset);
+                        invalid = true;
+                        continue;
+                    }
+                    long childOffset = (long)rawChildOffset;
                     TraversePage(childOffset, childBid, expectedType, isBlockTree, depth + 1);
                 }
             } else if (isBlockTree) {

--- a/OfficeIMO.Email/Store/Pst/PstPropertyContextReader.cs
+++ b/OfficeIMO.Email/Store/Pst/PstPropertyContextReader.cs
@@ -37,14 +37,16 @@ internal sealed class PstPropertyContextReader {
         long maximum = Math.Min(_options.MaxDecodedPropertyBytesPerItem,
             maximumDecodedBytes ?? _options.MaxDecodedPropertyBytesPerItem);
         if (rootHid != 0) {
+            int scannedPropertyCount = 0;
             foreach (byte[] record in _heap.EnumerateBthLeafRecords(rootHid, 2, 6, indexLevels)) {
                 _cancellationToken.ThrowIfCancellationRequested();
+                scannedPropertyCount++;
+                if (scannedPropertyCount > _options.MaxPropertiesPerItem) {
+                    throw new EmailStoreLimitExceededException(nameof(EmailStoreReaderOptions.MaxPropertiesPerItem),
+                        scannedPropertyCount, _options.MaxPropertiesPerItem);
+                }
                 ushort id = PstBinary.UInt16(record, 0);
                 if (includedPropertyIds != null && !includedPropertyIds.Contains(id)) continue;
-                if (properties.Count >= _options.MaxPropertiesPerItem) {
-                    throw new EmailStoreLimitExceededException(nameof(EmailStoreReaderOptions.MaxPropertiesPerItem),
-                        properties.Count + 1L, _options.MaxPropertiesPerItem);
-                }
                 var type = (MapiPropertyType)PstBinary.UInt16(record, 2);
                 uint rawValue = PstBinary.UInt32(record, 4);
                 if (deferredPropertyIds != null && deferredPropertyIds.Contains(id)) {

--- a/OfficeIMO.Email/Store/Pst/PstStoreReader.cs
+++ b/OfficeIMO.Email/Store/Pst/PstStoreReader.cs
@@ -267,7 +267,6 @@ internal sealed partial class PstStoreReader {
         if (options == null) throw new ArgumentNullException(nameof(options));
         _cancellationToken = cancellationToken;
         PstNodeReference node = ResolveReferencedNode(reference);
-        ResetAttachmentBudget();
         return ReadItem(node, reference.FolderId, _format,
             reference.IsAssociated, reference.IsOrphaned, options, reference.Summary);
     }

--- a/OfficeIMO.Excel.Tests/Excel.Xlsb.Foundation.cs
+++ b/OfficeIMO.Excel.Tests/Excel.Xlsb.Foundation.cs
@@ -1047,6 +1047,32 @@ namespace OfficeIMO.Tests {
                 .Elements<NumberingFormat>(), format => format.FormatCode?.Value == "0.0000");
         }
 
+        [Theory]
+        [InlineData("cell")]
+        [InlineData("table")]
+        [InlineData("pivot")]
+        public void Xlsb_NewWorkbook_RejectsOversizedStyleNamesBeforeEncoding(string target) {
+            using ExcelDocument document = ExcelDocument.Create();
+            ExcelSheet sheet = document.AddWorksheet("Styles");
+            sheet.CellValue(1, 1, "Value");
+            sheet.CellBold(1, 1);
+            Stylesheet stylesheet = document.WorkbookPartRoot.WorkbookStylesPart!.Stylesheet!;
+            stylesheet.TableStyles ??= new TableStyles { Count = 0U };
+            string oversized = new string('s', 100_000);
+            if (target == "cell") {
+                Assert.Single(stylesheet.CellStyles!.Elements<CellStyle>()).Name = oversized;
+            } else if (target == "table") {
+                stylesheet.TableStyles!.DefaultTableStyle = oversized;
+            } else {
+                stylesheet.TableStyles!.DefaultPivotStyle = oversized;
+            }
+
+            NotSupportedException exception = Assert.Throws<NotSupportedException>(() =>
+                document.ToBytes(ExcelFileFormat.Xlsb));
+
+            Assert.Contains("style", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
         [Fact]
         public void Xlsb_NewWorkbook_WritesWorksheetGeometry() {
             using ExcelDocument document = ExcelDocument.Create();

--- a/OfficeIMO.Excel/Xlsb/Write/XlsbStylesheetPartWriter.cs
+++ b/OfficeIMO.Excel/Xlsb/Write/XlsbStylesheetPartWriter.cs
@@ -5,6 +5,7 @@ using OfficeIMO.Excel.Xlsb.Biff12;
 namespace OfficeIMO.Excel.Xlsb.Write {
     /// <summary>Writes the core BIFF12 formatting collections referenced by normal worksheet cells.</summary>
     internal static class XlsbStylesheetPartWriter {
+        private const int MaximumStyleNameLength = 255;
         private const int BrtBeginStyleSheet = 278;
         private const int BrtEndStyleSheet = 279;
         private const int BrtBeginFills = 603;
@@ -274,6 +275,7 @@ namespace OfficeIMO.Excel.Xlsb.Write {
             }
 
             string name = normal?.Name?.Value ?? "Normal";
+            ValidateStyleName(name, "cell style");
             using var payload = new MemoryStream(16 + name.Length * 2);
             WriteUInt32(payload, formatId);
             payload.WriteByte(1);
@@ -289,12 +291,21 @@ namespace OfficeIMO.Excel.Xlsb.Write {
         private static void WriteTableStyles(Stream output, TableStyles? styles) {
             string table = styles?.DefaultTableStyle?.Value ?? "TableStyleMedium2";
             string pivot = styles?.DefaultPivotStyle?.Value ?? "PivotStyleLight16";
+            ValidateStyleName(table, "default table style");
+            ValidateStyleName(pivot, "default pivot style");
             using var payload = new MemoryStream(12 + (table.Length + pivot.Length) * 2);
             WriteUInt32(payload, 0);
             WriteWideString(payload, table);
             WriteWideString(payload, pivot);
             XlsbRecordWriter.Write(output, BrtBeginTableStyles, payload.ToArray());
             XlsbRecordWriter.Write(output, BrtEndTableStyles);
+        }
+
+        private static void ValidateStyleName(string value, string description) {
+            if (value.Length > MaximumStyleNameLength) {
+                throw new NotSupportedException(
+                    $"Native XLSB generation found a {description} name longer than {MaximumStyleNameLength} characters.");
+            }
         }
 
         private static void WriteColor(Stream output, ColorType? color) {

--- a/OfficeIMO.GoogleWorkspace.Tests/GoogleWorkspace.Diagnostics.cs
+++ b/OfficeIMO.GoogleWorkspace.Tests/GoogleWorkspace.Diagnostics.cs
@@ -520,6 +520,29 @@ namespace OfficeIMO.Tests {
             Assert.Equal(64 * 1024, exception.ResponseBody.Length);
         }
 
+        [Fact]
+        public async Task Test_GoogleWorkspaceHttpTransport_TimesOutWhileReadingUnboundedByteResponse() {
+            using var httpClient = new HttpClient(new FakeHttpMessageHandler(_ =>
+                Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
+                    Content = new BlockingReadContent()
+                })));
+            using var transport = new GoogleWorkspaceHttpTransport(
+                new GoogleWorkspaceSessionOptions {
+                    HttpClient = httpClient,
+                    RequestTimeout = TimeSpan.FromMilliseconds(50),
+                    MaxRetryCount = 0
+                });
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                transport.SendBytesAsync(
+                    "token",
+                    HttpMethod.Get,
+                    "https://www.googleapis.com/drive/v3/files/file-1?alt=media",
+                    GoogleWorkspaceRequestSafety.Safe,
+                    "Google Drive API",
+                    new TranslationReport()));
+        }
+
         private static HttpResponseMessage CreateJsonResponse(string json) {
             return new HttpResponseMessage(HttpStatusCode.OK) {
                 Content = new StringContent(json, Encoding.UTF8, "application/json")
@@ -561,6 +584,42 @@ namespace OfficeIMO.Tests {
                 length = 0;
                 return false;
             }
+        }
+
+        private sealed class BlockingReadContent : HttpContent {
+            protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context) =>
+                throw new InvalidOperationException("ResponseContentRead attempted to buffer the response.");
+
+            protected override Task<Stream> CreateContentReadStreamAsync() =>
+                Task.FromResult<Stream>(new BlockingReadStream());
+
+            protected override bool TryComputeLength(out long length) {
+                length = 0;
+                return false;
+            }
+        }
+
+        private sealed class BlockingReadStream : Stream {
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => false;
+            public override long Length => throw new NotSupportedException();
+            public override long Position {
+                get => throw new NotSupportedException();
+                set => throw new NotSupportedException();
+            }
+
+            public override void Flush() { }
+            public override int Read(byte[] buffer, int offset, int count) =>
+                throw new InvalidOperationException("The response body must be read asynchronously.");
+            public override async Task<int> ReadAsync(byte[] buffer, int offset, int count,
+                CancellationToken cancellationToken) {
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
+                return 0;
+            }
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+            public override void SetLength(long value) => throw new NotSupportedException();
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
         }
 
         private sealed class FakeHttpMessageHandler : HttpMessageHandler {

--- a/OfficeIMO.GoogleWorkspace.Tests/GoogleWorkspace.Diagnostics.cs
+++ b/OfficeIMO.GoogleWorkspace.Tests/GoogleWorkspace.Diagnostics.cs
@@ -543,6 +543,42 @@ namespace OfficeIMO.Tests {
                     new TranslationReport()));
         }
 
+        [Fact]
+        public async Task Test_GoogleWorkspaceHttpTransport_RetriesSafeResponseBodyReadFailures() {
+            int attempts = 0;
+            using var httpClient = new HttpClient(new FakeHttpMessageHandler(_ => {
+                attempts++;
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
+                    Content = attempts == 1
+                        ? new TransientReadFailureContent()
+                        : new ByteArrayContent(new byte[] { 1, 2, 3, 4 })
+                });
+            }));
+            var entries = new List<GoogleWorkspaceDiagnosticEntry>();
+            using var transport = new GoogleWorkspaceHttpTransport(
+                new GoogleWorkspaceSessionOptions {
+                    HttpClient = httpClient,
+                    MaxRetryCount = 1,
+                    RetryBaseDelay = TimeSpan.FromMilliseconds(1),
+                    RetryMaxDelay = TimeSpan.FromMilliseconds(1),
+                    DiagnosticSink = entries.Add
+                });
+
+            byte[] bytes = await transport.SendBytesAsync(
+                "token",
+                HttpMethod.Get,
+                "https://www.googleapis.com/drive/v3/files/file-1?alt=media",
+                GoogleWorkspaceRequestSafety.Safe,
+                "Google Drive API",
+                new TranslationReport());
+
+            Assert.Equal(new byte[] { 1, 2, 3, 4 }, bytes);
+            Assert.Equal(2, attempts);
+            Assert.Contains(entries, entry =>
+                entry.Code == GoogleWorkspaceDiagnosticCodes.ApiRetry &&
+                entry.Message.Contains("reading response", StringComparison.Ordinal));
+        }
+
         private static HttpResponseMessage CreateJsonResponse(string json) {
             return new HttpResponseMessage(HttpStatusCode.OK) {
                 Content = new StringContent(json, Encoding.UTF8, "application/json")
@@ -597,6 +633,25 @@ namespace OfficeIMO.Tests {
                 length = 0;
                 return false;
             }
+        }
+
+        private sealed class TransientReadFailureContent : HttpContent {
+            protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context) =>
+                throw new InvalidOperationException("ResponseContentRead attempted to buffer the response.");
+
+            protected override Task<Stream> CreateContentReadStreamAsync() =>
+                Task.FromResult<Stream>(new TransientReadFailureStream());
+
+            protected override bool TryComputeLength(out long length) {
+                length = 0;
+                return false;
+            }
+        }
+
+        private sealed class TransientReadFailureStream : MemoryStream {
+            public override Task<int> ReadAsync(byte[] buffer, int offset, int count,
+                CancellationToken cancellationToken) =>
+                Task.FromException<int>(new IOException("Transient connection failure while reading response body."));
         }
 
         private sealed class BlockingReadStream : Stream {

--- a/OfficeIMO.GoogleWorkspace.Tests/GoogleWorkspace.Diagnostics.cs
+++ b/OfficeIMO.GoogleWorkspace.Tests/GoogleWorkspace.Diagnostics.cs
@@ -469,6 +469,57 @@ namespace OfficeIMO.Tests {
             }
         }
 
+        [Fact]
+        public async Task Test_GoogleWorkspaceHttpTransport_BoundsUnknownLengthByteResponses() {
+            using var httpClient = new HttpClient(new FakeHttpMessageHandler(_ =>
+                Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
+                    Content = new UnknownLengthContent(new byte[128])
+                })));
+            using var transport = new GoogleWorkspaceHttpTransport(
+                new GoogleWorkspaceSessionOptions {
+                    HttpClient = httpClient,
+                    MaxRetryCount = 0
+                });
+
+            await Assert.ThrowsAsync<InvalidDataException>(() =>
+                transport.SendBytesAsync(
+                    "token",
+                    HttpMethod.Get,
+                    "https://lh3.googleusercontent.com/image.png",
+                    GoogleWorkspaceRequestSafety.Safe,
+                    "Google content",
+                    new TranslationReport(),
+                    maxResponseBytes: 8));
+        }
+
+        [Fact]
+        public async Task Test_GoogleWorkspaceHttpTransport_TruncatesUnknownLengthErrorResponses() {
+            byte[] responseBytes = Encoding.UTF8.GetBytes(
+                new string('x', 128 * 1024));
+            using var httpClient = new HttpClient(new FakeHttpMessageHandler(_ =>
+                Task.FromResult(new HttpResponseMessage(HttpStatusCode.BadRequest) {
+                    Content = new UnknownLengthContent(responseBytes)
+                })));
+            using var transport = new GoogleWorkspaceHttpTransport(
+                new GoogleWorkspaceSessionOptions {
+                    HttpClient = httpClient,
+                    MaxRetryCount = 0
+                });
+
+            GoogleWorkspaceApiException exception =
+                await Assert.ThrowsAsync<GoogleWorkspaceApiException>(() =>
+                    transport.SendBytesAsync(
+                        "token",
+                        HttpMethod.Get,
+                        "https://lh3.googleusercontent.com/image.png",
+                        GoogleWorkspaceRequestSafety.Safe,
+                        "Google content",
+                        new TranslationReport(),
+                        maxResponseBytes: 8));
+
+            Assert.Equal(64 * 1024, exception.ResponseBody.Length);
+        }
+
         private static HttpResponseMessage CreateJsonResponse(string json) {
             return new HttpResponseMessage(HttpStatusCode.OK) {
                 Content = new StringContent(json, Encoding.UTF8, "application/json")
@@ -487,6 +538,29 @@ namespace OfficeIMO.Tests {
         private sealed class TransportReadResponse {
             [System.Text.Json.Serialization.JsonPropertyName("id")]
             public string? Id { get; set; }
+        }
+
+        private sealed class UnknownLengthContent : HttpContent {
+            private readonly byte[] _bytes;
+
+            internal UnknownLengthContent(byte[] bytes) {
+                _bytes = bytes;
+            }
+
+            protected override Task SerializeToStreamAsync(
+                Stream stream,
+                TransportContext? context) =>
+                throw new InvalidOperationException(
+                    "ResponseContentRead attempted to buffer the response.");
+
+            protected override Task<Stream> CreateContentReadStreamAsync() =>
+                Task.FromResult<Stream>(new MemoryStream(_bytes,
+                    writable: false));
+
+            protected override bool TryComputeLength(out long length) {
+                length = 0;
+                return false;
+            }
         }
 
         private sealed class FakeHttpMessageHandler : HttpMessageHandler {

--- a/OfficeIMO.GoogleWorkspace/GoogleWorkspaceHttpTransport.cs
+++ b/OfficeIMO.GoogleWorkspace/GoogleWorkspaceHttpTransport.cs
@@ -1,6 +1,7 @@
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Net;
 using System.Net.Http.Headers;
-using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -11,6 +12,7 @@ namespace OfficeIMO.GoogleWorkspace {
     /// Dependency-light HTTP transport shared by Google Workspace domain packages.
     /// </summary>
     public sealed class GoogleWorkspaceHttpTransport : IDisposable {
+        private const long MaximumErrorResponseBytes = 64L * 1024;
         private static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions {
             DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
             PropertyNamingPolicy = null,
@@ -215,29 +217,81 @@ namespace OfficeIMO.GoogleWorkspace {
             string serviceName,
             TranslationReport report,
             CancellationToken cancellationToken = default,
-            bool preserveRequestUri = false) {
+            bool preserveRequestUri = false,
+            bool includeAuthorization = true,
+            long? maxResponseBytes = null) {
             ThrowIfDisposed();
+            if (maxResponseBytes.HasValue && maxResponseBytes.Value <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(maxResponseBytes));
+            }
             string effectiveUri = preserveRequestUri
                 ? uri
                 : AppendQueryParameter(uri, "quotaUser", _options.QuotaUser);
             string? requestId = _options.RequestIdFactory?.Invoke();
             var retryOptions = GoogleWorkspaceRetryOptions.FromSessionOptions(_options);
 
-            using (var response = await GoogleWorkspaceRetryPolicy.SendAsync(
+            return await GoogleWorkspaceRetryPolicy.SendAndProcessAsync(
                 _client,
-                () => CreateRequest(accessToken, method, effectiveUri, null, requestId),
+                () => CreateRequest(accessToken, method, effectiveUri, null, requestId, includeAuthorization),
                 retryOptions,
                 requestSafety,
                 _options.RequestTimeout,
                 cancellationToken,
-                retryEvent => ReportRetry(report, serviceName, retryEvent)).ConfigureAwait(false)) {
-                if (!response.IsSuccessStatusCode) {
-                    string body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    throw GoogleWorkspaceApiException.Create(serviceName, method, effectiveUri, response.StatusCode, body);
-                }
+                async (response, responseToken) => {
+                    if (!response.IsSuccessStatusCode) {
+                        byte[] errorBytes = await ReadResponseBytesAsync(
+                            response.Content,
+                            MaximumErrorResponseBytes,
+                            responseToken,
+                            truncateAtLimit: true).ConfigureAwait(false);
+                        string body = Encoding.UTF8.GetString(errorBytes);
+                        throw GoogleWorkspaceApiException.Create(serviceName,
+                            method, effectiveUri, response.StatusCode, body);
+                    }
 
-                return await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+                    return await ReadResponseBytesAsync(response.Content,
+                        maxResponseBytes, responseToken).ConfigureAwait(false);
+                },
+                retryEvent => ReportRetry(report, serviceName, retryEvent))
+                .ConfigureAwait(false);
+        }
+
+        private static async Task<byte[]> ReadResponseBytesAsync(
+            HttpContent content,
+            long? maxResponseBytes,
+            CancellationToken cancellationToken,
+            bool truncateAtLimit = false) {
+            if (!maxResponseBytes.HasValue) {
+                return await content.ReadAsByteArrayAsync().ConfigureAwait(false);
             }
+            long limit = maxResponseBytes.Value;
+            if (content.Headers.ContentLength is long declaredLength
+                && declaredLength > limit && !truncateAtLimit) {
+                throw new InvalidDataException(
+                    $"The response declared {declaredLength} bytes, exceeding the configured limit of {limit} bytes.");
+            }
+
+            using Stream input = await content.ReadAsStreamAsync().ConfigureAwait(false);
+            using var output = new MemoryStream();
+            byte[] buffer = new byte[81920];
+            long total = 0;
+            while (true) {
+                int read = await input.ReadAsync(buffer, 0, buffer.Length,
+                    cancellationToken).ConfigureAwait(false);
+                if (read == 0) break;
+                if (read > limit - total) {
+                    if (truncateAtLimit) {
+                        output.Write(buffer, 0, checked((int)(limit - total)));
+                        break;
+                    }
+                    throw new InvalidDataException(
+                        $"The response exceeded the configured limit of {limit} bytes.");
+                }
+                output.Write(buffer, 0, read);
+                total += read;
+                if (truncateAtLimit && total == limit) break;
+            }
+            return output.ToArray();
         }
 
         public async Task<GoogleWorkspaceHttpResponse> SendRawAsync(
@@ -317,9 +371,12 @@ namespace OfficeIMO.GoogleWorkspace {
             HttpMethod method,
             string uri,
             Func<HttpContent?>? contentFactory,
-            string? requestId) {
+            string? requestId,
+            bool includeAuthorization = true) {
             var request = new HttpRequestMessage(method, uri);
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+            if (includeAuthorization) {
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+            }
             request.Headers.UserAgent.ParseAdd(BuildUserAgent(_options.ApplicationName));
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 

--- a/OfficeIMO.GoogleWorkspace/GoogleWorkspaceHttpTransport.cs
+++ b/OfficeIMO.GoogleWorkspace/GoogleWorkspaceHttpTransport.cs
@@ -261,14 +261,11 @@ namespace OfficeIMO.GoogleWorkspace {
             long? maxResponseBytes,
             CancellationToken cancellationToken,
             bool truncateAtLimit = false) {
-            if (!maxResponseBytes.HasValue) {
-                return await content.ReadAsByteArrayAsync().ConfigureAwait(false);
-            }
-            long limit = maxResponseBytes.Value;
-            if (content.Headers.ContentLength is long declaredLength
-                && declaredLength > limit && !truncateAtLimit) {
+            long? limit = maxResponseBytes;
+            if (limit.HasValue && content.Headers.ContentLength is long declaredLength
+                && declaredLength > limit.Value && !truncateAtLimit) {
                 throw new InvalidDataException(
-                    $"The response declared {declaredLength} bytes, exceeding the configured limit of {limit} bytes.");
+                    $"The response declared {declaredLength} bytes, exceeding the configured limit of {limit.Value} bytes.");
             }
 
             using Stream input = await content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -279,17 +276,17 @@ namespace OfficeIMO.GoogleWorkspace {
                 int read = await input.ReadAsync(buffer, 0, buffer.Length,
                     cancellationToken).ConfigureAwait(false);
                 if (read == 0) break;
-                if (read > limit - total) {
+                if (limit.HasValue && read > limit.Value - total) {
                     if (truncateAtLimit) {
-                        output.Write(buffer, 0, checked((int)(limit - total)));
+                        output.Write(buffer, 0, checked((int)(limit.Value - total)));
                         break;
                     }
                     throw new InvalidDataException(
-                        $"The response exceeded the configured limit of {limit} bytes.");
+                        $"The response exceeded the configured limit of {limit.Value} bytes.");
                 }
                 output.Write(buffer, 0, read);
                 total += read;
-                if (truncateAtLimit && total == limit) break;
+                if (truncateAtLimit && limit.HasValue && total == limit.Value) break;
             }
             return output.ToArray();
         }

--- a/OfficeIMO.GoogleWorkspace/GoogleWorkspaceRetryPolicy.cs
+++ b/OfficeIMO.GoogleWorkspace/GoogleWorkspaceRetryPolicy.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Cryptography;
+using System.IO;
 
 namespace OfficeIMO.GoogleWorkspace {
     /// <summary>
@@ -189,13 +190,33 @@ namespace OfficeIMO.GoogleWorkspace {
                     if (!CanRetry(requestSafety)
                         || !ShouldRetry(response.StatusCode)
                         || attempt >= retryBudget) {
-                        if (!disposeFinalResponse) {
-                            return await responseHandler(response,
-                                timeoutSource.Token).ConfigureAwait(false);
-                        }
-                        using (response) {
-                            return await responseHandler(response,
-                                timeoutSource.Token).ConfigureAwait(false);
+                        try {
+                            if (!disposeFinalResponse) {
+                                return await responseHandler(response,
+                                    timeoutSource.Token).ConfigureAwait(false);
+                            }
+                            using (response) {
+                                return await responseHandler(response,
+                                    timeoutSource.Token).ConfigureAwait(false);
+                            }
+                        } catch (HttpRequestException) when (CanRetry(requestSafety) && attempt < retryBudget) {
+                            response.Dispose();
+                            await DelayAfterTransportFailureAsync(method, uri, attempt, retryBudget,
+                                retryOptions, "network failure while reading response", cancellationToken,
+                                onRetry).ConfigureAwait(false);
+                            continue;
+                        } catch (IOException) when (CanRetry(requestSafety) && attempt < retryBudget) {
+                            response.Dispose();
+                            await DelayAfterTransportFailureAsync(method, uri, attempt, retryBudget,
+                                retryOptions, "network failure while reading response", cancellationToken,
+                                onRetry).ConfigureAwait(false);
+                            continue;
+                        } catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested && CanRetry(requestSafety) && attempt < retryBudget) {
+                            response.Dispose();
+                            await DelayAfterTransportFailureAsync(method, uri, attempt, retryBudget,
+                                retryOptions, "request timeout while reading response", cancellationToken,
+                                onRetry).ConfigureAwait(false);
+                            continue;
                         }
                     }
 
@@ -214,6 +235,27 @@ namespace OfficeIMO.GoogleWorkspace {
                         .ConfigureAwait(false);
                 }
             }
+        }
+
+        private static async Task DelayAfterTransportFailureAsync(
+            string method,
+            string uri,
+            int attempt,
+            int retryBudget,
+            GoogleWorkspaceRetryOptions retryOptions,
+            string trigger,
+            CancellationToken cancellationToken,
+            Action<GoogleWorkspaceRetryEvent>? onRetry) {
+            var (delay, delayStrategy) = GetRetryDelay(null, attempt, retryOptions);
+            onRetry?.Invoke(new GoogleWorkspaceRetryEvent(
+                method,
+                uri,
+                attempt + 1,
+                retryBudget,
+                trigger,
+                delay,
+                delayStrategy));
+            await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
         }
 
         private static bool CanRetry(GoogleWorkspaceRequestSafety requestSafety) {

--- a/OfficeIMO.GoogleWorkspace/GoogleWorkspaceRetryPolicy.cs
+++ b/OfficeIMO.GoogleWorkspace/GoogleWorkspaceRetryPolicy.cs
@@ -91,6 +91,57 @@ namespace OfficeIMO.GoogleWorkspace {
             TimeSpan requestTimeout,
             CancellationToken cancellationToken,
             Action<GoogleWorkspaceRetryEvent>? onRetry = null) {
+            return await SendCoreAsync(
+                client,
+                requestFactory,
+                retryOptions,
+                requestSafety,
+                requestTimeout,
+                HttpCompletionOption.ResponseContentRead,
+                cancellationToken,
+                (response, _) => Task.FromResult(response),
+                disposeFinalResponse: false,
+                onRetry).ConfigureAwait(false);
+        }
+
+        internal static Task<TResult> SendAndProcessAsync<TResult>(
+            HttpClient client,
+            Func<HttpRequestMessage> requestFactory,
+            GoogleWorkspaceRetryOptions retryOptions,
+            GoogleWorkspaceRequestSafety requestSafety,
+            TimeSpan requestTimeout,
+            CancellationToken cancellationToken,
+            Func<HttpResponseMessage, CancellationToken, Task<TResult>>
+                responseHandler,
+            Action<GoogleWorkspaceRetryEvent>? onRetry = null) {
+            if (responseHandler == null) {
+                throw new ArgumentNullException(nameof(responseHandler));
+            }
+            return SendCoreAsync(
+                client,
+                requestFactory,
+                retryOptions,
+                requestSafety,
+                requestTimeout,
+                HttpCompletionOption.ResponseHeadersRead,
+                cancellationToken,
+                responseHandler,
+                disposeFinalResponse: true,
+                onRetry);
+        }
+
+        private static async Task<TResult> SendCoreAsync<TResult>(
+            HttpClient client,
+            Func<HttpRequestMessage> requestFactory,
+            GoogleWorkspaceRetryOptions retryOptions,
+            GoogleWorkspaceRequestSafety requestSafety,
+            TimeSpan requestTimeout,
+            HttpCompletionOption completionOption,
+            CancellationToken cancellationToken,
+            Func<HttpResponseMessage, CancellationToken, Task<TResult>>
+                responseHandler,
+            bool disposeFinalResponse,
+            Action<GoogleWorkspaceRetryEvent>? onRetry) {
             if (retryOptions == null) throw new ArgumentNullException(nameof(retryOptions));
             int retryBudget = retryOptions.MaxRetryCount;
 
@@ -104,23 +155,11 @@ namespace OfficeIMO.GoogleWorkspace {
                     string method = request.Method.Method;
                     string uri = request.RequestUri?.AbsoluteUri ?? string.Empty;
 
+                    HttpResponseMessage response;
                     try {
-                        var response = await client.SendAsync(request, timeoutSource.Token).ConfigureAwait(false);
-                        if (!CanRetry(requestSafety) || !ShouldRetry(response.StatusCode) || attempt >= retryBudget) {
-                            return response;
-                        }
-
-                        var (delay, delayStrategy) = GetRetryDelay(response.Headers.RetryAfter, attempt, retryOptions);
-                        onRetry?.Invoke(new GoogleWorkspaceRetryEvent(
-                            method,
-                            uri,
-                            attempt + 1,
-                            retryBudget,
-                            $"HTTP {(int)response.StatusCode}",
-                            delay,
-                            delayStrategy));
-                        response.Dispose();
-                        await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+                        response = await client.SendAsync(request,
+                            completionOption,
+                            timeoutSource.Token).ConfigureAwait(false);
                     } catch (HttpRequestException) when (CanRetry(requestSafety) && attempt < retryBudget) {
                         var (delay, delayStrategy) = GetRetryDelay(null, attempt, retryOptions);
                         onRetry?.Invoke(new GoogleWorkspaceRetryEvent(
@@ -132,6 +171,7 @@ namespace OfficeIMO.GoogleWorkspace {
                             delay,
                             delayStrategy));
                         await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+                        continue;
                     } catch (TaskCanceledException) when (!cancellationToken.IsCancellationRequested && CanRetry(requestSafety) && attempt < retryBudget) {
                         var (delay, delayStrategy) = GetRetryDelay(null, attempt, retryOptions);
                         onRetry?.Invoke(new GoogleWorkspaceRetryEvent(
@@ -143,7 +183,35 @@ namespace OfficeIMO.GoogleWorkspace {
                             delay,
                             delayStrategy));
                         await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+                        continue;
                     }
+
+                    if (!CanRetry(requestSafety)
+                        || !ShouldRetry(response.StatusCode)
+                        || attempt >= retryBudget) {
+                        if (!disposeFinalResponse) {
+                            return await responseHandler(response,
+                                timeoutSource.Token).ConfigureAwait(false);
+                        }
+                        using (response) {
+                            return await responseHandler(response,
+                                timeoutSource.Token).ConfigureAwait(false);
+                        }
+                    }
+
+                    var (statusDelay, statusDelayStrategy) = GetRetryDelay(
+                        response.Headers.RetryAfter, attempt, retryOptions);
+                    onRetry?.Invoke(new GoogleWorkspaceRetryEvent(
+                        method,
+                        uri,
+                        attempt + 1,
+                        retryBudget,
+                        $"HTTP {(int)response.StatusCode}",
+                        statusDelay,
+                        statusDelayStrategy));
+                    response.Dispose();
+                    await Task.Delay(statusDelay, cancellationToken)
+                        .ConfigureAwait(false);
                 }
             }
         }

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.Flow.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.Flow.cs
@@ -267,6 +267,7 @@ internal sealed partial class HtmlToMarkdownConverter {
         if (language.Length == 0) language = ReadCodeLanguageAttribute(codeElement);
         if (language.Length == 0) language = ExtractCodeLanguage(element.GetAttribute("class"));
         if (language.Length == 0) language = ReadCodeLanguageAttribute(element);
+        language = NormalizeCodeLanguage(language);
 
         string content = codeElement?.TextContent ?? element.TextContent ?? string.Empty;
         content = content.Replace("\r\n", "\n").Replace('\r', '\n').TrimEnd('\n');
@@ -307,6 +308,24 @@ internal sealed partial class HtmlToMarkdownConverter {
         }
 
         return string.Empty;
+    }
+
+    private static string NormalizeCodeLanguage(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) return string.Empty;
+        string candidate = value!.Trim();
+        if (candidate.Length > 64) return string.Empty;
+        for (int index = 0; index < candidate.Length; index++) {
+            char character = candidate[index];
+            if (!(char.IsLetterOrDigit(character)
+                || character == '-'
+                || character == '_'
+                || character == '+'
+                || character == '.'
+                || character == '#')) {
+                return string.Empty;
+            }
+        }
+        return candidate;
     }
 
 }

--- a/OfficeIMO.Markdown.Tests/Markdown/Markdown_HtmlToMarkdown_EpubSemantics_Tests.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown/Markdown_HtmlToMarkdown_EpubSemantics_Tests.cs
@@ -103,6 +103,19 @@ public sealed class MarkdownHtmlToMarkdownTestsEpubSemantics {
     }
 
     [Fact]
+    public void HtmlToMarkdown_RejectsFenceSyntaxInCodeLanguageAttributes() {
+        const string html = "<pre data-language=\"csharp&#10;```&#10;# injected\">safe()</pre>";
+
+        MarkdownDoc document = HtmlConversionDocument.Parse(html).ToMarkdownDocument();
+        CodeBlock code = Assert.Single(document.Blocks.OfType<CodeBlock>());
+        string markdown = document.ToMarkdown();
+
+        Assert.Equal(string.Empty, code.Language);
+        Assert.Contains("safe()", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("# injected", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void HtmlToMarkdown_PreservesReversedAndValueResetOrderedListMarkers() {
         const string html = """
 <ol reversed><li>Three</li><li value="7">Seven</li><li>Six</li></ol>

--- a/OfficeIMO.PowerPoint.GoogleSlides/GoogleSlidesBatchCompiler.cs
+++ b/OfficeIMO.PowerPoint.GoogleSlides/GoogleSlidesBatchCompiler.cs
@@ -23,7 +23,7 @@ namespace OfficeIMO.PowerPoint.GoogleSlides {
                     IsSkipped = source.Hidden,
                 };
                 PowerPointSlideBackground background = source.GetBackground();
-                if (background.Kind == PowerPointSlideBackgroundKind.SolidColor) target.BackgroundColorHex = background.Color;
+                if (background.Kind == PowerPointSlideBackgroundKind.SolidColor) target.BackgroundColorHex = NormalizeColorHex(background.Color);
                 else if (IsSupportedSlidesBackgroundImage(background)) {
                     target.BackgroundImage = new GoogleSlidesImage(
                         ObjectId("background", slideIndex, 0),
@@ -83,7 +83,7 @@ namespace OfficeIMO.PowerPoint.GoogleSlides {
                             PowerPointTextRun? firstRun = textBox.Paragraphs.SelectMany(paragraph => paragraph.Runs).FirstOrDefault();
                             if (firstRun != null) {
                                 text.Bold = firstRun.Bold; text.Italic = firstRun.Italic; text.Underline = firstRun.Underline;
-                                text.FontSize = firstRun.FontSize; text.FontFamily = firstRun.FontName; text.ForegroundColorHex = firstRun.Color;
+                                text.FontSize = firstRun.FontSize; text.FontFamily = firstRun.FontName; text.ForegroundColorHex = NormalizeColorHex(firstRun.Color);
                                 text.Hyperlink = firstRun.Hyperlink?.AbsoluteUri;
                             }
                             target.Add(text); plan.NativeTextBoxCount++;
@@ -156,7 +156,7 @@ namespace OfficeIMO.PowerPoint.GoogleSlides {
                             Underline = run.Underline,
                             FontSize = run.FontSize,
                             FontFamily = run.FontName,
-                            ForegroundColorHex = run.Color,
+                            ForegroundColorHex = NormalizeColorHex(run.Color),
                             Hyperlink = run.Hyperlink?.AbsoluteUri,
                         });
                     }
@@ -203,9 +203,9 @@ namespace OfficeIMO.PowerPoint.GoogleSlides {
         }
 
         private static void PreserveShapeStyle(GoogleSlidesShapeStyle target, PowerPointShape source) {
-            target.FillColorHex = source.FillColor;
+            target.FillColorHex = NormalizeColorHex(source.FillColor);
             target.FillTransparencyPercent = source.FillTransparency;
-            target.OutlineColorHex = source.OutlineColor;
+            target.OutlineColorHex = NormalizeColorHex(source.OutlineColor);
             target.OutlineWidthPoints = source.OutlineWidthPoints;
         }
 
@@ -232,6 +232,22 @@ namespace OfficeIMO.PowerPoint.GoogleSlides {
             "image/gif" => ".gif",
             _ => ".png",
         };
+
+        private static string? NormalizeColorHex(string? value) {
+            if (string.IsNullOrWhiteSpace(value)) return null;
+            string candidate = value!.Trim().TrimStart('#');
+            if (candidate.Length >= 6) candidate = candidate.Substring(candidate.Length - 6);
+            if (candidate.Length != 6) return null;
+            for (int index = 0; index < candidate.Length; index++) {
+                char character = candidate[index];
+                if (!((character >= '0' && character <= '9')
+                    || (character >= 'a' && character <= 'f')
+                    || (character >= 'A' && character <= 'F'))) {
+                    return null;
+                }
+            }
+            return candidate.ToUpperInvariant();
+        }
 
         private static bool HasMergedCells(PowerPointTable table) {
             return table.RowItems.SelectMany(row => row.Cells).Any(cell => cell.IsMergedCell || cell.IsMergeAnchor);

--- a/OfficeIMO.PowerPoint.GoogleSlides/GoogleSlidesExporter.cs
+++ b/OfficeIMO.PowerPoint.GoogleSlides/GoogleSlidesExporter.cs
@@ -1,6 +1,7 @@
 using OfficeIMO.GoogleWorkspace;
 using OfficeIMO.GoogleWorkspace.Drive;
 using OfficeIMO.PowerPoint;
+using System.Globalization;
 using System.Text.Json.Nodes;
 
 namespace OfficeIMO.PowerPoint.GoogleSlides {
@@ -432,10 +433,15 @@ namespace OfficeIMO.PowerPoint.GoogleSlides {
         private static JsonObject Rgb(string hex) {
             string value = hex.TrimStart('#'); if (value.Length >= 6) value = value.Substring(value.Length - 6);
             if (value.Length != 6) return new JsonObject();
+            if (!int.TryParse(value.Substring(0, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out int red)
+                || !int.TryParse(value.Substring(2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out int green)
+                || !int.TryParse(value.Substring(4, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out int blue)) {
+                return new JsonObject();
+            }
             return Obj(
-                ("red", Convert.ToInt32(value.Substring(0, 2), 16) / 255d),
-                ("green", Convert.ToInt32(value.Substring(2, 2), 16) / 255d),
-                ("blue", Convert.ToInt32(value.Substring(4, 2), 16) / 255d));
+                ("red", red / 255d),
+                ("green", green / 255d),
+                ("blue", blue / 255d));
         }
 
         private static List<JsonObject> BuildSpeakerNotesRequests(GoogleSlidesBatch batch, GoogleSlidesApiPresentationResponse current) {

--- a/OfficeIMO.PowerPoint.GoogleSlides/GoogleSlidesImporter.cs
+++ b/OfficeIMO.PowerPoint.GoogleSlides/GoogleSlidesImporter.cs
@@ -9,9 +9,14 @@ namespace OfficeIMO.PowerPoint.GoogleSlides {
             if (string.IsNullOrWhiteSpace(presentationId)) throw new ArgumentException("Presentation ID is required.", nameof(presentationId));
             if (session == null) throw new ArgumentNullException(nameof(session));
             GoogleSlidesImportOptions effective = options ?? new GoogleSlidesImportOptions();
+            if (effective.MaxImageBytes <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(options),
+                    "MaxImageBytes must be greater than zero.");
+            }
             return effective.Mode == GoogleSlidesImportMode.DriveExport
                 ? await ImportDriveAsync(presentationId, session, effective, cancellationToken).ConfigureAwait(false)
-                : await ImportNativeAsync(presentationId, session, cancellationToken).ConfigureAwait(false);
+                : await ImportNativeAsync(presentationId, session, effective,
+                    cancellationToken).ConfigureAwait(false);
         }
 
         private static async Task<GoogleSlidesImportResult> ImportDriveAsync(string id, GoogleWorkspaceSession session, GoogleSlidesImportOptions options, CancellationToken cancellationToken) {
@@ -28,7 +33,9 @@ namespace OfficeIMO.PowerPoint.GoogleSlides {
             return new GoogleSlidesImportResult(presentation, Reference(source, id, report), report);
         }
 
-        private static async Task<GoogleSlidesImportResult> ImportNativeAsync(string id, GoogleWorkspaceSession session, CancellationToken cancellationToken) {
+        private static async Task<GoogleSlidesImportResult> ImportNativeAsync(string id,
+            GoogleWorkspaceSession session, GoogleSlidesImportOptions options,
+            CancellationToken cancellationToken) {
             var report = new TranslationReport();
             using var drive = new GoogleDriveClient(session);
             GoogleDriveFile source = await drive.GetFileAsync(id, report: report, cancellationToken: cancellationToken).ConfigureAwait(false);
@@ -38,12 +45,20 @@ namespace OfficeIMO.PowerPoint.GoogleSlides {
             GoogleSlidesApiPresentationResponse response = await transport.SendJsonAsync<GoogleSlidesApiPresentationResponse>(token.AccessToken, HttpMethod.Get,
                 $"https://slides.googleapis.com/v1/presentations/{Uri.EscapeDataString(id)}", null, GoogleWorkspaceRequestSafety.Safe, "Google Slides API", report,
                 GoogleSlidesJsonSerializerContext.Default.GoogleSlidesApiPresentationResponse, cancellationToken).ConfigureAwait(false);
-            PowerPointPresentation presentation = await ProjectAsync(response, transport, token.AccessToken, report, cancellationToken).ConfigureAwait(false);
+            PowerPointPresentation presentation = await ProjectAsync(response,
+                transport, token.AccessToken, options, report,
+                cancellationToken).ConfigureAwait(false);
             report.Add(TranslationSeverity.Info, "NativeImport", "Slides, text boxes, core text styles, tables, images, geometry, and speaker-note text were projected into OfficeIMO.", code: "SLIDES.IMPORT.NATIVE", action: TranslationAction.Preserve);
             return new GoogleSlidesImportResult(presentation, Reference(source, id, report, response), report);
         }
 
-        private static async Task<PowerPointPresentation> ProjectAsync(GoogleSlidesApiPresentationResponse source, GoogleWorkspaceHttpTransport transport, string token, TranslationReport report, CancellationToken cancellationToken) {
+        private static async Task<PowerPointPresentation> ProjectAsync(
+            GoogleSlidesApiPresentationResponse source,
+            GoogleWorkspaceHttpTransport transport,
+            string token,
+            GoogleSlidesImportOptions options,
+            TranslationReport report,
+            CancellationToken cancellationToken) {
             var stream = new MemoryStream();
             PowerPointPresentation presentation = PowerPointPresentation.Create(stream);
             try {
@@ -57,15 +72,18 @@ namespace OfficeIMO.PowerPoint.GoogleSlides {
                     } else if (sourceSlide.PageProperties?.PageBackgroundFill?.StretchedPictureFill?.ContentUrl is string backgroundUrl
                         && !string.IsNullOrWhiteSpace(backgroundUrl)) {
                         try {
+                            Uri trustedUrl = GetTrustedImageUrl(backgroundUrl);
                             byte[] bytes = await transport.SendBytesAsync(
                                 token,
                                 HttpMethod.Get,
-                                backgroundUrl,
+                                trustedUrl.AbsoluteUri,
                                 GoogleWorkspaceRequestSafety.Safe,
                                 "Google Slides background image",
                                 report,
                                 cancellationToken,
-                                preserveRequestUri: true).ConfigureAwait(false);
+                                preserveRequestUri: true,
+                                includeAuthorization: false,
+                                maxResponseBytes: options.MaxImageBytes).ConfigureAwait(false);
                             using var image = new MemoryStream(bytes, writable: false);
                             slide.SetBackgroundImage(image, DetectImageType(bytes));
                         } catch (Exception ex) when (!(ex is OperationCanceledException)) {
@@ -125,15 +143,18 @@ namespace OfficeIMO.PowerPoint.GoogleSlides {
                             }
                         } else if (element.Image?.ContentUrl is string url && !string.IsNullOrWhiteSpace(url)) {
                             try {
+                                Uri trustedUrl = GetTrustedImageUrl(url);
                                 byte[] bytes = await transport.SendBytesAsync(
                                     token,
                                     HttpMethod.Get,
-                                    url,
+                                    trustedUrl.AbsoluteUri,
                                     GoogleWorkspaceRequestSafety.Safe,
                                     "Google Slides image",
                                     report,
                                     cancellationToken,
-                                    preserveRequestUri: true).ConfigureAwait(false);
+                                    preserveRequestUri: true,
+                                    includeAuthorization: false,
+                                    maxResponseBytes: options.MaxImageBytes).ConfigureAwait(false);
                                 using var image = new MemoryStream(bytes, writable: false);
                                 PowerPointPicture picture = slide.AddPicturePoints(image, DetectImageType(bytes), left, top, Math.Max(1, width), Math.Max(1, height));
                                 ApplyTransform(picture, geometry);
@@ -355,6 +376,24 @@ namespace OfficeIMO.PowerPoint.GoogleSlides {
             }
             return ImagePartType.Jpeg;
         }
+
+        private static Uri GetTrustedImageUrl(string value) {
+            if (!Uri.TryCreate(value, UriKind.Absolute, out Uri? uri)
+                || !string.Equals(uri.Scheme, Uri.UriSchemeHttps,
+                    StringComparison.OrdinalIgnoreCase)
+                || !uri.IsDefaultPort && uri.Port != 443
+                || !IsGoogleContentHost(uri.Host)) {
+                throw new InvalidDataException(
+                    "Native Google Slides image URLs must use HTTPS on a Google content host.");
+            }
+            return uri;
+        }
+
+        private static bool IsGoogleContentHost(string host) =>
+            string.Equals(host, "googleusercontent.com",
+                StringComparison.OrdinalIgnoreCase)
+            || host.EndsWith(".googleusercontent.com",
+                StringComparison.OrdinalIgnoreCase);
 
         private static void EnsurePresentation(GoogleDriveFile file, string id) {
             if (!string.Equals(file.MimeType, GoogleDriveMimeTypes.Presentation, StringComparison.Ordinal)) throw new InvalidOperationException($"Drive file '{id}' is not a Google presentation.");

--- a/OfficeIMO.PowerPoint.GoogleSlides/GoogleSlidesOptions.cs
+++ b/OfficeIMO.PowerPoint.GoogleSlides/GoogleSlidesOptions.cs
@@ -34,5 +34,10 @@ namespace OfficeIMO.PowerPoint.GoogleSlides {
         public GoogleSlidesImportMode Mode { get; set; } = GoogleSlidesImportMode.DriveExport;
         public PowerPointLoadOptions LoadOptions { get; set; } = new PowerPointLoadOptions();
         public IProgress<OfficeIMO.GoogleWorkspace.Drive.GoogleDriveTransferProgress>? Progress { get; set; }
+
+        /// <summary>
+        /// Maximum bytes accepted for each Google-hosted image during native import.
+        /// </summary>
+        public long MaxImageBytes { get; set; } = 50L * 1024 * 1024;
     }
 }

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.GoogleSlides.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.GoogleSlides.cs
@@ -52,6 +52,22 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void BatchCompiler_DropsMalformedRichTextColorsBeforeJsonGeneration() {
+            using PowerPointPresentation presentation = PowerPointPresentation.Create();
+            PowerPointTextRun run = presentation.AddSlide()
+                .AddTextBoxPoints("Unsafe color", 20, 30, 300, 80)
+                .Paragraphs[0].Runs[0];
+            run.Color = "GG0000";
+
+            GoogleSlidesTextBox text = Assert.Single(
+                Assert.Single(presentation.BuildGoogleSlidesBatch().Slides)
+                    .Elements.OfType<GoogleSlidesTextBox>());
+
+            Assert.Null(text.ForegroundColorHex);
+            Assert.Null(Assert.Single(text.TextRuns).ForegroundColorHex);
+        }
+
+        [Fact]
         public void BatchCompiler_DoesNotSendUnsupportedNativeImageFormats() {
             string svgPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".svg");
             try {
@@ -669,10 +685,10 @@ namespace OfficeIMO.Tests {
                 if (request.RequestUri!.Host == "www.googleapis.com") {
                     return Task.FromResult(Json("{\"id\":\"deck-transform\",\"mimeType\":\"application/vnd.google-apps.presentation\",\"capabilities\":{\"canDownload\":false}}"));
                 }
-                if (request.RequestUri.Host == "images.example.test") {
+                if (request.RequestUri.Host == "lh3.googleusercontent.com") {
                     return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(gif) });
                 }
-                const string slides = "{\"presentationId\":\"deck-transform\",\"slides\":[{\"objectId\":\"slide-1\",\"pageElements\":[{\"objectId\":\"shape-rotated\",\"size\":{\"width\":{\"magnitude\":80,\"unit\":\"PT\"},\"height\":{\"magnitude\":40,\"unit\":\"PT\"}},\"transform\":{\"scaleX\":0,\"scaleY\":0,\"shearX\":-1,\"shearY\":1,\"translateX\":100,\"translateY\":50,\"unit\":\"PT\"},\"shape\":{\"shapeType\":\"RECTANGLE\"}},{\"objectId\":\"table-rotated\",\"size\":{\"width\":{\"magnitude\":100,\"unit\":\"PT\"},\"height\":{\"magnitude\":40,\"unit\":\"PT\"}},\"transform\":{\"scaleX\":0,\"scaleY\":0,\"shearX\":-1,\"shearY\":1,\"translateX\":200,\"translateY\":50,\"unit\":\"PT\"},\"table\":{\"rows\":1,\"columns\":1,\"tableRows\":[{\"tableCells\":[{\"text\":{\"textElements\":[]}}]}]}},{\"objectId\":\"image-rotated\",\"size\":{\"width\":{\"magnitude\":60,\"unit\":\"PT\"},\"height\":{\"magnitude\":30,\"unit\":\"PT\"}},\"transform\":{\"scaleX\":0,\"scaleY\":0,\"shearX\":-1,\"shearY\":1,\"translateX\":300,\"translateY\":50,\"unit\":\"PT\"},\"image\":{\"contentUrl\":\"https://images.example.test/image.gif\"}},{\"objectId\":\"shape-skewed\",\"size\":{\"width\":{\"magnitude\":80,\"unit\":\"PT\"},\"height\":{\"magnitude\":40,\"unit\":\"PT\"}},\"transform\":{\"scaleX\":1,\"scaleY\":1,\"shearX\":0.25,\"translateX\":400,\"translateY\":50,\"unit\":\"PT\"},\"shape\":{\"shapeType\":\"RECTANGLE\"}}]}]}";
+                const string slides = "{\"presentationId\":\"deck-transform\",\"slides\":[{\"objectId\":\"slide-1\",\"pageElements\":[{\"objectId\":\"shape-rotated\",\"size\":{\"width\":{\"magnitude\":80,\"unit\":\"PT\"},\"height\":{\"magnitude\":40,\"unit\":\"PT\"}},\"transform\":{\"scaleX\":0,\"scaleY\":0,\"shearX\":-1,\"shearY\":1,\"translateX\":100,\"translateY\":50,\"unit\":\"PT\"},\"shape\":{\"shapeType\":\"RECTANGLE\"}},{\"objectId\":\"table-rotated\",\"size\":{\"width\":{\"magnitude\":100,\"unit\":\"PT\"},\"height\":{\"magnitude\":40,\"unit\":\"PT\"}},\"transform\":{\"scaleX\":0,\"scaleY\":0,\"shearX\":-1,\"shearY\":1,\"translateX\":200,\"translateY\":50,\"unit\":\"PT\"},\"table\":{\"rows\":1,\"columns\":1,\"tableRows\":[{\"tableCells\":[{\"text\":{\"textElements\":[]}}]}]}},{\"objectId\":\"image-rotated\",\"size\":{\"width\":{\"magnitude\":60,\"unit\":\"PT\"},\"height\":{\"magnitude\":30,\"unit\":\"PT\"}},\"transform\":{\"scaleX\":0,\"scaleY\":0,\"shearX\":-1,\"shearY\":1,\"translateX\":300,\"translateY\":50,\"unit\":\"PT\"},\"image\":{\"contentUrl\":\"https://lh3.googleusercontent.com/image.gif\"}},{\"objectId\":\"shape-skewed\",\"size\":{\"width\":{\"magnitude\":80,\"unit\":\"PT\"},\"height\":{\"magnitude\":40,\"unit\":\"PT\"}},\"transform\":{\"scaleX\":1,\"scaleY\":1,\"shearX\":0.25,\"translateX\":400,\"translateY\":50,\"unit\":\"PT\"},\"shape\":{\"shapeType\":\"RECTANGLE\"}}]}]}";
                 return Task.FromResult(Json(slides));
             }));
 
@@ -699,11 +715,12 @@ namespace OfficeIMO.Tests {
             byte[] gif = Convert.FromBase64String("R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==");
             using var httpClient = new HttpClient(new DelegateHandler(request => {
                 if (request.RequestUri!.Host == "www.googleapis.com") return Task.FromResult(Json("{\"id\":\"deck-gif\",\"mimeType\":\"application/vnd.google-apps.presentation\",\"capabilities\":{\"canDownload\":true}}"));
-                if (request.RequestUri.Host == "images.example.test") {
-                    Assert.Equal("https://images.example.test/image.gif", request.RequestUri.AbsoluteUri);
+                if (request.RequestUri.Host == "lh3.googleusercontent.com") {
+                    Assert.Equal("https://lh3.googleusercontent.com/image.gif", request.RequestUri.AbsoluteUri);
+                    Assert.Null(request.Headers.Authorization);
                     return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(gif) });
                 }
-                const string slides = "{\"presentationId\":\"deck-gif\",\"pageSize\":{\"width\":{\"magnitude\":720,\"unit\":\"PT\"},\"height\":{\"magnitude\":405,\"unit\":\"PT\"}},\"slides\":[{\"objectId\":\"slide-1\",\"pageProperties\":{\"pageBackgroundFill\":{\"stretchedPictureFill\":{\"contentUrl\":\"https://images.example.test/image.gif\"}}},\"pageElements\":[{\"objectId\":\"image-1\",\"size\":{\"width\":{\"magnitude\":100,\"unit\":\"PT\"},\"height\":{\"magnitude\":100,\"unit\":\"PT\"}},\"transform\":{\"translateX\":20,\"translateY\":30,\"unit\":\"PT\"},\"image\":{\"contentUrl\":\"https://images.example.test/image.gif\"}}]}]}";
+                const string slides = "{\"presentationId\":\"deck-gif\",\"pageSize\":{\"width\":{\"magnitude\":720,\"unit\":\"PT\"},\"height\":{\"magnitude\":405,\"unit\":\"PT\"}},\"slides\":[{\"objectId\":\"slide-1\",\"pageProperties\":{\"pageBackgroundFill\":{\"stretchedPictureFill\":{\"contentUrl\":\"https://lh3.googleusercontent.com/image.gif\"}}},\"pageElements\":[{\"objectId\":\"image-1\",\"size\":{\"width\":{\"magnitude\":100,\"unit\":\"PT\"},\"height\":{\"magnitude\":100,\"unit\":\"PT\"}},\"transform\":{\"translateX\":20,\"translateY\":30,\"unit\":\"PT\"},\"image\":{\"contentUrl\":\"https://lh3.googleusercontent.com/image.gif\"}}]}]}";
                 return Task.FromResult(Json(slides));
             }));
 
@@ -716,6 +733,70 @@ namespace OfficeIMO.Tests {
                 Assert.Equal("image/gif", slide.GetBackground().ImageContentType);
                 Assert.DoesNotContain(imported.Report.Notices, notice => notice.Code == "SLIDES.IMPORT.IMAGE_FALLBACK");
                 Assert.DoesNotContain(imported.Report.Notices, notice => notice.Code == "SLIDES.IMPORT.BACKGROUND_IMAGE_FALLBACK");
+            }
+        }
+
+        [Fact]
+        public async Task NativeImporter_RejectsUntrustedImageContentUrls() {
+            int untrustedRequests = 0;
+            using var httpClient = new HttpClient(new DelegateHandler(request => {
+                if (request.RequestUri!.Host == "www.googleapis.com") {
+                    return Task.FromResult(Json(
+                        "{\"id\":\"deck-untrusted\",\"mimeType\":\"application/vnd.google-apps.presentation\"}"));
+                }
+                if (request.RequestUri.Host == "attacker.example.test") {
+                    untrustedRequests++;
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
+                        Content = new ByteArrayContent(new byte[1])
+                    });
+                }
+                const string slides = "{\"presentationId\":\"deck-untrusted\",\"slides\":[{\"objectId\":\"slide-1\",\"pageElements\":[{\"objectId\":\"image-1\",\"size\":{\"width\":{\"magnitude\":100,\"unit\":\"PT\"},\"height\":{\"magnitude\":100,\"unit\":\"PT\"}},\"image\":{\"contentUrl\":\"https://attacker.example.test/image.png\"}}]}]}";
+                return Task.FromResult(Json(slides));
+            }));
+
+            GoogleSlidesImportResult imported = await new GoogleSlidesImporter()
+                .ImportAsync("deck-untrusted", Session(httpClient),
+                    new GoogleSlidesImportOptions {
+                        Mode = GoogleSlidesImportMode.Native
+                    });
+
+            using (imported.Presentation) {
+                Assert.Equal(0, untrustedRequests);
+                Assert.Empty(Assert.Single(imported.Presentation.Slides).Pictures);
+                Assert.Contains(imported.Report.Notices, notice =>
+                    notice.Code == "SLIDES.IMPORT.IMAGE_FALLBACK");
+            }
+        }
+
+        [Fact]
+        public async Task NativeImporter_EnforcesPerImageResponseLimit() {
+            byte[] gif = Convert.FromBase64String(
+                "R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==");
+            using var httpClient = new HttpClient(new DelegateHandler(request => {
+                if (request.RequestUri!.Host == "www.googleapis.com") {
+                    return Task.FromResult(Json(
+                        "{\"id\":\"deck-image-limit\",\"mimeType\":\"application/vnd.google-apps.presentation\"}"));
+                }
+                if (request.RequestUri.Host == "lh3.googleusercontent.com") {
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
+                        Content = new ByteArrayContent(gif)
+                    });
+                }
+                const string slides = "{\"presentationId\":\"deck-image-limit\",\"slides\":[{\"objectId\":\"slide-1\",\"pageElements\":[{\"objectId\":\"image-1\",\"size\":{\"width\":{\"magnitude\":100,\"unit\":\"PT\"},\"height\":{\"magnitude\":100,\"unit\":\"PT\"}},\"image\":{\"contentUrl\":\"https://lh3.googleusercontent.com/image.gif\"}}]}]}";
+                return Task.FromResult(Json(slides));
+            }));
+
+            GoogleSlidesImportResult imported = await new GoogleSlidesImporter()
+                .ImportAsync("deck-image-limit", Session(httpClient),
+                    new GoogleSlidesImportOptions {
+                        Mode = GoogleSlidesImportMode.Native,
+                        MaxImageBytes = 8
+                    });
+
+            using (imported.Presentation) {
+                Assert.Empty(Assert.Single(imported.Presentation.Slides).Pictures);
+                Assert.Contains(imported.Report.Notices, notice =>
+                    notice.Code == "SLIDES.IMPORT.IMAGE_FALLBACK");
             }
         }
 

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.CustomShows.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.CustomShows.cs
@@ -254,16 +254,22 @@ namespace OfficeIMO.Tests {
                 });
                 LegacyPptWritePreflightReport report = imported
                     .AnalyzeLegacyPptWrite();
-                Assert.True(report.CanWrite,
-                    string.Join(Environment.NewLine, report.Findings));
-                appendedBytes = imported.ToBytes(PowerPointFileFormat.Ppt);
+                Assert.False(report.CanWrite);
+                Assert.Contains(report.Findings, finding =>
+                    finding.Code == "PPT-WRITE-IMPORT-LOSS");
+                Assert.Throws<NotSupportedException>(() =>
+                    imported.ToBytes(PowerPointFileFormat.Ppt));
+                appendedBytes = imported.ToBytes(PowerPointFileFormat.Ppt,
+                    new PowerPointSaveOptions {
+                        LossPolicy = PowerPointConversionLossPolicy.Allow
+                    });
             }
             LegacyPptPresentation withAppended = LegacyPptPresentation.Load(
                 appendedBytes);
             Assert.Equal(new[] { withAppended.Slides[0].SlideId,
                 withAppended.Slides[1].SlideId },
                 Assert.Single(withAppended.CustomShows).SlideIds);
-            Assert.True(withAppended.Package.DocumentStream.AsSpan(0,
+            Assert.False(withAppended.Package.DocumentStream.AsSpan(0,
                     original.Package.DocumentStream.Length)
                 .SequenceEqual(original.Package.DocumentStream));
 
@@ -273,17 +279,22 @@ namespace OfficeIMO.Tests {
                 imported.RemoveSlide(1);
                 LegacyPptWritePreflightReport report = imported
                     .AnalyzeLegacyPptWrite();
-                Assert.True(report.CanWrite,
-                    string.Join(Environment.NewLine, report.Findings));
-                removedBytes = imported.ToBytes(PowerPointFileFormat.Ppt);
+                Assert.False(report.CanWrite);
+                Assert.Contains(report.Findings, finding =>
+                    finding.Code == "PPT-WRITE-IMPORT-LOSS");
+                Assert.Throws<NotSupportedException>(() =>
+                    imported.ToBytes(PowerPointFileFormat.Ppt));
+                removedBytes = imported.ToBytes(PowerPointFileFormat.Ppt,
+                    new PowerPointSaveOptions {
+                        LossPolicy = PowerPointConversionLossPolicy.Allow
+                    });
             }
             LegacyPptPresentation removed = LegacyPptPresentation.Load(removedBytes);
             Assert.Single(removed.Slides);
             Assert.Equal(new[] { removed.Slides[0].SlideId },
                 Assert.Single(removed.CustomShows).SlideIds);
-            Assert.True(removed.Package.DocumentStream.AsSpan(0,
-                    withAppended.Package.DocumentStream.Length)
-                .SequenceEqual(withAppended.Package.DocumentStream));
+            Assert.False(removed.Package.DocumentStream.AsSpan()
+                .StartsWith(withAppended.Package.DocumentStream));
         }
 
         private static void AddCustomShow(PowerPointPresentation presentation,

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.ExternalObjects.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.ExternalObjects.cs
@@ -71,10 +71,22 @@ namespace OfficeIMO.Tests {
                 Assert.Equal(PowerPointFeatureSupportLevel.Preserved,
                     finding.SupportLevel);
                 Assert.Equal(1, finding.Count);
-                Assert.Equal(sourceBytes,
+                LegacyPptWritePreflightReport exactPreflight = imported
+                    .AnalyzeLegacyPptWrite();
+                Assert.False(exactPreflight.CanWrite);
+                Assert.Contains(exactPreflight.Findings, item =>
+                    item.Code == "PPT-WRITE-PRESERVED-LINKED-OLE");
+                Assert.Throws<NotSupportedException>(() =>
                     imported.ToBytes(PowerPointFileFormat.Ppt));
+                Assert.Equal(sourceBytes, imported.ToBytes(
+                    PowerPointFileFormat.Ppt, new PowerPointSaveOptions {
+                        LossPolicy = PowerPointConversionLossPolicy.Allow
+                    }));
                 textBox.Text = "Edited companion";
-                savedBytes = imported.ToBytes(PowerPointFileFormat.Ppt);
+                savedBytes = imported.ToBytes(PowerPointFileFormat.Ppt,
+                    new PowerPointSaveOptions {
+                        LossPolicy = PowerPointConversionLossPolicy.Allow
+                    });
             }
 
             AssertExternalObjectPreserved(source, savedBytes,
@@ -133,10 +145,22 @@ namespace OfficeIMO.Tests {
                 Assert.Equal(PowerPointFeatureSupportLevel.Preserved,
                     finding.SupportLevel);
                 Assert.Equal(1, finding.Count);
-                Assert.Equal(sourceBytes,
+                LegacyPptWritePreflightReport exactPreflight = imported
+                    .AnalyzeLegacyPptWrite();
+                Assert.False(exactPreflight.CanWrite);
+                Assert.Contains(exactPreflight.Findings, item =>
+                    item.Code == "PPT-WRITE-PRESERVED-ACTIVEX");
+                Assert.Throws<NotSupportedException>(() =>
                     imported.ToBytes(PowerPointFileFormat.Ppt));
+                Assert.Equal(sourceBytes, imported.ToBytes(
+                    PowerPointFileFormat.Ppt, new PowerPointSaveOptions {
+                        LossPolicy = PowerPointConversionLossPolicy.Allow
+                    }));
                 textBox.Text = "Edited companion";
-                savedBytes = imported.ToBytes(PowerPointFileFormat.Ppt);
+                savedBytes = imported.ToBytes(PowerPointFileFormat.Ppt,
+                    new PowerPointSaveOptions {
+                        LossPolicy = PowerPointConversionLossPolicy.Allow
+                    });
             }
 
             AssertExternalObjectPreserved(source, savedBytes,
@@ -195,8 +219,17 @@ namespace OfficeIMO.Tests {
             Assert.Contains(projected.LegacyPptImportDiagnostics,
                 diagnostic => diagnostic.Code ==
                     "PPT-OLE-LINK-IDENTITY");
-            Assert.Equal(sourceBytes,
+            LegacyPptWritePreflightReport preflight = projected
+                .AnalyzeLegacyPptWrite();
+            Assert.False(preflight.CanWrite);
+            Assert.Contains(preflight.Findings, finding =>
+                finding.Code == "PPT-WRITE-PRESERVED-LINKED-OLE");
+            Assert.Throws<NotSupportedException>(() =>
                 projected.ToBytes(PowerPointFileFormat.Ppt));
+            Assert.Equal(sourceBytes, projected.ToBytes(
+                PowerPointFileFormat.Ppt, new PowerPointSaveOptions {
+                    LossPolicy = PowerPointConversionLossPolicy.Allow
+                }));
         }
 
         private static void AssertExternalObjectPreserved(

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.Interactions.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.Interactions.cs
@@ -301,6 +301,8 @@ namespace OfficeIMO.Tests {
                 Assert.Contains(report.Findings, finding =>
                     finding.Code == "PPT-WRITE-PRESERVED-EXTERNAL-LINK");
                 Assert.False(report.CanWrite);
+                Assert.Throws<NotSupportedException>(() =>
+                    imported.ToBytes(PowerPointFileFormat.Ppt));
                 savedBytes = imported.ToBytes(PowerPointFileFormat.Ppt,
                     new PowerPointSaveOptions {
                         LossPolicy = PowerPointConversionLossPolicy.Allow
@@ -331,7 +333,17 @@ namespace OfficeIMO.Tests {
             byte[] savedBytes;
             using (var input = new MemoryStream(sourceBytes, writable: false))
             using (PowerPointPresentation imported = PowerPointPresentation.Load(input)) {
-                savedBytes = imported.ToBytes(PowerPointFileFormat.Ppt);
+                LegacyPptWritePreflightReport report = imported
+                    .AnalyzeLegacyPptWrite();
+                Assert.False(report.CanWrite);
+                Assert.Contains(report.Findings, finding =>
+                    finding.Code == "PPT-WRITE-PRESERVED-EXTERNAL-LINK");
+                Assert.Throws<NotSupportedException>(() =>
+                    imported.ToBytes(PowerPointFileFormat.Ppt));
+                savedBytes = imported.ToBytes(PowerPointFileFormat.Ppt,
+                    new PowerPointSaveOptions {
+                        LossPolicy = PowerPointConversionLossPolicy.Allow
+                    });
             }
 
             Assert.Equal(sourceBytes, savedBytes);
@@ -545,8 +557,15 @@ namespace OfficeIMO.Tests {
                     100000, 100000, 1000000, 500000);
                 AddShapeHyperlink(added, rectangle, target, mouseOver: false);
                 LegacyPptWritePreflightReport report = imported.AnalyzeLegacyPptWrite();
-                Assert.True(report.CanWrite, string.Join(Environment.NewLine, report.Findings));
-                savedBytes = imported.ToBytes(PowerPointFileFormat.Ppt);
+                Assert.False(report.CanWrite);
+                Assert.Contains(report.Findings, finding =>
+                    finding.Code == "PPT-WRITE-IMPORT-LOSS");
+                Assert.Throws<NotSupportedException>(() =>
+                    imported.ToBytes(PowerPointFileFormat.Ppt));
+                savedBytes = imported.ToBytes(PowerPointFileFormat.Ppt,
+                    new PowerPointSaveOptions {
+                        LossPolicy = PowerPointConversionLossPolicy.Allow
+                    });
             }
 
             LegacyPptPresentation saved = LegacyPptPresentation.Load(savedBytes);
@@ -554,7 +573,7 @@ namespace OfficeIMO.Tests {
             LegacyPptInteraction interaction = Assert.Single(saved.Slides[1].Shapes
                 .SelectMany(shape => shape.Interactions));
             Assert.Equal(target, interaction.Hyperlink!.Uri);
-            Assert.True(saved.Package.DocumentStream.AsSpan(0,
+            Assert.False(saved.Package.DocumentStream.AsSpan(0,
                     original.Package.DocumentStream.Length)
                 .SequenceEqual(original.Package.DocumentStream));
         }

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.InternalHyperlinks.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.InternalHyperlinks.cs
@@ -4,6 +4,7 @@ using OfficeIMO.Drawing;
 using OfficeIMO.PowerPoint;
 using OfficeIMO.PowerPoint.LegacyPpt;
 using OfficeIMO.PowerPoint.LegacyPpt.Capabilities;
+using OfficeIMO.PowerPoint.LegacyPpt.Internal;
 using OfficeIMO.PowerPoint.LegacyPpt.Model;
 using Xunit;
 using A = DocumentFormat.OpenXml.Drawing;
@@ -196,6 +197,17 @@ namespace OfficeIMO.Tests {
                     projectedTarget);
             });
             Assert.Empty(projected.ValidateDocument());
+
+            LegacyPptProjectionFingerprint fingerprint =
+                LegacyPptProjectionFingerprint.Create(
+                    projected.OpenXmlDocument,
+                    projected.LegacyPptProjectionMap!);
+            Assert.True(fingerprint.Matches(projected.OpenXmlDocument,
+                projected.LegacyPptProjectionMap!));
+            foreach (A.HyperlinkOnClick link in links) link.Remove();
+            projectedMaster.SlideMaster.Save();
+            Assert.False(fingerprint.Matches(projected.OpenXmlDocument,
+                projected.LegacyPptProjectionMap!));
         }
 
         [Fact]
@@ -277,9 +289,15 @@ namespace OfficeIMO.Tests {
                 AddInternalSlideHyperlink(appended, existing, appendedShape,
                     mouseOver: true, screenTip: "Back");
                 LegacyPptWritePreflightReport report = imported.AnalyzeLegacyPptWrite();
-                Assert.True(report.CanWrite,
-                    string.Join(Environment.NewLine, report.Findings));
-                savedBytes = imported.ToBytes(PowerPointFileFormat.Ppt);
+                Assert.False(report.CanWrite);
+                Assert.Contains(report.Findings, finding =>
+                    finding.Code == "PPT-WRITE-IMPORT-LOSS");
+                Assert.Throws<NotSupportedException>(() =>
+                    imported.ToBytes(PowerPointFileFormat.Ppt));
+                savedBytes = imported.ToBytes(PowerPointFileFormat.Ppt,
+                    new PowerPointSaveOptions {
+                        LossPolicy = PowerPointConversionLossPolicy.Allow
+                    });
             }
 
             LegacyPptPresentation saved = LegacyPptPresentation.Load(savedBytes);
@@ -295,7 +313,7 @@ namespace OfficeIMO.Tests {
                 backInteraction.Hyperlink!.TargetSlideId);
             Assert.Equal("Forward", forward.ScreenTip);
             Assert.Equal("Back", backInteraction.Hyperlink.ScreenTip);
-            Assert.True(saved.Package.DocumentStream.AsSpan(0,
+            Assert.False(saved.Package.DocumentStream.AsSpan(0,
                     original.Package.DocumentStream.Length)
                 .SequenceEqual(original.Package.DocumentStream));
         }
@@ -317,8 +335,17 @@ namespace OfficeIMO.Tests {
             using (var input = new MemoryStream(sourceBytes, writable: false))
             using (PowerPointPresentation imported = PowerPointPresentation.Load(input)) {
                 imported.MoveSlide(2, 1);
-                Assert.True(imported.AnalyzeLegacyPptWrite().CanWrite);
-                savedBytes = imported.ToBytes(PowerPointFileFormat.Ppt);
+                LegacyPptWritePreflightReport report = imported
+                    .AnalyzeLegacyPptWrite();
+                Assert.False(report.CanWrite);
+                Assert.Contains(report.Findings, finding =>
+                    finding.Code == "PPT-WRITE-IMPORT-LOSS");
+                Assert.Throws<NotSupportedException>(() =>
+                    imported.ToBytes(PowerPointFileFormat.Ppt));
+                savedBytes = imported.ToBytes(PowerPointFileFormat.Ppt,
+                    new PowerPointSaveOptions {
+                        LossPolicy = PowerPointConversionLossPolicy.Allow
+                    });
             }
 
             LegacyPptPresentation saved = LegacyPptPresentation.Load(savedBytes);

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.Media.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.Media.cs
@@ -370,8 +370,17 @@ namespace OfficeIMO.Tests {
             Assert.Equal(PowerPointFeatureSupportLevel.Preserved,
                 finding.SupportLevel);
             Assert.Equal(1, finding.Count);
-            Assert.Equal(sourceBytes,
+            LegacyPptWritePreflightReport preflight = projected
+                .AnalyzeLegacyPptWrite();
+            Assert.False(preflight.CanWrite);
+            Assert.Contains(preflight.Findings, item =>
+                item.Code == "PPT-WRITE-PRESERVED-EXTERNAL-MEDIA");
+            Assert.Throws<NotSupportedException>(() =>
                 projected.ToBytes(PowerPointFileFormat.Ppt));
+            Assert.Equal(sourceBytes, projected.ToBytes(
+                PowerPointFileFormat.Ppt, new PowerPointSaveOptions {
+                    LossPolicy = PowerPointConversionLossPolicy.Allow
+                }));
         }
 
         [Fact]

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.NamedActions.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.NamedActions.cs
@@ -78,7 +78,17 @@ namespace OfficeIMO.Tests {
                     relationship.Id == projectedProgram.Id?.Value);
             Assert.Equal(programUri, projectedRelationship.Uri);
             Assert.Empty(projected.ValidateDocument());
-            Assert.Equal(bytes, projected.ToBytes(PowerPointFileFormat.Ppt));
+            LegacyPptWritePreflightReport projectedPreflight = projected
+                .AnalyzeLegacyPptWrite();
+            Assert.False(projectedPreflight.CanWrite);
+            Assert.Contains(projectedPreflight.Findings, finding =>
+                finding.Code == "PPT-WRITE-PRESERVED-RUN-PROGRAM");
+            Assert.Throws<NotSupportedException>(() =>
+                projected.ToBytes(PowerPointFileFormat.Ppt));
+            Assert.Equal(bytes, projected.ToBytes(PowerPointFileFormat.Ppt,
+                new PowerPointSaveOptions {
+                    LossPolicy = PowerPointConversionLossPolicy.Allow
+                }));
         }
 
         [Fact]

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.OleObjects.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.OleObjects.cs
@@ -79,8 +79,17 @@ namespace OfficeIMO.Tests {
                 projectedOle.FollowColorScheme);
             Assert.Equal(storageBytes, projectedOle.GetData());
             Assert.Empty(projected.ValidateDocument());
-            Assert.Equal(binary,
+            LegacyPptWritePreflightReport projectedPreflight = projected
+                .AnalyzeLegacyPptWrite();
+            Assert.False(projectedPreflight.CanWrite);
+            Assert.Contains(projectedPreflight.Findings, finding =>
+                finding.Code == "PPT-WRITE-PRESERVED-OLE");
+            Assert.Throws<NotSupportedException>(() =>
                 projected.ToBytes(PowerPointFileFormat.Ppt));
+            Assert.Equal(binary, projected.ToBytes(PowerPointFileFormat.Ppt,
+                new PowerPointSaveOptions {
+                    LossPolicy = PowerPointConversionLossPolicy.Allow
+                }));
         }
 
         [Fact]
@@ -164,8 +173,17 @@ namespace OfficeIMO.Tests {
             }
             Assert.Equal(imageBytes, projectedBytes.ToArray());
             Assert.Empty(projected.ValidateDocument());
-            Assert.Equal(binary,
+            LegacyPptWritePreflightReport projectedPreflight = projected
+                .AnalyzeLegacyPptWrite();
+            Assert.False(projectedPreflight.CanWrite);
+            Assert.Contains(projectedPreflight.Findings, finding =>
+                finding.Code == "PPT-WRITE-PRESERVED-OLE");
+            Assert.Throws<NotSupportedException>(() =>
                 projected.ToBytes(PowerPointFileFormat.Ppt));
+            Assert.Equal(binary, projected.ToBytes(PowerPointFileFormat.Ppt,
+                new PowerPointSaveOptions {
+                    LossPolicy = PowerPointConversionLossPolicy.Allow
+                }));
         }
 
         [Fact]
@@ -610,12 +628,24 @@ namespace OfficeIMO.Tests {
             using (var input = new MemoryStream(sourceBytes))
             using (PowerPointPresentation imported =
                    PowerPointPresentation.Load(input)) {
-                Assert.Equal(sourceBytes,
+                LegacyPptWritePreflightReport exactPreflight = imported
+                    .AnalyzeLegacyPptWrite();
+                Assert.False(exactPreflight.CanWrite);
+                Assert.Contains(exactPreflight.Findings, finding =>
+                    finding.Code == "PPT-WRITE-PRESERVED-OLE");
+                Assert.Throws<NotSupportedException>(() =>
                     imported.ToBytes(PowerPointFileFormat.Ppt));
+                Assert.Equal(sourceBytes, imported.ToBytes(
+                    PowerPointFileFormat.Ppt, new PowerPointSaveOptions {
+                        LossPolicy = PowerPointConversionLossPolicy.Allow
+                    }));
                 PowerPointOleObject ole = Assert.Single(
                     imported.Slides[0].OleObjects);
                 ole.Left += 15875L;
-                savedBytes = imported.ToBytes(PowerPointFileFormat.Ppt);
+                savedBytes = imported.ToBytes(PowerPointFileFormat.Ppt,
+                    new PowerPointSaveOptions {
+                        LossPolicy = PowerPointConversionLossPolicy.Allow
+                    });
             }
 
             LegacyPptPresentation saved = LegacyPptPresentation.Load(

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.PackageSecurity.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.PackageSecurity.cs
@@ -703,6 +703,85 @@ namespace OfficeIMO.Tests {
         }
 
         [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void MalformedExternalObjectLists_FallBackWithoutCrashing(
+            bool duplicateList) {
+            byte[] binary;
+            using (PowerPointPresentation source =
+                   PowerPointPresentation.Create()) {
+                PowerPointSlide slide = source.AddSlide(
+                    P.SlideLayoutValues.Blank);
+                PowerPointAutoShape shape = slide.AddRectangle(
+                    100000, 100000, 1000000, 500000);
+                HyperlinkRelationship relationship = slide.SlidePart
+                    .AddHyperlinkRelationship(
+                        new Uri("https://example.com/malformed-list"), true);
+                ((P.Shape)shape.Element).NonVisualShapeProperties!
+                    .NonVisualDrawingProperties!
+                    .Append(new A.HyperlinkOnClick {
+                        Id = relationship.Id
+                    });
+                binary = source.ToBytes(PowerPointFileFormat.Ppt);
+            }
+
+            LegacyPptPresentation sourcePresentation =
+                LegacyPptPresentation.Load(binary);
+            LegacyPptPersistObject documentPersist = sourcePresentation
+                .Package.PersistObjects[sourcePresentation.Package
+                    .DocumentPersistId];
+            LegacyPptRecord document = LegacyPptRecordReader.ReadSingle(
+                documentPersist.RecordBytes, 0,
+                new LegacyPptImportOptions());
+            LegacyPptRecord list = Assert.Single(document.Children,
+                child => child.Type == 0x0409);
+            var documentChildren = new List<byte[]>();
+            foreach (LegacyPptRecord child in document.Children) {
+                if (!ReferenceEquals(child, list)) {
+                    documentChildren.Add(child.CopyRecordBytes());
+                    continue;
+                }
+                if (duplicateList) {
+                    documentChildren.Add(child.CopyRecordBytes());
+                    documentChildren.Add(child.CopyRecordBytes());
+                    continue;
+                }
+                LegacyPptRecord atom = Assert.Single(list.Children,
+                    item => item.Type == 0x040A);
+                var listChildren = new List<byte[]>();
+                foreach (LegacyPptRecord listChild in list.Children) {
+                    listChildren.Add(listChild.CopyRecordBytes());
+                    if (ReferenceEquals(listChild, atom)) {
+                        listChildren.Add(listChild.CopyRecordBytes());
+                    }
+                }
+                documentChildren.Add(BuildVbaRecord(list.Version,
+                    list.Instance, list.Type,
+                    JoinExternalObjectRecords(listChildren)));
+            }
+            byte[] malformed = AppendLegacyDocumentPersist(
+                sourcePresentation, BuildVbaRecord(document.Version,
+                    document.Instance, document.Type,
+                    JoinExternalObjectRecords(documentChildren)));
+
+            using var input = new MemoryStream(malformed, writable: false);
+            using PowerPointPresentation imported =
+                PowerPointPresentation.Load(input);
+            Assert.Single(imported.Slides[0].Shapes).Left += 1000;
+
+            LegacyPptWritePreflightReport report = imported
+                .AnalyzeLegacyPptWrite();
+            Assert.False(report.CanWrite);
+            Assert.Throws<NotSupportedException>(() =>
+                imported.ToBytes(PowerPointFileFormat.Ppt));
+            byte[] rewritten = imported.ToBytes(PowerPointFileFormat.Ppt,
+                new PowerPointSaveOptions {
+                    LossPolicy = PowerPointConversionLossPolicy.Allow
+                });
+            Assert.Single(LegacyPptPresentation.Load(rewritten).Slides);
+        }
+
+        [Theory]
         [InlineData(0, OfficePackageSecurityRule.EmbeddedPayloads)]
         [InlineData(1, OfficePackageSecurityRule.ExternalRelationships)]
         [InlineData(2, OfficePackageSecurityRule.ActiveX)]

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.RichText.Readers.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.RichText.Readers.cs
@@ -219,6 +219,53 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void TextProjection_DropsInvalidXmlCharactersFromLegacyFontsAndBullets() {
+            var characterRun = new LegacyPptCharacterRun(
+                0, 1, "A", bold: null, italic: null, underline: null,
+                shadow: null, farEastHint: null, kumi: null, emboss: null,
+                fontIndex: 1, oldEastAsianFontIndex: 2, ansiFontIndex: 3,
+                symbolFontIndex: 4, typeface: "Primary\u0001Font",
+                oldEastAsianTypeface: "East\uD800Font",
+                ansiTypeface: "Ansi\u0002Font",
+                symbolTypeface: "Symbol\uDC00Font", fontSizePoints: null,
+                color: null, colorSchemeIndex: null,
+                baselinePositionPercent: null,
+                hasUnprojectedFormatting: false);
+            var paragraphRun = new LegacyPptParagraphRun(
+                0, 1, 0, hasBullet: true, bulletHasFont: true,
+                bulletHasColor: null, bulletHasSize: null,
+                bulletCharacter: '\uD800', bulletFontIndex: 5,
+                bulletTypeface: "Bullet\u0003Font", bulletSize: null,
+                bulletColor: null, bulletColorSchemeIndex: null,
+                alignment: null, lineSpacing: null, spaceBefore: null,
+                spaceAfter: null, fontAlignment: null,
+                characterWrap: null, wordWrap: null, overflow: null,
+                textDirection: null, hasUnprojectedFormatting: false);
+            var body = new LegacyPptTextBody(
+                "A", new[] { characterRun }, new[] { paragraphRun },
+                hasStyleRecord: true,
+                hasUnprojectedCharacterFormatting: false,
+                hasUnprojectedParagraphFormatting: false);
+
+            A.Paragraph projected = Assert.Single(
+                LegacyPptTextProjection.CreateTextBody(body)
+                    .Elements<A.Paragraph>());
+            A.ParagraphProperties paragraphProperties =
+                projected.ParagraphProperties!;
+            Assert.Equal("BulletFont", paragraphProperties
+                .GetFirstChild<A.BulletFont>()!.Typeface!.Value);
+            Assert.Null(paragraphProperties.GetFirstChild<A.CharacterBullet>());
+            A.RunProperties runProperties = Assert.Single(
+                projected.Elements<A.Run>()).RunProperties!;
+            Assert.Equal("AnsiFont", runProperties
+                .GetFirstChild<A.LatinFont>()!.Typeface!.Value);
+            Assert.Equal("EastFont", runProperties
+                .GetFirstChild<A.EastAsianFont>()!.Typeface!.Value);
+            Assert.Equal("SymbolFont", runProperties
+                .GetFirstChild<A.SymbolFont>()!.Typeface!.Value);
+        }
+
+        [Fact]
         public void TextRulerReader_RejectsReservedMaskBitsWithoutEscapingBounds() {
             byte[] payload = { 0x00, 0x00, 0x00, 0x80 };
             var record = new LegacyPptRecord(payload, 0, 0, 0, 0x0FA6, 0, payload.Length);

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.RichText.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.RichText.cs
@@ -292,6 +292,23 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void NativeWriter_ReportsOutOfRangeRichTextLevelBeforeBuildingRuler() {
+            using PowerPointPresentation presentation = PowerPointPresentation.Create();
+            PowerPointTextBox textBox = presentation.AddSlide(P.SlideLayoutValues.Blank)
+                .AddTextBoxPoints("Unsafe level", 30, 30, 240, 120);
+            P.Shape shape = Assert.IsType<P.Shape>(textBox.Element);
+            A.Paragraph paragraph = Assert.Single(shape.TextBody!.Elements<A.Paragraph>());
+            paragraph.ParagraphProperties ??= new A.ParagraphProperties();
+            paragraph.ParagraphProperties.Level = 32767;
+            paragraph.ParagraphProperties.LeftMargin = 0;
+
+            LegacyPptWritePreflightReport preflight = presentation.AnalyzeLegacyPptWrite();
+
+            Assert.False(preflight.CanWrite);
+            Assert.Contains(preflight.Findings, finding => finding.Code == "PPT-WRITE-RICH-TEXT");
+        }
+
+        [Fact]
         public void NativeWriter_AuthorsTextFrameMarginsWrappingAnchorDirectionAndAutoFit() {
             byte[] bytes;
             using (PowerPointPresentation presentation = PowerPointPresentation
@@ -496,9 +513,15 @@ namespace OfficeIMO.Tests {
 
                 LegacyPptWritePreflightReport preflight = imported
                     .AnalyzeLegacyPptWrite();
-                Assert.True(preflight.CanWrite,
-                    string.Join(Environment.NewLine, preflight.Findings));
-                savedBytes = imported.ToBytes(PowerPointFileFormat.Ppt);
+                Assert.False(preflight.CanWrite);
+                Assert.Contains(preflight.Findings, finding =>
+                    finding.Code == "PPT-WRITE-IMPORT-LOSS");
+                Assert.Throws<NotSupportedException>(() =>
+                    imported.ToBytes(PowerPointFileFormat.Ppt));
+                savedBytes = imported.ToBytes(PowerPointFileFormat.Ppt,
+                    new PowerPointSaveOptions {
+                        LossPolicy = PowerPointConversionLossPolicy.Allow
+                    });
             }
 
             LegacyPptPresentation saved = LegacyPptPresentation.Load(
@@ -519,9 +542,8 @@ namespace OfficeIMO.Tests {
                 paragraph.Alignment);
             Assert.Contains(saved.Fonts,
                 font => font.Typeface == "OfficeIMO Appended");
-            Assert.Equal(original.Package.UserEdits.Count + 1,
-                saved.Package.UserEdits.Count);
-            Assert.True(saved.Package.DocumentStream.AsSpan(0,
+            Assert.Single(saved.Package.UserEdits);
+            Assert.False(saved.Package.DocumentStream.AsSpan(0,
                     original.Package.DocumentStream.Length)
                 .SequenceEqual(original.Package.DocumentStream));
 

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.Safety.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.Safety.cs
@@ -1,4 +1,5 @@
 using OfficeIMO.Drawing;
+using OfficeIMO.Drawing.Internal;
 using OfficeIMO.PowerPoint;
 using OfficeIMO.PowerPoint.LegacyPpt;
 using OfficeIMO.PowerPoint.LegacyPpt.Internal;
@@ -793,6 +794,23 @@ namespace OfficeIMO.Tests {
                     }));
             Assert.Contains("Compound stream bytes exceed",
                 routeException.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void CompoundWriterLayoutScalesAcrossManySiblingStorages() {
+            const int storageCount = 10_000;
+            OfficeCompoundStream[] streams = Enumerable.Range(0, storageCount)
+                .Select(index => new OfficeCompoundStream(
+                    "Storage" + index.ToString("D5") + "/Item",
+                    Array.Empty<byte>()))
+                .ToArray();
+
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+            OfficeCompoundWriterLayout layout = OfficeCompoundWriterLayout.Create(streams);
+            stopwatch.Stop();
+
+            Assert.Equal(storageCount, layout.Streams.Count);
+            Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(5), stopwatch.Elapsed.ToString());
         }
 
         [Fact]

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.ShapeWrite.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.ShapeWrite.cs
@@ -119,6 +119,25 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void NativeWriter_ReportsOversizedShadowOffsetsWithoutOverflowing() {
+            using PowerPointPresentation source = PowerPointPresentation.Create();
+            PowerPointAutoShape shape = source.AddSlide(P.SlideLayoutValues.Blank)
+                .AddShapePoints(A.ShapeTypeValues.Rectangle, 24, 24, 120, 70);
+            shape.SetShadow("222222", blurPoints: 1D, distancePoints: 1D,
+                angleDegrees: 0D, transparencyPercent: 0);
+            P.Shape element = Assert.IsType<P.Shape>(shape.Element);
+            A.OuterShadow shadow = element.ShapeProperties!
+                .GetFirstChild<A.EffectList>()!
+                .GetFirstChild<A.OuterShadow>()!;
+            shadow.Distance = long.MaxValue;
+
+            LegacyPptWritePreflightReport preflight = source.AnalyzeLegacyPptWrite();
+
+            Assert.False(preflight.CanWrite);
+            Assert.Contains(preflight.Findings, finding => finding.Code == "PPT-WRITE-SHAPE-STYLE");
+        }
+
+        [Fact]
         public void NativeWriter_AuthorsUnattachedConnectorsWithLineFormatting() {
             byte[] bytes;
             using (PowerPointPresentation source = PowerPointPresentation

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.Vba.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.Vba.cs
@@ -49,7 +49,17 @@ namespace OfficeIMO.Tests {
                 projected.OpenXmlDocument.DocumentType);
             Assert.Equal(projectBytes, ReadVbaProject(projected));
             Assert.Empty(projected.ValidateDocument());
-            Assert.Equal(binary, projected.ToBytes(PowerPointFileFormat.Ppt));
+            LegacyPptWritePreflightReport projectedPreflight = projected
+                .AnalyzeLegacyPptWrite();
+            Assert.False(projectedPreflight.CanWrite);
+            Assert.Contains(projectedPreflight.Findings, finding =>
+                finding.Code == "PPT-WRITE-PRESERVED-VBA");
+            Assert.Throws<NotSupportedException>(() =>
+                projected.ToBytes(PowerPointFileFormat.Ppt));
+            Assert.Equal(binary, projected.ToBytes(PowerPointFileFormat.Ppt,
+                new PowerPointSaveOptions {
+                    LossPolicy = PowerPointConversionLossPolicy.Allow
+                }));
         }
 
         [Fact]
@@ -78,7 +88,10 @@ namespace OfficeIMO.Tests {
             }
             Assert.Equal(projectBytes, ReadVbaProject(imported));
             byte[] binaryAfterPptxExport = imported.ToBytes(
-                PowerPointFileFormat.Ppt);
+                PowerPointFileFormat.Ppt,
+                new PowerPointSaveOptions {
+                    LossPolicy = PowerPointConversionLossPolicy.Allow
+                });
             Assert.Equal(projectBytes, Assert.IsType<LegacyPptVbaProject>(
                 LegacyPptPresentation.Load(binaryAfterPptxExport)
                     .VbaProject).GetBytes());
@@ -325,8 +338,17 @@ namespace OfficeIMO.Tests {
             using (var input = new MemoryStream(sourceBytes))
             using (PowerPointPresentation imported = PowerPointPresentation.Load(input)) {
                 Assert.Equal(projectBytes, ReadVbaProject(imported));
-                Assert.Equal(sourceBytes,
+                LegacyPptWritePreflightReport exactPreflight = imported
+                    .AnalyzeLegacyPptWrite();
+                Assert.False(exactPreflight.CanWrite);
+                Assert.Contains(exactPreflight.Findings, finding =>
+                    finding.Code == "PPT-WRITE-PRESERVED-VBA");
+                Assert.Throws<NotSupportedException>(() =>
                     imported.ToBytes(PowerPointFileFormat.Ppt));
+                Assert.Equal(sourceBytes, imported.ToBytes(
+                    PowerPointFileFormat.Ppt, new PowerPointSaveOptions {
+                        LossPolicy = PowerPointConversionLossPolicy.Allow
+                    }));
                 PowerPointTextBox title = Assert.Single(imported.Slides[0]
                     .TextBoxes, item => item.Text == "Compressed VBA");
                 title.Left += 15875L;

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.cs
@@ -723,7 +723,7 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
-        public void ImportedBinarySlideOrder_ReordersPersistGroupsIncrementally() {
+        public void ImportedBinarySlideOrder_RequiresExplicitFreshRewrite() {
             byte[] sourceBytes;
             using (PowerPointPresentation created = PowerPointPresentation.Create()) {
                 created.AddSlide(P.SlideLayoutValues.Blank).AddTextBox("First");
@@ -732,23 +732,34 @@ namespace OfficeIMO.Tests {
                 sourceBytes = created.ToBytes(PowerPointFileFormat.Ppt);
             }
             LegacyPptPresentation source = LegacyPptPresentation.Load(sourceBytes);
-
             using var input = new MemoryStream(sourceBytes);
             using PowerPointPresentation presentation = PowerPointPresentation.Load(input);
             presentation.MoveSlide(0, 2);
 
-            Assert.True(presentation.AnalyzeLegacyPptWrite().CanWrite);
-            LegacyPptPresentation saved = LegacyPptPresentation.Load(
+            LegacyPptWritePreflightReport report = presentation
+                .AnalyzeLegacyPptWrite();
+            Assert.False(report.CanWrite);
+            Assert.Contains(report.Findings, finding =>
+                finding.Code == "PPT-WRITE-IMPORT-LOSS");
+            Assert.Throws<NotSupportedException>(() =>
                 presentation.ToBytes(PowerPointFileFormat.Ppt));
+            LegacyPptPresentation saved = LegacyPptPresentation.Load(
+                presentation.ToBytes(PowerPointFileFormat.Ppt,
+                    new PowerPointSaveOptions {
+                        LossPolicy = PowerPointConversionLossPolicy.Allow
+                    }));
             Assert.Equal(new[] { "Second", "Third", "First" }, saved.Slides.Select(slide =>
                 slide.Shapes.Single(shape => shape.Kind == LegacyPptShapeKind.TextBox).Text));
-            Assert.Equal(source.Package.UserEdits.Count + 1, saved.Package.UserEdits.Count);
-            Assert.True(saved.Package.DocumentStream.AsSpan(0, source.Package.DocumentStream.Length)
-                .SequenceEqual(source.Package.DocumentStream));
+            Assert.False(saved.Package.DocumentStream.AsSpan(0,
+                    Math.Min(saved.Package.DocumentStream.Length,
+                        source.Package.DocumentStream.Length))
+                .SequenceEqual(source.Package.DocumentStream.AsSpan(0,
+                    Math.Min(saved.Package.DocumentStream.Length,
+                        source.Package.DocumentStream.Length))));
         }
 
         [Fact]
-        public void ImportedBinarySlideDeletion_RemovesPersistGroupIncrementally() {
+        public void ImportedBinarySlideDeletion_RequiresExplicitFreshRewrite() {
             byte[] sourceBytes;
             using (PowerPointPresentation created = PowerPointPresentation.Create()) {
                 created.AddSlide(P.SlideLayoutValues.Blank).AddTextBox("Keep first");
@@ -756,24 +767,30 @@ namespace OfficeIMO.Tests {
                 created.AddSlide(P.SlideLayoutValues.Blank).AddTextBox("Keep last");
                 sourceBytes = created.ToBytes(PowerPointFileFormat.Ppt);
             }
-            LegacyPptPresentation source = LegacyPptPresentation.Load(sourceBytes);
-
             using var input = new MemoryStream(sourceBytes);
             using PowerPointPresentation presentation = PowerPointPresentation.Load(input);
             presentation.RemoveSlide(1);
 
-            Assert.True(presentation.AnalyzeLegacyPptWrite().CanWrite);
-            LegacyPptPresentation saved = LegacyPptPresentation.Load(
+            LegacyPptWritePreflightReport report = presentation
+                .AnalyzeLegacyPptWrite();
+            Assert.False(report.CanWrite);
+            Assert.Contains(report.Findings, finding =>
+                finding.Code == "PPT-WRITE-IMPORT-LOSS");
+            Assert.Throws<NotSupportedException>(() =>
                 presentation.ToBytes(PowerPointFileFormat.Ppt));
+            LegacyPptPresentation saved = LegacyPptPresentation.Load(
+                presentation.ToBytes(PowerPointFileFormat.Ppt,
+                    new PowerPointSaveOptions {
+                        LossPolicy = PowerPointConversionLossPolicy.Allow
+                    }));
             Assert.Equal(new[] { "Keep first", "Keep last" }, saved.Slides.Select(slide =>
                 slide.Shapes.Single(shape => shape.Kind == LegacyPptShapeKind.TextBox).Text));
-            Assert.Equal(source.Package.UserEdits.Count + 1, saved.Package.UserEdits.Count);
-            Assert.True(saved.Package.DocumentStream.AsSpan(0, source.Package.DocumentStream.Length)
-                .SequenceEqual(source.Package.DocumentStream));
+            Assert.False(saved.Slides.Any(slide => slide.Shapes.Any(shape =>
+                shape.Text == "Delete middle")));
         }
 
         [Fact]
-        public void ImportedBinarySlideAddition_AppendsPersistAndDrawingClusters() {
+        public void ImportedBinarySlideAddition_RequiresExplicitFreshRewrite() {
             LegacyPptPresentation source = LegacyPptPresentation.Load(FixturePath);
             using PowerPointPresentation presentation = PowerPointPresentation.Load(FixturePath);
             PowerPointSlide added = presentation.AddSlide();
@@ -781,9 +798,18 @@ namespace OfficeIMO.Tests {
             added.AddRectangle(300000, 1200000, 1200000, 600000);
             added.Hidden = true;
 
-            Assert.True(presentation.AnalyzeLegacyPptWrite().CanWrite);
-            LegacyPptPresentation saved = LegacyPptPresentation.Load(
+            LegacyPptWritePreflightReport report = presentation
+                .AnalyzeLegacyPptWrite();
+            Assert.False(report.CanWrite);
+            Assert.Contains(report.Findings, finding =>
+                finding.Code == "PPT-WRITE-IMPORT-LOSS");
+            Assert.Throws<NotSupportedException>(() =>
                 presentation.ToBytes(PowerPointFileFormat.Ppt));
+            LegacyPptPresentation saved = LegacyPptPresentation.Load(
+                presentation.ToBytes(PowerPointFileFormat.Ppt,
+                    new PowerPointSaveOptions {
+                        LossPolicy = PowerPointConversionLossPolicy.Allow
+                    }));
 
             Assert.Equal(2, saved.Slides.Count);
             Assert.Contains(saved.Slides[0].Shapes, shape => shape.Text == "OfficeIMO PowerPoint Basics");
@@ -796,9 +822,12 @@ namespace OfficeIMO.Tests {
                 saved.Slides[1].LayoutPlaceholderTypes[0]);
             Assert.Equal(LegacyPptPlaceholderKind.Subtitle,
                 saved.Slides[1].LayoutPlaceholderTypes[1]);
-            Assert.Equal(source.Package.UserEdits.Count + 1, saved.Package.UserEdits.Count);
-            Assert.True(saved.Package.DocumentStream.AsSpan(0, source.Package.DocumentStream.Length)
-                .SequenceEqual(source.Package.DocumentStream));
+            Assert.False(saved.Package.DocumentStream.AsSpan(0,
+                    Math.Min(saved.Package.DocumentStream.Length,
+                        source.Package.DocumentStream.Length))
+                .SequenceEqual(source.Package.DocumentStream.AsSpan(0,
+                    Math.Min(saved.Package.DocumentStream.Length,
+                        source.Package.DocumentStream.Length))));
         }
 
         [Fact]
@@ -815,9 +844,18 @@ namespace OfficeIMO.Tests {
                 out uint projectedMasterId));
             Assert.Equal(selectedMaster.MasterId, projectedMasterId);
 
-            Assert.True(presentation.AnalyzeLegacyPptWrite().CanWrite);
-            LegacyPptPresentation saved = LegacyPptPresentation.Load(
+            LegacyPptWritePreflightReport report = presentation
+                .AnalyzeLegacyPptWrite();
+            Assert.False(report.CanWrite);
+            Assert.Contains(report.Findings, finding =>
+                finding.Code == "PPT-WRITE-IMPORT-LOSS");
+            Assert.Throws<NotSupportedException>(() =>
                 presentation.ToBytes(PowerPointFileFormat.Ppt));
+            LegacyPptPresentation saved = LegacyPptPresentation.Load(
+                presentation.ToBytes(PowerPointFileFormat.Ppt,
+                    new PowerPointSaveOptions {
+                        LossPolicy = PowerPointConversionLossPolicy.Allow
+                    }));
 
             Assert.Equal(selectedMaster.MasterId, saved.Slides[1].MasterId);
             Assert.Contains(saved.Slides[1].Shapes, shape => shape.Text == "Uses second binary master");

--- a/OfficeIMO.PowerPoint/LegacyPpt/Internal/LegacyPptProjectionFingerprint.cs
+++ b/OfficeIMO.PowerPoint/LegacyPpt/Internal/LegacyPptProjectionFingerprint.cs
@@ -558,7 +558,14 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Internal {
                 NormalizeShapeFormatting(shape.ShapeProperties,
                     shapeProjection);
                 if (shape.TextBody != null) {
-                    shape.TextBody.RemoveAllChildren<A.Paragraph>();
+                    bool retainsSecuritySensitiveTextInteractions =
+                        !normalizeInteractions && shape.TextBody.Descendants()
+                            .Any(element => element is A.HyperlinkOnClick
+                                or A.HyperlinkOnHover
+                                or A.HyperlinkOnMouseOver);
+                    if (!retainsSecuritySensitiveTextInteractions) {
+                        shape.TextBody.RemoveAllChildren<A.Paragraph>();
+                    }
                     if (shapeProjection.CanEditTextFrame
                         && shape.TextBody.BodyProperties != null) {
                         shape.TextBody.BodyProperties.ClearAllAttributes();

--- a/OfficeIMO.PowerPoint/LegacyPpt/Internal/LegacyPptTextProjection.cs
+++ b/OfficeIMO.PowerPoint/LegacyPpt/Internal/LegacyPptTextProjection.cs
@@ -211,7 +211,9 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Internal {
                 return;
             }
             AppendBulletDecorationProperties(properties, run);
-            if (run.HasBullet == true && run.BulletCharacter.HasValue) {
+            if (run.HasBullet == true && run.BulletCharacter.HasValue
+                && LegacyPptXmlText.IsValidAttributeCharacter(
+                    run.BulletCharacter.Value)) {
                 properties.Append(new A.CharacterBullet { Char = run.BulletCharacter.Value.ToString() });
             }
         }
@@ -241,8 +243,12 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Internal {
             }
             if (run.BulletHasFont == false) {
                 properties.Append(new A.BulletFontText());
-            } else if (run.BulletHasFont == true && run.BulletTypeface != null) {
-                properties.Append(new A.BulletFont { Typeface = run.BulletTypeface });
+            } else if (run.BulletHasFont == true) {
+                string? typeface = LegacyPptXmlText.SanitizeAttributeValue(
+                    run.BulletTypeface);
+                if (!string.IsNullOrEmpty(typeface)) {
+                    properties.Append(new A.BulletFont { Typeface = typeface });
+                }
             }
         }
 
@@ -586,12 +592,19 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Internal {
                     new A.RgbColorModelHex { Val = source.Color }));
             }
             string? latinTypeface = source.AnsiTypeface ?? source.Typeface;
-            if (latinTypeface != null) properties.Append(new A.LatinFont { Typeface = latinTypeface });
-            if (source.OldEastAsianTypeface != null) {
-                properties.Append(new A.EastAsianFont { Typeface = source.OldEastAsianTypeface });
+            latinTypeface = LegacyPptXmlText.SanitizeAttributeValue(latinTypeface);
+            if (!string.IsNullOrEmpty(latinTypeface)) {
+                properties.Append(new A.LatinFont { Typeface = latinTypeface });
             }
-            if (source.SymbolTypeface != null) {
-                properties.Append(new A.SymbolFont { Typeface = source.SymbolTypeface });
+            string? eastAsianTypeface = LegacyPptXmlText.SanitizeAttributeValue(
+                source.OldEastAsianTypeface);
+            if (!string.IsNullOrEmpty(eastAsianTypeface)) {
+                properties.Append(new A.EastAsianFont { Typeface = eastAsianTypeface });
+            }
+            string? symbolTypeface = LegacyPptXmlText.SanitizeAttributeValue(
+                source.SymbolTypeface);
+            if (!string.IsNullOrEmpty(symbolTypeface)) {
+                properties.Append(new A.SymbolFont { Typeface = symbolTypeface });
             }
         }
 

--- a/OfficeIMO.PowerPoint/LegacyPpt/Internal/LegacyPptXmlText.cs
+++ b/OfficeIMO.PowerPoint/LegacyPpt/Internal/LegacyPptXmlText.cs
@@ -1,0 +1,40 @@
+using System.Text;
+
+namespace OfficeIMO.PowerPoint.LegacyPpt.Internal {
+    internal static class LegacyPptXmlText {
+        internal static string? SanitizeAttributeValue(string? value) {
+            if (value == null || value.Length == 0) return value;
+            StringBuilder? sanitized = null;
+            for (int index = 0; index < value.Length; index++) {
+                char current = value[index];
+                if (IsValidBmpCharacter(current)) {
+                    sanitized?.Append(current);
+                    continue;
+                }
+                if (char.IsHighSurrogate(current)
+                    && index + 1 < value.Length
+                    && char.IsLowSurrogate(value[index + 1])) {
+                    if (sanitized != null) {
+                        sanitized.Append(current);
+                        sanitized.Append(value[index + 1]);
+                    }
+                    index++;
+                    continue;
+                }
+                if (sanitized == null) {
+                    sanitized = new StringBuilder(value.Length);
+                    sanitized.Append(value, 0, index);
+                }
+            }
+            return sanitized?.ToString() ?? value;
+        }
+
+        internal static bool IsValidAttributeCharacter(char value) =>
+            IsValidBmpCharacter(value);
+
+        private static bool IsValidBmpCharacter(char value) =>
+            value == '\t' || value == '\n' || value == '\r'
+            || value >= ' ' && value <= '\uD7FF'
+            || value >= '\uE000' && value <= '\uFFFD';
+    }
+}

--- a/OfficeIMO.PowerPoint/LegacyPpt/LegacyPptPresentation.Fonts.cs
+++ b/OfficeIMO.PowerPoint/LegacyPpt/LegacyPptPresentation.Fonts.cs
@@ -28,6 +28,7 @@ namespace OfficeIMO.PowerPoint.LegacyPpt {
                 string typeface = atom.ReadUtf16Text(0, 64);
                 int terminator = typeface.IndexOf('\0');
                 if (terminator >= 0) typeface = typeface.Substring(0, terminator);
+                typeface = LegacyPptXmlText.SanitizeAttributeValue(typeface) ?? string.Empty;
                 if (typeface.Length == 0) {
                     AddDiagnostic("PPT-FONT-NAME-EMPTY", LegacyPptDiagnosticSeverity.Warning,
                         $"Font index {index} has an empty typeface name and was skipped.", atom.Offset);

--- a/OfficeIMO.PowerPoint/LegacyPpt/Write/LegacyPptPreservingWriter.ChangePlan.cs
+++ b/OfficeIMO.PowerPoint/LegacyPpt/Write/LegacyPptPreservingWriter.ChangePlan.cs
@@ -583,22 +583,7 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Write {
                 }
                 bool originalTopologyChanged = !currentSlideOrder.Select(slide => slide.PersistId)
                     .SequenceEqual(projectionMap.Slides.Select(slide => slide.PersistId));
-                if (addedSlides.Count > 0) {
-                    if (originalTopologyChanged || currentSlideOrder.Count != projectionMap.Slides.Count
-                        || !TryAppendNewSlides(package, projectionMap, addedSlides, rewritten,
-                            interactionCatalog, interactionContext, textFonts,
-                            pictureBullets,
-                            out IReadOnlyList<uint> addedSlideIds)) {
-                        return false;
-                    }
-                    slideIds.AddRange(addedSlideIds);
-                } else if (originalTopologyChanged) {
-                    if (!TryRewriteDocumentSlideOrder(package, projectionMap, currentSlideOrder,
-                            out byte[] documentRecord)) {
-                        return false;
-                    }
-                    rewritten.Add(package.DocumentPersistId, documentRecord);
-                }
+                if (addedSlides.Count > 0 || originalTopologyChanged) return false;
                 if (materializedLayoutDrawingUpdates.Count > 0) {
                     rewritten.TryGetValue(package.DocumentPersistId,
                         out byte[]? currentDocumentBytes);

--- a/OfficeIMO.PowerPoint/LegacyPpt/Write/LegacyPptPreservingWriter.Interactions.cs
+++ b/OfficeIMO.PowerPoint/LegacyPpt/Write/LegacyPptPreservingWriter.Interactions.cs
@@ -115,8 +115,12 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Write {
             LegacyPptProjectionMap projectionMap,
             LegacyPptWriter.LegacyPptWriterInteractionCatalog catalog,
             out PreservingInteractionContext context) {
+            if (!TryReadExternalObjectIdSeed(package, out uint externalObjectIdSeed)) {
+                context = null!;
+                return false;
+            }
             context = new PreservingInteractionContext(presentation, projectionMap,
-                ReadExternalObjectIdSeed(package));
+                externalObjectIdSeed);
             foreach (LegacyPptWriter.LegacyPptWriterHyperlink hyperlink
                      in catalog.Hyperlinks) {
                 if (!context.TryMap(hyperlink, out _)) return false;
@@ -124,14 +128,22 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Write {
             return true;
         }
 
-        private static uint ReadExternalObjectIdSeed(LegacyPptPackage package) {
+        private static bool TryReadExternalObjectIdSeed(
+            LegacyPptPackage package,
+            out uint seed) {
+            seed = 0;
             if (!TryReadDocument(package, out LegacyPptRecord? document)
-                || document == null) return 0;
-            LegacyPptRecord? list = document.Children.SingleOrDefault(record =>
-                record.Type == RecordExternalObjectList);
-            LegacyPptRecord? atom = list?.Children.SingleOrDefault(record =>
-                record.Type == RecordExternalObjectListAtom);
-            return atom?.PayloadLength == 4 ? atom.ReadUInt32(0) : 0;
+                || document == null) return true;
+            LegacyPptRecord[] lists = document.Children.Where(record =>
+                record.Type == RecordExternalObjectList).Take(2).ToArray();
+            if (lists.Length > 1) return false;
+            if (lists.Length == 0) return true;
+            LegacyPptRecord[] atoms = lists[0].Children.Where(record =>
+                record.Type == RecordExternalObjectListAtom).Take(2).ToArray();
+            if (atoms.Length > 1) return false;
+            if (atoms.Length == 0 || atoms[0].PayloadLength != 4) return true;
+            seed = atoms[0].ReadUInt32(0);
+            return true;
         }
 
         private static bool TryAppendNewHyperlinks(LegacyPptPackage package,

--- a/OfficeIMO.PowerPoint/LegacyPpt/Write/LegacyPptWritePreflight.cs
+++ b/OfficeIMO.PowerPoint/LegacyPpt/Write/LegacyPptWritePreflight.cs
@@ -14,8 +14,7 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Write {
             bool canPreserve = presentation.CanPreserveOriginalLegacyPackage
                 || LegacyPptPreservingWriter.CanWritePresentation(
                     presentation);
-            if (canPreserve
-                && !presentation.CanPreserveOriginalLegacyPackage) {
+            if (canPreserve) {
                 AddPreservedActiveContentFindings(presentation, findings);
             }
             if (canPreserve && packageFindingCount == 0) {

--- a/OfficeIMO.PowerPoint/LegacyPpt/Write/LegacyPptWriter.RichText.cs
+++ b/OfficeIMO.PowerPoint/LegacyPpt/Write/LegacyPptWriter.RichText.cs
@@ -473,6 +473,10 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Write {
                     .ParagraphProperties;
                 if (properties == null) continue;
                 int level = properties.Level?.Value ?? 0;
+                if (level < 0 || level > 4) {
+                    reason = "Base binary PowerPoint text supports paragraph levels zero through four.";
+                    return false;
+                }
                 maximumLevel = Math.Max(maximumLevel, level);
                 if (properties.LeftMargin?.HasValue == true) {
                     if (!TryToMasterInt16(properties.LeftMargin.Value,

--- a/OfficeIMO.PowerPoint/LegacyPpt/Write/LegacyPptWriter.ShapeFormatting.cs
+++ b/OfficeIMO.PowerPoint/LegacyPpt/Write/LegacyPptWriter.ShapeFormatting.cs
@@ -432,16 +432,20 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Write {
             }
             int direction = shadow.Direction?.Value ?? 0;
             double radians = direction / 60000D * Math.PI / 180D;
-            long offsetX = checked((long)Math.Round(Math.Cos(radians)
-                * distance, MidpointRounding.AwayFromZero));
-            long offsetY = checked((long)Math.Round(Math.Sin(radians)
-                * distance, MidpointRounding.AwayFromZero));
-            if (offsetX < int.MinValue || offsetX > int.MaxValue
-                || offsetY < int.MinValue || offsetY > int.MaxValue
+            double roundedOffsetX = Math.Round(Math.Cos(radians)
+                * distance, MidpointRounding.AwayFromZero);
+            double roundedOffsetY = Math.Round(Math.Sin(radians)
+                * distance, MidpointRounding.AwayFromZero);
+            if (double.IsNaN(roundedOffsetX) || double.IsInfinity(roundedOffsetX)
+                || double.IsNaN(roundedOffsetY) || double.IsInfinity(roundedOffsetY)
+                || roundedOffsetX < int.MinValue || roundedOffsetX > int.MaxValue
+                || roundedOffsetY < int.MinValue || roundedOffsetY > int.MaxValue
                 || blur > int.MaxValue) {
                 reason = "The outer shadow exceeds the classic OfficeArt coordinate range.";
                 return false;
             }
+            int offsetX = (int)roundedOffsetX;
+            int offsetY = (int)roundedOffsetY;
             properties.Add(new LegacyPptWriterFoptProperty(0x0200, 0U));
             properties.Add(new LegacyPptWriterFoptProperty(0x0201,
                 PackOfficeArtColor(color)));
@@ -450,9 +454,9 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Write {
                     ToOfficeArtOpacity(alpha.Value)));
             }
             properties.Add(new LegacyPptWriterFoptProperty(0x0205,
-                unchecked((uint)checked((int)offsetX))));
+                unchecked((uint)offsetX)));
             properties.Add(new LegacyPptWriterFoptProperty(0x0206,
-                unchecked((uint)checked((int)offsetY))));
+                unchecked((uint)offsetY)));
             if (blur > 0L) {
                 properties.Add(new LegacyPptWriterFoptProperty(0x021C,
                     checked((uint)blur)));

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.ValidationAndSave.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.ValidationAndSave.cs
@@ -345,6 +345,8 @@ namespace OfficeIMO.PowerPoint {
             if (options == null
                 && TryCopyOriginalEncryptedLegacyPackage(
                     out byte[] originalEncryptedBytes)) {
+                LegacyPptWritePreflight.ThrowIfBlocked(
+                    AnalyzeLegacyPptWrite(), options);
                 return originalEncryptedBytes;
             }
             ApplySignatureMutationPolicy();
@@ -371,6 +373,8 @@ namespace OfficeIMO.PowerPoint {
             if (LastSignatureReport?.Action
                     != PowerPointSignatureMutationAction.Removed
                 && TryCopyOriginalLegacyPackage(out byte[] originalBytes)) {
+                LegacyPptWritePreflight.ThrowIfBlocked(
+                    AnalyzeLegacyPptWrite(), options);
                 return originalBytes;
             }
             ApplySignatureMutationPolicy();
@@ -378,6 +382,8 @@ namespace OfficeIMO.PowerPoint {
             PresentationRoot.Save();
             _document!.Save();
             if (LegacyPptPreservingWriter.TryWritePresentation(this, out byte[] preservedBytes)) {
+                LegacyPptWritePreflight.ThrowIfBlocked(
+                    AnalyzeLegacyPptWrite(), options);
                 return preservedBytes;
             }
             if (LastSignatureReport?.Action == PowerPointSignatureMutationAction.Preserved

--- a/OfficeIMO.Reader.Email/EmailStoreReaderProjection.cs
+++ b/OfficeIMO.Reader.Email/EmailStoreReaderProjection.cs
@@ -64,16 +64,18 @@ internal static class EmailStoreReaderProjection {
                 folder.Id, folder.ParentId, folder.Name)).ToArray(),
             itemDiagnostics,
             cancellationToken);
-        int probeLimit = adapterOptions.MaxItems == int.MaxValue
+        EmailStoreReaderOptions storeOptions = GetStoreOptions(adapterOptions);
+        int maximumItems = Math.Min(adapterOptions.MaxItems, storeOptions.MaxItemCount);
+        int probeLimit = maximumItems == int.MaxValue
             ? int.MaxValue
-            : adapterOptions.MaxItems + 1;
+            : maximumItems + 1;
         EmailStoreQuery? query = adapterOptions.Query == null
             ? null
             : CopyQuery(adapterOptions.Query, Math.Min(adapterOptions.Query.MaxResults, probeLimit));
         IEnumerable<EmailStoreItemReference> references = query == null
             ? session.EnumerateItems(new EmailStoreEnumerationOptions(
-                includeAssociatedItems: GetStoreOptions(adapterOptions).IncludeAssociatedItems,
-                includeOrphanedItems: GetStoreOptions(adapterOptions).IncludeOrphanedItems,
+                includeAssociatedItems: storeOptions.IncludeAssociatedItems,
+                includeOrphanedItems: storeOptions.IncludeOrphanedItems,
                 maxItems: probeLimit), cancellationToken)
             : session.Search(query, cancellationToken).Select(result => result.Reference);
         int attempted = 0;
@@ -81,7 +83,7 @@ internal static class EmailStoreReaderProjection {
         bool selectionLimitReached = false;
         foreach (EmailStoreItemReference reference in references) {
             cancellationToken.ThrowIfCancellationRequested();
-            if (attempted >= adapterOptions.MaxItems) {
+            if (attempted >= maximumItems) {
                 selectionLimitReached = true;
                 break;
             }

--- a/OfficeIMO.Reader.OneNote/OneNoteReaderAdapter.Chunking.cs
+++ b/OfficeIMO.Reader.OneNote/OneNoteReaderAdapter.Chunking.cs
@@ -206,16 +206,7 @@ internal static partial class OneNoteReaderAdapter {
         foreach (ProjectionPart source in units) {
             if (!source.Fits(maxChars)) {
                 FlushProjectionPart(result, text, markdown);
-                IReadOnlyList<string> textParts = DocumentReaderEngine.SplitAdapterProjection(
-                    source.Text, maxChars);
-                IReadOnlyList<string> markdownParts = DocumentReaderEngine.SplitAdapterProjection(
-                    source.Markdown, maxChars);
-                int partCount = Math.Max(textParts.Count, markdownParts.Count);
-                for (int partIndex = 0; partIndex < partCount; partIndex++) {
-                    result.Add(new ProjectionPart(
-                        partIndex < textParts.Count ? textParts[partIndex] : string.Empty,
-                        partIndex < markdownParts.Count ? markdownParts[partIndex] : string.Empty));
-                }
+                result.Add(source);
                 continue;
             }
             string textSeparator = text.Length == 0 || source.Text.Length == 0 ? string.Empty : Environment.NewLine;

--- a/OfficeIMO.Reader.OneNote/OneNoteReaderAdapter.Chunking.cs
+++ b/OfficeIMO.Reader.OneNote/OneNoteReaderAdapter.Chunking.cs
@@ -204,6 +204,20 @@ internal static partial class OneNoteReaderAdapter {
         var markdown = new StringBuilder();
 
         foreach (ProjectionPart source in units) {
+            if (!source.Fits(maxChars)) {
+                FlushProjectionPart(result, text, markdown);
+                IReadOnlyList<string> textParts = DocumentReaderEngine.SplitAdapterProjection(
+                    source.Text, maxChars);
+                IReadOnlyList<string> markdownParts = DocumentReaderEngine.SplitAdapterProjection(
+                    source.Markdown, maxChars);
+                int partCount = Math.Max(textParts.Count, markdownParts.Count);
+                for (int partIndex = 0; partIndex < partCount; partIndex++) {
+                    result.Add(new ProjectionPart(
+                        partIndex < textParts.Count ? textParts[partIndex] : string.Empty,
+                        partIndex < markdownParts.Count ? markdownParts[partIndex] : string.Empty));
+                }
+                continue;
+            }
             string textSeparator = text.Length == 0 || source.Text.Length == 0 ? string.Empty : Environment.NewLine;
             string markdownSeparator = markdown.Length == 0 || source.Markdown.Length == 0
                 ? string.Empty
@@ -211,9 +225,7 @@ internal static partial class OneNoteReaderAdapter {
             bool fits = text.Length + textSeparator.Length + source.Text.Length <= maxChars &&
                         markdown.Length + markdownSeparator.Length + source.Markdown.Length <= maxChars;
             if (!fits && (text.Length > 0 || markdown.Length > 0)) {
-                result.Add(new ProjectionPart(text.ToString(), markdown.ToString()));
-                text.Clear();
-                markdown.Clear();
+                FlushProjectionPart(result, text, markdown);
                 textSeparator = string.Empty;
                 markdownSeparator = string.Empty;
             }
@@ -225,6 +237,16 @@ internal static partial class OneNoteReaderAdapter {
             result.Add(new ProjectionPart(text.ToString(), markdown.ToString()));
         }
         return result;
+    }
+
+    private static void FlushProjectionPart(
+        ICollection<ProjectionPart> result,
+        StringBuilder text,
+        StringBuilder markdown) {
+        if (text.Length == 0 && markdown.Length == 0) return;
+        result.Add(new ProjectionPart(text.ToString(), markdown.ToString()));
+        text.Clear();
+        markdown.Clear();
     }
 
     private readonly struct ProjectionPart {

--- a/OfficeIMO.Reader.Subtitles/SubtitleReaderAdapter.cs
+++ b/OfficeIMO.Reader.Subtitles/SubtitleReaderAdapter.cs
@@ -102,17 +102,52 @@ internal static class SubtitleReaderAdapter {
         int firstPartPrefixLength) {
         int limit = Math.Max(1, maxChars);
         int firstMarkdownLimit = Math.Max(1, limit - firstPartPrefixLength);
-        IReadOnlyList<string> textParts = DocumentReaderEngine.SplitAdapterProjection(value, limit);
-        IReadOnlyList<string> markdownParts = DocumentReaderEngine.SplitAdapterProjection(
-            EscapeCueMarkdown(value), firstMarkdownLimit, limit);
-        int partCount = Math.Max(textParts.Count, markdownParts.Count);
-        var result = new List<SubtitleProjectionPart>(partCount);
-        for (int index = 0; index < partCount; index++) {
-            result.Add(new SubtitleProjectionPart(
-                index < textParts.Count ? textParts[index] : string.Empty,
-                index < markdownParts.Count ? markdownParts[index] : string.Empty));
+        var result = new List<SubtitleProjectionPart>();
+        int offset = 0;
+        int markdownLimit = firstMarkdownLimit;
+        while (offset < value.Length) {
+            int length = FindAlignedCuePartLength(value, offset, limit, markdownLimit);
+            string text = value.Substring(offset, length);
+            result.Add(new SubtitleProjectionPart(text, EscapeCueMarkdown(text)));
+            offset += length;
+            markdownLimit = limit;
         }
         return result;
+    }
+
+    private static int FindAlignedCuePartLength(
+        string value,
+        int offset,
+        int textLimit,
+        int markdownLimit) {
+        int length = 0;
+        int markdownLength = 0;
+        while (offset + length < value.Length) {
+            int scalarLength = char.IsHighSurrogate(value[offset + length]) &&
+                offset + length + 1 < value.Length && char.IsLowSurrogate(value[offset + length + 1])
+                ? 2
+                : 1;
+            int escapedLength = scalarLength == 1
+                ? EscapedCueCharacterLength(value[offset + length])
+                : scalarLength;
+            if (length > 0 &&
+                (length + scalarLength > textLimit || markdownLength + escapedLength > markdownLimit)) {
+                break;
+            }
+            length += scalarLength;
+            markdownLength += escapedLength;
+            if (length >= textLimit || markdownLength >= markdownLimit) break;
+        }
+        return Math.Max(1, length);
+    }
+
+    private static int EscapedCueCharacterLength(char value) {
+        switch (value) {
+            case '&': return 5;
+            case '<':
+            case '>': return 4;
+            default: return 1;
+        }
     }
 
     private static string EscapeCueMarkdown(string value) => value

--- a/OfficeIMO.Reader.Subtitles/SubtitleReaderAdapter.cs
+++ b/OfficeIMO.Reader.Subtitles/SubtitleReaderAdapter.cs
@@ -40,7 +40,8 @@ internal static class SubtitleReaderAdapter {
                 ? "**" + SubtitleParser.FormatTimestamp(cue.Start) + " → " + SubtitleParser.FormatTimestamp(cue.End) + "**" +
                     Environment.NewLine + Environment.NewLine
                 : string.Empty;
-            IReadOnlyList<string> cueParts = SplitCueText(cue.Text, readerOptions.MaxChars, markdownPrefix.Length);
+            IReadOnlyList<SubtitleProjectionPart> cueParts = SplitCueProjection(
+                cue.Text, readerOptions.MaxChars, markdownPrefix.Length);
             string[]? warnings = BuildCueWarnings(cue.Truncated, cueParts.Count > 1);
             for (int partIndex = 0; partIndex < cueParts.Count; partIndex++) {
                 string anchor = partIndex == 0
@@ -55,14 +56,14 @@ internal static class SubtitleReaderAdapter {
                     SourceBlockKind = "subtitle-cue",
                     BlockAnchor = anchor
                 };
-                string text = cueParts[partIndex];
+                SubtitleProjectionPart part = cueParts[partIndex];
                 var chunk = new ReaderChunk {
                     Id = anchor,
                     Kind = ReaderInputKind.Text,
                     ContinuesPreviousChunk = partIndex > 0,
                     Location = location,
-                    Text = text,
-                    Markdown = partIndex == 0 ? markdownPrefix + text : text,
+                    Text = part.Text,
+                    Markdown = partIndex == 0 ? markdownPrefix + part.Markdown : part.Markdown,
                     Warnings = warnings
                 };
                 DocumentReaderEngine.ApplyAdapterSource(chunk, input, readerOptions.ComputeHashes);
@@ -95,11 +96,29 @@ internal static class SubtitleReaderAdapter {
         return result;
     }
 
-    private static IReadOnlyList<string> SplitCueText(string value, int maxChars, int firstPartPrefixLength) {
+    private static IReadOnlyList<SubtitleProjectionPart> SplitCueProjection(
+        string value,
+        int maxChars,
+        int firstPartPrefixLength) {
         int limit = Math.Max(1, maxChars);
-        int firstLimit = Math.Max(1, limit - firstPartPrefixLength);
-        return DocumentReaderEngine.SplitAdapterProjection(value, firstLimit, limit);
+        int firstMarkdownLimit = Math.Max(1, limit - firstPartPrefixLength);
+        IReadOnlyList<string> textParts = DocumentReaderEngine.SplitAdapterProjection(value, limit);
+        IReadOnlyList<string> markdownParts = DocumentReaderEngine.SplitAdapterProjection(
+            EscapeCueMarkdown(value), firstMarkdownLimit, limit);
+        int partCount = Math.Max(textParts.Count, markdownParts.Count);
+        var result = new List<SubtitleProjectionPart>(partCount);
+        for (int index = 0; index < partCount; index++) {
+            result.Add(new SubtitleProjectionPart(
+                index < textParts.Count ? textParts[index] : string.Empty,
+                index < markdownParts.Count ? markdownParts[index] : string.Empty));
+        }
+        return result;
     }
+
+    private static string EscapeCueMarkdown(string value) => value
+        .Replace("&", "&amp;")
+        .Replace("<", "&lt;")
+        .Replace(">", "&gt;");
 
     private static string[]? BuildCueWarnings(bool cueTruncated, bool wasSplit) {
         if (!cueTruncated && !wasSplit) return null;
@@ -155,5 +174,15 @@ internal static class SubtitleReaderAdapter {
         using var stream = new MemoryStream(bytes, writable: false);
         using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
         return reader.ReadToEnd();
+    }
+
+    private readonly struct SubtitleProjectionPart {
+        internal SubtitleProjectionPart(string text, string markdown) {
+            Text = text;
+            Markdown = markdown;
+        }
+
+        internal string Text { get; }
+        internal string Markdown { get; }
     }
 }

--- a/OfficeIMO.Reader.Tests/Reader.EmailStore.Modular.cs
+++ b/OfficeIMO.Reader.Tests/Reader.EmailStore.Modular.cs
@@ -180,6 +180,35 @@ public sealed class ReaderEmailStoreModularTests {
     }
 
     [Fact]
+    public void RegisteredStoreItemBoundCannotBeWidenedByTheReaderProjection() {
+        string root = Path.Combine(Path.GetTempPath(),
+            "officeimo-reader-store-bound-" + Guid.NewGuid().ToString("N"));
+        try {
+            Directory.CreateDirectory(root);
+            File.WriteAllText(Path.Combine(root, "first.eml"), "Subject: First\r\n\r\nBody");
+            File.WriteAllText(Path.Combine(root, "second.eml"), "Subject: Second\r\n\r\nBody");
+            var storeOptions = new EmailStoreReaderOptions(maxItemCount: 1);
+            var adapterOptions = new ReaderEmailStoreOptions {
+                MaxItems = 10,
+                StoreOptions = storeOptions
+            };
+            using EmailStoreSession session = EmailStoreSession.Open(root, storeOptions);
+
+            OfficeIMO.Reader.Email.EmailStoreProjection projection = EmailStoreReaderProjection.Create(
+                session,
+                "mailbox",
+                adapterOptions,
+                default);
+
+            Assert.Single(projection.Documents);
+            Assert.Equal("First", projection.Documents[0].Subject);
+            Assert.True(projection.SelectionLimitReached);
+        } finally {
+            if (Directory.Exists(root)) Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public void Store_source_hash_is_opt_in_while_chunk_hashes_remain_available() {
         byte[] emlx = CreateEmlx(CreateMultipartMessage(), null);
         string path = Path.Combine(Path.GetTempPath(), "officeimo-reader-store-" + Guid.NewGuid().ToString("N") + ".emlx");

--- a/OfficeIMO.Reader.Tests/Reader.MediaAdapters.Subtitles.cs
+++ b/OfficeIMO.Reader.Tests/Reader.MediaAdapters.Subtitles.cs
@@ -18,4 +18,17 @@ public sealed partial class ReaderMediaAdapterTests {
         Assert.Equal("first\nsecond", chunk.Text);
         Assert.EndsWith("first\nsecond", chunk.Markdown, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void SubtitleAdapter_EncodedMarkupRemainsLiteralInMarkdown() {
+        const string srt = "1\n00:00:00,000 --> 00:00:01,000\n&lt;img src=x onerror=alert(1)&gt;\n";
+        OfficeDocumentReader reader = new OfficeDocumentReaderBuilder().AddSubtitleHandler().Build();
+
+        ReaderChunk chunk = Assert.Single(reader.ReadDocument(
+            Encoding.UTF8.GetBytes(srt), "encoded.srt").Chunks);
+
+        Assert.Equal("<img src=x onerror=alert(1)>", chunk.Text);
+        Assert.DoesNotContain("<img", chunk.Markdown, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("&lt;img", chunk.Markdown, StringComparison.Ordinal);
+    }
 }

--- a/OfficeIMO.Reader.Tests/Reader.MediaAdapters.Subtitles.cs
+++ b/OfficeIMO.Reader.Tests/Reader.MediaAdapters.Subtitles.cs
@@ -5,6 +5,11 @@ using Xunit;
 namespace OfficeIMO.Tests;
 
 public sealed partial class ReaderMediaAdapterTests {
+    private static string EscapeSubtitleMarkdown(string value) => value
+        .Replace("&", "&amp;")
+        .Replace("<", "&lt;")
+        .Replace(">", "&gt;");
+
     [Theory]
     [InlineData("first<br>second")]
     [InlineData("first<BR/>second")]

--- a/OfficeIMO.Reader.Tests/Reader.MediaAdapters.cs
+++ b/OfficeIMO.Reader.Tests/Reader.MediaAdapters.cs
@@ -785,6 +785,27 @@ public sealed partial class ReaderMediaAdapterTests {
     }
 
     [Fact]
+    public void SubtitleAdapter_SplitsEscapedMarkdownAtMatchingSourceRanges() {
+        string cueText = string.Concat(Enumerable.Repeat("123456<789&ABC>DEF", 40));
+        string srt = "1\n00:00:00,000 --> 00:00:01,000\n" + cueText + "\n";
+        OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
+            .AddSubtitleHandler(new ReaderSubtitleOptions { IncludeTimestampsInMarkdown = false })
+            .Build();
+
+        OfficeDocumentReadResult result = reader.ReadDocument(
+            Encoding.UTF8.GetBytes(srt),
+            "aligned.srt",
+            new ReaderOptions { MaxChars = 256 });
+
+        Assert.True(result.Chunks.Count > 1);
+        Assert.Equal(cueText, string.Concat(result.Chunks.Select(chunk => chunk.Text)));
+        Assert.Equal(EscapeSubtitleMarkdown(cueText),
+            string.Concat(result.Chunks.Select(chunk => chunk.Markdown)));
+        Assert.All(result.Chunks, chunk =>
+            Assert.Equal(EscapeSubtitleMarkdown(chunk.Text), chunk.Markdown));
+    }
+
+    [Fact]
     public void AdapterSnapshot_ReappliesTheRegisteredDefaultInputLimit() {
         const string extension = ".adapterlimit";
         OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()

--- a/OfficeIMO.Reader.Tests/Reader.OneNote.Modular.cs
+++ b/OfficeIMO.Reader.Tests/Reader.OneNote.Modular.cs
@@ -232,7 +232,7 @@ public sealed class ReaderOneNoteModularTests {
     }
 
     [Fact]
-    public void OneNoteAdapter_SplitsOversizedNonTextUnitsAtMaxChars() {
+    public void OneNoteAdapter_PreservesOversizedNonTextUnitsAtSharedSourceBoundaries() {
         string title = "Heading " + new string('h', 40);
         string altText = "Preview " + new string('i', 40);
         var section = new OneNoteSection { Name = "Oversized" };
@@ -249,15 +249,15 @@ public sealed class ReaderOneNoteModularTests {
             section,
             readerOptions: new ReaderOptions { MaxChars = 16 });
 
-        Assert.True(result.Chunks.Count > 2);
-        Assert.All(result.Chunks, chunk => {
-            Assert.True(chunk.Text.Length <= 16, chunk.Text);
-            Assert.True(chunk.Markdown!.Length <= 16, chunk.Markdown);
-        });
-        Assert.Equal(title + "[Image: " + altText + "]",
-            string.Concat(result.Chunks.Select(chunk => chunk.Text)));
-        Assert.Equal("# " + title + "![" + altText + "](onenote-page-0001-asset-0001)",
-            string.Concat(result.Chunks.Select(chunk => chunk.Markdown)));
+        Assert.Equal(2, result.Chunks.Count);
+        Assert.Equal(title, result.Chunks[0].Text);
+        Assert.Equal("# " + title, result.Chunks[0].Markdown);
+        Assert.Equal("[Image: " + altText + "]", result.Chunks[1].Text);
+        Assert.Equal("![" + altText + "](onenote-page-0001-asset-0001)",
+            result.Chunks[1].Markdown);
+        Assert.All(result.Chunks, chunk =>
+            Assert.Contains(chunk.Warnings!, warning =>
+                warning.Contains("preserved as one chunk", StringComparison.OrdinalIgnoreCase)));
     }
 
     [Theory]

--- a/OfficeIMO.Reader.Tests/Reader.OneNote.Modular.cs
+++ b/OfficeIMO.Reader.Tests/Reader.OneNote.Modular.cs
@@ -232,7 +232,7 @@ public sealed class ReaderOneNoteModularTests {
     }
 
     [Fact]
-    public void OneNoteAdapter_PreservesOversizedMarkdownConstructsAsWholeChunks() {
+    public void OneNoteAdapter_SplitsOversizedNonTextUnitsAtMaxChars() {
         string title = "Heading " + new string('h', 40);
         string altText = "Preview " + new string('i', 40);
         var section = new OneNoteSection { Name = "Oversized" };
@@ -249,17 +249,15 @@ public sealed class ReaderOneNoteModularTests {
             section,
             readerOptions: new ReaderOptions { MaxChars = 16 });
 
-        Assert.Collection(result.Chunks,
-            heading => {
-                Assert.Equal(title, heading.Text);
-                Assert.Equal("# " + title, heading.Markdown);
-                Assert.Contains(heading.Warnings!, warning => warning.Contains("preserved as one chunk", StringComparison.OrdinalIgnoreCase));
-            },
-            image => {
-                Assert.Equal("[Image: " + altText + "]", image.Text);
-                Assert.Equal("![" + altText + "](onenote-page-0001-asset-0001)", image.Markdown);
-                Assert.Contains(image.Warnings!, warning => warning.Contains("preserved as one chunk", StringComparison.OrdinalIgnoreCase));
-            });
+        Assert.True(result.Chunks.Count > 2);
+        Assert.All(result.Chunks, chunk => {
+            Assert.True(chunk.Text.Length <= 16, chunk.Text);
+            Assert.True(chunk.Markdown!.Length <= 16, chunk.Markdown);
+        });
+        Assert.Equal(title + "[Image: " + altText + "]",
+            string.Concat(result.Chunks.Select(chunk => chunk.Text)));
+        Assert.Equal("# " + title + "![" + altText + "](onenote-page-0001-asset-0001)",
+            string.Concat(result.Chunks.Select(chunk => chunk.Markdown)));
     }
 
     [Theory]

--- a/OfficeIMO.Reader.Tests/Reader.Tool.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Tool.cs
@@ -306,7 +306,7 @@ public sealed class ReaderToolTests {
     }
 
     [Fact]
-    public void FolderDiscoverySelectsTheSameBoundedLexicographicSubset() {
+    public void FolderDiscoveryStopsAtTheConfiguredSupportedFileBound() {
         using var temporary = new ReaderToolTemporaryDirectory();
         for (int index = 99; index >= 0; index--) {
             File.WriteAllText(Path.Combine(temporary.Path, index.ToString("D3") + ".md"), "# Document");
@@ -322,7 +322,28 @@ public sealed class ReaderToolTests {
             CancellationToken.None);
 
         Assert.Equal(3, paths.Count);
-        Assert.Equal(new[] { "000.md", "001.md", "002.md" }, paths.Select(Path.GetFileName));
+        Assert.All(paths, path => Assert.Equal(".md", Path.GetExtension(path)));
+    }
+
+    [Fact]
+    public void FolderDiscoveryStopsWhenTheNextSupportedFileExceedsTheByteBudget() {
+        using var temporary = new ReaderToolTemporaryDirectory();
+        File.WriteAllText(Path.Combine(temporary.Path, "oversized.md"),
+            new string('x', 128));
+        File.WriteAllText(Path.Combine(temporary.Path, "unvisited.md"),
+            new string('y', 128));
+        OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
+            .AddMarkdownHandler().Build();
+
+        IReadOnlyList<string> paths = ReaderToolFileDiscovery.FindSupportedFiles(
+            temporary.Path,
+            reader,
+            recurse: true,
+            maxFiles: 100,
+            maxTotalBytes: 64,
+            CancellationToken.None);
+
+        Assert.Empty(paths);
     }
 
     [Fact]

--- a/OfficeIMO.Reader.Tool/ReaderToolFileDiscovery.cs
+++ b/OfficeIMO.Reader.Tool/ReaderToolFileDiscovery.cs
@@ -17,6 +17,7 @@ internal static class ReaderToolFileDiscovery {
             AttributesToSkip = FileAttributes.ReparsePoint,
             ReturnSpecialDirectories = false
         };
+        long totalBytes = 0;
 
         foreach (string file in Directory.EnumerateFiles(
             Path.GetFullPath(rootPath),
@@ -28,20 +29,15 @@ internal static class ReaderToolFileDiscovery {
                 continue;
             }
 
-            selected.Add(file);
-            if (selected.Count > maxFiles) {
-                selected.Remove(selected.Max!);
-            }
-        }
-
-        var results = new List<string>(selected.Count);
-        long totalBytes = 0;
-        foreach (string file in selected) {
             long length = new FileInfo(file).Length;
-            if (maxTotalBytes.HasValue && length > maxTotalBytes.Value - totalBytes) break;
+            if (maxTotalBytes.HasValue
+                && length > maxTotalBytes.Value - totalBytes) {
+                break;
+            }
             totalBytes += length;
-            results.Add(file);
+            selected.Add(file);
+            if (selected.Count >= maxFiles) break;
         }
-        return results;
+        return selected.ToList();
     }
 }

--- a/OfficeIMO.SharedSource/Compound/OfficeCompoundWriterLayout.cs
+++ b/OfficeIMO.SharedSource/Compound/OfficeCompoundWriterLayout.cs
@@ -62,8 +62,7 @@ namespace OfficeIMO.Drawing.Internal {
             foreach (string name in segments) {
                 ValidateName(name);
                 path = path.Length == 0 ? name : string.Concat(path, "/", name);
-                OfficeCompoundWriterEntry? existing = parent.Children.FirstOrDefault(child =>
-                    string.Equals(child.Name, name, StringComparison.OrdinalIgnoreCase));
+                OfficeCompoundWriterEntry? existing = parent.FindChild(name);
                 if (existing != null) {
                     if (existing.ObjectType != 1) {
                         throw new ArgumentException(string.Concat("Conflicting compound storage path '", path, "'."),
@@ -73,7 +72,7 @@ namespace OfficeIMO.Drawing.Internal {
                     continue;
                 }
                 var created = new OfficeCompoundWriterEntry(name, path, 1, null);
-                parent.Children.Add(created);
+                parent.AddChild(created);
                 parent = created;
             }
         }
@@ -104,8 +103,7 @@ namespace OfficeIMO.Drawing.Internal {
                 ValidateName(name);
                 path = path.Length == 0 ? name : string.Concat(path, "/", name);
                 bool isStream = i + 1 == segments.Length;
-                OfficeCompoundWriterEntry? existing = parent.Children.FirstOrDefault(child =>
-                    string.Equals(child.Name, name, StringComparison.OrdinalIgnoreCase));
+                OfficeCompoundWriterEntry? existing = parent.FindChild(name);
                 if (existing != null) {
                     if (isStream || existing.ObjectType != 1) {
                         throw new ArgumentException(string.Concat("Duplicate or conflicting compound path '", path, "'."), nameof(stream));
@@ -116,7 +114,7 @@ namespace OfficeIMO.Drawing.Internal {
 
                 var created = new OfficeCompoundWriterEntry(name, path, isStream ? (byte)2 : (byte)1,
                     isStream ? stream : (OfficeCompoundStream?)null);
-                parent.Children.Add(created);
+                parent.AddChild(created);
                 parent = created;
             }
         }
@@ -161,6 +159,9 @@ namespace OfficeIMO.Drawing.Internal {
     }
 
     internal sealed class OfficeCompoundWriterEntry {
+        private readonly Dictionary<string, OfficeCompoundWriterEntry> _childrenByName =
+            new Dictionary<string, OfficeCompoundWriterEntry>(StringComparer.OrdinalIgnoreCase);
+
         internal OfficeCompoundWriterEntry(string name, string path, byte objectType, OfficeCompoundStream? stream) {
             Name = name;
             Path = path;
@@ -177,6 +178,21 @@ namespace OfficeIMO.Drawing.Internal {
         internal OfficeCompoundStream? Stream { get; }
 
         internal List<OfficeCompoundWriterEntry> Children { get; } = new List<OfficeCompoundWriterEntry>();
+
+        internal OfficeCompoundWriterEntry? FindChild(string name) =>
+            _childrenByName.TryGetValue(name, out OfficeCompoundWriterEntry? child)
+                ? child
+                : null;
+
+        internal void AddChild(OfficeCompoundWriterEntry child) {
+            if (_childrenByName.ContainsKey(child.Name)) {
+                throw new ArgumentException(
+                    string.Concat("Duplicate compound entry '", child.Name, "'."),
+                    nameof(child));
+            }
+            _childrenByName.Add(child.Name, child);
+            Children.Add(child);
+        }
 
         internal Guid ClassId { get; private set; }
 


### PR DESCRIPTION
## Summary

- enforce bounded parsing, projection, and preservation across legacy PowerPoint, XLSB, PST, mailbox-directory, OneNote, subtitle, Markdown, and Reader folder workflows
- require an explicit legacy PowerPoint loss-policy opt-in before preserving imported active content or unsupported topology
- sanitize malformed legacy text, bullet, shadow, color, and action data before it reaches Open XML or Google Slides surfaces
- prevent native Slides image requests from leaking bearer tokens, restrict them to HTTPS Google content hosts, and stream Google response bodies through cancellation-aware limits and timeouts
- keep mailbox reads rooted to canonical physical paths while rejecting swapped links and non-regular descriptors, including when the mailbox itself is a filesystem root
- keep subtitle and OneNote text/Markdown chunks aligned to the same source ranges

## Compatibility notes

Legacy PPT edits that preserve external links, VBA, OLE, or other active content now require PowerPointSaveOptions.LossPolicy = Allow. Native Google Slides image import accepts ephemeral HTTPS googleusercontent.com content URLs; Drive-export import remains the broad fallback. Oversized inseparable OneNote units may exceed the best-effort MaxChars target and carry an explicit warning instead of emitting mismatched projections.

## Validation

Affected security and review regressions pass on .NET 8 and .NET 10. The complete legacy PowerPoint suite passes 564 tests per target with one platform-only skip, Google Slides passes 35 tests per target with one live-test skip, mailbox-directory session tests pass 26 tests per target, focused Google transport tests pass 6 per target, and combined subtitle/OneNote tests pass 46 per target. Affected netstandard2.0 builds are warning-free.