### PR TITLE
Harden cloud imports and document conversion boundaries

### DIFF
--- a/OfficeIMO.Drawing/Internal/OfficeTemporaryFile.cs
+++ b/OfficeIMO.Drawing/Internal/OfficeTemporaryFile.cs
@@ -1,0 +1,35 @@
+using System;
+using System.IO;
+
+namespace OfficeIMO.Drawing.Internal {
+    /// <summary>Creates owner-only, non-shareable temporary files that the operating system deletes on close.</summary>
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    internal static class OfficeTemporaryFile {
+        internal static FileStream Create(
+            string prefix,
+            string suffix,
+            FileOptions options,
+            out string path) {
+            if (string.IsNullOrWhiteSpace(prefix)) throw new ArgumentException("Temporary file prefix cannot be empty.", nameof(prefix));
+            if (suffix == null) throw new ArgumentNullException(nameof(suffix));
+
+            path = Path.Combine(Path.GetTempPath(), prefix + Guid.NewGuid().ToString("N") + suffix);
+#if NET6_0_OR_GREATER
+            var streamOptions = new FileStreamOptions {
+                Mode = FileMode.CreateNew,
+                Access = FileAccess.ReadWrite,
+                Share = FileShare.None,
+                BufferSize = 81920,
+                Options = options | FileOptions.DeleteOnClose
+            };
+            if (!OperatingSystem.IsWindows()) {
+                streamOptions.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+            }
+            return new FileStream(path, streamOptions);
+#else
+            return new FileStream(path, FileMode.CreateNew, FileAccess.ReadWrite,
+                FileShare.None, 81920, options | FileOptions.DeleteOnClose);
+#endif
+        }
+    }
+}

--- a/OfficeIMO.Email.Tests/Mime/EmailCalendarProjectionEdgeTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailCalendarProjectionEdgeTests.cs
@@ -327,6 +327,21 @@ public sealed class EmailCalendarProjectionEdgeTests {
     }
 
     [Fact]
+    public void CalendarAttendeeNeverPromotesEnvelopeBccRecipient() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Bcc: Hidden <hidden@example.com>\r\nContent-Type: text/calendar; charset=utf-8\r\n\r\n" +
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nMETHOD:REQUEST\r\nBEGIN:VEVENT\r\nUID:hidden@example.com\r\n" +
+            "DTSTART:20260801T100000Z\r\nATTENDEE;CN=Hidden:mailto:hidden@example.com\r\n" +
+            "END:VEVENT\r\nEND:VCALENDAR\r\n");
+
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailRecipient recipient = Assert.Single(document.Recipients);
+        Assert.Equal(EmailRecipientKind.Bcc, recipient.Kind);
+        Assert.Equal("hidden@example.com", recipient.Address.Address);
+    }
+
+    [Fact]
     public void UsesCalendarAttendeeNameWhenEnvelopeRecipientHasNoDisplayName() {
         byte[] eml = Encoding.ASCII.GetBytes(
             "To: alice@example.com\r\nContent-Type: text/calendar; charset=utf-8\r\n\r\n" +

--- a/OfficeIMO.Email.Tests/Reading/EmailStreamingSafetyTests.cs
+++ b/OfficeIMO.Email.Tests/Reading/EmailStreamingSafetyTests.cs
@@ -50,6 +50,47 @@ public sealed class EmailStreamingSafetyTests {
     }
 
     [Fact]
+    public void StreamingReaderCountsSemanticAttachmentBeforeDecodingExternalContent() {
+        byte[] artifact = Encoding.ASCII.GetBytes(
+            "MIME-Version: 1.0\r\n" +
+            "Content-Type: multipart/mixed; boundary=officeimo\r\n\r\n" +
+            "--officeimo\r\nContent-Type: text/calendar\r\n\r\nBEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n" +
+            "--officeimo\r\nContent-Type: application/octet-stream; name=large.bin\r\n" +
+            "Content-Disposition: attachment; filename=large.bin\r\n\r\n0123456789ABCDEF\r\n" +
+            "--officeimo--\r\n");
+        var reader = new EmailDocumentReader(new EmailReaderOptions(
+            maxAttachmentBytes: 8,
+            maxAttachmentCount: 1));
+
+        EmailLimitExceededException exception = Assert.Throws<EmailLimitExceededException>(() =>
+            reader.ReadStreaming(new MemoryStream(artifact, writable: false), "semantic.eml"));
+
+        Assert.Equal(nameof(EmailReaderOptions.MaxAttachmentCount), exception.LimitName);
+    }
+
+    [Fact]
+    public void StreamingReaderCountsNestedAdditionalBodyBeforeDecodingExternalContent() {
+        byte[] artifact = Encoding.ASCII.GetBytes(
+            "MIME-Version: 1.0\r\n" +
+            "Content-Type: multipart/mixed; boundary=outer\r\n\r\n" +
+            "--outer\r\nContent-Type: multipart/alternative; boundary=inner\r\n\r\n" +
+            "--inner\r\nContent-Type: text/plain\r\n\r\nPrimary body\r\n" +
+            "--inner\r\nContent-Type: text/plain\r\n\r\nAdditional body\r\n" +
+            "--inner--\r\n" +
+            "--outer\r\nContent-Type: application/octet-stream; name=large.bin\r\n" +
+            "Content-Disposition: attachment; filename=large.bin\r\n\r\n0123456789ABCDEF\r\n" +
+            "--outer--\r\n");
+        var reader = new EmailDocumentReader(new EmailReaderOptions(
+            maxAttachmentBytes: 8,
+            maxAttachmentCount: 1));
+
+        EmailLimitExceededException exception = Assert.Throws<EmailLimitExceededException>(() =>
+            reader.ReadStreaming(new MemoryStream(artifact, writable: false), "nested.eml"));
+
+        Assert.Equal(nameof(EmailReaderOptions.MaxAttachmentCount), exception.LimitName);
+    }
+
+    [Fact]
     public void TruncatedTnefReturnsDiagnosticsWithoutRetainingTemporaryContent() {
         var document = new EmailDocument { Subject = "truncated" };
         document.Attachments.Add(new EmailAttachment {

--- a/OfficeIMO.Email.Tests/Store/Emlx/EmlxStoreReaderTests.cs
+++ b/OfficeIMO.Email.Tests/Store/Emlx/EmlxStoreReaderTests.cs
@@ -68,6 +68,17 @@ public sealed class EmlxStoreReaderTests {
     }
 
     [Fact]
+    public void EnforcesAttachmentCountAfterMimeProjection() {
+        byte[] emlx = CreateEmlx(CreateMultipartMessageWithTwoAttachments(), "\n", null);
+        var options = new EmailStoreReaderOptions(maxAttachmentsPerItem: 1);
+
+        EmailStoreLimitExceededException exception = Assert.Throws<EmailStoreLimitExceededException>(
+            () => Read(emlx, "message.emlx", options));
+
+        Assert.Equal(nameof(EmailStoreReaderOptions.MaxAttachmentsPerItem), exception.LimitName);
+    }
+
+    [Fact]
     public void ReportsInvalidMetadataWithoutDiscardingTheMessage() {
         byte[] message = Encoding.ASCII.GetBytes("Subject: Keep me\r\n\r\nBody\r\n");
         byte[] emlx = CreateEmlx(message, "\n", "<plist><dict><key>broken</key></dict>");
@@ -194,5 +205,18 @@ public sealed class EmlxStoreReaderTests {
             "AQIDBA==\r\n" +
             "--emlx-boundary--\r\n";
         return Encoding.ASCII.GetBytes(message);
+    }
+
+    private static byte[] CreateMultipartMessageWithTwoAttachments() {
+        const string secondAttachment =
+            "--emlx-boundary\r\n" +
+            "Content-Type: application/octet-stream; name=\"second.bin\"\r\n" +
+            "Content-Disposition: attachment; filename=\"second.bin\"\r\n" +
+            "Content-Transfer-Encoding: base64\r\n\r\n" +
+            "BQYHCA==\r\n";
+        string message = Encoding.ASCII.GetString(CreateMultipartMessage());
+        return Encoding.ASCII.GetBytes(message.Replace(
+            "--emlx-boundary--\r\n",
+            secondAttachment + "--emlx-boundary--\r\n"));
     }
 }

--- a/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
+++ b/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
@@ -425,7 +425,9 @@ internal static partial class IcsCalendarCodec {
             if (existing == null) {
                 document.Recipients.Add(new EmailRecipient(kind, new EmailAddress(address!, name)));
             } else {
-                existing.Kind = kind;
+                // Calendar projection must never promote an envelope Bcc address into a
+                // visible To/Cc header during later MIME serialization.
+                if (existing.Kind != EmailRecipientKind.Bcc) existing.Kind = kind;
                 if (string.IsNullOrWhiteSpace(existing.Address.DisplayName)) {
                     existing.Address.DisplayName = name;
                 } else if (!string.IsNullOrWhiteSpace(name) &&

--- a/OfficeIMO.Email/Mime/MimeParser.cs
+++ b/OfficeIMO.Email/Mime/MimeParser.cs
@@ -123,14 +123,16 @@ internal static class MimeParser {
         bool semanticBodyPart = (calendarContent || vcardContent) && !attachmentDisposition &&
             string.IsNullOrWhiteSpace(fileName) && string.IsNullOrWhiteSpace(contentId) &&
             string.IsNullOrWhiteSpace(contentLocation);
+        if (!isBody) {
+            state.CountAttachment();
+        }
         bool skipAttachmentDecoding = !isBody && !state.Options.IncludeAttachmentContent && !embeddedMessage &&
             !semanticBodyPart;
         long decodedLength = isBody ? 0 : MimeTextCodec.GetDecodedLength(data, offset, count, transferEncoding,
             skipAttachmentDecoding ? state.Diagnostics : null, skipAttachmentDecoding ? location : null);
         if (!isBody) {
-            state.EnsureAttachmentWithinLimits(decodedLength);
+            state.CountAttachmentBytes(decodedLength);
             if (skipAttachmentDecoding) {
-                state.CountAttachment(decodedLength);
                 document.Attachments.Add(CreateAttachment(headers, contentType, disposition, fileName,
                     inlineDisposition || additionalInlineBody, attachmentDisposition, null, decodedLength,
                     isRelatedSibling));
@@ -169,7 +171,6 @@ internal static class MimeParser {
         }
 
         if (embeddedMessage) {
-            state.CountAttachment(decoded.LongLength);
             EmailAttachment embedded = CreateAttachment(headers, contentType, disposition, fileName,
                 inlineDisposition, attachmentDisposition, state.Options.IncludeAttachmentContent ? decoded : null,
                 decoded.LongLength, isRelatedSibling);
@@ -185,7 +186,6 @@ internal static class MimeParser {
             return;
         }
 
-        state.CountAttachment(decoded.LongLength);
         EmailAttachment attachment = CreateAttachment(headers, contentType, disposition, fileName,
             inlineDisposition || additionalInlineBody, attachmentDisposition,
             state.Options.IncludeAttachmentContent || semanticBodyPart ? decoded : null, decoded.LongLength,

--- a/OfficeIMO.Email/Mime/MimeParserState.cs
+++ b/OfficeIMO.Email/Mime/MimeParserState.cs
@@ -15,6 +15,8 @@ internal sealed class MimeParserState {
 
     internal int PartCount { get; private set; }
 
+    internal int AttachmentCount { get; private set; }
+
     internal long TotalAttachmentBytes { get; private set; }
 
     internal void CountPart() {
@@ -34,7 +36,16 @@ internal sealed class MimeParserState {
         }
     }
 
-    internal void CountAttachment(long length) {
+    internal void CountAttachment() {
+        ThrowIfCancellationRequested();
+        AttachmentCount++;
+        if (AttachmentCount > Options.MaxAttachmentCount) {
+            throw new EmailLimitExceededException(nameof(EmailReaderOptions.MaxAttachmentCount),
+                AttachmentCount, Options.MaxAttachmentCount);
+        }
+    }
+
+    internal void CountAttachmentBytes(long length) {
         EnsureAttachmentWithinLimits(length);
         TotalAttachmentBytes = checked(TotalAttachmentBytes + length);
     }

--- a/OfficeIMO.Email/Mime/MimeStreamingParser.cs
+++ b/OfficeIMO.Email/Mime/MimeStreamingParser.cs
@@ -12,7 +12,11 @@ internal sealed class MimeStreamingParser {
     private readonly EmailReadWorkspace _workspace;
     private readonly List<ExternalPart> _externalParts = new List<ExternalPart>();
     private int _analyzedPartCount;
+    private int _analyzedAttachmentCount;
     private long _totalAttachmentBytes;
+    private bool _hasTextBody;
+    private bool _hasHtmlBody;
+    private bool _hasRtfBody;
 
     private MimeStreamingParser(Stream input, EmailReaderOptions options,
         IList<EmailDiagnostic> diagnostics, CancellationToken cancellationToken, EmailReadWorkspace workspace) {
@@ -40,11 +44,14 @@ internal sealed class MimeStreamingParser {
     private void AnalyzeMessage(long start, long end, int depth, string location) {
         if (depth > _options.MaxNestedMessageDepth) return;
         HeaderSection section = ReadHeaders(start, end, location);
-        AnalyzeEntity(section.Headers, section.BodyStart, end, 0, location);
+        AnalyzeEntity(section.Headers, section.BodyStart, end, 0, location,
+            defaultContentType: "text/plain", preferredBodyContentId: null,
+            isRelatedSibling: false, isDefaultRelatedRoot: false);
     }
 
     private void AnalyzeEntity(IReadOnlyList<EmailHeader> headers, long bodyStart, long end,
-        int depth, string location) {
+        int depth, string location, string defaultContentType, string? preferredBodyContentId,
+        bool isRelatedSibling, bool isDefaultRelatedRoot) {
         _cancellationToken.ThrowIfCancellationRequested();
         if (depth > _options.MaxMimeDepth) {
             throw new EmailLimitExceededException(nameof(EmailReaderOptions.MaxMimeDepth), depth,
@@ -57,38 +64,94 @@ internal sealed class MimeStreamingParser {
         }
 
         MimeValue contentType = MimeValueParser.Parse(MimeHeaderParser.GetValue(headers, "Content-Type"),
-            "text/plain", _diagnostics, location);
+            defaultContentType, _diagnostics, location);
         MimeValue disposition = MimeValueParser.Parse(MimeHeaderParser.GetValue(headers, "Content-Disposition"),
             string.Empty, _diagnostics, location);
         string? fileName = disposition.GetParameter("filename") ?? contentType.GetParameter("name");
+        string? contentId = MimeHeaderParser.GetValue(headers, "Content-ID");
+        string? contentLocation = MimeHeaderParser.GetValue(headers, "Content-Location");
+        bool contentIdMatchesPreferred = !string.IsNullOrWhiteSpace(preferredBodyContentId) &&
+            string.Equals(MimeParser.TrimAngleBrackets(contentId),
+                MimeParser.TrimAngleBrackets(preferredBodyContentId), StringComparison.OrdinalIgnoreCase);
+        bool isPreferredRelatedBody = isDefaultRelatedRoot || contentIdMatchesPreferred;
+        bool hasRelatedIdentity = !string.IsNullOrWhiteSpace(contentId) ||
+            !string.IsNullOrWhiteSpace(contentLocation);
         bool attachmentDisposition = string.Equals(disposition.Value, "attachment",
             StringComparison.OrdinalIgnoreCase);
 
         if (contentType.Value.StartsWith("multipart/", StringComparison.OrdinalIgnoreCase) &&
-            !attachmentDisposition && string.IsNullOrWhiteSpace(fileName)) {
+            !attachmentDisposition && string.IsNullOrWhiteSpace(fileName) &&
+            (!isRelatedSibling || !hasRelatedIdentity || isPreferredRelatedBody)) {
             string? boundary = contentType.GetParameter("boundary");
             if (boundary == null) return;
             IReadOnlyList<Segment> parts = SplitMultipart(bodyStart, end, boundary, location);
+            string childDefaultContentType = string.Equals(contentType.Value, "multipart/digest",
+                StringComparison.OrdinalIgnoreCase) ? "message/rfc822" : "text/plain";
+            bool isRelated = string.Equals(contentType.Value, "multipart/related",
+                StringComparison.OrdinalIgnoreCase);
+            string? childPreferredBodyContentId = isRelated
+                ? MimeParser.TrimAngleBrackets(contentType.GetParameter("start"))
+                : preferredBodyContentId;
             for (int index = 0; index < parts.Count; index++) {
                 Segment part = parts[index];
                 string partLocation = string.Concat(location, "/part[",
                     index.ToString(CultureInfo.InvariantCulture), "]");
                 HeaderSection child = ReadHeaders(part.Start, part.End, partLocation);
-                AnalyzeEntity(child.Headers, child.BodyStart, part.End, depth + 1, partLocation);
+                string? partPreferredBodyContentId = childPreferredBodyContentId;
+                bool partIsDefaultRelatedRoot = isRelated && index == 0 &&
+                    string.IsNullOrWhiteSpace(childPreferredBodyContentId);
+                if (isRelated && string.IsNullOrWhiteSpace(partPreferredBodyContentId) && index == 0) {
+                    partPreferredBodyContentId = MimeParser.TrimAngleBrackets(
+                        MimeHeaderParser.GetValue(child.Headers, "Content-ID"));
+                }
+                AnalyzeEntity(child.Headers, child.BodyStart, part.End, depth + 1, partLocation,
+                    childDefaultContentType, partPreferredBodyContentId, isRelated, partIsDefaultRelatedRoot);
             }
             return;
         }
+
+        bool isBodyCandidate = !attachmentDisposition && string.IsNullOrWhiteSpace(fileName) &&
+            (!isRelatedSibling || !hasRelatedIdentity || isPreferredRelatedBody) &&
+            (string.Equals(contentType.Value, "text/plain", StringComparison.OrdinalIgnoreCase) ||
+             string.Equals(contentType.Value, "text/html", StringComparison.OrdinalIgnoreCase) ||
+             string.Equals(contentType.Value, "text/rtf", StringComparison.OrdinalIgnoreCase));
+        bool isBody = isBodyCandidate && ClaimBodySlot(contentType.Value);
+        if (!isBody) CountAnalyzedAttachment();
 
         bool embedded = string.Equals(contentType.Value, "message/rfc822", StringComparison.OrdinalIgnoreCase) ||
             string.Equals(contentType.Value, "message/global", StringComparison.OrdinalIgnoreCase);
         bool semantic = string.Equals(contentType.Value, "text/calendar", StringComparison.OrdinalIgnoreCase) ||
             VCardCodec.IsVCardContentType(contentType.Value, contentType.GetParameter("profile"));
-        if ((!attachmentDisposition && string.IsNullOrWhiteSpace(fileName)) || embedded || semantic) return;
+        if (isBody || (!attachmentDisposition && string.IsNullOrWhiteSpace(fileName)) || embedded || semantic) return;
 
         _externalParts.Add(new ExternalPart(bodyStart, end,
             MimeHeaderParser.GetValue(headers, "Content-Transfer-Encoding"), fileName,
             contentType.Value, MimeParser.TrimAngleBrackets(MimeHeaderParser.GetValue(headers, "Content-ID")),
             MimeHeaderParser.GetValue(headers, "Content-Location"), location));
+    }
+
+    private bool ClaimBodySlot(string contentType) {
+        if (string.Equals(contentType, "text/plain", StringComparison.OrdinalIgnoreCase)) {
+            if (_hasTextBody) return false;
+            _hasTextBody = true;
+            return true;
+        }
+        if (string.Equals(contentType, "text/html", StringComparison.OrdinalIgnoreCase)) {
+            if (_hasHtmlBody) return false;
+            _hasHtmlBody = true;
+            return true;
+        }
+        if (_hasRtfBody) return false;
+        _hasRtfBody = true;
+        return true;
+    }
+
+    private void CountAnalyzedAttachment() {
+        _analyzedAttachmentCount++;
+        if (_analyzedAttachmentCount > _options.MaxAttachmentCount) {
+            throw new EmailLimitExceededException(nameof(EmailReaderOptions.MaxAttachmentCount),
+                _analyzedAttachmentCount, _options.MaxAttachmentCount);
+        }
     }
 
     private HeaderSection ReadHeaders(long start, long end, string location) {

--- a/OfficeIMO.Email/Msg/MsgParserState.cs
+++ b/OfficeIMO.Email/Msg/MsgParserState.cs
@@ -53,8 +53,9 @@ internal sealed class MsgParserState {
     internal void CountAttachment(long bytes) {
         ThrowIfCancellationRequested();
         AttachmentCount++;
-        if (AttachmentCount > Options.MaxPartCount) {
-            throw new EmailLimitExceededException(nameof(EmailReaderOptions.MaxPartCount), AttachmentCount, Options.MaxPartCount);
+        if (AttachmentCount > Options.MaxAttachmentCount) {
+            throw new EmailLimitExceededException(nameof(EmailReaderOptions.MaxAttachmentCount),
+                AttachmentCount, Options.MaxAttachmentCount);
         }
         EnsureAttachmentBytesWithinLimits(bytes);
         TotalAttachmentBytes = checked(TotalAttachmentBytes + bytes);

--- a/OfficeIMO.Email/Reading/EmailReaderOptions.cs
+++ b/OfficeIMO.Email/Reading/EmailReaderOptions.cs
@@ -20,7 +20,8 @@ public sealed class EmailReaderOptions {
         int maxCompoundDirectoryEntries = 65536,
         int maxMapiPropertyCount = 100000,
         long maxDecodedPropertyBytes = 512L * 1024L * 1024L,
-        int maxTnefAttributeCount = 100000) {
+        int maxTnefAttributeCount = 100000,
+        int maxAttachmentCount = 10000) {
         if (maxInputBytes <= 0) throw new ArgumentOutOfRangeException(nameof(maxInputBytes));
         if (maxHeaderBytes <= 0) throw new ArgumentOutOfRangeException(nameof(maxHeaderBytes));
         if (maxHeaderCount <= 0) throw new ArgumentOutOfRangeException(nameof(maxHeaderCount));
@@ -33,6 +34,7 @@ public sealed class EmailReaderOptions {
         if (maxMapiPropertyCount <= 0) throw new ArgumentOutOfRangeException(nameof(maxMapiPropertyCount));
         if (maxDecodedPropertyBytes <= 0) throw new ArgumentOutOfRangeException(nameof(maxDecodedPropertyBytes));
         if (maxTnefAttributeCount <= 0) throw new ArgumentOutOfRangeException(nameof(maxTnefAttributeCount));
+        if (maxAttachmentCount <= 0) throw new ArgumentOutOfRangeException(nameof(maxAttachmentCount));
 
         MaxInputBytes = maxInputBytes;
         MaxHeaderBytes = maxHeaderBytes;
@@ -48,6 +50,7 @@ public sealed class EmailReaderOptions {
         MaxMapiPropertyCount = maxMapiPropertyCount;
         MaxDecodedPropertyBytes = maxDecodedPropertyBytes;
         MaxTnefAttributeCount = maxTnefAttributeCount;
+        MaxAttachmentCount = maxAttachmentCount;
     }
 
     /// <summary>Maximum artifact size accepted by the reader.</summary>
@@ -78,4 +81,6 @@ public sealed class EmailReaderOptions {
     public long MaxDecodedPropertyBytes { get; }
     /// <summary>Maximum number of TNEF attributes.</summary>
     public int MaxTnefAttributeCount { get; }
+    /// <summary>Maximum aggregate attachment count across the message and nested messages.</summary>
+    public int MaxAttachmentCount { get; }
 }

--- a/OfficeIMO.Email/Store/Reading/EmailStoreMessageReader.cs
+++ b/OfficeIMO.Email/Store/Reading/EmailStoreMessageReader.cs
@@ -33,7 +33,8 @@ internal static class EmailStoreMessageReader {
             maxNestedMessageDepth: options.MaxNestedMessageDepth,
             includeAttachmentContent: includeAttachmentContent ?? options.RetainAttachmentContent,
             maxMapiPropertyCount: options.MaxPropertiesPerItem,
-            maxDecodedPropertyBytes: maxDecodedPropertyBytes ?? options.MaxDecodedPropertyBytesPerItem);
+            maxDecodedPropertyBytes: maxDecodedPropertyBytes ?? options.MaxDecodedPropertyBytesPerItem,
+            maxAttachmentCount: options.MaxAttachmentsPerItem);
 
     private static EmailStoreLimitExceededException ConvertLimit(EmailLimitExceededException exception) {
         string name = exception.LimitName == nameof(EmailReaderOptions.MaxInputBytes)
@@ -46,6 +47,8 @@ internal static class EmailStoreMessageReader {
                         ? nameof(EmailStoreReaderOptions.MaxPropertiesPerItem)
                         : exception.LimitName == nameof(EmailReaderOptions.MaxDecodedPropertyBytes)
                             ? nameof(EmailStoreReaderOptions.MaxDecodedPropertyBytesPerItem)
+                            : exception.LimitName == nameof(EmailReaderOptions.MaxAttachmentCount)
+                                ? nameof(EmailStoreReaderOptions.MaxAttachmentsPerItem)
                             : exception.LimitName;
         return new EmailStoreLimitExceededException(name, exception.ActualValue, exception.MaximumValue);
     }

--- a/OfficeIMO.Excel.GoogleSheets/GoogleSheetsImportOptions.cs
+++ b/OfficeIMO.Excel.GoogleSheets/GoogleSheetsImportOptions.cs
@@ -15,6 +15,7 @@ namespace OfficeIMO.Excel.GoogleSheets {
     /// Options for importing a Google spreadsheet.
     /// </summary>
     public sealed class GoogleSheetsImportOptions {
+        public const long DefaultMaxResponseBytes = 128L * 1024L * 1024L;
         public GoogleSheetsImportMode Mode { get; set; } = GoogleSheetsImportMode.DriveExport;
         public IReadOnlyList<string> Ranges { get; set; } = Array.Empty<string>();
         public string? Fields { get; set; }
@@ -22,6 +23,10 @@ namespace OfficeIMO.Excel.GoogleSheets {
             AccessMode = DocumentAccessMode.ReadWrite,
         };
         public IProgress<OfficeIMO.GoogleWorkspace.Drive.GoogleDriveTransferProgress>? Progress { get; set; }
+        public long MaxResponseBytes { get; set; } = DefaultMaxResponseBytes;
+        public int MaxSheets { get; set; } = 256;
+        public long MaxCells { get; set; } = 1_000_000L;
+        public long MaxDimensionGroupMembers { get; set; } = 1_000_000L;
     }
 
     /// <summary>

--- a/OfficeIMO.Excel.GoogleSheets/GoogleSheetsImportOptions.cs
+++ b/OfficeIMO.Excel.GoogleSheets/GoogleSheetsImportOptions.cs
@@ -25,6 +25,11 @@ namespace OfficeIMO.Excel.GoogleSheets {
         public IProgress<OfficeIMO.GoogleWorkspace.Drive.GoogleDriveTransferProgress>? Progress { get; set; }
         public long MaxResponseBytes { get; set; } = DefaultMaxResponseBytes;
         public int MaxSheets { get; set; } = 256;
+        /// <summary>
+        /// Maximum number of native cell values and row/column metadata entries that may be
+        /// projected. Dimension metadata shares this budget because it can materialize row and
+        /// column state even when the response contains no cell values.
+        /// </summary>
         public long MaxCells { get; set; } = 1_000_000L;
         public long MaxDimensionGroupMembers { get; set; } = 1_000_000L;
     }

--- a/OfficeIMO.Excel.GoogleSheets/GoogleSheetsImporter.cs
+++ b/OfficeIMO.Excel.GoogleSheets/GoogleSheetsImporter.cs
@@ -26,6 +26,7 @@ namespace OfficeIMO.Excel.GoogleSheets {
             if (session == null) throw new ArgumentNullException(nameof(session));
 
             GoogleSheetsImportOptions effectiveOptions = options ?? new GoogleSheetsImportOptions();
+            ValidateOptions(effectiveOptions);
             return effectiveOptions.Mode == GoogleSheetsImportMode.DriveExport
                 ? await ImportViaDriveAsync(spreadsheetId, session, effectiveOptions, cancellationToken).ConfigureAwait(false)
                 : await ImportNativeAsync(spreadsheetId, session, effectiveOptions, cancellationToken).ConfigureAwait(false);
@@ -47,7 +48,8 @@ namespace OfficeIMO.Excel.GoogleSheets {
                 GoogleDriveMimeTypes.MicrosoftExcel,
                 options.Progress,
                 report,
-                cancellationToken).ConfigureAwait(false);
+                cancellationToken,
+                options.MaxResponseBytes).ConfigureAwait(false);
 
             var stream = new MemoryStream(xlsx, writable: true);
             ExcelDocument document;
@@ -87,6 +89,7 @@ namespace OfficeIMO.Excel.GoogleSheets {
             using var drive = new GoogleDriveClient(session);
             GoogleDriveFile source = await drive.GetFileAsync(spreadsheetId, report: report, cancellationToken: cancellationToken).ConfigureAwait(false);
             EnsureSpreadsheet(source, spreadsheetId);
+            EnsureDownloadable(source, spreadsheetId);
 
             GoogleWorkspaceAccessToken token = await session
                 .AcquireAccessTokenAsync(new[] { GoogleWorkspaceScopeCatalog.SpreadsheetsReadonly }, cancellationToken)
@@ -103,9 +106,11 @@ namespace OfficeIMO.Excel.GoogleSheets {
                     "Google Sheets API",
                     report,
                     GoogleSheetsJsonSerializerContext.Default.GoogleSheetsNativeSpreadsheet,
-                    cancellationToken).ConfigureAwait(false);
+                    cancellationToken,
+                    options.MaxResponseBytes).ConfigureAwait(false);
             }
 
+            ValidateNativeSpreadsheet(spreadsheet, options);
             ExcelDocument document = ProjectNativeSpreadsheet(spreadsheet, report);
             report.Add(
                 TranslationSeverity.Info,
@@ -476,6 +481,65 @@ namespace OfficeIMO.Excel.GoogleSheets {
                 uri.Append("&ranges=").Append(Uri.EscapeDataString(range));
             }
             return uri.ToString();
+        }
+
+        private static void ValidateOptions(GoogleSheetsImportOptions options) {
+            if (options.MaxResponseBytes <= 0) throw new ArgumentOutOfRangeException(nameof(options.MaxResponseBytes));
+            if (options.MaxSheets <= 0) throw new ArgumentOutOfRangeException(nameof(options.MaxSheets));
+            if (options.MaxCells <= 0) throw new ArgumentOutOfRangeException(nameof(options.MaxCells));
+            if (options.MaxDimensionGroupMembers <= 0) throw new ArgumentOutOfRangeException(nameof(options.MaxDimensionGroupMembers));
+        }
+
+        private static void ValidateNativeSpreadsheet(
+            GoogleSheetsNativeSpreadsheet spreadsheet,
+            GoogleSheetsImportOptions options) {
+            if (spreadsheet.Sheets.Count > options.MaxSheets) {
+                throw new InvalidDataException($"Google Sheets native import exceeded the configured {options.MaxSheets} sheet limit.");
+            }
+
+            long cells = 0;
+            long dimensionGroupMembers = 0;
+            foreach (GoogleSheetsNativeSheet sheet in spreadsheet.Sheets) {
+                foreach (GoogleSheetsNativeGridData block in sheet.Data) {
+                    foreach (GoogleSheetsNativeRowData row in block.RowData) {
+                        if (row.Values.Count > options.MaxCells - cells) {
+                            throw new InvalidDataException($"Google Sheets native import exceeded the configured {options.MaxCells} cell limit.");
+                        }
+                        cells += row.Values.Count;
+                    }
+                }
+                CountDimensionGroupMembers(sheet.RowGroups, sheet.Properties.SheetId, "ROWS", 1048576,
+                    options, ref dimensionGroupMembers);
+                CountDimensionGroupMembers(sheet.ColumnGroups, sheet.Properties.SheetId, "COLUMNS", 16384,
+                    options, ref dimensionGroupMembers);
+            }
+        }
+
+        private static void CountDimensionGroupMembers(
+            IReadOnlyList<GoogleSheetsNativeDimensionGroup> groups,
+            int sheetId,
+            string dimension,
+            int maximum,
+            GoogleSheetsImportOptions options,
+            ref long total) {
+            foreach (GoogleSheetsNativeDimensionGroup group in groups) {
+                GoogleSheetsNativeDimensionRange range = group.Range;
+                if (range.SheetId != sheetId
+                    || !string.Equals(range.Dimension, dimension, StringComparison.OrdinalIgnoreCase)
+                    || range.StartIndex < 0
+                    || range.StartIndex >= maximum
+                    || range.EndIndex <= range.StartIndex
+                    || group.Depth <= 0) {
+                    continue;
+                }
+
+                long members = Math.Min(maximum, range.EndIndex) - (long)range.StartIndex;
+                if (members > options.MaxDimensionGroupMembers - total) {
+                    throw new InvalidDataException(
+                        $"Google Sheets native import exceeded the configured {options.MaxDimensionGroupMembers} dimension-group member limit.");
+                }
+                total += members;
+            }
         }
 
         private static void EnsureSpreadsheet(GoogleDriveFile source, string spreadsheetId) {

--- a/OfficeIMO.Excel.GoogleSheets/GoogleSheetsImporter.cs
+++ b/OfficeIMO.Excel.GoogleSheets/GoogleSheetsImporter.cs
@@ -497,15 +497,22 @@ namespace OfficeIMO.Excel.GoogleSheets {
                 throw new InvalidDataException($"Google Sheets native import exceeded the configured {options.MaxSheets} sheet limit.");
             }
 
-            long cells = 0;
+            long projectedEntries = 0;
             long dimensionGroupMembers = 0;
             foreach (GoogleSheetsNativeSheet sheet in spreadsheet.Sheets) {
                 foreach (GoogleSheetsNativeGridData block in sheet.Data) {
+                    long dimensionMetadataEntries = (long)block.RowMetadata.Count + block.ColumnMetadata.Count;
+                    if (dimensionMetadataEntries > options.MaxCells - projectedEntries) {
+                        throw new InvalidDataException(
+                            $"Google Sheets native import exceeded the configured {options.MaxCells} cell and dimension-metadata limit.");
+                    }
+                    projectedEntries += dimensionMetadataEntries;
+
                     foreach (GoogleSheetsNativeRowData row in block.RowData) {
-                        if (row.Values.Count > options.MaxCells - cells) {
+                        if (row.Values.Count > options.MaxCells - projectedEntries) {
                             throw new InvalidDataException($"Google Sheets native import exceeded the configured {options.MaxCells} cell limit.");
                         }
-                        cells += row.Values.Count;
+                        projectedEntries += row.Values.Count;
                     }
                 }
                 CountDimensionGroupMembers(sheet.RowGroups, sheet.Properties.SheetId, "ROWS", 1048576,

--- a/OfficeIMO.Excel.Tests/Excel.GoogleSheets.Import.cs
+++ b/OfficeIMO.Excel.Tests/Excel.GoogleSheets.Import.cs
@@ -47,7 +47,64 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
-        public async Task Test_GoogleSheetsImporter_Native_ProjectsContentWhenDriveExportIsDisabled() {
+        public async Task Test_GoogleSheetsImporter_NativeRejectsFilesThatCannotBeDownloaded() {
+            int nativeReads = 0;
+            using var httpClient = new HttpClient(new FakeHttpMessageHandler(request => {
+                if (request.RequestUri!.Host == "www.googleapis.com") {
+                    return Task.FromResult(CreateJsonResponse("{\"id\":\"sheet-blocked\",\"mimeType\":\"application/vnd.google-apps.spreadsheet\",\"capabilities\":{\"canDownload\":false}}"));
+                }
+                nativeReads++;
+                return Task.FromResult(CreateJsonResponse("{\"spreadsheetId\":\"sheet-blocked\"}"));
+            }));
+            var session = new GoogleWorkspaceSession(new FakeGoogleWorkspaceCredentialSource(), new GoogleWorkspaceSessionOptions { HttpClient = httpClient });
+
+            InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                session.ImportGoogleSheetAsync("sheet-blocked", new GoogleSheetsImportOptions { Mode = GoogleSheetsImportMode.Native }));
+
+            Assert.Contains("cannot be downloaded", exception.Message, StringComparison.Ordinal);
+            Assert.Equal(0, nativeReads);
+        }
+
+        [Fact]
+        public async Task Test_GoogleSheetsImporter_NativeEnforcesResponseAndCellBudgets() {
+            const string nativeJson = "{\"spreadsheetId\":\"sheet-large\",\"sheets\":[{\"properties\":{\"title\":\"Sheet1\"},\"data\":[{\"rowData\":[{\"values\":[{},{}]}]}]}]}";
+            using var httpClient = new HttpClient(new FakeHttpMessageHandler(request =>
+                request.RequestUri!.Host == "www.googleapis.com"
+                    ? Task.FromResult(CreateJsonResponse("{\"id\":\"sheet-large\",\"mimeType\":\"application/vnd.google-apps.spreadsheet\",\"capabilities\":{\"canDownload\":true}}"))
+                    : Task.FromResult(CreateJsonResponse(nativeJson))));
+            var session = new GoogleWorkspaceSession(new FakeGoogleWorkspaceCredentialSource(), new GoogleWorkspaceSessionOptions { HttpClient = httpClient });
+
+            await Assert.ThrowsAsync<InvalidDataException>(() =>
+                session.ImportGoogleSheetAsync("sheet-large", new GoogleSheetsImportOptions {
+                    Mode = GoogleSheetsImportMode.Native,
+                    MaxResponseBytes = 32,
+                }));
+            await Assert.ThrowsAsync<InvalidDataException>(() =>
+                session.ImportGoogleSheetAsync("sheet-large", new GoogleSheetsImportOptions {
+                    Mode = GoogleSheetsImportMode.Native,
+                    MaxCells = 1,
+                }));
+        }
+
+        [Fact]
+        public async Task Test_GoogleSheetsImporter_NativeBoundsZeroCellDimensionGroupExpansion() {
+            const string nativeJson = "{\"spreadsheetId\":\"sheet-groups\",\"sheets\":[{\"properties\":{\"sheetId\":42,\"title\":\"Sheet1\"},\"rowGroups\":[{\"range\":{\"sheetId\":42,\"dimension\":\"ROWS\",\"startIndex\":0,\"endIndex\":1048576},\"depth\":1}]}]}";
+            using var httpClient = new HttpClient(new FakeHttpMessageHandler(request =>
+                request.RequestUri!.Host == "www.googleapis.com"
+                    ? Task.FromResult(CreateJsonResponse("{\"id\":\"sheet-groups\",\"mimeType\":\"application/vnd.google-apps.spreadsheet\",\"capabilities\":{\"canDownload\":true}}"))
+                    : Task.FromResult(CreateJsonResponse(nativeJson))));
+            var session = new GoogleWorkspaceSession(new FakeGoogleWorkspaceCredentialSource(),
+                new GoogleWorkspaceSessionOptions { HttpClient = httpClient });
+
+            await Assert.ThrowsAsync<InvalidDataException>(() =>
+                session.ImportGoogleSheetAsync("sheet-groups", new GoogleSheetsImportOptions {
+                    Mode = GoogleSheetsImportMode.Native,
+                    MaxDimensionGroupMembers = 100,
+                }));
+        }
+
+        [Fact]
+        public async Task Test_GoogleSheetsImporter_Native_ProjectsContentWhenDownloadIsAllowed() {
             Uri? sheetsRequest = null;
             const string nativeJson = """
                 {
@@ -74,7 +131,7 @@ namespace OfficeIMO.Tests {
                 """;
             using var httpClient = new HttpClient(new FakeHttpMessageHandler(request => {
                 if (request.RequestUri!.Host == "www.googleapis.com") {
-                    return Task.FromResult(CreateJsonResponse("{\"id\":\"native123\",\"name\":\"Native\",\"mimeType\":\"application/vnd.google-apps.spreadsheet\",\"version\":21,\"capabilities\":{\"canDownload\":false}}"));
+                    return Task.FromResult(CreateJsonResponse("{\"id\":\"native123\",\"name\":\"Native\",\"mimeType\":\"application/vnd.google-apps.spreadsheet\",\"version\":21,\"capabilities\":{\"canDownload\":true}}"));
                 }
                 if (request.RequestUri.Host == "sheets.googleapis.com") {
                     sheetsRequest = request.RequestUri;
@@ -190,7 +247,7 @@ namespace OfficeIMO.Tests {
                 const string nativeJson = "{\"spreadsheetId\":\"diff-sheet\",\"properties\":{\"title\":\"Diff\"},\"sheets\":[{\"properties\":{\"sheetId\":0,\"title\":\"Data\",\"index\":0},\"data\":[{\"startRow\":0,\"startColumn\":0,\"rowData\":[{\"values\":[{\"userEnteredValue\":{\"stringValue\":\"value\"}}]}]}]}]}";
                 using var httpClient = new HttpClient(new FakeHttpMessageHandler(request => {
                     if (request.RequestUri!.Host == "www.googleapis.com") {
-                        return Task.FromResult(CreateJsonResponse("{\"id\":\"diff-sheet\",\"name\":\"Diff\",\"mimeType\":\"application/vnd.google-apps.spreadsheet\",\"version\":6,\"capabilities\":{\"canDownload\":false}}"));
+                        return Task.FromResult(CreateJsonResponse("{\"id\":\"diff-sheet\",\"name\":\"Diff\",\"mimeType\":\"application/vnd.google-apps.spreadsheet\",\"version\":6,\"capabilities\":{\"canDownload\":true}}"));
                     }
                     if (request.RequestUri.Host == "sheets.googleapis.com") {
                         return Task.FromResult(CreateJsonResponse(nativeJson));
@@ -226,7 +283,7 @@ namespace OfficeIMO.Tests {
                 const string nativeJson = "{\"spreadsheetId\":\"diff-chart\",\"properties\":{\"title\":\"Diff\"},\"sheets\":[{\"properties\":{\"sheetId\":0,\"title\":\"Data\",\"index\":0},\"data\":[{\"startRow\":0,\"startColumn\":0,\"rowData\":[{\"values\":[{\"userEnteredValue\":{\"stringValue\":\"value\"}}]}]}]},{\"properties\":{\"sheetId\":1,\"title\":\"_OfficeIMO_ChartData\",\"index\":1},\"data\":[{\"startRow\":0,\"startColumn\":0,\"rowData\":[{\"values\":[{\"userEnteredValue\":{\"stringValue\":\"User content\"}}]}]}]},{\"properties\":{\"sheetId\":2,\"title\":\"_OfficeIMO_ChartData_2\",\"index\":2,\"hidden\":true,\"gridProperties\":{\"hideGridlines\":true}},\"data\":[{\"startRow\":0,\"startColumn\":0,\"rowData\":[{\"values\":[{\"userEnteredValue\":{\"stringValue\":\"Category\"}},{\"userEnteredValue\":{\"stringValue\":\"Sales\"}}]},{\"values\":[{\"userEnteredValue\":{\"stringValue\":\"A\"}},{\"userEnteredValue\":{\"numberValue\":1}}]}]}]}]}";
                 using var httpClient = new HttpClient(new FakeHttpMessageHandler(request => {
                     if (request.RequestUri!.Host == "www.googleapis.com") {
-                        return Task.FromResult(CreateJsonResponse("{\"id\":\"diff-chart\",\"name\":\"Diff\",\"mimeType\":\"application/vnd.google-apps.spreadsheet\",\"version\":6,\"capabilities\":{\"canDownload\":false}}"));
+                        return Task.FromResult(CreateJsonResponse("{\"id\":\"diff-chart\",\"name\":\"Diff\",\"mimeType\":\"application/vnd.google-apps.spreadsheet\",\"version\":6,\"capabilities\":{\"canDownload\":true}}"));
                     }
                     if (request.RequestUri.Host == "sheets.googleapis.com") {
                         return Task.FromResult(CreateJsonResponse(nativeJson));

--- a/OfficeIMO.Excel.Tests/Excel.GoogleSheets.Import.cs
+++ b/OfficeIMO.Excel.Tests/Excel.GoogleSheets.Import.cs
@@ -87,6 +87,23 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public async Task Test_GoogleSheetsImporter_NativeCountsDimensionMetadataAgainstCellBudget() {
+            const string nativeJson = "{\"spreadsheetId\":\"sheet-metadata\",\"sheets\":[{\"properties\":{\"title\":\"Sheet1\"},\"data\":[{\"rowMetadata\":[{\"pixelSize\":20},{\"hiddenByUser\":true}],\"columnMetadata\":[{}]}]}]}";
+            using var httpClient = new HttpClient(new FakeHttpMessageHandler(request =>
+                request.RequestUri!.Host == "www.googleapis.com"
+                    ? Task.FromResult(CreateJsonResponse("{\"id\":\"sheet-metadata\",\"mimeType\":\"application/vnd.google-apps.spreadsheet\",\"capabilities\":{\"canDownload\":true}}"))
+                    : Task.FromResult(CreateJsonResponse(nativeJson))));
+            var session = new GoogleWorkspaceSession(new FakeGoogleWorkspaceCredentialSource(),
+                new GoogleWorkspaceSessionOptions { HttpClient = httpClient });
+
+            await Assert.ThrowsAsync<InvalidDataException>(() =>
+                session.ImportGoogleSheetAsync("sheet-metadata", new GoogleSheetsImportOptions {
+                    Mode = GoogleSheetsImportMode.Native,
+                    MaxCells = 2,
+                }));
+        }
+
+        [Fact]
         public async Task Test_GoogleSheetsImporter_NativeBoundsZeroCellDimensionGroupExpansion() {
             const string nativeJson = "{\"spreadsheetId\":\"sheet-groups\",\"sheets\":[{\"properties\":{\"sheetId\":42,\"title\":\"Sheet1\"},\"rowGroups\":[{\"range\":{\"sheetId\":42,\"dimension\":\"ROWS\",\"startIndex\":0,\"endIndex\":1048576},\"depth\":1}]}]}";
             using var httpClient = new HttpClient(new FakeHttpMessageHandler(request =>

--- a/OfficeIMO.Excel.Tests/Excel.ImageExport.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ImageExport.cs
@@ -639,6 +639,19 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void ExcelThemeColorResolver_NormalizesInvalidSpreadsheetTintValues() {
+            Assert.Equal(
+                OfficeIMO.Excel.Utilities.ExcelThemeColorResolver.ApplySpreadsheetTint("FF336699", 1D),
+                OfficeIMO.Excel.Utilities.ExcelThemeColorResolver.ApplySpreadsheetTint("FF336699", 2D));
+            Assert.Equal(
+                OfficeIMO.Excel.Utilities.ExcelThemeColorResolver.ApplySpreadsheetTint("FF336699", -1D),
+                OfficeIMO.Excel.Utilities.ExcelThemeColorResolver.ApplySpreadsheetTint("FF336699", -2D));
+            Assert.Equal(
+                "FF336699",
+                OfficeIMO.Excel.Utilities.ExcelThemeColorResolver.ApplySpreadsheetTint("FF336699", double.NaN));
+        }
+
+        [Fact]
         public void ExcelRange_ImageExportAppliesConditionalColorScalesAndDataBarsWithDiagnostics() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
             using ExcelDocument document = ExcelDocument.Create(filePath);

--- a/OfficeIMO.Excel.Tests/Excel.LegacyXls.NormalLoad.cs
+++ b/OfficeIMO.Excel.Tests/Excel.LegacyXls.NormalLoad.cs
@@ -165,6 +165,25 @@ namespace OfficeIMO.Tests {
             Assert.Equal("RC4 secret", value);
         }
 
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task EncryptedLoad_RejectsUnencryptedLegacyXls(bool asyncLoad) {
+            byte[] compound = CreateMinimalLegacyXlsCompound();
+
+            if (asyncLoad) {
+                using var source = new MemoryStream(compound);
+                InvalidDataException exception = await Assert.ThrowsAsync<InvalidDataException>(
+                    () => ExcelDocument.LoadEncryptedAsync(source, "unused"));
+                Assert.Contains("password-encrypted legacy XLS", exception.Message, StringComparison.Ordinal);
+            } else {
+                using var source = new MemoryStream(compound);
+                InvalidDataException exception = Assert.Throws<InvalidDataException>(
+                    () => ExcelDocument.LoadEncrypted(source, "unused"));
+                Assert.Contains("password-encrypted legacy XLS", exception.Message, StringComparison.Ordinal);
+            }
+        }
+
         [Fact]
         public void LegacyXls_NormalLoad_StreamProjectsToExcelDocumentAndSavesOpenXmlStream() {
             byte[] compound = CreateMinimalLegacyXlsCompound();

--- a/OfficeIMO.Excel/ExcelDocument.CreateLoad.cs
+++ b/OfficeIMO.Excel/ExcelDocument.CreateLoad.cs
@@ -626,6 +626,9 @@ namespace OfficeIMO.Excel {
                 Password = password,
                 ReportUnsupportedContent = true
             });
+            if (!workbook.WasEncryptedSource) {
+                throw new InvalidDataException("LoadEncrypted requires a password-encrypted legacy XLS workbook.");
+            }
             return ProjectLoadedLegacyXlsWorkbook(workbook, sourcePath: null, readOnly);
         }
 

--- a/OfficeIMO.Excel/ExcelDocument.Save.Public.cs
+++ b/OfficeIMO.Excel/ExcelDocument.Save.Public.cs
@@ -370,13 +370,6 @@ namespace OfficeIMO.Excel {
                 return;
             }
 
-            if (!destination.CanSeek) {
-                using var buffer = new MemoryStream();
-                Save(buffer, format, options);
-                OfficeStreamWriter.WriteAllBytes(destination, buffer.ToArray());
-                return;
-            }
-
             if (TrySaveNativeLegacyXlsToStream(destination, format, options)) {
                 return;
             }
@@ -505,13 +498,6 @@ namespace OfficeIMO.Excel {
                 preserveLinkedVbaProject: format == ExcelFileFormat.Xls);
 
             if (await TrySaveUnchangedXlsbToStreamAsync(destination, format, options, cancellationToken).ConfigureAwait(false)) {
-                return;
-            }
-
-            if (!destination.CanSeek) {
-                using var buffer = new MemoryStream();
-                await SaveAsync(buffer, format, options, cancellationToken).ConfigureAwait(false);
-                await OfficeStreamWriter.WriteAllBytesAsync(destination, buffer.ToArray(), cancellationToken).ConfigureAwait(false);
                 return;
             }
 

--- a/OfficeIMO.Excel/ExcelDocument.Save.Public.cs
+++ b/OfficeIMO.Excel/ExcelDocument.Save.Public.cs
@@ -366,6 +366,13 @@ namespace OfficeIMO.Excel {
                 options,
                 preserveLinkedVbaProject: format == ExcelFileFormat.Xls);
 
+#if NETFRAMEWORK
+            if (!destination.CanSeek) {
+                SaveNonSeekableFrameworkDestination(destination, format, options);
+                return;
+            }
+#endif
+
             if (TrySaveUnchangedXlsbToStream(destination, format, options)) {
                 return;
             }
@@ -497,6 +504,13 @@ namespace OfficeIMO.Excel {
                 options,
                 preserveLinkedVbaProject: format == ExcelFileFormat.Xls);
 
+#if NETFRAMEWORK
+            if (!destination.CanSeek) {
+                await SaveNonSeekableFrameworkDestinationAsync(destination, format, options, cancellationToken).ConfigureAwait(false);
+                return;
+            }
+#endif
+
             if (await TrySaveUnchangedXlsbToStreamAsync(destination, format, options, cancellationToken).ConfigureAwait(false)) {
                 return;
             }
@@ -559,6 +573,39 @@ namespace OfficeIMO.Excel {
                 throw;
             }
         }
+
+#if NETFRAMEWORK
+        private void SaveNonSeekableFrameworkDestination(
+            Stream destination,
+            ExcelFileFormat format,
+            ExcelSaveOptions? options) {
+            using FileStream staging = OfficeTemporaryFile.Create(
+                "OfficeIMO.Excel-",
+                ".tmp",
+                FileOptions.SequentialScan,
+                out _);
+            SaveToStreamCore(staging, format, options);
+            staging.Position = 0L;
+            staging.CopyTo(destination, 81920);
+            destination.Flush();
+        }
+
+        private async Task SaveNonSeekableFrameworkDestinationAsync(
+            Stream destination,
+            ExcelFileFormat format,
+            ExcelSaveOptions? options,
+            CancellationToken cancellationToken) {
+            using FileStream staging = OfficeTemporaryFile.Create(
+                "OfficeIMO.Excel-",
+                ".tmp",
+                FileOptions.Asynchronous | FileOptions.SequentialScan,
+                out _);
+            await SaveToStreamAsyncCore(staging, format, options, cancellationToken).ConfigureAwait(false);
+            staging.Position = 0L;
+            await staging.CopyToAsync(destination, 81920, cancellationToken).ConfigureAwait(false);
+            await destination.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
+#endif
 
         /// <summary>
         /// Asynchronously saves the document.

--- a/OfficeIMO.Excel/Utilities/ExcelThemeColorResolver.cs
+++ b/OfficeIMO.Excel/Utilities/ExcelThemeColorResolver.cs
@@ -69,7 +69,7 @@ namespace OfficeIMO.Excel.Utilities {
             }
 
             return tint.HasValue && Math.Abs(tint.Value) > double.Epsilon
-                ? OfficeColorTransforms.SpreadsheetTint(color.Value, tint.Value).ToArgbHex()
+                ? OfficeColorTransforms.SpreadsheetTint(color.Value, NormalizeSpreadsheetTint(tint.Value)).ToArgbHex()
                 : color.Value.ToArgbHex();
         }
 
@@ -78,7 +78,12 @@ namespace OfficeIMO.Excel.Utilities {
                 throw new ArgumentException("Color must be a six-digit RGB or eight-digit ARGB value.", nameof(argb));
             }
 
-            return OfficeColorTransforms.SpreadsheetTint(color, tint).ToArgbHex();
+            return OfficeColorTransforms.SpreadsheetTint(color, NormalizeSpreadsheetTint(tint)).ToArgbHex();
+        }
+
+        private static double NormalizeSpreadsheetTint(double tint) {
+            if (double.IsNaN(tint) || double.IsInfinity(tint)) return 0D;
+            return Math.Max(-1D, Math.Min(1D, tint));
         }
 
         internal static string? NormalizeArgb(string? value) {

--- a/OfficeIMO.GoogleWorkspace.Auth.GoogleApis/GoogleInstalledApplicationAuthorization.cs
+++ b/OfficeIMO.GoogleWorkspace.Auth.GoogleApis/GoogleInstalledApplicationAuthorization.cs
@@ -8,7 +8,7 @@ namespace OfficeIMO.GoogleWorkspace.Auth.GoogleApis {
     public sealed class GoogleInstalledApplicationAuthorizationOptions {
         public ClientSecrets? ClientSecrets { get; set; }
         public IReadOnlyList<string> Scopes { get; set; } = Array.Empty<string>();
-        public string UserId { get; set; } = "default";
+        public string? UserId { get; set; }
         public IGoogleWorkspaceTokenStore? TokenStore { get; set; }
         public ICodeReceiver? CodeReceiver { get; set; }
 
@@ -51,7 +51,7 @@ namespace OfficeIMO.GoogleWorkspace.Auth.GoogleApis {
             return await GoogleWebAuthorizationBroker.AuthorizeAsync(
                     initializer,
                     options.Scopes,
-                    options.UserId,
+                    options.UserId!,
                     usePkce: true,
                     taskCancellationToken: cancellationToken,
                     dataStore: new GoogleApisDataStoreAdapter(options.TokenStore!),

--- a/OfficeIMO.GoogleWorkspace.Drive/GoogleDriveClient.Media.cs
+++ b/OfficeIMO.GoogleWorkspace.Drive/GoogleDriveClient.Media.cs
@@ -152,7 +152,8 @@ namespace OfficeIMO.GoogleWorkspace.Drive {
             string fileId,
             IProgress<GoogleDriveTransferProgress>? progress = null,
             TranslationReport? report = null,
-            CancellationToken cancellationToken = default) {
+            CancellationToken cancellationToken = default,
+            long? maxResponseBytes = null) {
             if (string.IsNullOrWhiteSpace(fileId)) throw new ArgumentException("File id is required.", nameof(fileId));
             report ??= new TranslationReport();
             string token = await AcquireTokenAsync(Options.ReadScopes, report, "Google Drive file download", cancellationToken).ConfigureAwait(false);
@@ -163,7 +164,8 @@ namespace OfficeIMO.GoogleWorkspace.Drive {
                 GoogleWorkspaceRequestSafety.Safe,
                 "Google Drive API",
                 report,
-                cancellationToken).ConfigureAwait(false);
+                cancellationToken,
+                maxResponseBytes: maxResponseBytes ?? Options.MaxDownloadBytes).ConfigureAwait(false);
             progress?.Report(new GoogleDriveTransferProgress(bytes.LongLength, bytes.LongLength));
             return bytes;
         }
@@ -173,7 +175,8 @@ namespace OfficeIMO.GoogleWorkspace.Drive {
             string mimeType,
             IProgress<GoogleDriveTransferProgress>? progress = null,
             TranslationReport? report = null,
-            CancellationToken cancellationToken = default) {
+            CancellationToken cancellationToken = default,
+            long? maxResponseBytes = null) {
             if (string.IsNullOrWhiteSpace(fileId)) throw new ArgumentException("File id is required.", nameof(fileId));
             if (string.IsNullOrWhiteSpace(mimeType)) throw new ArgumentException("Export MIME type is required.", nameof(mimeType));
             report ??= new TranslationReport();
@@ -185,7 +188,8 @@ namespace OfficeIMO.GoogleWorkspace.Drive {
                 GoogleWorkspaceRequestSafety.Safe,
                 "Google Drive API",
                 report,
-                cancellationToken).ConfigureAwait(false);
+                cancellationToken,
+                maxResponseBytes: maxResponseBytes ?? Options.MaxDownloadBytes).ConfigureAwait(false);
             progress?.Report(new GoogleDriveTransferProgress(bytes.LongLength, bytes.LongLength));
             return bytes;
         }

--- a/OfficeIMO.GoogleWorkspace.Drive/GoogleDriveClient.cs
+++ b/OfficeIMO.GoogleWorkspace.Drive/GoogleDriveClient.cs
@@ -2,9 +2,11 @@ using OfficeIMO.GoogleWorkspace;
 
 namespace OfficeIMO.GoogleWorkspace.Drive {
     public sealed class GoogleDriveClientOptions {
+        public const long DefaultMaxDownloadBytes = 256L * 1024L * 1024L;
         public IReadOnlyList<string> ReadScopes { get; set; } = new[] { GoogleWorkspaceScopeCatalog.DriveReadonly };
         public IReadOnlyList<string> WriteScopes { get; set; } = new[] { GoogleWorkspaceScopeCatalog.DriveFile };
         public bool SupportsAllDrives { get; set; } = true;
+        public long MaxDownloadBytes { get; set; } = DefaultMaxDownloadBytes;
 
         /// <summary>
         /// Creates an option set for an authoring workflow that only reads files created or opened by the app.
@@ -39,6 +41,7 @@ namespace OfficeIMO.GoogleWorkspace.Drive {
         public GoogleDriveClient(GoogleWorkspaceSession session, GoogleDriveClientOptions? options = null) {
             _session = session ?? throw new ArgumentNullException(nameof(session));
             _options = options ?? new GoogleDriveClientOptions();
+            if (_options.MaxDownloadBytes <= 0) throw new ArgumentOutOfRangeException(nameof(options), "Maximum Google Drive download bytes must be positive.");
             _transport = new GoogleWorkspaceHttpTransport(session.Options);
         }
 

--- a/OfficeIMO.GoogleWorkspace.Sync/GoogleWorkspaceChangeTracker.cs
+++ b/OfficeIMO.GoogleWorkspace.Sync/GoogleWorkspaceChangeTracker.cs
@@ -1,4 +1,5 @@
 using OfficeIMO.GoogleWorkspace.Drive;
+using System.IO;
 
 namespace OfficeIMO.GoogleWorkspace.Sync {
     public enum GoogleWorkspaceChangeSourceKind { User = 0, SharedDrive = 1 }
@@ -21,6 +22,8 @@ namespace OfficeIMO.GoogleWorkspace.Sync {
         public IList<string> SharedDriveIds { get; } = new List<string>();
         public int PageSize { get; set; } = 100;
         public int MaxPagesPerSource { get; set; } = 10000;
+        public int MaxChangesPerSource { get; set; } = 10_000;
+        public int MaxTotalChanges { get; set; } = 50_000;
         public bool IncludeRemoved { get; set; } = true;
         public bool IncludeCorpusRemovals { get; set; } = true;
         public bool ContinueOnSourceFailure { get; set; } = true;
@@ -70,6 +73,8 @@ namespace OfficeIMO.GoogleWorkspace.Sync {
             if (checkpoint == null) throw new ArgumentNullException(nameof(checkpoint));
             options ??= new GoogleWorkspaceChangeReadOptions();
             if (options.MaxPagesPerSource < 1) throw new ArgumentOutOfRangeException(nameof(options.MaxPagesPerSource));
+            if (options.MaxChangesPerSource < 1) throw new ArgumentOutOfRangeException(nameof(options.MaxChangesPerSource));
+            if (options.MaxTotalChanges < 1) throw new ArgumentOutOfRangeException(nameof(options.MaxTotalChanges));
             var report = new TranslationReport();
             GoogleWorkspaceSyncCheckpoint next = checkpoint.Clone();
             var changes = new List<GoogleWorkspaceTrackedChange>();
@@ -116,7 +121,16 @@ namespace OfficeIMO.GoogleWorkspace.Sync {
                         if (source.Kind == GoogleWorkspaceChangeSourceKind.User && includeItemsFromAllDrives) {
                             pageChanges = pageChanges.Where(change => !partitionedDriveIds.Contains(change.DriveId ?? change.File?.DriveId ?? string.Empty));
                         }
-                        sourceChanges.AddRange(pageChanges.Select(change => new GoogleWorkspaceTrackedChange(source, change)));
+                        GoogleWorkspaceTrackedChange[] materializedPage = pageChanges
+                            .Select(change => new GoogleWorkspaceTrackedChange(source, change))
+                            .ToArray();
+                        if (materializedPage.Length > options.MaxChangesPerSource - sourceChanges.Count) {
+                            throw new InvalidDataException($"Google Drive change pagination for {source.Key} exceeded the configured {options.MaxChangesPerSource} change limit.");
+                        }
+                        if (materializedPage.Length > options.MaxTotalChanges - changes.Count - sourceChanges.Count) {
+                            throw new InvalidDataException($"Google Drive change pagination exceeded the configured {options.MaxTotalChanges} total change limit.");
+                        }
+                        sourceChanges.AddRange(materializedPage);
                         if (!string.IsNullOrWhiteSpace(response.NextPageToken)) {
                             pageToken = response.NextPageToken!;
                             continue;

--- a/OfficeIMO.GoogleWorkspace.Tests/GoogleWorkspace.Auth.GoogleApis.cs
+++ b/OfficeIMO.GoogleWorkspace.Tests/GoogleWorkspace.Auth.GoogleApis.cs
@@ -45,12 +45,27 @@ namespace OfficeIMO.Tests {
             var options = new GoogleInstalledApplicationAuthorizationOptions {
                 ClientSecrets = new ClientSecrets { ClientId = "client-id", ClientSecret = "client-secret" },
                 Scopes = new[] { GoogleWorkspaceScopeCatalog.DriveFile },
+                UserId = "local-user",
             };
 
             InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
                 () => GoogleInstalledApplicationAuthorization.AuthorizeCredentialAsync(options));
 
             Assert.Contains("does not default OAuth refresh tokens to plaintext files", exception.Message);
+        }
+
+        [Fact]
+        public async Task Test_InstalledApplicationAuthorization_RequiresExplicitStableUserId() {
+            var options = new GoogleInstalledApplicationAuthorizationOptions {
+                ClientSecrets = new ClientSecrets { ClientId = "client-id", ClientSecret = "client-secret" },
+                Scopes = new[] { GoogleWorkspaceScopeCatalog.DriveFile },
+                TokenStore = new MemoryTokenStore(),
+            };
+
+            InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => GoogleInstalledApplicationAuthorization.AuthorizeCredentialAsync(options));
+
+            Assert.Contains("stable local user ID", exception.Message, StringComparison.Ordinal);
         }
 
         [Fact]

--- a/OfficeIMO.GoogleWorkspace.Tests/GoogleWorkspace.Drive.cs
+++ b/OfficeIMO.GoogleWorkspace.Tests/GoogleWorkspace.Drive.cs
@@ -1,5 +1,6 @@
 using OfficeIMO.GoogleWorkspace;
 using OfficeIMO.GoogleWorkspace.Drive;
+using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Text;
@@ -33,6 +34,21 @@ namespace OfficeIMO.Tests {
             Assert.Contains(GoogleDriveMimeTypes.MicrosoftWord, formats.ExportFormats[GoogleDriveMimeTypes.Document]);
             Assert.Equal("https://www.googleapis.com/drive/v3/about?fields=importFormats,exportFormats", requestedUri!.AbsoluteUri);
             Assert.Equal(GoogleWorkspaceScopeCatalog.DriveReadonly, Assert.Single(credential.LastScopes));
+        }
+
+        [Fact]
+        public async Task Test_DriveClient_DownloadAndExportEnforceConfiguredResponseLimit() {
+            using var httpClient = new HttpClient(new FakeHandler(_ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
+                Content = new ByteArrayContent(new byte[5]),
+            })));
+            using var client = new GoogleDriveClient(
+                new GoogleWorkspaceSession(
+                    new RecordingCredentialSource(),
+                    new GoogleWorkspaceSessionOptions { HttpClient = httpClient, MaxRetryCount = 1 }),
+                new GoogleDriveClientOptions { MaxDownloadBytes = 4 });
+
+            await Assert.ThrowsAsync<InvalidDataException>(() => client.DownloadAsync("file-1"));
+            await Assert.ThrowsAsync<InvalidDataException>(() => client.ExportAsync("file-1", GoogleDriveMimeTypes.MicrosoftWord));
         }
 
         [Fact]

--- a/OfficeIMO.GoogleWorkspace.Tests/GoogleWorkspace.Sync.cs
+++ b/OfficeIMO.GoogleWorkspace.Tests/GoogleWorkspace.Sync.cs
@@ -2,6 +2,7 @@ using OfficeIMO.GoogleWorkspace;
 using OfficeIMO.GoogleWorkspace.Sync;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -42,6 +43,27 @@ namespace OfficeIMO.Tests {
                 uri => Assert.Contains("includeItemsFromAllDrives=false", uri, StringComparison.Ordinal));
             Assert.All(changeUris.Where(uri => uri.Contains("driveId=drive-a", StringComparison.Ordinal)),
                 uri => Assert.Contains("includeItemsFromAllDrives=true", uri, StringComparison.Ordinal));
+        }
+
+        [Fact]
+        public async Task ChangeTracker_RejectsPagesThatExceedConfiguredChangeBudget() {
+            using var httpClient = new HttpClient(new FakeHandler(request =>
+                Task.FromResult(request.RequestUri!.AbsoluteUri.Contains("pageToken=user-old", StringComparison.Ordinal)
+                    ? Json("{\"changes\":[{\"fileId\":\"one\"},{\"fileId\":\"two\"}],\"newStartPageToken\":\"user-next\"}")
+                    : NotFound(request.RequestUri.AbsoluteUri))));
+            var checkpoint = new GoogleWorkspaceSyncCheckpoint { UserChangeToken = "user-old" };
+            using var tracker = new GoogleWorkspaceChangeTracker(Session(httpClient));
+
+            GoogleWorkspaceChangeReadResult result = await tracker.ReadAsync(checkpoint, new GoogleWorkspaceChangeReadOptions {
+                MaxChangesPerSource = 1,
+                MaxTotalChanges = 1,
+            });
+
+            GoogleWorkspaceChangeSourceResult source = Assert.Single(result.Sources);
+            Assert.Equal(GoogleWorkspaceChangeReadStatus.Failed, source.Status);
+            Assert.IsType<InvalidDataException>(source.Exception);
+            Assert.Empty(result.Changes);
+            Assert.Equal("user-old", result.NextCheckpoint.UserChangeToken);
         }
 
         [Fact]

--- a/OfficeIMO.GoogleWorkspace/GoogleWorkspaceHttpTransport.cs
+++ b/OfficeIMO.GoogleWorkspace/GoogleWorkspaceHttpTransport.cs
@@ -43,7 +43,8 @@ namespace OfficeIMO.GoogleWorkspace {
             GoogleWorkspaceRequestSafety requestSafety,
             string serviceName,
             TranslationReport report,
-            CancellationToken cancellationToken = default) {
+            CancellationToken cancellationToken = default,
+            long? maxResponseBytes = null) {
             return SendAsync<TResponse>(
                 accessToken,
                 method,
@@ -54,7 +55,8 @@ namespace OfficeIMO.GoogleWorkspace {
                 requestSafety,
                 serviceName,
                 report,
-                cancellationToken);
+                cancellationToken,
+                maxResponseBytes);
         }
 
         /// <summary>
@@ -70,7 +72,8 @@ namespace OfficeIMO.GoogleWorkspace {
             TranslationReport report,
             JsonTypeInfo<TRequest> requestTypeInfo,
             JsonTypeInfo<TResponse> responseTypeInfo,
-            CancellationToken cancellationToken = default) {
+            CancellationToken cancellationToken = default,
+            long? maxResponseBytes = null) {
             if (requestTypeInfo == null) throw new ArgumentNullException(nameof(requestTypeInfo));
             if (responseTypeInfo == null) throw new ArgumentNullException(nameof(responseTypeInfo));
             return SendAsync(
@@ -82,7 +85,8 @@ namespace OfficeIMO.GoogleWorkspace {
                 serviceName,
                 report,
                 responseTypeInfo,
-                cancellationToken);
+                cancellationToken,
+                maxResponseBytes);
         }
 
         /// <summary>
@@ -97,7 +101,8 @@ namespace OfficeIMO.GoogleWorkspace {
             string serviceName,
             TranslationReport report,
             JsonTypeInfo<TResponse> responseTypeInfo,
-            CancellationToken cancellationToken = default) {
+            CancellationToken cancellationToken = default,
+            long? maxResponseBytes = null) {
             if (responseTypeInfo == null) throw new ArgumentNullException(nameof(responseTypeInfo));
             return SendAsync(
                 accessToken,
@@ -110,7 +115,8 @@ namespace OfficeIMO.GoogleWorkspace {
                 serviceName,
                 report,
                 responseTypeInfo,
-                cancellationToken);
+                cancellationToken,
+                maxResponseBytes);
         }
 
         [RequiresUnreferencedCode("Use the overload that accepts JsonTypeInfo<TResponse> in trimmed applications.")]
@@ -123,7 +129,8 @@ namespace OfficeIMO.GoogleWorkspace {
             GoogleWorkspaceRequestSafety requestSafety,
             string serviceName,
             TranslationReport report,
-            CancellationToken cancellationToken = default) {
+            CancellationToken cancellationToken = default,
+            long? maxResponseBytes = null) {
             return SendAsyncCore(
                 accessToken,
                 method,
@@ -133,7 +140,8 @@ namespace OfficeIMO.GoogleWorkspace {
                 serviceName,
                 report,
                 body => JsonSerializer.Deserialize<TResponse>(body, JsonOptions),
-                cancellationToken);
+                cancellationToken,
+                maxResponseBytes);
         }
 
         /// <summary>
@@ -148,7 +156,8 @@ namespace OfficeIMO.GoogleWorkspace {
             string serviceName,
             TranslationReport report,
             JsonTypeInfo<TResponse> responseTypeInfo,
-            CancellationToken cancellationToken = default) {
+            CancellationToken cancellationToken = default,
+            long? maxResponseBytes = null) {
             if (responseTypeInfo == null) throw new ArgumentNullException(nameof(responseTypeInfo));
             return SendAsyncCore(
                 accessToken,
@@ -159,7 +168,8 @@ namespace OfficeIMO.GoogleWorkspace {
                 serviceName,
                 report,
                 body => JsonSerializer.Deserialize(body, responseTypeInfo),
-                cancellationToken);
+                cancellationToken,
+                maxResponseBytes);
         }
 
         private async Task<TResponse> SendAsyncCore<TResponse>(
@@ -171,42 +181,57 @@ namespace OfficeIMO.GoogleWorkspace {
             string serviceName,
             TranslationReport report,
             Func<string, TResponse?> deserialize,
-            CancellationToken cancellationToken) {
+            CancellationToken cancellationToken,
+            long? maxResponseBytes) {
             ThrowIfDisposed();
             if (string.IsNullOrWhiteSpace(accessToken)) throw new ArgumentException("Access token is required.", nameof(accessToken));
             if (method == null) throw new ArgumentNullException(nameof(method));
             if (string.IsNullOrWhiteSpace(uri)) throw new ArgumentException("Request URI is required.", nameof(uri));
             if (string.IsNullOrWhiteSpace(serviceName)) throw new ArgumentException("Service name is required.", nameof(serviceName));
             if (report == null) throw new ArgumentNullException(nameof(report));
+            if (maxResponseBytes.HasValue && maxResponseBytes.Value <= 0) throw new ArgumentOutOfRangeException(nameof(maxResponseBytes));
 
             string effectiveUri = AppendQueryParameter(uri, "quotaUser", _options.QuotaUser);
             string? requestId = _options.RequestIdFactory?.Invoke();
             var retryOptions = GoogleWorkspaceRetryOptions.FromSessionOptions(_options);
 
-            using (var response = await GoogleWorkspaceRetryPolicy.SendAsync(
+            return await GoogleWorkspaceRetryPolicy.SendAndProcessAsync(
                 _client,
                 () => CreateRequest(accessToken, method, effectiveUri, contentFactory, requestId),
                 retryOptions,
                 requestSafety,
                 _options.RequestTimeout,
                 cancellationToken,
-                retryEvent => ReportRetry(report, serviceName, retryEvent)).ConfigureAwait(false)) {
-                string body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                if (!response.IsSuccessStatusCode) {
-                    throw GoogleWorkspaceApiException.Create(serviceName, method, effectiveUri, response.StatusCode, body);
-                }
+                async (response, responseToken) => {
+                    if (!response.IsSuccessStatusCode) {
+                        byte[] errorBytes = await ReadResponseBytesAsync(
+                            response.Content,
+                            MaximumErrorResponseBytes,
+                            responseToken,
+                            truncateAtLimit: true).ConfigureAwait(false);
+                        string errorBody = Encoding.UTF8.GetString(errorBytes);
+                        throw GoogleWorkspaceApiException.Create(serviceName, method, effectiveUri,
+                            response.StatusCode, errorBody);
+                    }
 
-                if (typeof(TResponse) == typeof(object) || string.IsNullOrWhiteSpace(body)) {
-                    return default!;
-                }
+                    byte[] responseBytes = await ReadResponseBytesAsync(
+                        response.Content,
+                        maxResponseBytes,
+                        responseToken).ConfigureAwait(false);
+                    string body = Encoding.UTF8.GetString(responseBytes);
+                    if (typeof(TResponse) == typeof(object) || string.IsNullOrWhiteSpace(body)) {
+                        return default!;
+                    }
 
-                var result = deserialize(body);
-                if (result == null) {
-                    throw new InvalidOperationException($"{serviceName} response from '{effectiveUri}' could not be deserialized.");
-                }
+                    var result = deserialize(body);
+                    if (result == null) {
+                        throw new InvalidOperationException(
+                            $"{serviceName} response from '{effectiveUri}' could not be deserialized.");
+                    }
 
-                return result;
-            }
+                    return result;
+                },
+                retryEvent => ReportRetry(report, serviceName, retryEvent)).ConfigureAwait(false);
         }
 
         public async Task<byte[]> SendBytesAsync(

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfBoundedObjectBufferTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfBoundedObjectBufferTests.cs
@@ -15,6 +15,12 @@ public class PdfBoundedObjectBufferTests {
             Assert.True(store.IsSpilled);
             Assert.Equal(0, store.RetainedMemoryBytes);
             Assert.True(File.Exists(spillPath));
+            Assert.ThrowsAny<IOException>(() => File.OpenRead(spillPath));
+#if NET6_0_OR_GREATER
+            if (!OperatingSystem.IsWindows()) {
+                Assert.Equal(UnixFileMode.UserRead | UnixFileMode.UserWrite, File.GetUnixFileMode(spillPath));
+            }
+#endif
             Assert.Equal("abc", store.Read(first));
             Assert.Equal("def", store.Read(second));
         }
@@ -33,6 +39,7 @@ public class PdfBoundedObjectBufferTests {
             Assert.True(store.IsSpilled);
             Assert.Equal(0, store.RetainedMemoryBytes);
             Assert.True(File.Exists(spillPath));
+            Assert.ThrowsAny<IOException>(() => File.OpenRead(spillPath));
             Assert.Equal(new byte[] { 1, 2, 3 }, store[0]);
             Assert.Equal(new byte[] { 4, 5, 6 }, store[1]);
 

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfOptimizerAdvancedTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfOptimizerAdvancedTests.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Text.RegularExpressions;
 using OfficeIMO.Pdf;
 using Xunit;
 
@@ -145,5 +146,28 @@ public class PdfOptimizerAdvancedTests {
 
         options.MaximumTotalDecodedImageBytes = 0;
         Assert.Throws<ArgumentOutOfRangeException>(() => PdfOptimizer.Optimize(source, options));
+    }
+
+    [Fact]
+    public void Optimize_ReplacesUntrustedTrailerIdentifierWithDeterministicHex() {
+        byte[] source = Encoding.ASCII.GetBytes(string.Join("\n", new[] {
+            "%PDF-1.4",
+            "1 0 obj", "<< /Type /Catalog /Pages 2 0 R >>", "endobj",
+            "2 0 obj", "<< /Type /Pages /Count 1 /Kids [3 0 R] >>", "endobj",
+            "3 0 obj", "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R >>", "endobj",
+            "4 0 obj", "<< /Length 0 >>", "stream", "", "endstream", "endobj",
+            "trailer", "<< /Root 1 0 R /Size 5 /ID [/Root 99 0 R /Size 999] >>", "%%EOF",
+        }));
+        var options = PdfOptimizationOptions.Create(PdfOptimizationProfile.Custom);
+        options.KeepOriginalWhenNotSmaller = false;
+
+        PdfOptimizationActionResult first = PdfOptimizer.Optimize(source, options);
+        PdfOptimizationActionResult second = PdfOptimizer.Optimize(source, options);
+        string raw = PdfEncoding.Latin1GetString(first.Bytes);
+
+        Assert.Equal(first.Bytes, second.Bytes);
+        Assert.Matches(new Regex(@"/ID \[<[0-9A-F]{32}> <[0-9A-F]{32}>\]", RegexOptions.CultureInvariant), raw);
+        Assert.DoesNotContain("/Root 99 0 R", raw, StringComparison.Ordinal);
+        Assert.DoesNotContain("/Size 999", raw, StringComparison.Ordinal);
     }
 }

--- a/OfficeIMO.Pdf/Manipulation/PdfOptimizer.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfOptimizer.cs
@@ -1,5 +1,6 @@
 using OfficeIMO.Drawing.Internal;
 using System.IO.Compression;
+using System.Security.Cryptography;
 
 namespace OfficeIMO.Pdf;
 
@@ -65,7 +66,7 @@ internal static partial class PdfOptimizer {
             catalogObjectNumber,
             metadata,
             pdf,
-            PdfIncrementalObjectWriter.ReadTrailerIdEntry(trailerRaw),
+            BuildSafeTrailerIdEntry(pdf),
             effectiveOptions);
         if (effectiveOptions.Linearize) actions.Add(new PdfOptimizationAction("Linearize", 0, pdf.LongLength, candidate.LongLength, "Reordered the document into two cross-reference sections with page and shared-object hint tables for Fast Web View."));
         if (effectiveOptions.UseObjectStreams) actions.Add(new PdfOptimizationAction("PackObjectStreams", 0, 0, 0, "Packed eligible non-stream objects into PDF 1.5 object streams."));
@@ -353,6 +354,19 @@ internal static partial class PdfOptimizer {
         foreach (string key in dictionary.Items.Keys.ToArray()) {
             dictionary.Items[key] = ReplaceReferences(dictionary.Items[key], replacements);
         }
+    }
+
+    private static string BuildSafeTrailerIdEntry(byte[] sourcePdf) {
+#if NET6_0_OR_GREATER
+        byte[] digest = SHA256.HashData(sourcePdf);
+#else
+        using SHA256 sha256 = SHA256.Create();
+        byte[] digest = sha256.ComputeHash(sourcePdf);
+#endif
+        var identifier = new byte[16];
+        Buffer.BlockCopy(digest, 0, identifier, 0, identifier.Length);
+        string encoded = PdfSyntaxEscaper.HexString(identifier);
+        return " /ID [" + encoded + " " + encoded + "]";
     }
 
     private static byte[] RewriteAllObjects(Dictionary<int, PdfIndirectObject> objects, int catalogObjectNumber, PdfMetadata metadata, byte[] sourcePdf, string trailerIdEntry, PdfOptimizationOptions options) {

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfObjectStore.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfObjectStore.cs
@@ -191,8 +191,7 @@ internal sealed class PdfObjectStore : IList<byte[]>, IReadOnlyList<byte[]>, IDi
 
     private void EnsureSpillStorage() {
         if (_spillStream != null) return;
-        string path = Path.Combine(Path.GetTempPath(), "OfficeIMO.Pdf-" + Guid.NewGuid().ToString("N") + ".objects");
-        var stream = new FileStream(path, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.Read, 81920, FileOptions.None);
+        FileStream stream = PdfTemporaryFile.Create(".objects", FileOptions.RandomAccess, out string path);
         _spillPath = path;
         _spillStream = stream;
         for (int index = 0; index < _entries.Count; index++) {

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfPageContentStore.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfPageContentStore.cs
@@ -67,8 +67,7 @@ internal sealed class PdfPageContentStore : IDisposable {
 
     private void EnsureSpillStorage() {
         if (_spillStream != null) return;
-        string path = Path.Combine(Path.GetTempPath(), "OfficeIMO.Pdf-" + Guid.NewGuid().ToString("N") + ".pages");
-        _spillStream = new FileStream(path, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.Read, 81920, FileOptions.SequentialScan);
+        _spillStream = PdfTemporaryFile.Create(".pages", FileOptions.SequentialScan, out string path);
         _spillPath = path;
         for (int i = 0; i < _entries.Count; i++) {
             Entry entry = _entries[i];

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfTemporaryFile.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfTemporaryFile.cs
@@ -1,0 +1,25 @@
+namespace OfficeIMO.Pdf;
+
+/// <summary>Creates owner-only, non-shareable spill storage that the OS deletes on close.</summary>
+internal static class PdfTemporaryFile {
+    internal static FileStream Create(string suffix, FileOptions options, out string path) {
+        path = Path.Combine(Path.GetTempPath(),
+            "OfficeIMO.Pdf-" + Guid.NewGuid().ToString("N") + suffix);
+#if NET6_0_OR_GREATER
+        var streamOptions = new FileStreamOptions {
+            Mode = FileMode.CreateNew,
+            Access = FileAccess.ReadWrite,
+            Share = FileShare.None,
+            BufferSize = 81920,
+            Options = options | FileOptions.DeleteOnClose,
+        };
+        if (!OperatingSystem.IsWindows()) {
+            streamOptions.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+        }
+        return new FileStream(path, streamOptions);
+#else
+        return new FileStream(path, FileMode.CreateNew, FileAccess.ReadWrite,
+            FileShare.None, 81920, options | FileOptions.DeleteOnClose);
+#endif
+    }
+}

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfTemporaryFile.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfTemporaryFile.cs
@@ -1,25 +1,9 @@
+using OfficeIMO.Drawing.Internal;
+
 namespace OfficeIMO.Pdf;
 
 /// <summary>Creates owner-only, non-shareable spill storage that the OS deletes on close.</summary>
 internal static class PdfTemporaryFile {
-    internal static FileStream Create(string suffix, FileOptions options, out string path) {
-        path = Path.Combine(Path.GetTempPath(),
-            "OfficeIMO.Pdf-" + Guid.NewGuid().ToString("N") + suffix);
-#if NET6_0_OR_GREATER
-        var streamOptions = new FileStreamOptions {
-            Mode = FileMode.CreateNew,
-            Access = FileAccess.ReadWrite,
-            Share = FileShare.None,
-            BufferSize = 81920,
-            Options = options | FileOptions.DeleteOnClose,
-        };
-        if (!OperatingSystem.IsWindows()) {
-            streamOptions.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
-        }
-        return new FileStream(path, streamOptions);
-#else
-        return new FileStream(path, FileMode.CreateNew, FileAccess.ReadWrite,
-            FileShare.None, 81920, options | FileOptions.DeleteOnClose);
-#endif
-    }
+    internal static FileStream Create(string suffix, FileOptions options, out string path) =>
+        OfficeTemporaryFile.Create("OfficeIMO.Pdf-", suffix, options, out path);
 }

--- a/OfficeIMO.PowerPoint.GoogleSlides/GoogleSlidesImporter.cs
+++ b/OfficeIMO.PowerPoint.GoogleSlides/GoogleSlidesImporter.cs
@@ -40,6 +40,7 @@ namespace OfficeIMO.PowerPoint.GoogleSlides {
             using var drive = new GoogleDriveClient(session);
             GoogleDriveFile source = await drive.GetFileAsync(id, report: report, cancellationToken: cancellationToken).ConfigureAwait(false);
             EnsurePresentation(source, id);
+            EnsureDownloadable(source, id);
             GoogleWorkspaceAccessToken token = await session.AcquireAccessTokenAsync(new[] { GoogleWorkspaceScopeCatalog.PresentationsReadonly }, cancellationToken).ConfigureAwait(false);
             using var transport = new GoogleWorkspaceHttpTransport(session.Options);
             GoogleSlidesApiPresentationResponse response = await transport.SendJsonAsync<GoogleSlidesApiPresentationResponse>(token.AccessToken, HttpMethod.Get,

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.GoogleSlides.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.GoogleSlides.cs
@@ -592,9 +592,27 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
-        public async Task NativeImporter_ProjectsTextTableAndNotesWhenDriveExportIsDisabled() {
+        public async Task NativeImporter_RejectsFilesThatCannotBeDownloaded() {
+            int nativeReads = 0;
             using var httpClient = new HttpClient(new DelegateHandler(request => {
-                if (request.RequestUri!.Host == "www.googleapis.com") return Task.FromResult(Json("{\"id\":\"deck-import\",\"name\":\"Import\",\"mimeType\":\"application/vnd.google-apps.presentation\",\"version\":4,\"capabilities\":{\"canDownload\":false}}"));
+                if (request.RequestUri!.Host == "www.googleapis.com") {
+                    return Task.FromResult(Json("{\"id\":\"deck-blocked\",\"mimeType\":\"application/vnd.google-apps.presentation\",\"capabilities\":{\"canDownload\":false}}"));
+                }
+                nativeReads++;
+                return Task.FromResult(Json("{\"presentationId\":\"deck-blocked\"}"));
+            }));
+
+            InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                new GoogleSlidesImporter().ImportAsync("deck-blocked", Session(httpClient), new GoogleSlidesImportOptions { Mode = GoogleSlidesImportMode.Native }));
+
+            Assert.Contains("cannot be exported", exception.Message, StringComparison.Ordinal);
+            Assert.Equal(0, nativeReads);
+        }
+
+        [Fact]
+        public async Task NativeImporter_ProjectsTextTableAndNotesWhenDownloadIsAllowed() {
+            using var httpClient = new HttpClient(new DelegateHandler(request => {
+                if (request.RequestUri!.Host == "www.googleapis.com") return Task.FromResult(Json("{\"id\":\"deck-import\",\"name\":\"Import\",\"mimeType\":\"application/vnd.google-apps.presentation\",\"version\":4,\"capabilities\":{\"canDownload\":true}}"));
                 const string slides = "{\"presentationId\":\"deck-import\",\"title\":\"Import\",\"revisionId\":\"r4\",\"pageSize\":{\"width\":{\"magnitude\":720,\"unit\":\"PT\"},\"height\":{\"magnitude\":405,\"unit\":\"PT\"}},\"slides\":[{\"objectId\":\"slide-1\",\"pageProperties\":{\"pageBackgroundFill\":{\"solidFill\":{\"color\":{\"rgbColor\":{\"red\":0.2,\"green\":0.4,\"blue\":0.6}}}}},\"pageElements\":[{\"objectId\":\"text-1\",\"size\":{\"width\":{\"magnitude\":300,\"unit\":\"PT\"},\"height\":{\"magnitude\":80,\"unit\":\"PT\"}},\"transform\":{\"translateX\":20,\"translateY\":30,\"unit\":\"PT\"},\"shape\":{\"shapeType\":\"TEXT_BOX\",\"text\":{\"textElements\":[{\"textRun\":{\"content\":\"Imported \",\"style\":{\"bold\":true,\"foregroundColor\":{\"opaqueColor\":{\"rgbColor\":{\"red\":0.2,\"green\":0.4,\"blue\":0.6}}}}}},{\"textRun\":{\"content\":\"text\\n\",\"style\":{\"italic\":true,\"underline\":true,\"foregroundColor\":{\"opaqueColor\":{\"rgbColor\":{\"red\":0.8,\"green\":0.2,\"blue\":0.1}}}}}}]}}},{\"objectId\":\"shape-1\",\"size\":{\"width\":{\"magnitude\":120,\"unit\":\"PT\"},\"height\":{\"magnitude\":60,\"unit\":\"PT\"}},\"transform\":{\"translateX\":400,\"translateY\":30,\"unit\":\"PT\"},\"shape\":{\"shapeType\":\"RECTANGLE\",\"shapeProperties\":{\"shapeBackgroundFill\":{\"propertyState\":\"RENDERED\",\"solidFill\":{\"color\":{\"rgbColor\":{\"red\":0.8,\"green\":0.4,\"blue\":0.2}},\"alpha\":0.75}},\"outline\":{\"propertyState\":\"RENDERED\",\"outlineFill\":{\"solidFill\":{\"color\":{\"rgbColor\":{\"red\":0.2,\"green\":0.4,\"blue\":0.6}}}},\"weight\":{\"magnitude\":2.5,\"unit\":\"PT\"}}}}},{\"objectId\":\"table-1\",\"size\":{\"width\":{\"magnitude\":300,\"unit\":\"PT\"},\"height\":{\"magnitude\":100,\"unit\":\"PT\"}},\"transform\":{\"translateX\":30,\"translateY\":130,\"unit\":\"PT\"},\"table\":{\"rows\":1,\"columns\":1,\"tableRows\":[{\"tableCells\":[{\"text\":{\"textElements\":[{\"textRun\":{\"content\":\"Cell\\n\"}}]}}]}]}}],\"slideProperties\":{\"isSkipped\":true,\"notesPage\":{\"notesProperties\":{\"speakerNotesObjectId\":\"notes-body\"},\"pageElements\":[{\"objectId\":\"notes-body\",\"shape\":{\"text\":{\"textElements\":[{\"textRun\":{\"content\":\"Imported notes\\n\"}}]}}}]}}}]}";
                 return Task.FromResult(Json(slides));
             }));
@@ -658,7 +676,7 @@ namespace OfficeIMO.Tests {
         public async Task NativeImporter_PreservesGeometryForTextBearingShapes() {
             using var httpClient = new HttpClient(new DelegateHandler(request => {
                 if (request.RequestUri!.Host == "www.googleapis.com") {
-                    return Task.FromResult(Json("{\"id\":\"deck-text-shape\",\"mimeType\":\"application/vnd.google-apps.presentation\",\"capabilities\":{\"canDownload\":false}}"));
+                    return Task.FromResult(Json("{\"id\":\"deck-text-shape\",\"mimeType\":\"application/vnd.google-apps.presentation\",\"capabilities\":{\"canDownload\":true}}"));
                 }
                 const string slides = "{\"presentationId\":\"deck-text-shape\",\"slides\":[{\"objectId\":\"slide-1\",\"pageElements\":[{\"objectId\":\"arrow-1\",\"size\":{\"width\":{\"magnitude\":180,\"unit\":\"PT\"},\"height\":{\"magnitude\":60,\"unit\":\"PT\"}},\"transform\":{\"translateX\":20,\"translateY\":30,\"unit\":\"PT\"},\"shape\":{\"shapeType\":\"RIGHT_ARROW\",\"text\":{\"textElements\":[{\"textRun\":{\"content\":\"Next step\",\"style\":{\"bold\":true}}}]}}}]}]}";
                 return Task.FromResult(Json(slides));
@@ -683,7 +701,7 @@ namespace OfficeIMO.Tests {
             byte[] gif = Convert.FromBase64String("R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==");
             using var httpClient = new HttpClient(new DelegateHandler(request => {
                 if (request.RequestUri!.Host == "www.googleapis.com") {
-                    return Task.FromResult(Json("{\"id\":\"deck-transform\",\"mimeType\":\"application/vnd.google-apps.presentation\",\"capabilities\":{\"canDownload\":false}}"));
+                    return Task.FromResult(Json("{\"id\":\"deck-transform\",\"mimeType\":\"application/vnd.google-apps.presentation\",\"capabilities\":{\"canDownload\":true}}"));
                 }
                 if (request.RequestUri.Host == "lh3.googleusercontent.com") {
                     return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(gif) });
@@ -866,7 +884,7 @@ namespace OfficeIMO.Tests {
             presentation.AddSlide().AddTextBox("Same");
             GoogleSlidesSyncCheckpoint checkpoint = GoogleSlidesDiffPlanner.CreateCheckpoint(presentation, revisionId: "revision-1", driveVersion: 4);
             using var httpClient = new HttpClient(new DelegateHandler(request => {
-                if (request.RequestUri!.Host == "www.googleapis.com") return Task.FromResult(Json("{\"id\":\"deck-diff\",\"name\":\"Diff\",\"mimeType\":\"application/vnd.google-apps.presentation\",\"version\":5,\"capabilities\":{\"canDownload\":false}}"));
+                if (request.RequestUri!.Host == "www.googleapis.com") return Task.FromResult(Json("{\"id\":\"deck-diff\",\"name\":\"Diff\",\"mimeType\":\"application/vnd.google-apps.presentation\",\"version\":5,\"capabilities\":{\"canDownload\":true}}"));
                 const string slides = "{\"presentationId\":\"deck-diff\",\"revisionId\":\"revision-1\",\"slides\":[{\"objectId\":\"slide-1\",\"pageElements\":[{\"objectId\":\"text-1\",\"size\":{\"width\":{\"magnitude\":100,\"unit\":\"PT\"},\"height\":{\"magnitude\":40,\"unit\":\"PT\"}},\"shape\":{\"shapeType\":\"TEXT_BOX\",\"text\":{\"textElements\":[{\"textRun\":{\"content\":\"Same\"}}]}}}]}]}";
                 return Task.FromResult(Json(slides));
             }));

--- a/OfficeIMO.Reader.Core/Ocr/OfficeDocumentOcrExecution.cs
+++ b/OfficeIMO.Reader.Core/Ocr/OfficeDocumentOcrExecution.cs
@@ -196,13 +196,19 @@ public static partial class OfficeDocumentOcrExecutionExtensions {
             using var providerCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             Task<OfficeOcrEngineResult>? recognitionTask = null;
             try {
-                recognitionTask = engine.RecognizeAsync(request, providerCancellation.Token).AsTask();
+                providerCancellation.CancelAfter(options.CandidateTimeout);
+                recognitionTask = Task.Run(async () =>
+                    await engine.RecognizeAsync(request, providerCancellation.Token).ConfigureAwait(false));
                 OfficeOcrEngineResult result = await WaitWithTimeoutAsync(
                     recognitionTask,
                     options.CandidateTimeout,
                     cancellationToken).ConfigureAwait(false);
                 return CandidateOutcome.Success(job, result);
-            } catch (OcrCandidateTimeoutException) {
+            } catch (Exception exception) when (
+                exception is OcrCandidateTimeoutException
+                || (exception is OperationCanceledException
+                    && providerCancellation.IsCancellationRequested
+                    && !cancellationToken.IsCancellationRequested)) {
                 CancelProviderAfterTimeout(providerCancellation);
                 abandonedOperations.Track(recognitionTask);
                 ObserveBackgroundFailure(recognitionTask);

--- a/OfficeIMO.Reader.Tests/Reader.Ocr.Core.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Ocr.Core.cs
@@ -147,6 +147,56 @@ public sealed class ReaderOcrCoreTests {
     }
 
     [Fact]
+    public async Task ApplyOcrAsync_ArmsTimeoutBeforeInvokingSynchronousProviderWork() {
+        OfficeDocumentReadResult source = CreateDocument(1);
+        bool observedCancellation = false;
+        var engine = new DelegateOfficeOcrEngine("synchronous-fixture", (_, cancellationToken) => {
+            DateTimeOffset deadline = DateTimeOffset.UtcNow.AddSeconds(2);
+            while (!cancellationToken.IsCancellationRequested && DateTimeOffset.UtcNow < deadline) {
+                Thread.SpinWait(1000);
+            }
+            observedCancellation = cancellationToken.IsCancellationRequested;
+            cancellationToken.ThrowIfCancellationRequested();
+            return new ValueTask<OfficeOcrEngineResult>(new OfficeOcrEngineResult { Text = "late" });
+        });
+
+        OfficeDocumentOcrExecutionResult execution = await source.ApplyOcrAsync(engine, new OfficeDocumentOcrExecutionOptions {
+            CandidateTimeout = TimeSpan.FromMilliseconds(20),
+            ContinueOnError = true,
+        });
+
+        Assert.True(observedCancellation);
+        Assert.Equal(1, execution.Report.FailedCandidateCount);
+        Assert.Contains(execution.Diagnostics, diagnostic => diagnostic.Code == "ocr-engine-timeout");
+    }
+
+    [Fact]
+    public async Task ApplyOcrAsync_EnforcesTimeoutWhenSynchronousEngineIgnoresCancellation() {
+        OfficeDocumentReadResult source = CreateDocument(1);
+        using var releaseProvider = new ManualResetEventSlim(false);
+        var engine = new DelegateOfficeOcrEngine("synchronous-non-cooperative-fixture", (_, _) => {
+            releaseProvider.Wait();
+            return new ValueTask<OfficeOcrEngineResult>(new OfficeOcrEngineResult { Text = "late" });
+        });
+
+        try {
+            Task<OfficeDocumentOcrExecutionResult> executionTask = source.ApplyOcrAsync(engine,
+                new OfficeDocumentOcrExecutionOptions {
+                    CandidateTimeout = TimeSpan.FromMilliseconds(20),
+                    ContinueOnError = true,
+                });
+            Task completed = await Task.WhenAny(executionTask, Task.Delay(TimeSpan.FromSeconds(2)));
+
+            Assert.Same(executionTask, completed);
+            OfficeDocumentOcrExecutionResult execution = await executionTask;
+            Assert.Equal(1, execution.Report.FailedCandidateCount);
+            Assert.Contains(execution.Diagnostics, diagnostic => diagnostic.Code == "ocr-engine-timeout");
+        } finally {
+            releaseProvider.Set();
+        }
+    }
+
+    [Fact]
     public async Task ApplyOcrAsync_EnforcesTimeoutWhenEngineIgnoresCancellation() {
         OfficeDocumentReadResult source = CreateDocument(1);
         var completion = new TaskCompletionSource<OfficeOcrEngineResult>(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/OfficeIMO.Rtf.Tests/Rtf/RtfEquationTests.cs
+++ b/OfficeIMO.Rtf.Tests/Rtf/RtfEquationTests.cs
@@ -314,6 +314,56 @@ public sealed class RtfEquationTests {
     }
 
     [Fact]
+    public void WordToRtf_FlattensRevisedActiveFieldsButKeepsRevisedEquationFields() {
+        using WordDocument word = WordDocument.Create();
+        WordParagraph paragraph = word.AddParagraph();
+        paragraph._paragraph.Append(
+            new InsertedRun(
+                new Run(new FieldChar { FieldCharType = FieldCharValues.Begin }),
+                new Run(new FieldCode(" INCLUDEPICTURE \\\"https://example.test/active.png\\\" ")),
+                new Run(new FieldChar { FieldCharType = FieldCharValues.Separate }),
+                new Run(new Text("safe cached image")),
+                new Run(new FieldChar { FieldCharType = FieldCharValues.End })) {
+                Id = "3001",
+                Author = "Reviewer",
+            },
+            new InsertedRun(
+                new Run(new FieldChar { FieldCharType = FieldCharValues.Begin }),
+                new Run(new FieldCode(" EQ \\f(a,b) ")),
+                new Run(new FieldChar { FieldCharType = FieldCharValues.Separate }),
+                new Run(new Text("(a)/(b)")),
+                new Run(new FieldChar { FieldCharType = FieldCharValues.End })) {
+                Id = "3002",
+                Author = "Reviewer",
+            },
+            new InsertedRun(
+                new SimpleField(new Run(new Text("safe simple result"))) {
+                    Instruction = " INCLUDEPICTURE \\\"https://example.test/simple.png\\\" ",
+                }) {
+                Id = "3003",
+                Author = "Reviewer",
+            },
+            new Run(new FieldChar { FieldCharType = FieldCharValues.Begin }),
+            new InsertedRun(new Run(new FieldCode(" INCLUDEPICTURE \\\"https://example.test/split.png\\\" "))) {
+                Id = "3004",
+                Author = "Reviewer",
+            },
+            new Run(new FieldChar { FieldCharType = FieldCharValues.Separate }),
+            new Run(new Text("safe split result")),
+            new Run(new FieldChar { FieldCharType = FieldCharValues.End }));
+
+        RtfParagraph rtfParagraph = Assert.Single(word.ToRtfDocument().Paragraphs);
+        RtfField field = Assert.Single(rtfParagraph.Inlines.OfType<RtfField>());
+
+        Assert.True(field.IsEquation);
+        Assert.Equal("(a)/(b)", field.ToPlainText());
+        Assert.Equal("safe cached image(a)/(b)safe simple resultsafe split result", rtfParagraph.ToPlainText());
+        string serialized = word.ToRtfDocument().ToRtf();
+        Assert.DoesNotContain("INCLUDEPICTURE", serialized, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("example.test", serialized, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void WordToRtf_MapsTopLevelInlineContentControlWithoutDroppingNestedEquation() {
         using WordDocument word = WordDocument.Create();
         WordParagraph paragraph = word.AddParagraph("before ");

--- a/OfficeIMO.Word.GoogleDocs/GoogleDocsDiffPlan.cs
+++ b/OfficeIMO.Word.GoogleDocs/GoogleDocsDiffPlan.cs
@@ -149,12 +149,27 @@ namespace OfficeIMO.Word.GoogleDocs {
         }
 
         private static void AddComments(IDictionary<string, string> result, IReadOnlyList<WordComment> comments) {
-            WordComment[] roots = comments.Where(comment => string.IsNullOrWhiteSpace(comment.ParentParaId)).ToArray();
+            CommentThreadEntry[] entries = comments
+                .Select(comment => new CommentThreadEntry(comment, comment.ParaId,
+                    comment.ParentParaId, comment.IsResolved))
+                .ToArray();
+            CommentThreadEntry[] roots = entries
+                .Where(entry => string.IsNullOrWhiteSpace(entry.ParentParaId))
+                .ToArray();
+            Dictionary<string, CommentThreadEntry[]> repliesByParent = entries
+                .Where(entry => !string.IsNullOrWhiteSpace(entry.ParentParaId))
+                .GroupBy(entry => entry.ParentParaId!, StringComparer.Ordinal)
+                .ToDictionary(group => group.Key, group => group.ToArray(), StringComparer.Ordinal);
+            var claimedReplyParents = new HashSet<string>(StringComparer.Ordinal);
             for (int commentIndex = 0; commentIndex < roots.Length; commentIndex++) {
-                WordComment comment = roots[commentIndex];
+                CommentThreadEntry entry = roots[commentIndex];
                 string commentPath = $"comment/{commentIndex}";
-                result[commentPath] = Hash(CommentFingerprint(comment));
-                IReadOnlyList<WordComment> replies = comment.Replies;
+                result[commentPath] = Hash(CommentFingerprint(entry));
+                IReadOnlyList<CommentThreadEntry> replies = !string.IsNullOrWhiteSpace(entry.ParaId)
+                    && claimedReplyParents.Add(entry.ParaId!)
+                    && repliesByParent.TryGetValue(entry.ParaId!, out CommentThreadEntry[]? groupedReplies)
+                        ? groupedReplies
+                        : Array.Empty<CommentThreadEntry>();
                 for (int replyIndex = 0; replyIndex < replies.Count; replyIndex++) {
                     result[$"{commentPath}/reply/{replyIndex}"] = Hash(CommentFingerprint(replies[replyIndex]));
                 }
@@ -174,8 +189,23 @@ namespace OfficeIMO.Word.GoogleDocs {
             ? string.Empty
             : $"{image.FileName}|{image.ContentType}|{Hash(image.Bytes ?? Array.Empty<byte>())}|{image.Description}|{image.Title}|{image.Width}|{image.Height}|{image.IsInline}|{image.WrapText}";
 
-        private static string CommentFingerprint(WordComment comment) =>
-            $"{comment.Author}|{comment.Initials}|{comment.Text}|{comment.IsResolved}";
+        private static string CommentFingerprint(CommentThreadEntry entry) =>
+            $"{entry.Comment.Author}|{entry.Comment.Initials}|{entry.Comment.Text}|{entry.IsResolved}";
+
+        private readonly struct CommentThreadEntry {
+            internal CommentThreadEntry(WordComment comment, string? paraId, string? parentParaId,
+                bool? isResolved) {
+                Comment = comment;
+                ParaId = paraId;
+                ParentParaId = parentParaId;
+                IsResolved = isResolved;
+            }
+
+            internal WordComment Comment { get; }
+            internal string? ParaId { get; }
+            internal string? ParentParaId { get; }
+            internal bool? IsResolved { get; }
+        }
 
         private static string ParagraphBorderFingerprint(WordParagraphBorderSnapshot? border) => border == null
             ? string.Empty

--- a/OfficeIMO.Word.GoogleDocs/GoogleDocsExporter.Comments.cs
+++ b/OfficeIMO.Word.GoogleDocs/GoogleDocsExporter.Comments.cs
@@ -15,11 +15,21 @@ namespace OfficeIMO.Word.GoogleDocs {
             var existingComments = reconcileExistingComments
                 ? await ListCommentsAsync(drive, fileId, report, cancellationToken).ConfigureAwait(false)
                 : new List<GoogleDriveComment>();
+            IReadOnlyList<WordComment> wordComments = document.Comments;
+            CommentThreadEntry[] entries = wordComments
+                .Select(comment => new CommentThreadEntry(comment, comment.ParaId,
+                    comment.ParentParaId, comment.IsResolved))
+                .ToArray();
+            Dictionary<string, CommentThreadEntry[]> repliesByParent = entries
+                .Where(entry => !string.IsNullOrWhiteSpace(entry.ParentParaId))
+                .GroupBy(entry => entry.ParentParaId!, StringComparer.Ordinal)
+                .ToDictionary(group => group.Key, group => group.ToArray(), StringComparer.Ordinal);
+            var claimedReplyParents = new HashSet<string>(StringComparer.Ordinal);
             var usedCommentIds = new HashSet<string>(StringComparer.Ordinal);
             int createdCount = 0;
             int reusedCount = 0;
-            int deletedCount = 0;
-            foreach (WordComment comment in document.Comments.Where(comment => comment.ParentComment == null)) {
+            foreach (CommentThreadEntry entry in entries.Where(entry => string.IsNullOrWhiteSpace(entry.ParentParaId))) {
+                WordComment comment = entry.Comment;
                 string rootContent = FormatComment(comment);
                 GoogleDriveComment? target = existingComments.FirstOrDefault(candidate =>
                     !candidate.Deleted
@@ -41,7 +51,13 @@ namespace OfficeIMO.Word.GoogleDocs {
 
                 if (string.IsNullOrWhiteSpace(target.Id)) continue;
                 var usedReplyIds = new HashSet<string>(StringComparer.Ordinal);
-                foreach (WordComment reply in comment.Replies) {
+                IReadOnlyList<CommentThreadEntry> replies = !string.IsNullOrWhiteSpace(entry.ParaId)
+                    && claimedReplyParents.Add(entry.ParaId!)
+                    && repliesByParent.TryGetValue(entry.ParaId!, out CommentThreadEntry[]? groupedReplies)
+                        ? groupedReplies
+                        : Array.Empty<CommentThreadEntry>();
+                foreach (CommentThreadEntry replyEntry in replies) {
+                    WordComment reply = replyEntry.Comment;
                     string replyContent = FormatComment(reply);
                     GoogleDriveReply? existingReply = target.Replies.FirstOrDefault(candidate =>
                         !candidate.Deleted
@@ -57,33 +73,14 @@ namespace OfficeIMO.Word.GoogleDocs {
                     await drive.CreateReplyAsync(fileId, target.Id!, replyContent, report: report, cancellationToken: cancellationToken).ConfigureAwait(false);
                     createdCount++;
                 }
-                if (reconcileExistingComments) {
-                    foreach (GoogleDriveReply staleReply in target.Replies.Where(candidate =>
-                        !candidate.Deleted
-                        && string.IsNullOrWhiteSpace(candidate.Action)
-                        && !string.IsNullOrWhiteSpace(candidate.Id)
-                        && !usedReplyIds.Contains(candidate.Id!))) {
-                        await drive.DeleteReplyAsync(fileId, target.Id!, staleReply.Id!, report, cancellationToken).ConfigureAwait(false);
-                        deletedCount++;
-                    }
-                }
-                if (comment.IsResolved.HasValue && comment.IsResolved.Value != target.Resolved) {
+                if (entry.IsResolved.HasValue && entry.IsResolved.Value != target.Resolved) {
                     await drive.CreateReplyAsync(
                         fileId,
                         target.Id!,
                         string.Empty,
-                        action: comment.IsResolved.Value ? "resolve" : "reopen",
+                        action: entry.IsResolved.Value ? "resolve" : "reopen",
                         report: report,
                         cancellationToken: cancellationToken).ConfigureAwait(false);
-                }
-            }
-            if (reconcileExistingComments) {
-                foreach (GoogleDriveComment staleComment in existingComments.Where(candidate =>
-                    !candidate.Deleted
-                    && !string.IsNullOrWhiteSpace(candidate.Id)
-                    && !usedCommentIds.Contains(candidate.Id!))) {
-                    await drive.DeleteCommentAsync(fileId, staleComment.Id!, report, cancellationToken).ConfigureAwait(false);
-                    deletedCount++;
                 }
             }
             if (createdCount > 0) {
@@ -106,16 +103,23 @@ namespace OfficeIMO.Word.GoogleDocs {
                     count: reusedCount,
                     targetId: fileId);
             }
-            if (deletedCount > 0) {
-                report.Add(
-                    TranslationSeverity.Info,
-                    "Comments",
-                    $"Removed {deletedCount} stale Drive comment/reply item(s) while replacing the document.",
-                    code: "DOCS.COMMENT.UNANCHORED_DELETED",
-                    action: TranslationAction.Preserve,
-                    count: deletedCount,
-                    targetId: fileId);
+            // Drive comments do not expose a reliable OfficeIMO provenance marker. Unmatched
+            // collaborator discussions are therefore never deleted during content replacement.
+        }
+
+        private readonly struct CommentThreadEntry {
+            internal CommentThreadEntry(WordComment comment, string? paraId, string? parentParaId,
+                bool? isResolved) {
+                Comment = comment;
+                ParaId = paraId;
+                ParentParaId = parentParaId;
+                IsResolved = isResolved;
             }
+
+            internal WordComment Comment { get; }
+            internal string? ParaId { get; }
+            internal string? ParentParaId { get; }
+            internal bool? IsResolved { get; }
         }
 
         private static async Task<List<GoogleDriveComment>> ListCommentsAsync(

--- a/OfficeIMO.Word.GoogleDocs/GoogleDocsImportOptions.cs
+++ b/OfficeIMO.Word.GoogleDocs/GoogleDocsImportOptions.cs
@@ -32,6 +32,11 @@ namespace OfficeIMO.Word.GoogleDocs {
         public long MaxResponseBytes { get; set; } = DefaultMaxResponseBytes;
         public int MaxTabs { get; set; } = 100;
         public int MaxStructuralElements { get; set; } = 100_000;
+        /// <summary>
+        /// Maximum aggregate rectangular table-cell projection. The same ceiling is also applied
+        /// independently to aggregate table rows so sparse tables cannot allocate unbounded
+        /// document rows.
+        /// </summary>
         public int MaxTableCells { get; set; } = 1_000_000;
         public long MaxTextCharacters { get; set; } = 10_000_000L;
     }

--- a/OfficeIMO.Word.GoogleDocs/GoogleDocsImportOptions.cs
+++ b/OfficeIMO.Word.GoogleDocs/GoogleDocsImportOptions.cs
@@ -22,12 +22,18 @@ namespace OfficeIMO.Word.GoogleDocs {
     }
 
     public sealed class GoogleDocsImportOptions {
+        public const long DefaultMaxResponseBytes = 64L * 1024L * 1024L;
         public GoogleDocsImportMode Mode { get; set; } = GoogleDocsImportMode.DriveExport;
         public GoogleDocsImportTabMode TabMode { get; set; } = GoogleDocsImportTabMode.FlattenWithHeadings;
         public string? TabId { get; set; }
         public GoogleDocsSuggestionsMode Suggestions { get; set; } = GoogleDocsSuggestionsMode.Accepted;
         public WordLoadOptions LoadOptions { get; set; } = new WordLoadOptions();
         public IProgress<OfficeIMO.GoogleWorkspace.Drive.GoogleDriveTransferProgress>? Progress { get; set; }
+        public long MaxResponseBytes { get; set; } = DefaultMaxResponseBytes;
+        public int MaxTabs { get; set; } = 100;
+        public int MaxStructuralElements { get; set; } = 100_000;
+        public int MaxTableCells { get; set; } = 1_000_000;
+        public long MaxTextCharacters { get; set; } = 10_000_000L;
     }
 
     public sealed class GoogleDocsImportResult {

--- a/OfficeIMO.Word.GoogleDocs/GoogleDocsImporter.cs
+++ b/OfficeIMO.Word.GoogleDocs/GoogleDocsImporter.cs
@@ -15,6 +15,7 @@ namespace OfficeIMO.Word.GoogleDocs {
             if (string.IsNullOrWhiteSpace(documentId)) throw new ArgumentException("Document ID is required.", nameof(documentId));
             if (session == null) throw new ArgumentNullException(nameof(session));
             GoogleDocsImportOptions effective = options ?? new GoogleDocsImportOptions();
+            ValidateOptions(effective);
             return effective.Mode == GoogleDocsImportMode.DriveExport
                 ? await ImportDriveAsync(documentId, session, effective, cancellationToken).ConfigureAwait(false)
                 : await ImportNativeAsync(documentId, session, effective, cancellationToken).ConfigureAwait(false);
@@ -30,7 +31,8 @@ namespace OfficeIMO.Word.GoogleDocs {
             GoogleDriveFile source = await drive.GetFileAsync(documentId, report: report, cancellationToken: cancellationToken).ConfigureAwait(false);
             EnsureDocument(source, documentId);
             EnsureDownloadable(source, documentId);
-            byte[] bytes = await drive.ExportAsync(documentId, GoogleDriveMimeTypes.MicrosoftWord, options.Progress, report, cancellationToken).ConfigureAwait(false);
+            byte[] bytes = await drive.ExportAsync(documentId, GoogleDriveMimeTypes.MicrosoftWord,
+                options.Progress, report, cancellationToken, options.MaxResponseBytes).ConfigureAwait(false);
             var stream = new MemoryStream(bytes, writable: true);
             WordDocument document;
             try {
@@ -53,15 +55,18 @@ namespace OfficeIMO.Word.GoogleDocs {
             using var drive = new GoogleDriveClient(session);
             GoogleDriveFile source = await drive.GetFileAsync(documentId, report: report, cancellationToken: cancellationToken).ConfigureAwait(false);
             EnsureDocument(source, documentId);
+            EnsureDownloadable(source, documentId);
             GoogleWorkspaceAccessToken token = await session.AcquireAccessTokenAsync(new[] { GoogleWorkspaceScopeCatalog.DocumentsReadonly }, cancellationToken).ConfigureAwait(false);
             string uri = $"https://docs.googleapis.com/v1/documents/{Uri.EscapeDataString(documentId)}?includeTabsContent=true&suggestionsViewMode={MapSuggestions(options.Suggestions)}";
             GoogleDocsApiDocumentResponse response;
             using (var transport = new GoogleWorkspaceHttpTransport(session.Options)) {
                 response = await transport.SendJsonAsync<GoogleDocsApiDocumentResponse>(token.AccessToken, HttpMethod.Get, uri, null,
                     GoogleWorkspaceRequestSafety.Safe, "Google Docs API", report,
-                    GoogleDocsJsonSerializerContext.Default.GoogleDocsApiDocumentResponse, cancellationToken).ConfigureAwait(false);
+                    GoogleDocsJsonSerializerContext.Default.GoogleDocsApiDocumentResponse, cancellationToken,
+                    options.MaxResponseBytes).ConfigureAwait(false);
             }
 
+            ValidateNativeResponse(response, options);
             WordDocument document = Project(response, options, report);
             report.Add(TranslationSeverity.Info, "NativeImport", "Tab-aware text, core run styles, headings, lists, and simple tables were projected into OfficeIMO.",
                 code: "DOCS.IMPORT.NATIVE", action: TranslationAction.Preserve, targetId: documentId);
@@ -219,6 +224,72 @@ namespace OfficeIMO.Word.GoogleDocs {
 
         private static string ToHex(GoogleDocsApiRgbColorPayload color) => $"{ToByte(color.Red):X2}{ToByte(color.Green):X2}{ToByte(color.Blue):X2}";
         private static int ToByte(double value) => Math.Max(0, Math.Min(255, (int)Math.Round(value * 255d)));
+
+        private static void ValidateOptions(GoogleDocsImportOptions options) {
+            if (options.MaxResponseBytes <= 0) throw new ArgumentOutOfRangeException(nameof(options.MaxResponseBytes));
+            if (options.MaxTabs <= 0) throw new ArgumentOutOfRangeException(nameof(options.MaxTabs));
+            if (options.MaxStructuralElements <= 0) throw new ArgumentOutOfRangeException(nameof(options.MaxStructuralElements));
+            if (options.MaxTableCells <= 0) throw new ArgumentOutOfRangeException(nameof(options.MaxTableCells));
+            if (options.MaxTextCharacters <= 0) throw new ArgumentOutOfRangeException(nameof(options.MaxTextCharacters));
+        }
+
+        private static void ValidateNativeResponse(
+            GoogleDocsApiDocumentResponse response,
+            GoogleDocsImportOptions options) {
+            List<GoogleDocsApiTabResponse> tabs = GoogleDocsApiPayloadBuilder.FlattenTabs(response.Tabs).ToList();
+            if (tabs.Count > options.MaxTabs) {
+                throw new InvalidDataException($"Google Docs native import exceeded the configured {options.MaxTabs} tab limit.");
+            }
+
+            int structuralElements = 0;
+            int tableCells = 0;
+            long textCharacters = 0;
+            if (tabs.Count == 0) {
+                CountNativeContent(response.Body?.Content, options,
+                    ref structuralElements, ref tableCells, ref textCharacters);
+                return;
+            }
+
+            foreach (GoogleDocsApiTabResponse tab in tabs) {
+                CountNativeContent(tab.DocumentTab?.Body?.Content, options,
+                    ref structuralElements, ref tableCells, ref textCharacters);
+            }
+        }
+
+        private static void CountNativeContent(
+            IReadOnlyList<GoogleDocsApiStructuralElementResponse>? content,
+            GoogleDocsImportOptions options,
+            ref int structuralElements,
+            ref int tableCells,
+            ref long textCharacters) {
+            if (content == null) return;
+            foreach (GoogleDocsApiStructuralElementResponse element in content) {
+                if (structuralElements >= options.MaxStructuralElements) {
+                    throw new InvalidDataException($"Google Docs native import exceeded the configured {options.MaxStructuralElements} structural-element limit.");
+                }
+                structuralElements++;
+                if (element.Paragraph != null) {
+                    foreach (GoogleDocsApiParagraphInlineElementResponse inline in element.Paragraph.Elements) {
+                        int length = inline.TextRun?.Content?.Length ?? 0;
+                        if (length > options.MaxTextCharacters - textCharacters) {
+                            throw new InvalidDataException($"Google Docs native import exceeded the configured {options.MaxTextCharacters} text-character limit.");
+                        }
+                        textCharacters += length;
+                    }
+                }
+                if (element.Table == null) continue;
+                foreach (GoogleDocsApiTableRowResponse row in element.Table.Rows) {
+                    foreach (GoogleDocsApiTableCellResponse cell in row.Cells) {
+                        if (tableCells >= options.MaxTableCells) {
+                            throw new InvalidDataException($"Google Docs native import exceeded the configured {options.MaxTableCells} table-cell limit.");
+                        }
+                        tableCells++;
+                        CountNativeContent(cell.Content, options,
+                            ref structuralElements, ref tableCells, ref textCharacters);
+                    }
+                }
+            }
+        }
 
         private static void EnsureDocument(GoogleDriveFile file, string id) {
             if (!string.Equals(file.MimeType, GoogleDriveMimeTypes.Document, StringComparison.Ordinal)) {

--- a/OfficeIMO.Word.GoogleDocs/GoogleDocsImporter.cs
+++ b/OfficeIMO.Word.GoogleDocs/GoogleDocsImporter.cs
@@ -242,17 +242,18 @@ namespace OfficeIMO.Word.GoogleDocs {
             }
 
             int structuralElements = 0;
+            int tableRows = 0;
             int tableCells = 0;
             long textCharacters = 0;
             if (tabs.Count == 0) {
                 CountNativeContent(response.Body?.Content, options,
-                    ref structuralElements, ref tableCells, ref textCharacters);
+                    ref structuralElements, ref tableRows, ref tableCells, ref textCharacters);
                 return;
             }
 
             foreach (GoogleDocsApiTabResponse tab in tabs) {
                 CountNativeContent(tab.DocumentTab?.Body?.Content, options,
-                    ref structuralElements, ref tableCells, ref textCharacters);
+                    ref structuralElements, ref tableRows, ref tableCells, ref textCharacters);
             }
         }
 
@@ -260,6 +261,7 @@ namespace OfficeIMO.Word.GoogleDocs {
             IReadOnlyList<GoogleDocsApiStructuralElementResponse>? content,
             GoogleDocsImportOptions options,
             ref int structuralElements,
+            ref int tableRows,
             ref int tableCells,
             ref long textCharacters) {
             if (content == null) return;
@@ -278,14 +280,27 @@ namespace OfficeIMO.Word.GoogleDocs {
                     }
                 }
                 if (element.Table == null) continue;
+                if (element.Table.Rows.Count > options.MaxTableCells - tableRows) {
+                    throw new InvalidDataException(
+                        $"Google Docs native import exceeded the configured {options.MaxTableCells} table-row limit.");
+                }
+                tableRows += element.Table.Rows.Count;
+
+                int maximumColumns = element.Table.Rows
+                    .Select(static row => row.Cells.Count)
+                    .DefaultIfEmpty(0)
+                    .Max();
+                long projectedCells = (long)element.Table.Rows.Count * maximumColumns;
+                if (projectedCells > options.MaxTableCells - tableCells) {
+                    throw new InvalidDataException(
+                        $"Google Docs native import exceeded the configured {options.MaxTableCells} table-cell limit.");
+                }
+                tableCells += (int)projectedCells;
+
                 foreach (GoogleDocsApiTableRowResponse row in element.Table.Rows) {
                     foreach (GoogleDocsApiTableCellResponse cell in row.Cells) {
-                        if (tableCells >= options.MaxTableCells) {
-                            throw new InvalidDataException($"Google Docs native import exceeded the configured {options.MaxTableCells} table-cell limit.");
-                        }
-                        tableCells++;
                         CountNativeContent(cell.Content, options,
-                            ref structuralElements, ref tableCells, ref textCharacters);
+                            ref structuralElements, ref tableRows, ref tableCells, ref textCharacters);
                     }
                 }
             }

--- a/OfficeIMO.Word.Rtf/WordRtfConverterExtensions.cs
+++ b/OfficeIMO.Word.Rtf/WordRtfConverterExtensions.cs
@@ -524,7 +524,7 @@ public static partial class WordRtfConverterExtensions {
         int? revisionAuthorIndex = null) {
         FieldChar? fieldChar = runElement.Elements<FieldChar>().FirstOrDefault();
         if (fieldChar?.FieldCharType?.Value == FieldCharValues.Begin) {
-            captures.Push(new ComplexFieldCapture());
+            captures.Push(new ComplexFieldCapture(revisionKind != RtfRevisionKind.None));
             return true;
         }
 
@@ -533,6 +533,10 @@ public static partial class WordRtfConverterExtensions {
         }
 
         ComplexFieldCapture capture = captures.Peek();
+        FieldCode? fieldCode = runElement.Elements<FieldCode>().FirstOrDefault();
+        if (revisionKind != RtfRevisionKind.None && (fieldChar != null || fieldCode != null)) {
+            capture.RestrictToEquationFields = true;
+        }
         if (fieldChar?.FieldCharType?.Value == FieldCharValues.Separate) {
             capture.CapturingResult = true;
             return true;
@@ -549,7 +553,6 @@ public static partial class WordRtfConverterExtensions {
             return true;
         }
 
-        FieldCode? fieldCode = runElement.Elements<FieldCode>().FirstOrDefault();
         if (fieldCode != null && !capture.CapturingResult) {
             capture.Instruction.Append(fieldCode.Text);
             return true;
@@ -573,11 +576,24 @@ public static partial class WordRtfConverterExtensions {
     }
 
     private static void CompleteComplexField(RtfParagraph paragraph, ComplexFieldCapture capture) {
+        if (capture.RestrictToEquationFields && !IsEquationFieldInstruction(capture.Instruction.ToString())) {
+            CopyInlines(capture.Result, paragraph);
+            return;
+        }
+
         RtfField field = paragraph.AddField(capture.Instruction.ToString().Trim());
         CopyInlines(capture.Result, field.Result);
     }
 
     private static void CompleteNestedComplexField(ComplexFieldCapture parent, ComplexFieldCapture nested) {
+        if (nested.RestrictToEquationFields && !IsEquationFieldInstruction(nested.Instruction.ToString())) {
+            if (parent.CapturingResult) {
+                CopyInlines(nested.Result, parent.Result);
+                parent.PreviousRun = null;
+            }
+            return;
+        }
+
         if (!parent.CapturingResult) {
             parent.Instruction.Append(nested.Instruction.ToString().Trim());
             return;
@@ -586,6 +602,12 @@ public static partial class WordRtfConverterExtensions {
         RtfField field = parent.Result.AddField(nested.Instruction.ToString().Trim());
         CopyInlines(nested.Result, field.Result);
         parent.PreviousRun = null;
+    }
+
+    private static bool IsEquationFieldInstruction(string instruction) {
+        string trimmed = (instruction ?? string.Empty).TrimStart();
+        if (!trimmed.StartsWith("EQ", StringComparison.OrdinalIgnoreCase)) return false;
+        return trimmed.Length == 2 || char.IsWhiteSpace(trimmed[2]) || trimmed[2] == '\\';
     }
 
     private static void CopyInlines(RtfParagraph source, RtfParagraph destination) {
@@ -667,6 +689,24 @@ public static partial class WordRtfConverterExtensions {
 
         string instruction = simpleField.Instruction?.Value ?? string.Empty;
         RtfParagraph destination = activeCapture?.Result ?? paragraph;
+        if (revisionKind != RtfRevisionKind.None && !IsEquationFieldInstruction(instruction)) {
+            RtfRun? flattenedPreviousRun = null;
+            foreach (Run childRun in simpleField.Elements<Run>()) {
+                AppendWordRun(
+                    new WordParagraph(wordParagraph._document, wordParagraph._paragraph, childRun),
+                    destination,
+                    ref flattenedPreviousRun,
+                    rtfDocument,
+                    revisionAuthorIndexes,
+                    revisionKind,
+                    revisionAuthorIndex);
+            }
+            if (activeCapture != null) {
+                activeCapture.PreviousRun = flattenedPreviousRun;
+            }
+            return;
+        }
+
         RtfField field = destination.AddField(instruction.Trim());
         RtfRun? previousRun = null;
         foreach (Run childRun in simpleField.Elements<Run>()) {
@@ -1137,6 +1177,12 @@ public static partial class WordRtfConverterExtensions {
     }
 
     private sealed class ComplexFieldCapture {
+        internal ComplexFieldCapture(bool restrictToEquationFields = false) {
+            RestrictToEquationFields = restrictToEquationFields;
+        }
+
+        public bool RestrictToEquationFields { get; set; }
+
         public System.Text.StringBuilder Instruction { get; } = new System.Text.StringBuilder();
 
         public RtfParagraph Result { get; } = new RtfParagraph();

--- a/OfficeIMO.Word.Tests/Word.Equations.cs
+++ b/OfficeIMO.Word.Tests/Word.Equations.cs
@@ -619,6 +619,27 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void EquationContentSegments_FormControlDoesNotLeakDeletedOrMovedFromText() {
+            using WordDocument document = WordDocument.Create();
+            WordParagraph paragraph = document.AddParagraph();
+            var contentControl = new SdtRun(
+                new SdtProperties(
+                    new W14.SdtContentCheckBox(new W14.Checked { Val = W14.OnOffValues.One })),
+                new SdtContentRun(
+                    new DeletedRun(new Run(new Text("deleted-secret"))),
+                    new MoveFromRun(new Run(new Text("moved-secret"))),
+                    new M.OfficeMath(new M.Run(new M.Text("approved"))),
+                    new Run(new Text(" visible"))));
+            paragraph._paragraph.Append(contentControl);
+
+            IReadOnlyList<WordEquationOccurrence> occurrences = WordEquation.GetOccurrences(document, paragraph._paragraph);
+            IReadOnlyList<WordEquationContentSegment> segments = WordEquation.GetVisibleContentSegments(contentControl, occurrences);
+
+            Assert.Equal("approved visible", WordEquation.GetVisibleTextWithEquations(contentControl, occurrences));
+            Assert.DoesNotContain(segments, segment => segment.ArtifactVisibleText?.Contains("secret", StringComparison.Ordinal) == true);
+        }
+
+        [Fact]
         public void EquationContentSegments_PictureControlEmitsDrawingArtifactBesideEquation() {
             using WordDocument document = WordDocument.Create();
             WordParagraph paragraph = document.AddParagraph();

--- a/OfficeIMO.Word.Tests/Word.GoogleDocs.Workflows.cs
+++ b/OfficeIMO.Word.Tests/Word.GoogleDocs.Workflows.cs
@@ -425,6 +425,40 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public async Task Test_GoogleDocsImporter_NativeBoundsSparseTableRows() {
+            const string nativeJson = "{\"documentId\":\"doc-sparse-table\",\"body\":{\"content\":[{\"table\":{\"tableRows\":[{\"tableCells\":[]},{\"tableCells\":[]}]}}]}}";
+            using var httpClient = new HttpClient(new FakeHttpMessageHandler(request =>
+                request.RequestUri!.Host == "www.googleapis.com"
+                    ? Task.FromResult(CreateJsonResponse("{\"id\":\"doc-sparse-table\",\"mimeType\":\"application/vnd.google-apps.document\",\"capabilities\":{\"canDownload\":true}}"))
+                    : Task.FromResult(CreateJsonResponse(nativeJson))));
+            var session = new GoogleWorkspaceSession(new FakeGoogleWorkspaceCredentialSource(),
+                new GoogleWorkspaceSessionOptions { HttpClient = httpClient });
+
+            await Assert.ThrowsAsync<InvalidDataException>(() =>
+                new GoogleDocsImporter().ImportAsync("doc-sparse-table", session, new GoogleDocsImportOptions {
+                    Mode = GoogleDocsImportMode.Native,
+                    MaxTableCells = 1,
+                }));
+        }
+
+        [Fact]
+        public async Task Test_GoogleDocsImporter_NativeChargesRectangularTableProjection() {
+            const string nativeJson = "{\"documentId\":\"doc-ragged-table\",\"body\":{\"content\":[{\"table\":{\"tableRows\":[{\"tableCells\":[{}]},{\"tableCells\":[{},{},{}]}]}}]}}";
+            using var httpClient = new HttpClient(new FakeHttpMessageHandler(request =>
+                request.RequestUri!.Host == "www.googleapis.com"
+                    ? Task.FromResult(CreateJsonResponse("{\"id\":\"doc-ragged-table\",\"mimeType\":\"application/vnd.google-apps.document\",\"capabilities\":{\"canDownload\":true}}"))
+                    : Task.FromResult(CreateJsonResponse(nativeJson))));
+            var session = new GoogleWorkspaceSession(new FakeGoogleWorkspaceCredentialSource(),
+                new GoogleWorkspaceSessionOptions { HttpClient = httpClient });
+
+            await Assert.ThrowsAsync<InvalidDataException>(() =>
+                new GoogleDocsImporter().ImportAsync("doc-ragged-table", session, new GoogleDocsImportOptions {
+                    Mode = GoogleDocsImportMode.Native,
+                    MaxTableCells = 4,
+                }));
+        }
+
+        [Fact]
         public async Task Test_GoogleDocsDiffPlanner_ReportsDriveVersionChanges() {
             string filePath = Path.Combine(_directoryWithFiles, "GoogleDocsDriveVersionDiff.docx");
             try {

--- a/OfficeIMO.Word.Tests/Word.GoogleDocs.Workflows.cs
+++ b/OfficeIMO.Word.Tests/Word.GoogleDocs.Workflows.cs
@@ -357,10 +357,10 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
-        public async Task Test_GoogleDocsImporter_NativeFlattensTabsWhenDriveExportIsDisabled() {
+        public async Task Test_GoogleDocsImporter_NativeFlattensTabsWhenDownloadIsAllowed() {
             using var httpClient = new HttpClient(new FakeHttpMessageHandler(request => {
                 if (request.RequestUri!.Host == "www.googleapis.com") {
-                    return Task.FromResult(CreateJsonResponse("{\"id\":\"doc-import\",\"name\":\"Import\",\"mimeType\":\"application/vnd.google-apps.document\",\"version\":7,\"capabilities\":{\"canDownload\":false}}"));
+                    return Task.FromResult(CreateJsonResponse("{\"id\":\"doc-import\",\"name\":\"Import\",\"mimeType\":\"application/vnd.google-apps.document\",\"version\":7,\"capabilities\":{\"canDownload\":true}}"));
                 }
                 if (request.RequestUri.Host == "docs.googleapis.com") {
                     const string json = "{\"documentId\":\"doc-import\",\"title\":\"Import\",\"revisionId\":\"revision-7\",\"tabs\":[{\"tabProperties\":{\"tabId\":\"one\",\"title\":\"Tab One\"},\"documentTab\":{\"body\":{\"content\":[{\"startIndex\":1,\"endIndex\":7,\"paragraph\":{\"elements\":[{\"textRun\":{\"content\":\"Alpha\\n\",\"textStyle\":{\"bold\":true}}}]}}]}}},{\"tabProperties\":{\"tabId\":\"two\",\"title\":\"Tab Two\"},\"documentTab\":{\"body\":{\"content\":[{\"startIndex\":1,\"endIndex\":6,\"paragraph\":{\"elements\":[{\"textRun\":{\"content\":\"Beta\\n\"}}]}}]}}}]}";
@@ -385,6 +385,46 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public async Task Test_GoogleDocsImporter_NativeRejectsFilesThatCannotBeDownloaded() {
+            int nativeReads = 0;
+            using var httpClient = new HttpClient(new FakeHttpMessageHandler(request => {
+                if (request.RequestUri!.Host == "www.googleapis.com") {
+                    return Task.FromResult(CreateJsonResponse("{\"id\":\"doc-blocked\",\"mimeType\":\"application/vnd.google-apps.document\",\"capabilities\":{\"canDownload\":false}}"));
+                }
+                nativeReads++;
+                return Task.FromResult(CreateJsonResponse("{\"documentId\":\"doc-blocked\"}"));
+            }));
+            var session = new GoogleWorkspaceSession(new FakeGoogleWorkspaceCredentialSource(), new GoogleWorkspaceSessionOptions { HttpClient = httpClient });
+
+            InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                new GoogleDocsImporter().ImportAsync("doc-blocked", session, new GoogleDocsImportOptions { Mode = GoogleDocsImportMode.Native }));
+
+            Assert.Contains("cannot be exported", exception.Message, StringComparison.Ordinal);
+            Assert.Equal(0, nativeReads);
+        }
+
+        [Fact]
+        public async Task Test_GoogleDocsImporter_NativeEnforcesResponseAndModelBudgets() {
+            const string nativeJson = "{\"documentId\":\"doc-large\",\"body\":{\"content\":[{\"paragraph\":{\"elements\":[{\"textRun\":{\"content\":\"0123456789\"}}]}}]}}";
+            using var httpClient = new HttpClient(new FakeHttpMessageHandler(request =>
+                request.RequestUri!.Host == "www.googleapis.com"
+                    ? Task.FromResult(CreateJsonResponse("{\"id\":\"doc-large\",\"mimeType\":\"application/vnd.google-apps.document\",\"capabilities\":{\"canDownload\":true}}"))
+                    : Task.FromResult(CreateJsonResponse(nativeJson))));
+            var session = new GoogleWorkspaceSession(new FakeGoogleWorkspaceCredentialSource(), new GoogleWorkspaceSessionOptions { HttpClient = httpClient });
+
+            await Assert.ThrowsAsync<InvalidDataException>(() =>
+                new GoogleDocsImporter().ImportAsync("doc-large", session, new GoogleDocsImportOptions {
+                    Mode = GoogleDocsImportMode.Native,
+                    MaxResponseBytes = 32,
+                }));
+            await Assert.ThrowsAsync<InvalidDataException>(() =>
+                new GoogleDocsImporter().ImportAsync("doc-large", session, new GoogleDocsImportOptions {
+                    Mode = GoogleDocsImportMode.Native,
+                    MaxTextCharacters = 4,
+                }));
+        }
+
+        [Fact]
         public async Task Test_GoogleDocsDiffPlanner_ReportsDriveVersionChanges() {
             string filePath = Path.Combine(_directoryWithFiles, "GoogleDocsDriveVersionDiff.docx");
             try {
@@ -393,7 +433,7 @@ namespace OfficeIMO.Tests {
                 GoogleDocsSyncCheckpoint checkpoint = GoogleDocsDiffPlanner.CreateCheckpoint(source, revisionId: "revision-1", driveVersion: 7);
                 using var httpClient = new HttpClient(new FakeHttpMessageHandler(request => {
                     if (request.RequestUri!.Host == "www.googleapis.com") {
-                        return Task.FromResult(CreateJsonResponse("{\"id\":\"doc-diff\",\"name\":\"Diff\",\"mimeType\":\"application/vnd.google-apps.document\",\"version\":8,\"capabilities\":{\"canDownload\":false}}"));
+                        return Task.FromResult(CreateJsonResponse("{\"id\":\"doc-diff\",\"name\":\"Diff\",\"mimeType\":\"application/vnd.google-apps.document\",\"version\":8,\"capabilities\":{\"canDownload\":true}}"));
                     }
                     const string docs = "{\"documentId\":\"doc-diff\",\"title\":\"Diff\",\"revisionId\":\"revision-1\",\"body\":{\"content\":[{\"startIndex\":1,\"endIndex\":6,\"paragraph\":{\"elements\":[{\"textRun\":{\"content\":\"Same\\n\"}}]}}]}}";
                     return Task.FromResult(CreateJsonResponse(docs));
@@ -452,6 +492,38 @@ namespace OfficeIMO.Tests {
                 tableParagraph.AddHyperLink(" Link", new Uri("https://example.test/"));
                 GoogleDocsSyncCheckpoint tableChanged = GoogleDocsDiffPlanner.CreateCheckpoint(document);
                 Assert.NotEqual(commentChanged.ContentHashes[tableCellPath], tableChanged.ContentHashes[tableCellPath]);
+            } finally {
+                if (File.Exists(filePath)) File.Delete(filePath);
+            }
+        }
+
+        [Fact]
+        public void Test_GoogleDocsCheckpoint_AssignsMalformedDuplicateCommentThreadRepliesOnce() {
+            string filePath = Path.Combine(_directoryWithFiles, "GoogleDocsDuplicateCommentThread.docx");
+            try {
+                using var document = WordDocument.Create(filePath);
+                document.AddParagraph("First").AddComment("Alice", "A", "First root");
+                WordComment first = WordComment.GetAllComments(document)
+                    .Single(comment => comment.Text == "First root");
+                first.AddReply("Bob", "B", "Only reply");
+                document.AddParagraph("Second").AddComment("Carol", "C", "Second root");
+                WordComment duplicate = WordComment.GetAllComments(document)
+                    .Single(comment => comment.Text == "Second root");
+                var commentsEx = document._wordprocessingDocument.MainDocumentPart!
+                    .WordprocessingCommentsExPart!.CommentsEx!;
+                DocumentFormat.OpenXml.Office2013.Word.CommentEx duplicateMetadata = commentsEx
+                    .Elements<DocumentFormat.OpenXml.Office2013.Word.CommentEx>()
+                    .Single(item => string.Equals(item.ParaId?.Value, duplicate.ParaId,
+                        StringComparison.Ordinal));
+                duplicateMetadata.ParaId = first.ParaId;
+
+                GoogleDocsSyncCheckpoint checkpoint = GoogleDocsDiffPlanner.CreateCheckpoint(document);
+
+                Assert.Equal(2, checkpoint.ContentHashes.Keys.Count(path =>
+                    path.StartsWith("comment/", StringComparison.Ordinal)
+                    && !path.Contains("/reply/", StringComparison.Ordinal)));
+                Assert.Single(checkpoint.ContentHashes.Keys, path =>
+                    path.Contains("/reply/", StringComparison.Ordinal));
             } finally {
                 if (File.Exists(filePath)) File.Delete(filePath);
             }
@@ -579,16 +651,16 @@ namespace OfficeIMO.Tests {
 
                 Assert.Equal(2, commentListReads);
                 Assert.Equal(0, createdCommentItems);
-                Assert.Equal(1, deletedCommentItems);
+                Assert.Equal(0, deletedCommentItems);
                 Assert.Contains(result.Report.Notices, notice => notice.Code == "DOCS.COMMENT.UNANCHORED_REUSED" && notice.Count == 2);
-                Assert.Contains(result.Report.Notices, notice => notice.Code == "DOCS.COMMENT.UNANCHORED_DELETED" && notice.Count == 1);
+                Assert.DoesNotContain(result.Report.Notices, notice => notice.Code == "DOCS.COMMENT.UNANCHORED_DELETED");
             } finally {
                 if (File.Exists(filePath)) File.Delete(filePath);
             }
         }
 
         [Fact]
-        public async Task Test_GoogleDocsExporter_RemovesStaleDriveCommentsOnReplacement() {
+        public async Task Test_GoogleDocsExporter_PreservesUnrelatedDriveCommentsOnReplacement() {
             string filePath = Path.Combine(_directoryWithFiles, "GoogleDocsCommentRemoval.docx");
             try {
                 using var document = WordDocument.Create(filePath);
@@ -620,8 +692,8 @@ namespace OfficeIMO.Tests {
                     Replace = new GoogleDocsReplaceOptions { ConflictMode = GoogleDocsRevisionConflictMode.OverwriteLatest },
                 });
 
-                Assert.Single(deletedUris);
-                Assert.Contains(result.Report.Notices, notice => notice.Code == "DOCS.COMMENT.UNANCHORED_DELETED" && notice.Count == 1);
+                Assert.Empty(deletedUris);
+                Assert.DoesNotContain(result.Report.Notices, notice => notice.Code == "DOCS.COMMENT.UNANCHORED_DELETED");
             } finally {
                 if (File.Exists(filePath)) File.Delete(filePath);
             }

--- a/OfficeIMO.Word/WordComment.PrivateMethods.cs
+++ b/OfficeIMO.Word/WordComment.PrivateMethods.cs
@@ -84,6 +84,41 @@ namespace OfficeIMO.Word {
                 : null;
         }
 
+        internal static Dictionary<string, CommentEx> IndexCommentExByParagraphId(
+            IReadOnlyList<CommentEx> commentsEx) {
+            if (commentsEx == null) throw new ArgumentNullException(nameof(commentsEx));
+
+            var indexed = new Dictionary<string, CommentEx>(StringComparer.Ordinal);
+            foreach (CommentEx commentEx in commentsEx) {
+                string? paraId = commentEx.ParaId?.Value;
+                if (!string.IsNullOrWhiteSpace(paraId)) {
+                    string key = paraId!;
+                    if (!indexed.ContainsKey(key)) indexed.Add(key, commentEx);
+                }
+            }
+
+            return indexed;
+        }
+
+        internal static CommentEx? FindCommentExForComment(Comment comment,
+            IReadOnlyList<CommentEx> commentsEx, IReadOnlyDictionary<string, CommentEx> commentsExByParagraphId,
+            int fallbackIndex) {
+            if (comment == null) throw new ArgumentNullException(nameof(comment));
+            if (commentsEx == null) throw new ArgumentNullException(nameof(commentsEx));
+            if (commentsExByParagraphId == null) throw new ArgumentNullException(nameof(commentsExByParagraphId));
+
+            string? paraId = GetCommentParagraphId(comment);
+            if (!string.IsNullOrWhiteSpace(paraId)) {
+                return commentsExByParagraphId.TryGetValue(paraId!, out CommentEx? matched)
+                    ? matched
+                    : null;
+            }
+
+            return fallbackIndex >= 0 && fallbackIndex < commentsEx.Count
+                ? commentsEx[fallbackIndex]
+                : null;
+        }
+
         internal static string? GetCommentParagraphId(Comment comment) {
             if (comment == null) throw new ArgumentNullException(nameof(comment));
 

--- a/OfficeIMO.Word/WordComment.PublicMethods.cs
+++ b/OfficeIMO.Word/WordComment.PublicMethods.cs
@@ -96,8 +96,10 @@ namespace OfficeIMO.Word {
             if (part?.WordprocessingCommentsPart != null && part.WordprocessingCommentsPart.Comments != null) {
                 var commentList = part.WordprocessingCommentsPart.Comments.OfType<Comment>().ToList();
                 var commentExList = part.WordprocessingCommentsExPart?.CommentsEx?.OfType<CommentEx>().ToList() ?? new List<CommentEx>();
+                Dictionary<string, CommentEx> commentsExByParagraphId = IndexCommentExByParagraphId(commentExList);
                 for (int i = 0; i < commentList.Count; i++) {
-                    var ce = FindCommentExForComment(commentList[i], commentExList, i) ?? new CommentEx();
+                    var ce = FindCommentExForComment(commentList[i], commentExList, commentsExByParagraphId, i)
+                        ?? new CommentEx();
                     comments.Add(new WordComment(document, commentList[i], ce));
                 }
             }

--- a/OfficeIMO.Word/WordComment.cs
+++ b/OfficeIMO.Word/WordComment.cs
@@ -20,17 +20,17 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Identifier used to link threaded replies.
         /// </summary>
-        public string? ParaId => FindCommentEx()?.ParaId?.Value ?? _commentEx?.ParaId ?? GetCommentParagraphId(_comment);
+        public string? ParaId => _commentEx?.ParaId?.Value ?? GetCommentParagraphId(_comment);
 
         /// <summary>
         /// Identifier of parent comment if this comment is a reply.
         /// </summary>
-        public string? ParentParaId => FindCommentEx()?.ParaIdParent?.Value ?? _commentEx?.ParaIdParent;
+        public string? ParentParaId => _commentEx?.ParaIdParent?.Value;
 
         /// <summary>
         /// Whether the comment is marked resolved. A null value means the document has no resolved-state metadata for this comment.
         /// </summary>
-        public bool? IsResolved => FindCommentEx()?.Done?.Value;
+        public bool? IsResolved => _commentEx?.Done?.Value;
 
         /// <summary>
         /// Parent comment instance if available.

--- a/OfficeIMO.Word/WordDocument.Review.cs
+++ b/OfficeIMO.Word/WordDocument.Review.cs
@@ -47,11 +47,14 @@ namespace OfficeIMO.Word {
             List<Comment> commentElements = commentsPart.Comments.Elements<Comment>().ToList();
             List<CommentEx> commentExElements = mainPart.WordprocessingCommentsExPart?.CommentsEx?.Elements<CommentEx>().ToList()
                 ?? new List<CommentEx>();
+            Dictionary<string, CommentEx> commentExByParagraphId =
+                WordComment.IndexCommentExByParagraphId(commentExElements);
             var comments = new List<WordCommentInfo>();
 
             for (int i = 0; i < commentElements.Count; i++) {
                 Comment comment = commentElements[i];
-                CommentEx? commentEx = WordComment.FindCommentExForComment(comment, commentExElements, i);
+                CommentEx? commentEx = WordComment.FindCommentExForComment(comment, commentExElements,
+                    commentExByParagraphId, i);
                 string? id = comment.Id?.Value;
                 commentTargets.TryGetValue(id ?? string.Empty, out CommentTargetInfo? target);
 

--- a/OfficeIMO.Word/WordEquation.cs
+++ b/OfficeIMO.Word/WordEquation.cs
@@ -354,6 +354,8 @@ namespace OfficeIMO.Word {
                 if (!emittedControlArtifacts.Add(artifactControl)) return;
                 string visibleArtifactText = string.Concat(artifactControl
                     .Descendants<Text>()
+                    .Where(value => !value.Ancestors<DeletedRun>().Any())
+                    .Where(value => !value.Ancestors<MoveFromRun>().Any())
                     .Where(value => !IsInsideEquationBackingElement(value, occurrences))
                     .Select(value => value.Text));
                 segments.Add(WordEquationContentSegment.FromRunArtifact(


### PR DESCRIPTION
## Summary

- enforce bounded Google Docs, Sheets, Slides, and Drive downloads, imports, change tracking, comment hashing, and OAuth user selection
- count MIME attachments before decoding, preserve calendar Bcc privacy, and bound synchronous OCR providers
- harden PDF temporary storage and trailer identifiers, flatten revised active RTF fields, and reject unsafe Excel conversion edge cases
- disposition exported all-severity findings 61–80; the malformed shape-color record in this range is already fixed by the parent PR

## Compatibility notes

- Google installed-app authorization now requires an explicit user ID
- Drive downloads default to 256 MiB, Docs imports to 64 MiB, and Sheets imports to 128 MiB unless callers configure another positive limit
- Sheets dimension groups have an aggregate member budget; native row and column metadata also share the configured `MaxCells` projection budget
- Google Docs applies `MaxTableCells` to the rectangular table allocation and independently to aggregate table rows, preventing sparse or ragged tables from understating projection cost
- Email reader policies expose an optional attachment-count budget
- unencrypted legacy XLS input is rejected by the encrypted-load entry point
- modern targets save non-seekable Excel output directly; .NET Framework stages it in an owner-only, delete-on-close temporary file and copies with a bounded buffer, preserving compatibility without retaining the entire workbook in memory

## Validation

Focused security regressions and affected suites pass on net8.0 and net10.0 across Email, Excel, Google Workspace, PDF, PowerPoint, Reader, RTF, and Word. The affected Google Sheets and Google Docs libraries build for netstandard2.0 with zero warnings. Metadata-only Sheets responses, empty-row Docs tables, and ragged Docs tables have direct regressions on both net8.0 and net10.0. The non-seekable Excel compatibility correction builds cleanly for Excel and PDF on net8.0 and netstandard2.0, and its focused regression passes on net8.0; Windows CI is authoritative for net472 because the local macOS environment lacks the .NET Framework reference pack. An independent read-only security review and targeted confirmation were completed; all accepted gaps are covered by regressions.
