### PR TITLE
Harden PDF mutation and document rendering boundaries

### DIFF
--- a/OfficeIMO.Drawing.Tests/Drawing.SvgReader.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.SvgReader.cs
@@ -782,6 +782,65 @@ public class DrawingSvgReaderTests {
     }
 
     [Fact]
+    public void SvgReaderCachesRepeatedGradientTransformResolution() {
+        const int shapeCount = 256;
+        string transform = string.Join(" ", Enumerable.Repeat("translate(0 0)", 32));
+        var svg = new StringBuilder(
+            "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 1'><defs><linearGradient id='shared' gradientTransform='");
+        svg.Append(transform)
+            .Append("'><stop stop-color='red'/><stop offset='1' stop-color='blue'/></linearGradient></defs>");
+        for (int index = 0; index < shapeCount; index++) {
+            svg.Append("<rect x='").Append(index)
+                .Append("' width='1' height='1' fill='url(#shared)'/>");
+        }
+        svg.Append("</svg>");
+        var timer = Stopwatch.StartNew();
+
+        bool success = OfficeSvgDrawingReader.TryRead(
+            Encoding.UTF8.GetBytes(svg.ToString()),
+            out OfficeDrawing? drawing,
+            out int unsupported);
+        timer.Stop();
+
+        Assert.True(success);
+        Assert.NotNull(drawing);
+        Assert.Equal(0, unsupported);
+        Assert.Equal(shapeCount, drawing!.Shapes.Count);
+        Assert.True(timer.Elapsed < TimeSpan.FromSeconds(5), "Repeated gradient resolution exceeded the bounded parse time.");
+    }
+
+    [Fact]
+    public void SvgReaderCachesInvalidInheritedGradientDefinitions() {
+        const int childCount = 1024;
+        string transform = string.Join(" ", Enumerable.Repeat("translate(0 0)", 512));
+        var svg = new StringBuilder(
+            "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1024 1'><defs><linearGradient id='invalid' gradientTransform='");
+        svg.Append(transform).Append("' x1='0' y1='0' x2='0' y2='0'><stop stop-color='red'/></linearGradient>");
+        for (int index = 0; index < childCount; index++) {
+            svg.Append("<linearGradient id='child-").Append(index).Append("' href='#invalid'/>");
+        }
+        svg.Append("</defs>");
+        for (int index = 0; index < childCount; index++) {
+            svg.Append("<rect x='").Append(index)
+                .Append("' width='1' height='1' fill='url(#child-").Append(index).Append(")'/>");
+        }
+        svg.Append("</svg>");
+        var timer = Stopwatch.StartNew();
+
+        bool success = OfficeSvgDrawingReader.TryRead(
+            Encoding.UTF8.GetBytes(svg.ToString()),
+            out OfficeDrawing? drawing,
+            out int unsupported);
+        timer.Stop();
+
+        Assert.True(success);
+        Assert.NotNull(drawing);
+        Assert.Equal(childCount, unsupported);
+        Assert.Equal(childCount, drawing!.Shapes.Count);
+        Assert.True(timer.Elapsed < TimeSpan.FromSeconds(5), "Invalid inherited gradients were reparsed instead of cached.");
+    }
+
+    [Fact]
     public void SvgReaderRejectsDocumentsWithDoctypeOrExternalEntities() {
         const string svg = "<!DOCTYPE svg [<!ENTITY xxe SYSTEM 'file:///secret.txt'>]><svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'><text>&xxe;</text></svg>";
 

--- a/OfficeIMO.Drawing/OfficeSvgDrawingReader.PaintServers.cs
+++ b/OfficeIMO.Drawing/OfficeSvgDrawingReader.PaintServers.cs
@@ -126,6 +126,8 @@ public static partial class OfficeSvgDrawingReader {
 
     private sealed class SvgPaintServerRegistry {
         private readonly SvgDefinitionRegistry _definitions;
+        private readonly Dictionary<string, SvgGradientDefinition> _resolved = new(StringComparer.Ordinal);
+        private readonly HashSet<string> _invalid = new(StringComparer.Ordinal);
 
         internal SvgPaintServerRegistry(SvgDefinitionRegistry definitions) {
             _definitions = definitions;
@@ -138,8 +140,15 @@ public static partial class OfficeSvgDrawingReader {
                 || (!element!.Name.LocalName.Equals("linearGradient", StringComparison.OrdinalIgnoreCase)
                     && !element.Name.LocalName.Equals("radialGradient", StringComparison.OrdinalIgnoreCase))) return false;
 
-            var resolving = new HashSet<string>(StringComparer.Ordinal);
-            if (!TryResolveDefinition(id, element, resolving, 0, out SvgGradientDefinition? definition)) return false;
+            if (!_resolved.TryGetValue(id, out SvgGradientDefinition? definition)) {
+                if (_invalid.Contains(id)) return false;
+                var resolving = new HashSet<string>(StringComparer.Ordinal);
+                if (!TryResolveDefinition(id, element, resolving, 0, out definition) || definition == null) {
+                    _invalid.Add(id);
+                    return false;
+                }
+                _resolved[id] = definition;
+            }
             try {
                 if (definition!.UserSpaceOnUse || definition.GradientTransform != OfficeTransform.Identity || definition.SpreadMode != SvgGradientSpreadMode.Pad) {
                     paint = new SvgResolvedPaint(definition);
@@ -173,7 +182,15 @@ public static partial class OfficeSvgDrawingReader {
             int depth,
             out SvgGradientDefinition? definition) {
             definition = null;
-            if (depth >= MaximumGradientReferenceDepth || !resolving.Add(id)) return false;
+            if (_resolved.TryGetValue(id, out SvgGradientDefinition? cached)) {
+                definition = cached;
+                return true;
+            }
+            if (_invalid.Contains(id)) return false;
+            if (depth >= MaximumGradientReferenceDepth || !resolving.Add(id)) {
+                _invalid.Add(id);
+                return false;
+            }
             try {
                 SvgGradientKind kind = element.Name.LocalName.Equals("linearGradient", StringComparison.OrdinalIgnoreCase)
                     ? SvgGradientKind.Linear
@@ -211,6 +228,7 @@ public static partial class OfficeSvgDrawingReader {
                         || !TryCoordinate(element, "y2", defaultY2, allowOutsideUnit: false, userSpaceOnUse, out SvgGradientCoordinate y2)
                         || (x1.Equals(x2) && y1.Equals(y2))) return false;
                     definition = SvgGradientDefinition.Linear(x1, y1, x2, y2, stops, userSpaceOnUse, gradientTransform, spreadMode);
+                    _resolved[id] = definition;
                     return true;
                 }
 
@@ -228,9 +246,11 @@ public static partial class OfficeSvgDrawingReader {
                     || (focalX.Equals(centerX) && focalY.Equals(centerY) && focalRadius.Equals(radius))) return false;
                 if (!userSpaceOnUse && focalRadius.Value > radius.Value) return false;
                 definition = SvgGradientDefinition.Radial(focalX, focalY, focalRadius, centerX, centerY, radius, stops, userSpaceOnUse, gradientTransform, spreadMode);
+                _resolved[id] = definition;
                 return true;
             } finally {
                 resolving.Remove(id);
+                if (definition == null) _invalid.Add(id);
             }
         }
 

--- a/OfficeIMO.Html.Pdf/HtmlPdfRenderedConverter.cs
+++ b/OfficeIMO.Html.Pdf/HtmlPdfRenderedConverter.cs
@@ -512,6 +512,7 @@ internal static class HtmlPdfRenderedConverter {
             FlushShapes();
         }
 
+        if (source.Elements.Count == 0) return;
         if (string.IsNullOrWhiteSpace(visual.AlternativeText)) {
             AddElements(canvas, source.Elements);
         } else {

--- a/OfficeIMO.Html.Tests/Html.Pdf.cs
+++ b/OfficeIMO.Html.Tests/Html.Pdf.cs
@@ -15,6 +15,21 @@ namespace OfficeIMO.Tests;
 
 public sealed class HtmlPdfTests {
     [Fact]
+    public void HtmlToPdf_SkipsEmptySvgWithAlternativeText() {
+        string svg = Convert.ToBase64String(Encoding.UTF8.GetBytes(
+            "<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10'></svg>"));
+        string html = "<img src='data:image/svg+xml;base64," + svg +
+            "' alt='Empty vector'><p>After empty vector</p>";
+
+        byte[] pdf = HtmlConversionDocument.Parse(html).ToPdf();
+
+        Assert.Contains(
+            "After empty vector",
+            PdfCore.PdfReadDocument.Open(pdf).ExtractText(),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Html_DirectOutputs_UseOneSharedOptionsShape() {
         const string html = "<main><h1>Quarterly report</h1><p>Direct HTML rendering.</p></main>";
         var options = new HtmlPdfSaveOptions {

--- a/OfficeIMO.Html.Tests/Html.Rendering.Gradients.cs
+++ b/OfficeIMO.Html.Tests/Html.Rendering.Gradients.cs
@@ -514,4 +514,26 @@ public sealed partial class HtmlRenderingTests {
         Assert.Contains(rendered.Diagnostics, diagnostic => diagnostic.Code == HtmlRenderDiagnosticCodes.GradientStopLimitExceeded);
         Assert.DoesNotContain(rendered.Diagnostics, diagnostic => diagnostic.Code == HtmlRenderDiagnosticCodes.BackgroundImageValueUnsupported);
     }
+
+    [Fact]
+    public void CssLengthAndGradientParsingRejectNonFiniteResults() {
+        Assert.False(HtmlRenderCssValues.TryLength(
+            "1e308cm",
+            reference: 100D,
+            fontSize: 16D,
+            rootFontSize: 16D,
+            out _));
+        Assert.False(HtmlRenderCssValues.TryLength(
+            "1e308em",
+            reference: 100D,
+            fontSize: 16D,
+            rootFontSize: 16D,
+            out _));
+        Assert.False(HtmlCssGradientStops.TryParse(
+            new[] { "red 0px", "blue 1e308cm" },
+            startIndex: 0,
+            maximumStops: 8,
+            out _,
+            out _));
+    }
 }

--- a/OfficeIMO.Html.Tests/Html.Rendering.Grid.cs
+++ b/OfficeIMO.Html.Tests/Html.Rendering.Grid.cs
@@ -382,6 +382,29 @@ public sealed partial class HtmlRenderingTests {
         Assert.Equal(nameof(HtmlRenderOptions.MaxLayoutOperations), exception.LimitSource);
     }
 
+    [Fact]
+    public void HtmlGrid_HandlesManyItemsSharingOneRowWithoutQuadraticOccupancyScans() {
+        const int itemCount = 2048;
+        var html = new StringBuilder("<div style='display:grid;grid-template-columns:1fr;grid-template-rows:20px'>");
+        for (int index = 0; index < itemCount; index++) {
+            html.Append("<span style='grid-row:1;grid-column:1'>x</span>");
+        }
+        html.Append("</div>");
+
+        HtmlRenderDocument rendered = HtmlRenderTestDriver.Render(
+            html.ToString(),
+            new HtmlRenderOptions {
+                ViewportWidth = 100D,
+                Margins = HtmlRenderMargins.All(0D),
+                MaxLayoutOperations = 100_000
+            });
+
+        Assert.Single(rendered.Pages);
+        Assert.DoesNotContain(
+            rendered.Diagnostics,
+            diagnostic => diagnostic.Code == HtmlRenderDiagnosticCodes.LayoutOperationLimitExceeded);
+    }
+
     private static HtmlRenderDocument RenderGrid(string html, double viewportWidth) =>
         HtmlRenderTestDriver.Render(HtmlConversionDocument.Parse(html), new HtmlRenderOptions { ViewportWidth = viewportWidth, Margins = HtmlRenderMargins.All(0D) });
 

--- a/OfficeIMO.Html/Rendering/HtmlCssGradientStops.cs
+++ b/OfficeIMO.Html/Rendering/HtmlCssGradientStops.cs
@@ -53,7 +53,7 @@ internal sealed class HtmlCssGradientStops {
             if (stop.Position == null) continue;
             if (!HtmlRenderCssValues.TryLength(stop.Position, referenceLength, fontSize, rootFontSize, out double pixels)) return false;
             double offset = pixels / referenceLength;
-            if (offset < 0D || offset > 1D) return false;
+            if (double.IsNaN(offset) || double.IsInfinity(offset) || offset < 0D || offset > 1D) return false;
             offsets[index] = offset;
         }
 

--- a/OfficeIMO.Html/Rendering/HtmlRenderCssValues.cs
+++ b/OfficeIMO.Html/Rendering/HtmlRenderCssValues.cs
@@ -40,38 +40,40 @@ internal static class HtmlRenderCssValues {
             case "":
             case "px":
                 result = number;
-                return true;
+                return IsFinite(result);
             case "pt":
                 result = number * HtmlRenderOptions.CssPixelsPerInch / 72D;
-                return true;
+                return IsFinite(result);
             case "pc":
                 result = number * HtmlRenderOptions.CssPixelsPerInch / 6D;
-                return true;
+                return IsFinite(result);
             case "in":
                 result = number * HtmlRenderOptions.CssPixelsPerInch;
-                return true;
+                return IsFinite(result);
             case "cm":
                 result = number * HtmlRenderOptions.CssPixelsPerInch / 2.54D;
-                return true;
+                return IsFinite(result);
             case "mm":
                 result = number * HtmlRenderOptions.CssPixelsPerInch / 25.4D;
-                return true;
+                return IsFinite(result);
             case "q":
                 result = number * HtmlRenderOptions.CssPixelsPerInch / 101.6D;
-                return true;
+                return IsFinite(result);
             case "em":
                 result = number * fontSize;
-                return true;
+                return IsFinite(result);
             case "rem":
                 result = number * rootFontSize;
-                return true;
+                return IsFinite(result);
             case "%":
                 result = reference * number / 100D;
-                return true;
+                return IsFinite(result);
             default:
                 return false;
         }
     }
+
+    private static bool IsFinite(double value) => !double.IsNaN(value) && !double.IsInfinity(value);
 
     internal static void ApplyBoxShorthand(string? value, double reference, double fontSize, double rootFontSize, ref double top, ref double right, ref double bottom, ref double left) {
         IReadOnlyList<string> parts = SplitWhitespace(value);

--- a/OfficeIMO.Html/Rendering/HtmlRenderLayoutEngine.Grid.cs
+++ b/OfficeIMO.Html/Rendering/HtmlRenderLayoutEngine.Grid.cs
@@ -125,8 +125,19 @@ internal sealed partial class HtmlRenderLayoutEngine {
         IEnumerable<double> rowBreakOffsets = Enumerable.Range(1, Math.Max(0, rowCount - 1))
             .Where(boundary => !items.Any(item => item.Row < boundary && item.Row + item.RowSpan > boundary))
             .Select(boundary => contentY + rows.Positions[boundary]);
+        var rowItemCountDeltas = new int[rowCount + 1];
+        foreach (GridItem item in items) {
+            rowItemCountDeltas[item.Row]++;
+            rowItemCountDeltas[Math.Min(rowCount, item.Row + item.RowSpan)]--;
+        }
+        var rowItemCounts = new int[rowCount];
+        int activeRowItems = 0;
+        for (int row = 0; row < rowCount; row++) {
+            activeRowItems += rowItemCountDeltas[row];
+            rowItemCounts[row] = activeRowItems;
+        }
         IEnumerable<double> itemBreakOffsets = items
-            .Where(item => item.RowSpan == 1 && items.Count(other => other.Row <= item.Row && other.Row + other.RowSpan > item.Row) == 1)
+            .Where(item => item.RowSpan == 1 && rowItemCounts[item.Row] == 1)
             .SelectMany(item => item.Block!.BreakOffsets.Select(offset =>
                 contentY + rows.Positions[item.Row] + item.OffsetY + offset));
         IEnumerable<double> breakOffsets = rowBreakOffsets.Concat(itemBreakOffsets).Distinct().OrderBy(offset => offset);

--- a/OfficeIMO.Html/Rendering/HtmlRenderStyleResolver.cs
+++ b/OfficeIMO.Html/Rendering/HtmlRenderStyleResolver.cs
@@ -256,7 +256,8 @@ internal sealed partial class HtmlRenderStyleResolver {
             case "larger": return parentFontSize * 1.2D;
         }
 
-        return HtmlRenderCssValues.TryLength(normalized, parentFontSize, parentFontSize, _options.DefaultFontSize, out double size) && size > 0D
+        return HtmlRenderCssValues.TryLength(normalized, parentFontSize, parentFontSize, _options.DefaultFontSize, out double size) &&
+            !double.IsNaN(size) && !double.IsInfinity(size) && size > 0D
             ? size
             : parentFontSize;
     }

--- a/OfficeIMO.OpenDocument.Tests/OpenDocument.CurrentReviewRegressions.cs
+++ b/OfficeIMO.OpenDocument.Tests/OpenDocument.CurrentReviewRegressions.cs
@@ -80,6 +80,34 @@ public sealed class OpenDocumentCurrentReviewRegressionTests {
     }
 
     [Fact]
+    public void FlatSvgBinaryDataIsParsedAndReserializedBeforePackaging() {
+        const string safeSvg = "<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10'><rect width='10' height='10' fill='red'/></svg>";
+        const string activeSvg = "<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10'><script>alert(1)</script><rect width='10' height='10' fill='red' onclick='alert(2)'/></svg>";
+        OdtDocument source = OdtDocument.Create();
+        source.AddParagraph().AddImage(
+            Encoding.UTF8.GetBytes(safeSvg),
+            "shape.svg",
+            OdfLength.Centimeters(1),
+            OdfLength.Centimeters(1));
+        XDocument flat = source.ToFlatXml();
+        XElement imageElement = Assert.Single(flat.Descendants(OdfNamespaces.Draw + "image"));
+        imageElement.SetAttributeValue(OdfNamespaces.Draw + "mime-type", "image/svg+xml");
+        imageElement.Element(OdfNamespaces.Office + "binary-data")!.Value =
+            Convert.ToBase64String(Encoding.UTF8.GetBytes(activeSvg));
+        using var stream = new MemoryStream();
+        flat.Save(stream);
+        stream.Position = 0;
+
+        OdtDocument reopened = OdtDocument.LoadFlatXml(stream);
+        string packagedSvg = Encoding.UTF8.GetString(
+            reopened.Paragraphs.Single().Images.Single().GetImageBytes());
+
+        Assert.Contains("<rect", packagedSvg, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("<script", packagedSvg, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("onclick", packagedSvg, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void PackageVersionFallsBackToContentPartWhenManifestVersionIsMissing() {
         OdtDocument source = OdtDocument.Create();
         source.AddParagraph("ODF 1.3");

--- a/OfficeIMO.OpenDocument/Core/OdfDocument.FlatXml.cs
+++ b/OfficeIMO.OpenDocument/Core/OdfDocument.FlatXml.cs
@@ -1,3 +1,4 @@
+using OfficeIMO.Drawing;
 using OfficeIMO.Drawing.Internal;
 namespace OfficeIMO.OpenDocument;
 
@@ -131,6 +132,12 @@ public abstract partial class OdfDocument {
             if (data.LongLength > options.MaxEntryUncompressedBytes) throw new InvalidDataException("Flat OpenDocument image exceeds MaxEntryUncompressedBytes.");
             string? mediaType = (string?)image.Attribute(OdfNamespaces.Draw + "mime-type");
             string extension = ImageExtension(mediaType, data);
+            if (extension == ".svg") {
+                if (!OfficeSvgDrawingReader.TryRead(data, out OfficeDrawing? drawing) || drawing == null) {
+                    throw new InvalidDataException("Flat OpenDocument SVG image is not a supported bounded vector image.");
+                }
+                data = Encoding.UTF8.GetBytes(OfficeDrawingSvgExporter.ToSvg(drawing));
+            }
             string path = "Pictures/flat-image" + index++.ToString(CultureInfo.InvariantCulture) + extension;
             package.AddOrReplaceEntry(path, data, ImageMediaType(extension));
             image.SetAttributeValue(OdfNamespaces.XLink + "href", path);

--- a/OfficeIMO.Pdf.Tests/Pdf/Fixtures/Interoperability/corpus-manifest.json
+++ b/OfficeIMO.Pdf.Tests/Pdf/Fixtures/Interoperability/corpus-manifest.json
@@ -70,8 +70,8 @@
       "expectedRepairCodes": [],
       "expectedRenderSucceeded": true,
       "expectedRenderDiagnosticCodes": [],
-      "expectedMutationMode": "AppendOnly",
-      "features": [ "word-2003", "acrobat-9", "embedded-file", "name-tree", "tagged" ]
+      "expectedMutationMode": "Blocked",
+      "features": [ "word-2003", "acrobat-9", "embedded-file", "name-tree", "tagged", "document-javascript" ]
     },
     {
       "id": "producer-external-link",
@@ -89,7 +89,7 @@
       "expectedRepairCodes": [],
       "expectedRenderSucceeded": true,
       "expectedRenderDiagnosticCodes": [ "render.resource.annotation-appearance-missing" ],
-      "expectedMutationMode": "AppendOnly",
+      "expectedMutationMode": "Blocked",
       "features": [ "word-2003", "acrobat-9", "external-document", "launch-action", "link-annotation", "tagged" ]
     },
     {

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfAttachmentEditorTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfAttachmentEditorTests.cs
@@ -165,7 +165,8 @@ public class PdfAttachmentEditorTests {
         byte[] source = PdfAssociatedFileTestSupport.BuildPageAssociatedFilePdf();
         var options = new PdfReadOptions { Limits = new PdfReadLimits { MaxDecodedStreamBytes = 8 } };
 
-        PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() => PdfReadDocument.Open(source, options));
+        PdfReadDocument document = PdfReadDocument.Open(source, options);
+        PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() => document.ExtractAttachments());
 
         Assert.Equal(PdfReadLimitKind.DecodedStreamBytes, exception.Kind);
         Assert.Equal(8, exception.Limit);

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfAttachmentExtractorTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfAttachmentExtractorTests.cs
@@ -96,6 +96,21 @@ public class PdfAttachmentExtractorTests {
     }
 
     [Fact]
+    public void InspectAttachments_DoesNotPresentDeclaredOrEncodedSizeAsDecodedSize() {
+        byte[] payload = Encoding.UTF8.GetBytes(new string('A', 4096));
+        byte[] pdf = BuildFlateEmbeddedFilePdf(payload, declaredSize: 1);
+
+        PdfAttachmentInfo info = Assert.Single(PdfReadDocument.Open(pdf).Attachments);
+        PdfExtractedAttachment extracted = Assert.Single(PdfAttachmentExtractor.ExtractAttachments(pdf));
+
+        Assert.Equal(1, info.DeclaredSizeBytes);
+        Assert.True(info.EncodedSizeBytes > 1);
+        Assert.Equal(info.EncodedSizeBytes, info.SizeBytes);
+        Assert.Null(info.DecodedSizeBytes);
+        Assert.Equal(payload.Length, extracted.Bytes.Length);
+    }
+
+    [Fact]
     public void ExtractAttachments_ReadsCatalogAssociatedFilesWithoutEmbeddedFileNameTree() {
         IReadOnlyList<PdfExtractedAttachment> attachments = PdfAttachmentExtractor.ExtractAttachments(BuildAssociatedFileOnlyPdf());
 
@@ -145,10 +160,12 @@ public class PdfAttachmentExtractorTests {
             .Paragraph(p => p.Text("Aggregate attachment budget."))
             .ToBytes();
 
+        PdfReadDocument document = PdfReadDocument.Open(pdf, new PdfReadOptions {
+            Limits = new PdfReadLimits { MaxTotalAttachmentBytes = 5 }
+        });
+        Assert.Equal(2, document.Attachments.Count);
         PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() =>
-            PdfReadDocument.Open(pdf, new PdfReadOptions {
-                Limits = new PdfReadLimits { MaxTotalAttachmentBytes = 5 }
-            }));
+            document.ExtractAttachments());
 
         Assert.Equal(PdfReadLimitKind.AttachmentBytes, exception.Kind);
         Assert.Equal(5, exception.Limit);
@@ -163,10 +180,12 @@ public class PdfAttachmentExtractorTests {
         }
         byte[] pdf = BuildFlateEmbeddedFilePdf(payload, malformedPredictor: true);
 
+        PdfReadDocument document = PdfReadDocument.Open(pdf, new PdfReadOptions {
+            Limits = new PdfReadLimits { MaxTotalAttachmentBytes = 64 }
+        });
+        Assert.Single(document.Attachments);
         PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() =>
-            PdfReadDocument.Open(pdf, new PdfReadOptions {
-                Limits = new PdfReadLimits { MaxTotalAttachmentBytes = 64 }
-            }));
+            document.ExtractAttachments());
 
         Assert.Equal(PdfReadLimitKind.AttachmentBytes, exception.Kind);
         Assert.Equal(64, exception.Limit);
@@ -273,7 +292,7 @@ public class PdfAttachmentExtractorTests {
         return Encoding.ASCII.GetBytes(pdf);
     }
 
-    private static byte[] BuildFlateEmbeddedFilePdf(byte[] payload, bool malformedPredictor = false) {
+    private static byte[] BuildFlateEmbeddedFilePdf(byte[] payload, bool malformedPredictor = false, int? declaredSize = null) {
         byte[] compressed = DeflateZlib(payload);
         string header = string.Join("\n", new[] {
             "%PDF-1.4",
@@ -297,6 +316,7 @@ public class PdfAttachmentExtractorTests {
             "endobj",
             "6 0 obj",
             "<< /Type /EmbeddedFile /Subtype /application#2Foctet-stream /Length " + compressed.Length.ToString(System.Globalization.CultureInfo.InvariantCulture) + " /Filter /FlateDecode" +
+                (declaredSize.HasValue ? " /Params << /Size " + declaredSize.Value.ToString(System.Globalization.CultureInfo.InvariantCulture) + " >>" : string.Empty) +
                 (malformedPredictor ? " /DecodeParms << /Predictor 12 /Columns 4 >>" : string.Empty) + " >>",
             "stream"
         });

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfAuthoritativeInteroperabilityCorpusTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfAuthoritativeInteroperabilityCorpusTests.cs
@@ -92,11 +92,12 @@ public sealed class PdfAuthoritativeInteroperabilityCorpusTests {
             Assert.Equal(
                 ReadStringArray(item, "expectedRenderDiagnosticCodes"),
                 render.CapabilityDiagnostics.Select(diagnostic => diagnostic.Code).Distinct(StringComparer.Ordinal).ToArray());
-            Assert.Equal(
-                (PdfMutationExecutionMode)Enum.Parse(
-                    typeof(PdfMutationExecutionMode),
-                    RequireString(item, "expectedMutationMode")),
-                plan.ExecutionMode);
+            var expectedMutationMode = (PdfMutationExecutionMode)Enum.Parse(
+                typeof(PdfMutationExecutionMode),
+                RequireString(item, "expectedMutationMode"));
+            Assert.True(
+                expectedMutationMode == plan.ExecutionMode,
+                id + " expected mutation mode " + expectedMutationMode + " but received " + plan.ExecutionMode + ".");
         }
     }
 

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfDestructiveCropTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfDestructiveCropTests.cs
@@ -43,4 +43,31 @@ public class PdfDestructiveCropTests {
         PdfMutationBlockedException exception = Assert.Throws<PdfMutationBlockedException>(() => PdfPageEditor.DestructiveCropPages(source, 0, 0, 300, 500));
         Assert.Contains(exception.Plan.BlockerCodes, static code => code.Contains("Forms", StringComparison.Ordinal));
     }
+
+    [Fact]
+    public void DestructiveCrop_RemovesPageThumbnailReferenceAndPayload() {
+        byte[] source = PdfDocument.Create().Paragraph(p => p.Text("Thumbnail crop source")).ToBytes();
+        int pageObjectNumber = PdfReadDocument.Open(source).Pages[0].ObjectNumber;
+        byte[] withThumbnail = PdfDocumentObjectGraphRewriter.Rewrite(source, null, null, (objects, security) => {
+            int thumbnailObjectNumber = objects.Keys.Max() + 1;
+            var imageDictionary = new PdfDictionary();
+            imageDictionary.Items["Type"] = new PdfName("XObject");
+            imageDictionary.Items["Subtype"] = new PdfName("Image");
+            imageDictionary.Items["Width"] = new PdfNumber(1);
+            imageDictionary.Items["Height"] = new PdfNumber(1);
+            imageDictionary.Items["ColorSpace"] = new PdfName("DeviceGray");
+            imageDictionary.Items["BitsPerComponent"] = new PdfNumber(8);
+            objects[thumbnailObjectNumber] = new PdfIndirectObject(
+                thumbnailObjectNumber,
+                0,
+                new PdfStream(imageDictionary, new byte[] { 0x7F }));
+            PdfDictionary page = Assert.IsType<PdfDictionary>(objects[pageObjectNumber].Value);
+            page.Items["Thumb"] = new PdfReference(thumbnailObjectNumber, 0);
+            return security.InfoObjectNumber;
+        });
+
+        byte[] cropped = PdfPageEditor.DestructiveCropPages(withThumbnail, 0, 0, 612, 792, new PdfDestructiveCropOptions { Dpi = 72 }).ToBytes();
+
+        Assert.DoesNotContain("/Thumb", PdfEncoding.Latin1GetString(cropped), StringComparison.Ordinal);
+    }
 }

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfDocumentMetadataTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfDocumentMetadataTests.cs
@@ -8,7 +8,7 @@ namespace OfficeIMO.Tests.Pdf;
 
 public class PdfDocumentMetadataTests {
     [Fact]
-    public void Meta_EscapesLiteralStringsAndInspectorReadsOriginalValues() {
+    public void Meta_EncodesTextStringsAndInspectorReadsOriginalValues() {
         const string title = "Quarterly (Q1) \\ Roadmap";
         const string author = "OfficeIMO\nTeam";
         const string subject = "PDF metadata (escaped) \\ subject";
@@ -21,10 +21,10 @@ public class PdfDocumentMetadataTests {
 
         string pdfText = Encoding.ASCII.GetString(bytes);
 
-        Assert.Contains("/Title (Quarterly \\(Q1\\) \\\\ Roadmap)", pdfText, StringComparison.Ordinal);
-        Assert.Contains("/Author (OfficeIMO\\nTeam)", pdfText, StringComparison.Ordinal);
-        Assert.Contains("/Subject (PDF metadata \\(escaped\\) \\\\ subject)", pdfText, StringComparison.Ordinal);
-        Assert.Contains("/Keywords (alpha,beta\\r\\ngamma\\tomega)", pdfText, StringComparison.Ordinal);
+        Assert.Contains("/Title " + PdfSyntaxEscaper.TextString(title), pdfText, StringComparison.Ordinal);
+        Assert.Contains("/Author " + PdfSyntaxEscaper.TextString(author), pdfText, StringComparison.Ordinal);
+        Assert.Contains("/Subject " + PdfSyntaxEscaper.TextString(subject), pdfText, StringComparison.Ordinal);
+        Assert.Contains("/Keywords " + PdfSyntaxEscaper.TextString(keywords), pdfText, StringComparison.Ordinal);
 
         PdfDocumentInfo info = PdfInspector.Inspect(bytes);
 

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfFormDataTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfFormDataTests.cs
@@ -37,4 +37,19 @@ public class PdfFormDataTests {
         Assert.ThrowsAny<Exception>(() => PdfFormDataSet.ParseXfdf("<!DOCTYPE xfdf [<!ENTITY x SYSTEM 'file:///tmp/x'>]><xfdf><fields><field name='A'><value>&x;</value></field></fields></xfdf>"));
         Assert.Throws<ArgumentException>(() => new PdfFormDataSet(new[] { new PdfFormDataField("A", new[] { "1" }), new PdfFormDataField("A", new[] { "2" }) }));
     }
+
+    [Fact]
+    public void ParseXfdfRejectsDocumentBeforeDomMaterializationAndImportExposesTheLimit() {
+        const string xfdf = "<xfdf xmlns='http://ns.adobe.com/xfdf/'><fields><field name='A'><value>bounded</value></field></fields></xfdf>";
+
+        Assert.Throws<InvalidOperationException>(() => PdfFormDataSet.ParseXfdf(
+            xfdf,
+            maxFields: 10,
+            maxValueCharacters: 100,
+            maxDocumentCharacters: xfdf.Length - 1));
+
+        byte[] source = PdfDocument.Create().TextField("A", value: "before").ToBytes();
+        var options = new PdfFormFillerOptions { MaxXfdfDocumentCharacters = xfdf.Length - 1 };
+        Assert.Throws<InvalidOperationException>(() => PdfDocument.Open(source).Forms.ImportXfdf(xfdf, options));
+    }
 }

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfITextInspiredCoverageTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfITextInspiredCoverageTests.cs
@@ -77,7 +77,7 @@ public class PdfITextInspiredCoverageTests {
 
     [Fact]
     public void IncrementalUpdater_AppendsSimpleFormFieldRevision() {
-        byte[] pdf = BuildCoveragePdf();
+        byte[] pdf = BuildDefaultAppearanceFormPdf("/Helv 12 Tf 0 g");
 
         byte[] updated = PdfIncrementalUpdater.UpdateFormFields(pdf, new Dictionary<string, string> {
             ["Name"] = "Grace"
@@ -93,7 +93,7 @@ public class PdfITextInspiredCoverageTests {
 
     [Fact]
     public void IncrementalUpdater_AppendsFormAppearanceStreams() {
-        byte[] pdf = BuildCoveragePdf();
+        byte[] pdf = BuildDefaultAppearanceFormPdf("/Helv 12 Tf 0 g");
 
         byte[] updated = PdfIncrementalUpdater.UpdateFormFields(pdf, new Dictionary<string, string> {
             ["Name"] = "Grace"

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfLayoutDebugOverlayTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfLayoutDebugOverlayTests.cs
@@ -41,4 +41,15 @@ public class PdfLayoutDebugOverlayTests {
         Assert.Equal(PdfReadLimitKind.InteractionRegions, exception.Kind);
         Assert.Equal(1, exception.Limit);
     }
+
+    [Fact]
+    public void DebugOverlay_RejectsRasterDimensionsBeyondPixelBudget() {
+        byte[] source = PdfDocument.Create().Paragraph(paragraph => paragraph.Text("Raster budget")).ToBytes();
+        var options = new PdfLayoutDebugOverlayOptions { MaxRasterPixels = 100 };
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+            PdfLayoutDebugOverlay.ToPng(source, 1, scale: 1D, options));
+
+        Assert.Contains("pixel limit", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfMergerPolicyTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfMergerPolicyTests.cs
@@ -57,6 +57,27 @@ public class PdfMergerPolicyTests {
     }
 
     [Fact]
+    public void Merge_DefaultAttachmentPolicyReportsIncomingMetadataWithoutDecodingPayload() {
+        byte[] first = PdfDocument.Create().Paragraph(p => p.Text("Primary without attachments")).ToBytes();
+        var incomingOptions = new PdfOptions().AddEmbeddedFile(
+            "oversized.bin",
+            Enumerable.Repeat((byte)0x41, 128).ToArray(),
+            "application/octet-stream");
+        byte[] second = PdfDocument.Create(incomingOptions).Paragraph(p => p.Text("Incoming attachment")).ToBytes();
+        var tightAttachmentLimit = new PdfReadOptions {
+            Limits = new PdfReadLimits { MaxTotalAttachmentBytes = 16 }
+        };
+
+        PdfMergeResult result = PdfMerger.MergeWithReport(
+            new PdfMergeOptions(),
+            new[] { first, second },
+            new[] { new PdfReadOptions(), tightAttachmentLimit });
+
+        Assert.Equal(1, result.Report.Sources[1].AttachmentCount);
+        Assert.Empty(PdfAttachmentExtractor.ExtractAttachments(result.ToBytes()));
+    }
+
+    [Fact]
     public void MergeWithReport_RejectIncomingPolicyFailsBeforeReturningArtifact() {
         byte[] first = PdfDocument.Create().Paragraph(p => p.Text("First")).ToBytes();
         byte[] second = PdfDocument.Create().ViewerPreferences(preferences => preferences.HideToolbar = true).Paragraph(p => p.Text("Second")).ToBytes();
@@ -316,16 +337,33 @@ public class PdfMergerPolicyTests {
     }
 
     [Fact]
-    public void MergeWithReport_RebuildsIncomingOptionalContentAsVisibleLayers() {
+    public void MergeWithReport_RejectsOptionalContentCombineThatCouldExposeHiddenLayers() {
         byte[] first = PdfDocument.Create().Paragraph(p => p.Text("First")).ToBytes();
         byte[] second = PdfOptionalContentSupport.BuildOptionalContentMetadataPdf();
         var options = new PdfMergeOptions { Policy = new PdfMergePolicy { CatalogState = PdfMergeStructureMode.Combine } };
 
-        PdfDocumentInfo info = PdfInspector.Inspect(PdfMerger.MergeWithReport(options, first, second).ToBytes());
+        NotSupportedException exception = Assert.Throws<NotSupportedException>(() =>
+            PdfMerger.MergeWithReport(options, first, second));
 
-        Assert.Equal(new[] { "Print layer", "Hidden layer" }, info.OptionalContentGroupNames);
-        Assert.All(info.OptionalContentGroups, static group => Assert.True(group.IsInitiallyVisible));
-        Assert.Equal("Merged layers", info.OptionalContent!.DefaultConfigurationName);
+        Assert.Contains("intentionally hid", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData(PdfMergeStructureMode.KeepPrimary)]
+    [InlineData(PdfMergeStructureMode.Drop)]
+    public void MergeWithReport_RejectsPoliciesThatDiscardIncomingHiddenLayerState(PdfMergeStructureMode mode) {
+        byte[] first = PdfDocument.Create().Paragraph(p => p.Text("First")).ToBytes();
+        byte[] second = PdfDocument.Create()
+            .Layer("Hidden evidence", layer => layer.Paragraph(p => p.Text("Must stay hidden")), new PdfLayerOptions {
+                InitiallyVisible = false
+            })
+            .ToBytes();
+        var options = new PdfMergeOptions { Policy = new PdfMergePolicy { CatalogState = mode } };
+
+        NotSupportedException exception = Assert.Throws<NotSupportedException>(() =>
+            PdfMerger.MergeWithReport(options, first, second));
+
+        Assert.Contains("hidden", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfMetadataSynchronizationTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfMetadataSynchronizationTests.cs
@@ -5,6 +5,22 @@ namespace OfficeIMO.Tests.Pdf;
 
 public class PdfMetadataSynchronizationTests {
     [Fact]
+    public void GeneratedInfoDictionaryEncodesUnicodeWithoutPdfSyntaxInjection() {
+        const string title = "\u0129 /Author \u0128Injected";
+
+        byte[] pdf = PdfDocument.Create()
+            .Meta(title: title)
+            .Paragraph(paragraph => paragraph.Text("Metadata encoding"))
+            .ToBytes();
+        PdfDocumentInfo info = PdfInspector.Inspect(pdf);
+        string raw = PdfEncoding.Latin1GetString(pdf);
+
+        Assert.Equal(title, info.Metadata.Title);
+        Assert.Null(info.Metadata.Author);
+        Assert.DoesNotContain(") /Author (Injected", raw, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void SynchronizeMetadata_UpdatesInfoAndXmpWhilePreservingCustomSchema() {
         var options = new PdfOptions { IncludeXmpMetadata = true }
             .SetElectronicInvoiceMetadata(new PdfElectronicInvoiceMetadata("ORDER", "invoice.xml", "1.0", "EN 16931"));

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfMutationPlannerTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfMutationPlannerTests.cs
@@ -431,6 +431,30 @@ public class PdfMutationPlannerTests {
     }
 
     [Fact]
+    public void ExternalSignatureFinalizationIgnoresContentsTextInsideMetadataStrings() {
+        byte[] source = PdfDocument.Create()
+            .Paragraph(paragraph => paragraph.Text("Signature contents lexical parsing"))
+            .ToBytes();
+        PdfExternalSignaturePreparation preparation = PdfIncrementalUpdater.PrepareExternalSignature(
+            source,
+            new PdfExternalSignatureOptions {
+                Reason = "Review /Contents <00000000> marker as ordinary text",
+                ReservedSignatureContentsBytes = 256
+            });
+
+        PdfMutationPlan plan = PdfMutationPlanner.Plan(
+            preparation.PreparedPdf,
+            PdfMutationOperation.FinalizeExternalSignature);
+        Assert.True(plan.CanExecute);
+
+        byte[] signed = PdfIncrementalUpdater.ApplyExternalSignature(
+            preparation,
+            new byte[] { 0x30, 0x01, 0x00 });
+
+        Assert.NotEmpty(signed);
+    }
+
+    [Fact]
     public void DocumentMutationPlanningRetainsBytesForSignatureReservationValidation() {
         byte[] source = PdfDocument.Create()
             .Paragraph(paragraph => paragraph.Text("Document signature planning source"))

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfMutationPlannerTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfMutationPlannerTests.cs
@@ -431,6 +431,31 @@ public class PdfMutationPlannerTests {
     }
 
     [Fact]
+    public void DocumentMutationPlanningRetainsBytesForSignatureReservationValidation() {
+        byte[] source = PdfDocument.Create()
+            .Paragraph(paragraph => paragraph.Text("Document signature planning source"))
+            .ToBytes();
+        PdfExternalSignaturePreparation preparation = PdfIncrementalUpdater.PrepareExternalSignature(
+            source,
+            new PdfExternalSignatureOptions { ReservedSignatureContentsBytes = 256 });
+        PdfDocument document = PdfDocument.Open(preparation.PreparedPdf);
+
+        PdfMutationPlan plan = document.PlanMutation(PdfMutationOperation.FinalizeExternalSignature);
+        PdfMutationPortfolioReport portfolio = document.AssessMutations(new[] {
+            PdfMutationOperation.FinalizeExternalSignature
+        });
+        PdfMutationPlan portfolioPlan = portfolio.Get(PdfMutationOperation.FinalizeExternalSignature);
+
+        Assert.True(plan.CanExecute);
+        Assert.True(portfolioPlan.CanExecute);
+        Assert.Equal(PdfMutationExecutionMode.AppendOnly, plan.ExecutionMode);
+        Assert.Equal(PdfMutationExecutionMode.AppendOnly, portfolioPlan.ExecutionMode);
+        Assert.DoesNotContain("SignatureReservation.Invalid", plan.BlockerCodes);
+        Assert.DoesNotContain("SignatureReservation.Invalid", portfolioPlan.BlockerCodes);
+        Assert.Same(portfolio.Preflight, portfolioPlan.Preflight);
+    }
+
+    [Fact]
     public void ExternalSignatureFinalizationRejectsByteRangeThatDoesNotMatchReservation() {
         byte[] source = PdfDocument.Create()
             .Paragraph(paragraph => paragraph.Text("Signature reservation validation"))
@@ -445,9 +470,12 @@ public class PdfMutationPlannerTests {
             (originalTailLength + 1L).ToString("00000000000000000000", System.Globalization.CultureInfo.InvariantCulture));
 
         PdfMutationPlan plan = PdfMutationPlanner.Plan(crafted, PdfMutationOperation.FinalizeExternalSignature);
+        PdfMutationPlan documentPlan = PdfDocument.Open(crafted).PlanMutation(PdfMutationOperation.FinalizeExternalSignature);
 
         Assert.False(plan.CanExecute);
+        Assert.False(documentPlan.CanExecute);
         Assert.Contains("SignatureReservation.Invalid", plan.BlockerCodes);
+        Assert.Contains("SignatureReservation.Invalid", documentPlan.BlockerCodes);
         Assert.Throws<PdfMutationBlockedException>(() =>
             PdfDocument.Open(crafted).CompleteExternalSignature(new byte[] { 0x30, 0x01, 0x00 }));
     }

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfMutationPlannerTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfMutationPlannerTests.cs
@@ -455,6 +455,32 @@ public class PdfMutationPlannerTests {
     }
 
     [Fact]
+    public void ExternalSignatureFinalizationIgnoresObjectHeadersInsideMetadataStrings() {
+        byte[] source = PdfDocument.Create()
+            .Paragraph(paragraph => paragraph.Text("Signature object-boundary lexical parsing"))
+            .ToBytes();
+        PdfExternalSignaturePreparation preparation = PdfIncrementalUpdater.PrepareExternalSignature(
+            source,
+            new PdfExternalSignatureOptions {
+                Reason = "Review note\n99 0 obj should remain ordinary text",
+                ReservedSignatureContentsBytes = 256
+            });
+
+        PdfMutationPlan rawPlan = PdfMutationPlanner.Plan(
+            preparation.PreparedPdf,
+            PdfMutationOperation.FinalizeExternalSignature);
+        PdfMutationPlan documentPlan = PdfDocument.Open(preparation.PreparedPdf)
+            .PlanMutation(PdfMutationOperation.FinalizeExternalSignature);
+        byte[] signed = PdfIncrementalUpdater.ApplyExternalSignature(
+            preparation.PreparedPdf,
+            new byte[] { 0x30, 0x01, 0x00 });
+
+        Assert.True(rawPlan.CanExecute);
+        Assert.True(documentPlan.CanExecute);
+        Assert.NotEmpty(signed);
+    }
+
+    [Fact]
     public void DocumentMutationPlanningRetainsBytesForSignatureReservationValidation() {
         byte[] source = PdfDocument.Create()
             .Paragraph(paragraph => paragraph.Text("Document signature planning source"))

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfMutationPlannerTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfMutationPlannerTests.cs
@@ -64,6 +64,49 @@ public class PdfMutationPlannerTests {
     }
 
     [Fact]
+    public void ActiveContentBlocksAppendOnlyMetadataAndFormMutations() {
+        byte[] metadataSource = WithCatalogAction(
+            PdfDocument.Create().Paragraph(paragraph => paragraph.Text("Active metadata source")).ToBytes());
+        byte[] formSource = WithCatalogAction(
+            PdfDocument.Create().TextField("Account", value: "before").ToBytes());
+
+        PdfMutationPlan metadataPlan = PdfMutationPlanner.Plan(
+            metadataSource,
+            PdfMutationOperation.UpdateMetadata);
+        PdfMutationPlan formPlan = PdfMutationPlanner.Plan(
+            formSource,
+            PdfMutationOperation.FillFormFields,
+            fieldNames: new[] { "Account" });
+        PdfOperationResult<PdfDocument> metadataResult = PdfDocument.Open(metadataSource)
+            .TryUpdateMetadata(title: "should not be appended");
+        PdfOperationResult<PdfDocument> formResult = PdfDocument.Open(formSource).Forms.TryFill(
+            new Dictionary<string, string> { ["Account"] = "after" });
+
+        Assert.False(metadataPlan.CanExecute);
+        Assert.False(metadataPlan.AppendOnlyAvailable);
+        Assert.False(formPlan.CanExecute);
+        Assert.False(formPlan.AppendOnlyAvailable);
+        Assert.False(metadataResult.Succeeded);
+        Assert.False(formResult.Succeeded);
+    }
+
+    [Fact]
+    public void GoToEActionBlocksAppendOnlyMetadataMutation() {
+        byte[] source = WithCatalogAction(
+            PdfDocument.Create().Paragraph(paragraph => paragraph.Text("Embedded target action")).ToBytes(),
+            "GoToE");
+
+        PdfMutationPlan plan = PdfMutationPlanner.Plan(source, PdfMutationOperation.UpdateMetadata);
+        PdfOperationResult<PdfDocument> result = PdfDocument.Open(source)
+            .TryUpdateMetadata(title: "must not preserve GoToE");
+
+        Assert.True(PdfInspector.Probe(source).HasActiveContent);
+        Assert.False(plan.CanExecute);
+        Assert.False(plan.AppendOnlyAvailable);
+        Assert.False(result.Succeeded);
+    }
+
+    [Fact]
     public void Plan_BlocksPageTreeMutationForSignedIncrementalInput() {
         byte[] source = PdfRewritePreservationTestSupport.BuildSignedIncrementalProofPdf();
 
@@ -388,6 +431,40 @@ public class PdfMutationPlannerTests {
     }
 
     [Fact]
+    public void ExternalSignatureFinalizationRejectsByteRangeThatDoesNotMatchReservation() {
+        byte[] source = PdfDocument.Create()
+            .Paragraph(paragraph => paragraph.Text("Signature reservation validation"))
+            .ToBytes();
+        PdfExternalSignaturePreparation preparation = PdfIncrementalUpdater.PrepareExternalSignature(
+            source,
+            new PdfExternalSignatureOptions { ReservedSignatureContentsBytes = 256 });
+        long originalTailLength = preparation.ByteRangeValues[3];
+        byte[] crafted = ReplaceFirstAscii(
+            preparation.PreparedPdf,
+            originalTailLength.ToString("00000000000000000000", System.Globalization.CultureInfo.InvariantCulture),
+            (originalTailLength + 1L).ToString("00000000000000000000", System.Globalization.CultureInfo.InvariantCulture));
+
+        PdfMutationPlan plan = PdfMutationPlanner.Plan(crafted, PdfMutationOperation.FinalizeExternalSignature);
+
+        Assert.False(plan.CanExecute);
+        Assert.Contains("SignatureReservation.Invalid", plan.BlockerCodes);
+        Assert.Throws<PdfMutationBlockedException>(() =>
+            PdfDocument.Open(crafted).CompleteExternalSignature(new byte[] { 0x30, 0x01, 0x00 }));
+    }
+
+    [Fact]
+    public void ExternalSignatureFinalizationRejectsDuplicateContentsBoundToAnotherObject() {
+        byte[] crafted = BuildDuplicateContentsSignatureReservation(256);
+
+        PdfMutationPlan plan = PdfMutationPlanner.Plan(crafted, PdfMutationOperation.FinalizeExternalSignature);
+
+        Assert.False(plan.CanExecute);
+        Assert.Contains("SignatureReservation.Invalid", plan.BlockerCodes);
+        Assert.Throws<ArgumentException>(() =>
+            PdfDocument.Open(crafted).CompleteExternalSignature(new byte[] { 0x30, 0x01, 0x00 }));
+    }
+
+    [Fact]
     public void ExternalSignatureFinalizationRejectsEmptyAndAmbiguousRawCompletion() {
         byte[] source = PdfDocument.Create()
             .Paragraph(paragraph => paragraph.Text("Signature finalization ambiguity source"))
@@ -515,6 +592,75 @@ public class PdfMutationPlannerTests {
         Assert.Equal(PdfMutationExecutionMode.FullRewrite, ownerPlan.ExecutionMode);
         Assert.True(ownerResult.Succeeded, string.Join(" ", ownerResult.Diagnostics));
         Assert.False(PdfInspector.Probe(ownerResult.RequireValue().ToBytes()).HasEncryption);
+    }
+
+    private static byte[] ReplaceFirstAscii(byte[] source, string oldValue, string newValue) {
+        byte[] oldBytes = System.Text.Encoding.ASCII.GetBytes(oldValue);
+        byte[] newBytes = System.Text.Encoding.ASCII.GetBytes(newValue);
+        Assert.Equal(oldBytes.Length, newBytes.Length);
+        byte[] result = (byte[])source.Clone();
+        for (int index = 0; index <= result.Length - oldBytes.Length; index++) {
+            if (!result.AsSpan(index, oldBytes.Length).SequenceEqual(oldBytes)) continue;
+            Buffer.BlockCopy(newBytes, 0, result, index, newBytes.Length);
+            return result;
+        }
+        throw new InvalidOperationException("Expected ASCII marker was not found.");
+    }
+
+    private static byte[] WithCatalogAction(byte[] source, string actionType = "JavaScript") {
+        return PdfDocumentObjectGraphRewriter.Rewrite(source, null, null, (objects, security) => {
+            int rootObjectNumber = Assert.IsType<int>(security.RootObjectNumber);
+            PdfDictionary catalog = Assert.IsType<PdfDictionary>(objects[rootObjectNumber].Value);
+            var action = new PdfDictionary();
+            action.Items["S"] = new PdfName(actionType);
+            if (actionType == "JavaScript") action.Items["JS"] = new PdfStringObj("app.alert('blocked')", true);
+            catalog.Items["OpenAction"] = action;
+            return security.InfoObjectNumber;
+        });
+    }
+
+    private static byte[] BuildDuplicateContentsSignatureReservation(int reservedBytes) {
+        string zeros = new string('0', reservedBytes * 2);
+        string rangePlaceholder = string.Join(" ", Enumerable.Repeat(new string('0', 20), 4));
+        string pdf = string.Join("\n", new[] {
+            "%PDF-1.7",
+            "1 0 obj",
+            "<< /Type /Catalog /Pages 2 0 R /AcroForm 5 0 R >>",
+            "endobj",
+            "2 0 obj",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "endobj",
+            "3 0 obj",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 8 0 R /Annots [4 0 R] >>",
+            "endobj",
+            "4 0 obj",
+            "<< /FT /Sig /T (Approval) /V 6 0 R /Subtype /Widget /Rect [0 0 0 0] >>",
+            "endobj",
+            "5 0 obj",
+            "<< /Fields [4 0 R] /SigFlags 3 >>",
+            "endobj",
+            "6 0 obj",
+            "<< /Type /Sig /Filter /Adobe.PPKLite /SubFilter /adbe.pkcs7.detached /ByteRange [" + rangePlaceholder + "] /Contents <" + zeros + "> /Contents 7 0 R >>",
+            "endobj",
+            "7 0 obj",
+            "<" + zeros + ">",
+            "endobj",
+            "8 0 obj",
+            "<< /Length 0 >>\nstream\n\nendstream",
+            "endobj",
+            "trailer",
+            "<< /Root 1 0 R /Size 9 >>",
+            "%%EOF"
+        });
+        int literalStart = pdf.IndexOf("/Contents <" + zeros + ">", StringComparison.Ordinal) + "/Contents ".Length;
+        int literalEnd = literalStart + zeros.Length + 2;
+        string byteRange = string.Join(" ", new[] {
+            0L,
+            (long)literalStart,
+            (long)literalEnd,
+            (long)pdf.Length - literalEnd
+        }.Select(static value => value.ToString("00000000000000000000", System.Globalization.CultureInfo.InvariantCulture)));
+        return System.Text.Encoding.ASCII.GetBytes(pdf.Replace(rangePlaceholder, byteRange));
     }
 
     private sealed class ChunkedNonSeekableStream : Stream {

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfOutlineTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfOutlineTests.cs
@@ -38,6 +38,8 @@ public class PdfOutlineTests {
         Assert.Throws<ArgumentNullException>(() => canvas.Outline(null!, 1, 0D));
         Assert.Throws<ArgumentException>(() => canvas.Outline(" ", 1, 0D));
         Assert.Throws<ArgumentOutOfRangeException>(() => canvas.Outline("Title", 0, 0D));
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            canvas.Outline("Too deep", PdfPageCanvas.MaximumOutlineLevel + 1, 0D));
         Assert.Throws<ArgumentOutOfRangeException>(() => canvas.Outline("Title", 1, double.NaN));
     }
 

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfPublicApiContractTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfPublicApiContractTests.cs
@@ -129,7 +129,7 @@ public sealed class PdfPublicApiContractTests {
                 BindingFlags.DeclaredOnly).Length);
 
         Assert.InRange(exportedTypes.Length, 1, 500);
-        Assert.InRange(publicMemberCount, 1, 9850);
+        Assert.InRange(publicMemberCount, 1, 9900);
 
         string[] officeReferences = assembly.GetReferencedAssemblies()
             .Select(reference => reference.Name)

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfReadLimitTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfReadLimitTests.cs
@@ -484,6 +484,22 @@ public class PdfReadLimitTests {
     }
 
     [Fact]
+    public void TryDecodeRejectsLzwPredictorStreamsInsteadOfScanningIntermediateBytes() {
+        var dictionary = new PdfDictionary();
+        dictionary.Items["Filter"] = new PdfName("LZWDecode");
+        var decodeParameters = new PdfDictionary();
+        decodeParameters.Items["Predictor"] = new PdfNumber(12);
+        decodeParameters.Items["Columns"] = new PdfNumber(4);
+        dictionary.Items["DecodeParms"] = decodeParameters;
+        byte[] encoded = PackNineBitCodes(new[] { 256, 0, 65, 66, 67, 68, 257 });
+
+        bool decoded = StreamDecoder.TryDecode(dictionary, encoded, 1024, out byte[] output);
+
+        Assert.False(decoded);
+        Assert.Empty(output);
+    }
+
+    [Fact]
     public void AsciiDecodersStopBeforeMaterializingOutputBeyondBudget() {
         var hexDictionary = new PdfDictionary();
         hexDictionary.Items["Filter"] = new PdfName("ASCIIHexDecode");

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfReadLimitTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfReadLimitTests.cs
@@ -484,7 +484,7 @@ public class PdfReadLimitTests {
     }
 
     [Fact]
-    public void TryDecodeRejectsLzwPredictorStreamsInsteadOfScanningIntermediateBytes() {
+    public void TryDecodeAppliesLzwPredictorWithinTheOutputBudget() {
         var dictionary = new PdfDictionary();
         dictionary.Items["Filter"] = new PdfName("LZWDecode");
         var decodeParameters = new PdfDictionary();
@@ -495,8 +495,8 @@ public class PdfReadLimitTests {
 
         bool decoded = StreamDecoder.TryDecode(dictionary, encoded, 1024, out byte[] output);
 
-        Assert.False(decoded);
-        Assert.Empty(output);
+        Assert.True(decoded);
+        Assert.Equal(new byte[] { 65, 66, 67, 68 }, output);
     }
 
     [Fact]

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfSanitizerTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfSanitizerTests.cs
@@ -20,6 +20,7 @@ public class PdfSanitizerTests {
         Assert.Contains(result.RemovedFindings, finding => finding.Kind == PdfSanitizationFindingKind.ActiveAction && finding.Detail == "Launch");
         Assert.Contains(result.RemovedFindings, finding => finding.Kind == PdfSanitizationFindingKind.ActiveAction && finding.Detail == "SubmitForm");
         Assert.Contains(result.RemovedFindings, finding => finding.Kind == PdfSanitizationFindingKind.ActiveAction && finding.Detail == "GoToR");
+        Assert.Contains(result.RemovedFindings, finding => finding.Kind == PdfSanitizationFindingKind.ActiveAction && finding.Detail == "GoToE");
         Assert.Contains(result.RemovedFindings, finding => finding.Kind == PdfSanitizationFindingKind.ActiveAction && finding.Detail == "ImportData");
         Assert.Contains(result.RemovedFindings, finding => finding.Kind == PdfSanitizationFindingKind.UnsafeUri && finding.Detail == "javascript:alert('unsafe')");
         Assert.Contains(result.RemovedFindings, finding => finding.Kind == PdfSanitizationFindingKind.RichMedia && finding.Detail == "RichMedia");
@@ -96,7 +97,7 @@ public class PdfSanitizerTests {
         string pdf = string.Join("\n", new[] {
             "%PDF-1.7",
             "1 0 obj",
-            "<< /Type /Catalog /Pages 2 0 R /Names << /JavaScript << /Names [(Open) 6 0 R] >> >> /AA << /WC 12 0 R /WS 13 0 R >> >>",
+            "<< /Type /Catalog /Pages 2 0 R /Names << /JavaScript << /Names [(Open) 6 0 R] >> >> /AA << /WC 12 0 R /WS 13 0 R /WP 14 0 R >> >>",
             "endobj",
             "2 0 obj",
             "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
@@ -137,8 +138,11 @@ public class PdfSanitizerTests {
             "13 0 obj",
             "<< /S /ImportData /F (form-data.fdf) >>",
             "endobj",
+            "14 0 obj",
+            "<< /S /GoToE /F << /F (embedded.pdf) >> /D [0 /Fit] >>",
+            "endobj",
             "trailer",
-            "<< /Root 1 0 R /Size 14 >>",
+            "<< /Root 1 0 R /Size 15 >>",
             "%%EOF"
         }) + "\n";
 

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfSignatureMutationAnalyzerTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfSignatureMutationAnalyzerTests.cs
@@ -134,6 +134,42 @@ public class PdfSignatureMutationAnalyzerTests {
         Assert.False(report.AllExistingSignaturesArePreserved);
     }
 
+    [Fact]
+    public void Analyze_DoesNotTraversePageContentThroughSignatureWidgetBacklink() {
+        string sourceText = Encoding.ASCII.GetString(PdfRewritePreservationTestSupport.BuildSignedIncrementalProofPdf())
+            .Replace("/Subtype /Widget /Rect", "/Subtype /Widget /P 3 0 R /Rect", StringComparison.Ordinal)
+            .Replace(
+                "<< /Length 0 >>\nstream\n\nendstream",
+                "<< /Length 1048577 >>\nstream\n" + new string('q', 1_048_577) + "\nendstream",
+                StringComparison.Ordinal);
+        byte[] source = Encoding.ASCII.GetBytes(sourceText);
+        byte[] updated = AppendMetadataWithoutPolicy(source, "Later metadata");
+
+        PdfSignatureMutationReport report = PdfSignatureMutationAnalyzer.Analyze(
+            source,
+            updated,
+            PdfMutationOperation.UpdateMetadata);
+
+        PdfSignatureMutationResult result = Assert.Single(report.Signatures);
+        Assert.True(result.ActiveDefinitionPreserved);
+        Assert.True(result.IsStructurallyPreserved);
+    }
+
+    [Fact]
+    public void Analyze_StillComparesNestedDocMdpPermissionValues() {
+        byte[] source = PdfRewritePreservationTestSupport.BuildSignedIncrementalProofPdf();
+        byte[] changed = ReplaceFirst(source, "/MDP << /P 2", "/MDP << /P 3");
+
+        PdfSignatureMutationReport report = PdfSignatureMutationAnalyzer.Analyze(
+            source,
+            changed,
+            PdfMutationOperation.UpdateMetadata);
+
+        PdfSignatureMutationResult result = Assert.Single(report.Signatures);
+        Assert.False(result.ActiveDefinitionPreserved);
+        Assert.False(result.IsStructurallyPreserved);
+    }
+
     private static byte[] ReplaceFirst(byte[] source, string oldValue, string newValue) {
         byte[] oldBytes = Encoding.ASCII.GetBytes(oldValue);
         byte[] newBytes = Encoding.ASCII.GetBytes(newValue);

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfSignatureMutationAnalyzerTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfSignatureMutationAnalyzerTests.cs
@@ -137,11 +137,10 @@ public class PdfSignatureMutationAnalyzerTests {
     [Fact]
     public void Analyze_DoesNotTraversePageContentThroughSignatureWidgetBacklink() {
         string sourceText = Encoding.ASCII.GetString(PdfRewritePreservationTestSupport.BuildSignedIncrementalProofPdf())
-            .Replace("/Subtype /Widget /Rect", "/Subtype /Widget /P 3 0 R /Rect", StringComparison.Ordinal)
+            .Replace("/Subtype /Widget /Rect", "/Subtype /Widget /P 3 0 R /Rect")
             .Replace(
                 "<< /Length 0 >>\nstream\n\nendstream",
-                "<< /Length 1048577 >>\nstream\n" + new string('q', 1_048_577) + "\nendstream",
-                StringComparison.Ordinal);
+                "<< /Length 1048577 >>\nstream\n" + new string('q', 1_048_577) + "\nendstream");
         byte[] source = Encoding.ASCII.GetBytes(sourceText);
         byte[] updated = AppendMetadataWithoutPolicy(source, "Later metadata");
 

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfSignatureMutationAnalyzerTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfSignatureMutationAnalyzerTests.cs
@@ -101,6 +101,39 @@ public class PdfSignatureMutationAnalyzerTests {
         Assert.True(report.RevisionChainExtended);
     }
 
+    [Fact]
+    public void Analyze_RejectsSupersededActiveSignatureDictionary() {
+        byte[] source = PdfRewritePreservationTestSupport.BuildSignedIncrementalProofPdf();
+        PdfDocumentSecurityInfo security = PdfSyntax.ReadDocumentSecurityInfo(source);
+        PdfSignatureInfo signature = Assert.Single(security.Signatures);
+        var (objects, trailerRaw) = PdfSyntax.ParseObjects(source);
+        string byteRange = string.Join(" ", signature.ByteRangeValues.Select(value =>
+            value.ToString(System.Globalization.CultureInfo.InvariantCulture)));
+        string contents = ToHex(signature.ContentsBytes ?? Array.Empty<byte>());
+        byte[] replacement = PdfObjectBytes.WrapIndirectObject(
+            signature.ObjectNumber,
+            "<< /Type /Sig /Filter /Tampered.Handler /SubFilter /adbe.pkcs7.detached /ByteRange [" +
+            byteRange + "] /Contents <" + contents + "> >>");
+        byte[] superseded = PdfIncrementalObjectWriter.Append(
+            source,
+            objects,
+            security,
+            trailerRaw,
+            rawObjects: new[] { (signature.ObjectNumber, replacement) });
+
+        PdfSignatureMutationReport report = PdfSignatureMutationAnalyzer.Analyze(
+            source,
+            superseded,
+            PdfMutationOperation.UpdateMetadata);
+
+        PdfSignatureMutationResult result = Assert.Single(report.Signatures);
+        Assert.True(report.OriginalBytesArePrefix);
+        Assert.True(result.ByteRangePreserved);
+        Assert.False(result.ActiveDefinitionPreserved);
+        Assert.False(result.IsStructurallyPreserved);
+        Assert.False(report.AllExistingSignaturesArePreserved);
+    }
+
     private static byte[] ReplaceFirst(byte[] source, string oldValue, string newValue) {
         byte[] oldBytes = Encoding.ASCII.GetBytes(oldValue);
         byte[] newBytes = Encoding.ASCII.GetBytes(newValue);
@@ -116,6 +149,14 @@ public class PdfSignatureMutationAnalyzerTests {
         }
 
         throw new InvalidOperationException("Expected signature marker was not found.");
+    }
+
+    private static string ToHex(byte[] bytes) {
+        var builder = new StringBuilder(bytes.Length * 2);
+        for (int index = 0; index < bytes.Length; index++) {
+            builder.Append(bytes[index].ToString("X2", System.Globalization.CultureInfo.InvariantCulture));
+        }
+        return builder.ToString();
     }
 
     private static byte[] AppendMetadataWithoutPolicy(byte[] source, string title) {

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfStructuredExportTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfStructuredExportTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Text.Json;
 using System.Xml.Linq;
 using OfficeIMO.Pdf;
@@ -77,5 +78,38 @@ public class PdfStructuredExportTests {
         string json = PdfDocument.Open(source, readOptions).Read.ExportStructured(PdfStructuredExportFormat.Json);
 
         Assert.Contains("Encrypted structured output", json, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void XmlStructuredExportsReplaceXmlInvalidPdfText() {
+        const string content = "BT /F1 12 Tf 10 100 Td <010203> Tj ET";
+        const string toUnicode = "1 begincodespacerange\n<00> <FF>\nendcodespacerange\n" +
+            "3 beginbfchar\n<01> <006200650066006F00720065>\n<02> <D800>\n<03> <00610066007400650072>\nendbfchar";
+        string rawPdf = string.Join("\n", new[] {
+            "%PDF-1.4",
+            "1 0 obj", "<< /Type /Catalog /Pages 2 0 R >>", "endobj",
+            "2 0 obj", "<< /Type /Pages /Count 1 /Kids [3 0 R] >>", "endobj",
+            "3 0 obj", "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>", "endobj",
+            "4 0 obj", "<< /Length " + Encoding.ASCII.GetByteCount(content) + " >>", "stream",
+            content, "endstream", "endobj",
+            "5 0 obj", "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /ToUnicode 6 0 R >>", "endobj",
+            "6 0 obj", "<< /Length " + Encoding.ASCII.GetByteCount(toUnicode) + " >>", "stream",
+            toUnicode, "endstream", "endobj",
+            "trailer", "<< /Root 1 0 R /Size 7 >>", "%%EOF"
+        });
+        byte[] source = Encoding.ASCII.GetBytes(rawPdf);
+        PdfLogicalDocument logical = PdfLogicalDocument.Load(source);
+        Assert.Contains("\uD800", logical.Pages[0].TextBlocks[0].Text, StringComparison.Ordinal);
+
+        string alto = logical.ExportStructured(PdfStructuredExportFormat.AltoXml);
+        string hocr = logical.ExportStructured(PdfStructuredExportFormat.Hocr);
+        string pageXml = logical.ExportStructured(PdfStructuredExportFormat.PageXml);
+
+        Assert.NotNull(XDocument.Parse(alto));
+        Assert.NotNull(XDocument.Parse(hocr));
+        Assert.NotNull(XDocument.Parse(pageXml));
+        Assert.DoesNotContain("\uD800", alto, StringComparison.Ordinal);
+        Assert.DoesNotContain("\uD800", hocr, StringComparison.Ordinal);
+        Assert.DoesNotContain("\uD800", pageXml, StringComparison.Ordinal);
     }
 }

--- a/OfficeIMO.Pdf/Core/PdfDocument.Operations.cs
+++ b/OfficeIMO.Pdf/Core/PdfDocument.Operations.cs
@@ -85,7 +85,12 @@ public sealed partial class PdfDocument {
         IEnumerable<string>? fieldNames = null,
         PdfReadOptions? options = null,
         PdfMutationExecutionPreference executionPreference = PdfMutationExecutionPreference.Automatic) {
-        return PdfMutationPlanner.Plan(Preflight(options), operation, fieldNames, executionPreference);
+        var snapshot = GetReadSnapshot(options);
+        PdfDocumentPreflight preflight = PdfInspector.Preflight(
+            snapshot.Bytes,
+            snapshot.Options,
+            () => snapshot.Document);
+        return PdfMutationPlanner.Plan(preflight, snapshot.Bytes, operation, fieldNames, executionPreference);
     }
 
     /// <summary>
@@ -111,10 +116,19 @@ public sealed partial class PdfDocument {
         }
         if (requested.Length == 0) throw new ArgumentException("At least one mutation operation is required.", nameof(operations));
         string[]? requestedFieldNames = fieldNames?.ToArray();
-        PdfDocumentPreflight preflight = Preflight(options);
+        var snapshot = GetReadSnapshot(options);
+        PdfDocumentPreflight preflight = PdfInspector.Preflight(
+            snapshot.Bytes,
+            snapshot.Options,
+            () => snapshot.Document);
         var plans = new PdfMutationPlan[requested.Length];
         for (int index = 0; index < requested.Length; index++) {
-            plans[index] = PdfMutationPlanner.Plan(preflight, requested[index], requestedFieldNames, executionPreference);
+            plans[index] = PdfMutationPlanner.Plan(
+                preflight,
+                snapshot.Bytes,
+                requested[index],
+                requestedFieldNames,
+                executionPreference);
         }
         return new PdfMutationPortfolioReport(preflight, Array.AsReadOnly(plans));
     }

--- a/OfficeIMO.Pdf/Manipulation/PdfFormData.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfFormData.cs
@@ -19,5 +19,13 @@ internal static class PdfFormData {
     internal static byte[] Import(byte[] pdf, PdfFormDataSet data, PdfFormFillerOptions? options, PdfReadOptions? readOptions) { Guard.NotNull(data, nameof(data)); return PdfFormFiller.FillFields(pdf, data.ToFieldValues(), options, readOptions); }
     /// <summary>Imports XFDF through the validated full-rewrite filler.</summary>
     public static byte[] ImportXfdf(byte[] pdf, string xfdf, PdfFormFillerOptions? options = null) => ImportXfdf(pdf, xfdf, options, readOptions: null);
-    internal static byte[] ImportXfdf(byte[] pdf, string xfdf, PdfFormFillerOptions? options, PdfReadOptions? readOptions) => Import(pdf, PdfFormDataSet.ParseXfdf(xfdf), options, readOptions);
+    internal static byte[] ImportXfdf(byte[] pdf, string xfdf, PdfFormFillerOptions? options, PdfReadOptions? readOptions) {
+        PdfFormFillerOptions effective = options ?? new PdfFormFillerOptions();
+        PdfFormDataSet data = PdfFormDataSet.ParseXfdf(
+            xfdf,
+            effective.MaxXfdfFields,
+            effective.MaxXfdfValueCharacters,
+            effective.MaxXfdfDocumentCharacters);
+        return Import(pdf, data, effective, readOptions);
+    }
 }

--- a/OfficeIMO.Pdf/Manipulation/PdfFormDataSet.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfFormDataSet.cs
@@ -18,6 +18,13 @@ public sealed class PdfFormDataField {
 
 /// <summary>Dependency-free AcroForm data set with typed and XFDF interchange.</summary>
 public sealed class PdfFormDataSet {
+    /// <summary>Default maximum XFDF source length accepted before XML materialization.</summary>
+    public const int DefaultMaxXfdfDocumentCharacters = 8_000_000;
+    /// <summary>Default maximum number of XFDF fields.</summary>
+    public const int DefaultMaxXfdfFields = 100_000;
+    /// <summary>Default maximum aggregate XFDF value length.</summary>
+    public const int DefaultMaxXfdfValueCharacters = 4_000_000;
+
     private readonly PdfFormDataField[] _fields;
     /// <summary>Creates a unique-name data set.</summary>
     public PdfFormDataSet(IEnumerable<PdfFormDataField> fields) {
@@ -45,12 +52,19 @@ public sealed class PdfFormDataSet {
         return builder.ToString();
     }
     /// <summary>Parses bounded, DTD-free XFDF field data.</summary>
-    public static PdfFormDataSet ParseXfdf(string xfdf, int maxFields = 100000, int maxValueCharacters = 4000000) {
+    public static PdfFormDataSet ParseXfdf(
+        string xfdf,
+        int maxFields = DefaultMaxXfdfFields,
+        int maxValueCharacters = DefaultMaxXfdfValueCharacters,
+        int maxDocumentCharacters = DefaultMaxXfdfDocumentCharacters) {
         Guard.NotNull(xfdf, nameof(xfdf));
 #pragma warning disable CA1512 // ThrowIfNegativeOrZero is unavailable on every target framework.
-        if (maxFields <= 0) throw new ArgumentOutOfRangeException(nameof(maxFields)); if (maxValueCharacters <= 0) throw new ArgumentOutOfRangeException(nameof(maxValueCharacters));
+        if (maxFields <= 0) throw new ArgumentOutOfRangeException(nameof(maxFields));
+        if (maxValueCharacters <= 0) throw new ArgumentOutOfRangeException(nameof(maxValueCharacters));
+        if (maxDocumentCharacters <= 0) throw new ArgumentOutOfRangeException(nameof(maxDocumentCharacters));
 #pragma warning restore CA1512
-        var settings = new System.Xml.XmlReaderSettings { DtdProcessing = System.Xml.DtdProcessing.Prohibit, XmlResolver = null, MaxCharactersInDocument = Math.Max(maxValueCharacters, xfdf.Length) };
+        if (xfdf.Length > maxDocumentCharacters) throw new InvalidOperationException("XFDF document character limit exceeded.");
+        var settings = new System.Xml.XmlReaderSettings { DtdProcessing = System.Xml.DtdProcessing.Prohibit, XmlResolver = null, MaxCharactersInDocument = maxDocumentCharacters };
         var document = new System.Xml.XmlDocument { XmlResolver = null };
         using (var reader = System.Xml.XmlReader.Create(new StringReader(xfdf), settings)) {
             document.Load(reader);

--- a/OfficeIMO.Pdf/Manipulation/PdfFormFillerOptions.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfFormFillerOptions.cs
@@ -9,6 +9,15 @@ public sealed class PdfFormFillerOptions {
     private PdfConversionReport? _diagnosticsReport;
     private string _diagnosticsConverter = "OfficeIMO.Pdf";
 
+    /// <summary>Maximum XFDF source length accepted before XML materialization.</summary>
+    public int MaxXfdfDocumentCharacters { get; set; } = PdfFormDataSet.DefaultMaxXfdfDocumentCharacters;
+
+    /// <summary>Maximum number of fields accepted from one XFDF document.</summary>
+    public int MaxXfdfFields { get; set; } = PdfFormDataSet.DefaultMaxXfdfFields;
+
+    /// <summary>Maximum aggregate length of values accepted from one XFDF document.</summary>
+    public int MaxXfdfValueCharacters { get; set; } = PdfFormDataSet.DefaultMaxXfdfValueCharacters;
+
     /// <summary>
     /// When true, keeps the AcroForm /NeedAppearances flag set after filling fields for legacy viewers that ignore normal appearance streams.
     /// </summary>

--- a/OfficeIMO.Pdf/Manipulation/PdfIncrementalUpdater.Signatures.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfIncrementalUpdater.Signatures.cs
@@ -497,7 +497,7 @@ internal static partial class PdfIncrementalUpdater {
             return false;
         }
 
-        int objectEnd = IndexOf(pdf, PdfEncoding.Latin1GetBytes("endobj"), contentsMarkerOffset);
+        int objectEnd = FindContainingObjectEnd(pdf, objectStart, contentsMarkerOffset);
         if (objectEnd < 0 || objectEnd < contentsLiteralEndExclusive) {
             return false;
         }
@@ -606,26 +606,91 @@ internal static partial class PdfIncrementalUpdater {
         value == (byte)'/' || value == (byte)'%';
 
     private static int FindContainingObjectStart(byte[] pdf, int offset) {
-        int searchOffset = 0;
+        int index = 0;
         int objectStart = -1;
-        while (true) {
-            int candidate = IndexOf(pdf, PdfEncoding.Latin1GetBytes(" obj"), searchOffset, offset);
-            if (candidate < 0) {
-                return objectStart;
+        while (index < offset) {
+            if (SkipPdfLexicalValue(pdf, ref index, offset)) continue;
+            if (objectStart >= 0 && MatchesPdfKeyword(pdf, index, offset, "endobj")) {
+                objectStart = -1;
+                index += 6;
+                continue;
             }
-
-            objectStart = FindLineStart(pdf, candidate);
-            searchOffset = candidate + 4;
+            if (objectStart < 0 && TryMatchIndirectObjectHeader(pdf, index, offset)) {
+                objectStart = index;
+            }
+            index++;
         }
+
+        return objectStart;
     }
 
-    private static int FindLineStart(byte[] bytes, int offset) {
-        int index = offset;
-        while (index > 0 && bytes[index - 1] != (byte)'\n' && bytes[index - 1] != (byte)'\r') {
-            index--;
+    private static int FindContainingObjectEnd(byte[] pdf, int objectStart, int minimumOffset) {
+        int index = objectStart;
+        while (index < pdf.Length) {
+            if (SkipPdfLexicalValue(pdf, ref index, pdf.Length)) continue;
+            if (index >= minimumOffset && MatchesPdfKeyword(pdf, index, pdf.Length, "endobj")) {
+                return index;
+            }
+            index++;
         }
 
-        return index;
+        return -1;
+    }
+
+    private static bool SkipPdfLexicalValue(byte[] pdf, ref int index, int endExclusive) {
+        byte value = pdf[index];
+        if (value == (byte)'%') {
+            while (index < endExclusive && pdf[index] != (byte)'\r' && pdf[index] != (byte)'\n') index++;
+            return true;
+        }
+        if (value == (byte)'(') {
+            SkipPdfLiteralString(pdf, ref index, endExclusive);
+            return true;
+        }
+        if (value == (byte)'<' && (index + 1 >= endExclusive || pdf[index + 1] != (byte)'<')) {
+            index++;
+            while (index < endExclusive && pdf[index] != (byte)'>') index++;
+            if (index < endExclusive) index++;
+            return true;
+        }
+        return false;
+    }
+
+    private static bool TryMatchIndirectObjectHeader(byte[] pdf, int offset, int endExclusive) {
+        if (offset > 0 && !IsPdfWhitespace(pdf[offset - 1])) return false;
+        int index = offset;
+        if (!TrySkipUnsignedInteger(pdf, ref index, endExclusive, requirePositive: true) ||
+            !SkipRequiredPdfWhitespace(pdf, ref index, endExclusive) ||
+            !TrySkipUnsignedInteger(pdf, ref index, endExclusive, requirePositive: false) ||
+            !SkipRequiredPdfWhitespace(pdf, ref index, endExclusive)) {
+            return false;
+        }
+        return MatchesPdfKeyword(pdf, index, endExclusive, "obj");
+    }
+
+    private static bool TrySkipUnsignedInteger(byte[] pdf, ref int index, int endExclusive, bool requirePositive) {
+        int start = index;
+        bool nonZero = false;
+        while (index < endExclusive && pdf[index] >= (byte)'0' && pdf[index] <= (byte)'9') {
+            nonZero |= pdf[index] != (byte)'0';
+            index++;
+        }
+        return index > start && (!requirePositive || nonZero);
+    }
+
+    private static bool SkipRequiredPdfWhitespace(byte[] pdf, ref int index, int endExclusive) {
+        int start = index;
+        while (index < endExclusive && IsPdfWhitespace(pdf[index])) index++;
+        return index > start;
+    }
+
+    private static bool MatchesPdfKeyword(byte[] pdf, int offset, int endExclusive, string keyword) {
+        if (offset > 0 && pdf[offset - 1] == (byte)'/') return false;
+        if (offset > 0 && !IsPdfWhitespace(pdf[offset - 1]) && !IsPdfDelimiter(pdf[offset - 1])) return false;
+        byte[] expected = PdfEncoding.Latin1GetBytes(keyword);
+        if (!MatchesAt(pdf, expected, offset, endExclusive)) return false;
+        int after = offset + expected.Length;
+        return after >= endExclusive || IsPdfWhitespace(pdf[after]) || IsPdfDelimiter(pdf[after]);
     }
 
     private static bool IsZeroFilled(byte[] bytes, int offset, int length) {

--- a/OfficeIMO.Pdf/Manipulation/PdfIncrementalUpdater.Signatures.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfIncrementalUpdater.Signatures.cs
@@ -503,7 +503,8 @@ internal static partial class PdfIncrementalUpdater {
         }
 
         if (!TryReadIndirectObjectNumber(pdf, objectStart, objectEnd, out objectNumber) ||
-            CountPdfName(pdf, "/Contents", objectStart, objectEnd) != 1) {
+            !TryFindSolePdfNameOffset(pdf, "/Contents", objectStart, objectEnd, out int contentsNameOffset) ||
+            contentsNameOffset != contentsMarkerOffset) {
             return false;
         }
 
@@ -532,18 +533,68 @@ internal static partial class PdfIncrementalUpdater {
         return index > digitStart && objectNumber > 0 && index < objectEnd && IsPdfWhitespace(pdf[index]);
     }
 
-    private static int CountPdfName(byte[] pdf, string name, int start, int endExclusive) {
+    private static bool TryFindSolePdfNameOffset(
+        byte[] pdf,
+        string name,
+        int start,
+        int endExclusive,
+        out int nameOffset) {
         byte[] marker = PdfEncoding.Latin1GetBytes(name);
-        int count = 0;
-        int searchOffset = start;
-        while (searchOffset < endExclusive) {
-            int found = IndexOf(pdf, marker, searchOffset, endExclusive);
-            if (found < 0) return count;
-            int after = found + marker.Length;
-            if (after >= endExclusive || IsPdfWhitespace(pdf[after]) || IsPdfDelimiter(pdf[after])) count++;
-            searchOffset = after;
+        nameOffset = -1;
+        int index = start;
+        while (index < endExclusive) {
+            byte value = pdf[index];
+            if (value == (byte)'%') {
+                while (index < endExclusive && pdf[index] != (byte)'\r' && pdf[index] != (byte)'\n') index++;
+                continue;
+            }
+            if (value == (byte)'(') {
+                SkipPdfLiteralString(pdf, ref index, endExclusive);
+                continue;
+            }
+            if (value == (byte)'<' && index + 1 < endExclusive && pdf[index + 1] == (byte)'<') {
+                index += 2;
+                continue;
+            }
+            if (value == (byte)'<') {
+                index++;
+                while (index < endExclusive && pdf[index] != (byte)'>') index++;
+                if (index < endExclusive) index++;
+                continue;
+            }
+            if (value == (byte)'/' && MatchesAt(pdf, marker, index, endExclusive)) {
+                int after = index + marker.Length;
+                if (after >= endExclusive || IsPdfWhitespace(pdf[after]) || IsPdfDelimiter(pdf[after])) {
+                    if (nameOffset >= 0) return false;
+                    nameOffset = index;
+                }
+            }
+            index++;
         }
-        return count;
+        return nameOffset >= 0;
+    }
+
+    private static void SkipPdfLiteralString(byte[] pdf, ref int index, int endExclusive) {
+        int depth = 1;
+        index++;
+        while (index < endExclusive && depth > 0) {
+            byte value = pdf[index++];
+            if (value == (byte)'\\') {
+                if (index < endExclusive) index++;
+            } else if (value == (byte)'(') {
+                depth++;
+            } else if (value == (byte)')') {
+                depth--;
+            }
+        }
+    }
+
+    private static bool MatchesAt(byte[] value, byte[] expected, int offset, int endExclusive) {
+        if (offset < 0 || offset > endExclusive - expected.Length) return false;
+        for (int index = 0; index < expected.Length; index++) {
+            if (value[offset + index] != expected[index]) return false;
+        }
+        return true;
     }
 
     private static bool IsPdfWhitespace(byte value) =>

--- a/OfficeIMO.Pdf/Manipulation/PdfIncrementalUpdater.Signatures.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfIncrementalUpdater.Signatures.cs
@@ -146,11 +146,7 @@ internal static partial class PdfIncrementalUpdater {
         Guard.NotNull(preparedPdf, nameof(preparedPdf));
         Guard.NotNull(signatureContents, nameof(signatureContents));
         _ = PdfReadDocument.Open(preparedPdf, readOptions);
-        _ = PdfMutationPlanner.RequireAppendOnly(
-            preparedPdf,
-            PdfMutationOperation.FinalizeExternalSignature,
-            readOptions);
-        int placeholderCount = FindZeroFilledSignatureContents(preparedPdf, out int contentsHexOffset, out int contentsHexLength);
+        int placeholderCount = FindZeroFilledSignatureContents(preparedPdf, out int contentsHexOffset, out int contentsHexLength, out _);
         if (placeholderCount == 0) {
             throw new ArgumentException("PDF does not contain a zero-filled external signature /Contents placeholder.", nameof(preparedPdf));
         }
@@ -159,7 +155,60 @@ internal static partial class PdfIncrementalUpdater {
             throw new ArgumentException("PDF contains multiple zero-filled external signature placeholders. Complete the intended PdfExternalSignaturePreparation instead.", nameof(preparedPdf));
         }
 
+        _ = PdfMutationPlanner.RequireAppendOnly(
+            preparedPdf,
+            PdfMutationOperation.FinalizeExternalSignature,
+            readOptions);
         return ApplyExternalSignature(preparedPdf, signatureContents, contentsHexOffset, contentsHexLength);
+    }
+
+    internal static bool HasFinalizableExternalSignatureReservation(
+        byte[] preparedPdf,
+        PdfDocumentSecurityInfo security) {
+        int placeholderCount = FindZeroFilledSignatureContents(preparedPdf, out int contentsHexOffset, out int contentsHexLength, out int placeholderObjectNumber);
+        if (placeholderCount != 1 || contentsHexLength <= 0 || (contentsHexLength & 1) != 0) return false;
+
+        long contentsLiteralStart = contentsHexOffset - 1L;
+        long contentsLiteralEnd = contentsHexOffset + (long)contentsHexLength + 1L;
+        if (contentsLiteralStart < 0L || contentsLiteralEnd > preparedPdf.LongLength) return false;
+
+        PdfSignatureInfo[] candidates = security.Signatures.Where(signature =>
+            signature.ObjectNumber == placeholderObjectNumber &&
+            signature.HasUnsignedContentsPlaceholder &&
+            signature.ContentsSizeBytes == contentsHexLength / 2 &&
+            HasExactFinalizationByteRange(signature.ByteRangeValues, contentsLiteralStart, contentsLiteralEnd, preparedPdf.LongLength)).ToArray();
+        if (candidates.Length != 1) return false;
+
+        PdfSignatureInfo candidate = candidates[0];
+        for (int index = 0; index < security.Signatures.Count; index++) {
+            PdfSignatureInfo signature = security.Signatures[index];
+            if (ReferenceEquals(signature, candidate)) continue;
+            if (ByteRangesOverlap(signature.ByteRangeValues, contentsLiteralStart, contentsLiteralEnd)) return false;
+        }
+        return true;
+    }
+
+    private static bool HasExactFinalizationByteRange(
+        IReadOnlyList<long> values,
+        long contentsLiteralStart,
+        long contentsLiteralEnd,
+        long fileLength) =>
+        values.Count == 4 &&
+        values[0] == 0L &&
+        values[1] == contentsLiteralStart &&
+        values[2] == contentsLiteralEnd &&
+        values[3] == fileLength - contentsLiteralEnd;
+
+    private static bool ByteRangesOverlap(IReadOnlyList<long> values, long start, long end) {
+        if ((values.Count & 1) != 0) return true;
+        for (int index = 0; index < values.Count; index += 2) {
+            long rangeStart = values[index];
+            long rangeLength = values[index + 1];
+            if (rangeStart < 0L || rangeLength < 0L || rangeStart > long.MaxValue - rangeLength) return true;
+            long rangeEnd = rangeStart + rangeLength;
+            if (rangeStart < end && rangeEnd > start) return true;
+        }
+        return false;
     }
 
     /// <summary>Injects externally produced CMS/CAdES/TSA bytes into a prepared signature placeholder in a file.</summary>
@@ -391,9 +440,14 @@ internal static partial class PdfIncrementalUpdater {
         return builder.ToString();
     }
 
-    private static int FindZeroFilledSignatureContents(byte[] pdf, out int contentsHexOffset, out int contentsHexLength) {
+    private static int FindZeroFilledSignatureContents(
+        byte[] pdf,
+        out int contentsHexOffset,
+        out int contentsHexLength,
+        out int contentsObjectNumber) {
         contentsHexOffset = 0;
         contentsHexLength = 0;
+        contentsObjectNumber = 0;
         int placeholderCount = 0;
         byte[] marker = PdfEncoding.Latin1GetBytes("/Contents <");
         int searchOffset = 0;
@@ -418,10 +472,11 @@ internal static partial class PdfIncrementalUpdater {
                 pdf[end] == (byte)'>' &&
                 end > start &&
                 IsZeroFilled(pdf, start, end - start) &&
-                IsSignatureContentsPlaceholder(pdf, markerOffset, end + 1)) {
+                IsSignatureContentsPlaceholder(pdf, markerOffset, end + 1, out int objectNumber)) {
                 if (placeholderCount == 0) {
                     contentsHexOffset = start;
                     contentsHexLength = end - start;
+                    contentsObjectNumber = objectNumber;
                 }
 
                 placeholderCount++;
@@ -431,7 +486,12 @@ internal static partial class PdfIncrementalUpdater {
         }
     }
 
-    private static bool IsSignatureContentsPlaceholder(byte[] pdf, int contentsMarkerOffset, int contentsLiteralEndExclusive) {
+    private static bool IsSignatureContentsPlaceholder(
+        byte[] pdf,
+        int contentsMarkerOffset,
+        int contentsLiteralEndExclusive,
+        out int objectNumber) {
+        objectNumber = 0;
         int objectStart = FindContainingObjectStart(pdf, contentsMarkerOffset);
         if (objectStart < 0) {
             return false;
@@ -442,12 +502,57 @@ internal static partial class PdfIncrementalUpdater {
             return false;
         }
 
+        if (!TryReadIndirectObjectNumber(pdf, objectStart, objectEnd, out objectNumber) ||
+            CountPdfName(pdf, "/Contents", objectStart, objectEnd) != 1) {
+            return false;
+        }
+
         bool hasSignatureType =
             IndexOf(pdf, PdfEncoding.Latin1GetBytes("/Type /Sig"), objectStart, objectEnd) >= 0 ||
             IndexOf(pdf, PdfEncoding.Latin1GetBytes("/Type /DocTimeStamp"), objectStart, objectEnd) >= 0;
         return hasSignatureType &&
             IndexOf(pdf, PdfEncoding.Latin1GetBytes("/ByteRange ["), objectStart, objectEnd) >= 0;
     }
+
+    private static bool TryReadIndirectObjectNumber(
+        byte[] pdf,
+        int objectStart,
+        int objectEnd,
+        out int objectNumber) {
+        objectNumber = 0;
+        int index = objectStart;
+        while (index < objectEnd && IsPdfWhitespace(pdf[index])) index++;
+        int digitStart = index;
+        while (index < objectEnd && pdf[index] >= (byte)'0' && pdf[index] <= (byte)'9') {
+            int digit = pdf[index] - (byte)'0';
+            if (objectNumber > (int.MaxValue - digit) / 10) return false;
+            objectNumber = (objectNumber * 10) + digit;
+            index++;
+        }
+        return index > digitStart && objectNumber > 0 && index < objectEnd && IsPdfWhitespace(pdf[index]);
+    }
+
+    private static int CountPdfName(byte[] pdf, string name, int start, int endExclusive) {
+        byte[] marker = PdfEncoding.Latin1GetBytes(name);
+        int count = 0;
+        int searchOffset = start;
+        while (searchOffset < endExclusive) {
+            int found = IndexOf(pdf, marker, searchOffset, endExclusive);
+            if (found < 0) return count;
+            int after = found + marker.Length;
+            if (after >= endExclusive || IsPdfWhitespace(pdf[after]) || IsPdfDelimiter(pdf[after])) count++;
+            searchOffset = after;
+        }
+        return count;
+    }
+
+    private static bool IsPdfWhitespace(byte value) =>
+        value == 0 || value == (byte)'\t' || value == (byte)'\n' || value == (byte)'\f' || value == (byte)'\r' || value == (byte)' ';
+
+    private static bool IsPdfDelimiter(byte value) =>
+        value == (byte)'(' || value == (byte)')' || value == (byte)'<' || value == (byte)'>' ||
+        value == (byte)'[' || value == (byte)']' || value == (byte)'{' || value == (byte)'}' ||
+        value == (byte)'/' || value == (byte)'%';
 
     private static int FindContainingObjectStart(byte[] pdf, int offset) {
         int searchOffset = 0;

--- a/OfficeIMO.Pdf/Manipulation/PdfMerger.CatalogPolicy.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfMerger.CatalogPolicy.cs
@@ -38,11 +38,23 @@ internal static partial class PdfMerger {
 
     private static byte[] ApplyCatalogStatePolicy(byte[] merged, IReadOnlyList<ImportedSource> sources, int primarySourceIndex, PdfMergeStructureMode mode, List<PdfMergeDecision> decisions) {
         int incoming = sources.Where((source, index) => index != primarySourceIndex && HasCatalogState(source)).Count();
+        bool incomingOptionalContent = sources.Where((source, index) => index != primarySourceIndex)
+            .Any(static source => source.CatalogState.OptionalContent != null);
+        bool anyOptionalContent = sources.Any(static source => source.CatalogState.OptionalContent != null);
+        if (mode == PdfMergeStructureMode.KeepPrimary && incomingOptionalContent) {
+            throw new NotSupportedException("Keeping only the primary PDF optional-content configuration is blocked because incoming pages can reference hidden layers whose visibility state would be discarded.");
+        }
         if (mode == PdfMergeStructureMode.KeepPrimary) { decisions.Add(new PdfMergeDecision("CatalogState", mode, "Kept primary compatible catalog state.", droppedCount: incoming)); return merged; }
         if (mode == PdfMergeStructureMode.RejectIncoming) {
             if (incoming > 0) throw new InvalidOperationException("PDF merge policy rejected incoming catalog state from " + incoming + " source(s).");
             decisions.Add(new PdfMergeDecision("CatalogState", mode, "No incoming catalog state was present; kept primary catalog state."));
             return merged;
+        }
+        if (mode == PdfMergeStructureMode.Combine && anyOptionalContent) {
+            throw new NotSupportedException("Combining PDF optional-content configurations is blocked because rebuilding them with an all-visible default can expose content that a source intentionally hid.");
+        }
+        if (mode == PdfMergeStructureMode.Drop && anyOptionalContent) {
+            throw new NotSupportedException("Dropping PDF optional-content configuration is blocked because page content can remain associated with hidden layers and become visible without its source visibility state.");
         }
 
         string? version = mode == PdfMergeStructureMode.Combine ? FirstCatalogValue(sources, primarySourceIndex, static document => document.CatalogVersion) : null;
@@ -59,14 +71,12 @@ internal static partial class PdfMerger {
                 if (uri != null) catalog.Items["URI"] = uri;
                 PdfArray intents = CombineOutputIntents(sources, objects, externalMap, ref nextObjectNumber);
                 if (intents.Items.Count > 0) catalog.Items["OutputIntents"] = intents;
-                PdfDictionary? optionalContent = BuildMergedOptionalContent(objects);
-                if (optionalContent != null) catalog.Items["OCProperties"] = optionalContent;
             }
             return security.InfoObjectNumber.HasValue && objects.ContainsKey(security.InfoObjectNumber.Value) ? security.InfoObjectNumber : null;
         });
         string action = mode == PdfMergeStructureMode.Drop
             ? "Removed version, language, URI, output-intent, and optional-content catalog state."
-            : "Combined compatible scalar, URI, and output-intent state; rebuilt page-owned optional-content groups with a deterministic all-visible default.";
+            : "Combined compatible scalar, URI, and output-intent state after rejecting sources with optional-content configurations.";
         decisions.Add(new PdfMergeDecision("CatalogState", mode, action, incoming));
         return output;
     }
@@ -124,20 +134,6 @@ internal static partial class PdfMerger {
             foreach (PdfObject item in array.Items) result.Items.Add(CloneExternalObject(item, sourceIndex, sources[sourceIndex].Objects, targetObjects, map, ref next));
         }
         return result;
-    }
-
-    private static PdfDictionary? BuildMergedOptionalContent(Dictionary<int, PdfIndirectObject> objects) {
-        var groups = objects.Values
-            .Where(static item => item.Value is PdfDictionary dictionary && dictionary.Get<PdfName>("Type")?.Name == "OCG")
-            .OrderBy(static item => item.ObjectNumber)
-            .Select(static item => new PdfReference(item.ObjectNumber, item.Generation))
-            .ToArray();
-        if (groups.Length == 0) return null;
-        var groupArray = new PdfArray(); var order = new PdfArray(); var on = new PdfArray();
-        foreach (PdfReference group in groups) { groupArray.Items.Add(group); order.Items.Add(group); on.Items.Add(group); }
-        var defaults = new PdfDictionary(); defaults.Items["Name"] = new PdfStringObj("Merged layers", true); defaults.Items["Order"] = order; defaults.Items["ON"] = on;
-        var properties = new PdfDictionary(); properties.Items["OCGs"] = groupArray; properties.Items["D"] = defaults;
-        return properties;
     }
 
     private static PdfObject CloneExternalObject(PdfObject value, int sourceIndex, Dictionary<int, PdfIndirectObject> sourceObjects, Dictionary<int, PdfIndirectObject> targetObjects, Dictionary<ExternalObjectKey, int> map, ref int next) {

--- a/OfficeIMO.Pdf/Manipulation/PdfMerger.Policy.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfMerger.Policy.cs
@@ -16,7 +16,7 @@ internal static partial class PdfMerger {
             source.Document.NamedDestinations.Count,
             source.Document.PageLabels.Count,
             source.Document.FormFields.Count,
-            PdfAttachmentExtractor.ExtractAttachments(source.Document).Count,
+            source.Document.Attachments.Count,
             source.SourceSecurity,
             source.SourcePermissionPolicy)).ToArray();
         var decisions = new List<PdfMergeDecision>();
@@ -121,11 +121,14 @@ internal static partial class PdfMerger {
         PdfMergeStructureMode mode,
         PdfMergeCollisionMode collisionMode,
         List<PdfMergeDecision> decisions) {
-        IReadOnlyList<PdfExtractedAttachment>[] sourceAttachments = sources.Select(source => PdfAttachmentExtractor.ExtractAttachments(source.Document)).ToArray();
-        int incomingCount = sourceAttachments.Where((_, index) => index != primarySourceIndex).Sum(static items => items.Count);
+        int[] sourceAttachmentCounts = sources.Select(static source => source.Document.Attachments.Count).ToArray();
+        int incomingCount = sourceAttachmentCounts.Where((_, index) => index != primarySourceIndex).Sum();
         switch (mode) {
             case PdfMergeStructureMode.KeepPrimary:
-                if (incomingCount > 0) merged = ReplaceAttachments(merged, ConvertAttachments(sourceAttachments[primarySourceIndex]));
+                if (incomingCount > 0) {
+                    IReadOnlyList<PdfExtractedAttachment> primaryAttachments = PdfAttachmentExtractor.ExtractAttachments(sources[primarySourceIndex].Document);
+                    merged = ReplaceAttachments(merged, ConvertAttachments(primaryAttachments));
+                }
                 decisions.Add(new PdfMergeDecision("Attachments", mode, "Kept primary attachments.", droppedCount: incomingCount));
                 return merged;
             case PdfMergeStructureMode.RejectIncoming:
@@ -133,10 +136,11 @@ internal static partial class PdfMerger {
                 decisions.Add(new PdfMergeDecision("Attachments", mode, "No incoming attachments were present."));
                 return merged;
             case PdfMergeStructureMode.Drop:
-                if (sourceAttachments.Sum(static items => items.Count) > 0) merged = ReplaceAttachments(merged, Array.Empty<PdfEmbeddedFile>());
+                if (sourceAttachmentCounts.Sum() > 0) merged = ReplaceAttachments(merged, Array.Empty<PdfEmbeddedFile>());
                 decisions.Add(new PdfMergeDecision("Attachments", mode, "Removed embedded and associated files."));
                 return merged;
             case PdfMergeStructureMode.Combine:
+                IReadOnlyList<PdfExtractedAttachment>[] sourceAttachments = sources.Select(source => PdfAttachmentExtractor.ExtractAttachments(source.Document)).ToArray();
                 var renamed = new List<string>();
                 int dropped = 0;
                 IReadOnlyList<PdfEmbeddedFile> combined = CombineAttachments(sourceAttachments, collisionMode, renamed, ref dropped);

--- a/OfficeIMO.Pdf/Manipulation/PdfMutationPlanner.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfMutationPlanner.cs
@@ -41,7 +41,10 @@ internal static class PdfMutationPlanner {
         IEnumerable<string>? fieldNames = null,
         PdfMutationExecutionPreference executionPreference = PdfMutationExecutionPreference.Automatic) {
         Guard.NotNull(pdf, nameof(pdf));
-        return Plan(PdfInspector.Preflight(pdf, options), operation, fieldNames, executionPreference);
+        PdfDocumentPreflight preflight = PdfInspector.Preflight(pdf, options);
+        bool finalizationReservationValidated = operation != PdfMutationOperation.FinalizeExternalSignature ||
+            PdfIncrementalUpdater.HasFinalizableExternalSignatureReservation(pdf, preflight.Probe.Security);
+        return PlanCore(preflight, operation, fieldNames, executionPreference, finalizationReservationValidated);
     }
 
     /// <summary>Plans a mutation for a readable PDF stream.</summary>
@@ -98,6 +101,20 @@ internal static class PdfMutationPlanner {
         IEnumerable<string>? fieldNames = null,
         PdfMutationExecutionPreference executionPreference = PdfMutationExecutionPreference.Automatic) {
         Guard.NotNull(preflight, nameof(preflight));
+        return PlanCore(
+            preflight,
+            operation,
+            fieldNames,
+            executionPreference,
+            finalizationReservationValidated: operation != PdfMutationOperation.FinalizeExternalSignature);
+    }
+
+    private static PdfMutationPlan PlanCore(
+        PdfDocumentPreflight preflight,
+        PdfMutationOperation operation,
+        IEnumerable<string>? fieldNames,
+        PdfMutationExecutionPreference executionPreference,
+        bool finalizationReservationValidated) {
         ValidateOperation(operation);
         ValidateExecutionPreference(executionPreference);
 
@@ -118,7 +135,9 @@ internal static class PdfMutationPlanner {
             (securityRewrite ||
                 (!requiresAppendOnly &&
                 (!security.BlocksOfficeIMOFullRewriteMutation || unsignedSignatureFieldRewrite || normalizedObjectGraphRewrite || authorizedEncryptedRewrite || CanExtractPagesViaNormalization(preflight, operation))));
-        bool appendOnlyAvailable = appendOnlyImplemented && CanAppend(appendOnly, operation);
+        bool appendOnlyAvailable = appendOnlyImplemented &&
+            CanAppend(appendOnly, operation, finalizationReservationValidated) &&
+            !BlocksActiveContentPreservingMutation(preflight, operation);
 
         PdfMutationExecutionMode mode;
         if (executionPreference == PdfMutationExecutionPreference.RequireFullRewrite) {
@@ -141,6 +160,13 @@ internal static class PdfMutationPlanner {
         IReadOnlyList<string> blockers = mode == PdfMutationExecutionMode.Blocked
             ? GetBlockerCodes(preflight, appendOnly, operation, fullRewriteImplemented, appendOnlyImplemented, security)
             : Array.Empty<string>();
+        if (mode == PdfMutationExecutionMode.Blocked &&
+            operation == PdfMutationOperation.FinalizeExternalSignature &&
+            !finalizationReservationValidated) {
+            var reservationBlockers = blockers.ToList();
+            Add(reservationBlockers, "SignatureReservation.Invalid");
+            blockers = reservationBlockers.AsReadOnly();
+        }
         IReadOnlyList<PdfMutationCapabilityRecord> capabilityRecords = BuildCapabilityRecords(
             operation,
             structures,
@@ -211,7 +237,7 @@ internal static class PdfMutationPlanner {
         }
     }
 
-    private static bool CanAppend(PdfAppendOnlyMutationReport report, PdfMutationOperation operation) {
+    private static bool CanAppend(PdfAppendOnlyMutationReport report, PdfMutationOperation operation, bool finalizationReservationValidated) {
         switch (operation) {
             case PdfMutationOperation.UpdateMetadata:
                 return report.CanAppendMetadata;
@@ -220,7 +246,7 @@ internal static class PdfMutationPlanner {
             case PdfMutationOperation.PrepareExternalSignature:
                 return report.CanPrepareExternalSignature;
             case PdfMutationOperation.FinalizeExternalSignature:
-                return report.Security.Signatures.Any(static signature => signature.HasUnsignedContentsPlaceholder);
+                return finalizationReservationValidated && report.Security.Signatures.Any(static signature => signature.HasUnsignedContentsPlaceholder);
             case PdfMutationOperation.EnrichLongTermValidation:
                 return report.CanAppendLongTermValidation;
             case PdfMutationOperation.ModifyAnnotations:
@@ -228,6 +254,13 @@ internal static class PdfMutationPlanner {
             default:
                 return false;
         }
+    }
+
+    private static bool BlocksActiveContentPreservingMutation(PdfDocumentPreflight preflight, PdfMutationOperation operation) {
+        if (operation != PdfMutationOperation.UpdateMetadata && operation != PdfMutationOperation.FillFormFields) {
+            return false;
+        }
+        return preflight.Probe.HasActiveContent || preflight.UncheckedDocumentInfo?.HasActiveContent == true;
     }
 
     private static bool IsFullRewriteImplemented(PdfMutationOperation operation) {

--- a/OfficeIMO.Pdf/Manipulation/PdfMutationPlanner.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfMutationPlanner.cs
@@ -42,9 +42,7 @@ internal static class PdfMutationPlanner {
         PdfMutationExecutionPreference executionPreference = PdfMutationExecutionPreference.Automatic) {
         Guard.NotNull(pdf, nameof(pdf));
         PdfDocumentPreflight preflight = PdfInspector.Preflight(pdf, options);
-        bool finalizationReservationValidated = operation != PdfMutationOperation.FinalizeExternalSignature ||
-            PdfIncrementalUpdater.HasFinalizableExternalSignatureReservation(pdf, preflight.Probe.Security);
-        return PlanCore(preflight, operation, fieldNames, executionPreference, finalizationReservationValidated);
+        return Plan(preflight, pdf, operation, fieldNames, executionPreference);
     }
 
     /// <summary>Plans a mutation for a readable PDF stream.</summary>
@@ -107,6 +105,20 @@ internal static class PdfMutationPlanner {
             fieldNames,
             executionPreference,
             finalizationReservationValidated: operation != PdfMutationOperation.FinalizeExternalSignature);
+    }
+
+    /// <summary>Plans a mutation from a shared preflight while retaining source bytes for reservation validation.</summary>
+    internal static PdfMutationPlan Plan(
+        PdfDocumentPreflight preflight,
+        byte[] pdf,
+        PdfMutationOperation operation,
+        IEnumerable<string>? fieldNames = null,
+        PdfMutationExecutionPreference executionPreference = PdfMutationExecutionPreference.Automatic) {
+        Guard.NotNull(preflight, nameof(preflight));
+        Guard.NotNull(pdf, nameof(pdf));
+        bool finalizationReservationValidated = operation != PdfMutationOperation.FinalizeExternalSignature ||
+            PdfIncrementalUpdater.HasFinalizableExternalSignatureReservation(pdf, preflight.Probe.Security);
+        return PlanCore(preflight, operation, fieldNames, executionPreference, finalizationReservationValidated);
     }
 
     private static PdfMutationPlan PlanCore(

--- a/OfficeIMO.Pdf/Manipulation/PdfPageEditor.DestructiveCrop.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageEditor.DestructiveCrop.cs
@@ -47,7 +47,7 @@ internal static partial class PdfPageEditor {
                 var resources = new PdfDictionary(); resources.Items["XObject"] = xObjects;
                 page.Items["Resources"] = resources;
                 page.Items["Contents"] = new PdfReference(contentNumber, 0);
-                page.Items.Remove("Annots"); page.Items.Remove("StructParents");
+                page.Items.Remove("Annots"); page.Items.Remove("StructParents"); page.Items.Remove("Thumb");
             }
             return security.InfoObjectNumber.HasValue && objects.ContainsKey(security.InfoObjectNumber.Value) ? security.InfoObjectNumber : null;
         });

--- a/OfficeIMO.Pdf/Manipulation/PdfRewritePreservation.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfRewritePreservation.cs
@@ -170,6 +170,7 @@ public static partial class PdfRewritePreservation {
             CompareString(issues, prefix + ".Relationship", before.Relationship.ToString(), after.Relationship.ToString());
             CompareString(issues, prefix + ".Filter", before.Filter, after.Filter);
             CompareCounts(issues, prefix + ".SizeBytes", before.SizeBytes, after.SizeBytes, true);
+            CompareNullableInt(issues, prefix + ".DeclaredSizeBytes", before.DeclaredSizeBytes, after.DeclaredSizeBytes);
             CompareString(issues, prefix + ".Source", before.Source, after.Source);
         }
     }

--- a/OfficeIMO.Pdf/Manipulation/PdfSanitizer.Traversal.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfSanitizer.Traversal.cs
@@ -1,10 +1,6 @@
 namespace OfficeIMO.Pdf;
 
 internal static partial class PdfSanitizer {
-    private static readonly HashSet<string> UnsafeActionTypes = new HashSet<string>(StringComparer.Ordinal) {
-        "JavaScript", "Launch", "GoToR", "SubmitForm", "ImportData", "Movie", "Rendition", "RichMedia"
-    };
-
     private static readonly HashSet<string> RichAnnotationSubtypes = new HashSet<string>(StringComparer.Ordinal) {
         "RichMedia", "Movie", "Sound", "Screen", "3D", "FileAttachment"
     };
@@ -229,7 +225,7 @@ internal static partial class PdfSanitizer {
             return false;
         }
 
-        if (!UnsafeActionTypes.Contains(actionType) || policy.IsActionAllowed(actionType)) {
+        if (!PdfActiveContentPolicy.IsUnsafeActionType(actionType) || policy.IsActionAllowed(actionType)) {
             return false;
         }
 

--- a/OfficeIMO.Pdf/Model/PdfPageCanvas.cs
+++ b/OfficeIMO.Pdf/Model/PdfPageCanvas.cs
@@ -6,6 +6,9 @@ namespace OfficeIMO.Pdf;
 /// Builds foreground page content at absolute top-left page coordinates in the order items are added.
 /// </summary>
 public sealed class PdfPageCanvas {
+    /// <summary>Maximum supported outline hierarchy depth.</summary>
+    public const int MaximumOutlineLevel = 64;
+
     private readonly List<PdfCanvasItem> _items = new();
     private readonly bool _allowOutOfPageCoordinates;
 
@@ -36,8 +39,8 @@ public sealed class PdfPageCanvas {
             throw new ArgumentException("Canvas outline titles cannot be empty or whitespace.", nameof(title));
         }
 
-        if (level <= 0) {
-            throw new ArgumentOutOfRangeException(nameof(level), "Canvas outline levels must be positive.");
+        if (level <= 0 || level > MaximumOutlineLevel) {
+            throw new ArgumentOutOfRangeException(nameof(level), "Canvas outline levels must be between 1 and " + MaximumOutlineLevel + ".");
         }
 
         ValidateCanvasCoordinate(y, nameof(y));

--- a/OfficeIMO.Pdf/Reading/Core/PdfActiveContentPolicy.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfActiveContentPolicy.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+
+namespace OfficeIMO.Pdf;
+
+internal static class PdfActiveContentPolicy {
+    private static readonly HashSet<string> UnsafeActionTypes = new(StringComparer.Ordinal) {
+        "JavaScript", "Launch", "GoToR", "GoToE", "SubmitForm", "ImportData", "Movie", "Rendition", "RichMedia"
+    };
+
+    internal static readonly string[] MarkerNames = {
+        "JavaScript", "JS", "AA", "Launch", "GoToR", "GoToE", "SubmitForm", "ImportData", "Movie", "Rendition", "RichMedia"
+    };
+
+    internal static bool IsUnsafeActionType(string actionType) => UnsafeActionTypes.Contains(actionType);
+}

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.Attachments.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.Attachments.cs
@@ -6,30 +6,6 @@ public sealed partial class PdfReadDocument {
 
     private IReadOnlyList<PdfAttachmentInfo> ExtractAttachmentInfos() {
         // Catalog inspection must remain available for preflight even when payload extraction is restricted.
-        IReadOnlyList<PdfExtractedAttachment> attachments = PdfAttachmentExtractor.ExtractAttachments(_objects, _trailerRaw, _options.Limits);
-        if (attachments.Count == 0) {
-            return Array.Empty<PdfAttachmentInfo>();
-        }
-
-        var result = new List<PdfAttachmentInfo>(attachments.Count);
-        for (int i = 0; i < attachments.Count; i++) {
-            PdfExtractedAttachment attachment = attachments[i];
-            result.Add(new PdfAttachmentInfo(
-                attachment.Name,
-                attachment.FileName,
-                attachment.UnicodeFileName,
-                attachment.Description,
-                attachment.MimeType,
-                attachment.Relationship,
-                attachment.Filter,
-                attachment.FileSpecObjectNumber,
-                attachment.EmbeddedFileObjectNumber,
-                attachment.ByteLength,
-                attachment.Source,
-                attachment.CreationDate,
-                attachment.ModificationDate));
-        }
-
-        return result.AsReadOnly();
+        return PdfAttachmentExtractor.InspectAttachments(_objects, _trailerRaw, _options.Limits);
     }
 }

--- a/OfficeIMO.Pdf/Reading/Core/PdfSyntax.Markers.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfSyntax.Markers.cs
@@ -561,12 +561,12 @@ internal static partial class PdfSyntax {
         Guard.NotNull(pdf, nameof(pdf));
 
         if (options is not null) {
-            return ContainsAnyParsedPdfName(pdf, options, "JavaScript", "JS", "AA", "Launch", "SubmitForm", "RichMedia");
+            return ContainsAnyParsedPdfName(pdf, options, PdfActiveContentPolicy.MarkerNames);
         }
 
         string text = PdfEncoding.Latin1GetString(pdf);
-        return ContainsAnyPdfName(text, "JavaScript", "JS", "AA", "Launch", "SubmitForm", "RichMedia") ||
-            ContainsAnyParsedPdfName(pdf, "JavaScript", "JS", "AA", "Launch", "SubmitForm", "RichMedia");
+        return ContainsAnyPdfName(text, PdfActiveContentPolicy.MarkerNames) ||
+            ContainsAnyParsedPdfName(pdf, PdfActiveContentPolicy.MarkerNames);
     }
 
     internal static string? GetHeaderVersion(byte[] pdf) {

--- a/OfficeIMO.Pdf/Reading/Filters/StreamDecoder.cs
+++ b/OfficeIMO.Pdf/Reading/Filters/StreamDecoder.cs
@@ -137,13 +137,11 @@ internal static class StreamDecoder {
 
                         break;
                     case DecodeFilterKind.Lzw:
-                        if (HasActiveDecodeParms(dict, filterIndex, objects)) {
-                            return false;
-                        }
-
                         if (!LzwDecoder.TryDecode(current, maxOutputBytes, out current, GetEarlyChange(dict, filterIndex, objects))) {
                             return false;
                         }
+
+                        current = ApplyDecodeParms(dict, filterIndex, current, objects, maxOutputBytes);
 
                         break;
                     default:

--- a/OfficeIMO.Pdf/Reading/Filters/StreamDecoder.cs
+++ b/OfficeIMO.Pdf/Reading/Filters/StreamDecoder.cs
@@ -137,6 +137,10 @@ internal static class StreamDecoder {
 
                         break;
                     case DecodeFilterKind.Lzw:
+                        if (HasActiveDecodeParms(dict, filterIndex, objects)) {
+                            return false;
+                        }
+
                         if (!LzwDecoder.TryDecode(current, maxOutputBytes, out current, GetEarlyChange(dict, filterIndex, objects))) {
                             return false;
                         }

--- a/OfficeIMO.Pdf/Reading/Interaction/PdfLayoutDebugOverlay.cs
+++ b/OfficeIMO.Pdf/Reading/Interaction/PdfLayoutDebugOverlay.cs
@@ -60,9 +60,21 @@ internal static class PdfLayoutDebugOverlay {
         PdfLayoutDebugOverlayOptions? options = null,
         PdfTextLayoutOptions? layoutOptions = null,
         PdfReadOptions? readOptions = null) {
-        return OfficeDrawingRasterRenderer.ToPng(
-            CreateDrawing(pdf, pageNumber, options, layoutOptions, readOptions),
-            scale);
+        PdfLayoutDebugOverlayOptions effective = options ?? new PdfLayoutDebugOverlayOptions();
+        if (scale <= 0D || double.IsNaN(scale) || double.IsInfinity(scale)) {
+            throw new ArgumentOutOfRangeException(nameof(scale), "Overlay PNG scale must be positive and finite.");
+        }
+        if (effective.MaxRasterPixels <= 0L) {
+            throw new ArgumentOutOfRangeException(nameof(options), "Maximum overlay raster pixels must be positive.");
+        }
+        OfficeDrawing drawing = CreateDrawing(pdf, pageNumber, effective, layoutOptions, readOptions);
+        double width = Math.Ceiling(drawing.Width * scale);
+        double height = Math.Ceiling(drawing.Height * scale);
+        double pixels = width * height;
+        if (double.IsNaN(pixels) || double.IsInfinity(pixels) || pixels > effective.MaxRasterPixels) {
+            throw new InvalidOperationException("PDF layout overlay exceeds the configured raster pixel limit.");
+        }
+        return OfficeDrawingRasterRenderer.ToPng(drawing, scale);
     }
 
     private static void AddWords(

--- a/OfficeIMO.Pdf/Reading/Interaction/PdfLayoutDebugOverlayOptions.cs
+++ b/OfficeIMO.Pdf/Reading/Interaction/PdfLayoutDebugOverlayOptions.cs
@@ -4,6 +4,9 @@ namespace OfficeIMO.Pdf;
 
 /// <summary>Controls the shared-Drawing layout diagnostics projected over one PDF page.</summary>
 public sealed class PdfLayoutDebugOverlayOptions {
+    /// <summary>Default maximum number of pixels allocated by one PNG overlay.</summary>
+    public const long DefaultMaxRasterPixels = 64_000_000;
+
     /// <summary>Draw boxes around whitespace-delimited words.</summary>
     public bool ShowWords { get; set; } = true;
 
@@ -18,6 +21,9 @@ public sealed class PdfLayoutDebugOverlayOptions {
 
     /// <summary>Maximum boxes and labels added to one overlay.</summary>
     public int MaxElements { get; set; } = 20000;
+
+    /// <summary>Maximum number of pixels allocated when rasterizing one overlay.</summary>
+    public long MaxRasterPixels { get; set; } = DefaultMaxRasterPixels;
 
     /// <summary>Word-box color.</summary>
     public OfficeColor WordColor { get; set; } = OfficeColor.FromRgb(40, 120, 220);

--- a/OfficeIMO.Pdf/Reading/Logical/PdfStructuredExportEngine.cs
+++ b/OfficeIMO.Pdf/Reading/Logical/PdfStructuredExportEngine.cs
@@ -99,7 +99,7 @@ internal static class PdfStructuredExportEngine {
                     new XElement(
                         alto + "String",
                         new XAttribute("ID", "string_" + (pageIndex + 1) + "_" + (lineIndex + 1)),
-                        new XAttribute("CONTENT", line.Text),
+                        new XAttribute("CONTENT", XmlText(line.Text)),
                         BoxAttributes(line))));
             }
 
@@ -140,7 +140,7 @@ internal static class PdfStructuredExportEngine {
                     new XAttribute("class", "ocr_line"),
                     new XAttribute("id", "line_" + (pageIndex + 1) + "_" + (lineIndex + 1)),
                     new XAttribute("title", "bbox " + Integer(line.X) + " " + Integer(line.Y) + " " + Integer(line.X + line.Width) + " " + Integer(line.Y + line.Height)),
-                    line.Text));
+                    XmlText(line.Text)));
             }
 
             body.Add(pageElement);
@@ -173,7 +173,7 @@ internal static class PdfStructuredExportEngine {
                 pageNs + "TextLine",
                 new XAttribute("id", "line_" + pageIndex + "_" + (lineIndex + 1)),
                 new XElement(pageNs + "Coords", new XAttribute("points", Points(line))),
-                new XElement(pageNs + "TextEquiv", new XElement(pageNs + "Unicode", line.Text))));
+                new XElement(pageNs + "TextEquiv", new XElement(pageNs + "Unicode", XmlText(line.Text)))));
         }
 
         return new XDocument(
@@ -225,6 +225,34 @@ internal static class PdfStructuredExportEngine {
     private static string Number(double value) => value.ToString("0.###", CultureInfo.InvariantCulture);
 
     private static string Integer(double value) => Math.Max(0, (int)Math.Ceiling(value)).ToString(CultureInfo.InvariantCulture);
+
+    private static string XmlText(string value) {
+        StringBuilder? builder = null;
+        for (int i = 0; i < value.Length; i++) {
+            char current = value[i];
+            bool valid = current == '\t' || current == '\n' || current == '\r' ||
+                current >= ' ' && current <= '\uD7FF' ||
+                current >= '\uE000' && current <= '\uFFFD';
+            if (valid) {
+                builder?.Append(current);
+                continue;
+            }
+            if (char.IsHighSurrogate(current) && i + 1 < value.Length && char.IsLowSurrogate(value[i + 1])) {
+                if (builder != null) {
+                    builder.Append(current).Append(value[++i]);
+                } else {
+                    i++;
+                }
+                continue;
+            }
+            if (builder == null) {
+                builder = new StringBuilder(value.Length);
+                builder.Append(value, 0, i);
+            }
+            builder.Append('\uFFFD');
+        }
+        return builder?.ToString() ?? value;
+    }
 
     private static string Json(string value) {
         var builder = new StringBuilder(value.Length + 8);

--- a/OfficeIMO.Pdf/Reading/Model/PdfAttachmentInfo.cs
+++ b/OfficeIMO.Pdf/Reading/Model/PdfAttachmentInfo.cs
@@ -14,7 +14,8 @@ public sealed class PdfAttachmentInfo {
         string filter,
         int fileSpecObjectNumber,
         int embeddedFileObjectNumber,
-        int sizeBytes,
+        int encodedSizeBytes,
+        int? declaredSizeBytes,
         string source,
         DateTimeOffset? creationDate,
         DateTimeOffset? modificationDate) {
@@ -27,7 +28,8 @@ public sealed class PdfAttachmentInfo {
         Filter = filter;
         FileSpecObjectNumber = fileSpecObjectNumber;
         EmbeddedFileObjectNumber = embeddedFileObjectNumber;
-        SizeBytes = sizeBytes;
+        EncodedSizeBytes = encodedSizeBytes;
+        DeclaredSizeBytes = declaredSizeBytes;
         Source = source;
         CreationDate = creationDate;
         ModificationDate = modificationDate;
@@ -60,8 +62,26 @@ public sealed class PdfAttachmentInfo {
     /// <summary>Object number of the embedded file stream, or 0 for a direct stream.</summary>
     public int EmbeddedFileObjectNumber { get; }
 
-    /// <summary>Decoded attachment payload size in bytes.</summary>
-    public int SizeBytes { get; }
+    /// <summary>
+    /// Encoded attachment stream size in bytes. This is a compatibility alias for <see cref="EncodedSizeBytes"/>;
+    /// it is not the decoded attachment size when stream filters are present.
+    /// </summary>
+    public int SizeBytes => EncodedSizeBytes;
+
+    /// <summary>Exact encoded attachment stream size stored in the PDF.</summary>
+    public int EncodedSizeBytes { get; }
+
+    /// <summary>
+    /// Untrusted decoded-size claim from the embedded-file /Params /Size entry, when present.
+    /// Callers must not use this value as a resource limit.
+    /// </summary>
+    public int? DeclaredSizeBytes { get; }
+
+    /// <summary>
+    /// Decoded attachment size is unknown during metadata-only inspection. Extract the attachment under
+    /// <see cref="PdfReadLimits.MaxTotalAttachmentBytes"/> and inspect its payload length when the exact value is required.
+    /// </summary>
+    public int? DecodedSizeBytes { get; }
 
     /// <summary>Catalog source that referenced this attachment, for example Names/EmbeddedFiles or AF.</summary>
     public string Source { get; }

--- a/OfficeIMO.Pdf/Reading/PdfAttachmentExtractor.cs
+++ b/OfficeIMO.Pdf/Reading/PdfAttachmentExtractor.cs
@@ -78,16 +78,46 @@ internal static class PdfAttachmentExtractor {
     }
 
     internal static IReadOnlyList<PdfExtractedAttachment> ExtractAttachments(Dictionary<int, PdfIndirectObject> objects, string trailerRaw, PdfReadLimits? limits = null) {
-        Guard.NotNull(objects, nameof(objects));
-        PdfReadLimits effectiveLimits = limits ?? new PdfReadLimits();
-        effectiveLimits.Validate();
-        PdfDictionary? catalog = PdfSyntax.FindCatalog(objects, trailerRaw);
-        if (catalog is null) {
+        IReadOnlyList<AttachmentDescriptor> descriptors = CollectAttachmentDescriptors(objects, trailerRaw, limits, out AttachmentExtractionBudget budget);
+        if (descriptors.Count == 0) {
             return Array.Empty<PdfExtractedAttachment>();
         }
 
-        var attachments = new List<PdfExtractedAttachment>();
-        var budget = new AttachmentExtractionBudget(effectiveLimits);
+        var attachments = new List<PdfExtractedAttachment>(descriptors.Count);
+        for (int index = 0; index < descriptors.Count; index++) {
+            AttachmentDescriptor descriptor = descriptors[index];
+            attachments.Add(descriptor.ToExtractedAttachment(budget.GetDecodedBytes(descriptor.Stream, objects)));
+        }
+        return attachments.AsReadOnly();
+    }
+
+    internal static IReadOnlyList<PdfAttachmentInfo> InspectAttachments(
+        Dictionary<int, PdfIndirectObject> objects,
+        string trailerRaw,
+        PdfReadLimits? limits = null) {
+        IReadOnlyList<AttachmentDescriptor> descriptors = CollectAttachmentDescriptors(objects, trailerRaw, limits, out _);
+        if (descriptors.Count == 0) {
+            return Array.Empty<PdfAttachmentInfo>();
+        }
+
+        return descriptors.Select(static descriptor => descriptor.ToAttachmentInfo()).ToArray();
+    }
+
+    private static IReadOnlyList<AttachmentDescriptor> CollectAttachmentDescriptors(
+        Dictionary<int, PdfIndirectObject> objects,
+        string trailerRaw,
+        PdfReadLimits? limits,
+        out AttachmentExtractionBudget budget) {
+        Guard.NotNull(objects, nameof(objects));
+        PdfReadLimits effectiveLimits = limits ?? new PdfReadLimits();
+        effectiveLimits.Validate();
+        budget = new AttachmentExtractionBudget(effectiveLimits);
+        PdfDictionary? catalog = PdfSyntax.FindCatalog(objects, trailerRaw);
+        if (catalog is null) {
+            return Array.Empty<AttachmentDescriptor>();
+        }
+
+        var attachments = new List<AttachmentDescriptor>();
         if (catalog.Items.TryGetValue("Names", out var namesObject) &&
             ResolveDictionary(objects, namesObject) is PdfDictionary namesDictionary &&
             namesDictionary.Items.TryGetValue("EmbeddedFiles", out var embeddedFilesTreeObject)) {
@@ -102,12 +132,12 @@ internal static class PdfAttachmentExtractor {
 
         ReadFileAttachmentAnnotations(objects, attachments, budget);
 
-        return attachments.Count == 0 ? Array.Empty<PdfExtractedAttachment>() : attachments.AsReadOnly();
+        return attachments.Count == 0 ? Array.Empty<AttachmentDescriptor>() : attachments.AsReadOnly();
     }
 
     private static void ReadFileAttachmentAnnotations(
         Dictionary<int, PdfIndirectObject> objects,
-        List<PdfExtractedAttachment> attachments,
+        List<AttachmentDescriptor> attachments,
         AttachmentExtractionBudget budget) {
         var visited = new HashSet<PdfObject>();
         var existingFileSpecs = new HashSet<int>(
@@ -122,7 +152,7 @@ internal static class PdfAttachmentExtractor {
     private static void ReadFileAttachmentAnnotations(
         Dictionary<int, PdfIndirectObject> objects,
         PdfObject value,
-        List<PdfExtractedAttachment> attachments,
+        List<AttachmentDescriptor> attachments,
         ISet<PdfObject> visited,
         ISet<int> existingFileSpecs,
         AttachmentExtractionBudget budget) {
@@ -141,7 +171,7 @@ internal static class PdfAttachmentExtractor {
                     existingFileSpecs.Contains(referencedFileSpecObjectNumber);
                 if (!alreadyDecoded) {
                     string name = TryReadFileSpecName(objects, fileSpecObject) ?? "FileAttachment";
-                    PdfExtractedAttachment? attachment = TryBuildAttachment(
+                    AttachmentDescriptor? attachment = TryBuildAttachment(
                         objects,
                         name,
                         fileSpecObject,
@@ -175,7 +205,7 @@ internal static class PdfAttachmentExtractor {
     private static void ReadEmbeddedFilesNameTree(
         Dictionary<int, PdfIndirectObject> objects,
         PdfObject treeObject,
-        List<PdfExtractedAttachment> attachments,
+        List<AttachmentDescriptor> attachments,
         HashSet<int> visitedTrees,
         AttachmentExtractionBudget budget,
         PdfReadLimits limits,
@@ -207,7 +237,7 @@ internal static class PdfAttachmentExtractor {
                 }
 
                 PdfObject fileSpecObject = names.Items[i + 1];
-                PdfExtractedAttachment? attachment = TryBuildAttachment(objects, name.Value, fileSpecObject, "Names/EmbeddedFiles", budget);
+                AttachmentDescriptor? attachment = TryBuildAttachment(objects, name.Value, fileSpecObject, "Names/EmbeddedFiles", budget);
                 if (attachment != null) {
                     attachments.Add(attachment);
                 }
@@ -224,10 +254,10 @@ internal static class PdfAttachmentExtractor {
     private static void ReadAssociatedFiles(
         Dictionary<int, PdfIndirectObject> objects,
         PdfArray associatedFiles,
-        List<PdfExtractedAttachment> attachments,
+        List<AttachmentDescriptor> attachments,
         AttachmentExtractionBudget budget) {
         var existingFileSpecs = new HashSet<int>();
-        foreach (PdfExtractedAttachment attachment in attachments) {
+        foreach (AttachmentDescriptor attachment in attachments) {
             if (attachment.FileSpecObjectNumber > 0) {
                 existingFileSpecs.Add(attachment.FileSpecObjectNumber);
             }
@@ -241,7 +271,7 @@ internal static class PdfAttachmentExtractor {
             }
 
             string name = TryReadFileSpecName(objects, fileSpecObject) ?? "AF." + i.ToString(CultureInfo.InvariantCulture);
-            PdfExtractedAttachment? attachment = TryBuildAttachment(objects, name, fileSpecObject, "AF", budget);
+            AttachmentDescriptor? attachment = TryBuildAttachment(objects, name, fileSpecObject, "AF", budget);
             if (attachment != null) {
                 attachments.Add(attachment);
                 if (attachment.FileSpecObjectNumber > 0) {
@@ -251,7 +281,7 @@ internal static class PdfAttachmentExtractor {
         }
     }
 
-    private static PdfExtractedAttachment? TryBuildAttachment(
+    private static AttachmentDescriptor? TryBuildAttachment(
         Dictionary<int, PdfIndirectObject> objects,
         string name,
         PdfObject fileSpecObject,
@@ -281,13 +311,12 @@ internal static class PdfAttachmentExtractor {
         string? mimeType = TryReadStreamSubtype(objects, stream.Dictionary);
         PdfAssociatedFileRelationship relationship = TryReadRelationship(objects, fileSpec);
         string filter = GetFilterName(objects, stream.Dictionary.Items.TryGetValue("Filter", out var filterObject) ? filterObject : null);
-        byte[] bytes = budget.GetDecodedBytes(stream, objects);
-
         PdfDictionary? parameters = ResolveDictionary(objects, stream.Dictionary.Items.TryGetValue("Params", out PdfObject? parametersObject) ? parametersObject : null);
         DateTimeOffset? creationDate = TryReadPdfDate(objects, parameters, "CreationDate");
         DateTimeOffset? modificationDate = TryReadPdfDate(objects, parameters, "ModDate");
+        int? declaredSizeBytes = TryReadDeclaredAttachmentSize(objects, parameters);
 
-        return new PdfExtractedAttachment(
+        return new AttachmentDescriptor(
             name,
             fileName,
             unicodeFileName,
@@ -297,10 +326,109 @@ internal static class PdfAttachmentExtractor {
             filter,
             fileSpecObjectNumber,
             embeddedFileObjectNumber,
-            bytes,
+            stream.Data.Length,
+            declaredSizeBytes,
+            stream,
             source,
             creationDate,
-            modificationDate,
+            modificationDate);
+    }
+
+    private static int? TryReadDeclaredAttachmentSize(
+        Dictionary<int, PdfIndirectObject> objects,
+        PdfDictionary? parameters) {
+        if (parameters is not null &&
+            parameters.Items.TryGetValue("Size", out PdfObject? sizeObject) &&
+            ResolveObject(objects, sizeObject) is PdfNumber size &&
+            size.Value >= 0D &&
+            size.Value <= int.MaxValue &&
+            Math.Floor(size.Value) == size.Value) {
+            return (int)size.Value;
+        }
+
+        return null;
+    }
+
+    private sealed class AttachmentDescriptor {
+        internal AttachmentDescriptor(
+            string name,
+            string fileName,
+            string? unicodeFileName,
+            string? description,
+            string? mimeType,
+            PdfAssociatedFileRelationship relationship,
+            string filter,
+            int fileSpecObjectNumber,
+            int embeddedFileObjectNumber,
+            int encodedSizeBytes,
+            int? declaredSizeBytes,
+            PdfStream stream,
+            string source,
+            DateTimeOffset? creationDate,
+            DateTimeOffset? modificationDate) {
+            Name = name;
+            FileName = fileName;
+            UnicodeFileName = unicodeFileName;
+            Description = description;
+            MimeType = mimeType;
+            Relationship = relationship;
+            Filter = filter;
+            FileSpecObjectNumber = fileSpecObjectNumber;
+            EmbeddedFileObjectNumber = embeddedFileObjectNumber;
+            EncodedSizeBytes = encodedSizeBytes;
+            DeclaredSizeBytes = declaredSizeBytes;
+            Stream = stream;
+            Source = source;
+            CreationDate = creationDate;
+            ModificationDate = modificationDate;
+        }
+
+        internal string Name { get; }
+        internal string FileName { get; }
+        internal string? UnicodeFileName { get; }
+        internal string? Description { get; }
+        internal string? MimeType { get; }
+        internal PdfAssociatedFileRelationship Relationship { get; }
+        internal string Filter { get; }
+        internal int FileSpecObjectNumber { get; }
+        internal int EmbeddedFileObjectNumber { get; }
+        internal int EncodedSizeBytes { get; }
+        internal int? DeclaredSizeBytes { get; }
+        internal PdfStream Stream { get; }
+        internal string Source { get; }
+        internal DateTimeOffset? CreationDate { get; }
+        internal DateTimeOffset? ModificationDate { get; }
+
+        internal PdfAttachmentInfo ToAttachmentInfo() => new(
+            Name,
+            FileName,
+            UnicodeFileName,
+            Description,
+            MimeType,
+            Relationship,
+            Filter,
+            FileSpecObjectNumber,
+            EmbeddedFileObjectNumber,
+            EncodedSizeBytes,
+            DeclaredSizeBytes,
+            Source,
+            CreationDate,
+            ModificationDate);
+
+        internal PdfExtractedAttachment ToExtractedAttachment(byte[] bytes) => new(
+            Name,
+            FileName,
+            UnicodeFileName,
+            Description,
+            MimeType,
+            Relationship,
+            Filter,
+            FileSpecObjectNumber,
+            EmbeddedFileObjectNumber,
+            bytes,
+            Source,
+            CreationDate,
+            ModificationDate,
             copyBytes: false);
     }
 

--- a/OfficeIMO.Pdf/Reading/PdfInspector.cs
+++ b/OfficeIMO.Pdf/Reading/PdfInspector.cs
@@ -381,7 +381,7 @@ internal static class PdfInspector {
             Has("OutputIntents", "OutputIntent"),
             Has("EmbeddedFiles", "Filespec", "EmbeddedFile", "AF"),
             Has("OCProperties", "OCGs", "OCG", "OCMD"),
-            Has("JavaScript", "JS", "AA", "Launch", "SubmitForm", "RichMedia"),
+            Has(PdfActiveContentPolicy.MarkerNames),
             security);
     }
 

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfInfoDictionaryBuilder.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfInfoDictionaryBuilder.cs
@@ -35,7 +35,7 @@ internal static class PdfInfoDictionaryBuilder {
         sb.Append('/')
             .Append(PdfSyntaxEscaper.Name(key))
             .Append(' ')
-            .Append(PdfSyntaxEscaper.LiteralString(value!))
+            .Append(PdfSyntaxEscaper.TextString(value!))
             .Append(' ');
     }
 

--- a/OfficeIMO.Pdf/Signatures/PdfSignatureMutationAnalyzer.cs
+++ b/OfficeIMO.Pdf/Signatures/PdfSignatureMutationAnalyzer.cs
@@ -121,9 +121,9 @@ internal static class PdfSignatureMutationAnalyzer {
         if (before.ObjectNumber != after.ObjectNumber || before.FieldObjectNumber != after.FieldObjectNumber) return false;
         int comparedNodes = 0;
         var visitedReferences = new HashSet<string>(StringComparer.Ordinal);
-        if (!TryCompareObjectGraph(before.ObjectNumber, beforeObjects, afterObjects, visitedReferences, 0, ref comparedNodes)) return false;
+        if (!TryCompareObjectGraph(before.ObjectNumber, beforeObjects, afterObjects, visitedReferences, 0, ref comparedNodes, ignorePageBacklink: false)) return false;
         return !before.FieldObjectNumber.HasValue ||
-            TryCompareObjectGraph(before.FieldObjectNumber.Value, beforeObjects, afterObjects, visitedReferences, 0, ref comparedNodes);
+            TryCompareObjectGraph(before.FieldObjectNumber.Value, beforeObjects, afterObjects, visitedReferences, 0, ref comparedNodes, ignorePageBacklink: true);
     }
 
     private static bool TryCompareObjectGraph(
@@ -132,11 +132,12 @@ internal static class PdfSignatureMutationAnalyzer {
         Dictionary<int, PdfIndirectObject> afterObjects,
         ISet<string> visitedReferences,
         int depth,
-        ref int comparedNodes) {
+        ref int comparedNodes,
+        bool ignorePageBacklink) {
         if (!beforeObjects.TryGetValue(objectNumber, out PdfIndirectObject? before) ||
             !afterObjects.TryGetValue(objectNumber, out PdfIndirectObject? after) ||
             before.Generation != after.Generation) return false;
-        return TryCompareObjectGraph(before.Value, after.Value, beforeObjects, afterObjects, visitedReferences, depth, ref comparedNodes);
+        return TryCompareObjectGraph(before.Value, after.Value, beforeObjects, afterObjects, visitedReferences, depth, ref comparedNodes, ignorePageBacklink);
     }
 
     private static bool TryCompareObjectGraph(
@@ -146,7 +147,8 @@ internal static class PdfSignatureMutationAnalyzer {
         Dictionary<int, PdfIndirectObject> afterObjects,
         ISet<string> visitedReferences,
         int depth,
-        ref int comparedNodes) {
+        ref int comparedNodes,
+        bool ignorePageBacklink = false) {
         if (depth > 64 || ++comparedNodes > 4096 || before.GetType() != after.GetType()) return false;
         if (before is PdfNull) return true;
         if (before is PdfNumber beforeNumber && after is PdfNumber afterNumber) return beforeNumber.Value.Equals(afterNumber.Value);
@@ -159,29 +161,35 @@ internal static class PdfSignatureMutationAnalyzer {
             if (beforeReference.ObjectNumber != afterReference.ObjectNumber || beforeReference.Generation != afterReference.Generation) return false;
             string key = beforeReference.ObjectNumber.ToString(System.Globalization.CultureInfo.InvariantCulture) + ":" +
                 beforeReference.Generation.ToString(System.Globalization.CultureInfo.InvariantCulture);
-            return !visitedReferences.Add(key) || TryCompareObjectGraph(beforeReference.ObjectNumber, beforeObjects, afterObjects, visitedReferences, depth + 1, ref comparedNodes);
+            return !visitedReferences.Add(key) || TryCompareObjectGraph(beforeReference.ObjectNumber, beforeObjects, afterObjects, visitedReferences, depth + 1, ref comparedNodes, ignorePageBacklink: false);
         }
         if (before is PdfArray beforeArray && after is PdfArray afterArray) {
             if (beforeArray.Items.Count != afterArray.Items.Count) return false;
             for (int index = 0; index < beforeArray.Items.Count; index++) {
-                if (!TryCompareObjectGraph(beforeArray.Items[index], afterArray.Items[index], beforeObjects, afterObjects, visitedReferences, depth + 1, ref comparedNodes)) return false;
+                if (!TryCompareObjectGraph(beforeArray.Items[index], afterArray.Items[index], beforeObjects, afterObjects, visitedReferences, depth + 1, ref comparedNodes, ignorePageBacklink: false)) return false;
             }
             return true;
         }
         if (before is PdfDictionary beforeDictionary && after is PdfDictionary afterDictionary) {
-            if (beforeDictionary.Items.Count != afterDictionary.Items.Count) return false;
+            if (CountOwnedDictionaryEntries(beforeDictionary, ignorePageBacklink) != CountOwnedDictionaryEntries(afterDictionary, ignorePageBacklink)) return false;
             foreach (KeyValuePair<string, PdfObject> entry in beforeDictionary.Items) {
+                if (ignorePageBacklink && IsContextBacklink(entry.Key)) continue;
                 if (!afterDictionary.Items.TryGetValue(entry.Key, out PdfObject? afterValue) ||
-                    !TryCompareObjectGraph(entry.Value, afterValue, beforeObjects, afterObjects, visitedReferences, depth + 1, ref comparedNodes)) return false;
+                    !TryCompareObjectGraph(entry.Value, afterValue, beforeObjects, afterObjects, visitedReferences, depth + 1, ref comparedNodes, ignorePageBacklink: false)) return false;
             }
             return true;
         }
         if (before is PdfStream beforeStream && after is PdfStream afterStream) {
             if (beforeStream.Data.Length > 1_048_576 || !beforeStream.Data.SequenceEqual(afterStream.Data)) return false;
-            return TryCompareObjectGraph(beforeStream.Dictionary, afterStream.Dictionary, beforeObjects, afterObjects, visitedReferences, depth + 1, ref comparedNodes);
+            return TryCompareObjectGraph(beforeStream.Dictionary, afterStream.Dictionary, beforeObjects, afterObjects, visitedReferences, depth + 1, ref comparedNodes, ignorePageBacklink: false);
         }
         return false;
     }
+
+    private static int CountOwnedDictionaryEntries(PdfDictionary dictionary, bool ignorePageBacklink) =>
+        dictionary.Items.Count - (ignorePageBacklink && dictionary.Items.ContainsKey("P") ? 1 : 0);
+
+    private static bool IsContextBacklink(string key) => string.Equals(key, "P", StringComparison.Ordinal);
 
     private static int[] FindRevisionEnds(byte[] pdf) {
         byte[] marker = Encoding.ASCII.GetBytes("%%EOF");

--- a/OfficeIMO.Pdf/Signatures/PdfSignatureMutationAnalyzer.cs
+++ b/OfficeIMO.Pdf/Signatures/PdfSignatureMutationAnalyzer.cs
@@ -17,6 +17,8 @@ internal static class PdfSignatureMutationAnalyzer {
         PdfSignatureValidationReport beforeValidation = PdfSignatureValidator.Validate(before, readOptions);
         PdfReadOptions afterReadOptions = PdfReadOptions.WithMinimumInputBytes(readOptions, after.LongLength);
         PdfSignatureValidationReport afterValidation = PdfSignatureValidator.Validate(after, afterReadOptions);
+        Dictionary<int, PdfIndirectObject> beforeObjects = PdfSyntax.ParseObjects(before, readOptions).Map;
+        Dictionary<int, PdfIndirectObject> afterObjects = PdfSyntax.ParseObjects(after, afterReadOptions).Map;
         bool prefixPreserved = HasExactPrefix(after, before);
         bool revisionChainExtended = HasExtendedRevisionChain(beforeValidation.Security, afterValidation.Security);
         int[] beforeRevisionEnds = FindRevisionEnds(before);
@@ -33,6 +35,12 @@ internal static class PdfSignatureMutationAnalyzer {
             int[] coveredAfter = GetCoveredRevisions(afterRevisionEnds, afterSignedLength);
             bool byteRangePreserved = afterSignature is not null &&
                 beforeSignature.Signature.ByteRangeValues.SequenceEqual(afterSignature.Signature.ByteRangeValues);
+            bool activeDefinitionPreserved = afterSignature is not null &&
+                HasEquivalentActiveSignatureDefinition(
+                    beforeSignature.Signature,
+                    afterSignature.Signature,
+                    beforeObjects,
+                    afterObjects);
 
             results.Add(new PdfSignatureMutationResult(
                 beforeSignature,
@@ -43,6 +51,7 @@ internal static class PdfSignatureMutationAnalyzer {
                 Array.AsReadOnly(coveredAfter),
                 prefixPreserved,
                 byteRangePreserved,
+                activeDefinitionPreserved,
                 HasLaterRevisions(beforeSignature, coveredBefore, beforeValidation.Security),
                 afterSignature is not null && HasLaterRevisions(afterSignature, coveredAfter, afterValidation.Security),
                 permission));
@@ -102,6 +111,76 @@ internal static class PdfSignatureMutationAnalyzer {
         return secondOffset >= 0 && secondLength >= 0 && secondOffset <= long.MaxValue - secondLength
             ? secondOffset + secondLength
             : null;
+    }
+
+    private static bool HasEquivalentActiveSignatureDefinition(
+        PdfSignatureInfo before,
+        PdfSignatureInfo after,
+        Dictionary<int, PdfIndirectObject> beforeObjects,
+        Dictionary<int, PdfIndirectObject> afterObjects) {
+        if (before.ObjectNumber != after.ObjectNumber || before.FieldObjectNumber != after.FieldObjectNumber) return false;
+        int comparedNodes = 0;
+        var visitedReferences = new HashSet<string>(StringComparer.Ordinal);
+        if (!TryCompareObjectGraph(before.ObjectNumber, beforeObjects, afterObjects, visitedReferences, 0, ref comparedNodes)) return false;
+        return !before.FieldObjectNumber.HasValue ||
+            TryCompareObjectGraph(before.FieldObjectNumber.Value, beforeObjects, afterObjects, visitedReferences, 0, ref comparedNodes);
+    }
+
+    private static bool TryCompareObjectGraph(
+        int objectNumber,
+        Dictionary<int, PdfIndirectObject> beforeObjects,
+        Dictionary<int, PdfIndirectObject> afterObjects,
+        ISet<string> visitedReferences,
+        int depth,
+        ref int comparedNodes) {
+        if (!beforeObjects.TryGetValue(objectNumber, out PdfIndirectObject? before) ||
+            !afterObjects.TryGetValue(objectNumber, out PdfIndirectObject? after) ||
+            before.Generation != after.Generation) return false;
+        return TryCompareObjectGraph(before.Value, after.Value, beforeObjects, afterObjects, visitedReferences, depth, ref comparedNodes);
+    }
+
+    private static bool TryCompareObjectGraph(
+        PdfObject before,
+        PdfObject after,
+        Dictionary<int, PdfIndirectObject> beforeObjects,
+        Dictionary<int, PdfIndirectObject> afterObjects,
+        ISet<string> visitedReferences,
+        int depth,
+        ref int comparedNodes) {
+        if (depth > 64 || ++comparedNodes > 4096 || before.GetType() != after.GetType()) return false;
+        if (before is PdfNull) return true;
+        if (before is PdfNumber beforeNumber && after is PdfNumber afterNumber) return beforeNumber.Value.Equals(afterNumber.Value);
+        if (before is PdfBoolean beforeBoolean && after is PdfBoolean afterBoolean) return beforeBoolean.Value == afterBoolean.Value;
+        if (before is PdfName beforeName && after is PdfName afterName) return string.Equals(beforeName.Name, afterName.Name, StringComparison.Ordinal);
+        if (before is PdfStringObj beforeString && after is PdfStringObj afterString) {
+            return beforeString.UseTextStringEncoding == afterString.UseTextStringEncoding && beforeString.RawBytes.SequenceEqual(afterString.RawBytes);
+        }
+        if (before is PdfReference beforeReference && after is PdfReference afterReference) {
+            if (beforeReference.ObjectNumber != afterReference.ObjectNumber || beforeReference.Generation != afterReference.Generation) return false;
+            string key = beforeReference.ObjectNumber.ToString(System.Globalization.CultureInfo.InvariantCulture) + ":" +
+                beforeReference.Generation.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            return !visitedReferences.Add(key) || TryCompareObjectGraph(beforeReference.ObjectNumber, beforeObjects, afterObjects, visitedReferences, depth + 1, ref comparedNodes);
+        }
+        if (before is PdfArray beforeArray && after is PdfArray afterArray) {
+            if (beforeArray.Items.Count != afterArray.Items.Count) return false;
+            for (int index = 0; index < beforeArray.Items.Count; index++) {
+                if (!TryCompareObjectGraph(beforeArray.Items[index], afterArray.Items[index], beforeObjects, afterObjects, visitedReferences, depth + 1, ref comparedNodes)) return false;
+            }
+            return true;
+        }
+        if (before is PdfDictionary beforeDictionary && after is PdfDictionary afterDictionary) {
+            if (beforeDictionary.Items.Count != afterDictionary.Items.Count) return false;
+            foreach (KeyValuePair<string, PdfObject> entry in beforeDictionary.Items) {
+                if (!afterDictionary.Items.TryGetValue(entry.Key, out PdfObject? afterValue) ||
+                    !TryCompareObjectGraph(entry.Value, afterValue, beforeObjects, afterObjects, visitedReferences, depth + 1, ref comparedNodes)) return false;
+            }
+            return true;
+        }
+        if (before is PdfStream beforeStream && after is PdfStream afterStream) {
+            if (beforeStream.Data.Length > 1_048_576 || !beforeStream.Data.SequenceEqual(afterStream.Data)) return false;
+            return TryCompareObjectGraph(beforeStream.Dictionary, afterStream.Dictionary, beforeObjects, afterObjects, visitedReferences, depth + 1, ref comparedNodes);
+        }
+        return false;
     }
 
     private static int[] FindRevisionEnds(byte[] pdf) {

--- a/OfficeIMO.Pdf/Signatures/PdfSignatureMutationResult.cs
+++ b/OfficeIMO.Pdf/Signatures/PdfSignatureMutationResult.cs
@@ -11,6 +11,7 @@ public sealed class PdfSignatureMutationResult {
         IReadOnlyList<int> coveredRevisionsAfter,
         bool originalBytesPreserved,
         bool byteRangePreserved,
+        bool activeDefinitionPreserved,
         bool hasLaterRevisionsBefore,
         bool hasLaterRevisionsAfter,
         PdfSignatureMutationPermissionStatus permissionStatus) {
@@ -22,6 +23,7 @@ public sealed class PdfSignatureMutationResult {
         CoveredRevisionsAfter = coveredRevisionsAfter;
         OriginalBytesPreserved = originalBytesPreserved;
         ByteRangePreserved = byteRangePreserved;
+        ActiveDefinitionPreserved = activeDefinitionPreserved;
         HasLaterRevisionsBefore = hasLaterRevisionsBefore;
         HasLaterRevisionsAfter = hasLaterRevisionsAfter;
         PermissionStatus = permissionStatus;
@@ -54,6 +56,9 @@ public sealed class PdfSignatureMutationResult {
     /// <summary>True when the signature's exact /ByteRange values are unchanged.</summary>
     public bool ByteRangePreserved { get; }
 
+    /// <summary>True when the active signature and owning field object graphs are unchanged.</summary>
+    public bool ActiveDefinitionPreserved { get; }
+
     /// <summary>True when revisions or unsigned bytes followed the signature before the mutation.</summary>
     public bool HasLaterRevisionsBefore { get; }
 
@@ -68,5 +73,6 @@ public sealed class PdfSignatureMutationResult {
         IsPresentAfter &&
         OriginalBytesPreserved &&
         ByteRangePreserved &&
+        ActiveDefinitionPreserved &&
         Before.IsStructurallyValid == After!.IsStructurallyValid;
 }

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.Templates.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.Templates.cs
@@ -80,6 +80,17 @@ namespace OfficeIMO.Tests {
                                     new A.Offset { X = 100000L, Y = 50000L },
                                     new A.Extents { Cx = 200000L, Cy = 100000L }),
                                 new A.PresetGeometry { Preset = A.ShapeTypeValues.Rectangle }))));
+                    tree.Append(new DocumentFormat.OpenXml.Presentation.Picture(
+                        new NonVisualPictureProperties(
+                            new NonVisualDrawingProperties { Id = 912U, Name = "Long Boundary Logo" },
+                            new NonVisualPictureDrawingProperties(),
+                            new ApplicationNonVisualDrawingProperties()),
+                        new BlipFill(new A.Blip(), new A.Stretch(new A.FillRectangle())),
+                        new ShapeProperties(
+                            new A.Transform2D(
+                                new A.Offset { X = long.MaxValue, Y = 0L },
+                                new A.Extents { Cx = 1L, Cy = 1L }),
+                            new A.PresetGeometry { Preset = A.ShapeTypeValues.Rectangle })));
                     layoutPart.SlideLayout.Save();
                 }
 
@@ -92,6 +103,52 @@ namespace OfficeIMO.Tests {
                 Assert.Equal(1100000L, bounds.Top);
                 Assert.Equal(400000L, bounds.Width);
                 Assert.Equal(200000L, bounds.Height);
+                Assert.Null(Assert.Single(
+                    inventory.Assets,
+                    candidate => candidate.Name == "Long Boundary Logo").Bounds);
+            } finally {
+                Delete(templatePath);
+            }
+        }
+
+        [Fact]
+        public void InspectTemplate_DropsNonFiniteGroupedAssetBoundsInsteadOfOverflowing() {
+            string templatePath = CreateTemplatePresentation();
+            try {
+                using (PresentationDocument document = PresentationDocument.Open(templatePath, true)) {
+                    SlideLayoutPart layoutPart = document.PresentationPart!.SlideMasterParts.First()
+                        .SlideLayoutParts.First();
+                    ShapeTree tree = layoutPart.SlideLayout.CommonSlideData!.ShapeTree!;
+                    tree.Append(new GroupShape(
+                        new NonVisualGroupShapeProperties(
+                            new NonVisualDrawingProperties { Id = 910U, Name = "Extreme Group" },
+                            new NonVisualGroupShapeDrawingProperties(),
+                            new ApplicationNonVisualDrawingProperties()),
+                        new GroupShapeProperties(new A.TransformGroup(
+                            new A.Offset { X = long.MaxValue, Y = long.MaxValue },
+                            new A.Extents { Cx = long.MaxValue, Cy = long.MaxValue },
+                            new A.ChildOffset { X = 0L, Y = 0L },
+                            new A.ChildExtents { Cx = 1L, Cy = 1L })),
+                        new DocumentFormat.OpenXml.Presentation.Picture(
+                            new NonVisualPictureProperties(
+                                new NonVisualDrawingProperties { Id = 911U, Name = "Extreme Logo" },
+                                new NonVisualPictureDrawingProperties(),
+                                new ApplicationNonVisualDrawingProperties()),
+                            new BlipFill(new A.Blip(), new A.Stretch(new A.FillRectangle())),
+                            new ShapeProperties(
+                                new A.Transform2D(
+                                    new A.Offset { X = long.MaxValue, Y = long.MaxValue },
+                                    new A.Extents { Cx = long.MaxValue, Cy = long.MaxValue }),
+                                new A.PresetGeometry { Preset = A.ShapeTypeValues.Rectangle }))));
+                    layoutPart.SlideLayout.Save();
+                }
+
+                PowerPointTemplateInventory inventory = PowerPointTemplate.Inspect(templatePath);
+                PowerPointTemplateAssetInfo asset = Assert.Single(
+                    inventory.Assets,
+                    candidate => candidate.Name == "Extreme Logo");
+
+                Assert.Null(asset.Bounds);
             } finally {
                 Delete(templatePath);
             }

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.TemplateInventory.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.TemplateInventory.cs
@@ -218,7 +218,7 @@ namespace OfficeIMO.PowerPoint {
             foreach (GroupShape group in element.Ancestors<GroupShape>().Reverse()) {
                 mapping = mapping.Compose(CreateTemplateGroupMapping(group));
             }
-            return mapping.Map(localBounds.Value);
+            return mapping.TryMap(localBounds.Value, out PowerPointLayoutBox mapped) ? mapped : null;
         }
 
         private static TemplateBoundsMapping CreateTemplateGroupMapping(GroupShape group) {
@@ -268,21 +268,30 @@ namespace OfficeIMO.PowerPoint {
             private readonly double _offsetY;
             private readonly double _scaleX;
             private readonly double _scaleY;
+            private readonly bool _isValid;
 
             internal TemplateBoundsMapping(double offsetX, double offsetY, double scaleX, double scaleY) {
                 _offsetX = offsetX;
                 _offsetY = offsetY;
                 _scaleX = scaleX;
                 _scaleY = scaleY;
+                _isValid = IsFinite(offsetX) && IsFinite(offsetY) && IsFinite(scaleX) && IsFinite(scaleY);
             }
 
             internal static TemplateBoundsMapping Identity => new(0D, 0D, 1D, 1D);
 
-            internal PowerPointLayoutBox Map(PowerPointLayoutBox bounds) => new(
-                Round(_offsetX + (bounds.Left * _scaleX)),
-                Round(_offsetY + (bounds.Top * _scaleY)),
-                Round(bounds.Width * _scaleX),
-                Round(bounds.Height * _scaleY));
+            internal bool TryMap(PowerPointLayoutBox bounds, out PowerPointLayoutBox mapped) {
+                double left = _offsetX + (bounds.Left * _scaleX);
+                double top = _offsetY + (bounds.Top * _scaleY);
+                double width = bounds.Width * _scaleX;
+                double height = bounds.Height * _scaleY;
+                if (!_isValid || !CanRound(left) || !CanRound(top) || !CanRound(width) || !CanRound(height)) {
+                    mapped = default;
+                    return false;
+                }
+                mapped = new PowerPointLayoutBox(Round(left), Round(top), Round(width), Round(height));
+                return true;
+            }
 
             internal TemplateBoundsMapping Compose(TemplateBoundsMapping child) => new(
                 _offsetX + (child._offsetX * _scaleX),
@@ -290,8 +299,12 @@ namespace OfficeIMO.PowerPoint {
                 _scaleX * child._scaleX,
                 _scaleY * child._scaleY);
 
-            private static long Round(double value) =>
-                checked((long)Math.Round(value, MidpointRounding.AwayFromZero));
+            private static bool IsFinite(double value) => !double.IsNaN(value) && !double.IsInfinity(value);
+            private static bool CanRound(double value) =>
+                IsFinite(value) &&
+                value >= -9223372036854775808D &&
+                value < 9223372036854775808D;
+            private static long Round(double value) => (long)Math.Round(value, MidpointRounding.AwayFromZero);
         }
     }
 }


### PR DESCRIPTION
## Summary

- Bound XFDF parsing, PDF attachment extraction, overlay rasterization, outline depth, and active LZW predictors.
- Reject PDF merge, mutation, and signature-finalization paths that could expose hidden content or preserve unsafe actions.
- Validate signature placeholders lexically so metadata text cannot impersonate a Contents entry, an indirect-object header, or an object terminator.
- Keep signature graph comparison inside field-owned objects without ignoring nested DocMDP permissions.
- Preserve source bytes in document-level mutation planning so valid external-signature reservations are accepted and malformed reservations remain blocked.
- Sanitize structured PDF XML export, flat ODF SVG input, PDF metadata strings, and destructive-crop thumbnails.
- Harden PowerPoint group-bound mapping and HTML/SVG grid and gradient processing against overflow and repeated work.

## Compatibility

- Supported LZW predictor and EarlyChange parameters remain decodable within the configured output budget.
- Attachment metadata distinguishes exact encoded size from the untrusted declared decoded-size claim; exact decoded size remains available after bounded extraction.
- Non-destructive PDF cropping remains non-destructive by design; the destructive crop path removes hidden thumbnail content.