### PR TITLE
Harden document rendering and extraction limits

### DIFF
--- a/OfficeIMO.Drawing.Tests/Drawing.Tests.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.Tests.cs
@@ -3197,6 +3197,18 @@ public partial class DrawingTests {
     }
 
     [Fact]
+    public void OfficeTextMeasurerTreatsMalformedSurrogatesAsSingleReplacementScalars() {
+        var measurer = OfficeTextMeasurer.Create(OfficeFontInfo.Default);
+        OfficeTextMeasurementStyle style = measurer.CreateStyle(new OfficeFontInfo("Arial", 12));
+
+        double replacement = measurer.MeasureWidth("\ufffd", style);
+
+        Assert.Equal(replacement, measurer.MeasureWidth("\ud800", style), 6);
+        Assert.Equal(replacement, measurer.MeasureWidth("\udc00", style), 6);
+        Assert.Equal(replacement * 2D, measurer.MeasureWidth("\ud800\ud800", style), 6);
+    }
+
+    [Fact]
     public void OfficeTextElementsDetectsRightToLeftScriptScalars() {
         Assert.False(OfficeTextElements.ContainsRightToLeft(null));
         Assert.False(OfficeTextElements.ContainsRightToLeft("OfficeIMO 123"));

--- a/OfficeIMO.Drawing/OfficeTextMeasurer.cs
+++ b/OfficeIMO.Drawing/OfficeTextMeasurer.cs
@@ -155,8 +155,13 @@ public sealed class OfficeTextMeasurer {
 
     private static bool TryGetBaseScalar(string element, out int scalar) {
         for (int index = 0; index < element.Length;) {
-            scalar = char.ConvertToUtf32(element, index);
-            UnicodeCategory category = CharUnicodeInfo.GetUnicodeCategory(element, index);
+            bool surrogatePair = char.IsHighSurrogate(element[index])
+                && index + 1 < element.Length
+                && char.IsLowSurrogate(element[index + 1]);
+            scalar = surrogatePair ? char.ConvertToUtf32(element[index], element[index + 1]) : element[index];
+            UnicodeCategory category = surrogatePair
+                ? CharUnicodeInfo.GetUnicodeCategory(element, index)
+                : char.IsSurrogate(element[index]) ? UnicodeCategory.OtherNotAssigned : CharUnicodeInfo.GetUnicodeCategory(element, index);
             if (category != UnicodeCategory.Control
                 && category != UnicodeCategory.Format
                 && category != UnicodeCategory.NonSpacingMark
@@ -164,7 +169,7 @@ public sealed class OfficeTextMeasurer {
                 && category != UnicodeCategory.EnclosingMark
                 && scalar != 0x00AD
                 && scalar != 0x200B) return true;
-            index += scalar > char.MaxValue ? 2 : 1;
+            index += surrogatePair ? 2 : 1;
         }
 
         scalar = 0;

--- a/OfficeIMO.Drawing/OfficeTransform.cs
+++ b/OfficeIMO.Drawing/OfficeTransform.cs
@@ -54,7 +54,8 @@ public readonly struct OfficeTransform : IEquatable<OfficeTransform> {
     public static OfficeTransform RotateDegrees(double degrees) {
         ValidateFinite(degrees, nameof(degrees));
 
-        double radians = degrees * Math.PI / 180D;
+        double normalizedDegrees = Math.IEEERemainder(degrees, 360D);
+        double radians = normalizedDegrees * Math.PI / 180D;
         double cos = NormalizeZero(Math.Cos(radians));
         double sin = NormalizeZero(Math.Sin(radians));
         return new OfficeTransform(cos, sin, -sin, cos, 0, 0);

--- a/OfficeIMO.Html.Pdf/HtmlPdfRenderedConverter.cs
+++ b/OfficeIMO.Html.Pdf/HtmlPdfRenderedConverter.cs
@@ -481,7 +481,7 @@ internal static class HtmlPdfRenderedConverter {
                     });
                     continue;
                 }
-                if (element is not OfficeDrawingText text || text.Text.Length == 0) continue;
+            if (element is not OfficeDrawingText text || string.IsNullOrWhiteSpace(text.Text)) continue;
                 FlushShapes();
                 double fontSize = text.Font.Size * scaleY * PointsPerCssPixel;
                 double lineHeight = (text.LineHeight ?? text.Font.Size * 1.2D) * scaleY * PointsPerCssPixel;

--- a/OfficeIMO.Html.Tests/Html.Rendering.Columns.cs
+++ b/OfficeIMO.Html.Tests/Html.Rendering.Columns.cs
@@ -235,6 +235,27 @@ public sealed partial class HtmlRenderingTests {
         Assert.Equal(2L, exception.Limit);
     }
 
+    [Fact]
+    public void HtmlColumns_BalancingProbesMayTemporarilyExceedTheFinalColumnLimit() {
+        const string html = """
+            <div style='column-count:2;column-fill:balance'>
+              <div style='height:40px;break-inside:avoid'>One</div>
+              <div style='height:40px;break-inside:avoid'>Two</div>
+              <div style='height:40px;break-inside:avoid'>Three</div>
+            </div>
+            """;
+        var options = new HtmlRenderOptions {
+            ViewportWidth = 160D,
+            Margins = HtmlRenderMargins.All(0D),
+            MaxColumnCount = 2
+        };
+
+        HtmlRenderDocument rendered = HtmlRenderTestDriver.Render(html, options);
+
+        Assert.Contains(rendered.Pages.SelectMany(page => page.Visuals).OfType<HtmlRenderText>(), text => text.Text.Contains("One", StringComparison.Ordinal));
+        Assert.Contains(rendered.Pages.SelectMany(page => page.Visuals).OfType<HtmlRenderText>(), text => text.Text.Contains("Three", StringComparison.Ordinal));
+    }
+
     private static HtmlRenderDocument RenderColumns(string html, double viewportWidth) =>
         HtmlRenderTestDriver.Render(HtmlConversionDocument.Parse(html), new HtmlRenderOptions { ViewportWidth = viewportWidth, Margins = HtmlRenderMargins.All(0D) });
 

--- a/OfficeIMO.Html.Tests/Html.Rendering.SecurityBatch06.cs
+++ b/OfficeIMO.Html.Tests/Html.Rendering.SecurityBatch06.cs
@@ -103,6 +103,9 @@ public sealed partial class HtmlRenderingTests {
 
     [Theory]
     [InlineData("rotate(1e308deg)")]
+    [InlineData("rotate(1e308grad)")]
+    [InlineData("rotate(1e308rad)")]
+    [InlineData("rotate(1e308turn)")]
     [InlineData("skew(1e308deg,-1e308deg)")]
     public void HtmlTransforms_NormalizeHugeFiniteAnglesBeforeMatrixConstruction(string transformValue) {
         string html = "<div id='large-angle' style='width:10px;height:10px;margin:0;background:red;transform-origin:0 0;transform:"
@@ -123,6 +126,9 @@ public sealed partial class HtmlRenderingTests {
 
     [Theory]
     [InlineData("rotate(1e308deg)")]
+    [InlineData("rotate(1e308grad)")]
+    [InlineData("rotate(1e308rad)")]
+    [InlineData("rotate(1e308turn)")]
     [InlineData("skew(1e308deg,-1e308deg)")]
     public void HtmlSupports_AcceptsHugeFiniteTransformAnglesWithoutThrowing(string transformValue) {
         string html = "<style>@supports (transform:" + transformValue + "){#supported{display:none}}</style>"

--- a/OfficeIMO.Html.Tests/Html.Rendering.SecurityBatch06.cs
+++ b/OfficeIMO.Html.Tests/Html.Rendering.SecurityBatch06.cs
@@ -1,0 +1,220 @@
+using System.Text;
+using OfficeIMO.Drawing;
+using OfficeIMO.Html;
+using OfficeIMO.Html.Pdf;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed partial class HtmlRenderingTests {
+    [Fact]
+    public void HtmlRadialGradient_UsesOverflowSafeCornerDistance() {
+        Assert.True(HtmlCssRadialGradientParser.TryParse(
+            "radial-gradient(circle farthest-corner at 1e308px 1e308px,red,blue)",
+            maximumStops: 8,
+            out HtmlCssRadialGradientDefinition? definition,
+            out bool stopLimitExceeded));
+        Assert.False(stopLimitExceeded);
+        Assert.NotNull(definition);
+        Assert.True(definition!.TryResolve(40D, 20D, 16D, 16D, out OfficeRadialGradient? gradient));
+        Assert.NotNull(gradient);
+        Assert.False(double.IsNaN(gradient!.EndRadiusX));
+        Assert.False(double.IsInfinity(gradient.EndRadiusX));
+        Assert.False(double.IsNaN(gradient.EndRadiusY));
+        Assert.False(double.IsInfinity(gradient.EndRadiusY));
+    }
+
+    [Fact]
+    public void HtmlPdf_SkipsLinkedWhitespaceOnlySvgText() {
+        string svg = Convert.ToBase64String(Encoding.UTF8.GetBytes(
+            "<svg xmlns='http://www.w3.org/2000/svg' width='20' height='10'><a href='https://example.test'><text x='1' y='8'>   </text></a></svg>"));
+
+        byte[] pdf = HtmlConversionDocument.Parse(
+            "<img src='data:image/svg+xml;base64," + svg + "'><p>AfterWhitespaceVector</p>").ToPdf();
+
+        Assert.Contains("AfterWhitespaceVector", OfficeIMO.Pdf.PdfReadDocument.Open(pdf).ExtractText(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HtmlMargins_NegativeCollapsedPairsDoNotInflateFollowingFlow() {
+        const string html = "<div style='margin:0'>"
+            + "<div id='first' style='height:10px;margin:0 0 -100px;background:red'></div>"
+            + "<div id='second' style='height:10px;margin:-100px 0 0;background:blue'></div>"
+            + "<div id='tail' style='height:10px;margin:0;background:lime'></div>"
+            + "</div>";
+
+        HtmlRenderDocument rendered = HtmlRenderTestDriver.Render(html, new HtmlRenderOptions {
+            ViewportWidth = 40D,
+            ViewportHeight = 40D,
+            Margins = HtmlRenderMargins.All(0D),
+            BackgroundColor = OfficeColor.Transparent
+        });
+
+        HtmlRenderShape tail = Assert.Single(rendered.Pages[0].Visuals.OfType<HtmlRenderShape>(), shape => shape.Source == "div#tail");
+        Assert.InRange(tail.Y, 9.9D, 10.1D);
+    }
+
+    [Fact]
+    public void HtmlImages_RejectAuthoredDimensionsBeforeBuildingOversizedVisuals() {
+        var options = new HtmlRenderOptions {
+            ViewportWidth = 100D,
+            Margins = HtmlRenderMargins.All(0D),
+            MaxSurfaceWidth = 256,
+            MaxSurfaceHeight = 256
+        };
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+            HtmlRenderTestDriver.Render("<img style='display:block;width:1e308px;height:20px'>", options));
+
+        Assert.Contains("replaced content", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void HtmlColumns_RejectGeneratedColumnsDuringPlanConstruction() {
+        var html = new StringBuilder("<div style='height:1px;column-count:1;column-fill:auto;margin:0'>");
+        for (int index = 0; index < 100; index++) html.Append("<div style='height:1px;margin:0'>x</div>");
+        html.Append("</div>");
+        var options = new HtmlRenderOptions {
+            ViewportWidth = 100D,
+            Margins = HtmlRenderMargins.All(0D),
+            MaxColumnCount = 2
+        };
+
+        HtmlDomLimitException exception = Assert.Throws<HtmlDomLimitException>(() => HtmlRenderTestDriver.Render(html.ToString(), options));
+
+        Assert.Equal(HtmlRenderDiagnosticCodes.MultiColumnLimitExceeded, exception.Code);
+        Assert.Equal(3L, exception.Actual);
+    }
+
+    [Fact]
+    public void HtmlTransforms_RejectFiniteInputsWhoseCompositionOverflows() {
+        const string html = "<div id='overflowed' style='width:10px;height:10px;margin:0;background:red;transform:scale(1e308) scale(1e308)'></div>";
+
+        HtmlRenderDocument rendered = HtmlRenderTestDriver.Render(html, new HtmlRenderOptions {
+            ViewportWidth = 40D,
+            Margins = HtmlRenderMargins.All(0D)
+        });
+
+        Assert.Contains(rendered.Diagnostics, diagnostic =>
+            diagnostic.Code == HtmlRenderDiagnosticCodes.TransformValueUnsupported
+            && diagnostic.Source == "div#overflowed");
+        Assert.DoesNotContain(rendered.Pages[0].Visuals, visual => visual is HtmlRenderEffectGroup group && group.Source == "div#overflowed");
+    }
+
+    [Theory]
+    [InlineData("rotate(1e308deg)")]
+    [InlineData("skew(1e308deg,-1e308deg)")]
+    public void HtmlTransforms_NormalizeHugeFiniteAnglesBeforeMatrixConstruction(string transformValue) {
+        string html = "<div id='large-angle' style='width:10px;height:10px;margin:0;background:red;transform-origin:0 0;transform:"
+            + transformValue + "'></div>";
+
+        HtmlRenderDocument rendered = HtmlRenderTestDriver.Render(html, new HtmlRenderOptions {
+            ViewportWidth = 40D,
+            Margins = HtmlRenderMargins.All(0D)
+        });
+
+        HtmlRenderEffectGroup group = Assert.Single(
+            EnumerateRenderVisuals(rendered.Pages[0].Visuals).OfType<HtmlRenderEffectGroup>(),
+            visual => visual.Source == "div#large-angle");
+        Assert.DoesNotContain(rendered.Diagnostics, diagnostic => diagnostic.Code == HtmlRenderDiagnosticCodes.TransformValueUnsupported);
+        Assert.All(new[] { group.Transform.M11, group.Transform.M12, group.Transform.M21, group.Transform.M22 },
+            value => Assert.False(double.IsNaN(value) || double.IsInfinity(value)));
+    }
+
+    [Theory]
+    [InlineData("rotate(1e308deg)")]
+    [InlineData("skew(1e308deg,-1e308deg)")]
+    public void HtmlSupports_AcceptsHugeFiniteTransformAnglesWithoutThrowing(string transformValue) {
+        string html = "<style>@supports (transform:" + transformValue + "){#supported{display:none}}</style>"
+            + "<p id='supported'>SupportsLargeAngle</p>";
+        var document = HtmlDocumentParser.ParseDocument(html);
+        var element = document.QuerySelector("#supported")!;
+
+        IReadOnlyDictionary<AngleSharp.Dom.IElement, HtmlComputedStyle> styles = HtmlComputedStyleEngine.Compute(document);
+
+        Assert.Equal("none", styles[element].GetValue("display"));
+    }
+
+    [Fact]
+    public void HtmlTransforms_RejectOverflowingAbsoluteOriginsBeforeTranslationConstruction() {
+        bool parsed = HtmlCssTransformParser.TryParse(
+            "rotate(1deg)",
+            "1e308px 1e308px",
+            1e308D,
+            1e308D,
+            10D,
+            10D,
+            16D,
+            16D,
+            out _,
+            out string detail);
+
+        Assert.False(parsed);
+        Assert.Contains("transform-origin", detail, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("linear-gradient")]
+    [InlineData("radial-gradient")]
+    public void HtmlGradients_StopBeforeMaterializingUnboundedArgumentLists(string function) {
+        string background = function + "(" + string.Join(",", Enumerable.Repeat("red", 10_000)) + ")";
+        string html = "<div style='width:10px;height:10px;background:" + background + "'></div>";
+
+        HtmlRenderDocument rendered = HtmlRenderTestDriver.Render(html, new HtmlRenderOptions {
+            ViewportWidth = 20D,
+            Margins = HtmlRenderMargins.All(0D),
+            MaxGradientStops = 8
+        });
+
+        Assert.Contains(rendered.Diagnostics, diagnostic => diagnostic.Code == HtmlRenderDiagnosticCodes.GradientStopLimitExceeded);
+    }
+
+    [Fact]
+    public void HtmlFlex_NormalizesHugeGrowFactorsWithoutNaN() {
+        const string html = "<div style='display:flex;width:300px;height:10px;margin:0'>"
+            + "<div id='large' style='flex-grow:1e308;flex-basis:0;height:10px;background:red'></div>"
+            + "<div id='half' style='flex-grow:5e307;flex-basis:0;height:10px;background:blue'></div>"
+            + "</div>";
+
+        HtmlRenderDocument rendered = HtmlRenderTestDriver.Render(html, new HtmlRenderOptions {
+            ViewportWidth = 300D,
+            Margins = HtmlRenderMargins.All(0D)
+        });
+        HtmlRenderShape large = Assert.Single(rendered.Pages[0].Visuals.OfType<HtmlRenderShape>(), shape => shape.Source == "div#large");
+        HtmlRenderShape half = Assert.Single(rendered.Pages[0].Visuals.OfType<HtmlRenderShape>(), shape => shape.Source == "div#half");
+
+        Assert.Equal(200D, large.Width, 3);
+        Assert.Equal(100D, half.Width, 3);
+        Assert.False(double.IsNaN(large.Width));
+        Assert.False(double.IsNaN(half.Width));
+    }
+
+    [Fact]
+    public void HtmlTable_HandlesLongHeaderPrefixesWithOneSuffixPass() {
+        var html = new StringBuilder("<table style='border-collapse:collapse;margin:0'>");
+        for (int index = 0; index < 1_500; index++) html.Append("<tr><th>H</th></tr>");
+        html.Append("<tr><td id='body-cell'>Body</td></tr></table>");
+
+        HtmlRenderDocument rendered = HtmlRenderTestDriver.Render(html.ToString(), new HtmlRenderOptions {
+            ViewportWidth = 100D,
+            Margins = HtmlRenderMargins.All(0D),
+            MaxTableRows = 2_000,
+            MaxSurfaceHeight = 100_000
+        });
+
+        Assert.Contains("Body", rendered.Text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HtmlResources_PreloadAsStyleDoesNotBecomeAnActiveStylesheet() {
+        const string html = "<link rel='preload' as='style' href='https://example.test/preloaded.css'>"
+            + "<link rel='preload stylesheet' as='style' href='https://example.test/active.css'>";
+
+        HtmlResourceManifest manifest = HtmlResourcePipeline.BuildManifest(html, new HtmlResourcePipelineOptions {
+            UrlPolicy = HtmlUrlPolicy.CreateWebOnlyProfile()
+        });
+
+        Assert.Contains(manifest.Resources, resource => resource.Source == "https://example.test/preloaded.css" && resource.Kind == HtmlResourceKind.Other);
+        Assert.Contains(manifest.Resources, resource => resource.Source == "https://example.test/active.css" && resource.Kind == HtmlResourceKind.Stylesheet);
+    }
+}

--- a/OfficeIMO.Html/Rendering/HtmlCssLinearGradientParser.cs
+++ b/OfficeIMO.Html/Rendering/HtmlCssLinearGradientParser.cs
@@ -15,7 +15,13 @@ internal static class HtmlCssLinearGradientParser {
         int open = functionName.Length;
         if (open >= text.Length || text[open] != '(' || text[text.Length - 1] != ')') return false;
 
-        IReadOnlyList<string> arguments = HtmlRenderCssValues.SplitTopLevelCommas(text.Substring(open + 1, text.Length - open - 2));
+        if (!HtmlRenderCssValues.TrySplitTopLevelCommas(
+                text.Substring(open + 1, text.Length - open - 2),
+                maximumStops == int.MaxValue ? int.MaxValue : maximumStops + 1,
+                out IReadOnlyList<string> arguments)) {
+            stopLimitExceeded = true;
+            return false;
+        }
         if (arguments.Count < 2) return false;
 
         double officeAngle = 90D;

--- a/OfficeIMO.Html/Rendering/HtmlCssRadialGradientDefinition.cs
+++ b/OfficeIMO.Html/Rendering/HtmlCssRadialGradientDefinition.cs
@@ -38,9 +38,11 @@ internal sealed class HtmlCssRadialGradientDefinition {
         double rootFontSize,
         out OfficeRadialGradient? gradient) {
         gradient = null;
-        if (width <= 0D || height <= 0D
+        if (!IsFinitePositive(width) || !IsFinitePositive(height)
             || !HtmlRenderCssValues.TryLength(CenterX, width, fontSize, rootFontSize, out double centerXPixels)
-            || !HtmlRenderCssValues.TryLength(CenterY, height, fontSize, rootFontSize, out double centerYPixels)) {
+            || !HtmlRenderCssValues.TryLength(CenterY, height, fontSize, rootFontSize, out double centerYPixels)
+            || !IsFinite(centerXPixels)
+            || !IsFinite(centerYPixels)) {
             return false;
         }
 
@@ -61,20 +63,21 @@ internal sealed class HtmlCssRadialGradientDefinition {
                 return false;
             }
         } else {
-            ResolveExtent(width, height, centerXPixels, centerYPixels, out radiusXPixels, out radiusYPixels);
+            if (!TryResolveExtent(width, height, centerXPixels, centerYPixels, out radiusXPixels, out radiusYPixels)) return false;
         }
 
         double centerX = centerXPixels / width;
         double centerY = centerYPixels / height;
         double radiusX = Math.Max(MinimumRadius, radiusXPixels) / width;
         double radiusY = Math.Max(MinimumRadius, radiusYPixels) / height;
-        if (!Stops.TryResolve(Math.Max(MinimumRadius, radiusXPixels), fontSize, rootFontSize, out IReadOnlyList<OfficeGradientStop>? stops)
+        if (!IsFinite(centerX) || !IsFinite(centerY) || !IsFinitePositive(radiusX) || !IsFinitePositive(radiusY)
+            || !Stops.TryResolve(Math.Max(MinimumRadius, radiusXPixels), fontSize, rootFontSize, out IReadOnlyList<OfficeGradientStop>? stops)
             || stops == null) return false;
         gradient = new OfficeRadialGradient(centerX, centerY, 0D, 0D, centerX, centerY, radiusX, radiusY, stops);
         return true;
     }
 
-    private void ResolveExtent(
+    private bool TryResolveExtent(
         double width,
         double height,
         double centerX,
@@ -91,16 +94,29 @@ internal sealed class HtmlCssRadialGradientDefinition {
         double vertical = closest ? Math.Min(top, bottom) : Math.Max(top, bottom);
         if (Shape == HtmlCssRadialGradientShape.Circle) {
             double circleRadius = corner
-                ? Math.Sqrt((horizontal * horizontal) + (vertical * vertical))
+                ? StableHypot(horizontal, vertical)
                 : closest ? Math.Min(horizontal, vertical) : Math.Max(horizontal, vertical);
             radiusX = circleRadius;
             radiusY = circleRadius;
-            return;
+            return IsFiniteNonNegative(radiusX);
         }
 
         radiusX = corner ? horizontal * CornerScale : horizontal;
         radiusY = corner ? vertical * CornerScale : vertical;
+        return IsFiniteNonNegative(radiusX) && IsFiniteNonNegative(radiusY);
     }
+
+    private static double StableHypot(double x, double y) {
+        double maximum = Math.Max(Math.Abs(x), Math.Abs(y));
+        if (maximum == 0D) return 0D;
+        double normalizedX = x / maximum;
+        double normalizedY = y / maximum;
+        return maximum * Math.Sqrt(normalizedX * normalizedX + normalizedY * normalizedY);
+    }
+
+    private static bool IsFinite(double value) => !double.IsNaN(value) && !double.IsInfinity(value);
+    private static bool IsFinitePositive(double value) => value > 0D && IsFinite(value);
+    private static bool IsFiniteNonNegative(double value) => value >= 0D && IsFinite(value);
 }
 
 internal enum HtmlCssRadialGradientShape {

--- a/OfficeIMO.Html/Rendering/HtmlCssRadialGradientParser.cs
+++ b/OfficeIMO.Html/Rendering/HtmlCssRadialGradientParser.cs
@@ -18,7 +18,13 @@ internal static class HtmlCssRadialGradientParser {
         int open = functionName.Length;
         if (open >= text.Length || text[open] != '(' || text[text.Length - 1] != ')') return false;
 
-        IReadOnlyList<string> arguments = HtmlRenderCssValues.SplitTopLevelCommas(text.Substring(open + 1, text.Length - open - 2));
+        if (!HtmlRenderCssValues.TrySplitTopLevelCommas(
+                text.Substring(open + 1, text.Length - open - 2),
+                maximumStops == int.MaxValue ? int.MaxValue : maximumStops + 1,
+                out IReadOnlyList<string> arguments)) {
+            stopLimitExceeded = true;
+            return false;
+        }
         if (arguments.Count < 2) return false;
         int stopStart = HtmlCssGradientStops.IsColorStop(arguments[0]) ? 0 : 1;
         if (!HtmlCssGradientStops.TryParse(arguments, stopStart, maximumStops, out HtmlCssGradientStops? stops, out stopLimitExceeded)

--- a/OfficeIMO.Html/Rendering/HtmlCssTransformParser.cs
+++ b/OfficeIMO.Html/Rendering/HtmlCssTransformParser.cs
@@ -26,9 +26,15 @@ internal static class HtmlCssTransformParser {
         }
         originX += boxX;
         originY += boxY;
-        transform = OfficeTransform.Translate(-originX, -originY)
-            .Then(functions)
-            .Then(OfficeTransform.Translate(originX, originY));
+        if (!IsFinite(originX) || !IsFinite(originY)) {
+            detail = "transform-origin=" + transformOriginValue.Trim();
+            return false;
+        }
+        if (!TryThen(OfficeTransform.Translate(-originX, -originY), functions, out OfficeTransform centered)
+            || !TryThen(centered, OfficeTransform.Translate(originX, originY), out transform)) {
+            detail = "transform=" + value;
+            return false;
+        }
         return true;
     }
 
@@ -77,7 +83,10 @@ internal static class HtmlCssTransformParser {
                 detail = name + "(" + arguments + ")";
                 return false;
             }
-            transform = function.Then(transform);
+            if (!TryThen(function, transform, out transform)) {
+                detail = name + "(" + arguments + ")";
+                return false;
+            }
             found = true;
         }
         if (!found) detail = "transform=" + value;
@@ -136,26 +145,48 @@ internal static class HtmlCssTransformParser {
                 double skewY = 0D;
                 if (values.Count < 1 || values.Count > 2 || !TryAngle(values[0], out double skewX)
                     || values.Count == 2 && !TryAngle(values[1], out skewY)) return false;
-                transform = CreateSkew(skewX, values.Count == 2 ? skewY : 0D);
-                return true;
+                return TryCreateSkew(skewX, values.Count == 2 ? skewY : 0D, out transform);
             case "skewx":
                 if (values.Count != 1 || !TryAngle(values[0], out double xAngle)) return false;
-                transform = CreateSkew(xAngle, 0D);
-                return true;
+                return TryCreateSkew(xAngle, 0D, out transform);
             case "skewy":
                 if (values.Count != 1 || !TryAngle(values[0], out double yAngle)) return false;
-                transform = CreateSkew(0D, yAngle);
-                return true;
+                return TryCreateSkew(0D, yAngle, out transform);
             default:
                 return false;
         }
     }
 
-    private static OfficeTransform CreateSkew(double xDegrees, double yDegrees) {
-        double x = Math.Tan(xDegrees * Math.PI / 180D);
-        double y = Math.Tan(yDegrees * Math.PI / 180D);
-        return new OfficeTransform(1D, y, x, 1D, 0D, 0D);
+    private static bool TryCreateSkew(double xDegrees, double yDegrees, out OfficeTransform transform) {
+        double xRadians = Math.IEEERemainder(xDegrees, 180D) * Math.PI / 180D;
+        double yRadians = Math.IEEERemainder(yDegrees, 180D) * Math.PI / 180D;
+        double x = Math.Tan(xRadians);
+        double y = Math.Tan(yRadians);
+        if (!IsFinite(x) || !IsFinite(y)) {
+            transform = OfficeTransform.Identity;
+            return false;
+        }
+        transform = new OfficeTransform(1D, y, x, 1D, 0D, 0D);
+        return true;
     }
+
+    private static bool TryThen(OfficeTransform first, OfficeTransform next, out OfficeTransform transform) {
+        double m11 = next.M11 * first.M11 + next.M21 * first.M12;
+        double m12 = next.M12 * first.M11 + next.M22 * first.M12;
+        double m21 = next.M11 * first.M21 + next.M21 * first.M22;
+        double m22 = next.M12 * first.M21 + next.M22 * first.M22;
+        double offsetX = next.M11 * first.OffsetX + next.M21 * first.OffsetY + next.OffsetX;
+        double offsetY = next.M12 * first.OffsetX + next.M22 * first.OffsetY + next.OffsetY;
+        if (!IsFinite(m11) || !IsFinite(m12) || !IsFinite(m21) || !IsFinite(m22)
+            || !IsFinite(offsetX) || !IsFinite(offsetY)) {
+            transform = OfficeTransform.Identity;
+            return false;
+        }
+        transform = new OfficeTransform(m11, m12, m21, m22, offsetX, offsetY);
+        return true;
+    }
+
+    private static bool IsFinite(double value) => !double.IsNaN(value) && !double.IsInfinity(value);
 
     private static IReadOnlyList<string> SplitArguments(string value) {
         IReadOnlyList<string> commas = HtmlRenderCssValues.SplitTopLevelCommas(value);

--- a/OfficeIMO.Html/Rendering/HtmlCssTransformParser.cs
+++ b/OfficeIMO.Html/Rendering/HtmlCssTransformParser.cs
@@ -216,18 +216,23 @@ internal static class HtmlCssTransformParser {
         degrees = 0D;
         string normalized = value.Trim().ToLowerInvariant();
         double factor;
+        double period;
         string number;
         if (normalized.EndsWith("deg", StringComparison.Ordinal)) {
             factor = 1D;
+            period = 360D;
             number = normalized.Substring(0, normalized.Length - 3);
         } else if (normalized.EndsWith("grad", StringComparison.Ordinal)) {
             factor = 0.9D;
+            period = 400D;
             number = normalized.Substring(0, normalized.Length - 4);
         } else if (normalized.EndsWith("rad", StringComparison.Ordinal)) {
             factor = 180D / Math.PI;
+            period = Math.PI * 2D;
             number = normalized.Substring(0, normalized.Length - 3);
         } else if (normalized.EndsWith("turn", StringComparison.Ordinal)) {
             factor = 360D;
+            period = 1D;
             number = normalized.Substring(0, normalized.Length - 4);
         } else if (normalized == "0") {
             return true;
@@ -235,7 +240,7 @@ internal static class HtmlCssTransformParser {
             return false;
         }
         if (!TryNumber(number, out double parsed)) return false;
-        degrees = parsed * factor;
+        degrees = Math.IEEERemainder(parsed, period) * factor;
         return !double.IsNaN(degrees) && !double.IsInfinity(degrees);
     }
 

--- a/OfficeIMO.Html/Rendering/HtmlRenderCssValues.cs
+++ b/OfficeIMO.Html/Rendering/HtmlRenderCssValues.cs
@@ -190,6 +190,38 @@ internal static class HtmlRenderCssValues {
 
     internal static IReadOnlyList<string> SplitTopLevelCommas(string? value) => SplitTopLevel(value, ',');
 
+    internal static bool TrySplitTopLevelCommas(string? value, int maximumParts, out IReadOnlyList<string> parts) {
+        parts = Array.Empty<string>();
+        if (maximumParts <= 0 || string.IsNullOrWhiteSpace(value)) return false;
+
+        var resolved = new List<string>(Math.Min(maximumParts, 16));
+        int start = 0;
+        int depth = 0;
+        char quote = '\0';
+        string text = value!;
+        for (int index = 0; index < text.Length; index++) {
+            char current = text[index];
+            if (quote != '\0') {
+                if (current == quote && (index == 0 || text[index - 1] != '\\')) quote = '\0';
+                continue;
+            }
+
+            if (current == '\'' || current == '"') quote = current;
+            else if (current == '(') depth++;
+            else if (current == ')' && depth > 0) depth--;
+            else if (current == ',' && depth == 0) {
+                if (resolved.Count >= maximumParts) return false;
+                resolved.Add(text.Substring(start, index - start).Trim());
+                start = index + 1;
+            }
+        }
+
+        if (resolved.Count >= maximumParts) return false;
+        resolved.Add(text.Substring(start).Trim());
+        parts = resolved.AsReadOnly();
+        return true;
+    }
+
     internal static IReadOnlyList<string> SplitTopLevel(string? value, char separator) {
         if (string.IsNullOrWhiteSpace(value)) return Array.Empty<string>();
 

--- a/OfficeIMO.Html/Rendering/HtmlRenderFlowBlock.cs
+++ b/OfficeIMO.Html/Rendering/HtmlRenderFlowBlock.cs
@@ -28,9 +28,13 @@ internal sealed class HtmlRenderFlowBlock {
         double collapsibleMarginTop = 0D,
         double collapsibleMarginBottom = 0D,
         IElement? ownerElement = null,
-        bool collapsesThrough = false) {
+        bool collapsesThrough = false,
+        double? unclampedHeight = null) {
         Width = width;
         Height = height;
+        UnclampedHeight = unclampedHeight.HasValue && !double.IsNaN(unclampedHeight.Value) && !double.IsInfinity(unclampedHeight.Value)
+            ? unclampedHeight.Value
+            : height;
         Visuals = new List<HtmlRenderVisual>(visuals);
         BreakBefore = breakBefore;
         BreakAfter = breakAfter;
@@ -80,6 +84,7 @@ internal sealed class HtmlRenderFlowBlock {
 
     internal double Width { get; }
     internal double Height { get; }
+    internal double UnclampedHeight { get; }
     internal IReadOnlyList<HtmlRenderVisual> Visuals { get; }
     internal HtmlPageBreakTarget BreakBefore { get; }
     internal HtmlPageBreakTarget BreakAfter { get; }
@@ -118,7 +123,8 @@ internal sealed class HtmlRenderFlowBlock {
             collapsibleMarginTop: CollapsibleMarginTop,
             collapsibleMarginBottom: CollapsibleMarginBottom,
             ownerElement: OwnerElement,
-            collapsesThrough: CollapsesThrough);
+            collapsesThrough: CollapsesThrough,
+            unclampedHeight: UnclampedHeight);
 
     internal HtmlRenderFlowBlock WithStacking(int zIndex, int sourceOrder) =>
         new HtmlRenderFlowBlock(
@@ -140,7 +146,8 @@ internal sealed class HtmlRenderFlowBlock {
             collapsibleMarginTop: CollapsibleMarginTop,
             collapsibleMarginBottom: CollapsibleMarginBottom,
             ownerElement: OwnerElement,
-            collapsesThrough: CollapsesThrough);
+            collapsesThrough: CollapsesThrough,
+            unclampedHeight: UnclampedHeight);
 
     internal HtmlRenderFlowBlock WithVisuals(IEnumerable<HtmlRenderVisual> visuals) =>
         new HtmlRenderFlowBlock(
@@ -162,11 +169,13 @@ internal sealed class HtmlRenderFlowBlock {
             collapsibleMarginTop: CollapsibleMarginTop,
             collapsibleMarginBottom: CollapsibleMarginBottom,
             ownerElement: OwnerElement,
-            collapsesThrough: CollapsesThrough);
+            collapsesThrough: CollapsesThrough,
+            unclampedHeight: UnclampedHeight);
 
     internal HtmlRenderFlowBlock AdjustLeadingFlowSpace(double adjustment) {
         if (Math.Abs(adjustment) <= 0.0001D) return this;
-        double adjustedHeight = Math.Max(0.01D, Height - adjustment);
+        double adjustedUnclampedHeight = UnclampedHeight - adjustment;
+        double adjustedHeight = Math.Max(0.01D, adjustedUnclampedHeight);
         return new HtmlRenderFlowBlock(
             Width,
             adjustedHeight,
@@ -186,7 +195,8 @@ internal sealed class HtmlRenderFlowBlock {
             collapsibleMarginTop: CollapsibleMarginTop,
             collapsibleMarginBottom: CollapsibleMarginBottom,
             ownerElement: OwnerElement,
-            collapsesThrough: CollapsesThrough);
+            collapsesThrough: CollapsesThrough,
+            unclampedHeight: adjustedUnclampedHeight);
     }
 
     internal HtmlRenderFlowBlock WithCollapsibleMargins(double top, double bottom, IElement ownerElement, bool collapsesThrough = false) =>
@@ -209,11 +219,13 @@ internal sealed class HtmlRenderFlowBlock {
             collapsibleMarginTop: top,
             collapsibleMarginBottom: bottom,
             ownerElement: ownerElement,
-            collapsesThrough: collapsesThrough);
+            collapsesThrough: collapsesThrough,
+            unclampedHeight: UnclampedHeight);
 
     internal HtmlRenderFlowBlock AdjustTrailingFlowSpace(double adjustment) {
         if (Math.Abs(adjustment) <= 0.0001D) return this;
-        double adjustedHeight = Math.Max(0.01D, Height - adjustment);
+        double adjustedUnclampedHeight = UnclampedHeight - adjustment;
+        double adjustedHeight = Math.Max(0.01D, adjustedUnclampedHeight);
         return new HtmlRenderFlowBlock(
             Width,
             adjustedHeight,
@@ -233,7 +245,8 @@ internal sealed class HtmlRenderFlowBlock {
             collapsibleMarginTop: CollapsibleMarginTop,
             collapsibleMarginBottom: CollapsibleMarginBottom,
             ownerElement: OwnerElement,
-            collapsesThrough: CollapsesThrough);
+            collapsesThrough: CollapsesThrough,
+            unclampedHeight: adjustedUnclampedHeight);
     }
 }
 

--- a/OfficeIMO.Html/Rendering/HtmlRenderLayoutEngine.Blocks.cs
+++ b/OfficeIMO.Html/Rendering/HtmlRenderLayoutEngine.Blocks.cs
@@ -279,7 +279,8 @@ internal sealed partial class HtmlRenderLayoutEngine {
 
         bool zeroHeightCollapsible = CanUseZeroHeightForMarginCollapse(style, parentStyle, contentHeight);
         double boxHeight = zeroHeightCollapsible ? 0D : ResolveBoxHeight(contentHeight, style);
-        double outerHeight = style.MarginTop + boxHeight + style.MarginBottom;
+        double unclampedOuterHeight = style.MarginTop + boxHeight + style.MarginBottom;
+        double outerHeight = unclampedOuterHeight;
         if (outerHeight <= 0D) outerHeight = 0.01D;
         var visuals = new List<HtmlRenderVisual>();
         var overflowContent = new List<HtmlRenderVisual>();
@@ -350,7 +351,8 @@ internal sealed partial class HtmlRenderLayoutEngine {
             adjustedLineBreakGroups,
             adjustedContinuationGroups,
             adjustedTrailingGroups,
-            pageName: pageName);
+            pageName: pageName,
+            unclampedHeight: unclampedOuterHeight);
         block = ApplyElementSemantics(block, element);
         bool collapsesThrough = CanCollapseThroughEmptyBlock(style, usesBlockFormatting, children, contentVisuals, contentHeight);
         return AttachElementMargins(ApplyElementPositioning(block, style, containingWidth, containingHeight, element), style, element, collapsesThrough);

--- a/OfficeIMO.Html/Rendering/HtmlRenderLayoutEngine.Columns.Spanning.cs
+++ b/OfficeIMO.Html/Rendering/HtmlRenderLayoutEngine.Columns.Spanning.cs
@@ -150,7 +150,7 @@ internal sealed partial class HtmlRenderLayoutEngine {
         }
 
         double targetHeight = Math.Max(0.01D, ResolveBalancedColumnHeight(children, requestedCount));
-        MultiColumnPlan plan = BuildMultiColumnPlan(children, targetHeight);
+        MultiColumnPlan plan = BuildMultiColumnPlan(children, targetHeight, _options.MaxColumnCount, throwOnLimit: true);
         EnsureMultiColumnLimit(plan.ColumnCount);
         partitionHeight = Math.Max(targetHeight, plan.UsedHeight);
         AddColumnRuleVisuals(visuals, style, 0D, offsetY, columnWidth, gap, Math.Max(requestedCount, plan.ColumnCount), partitionHeight, source);

--- a/OfficeIMO.Html/Rendering/HtmlRenderLayoutEngine.Columns.cs
+++ b/OfficeIMO.Html/Rendering/HtmlRenderLayoutEngine.Columns.cs
@@ -46,7 +46,7 @@ internal sealed partial class HtmlRenderLayoutEngine {
         }
         targetHeight = Math.Max(0.01D, targetHeight);
 
-        MultiColumnPlan plan = BuildMultiColumnPlan(children, targetHeight);
+        MultiColumnPlan plan = BuildMultiColumnPlan(children, targetHeight, _options.MaxColumnCount, throwOnLimit: true);
         EnsureMultiColumnLimit(plan.ColumnCount);
         double contentHeight = declaredHeight ?? Math.Max(targetHeight, plan.UsedHeight);
         double boxHeight = ResolveBoxHeight(contentHeight, style);
@@ -119,7 +119,7 @@ internal sealed partial class HtmlRenderLayoutEngine {
         double upper = Math.Max(lower, totalHeight);
         for (int iteration = 0; iteration < 24; iteration++) {
             double candidate = (lower + upper) / 2D;
-            MultiColumnPlan plan = BuildMultiColumnPlan(blocks, candidate);
+            MultiColumnPlan plan = BuildMultiColumnPlan(blocks, candidate, requestedCount, throwOnLimit: false);
             bool fits = plan.ColumnCount <= requestedCount && plan.UsedHeight <= candidate + 0.0001D;
             if (fits) upper = candidate;
             else lower = candidate;
@@ -127,7 +127,11 @@ internal sealed partial class HtmlRenderLayoutEngine {
         return upper;
     }
 
-    private MultiColumnPlan BuildMultiColumnPlan(IReadOnlyList<HtmlRenderFlowBlock> blocks, double targetHeight) {
+    private MultiColumnPlan BuildMultiColumnPlan(
+        IReadOnlyList<HtmlRenderFlowBlock> blocks,
+        double targetHeight,
+        int maximumGeneratedColumns,
+        bool throwOnLimit) {
         var fragments = new List<MultiColumnFragment>();
         int column = 0;
         double y = 0D;
@@ -138,7 +142,10 @@ internal sealed partial class HtmlRenderLayoutEngine {
                 double available = targetHeight - y;
                 double remaining = child.Height - start;
                 if (available <= 0.0001D) {
-                    EnsureMultiColumnLimit(column + 2);
+                    if (column + 2 > maximumGeneratedColumns) {
+                        if (throwOnLimit) EnsureMultiColumnLimit(column + 2);
+                        return new MultiColumnPlan(fragments, column + 2, usedHeight);
+                    }
                     column++;
                     y = 0D;
                     continue;
@@ -150,7 +157,10 @@ internal sealed partial class HtmlRenderLayoutEngine {
                 } else {
                     end = FindFragmentEnd(child, start, available, child.Height);
                     if (end <= start + 0.0001D && y > 0.0001D) {
-                        EnsureMultiColumnLimit(column + 2);
+                        if (column + 2 > maximumGeneratedColumns) {
+                            if (throwOnLimit) EnsureMultiColumnLimit(column + 2);
+                            return new MultiColumnPlan(fragments, column + 2, usedHeight);
+                        }
                         column++;
                         y = 0D;
                         continue;
@@ -164,7 +174,10 @@ internal sealed partial class HtmlRenderLayoutEngine {
                 usedHeight = Math.Max(usedHeight, y);
                 start = end;
                 if (start < child.Height - 0.0001D) {
-                    EnsureMultiColumnLimit(column + 2);
+                    if (column + 2 > maximumGeneratedColumns) {
+                        if (throwOnLimit) EnsureMultiColumnLimit(column + 2);
+                        return new MultiColumnPlan(fragments, column + 2, usedHeight);
+                    }
                     column++;
                     y = 0D;
                 }

--- a/OfficeIMO.Html/Rendering/HtmlRenderLayoutEngine.Columns.cs
+++ b/OfficeIMO.Html/Rendering/HtmlRenderLayoutEngine.Columns.cs
@@ -138,6 +138,7 @@ internal sealed partial class HtmlRenderLayoutEngine {
                 double available = targetHeight - y;
                 double remaining = child.Height - start;
                 if (available <= 0.0001D) {
+                    EnsureMultiColumnLimit(column + 2);
                     column++;
                     y = 0D;
                     continue;
@@ -149,6 +150,7 @@ internal sealed partial class HtmlRenderLayoutEngine {
                 } else {
                     end = FindFragmentEnd(child, start, available, child.Height);
                     if (end <= start + 0.0001D && y > 0.0001D) {
+                        EnsureMultiColumnLimit(column + 2);
                         column++;
                         y = 0D;
                         continue;
@@ -162,6 +164,7 @@ internal sealed partial class HtmlRenderLayoutEngine {
                 usedHeight = Math.Max(usedHeight, y);
                 start = end;
                 if (start < child.Height - 0.0001D) {
+                    EnsureMultiColumnLimit(column + 2);
                     column++;
                     y = 0D;
                 }

--- a/OfficeIMO.Html/Rendering/HtmlRenderLayoutEngine.Flex.cs
+++ b/OfficeIMO.Html/Rendering/HtmlRenderLayoutEngine.Flex.cs
@@ -195,13 +195,20 @@ internal sealed partial class HtmlRenderLayoutEngine {
             double frozenTotal = items.Where(item => !unfrozen.Contains(item)).Sum(item => item.MainSize);
             double unfrozenBasisTotal = unfrozen.Sum(item => item.Basis);
             double remaining = availableForItems - frozenTotal - unfrozenBasisTotal;
-            double factorTotal = unfrozen.Sum(item => growing ? item.Style.FlexGrow : item.Style.FlexShrink * item.Basis);
+            double maximumFactor = unfrozen.Max(item => growing ? item.Style.FlexGrow : item.Style.FlexShrink);
+            if (maximumFactor <= 0D || double.IsNaN(maximumFactor) || double.IsInfinity(maximumFactor)) break;
+            double factorTotal = unfrozen.Sum(item => {
+                double normalized = (growing ? item.Style.FlexGrow : item.Style.FlexShrink) / maximumFactor;
+                return growing ? normalized : normalized * item.Basis;
+            });
             if (factorTotal <= 0D) break;
 
             var newlyFrozen = new List<FlexItem>();
             foreach (FlexItem item in unfrozen) {
-                double factor = growing ? item.Style.FlexGrow : item.Style.FlexShrink * item.Basis;
+                double normalized = (growing ? item.Style.FlexGrow : item.Style.FlexShrink) / maximumFactor;
+                double factor = growing ? normalized : normalized * item.Basis;
                 double proposed = item.Basis + remaining * factor / factorTotal;
+                if (double.IsNaN(proposed) || double.IsInfinity(proposed)) proposed = item.Basis;
                 double clamped = ClampFlexMainSize(item, proposed, vertical);
                 item.MainSize = clamped;
                 if (Math.Abs(clamped - proposed) > 0.0001D) newlyFrozen.Add(item);

--- a/OfficeIMO.Html/Rendering/HtmlRenderLayoutEngine.Images.cs
+++ b/OfficeIMO.Html/Rendering/HtmlRenderLayoutEngine.Images.cs
@@ -28,6 +28,7 @@ internal sealed partial class HtmlRenderLayoutEngine {
         ReplacedContentSize contentSize = ResolveReplacedContentSize(style, intrinsicWidth, intrinsicHeight, hasIntrinsicSize);
         double boxWidth = contentSize.Width + style.HorizontalInsets;
         double boxHeight = contentSize.Height + style.VerticalInsets;
+        EnsureReplacedBoxSize(boxWidth, boxHeight);
         var visuals = new List<HtmlRenderVisual>();
         var objectVisuals = new List<HtmlRenderVisual>();
         AddBoxPaint(visuals, style, style.MarginLeft, style.MarginTop, boxWidth, boxHeight, element);

--- a/OfficeIMO.Html/Rendering/HtmlRenderLayoutEngine.ReplacedElements.cs
+++ b/OfficeIMO.Html/Rendering/HtmlRenderLayoutEngine.ReplacedElements.cs
@@ -20,7 +20,10 @@ internal sealed partial class HtmlRenderLayoutEngine {
             ? imageInfo!.Height * HtmlRenderOptions.CssPixelsPerInch / Math.Max(1D, imageInfo.DpiY)
             : 150D;
         ReplacedContentSize size = ResolveReplacedContentSize(style, intrinsicWidth, intrinsicHeight, hasIntrinsicSize);
-        return size.Width + style.HorizontalInsets;
+        double boxWidth = size.Width + style.HorizontalInsets;
+        double boxHeight = size.Height + style.VerticalInsets;
+        EnsureReplacedBoxSize(boxWidth, boxHeight);
+        return boxWidth;
     }
 
     private ReplacedContentSize ResolveReplacedContentSize(
@@ -139,6 +142,17 @@ internal sealed partial class HtmlRenderLayoutEngine {
 
     private static double ClampWithMinimumPrecedence(double value, double minimum, double maximum) =>
         Math.Max(minimum, Math.Min(value, maximum));
+
+    private void EnsureReplacedBoxSize(double width, double height) {
+        double pixelWidth = Math.Ceiling(width * _options.Scale);
+        double pixelHeight = Math.Ceiling(height * _options.Scale);
+        if (double.IsNaN(pixelWidth) || double.IsInfinity(pixelWidth)
+            || double.IsNaN(pixelHeight) || double.IsInfinity(pixelHeight)
+            || pixelWidth > _options.MaxSurfaceWidth
+            || pixelHeight > _options.MaxSurfaceHeight) {
+            throw new InvalidOperationException("HTML replaced content exceeded the configured maximum image surface dimensions.");
+        }
+    }
 
     private static void PreserveVisibleCrop(ref double start, ref double end) {
         double total = start + end;

--- a/OfficeIMO.Html/Rendering/HtmlRenderLayoutEngine.Tables.cs
+++ b/OfficeIMO.Html/Rendering/HtmlRenderLayoutEngine.Tables.cs
@@ -162,6 +162,14 @@ internal sealed partial class HtmlRenderLayoutEngine {
         double contentX = style.MarginLeft + style.BorderLeftWidth + style.PaddingLeft;
         double rowY = tableY + style.BorderTopWidth + style.PaddingTop + verticalSpacing;
         double headerStart = rowY;
+        var hasBodyAfter = new bool[rowLayouts.Count];
+        bool bodySeen = false;
+        for (int rowIndex = rowLayouts.Count - 1; rowIndex >= 0; rowIndex--) {
+            hasBodyAfter[rowIndex] = bodySeen;
+            TableRowLayout candidate = rowLayouts[rowIndex];
+            if (!candidate.IsHeader && !candidate.IsFooter) bodySeen = true;
+        }
+
         for (int rowIndex = 0; rowIndex < rowLayouts.Count; rowIndex++) {
             CheckCancellation();
             TableRowLayout row = rowLayouts[rowIndex];
@@ -245,7 +253,7 @@ internal sealed partial class HtmlRenderLayoutEngine {
             }
 
             rowY += row.Height + verticalSpacing;
-            bool headerHasBodyAfter = row.IsHeader && rowLayouts.Skip(rowIndex + 1).Any(candidate => !candidate.IsHeader && !candidate.IsFooter);
+            bool headerHasBodyAfter = row.IsHeader && hasBodyAfter[rowIndex];
             if (!headerHasBodyAfter && canBreakAfterRows[rowIndex]) breakOffsets.Add(rowY);
         }
         if (style.BorderCollapse == "collapse") {

--- a/OfficeIMO.Html/Resources/HtmlResourcePipeline.Elements.cs
+++ b/OfficeIMO.Html/Resources/HtmlResourcePipeline.Elements.cs
@@ -331,6 +331,7 @@ public static partial class HtmlResourcePipeline {
             kind = HtmlResourceKind.Script;
         } else if (isPreload) {
             kind = GetPreloadKind(element.GetAttribute("as"));
+            if (kind == HtmlResourceKind.Stylesheet) kind = HtmlResourceKind.Other;
         } else if (relTokens.Contains("font")) {
             kind = HtmlResourceKind.Font;
         } else if (relTokens.Contains("icon") || relTokens.Contains("apple-touch-icon") || relTokens.Contains("shortcut icon")) {

--- a/OfficeIMO.OpenDocument.Tests/OpenDocument.AdvancedCapabilities.cs
+++ b/OfficeIMO.OpenDocument.Tests/OpenDocument.AdvancedCapabilities.cs
@@ -162,6 +162,38 @@ public sealed class OpenDocumentAdvancedCapabilityTests {
     }
 
     [Fact]
+    public void FlatXmlPartitionsReverseOrderedStyleDependencyChainsInLinearPasses() {
+        const int styleCount = 3_000;
+        XDocument flat = OdtDocument.Create().ToFlatXml();
+        XElement automatic = flat.Root!.Element(OdfNamespaces.Office + "automatic-styles")!;
+        for (int index = styleCount - 1; index >= 0; index--) {
+            var style = new XElement(
+                OdfNamespaces.Style + "style",
+                new XAttribute(OdfNamespaces.Style + "name", "chain-" + index),
+                new XAttribute(OdfNamespaces.Style + "family", "paragraph"));
+            if (index + 1 < styleCount) {
+                style.SetAttributeValue(OdfNamespaces.Style + "parent-style-name", "chain-" + (index + 1));
+            }
+            automatic.Add(style);
+        }
+        flat.Root.Element(OdfNamespaces.Office + "master-styles")!.Add(
+            new XElement(
+                OdfNamespaces.Style + "master-page",
+                new XAttribute(OdfNamespaces.Style + "name", "ChainMaster"),
+                new XAttribute(OdfNamespaces.Style + "page-layout-name", "chain-0")));
+        using var stream = new MemoryStream();
+        flat.Save(stream, SaveOptions.DisableFormatting);
+        stream.Position = 0;
+
+        OdtDocument reopened = OdtDocument.LoadFlatXml(stream);
+
+        XElement stylesAutomatic = reopened.Package.GetXml("styles.xml").Root!
+            .Element(OdfNamespaces.Office + "automatic-styles")!;
+        Assert.Equal(styleCount, stylesAutomatic.Elements(OdfNamespaces.Style + "style")
+            .Count(style => ((string?)style.Attribute(OdfNamespaces.Style + "name"))?.StartsWith("chain-", StringComparison.Ordinal) == true));
+    }
+
+    [Fact]
     public void FlatXmlSaveReportsPackageOnlyContentAsLossy() {
         OdtDocument document = OdtDocument.Create();
         document.AddParagraph("Flat projection");

--- a/OfficeIMO.OpenDocument/Core/OdfDocument.FlatXml.cs
+++ b/OfficeIMO.OpenDocument/Core/OdfDocument.FlatXml.cs
@@ -197,33 +197,46 @@ public abstract partial class OdfDocument {
             return;
         }
 
-        XElement? masters = flatRoot.Element(OdfNamespaces.Office + "master-styles");
-        var styleNames = new HashSet<string>(StringComparer.Ordinal);
-        if (masters != null) {
-            foreach (XAttribute attribute in masters.DescendantsAndSelf().Attributes()) styleNames.Add(attribute.Value);
+        XElement[] automaticStyles = source.Elements().ToArray();
+        var stylesByName = new Dictionary<string, List<XElement>>(StringComparer.Ordinal);
+        foreach (XElement element in automaticStyles) {
+            string? name = (string?)element.Attribute(OdfNamespaces.Style + "name");
+            if (string.IsNullOrEmpty(name)) continue;
+            if (!stylesByName.TryGetValue(name!, out List<XElement>? namedStyles)) {
+                namedStyles = new List<XElement>();
+                stylesByName.Add(name!, namedStyles);
+            }
+            namedStyles.Add(element);
         }
 
-        XElement[] automaticStyles = source.Elements().ToArray();
-        bool added;
-        do {
-            added = false;
-            foreach (XElement element in automaticStyles) {
-                string? name = (string?)element.Attribute(OdfNamespaces.Style + "name");
-                bool isStyleScoped = element.Name == OdfNamespaces.Style + "page-layout" ||
-                    element.Name == OdfNamespaces.Style + "presentation-page-layout" ||
-                    (name != null && styleNames.Contains(name));
-                if (!isStyleScoped) continue;
-                foreach (XAttribute attribute in element.DescendantsAndSelf().Attributes()) added |= styleNames.Add(attribute.Value);
+        var styleScopedElements = new HashSet<XElement>();
+        var pendingNames = new Queue<string>();
+        var queuedNames = new HashSet<string>(StringComparer.Ordinal);
+        void QueueReferences(XElement element) {
+            foreach (XAttribute attribute in element.DescendantsAndSelf().Attributes()) {
+                if (queuedNames.Add(attribute.Value)) pendingNames.Enqueue(attribute.Value);
             }
-        } while (added);
+        }
+
+        XElement? masters = flatRoot.Element(OdfNamespaces.Office + "master-styles");
+        if (masters != null) QueueReferences(masters);
+        foreach (XElement element in automaticStyles) {
+            if (element.Name != OdfNamespaces.Style + "page-layout"
+                && element.Name != OdfNamespaces.Style + "presentation-page-layout") continue;
+            if (styleScopedElements.Add(element)) QueueReferences(element);
+        }
+        while (pendingNames.Count > 0) {
+            string name = pendingNames.Dequeue();
+            if (!stylesByName.TryGetValue(name, out List<XElement>? namedStyles)) continue;
+            foreach (XElement element in namedStyles) {
+                if (styleScopedElements.Add(element)) QueueReferences(element);
+            }
+        }
 
         var styleScoped = new List<XElement>();
         var contentScoped = new List<XElement>();
         foreach (XElement element in automaticStyles) {
-            string? name = (string?)element.Attribute(OdfNamespaces.Style + "name");
-            bool belongsToStyles = element.Name == OdfNamespaces.Style + "page-layout" ||
-                element.Name == OdfNamespaces.Style + "presentation-page-layout" ||
-                (name != null && styleNames.Contains(name));
+            bool belongsToStyles = styleScopedElements.Contains(element);
             (belongsToStyles ? styleScoped : contentScoped).Add(new XElement(element));
         }
 

--- a/OfficeIMO.Reader.Core/OfficeDocumentModelTraversal.cs
+++ b/OfficeIMO.Reader.Core/OfficeDocumentModelTraversal.cs
@@ -113,11 +113,22 @@ internal static class OfficeDocumentModelTraversal {
         }
     }
 
-    internal static IEnumerable<OfficeDocumentFormField> Forms(OfficeDocumentReadResult document) {
+    internal static IEnumerable<OfficeDocumentFormField> Forms(
+        OfficeDocumentReadResult document,
+        int maxCandidates = int.MaxValue,
+        Action? candidateLimitExceeded = null) {
+        if (maxCandidates <= 0) yield break;
+        int candidateCount = 0;
         var seen = new HashSet<OfficeDocumentFormField>(ReferenceIdentityComparer<OfficeDocumentFormField>.Instance);
         var seenIds = new HashSet<string>(System.StringComparer.Ordinal);
         foreach (OfficeDocumentFormField form in document.Forms ?? System.Array.Empty<OfficeDocumentFormField>()) {
-            if (form != null && seen.Add(form) &&
+            if (candidateCount >= maxCandidates) {
+                candidateLimitExceeded?.Invoke();
+                yield break;
+            }
+            candidateCount++;
+            if (form == null) continue;
+            if (seen.Add(form) &&
                 (string.IsNullOrWhiteSpace(form.Id) || seenIds.Add(form.Id))) {
                 yield return form;
             }
@@ -125,7 +136,13 @@ internal static class OfficeDocumentModelTraversal {
         foreach (OfficeDocumentPage page in document.Pages ?? System.Array.Empty<OfficeDocumentPage>()) {
             if (page?.Forms == null) continue;
             foreach (OfficeDocumentFormField form in page.Forms) {
-                if (form != null && seen.Add(form) &&
+                if (candidateCount >= maxCandidates) {
+                    candidateLimitExceeded?.Invoke();
+                    yield break;
+                }
+                candidateCount++;
+                if (form == null) continue;
+                if (seen.Add(form) &&
                     (string.IsNullOrWhiteSpace(form.Id) || seenIds.Add(form.Id))) {
                     yield return form;
                 }
@@ -137,6 +154,11 @@ internal static class OfficeDocumentModelTraversal {
             if (chunk?.FormFields == null) continue;
             for (int index = 0; index < chunk.FormFields.Count; index++) {
                 ReaderFormField field = chunk.FormFields[index];
+                if (candidateCount >= maxCandidates) {
+                    candidateLimitExceeded?.Invoke();
+                    yield break;
+                }
+                candidateCount++;
                 if (field == null) continue;
                 OfficeDocumentFormField form = ProjectChunkForm(chunk, field, chunkIndex, index);
                 if (seenIds.Add(form.Id)) yield return form;

--- a/OfficeIMO.Reader.Core/Structured/OfficeDocumentStructuredExtractor.cs
+++ b/OfficeIMO.Reader.Core/Structured/OfficeDocumentStructuredExtractor.cs
@@ -80,7 +80,11 @@ public static partial class OfficeDocumentStructuredExtractor {
         OfficeDocumentReadResult document,
         ExtractionState state) {
         var selected = new List<OfficeDocumentFormField>();
-        foreach (OfficeDocumentFormField form in OfficeDocumentModelTraversal.Forms(document)) {
+        int candidateLimit = state.Options.MaxForms == int.MaxValue ? int.MaxValue : state.Options.MaxForms + 1;
+        foreach (OfficeDocumentFormField form in OfficeDocumentModelTraversal.Forms(
+                     document,
+                     candidateLimit,
+                     () => state.AddLimitDiagnostic("structured-form-limit", state.Options.MaxForms, "form candidates"))) {
             state.CancellationToken.ThrowIfCancellationRequested();
             if (selected.Count >= state.Options.MaxForms) {
                 state.AddLimitDiagnostic("structured-form-limit", state.Options.MaxForms, "forms");

--- a/OfficeIMO.Reader.Tests/Reader.StructuredExtraction.cs
+++ b/OfficeIMO.Reader.Tests/Reader.StructuredExtraction.cs
@@ -127,6 +127,21 @@ public sealed class ReaderStructuredExtractionTests {
     }
 
     [Fact]
+    public void Extract_BoundsDuplicateFormCandidatesBeforeIdentityMaterialization() {
+        OfficeDocumentFormField[] duplicates = Enumerable.Range(0, 50_000)
+            .Select(index => new OfficeDocumentFormField { Id = "duplicate", Name = "Duplicate " + index })
+            .ToArray();
+        var document = new OfficeDocumentReadResult { Forms = duplicates };
+
+        OfficeDocumentStructuredExtractionResult result = OfficeDocumentStructuredExtractor.Extract(
+            document,
+            new OfficeDocumentStructuredExtractionOptions { MaxForms = 2 });
+
+        Assert.Single(result.Forms);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "structured-form-limit");
+    }
+
+    [Fact]
     public void Extract_ProjectsChunkOnlyFormFieldsIntoTypedFormsAndRecords() {
         var document = new OfficeDocumentReadResult {
             Chunks = new[] {

--- a/OfficeIMO.Rtf.Tests/Rtf/WordRtfWorkflowTests.cs
+++ b/OfficeIMO.Rtf.Tests/Rtf/WordRtfWorkflowTests.cs
@@ -61,7 +61,7 @@ public class WordRtfWorkflowTests {
     }
 
     [Fact]
-    public void Compare_Uses_Word_Structural_Comparison_And_Cleans_Temporary_Files() {
+    public void Compare_Uses_Word_Structural_Comparison_Without_Temporary_Files() {
         RtfDocument source = RtfDocument.Create();
         source.AddParagraph("Before");
         RtfDocument target = RtfDocument.Create();
@@ -71,8 +71,8 @@ public class WordRtfWorkflowTests {
 
         Assert.True(result.WorkflowResult.HasChanges);
         Assert.NotEmpty(result.WorkflowResult.Findings);
-        Assert.False(File.Exists(result.WorkflowResult.SourcePath));
-        Assert.False(File.Exists(result.WorkflowResult.TargetPath));
+        Assert.Equal("source.rtf", result.WorkflowResult.SourcePath);
+        Assert.Equal("target.rtf", result.WorkflowResult.TargetPath);
         Assert.Contains(result.Report.Diagnostics, diagnostic => diagnostic.Code == "RtfWordCompareCompleted");
     }
 

--- a/OfficeIMO.Word.Rtf/WordRtfWorkflowExtensions.cs
+++ b/OfficeIMO.Word.Rtf/WordRtfWorkflowExtensions.cs
@@ -113,21 +113,17 @@ public static class WordRtfWorkflowExtensions {
         RtfConversionResult<WordDocument> targetConversion = target.ToWordDocumentResult();
         using WordDocument sourceWord = sourceConversion.Value;
         using WordDocument targetWord = targetConversion.Value;
-        string sourcePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".docx");
-        string targetPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".docx");
-        try {
-            sourceWord.Save(sourcePath);
-            targetWord.Save(targetPath);
-            WordComparisonResult comparison = WordDocumentComparer.CompareStructure(sourcePath, targetPath, options);
-            var report = new RtfConversionReport();
-            report.Merge(sourceConversion.Report);
-            report.Merge(targetConversion.Report);
-            report.Add(RtfConversionSeverity.Information, "RtfWordCompareCompleted", "RTF documents were compared by OfficeIMO.Word.", RtfConversionAction.Preserved, feature: "compare");
-            return new RtfWordWorkflowResult<WordComparisonResult>(source, comparison, report);
-        } finally {
-            TryDelete(sourcePath);
-            TryDelete(targetPath);
-        }
+        WordComparisonResult comparison = WordDocumentComparer.CompareStructure(
+            sourceWord,
+            targetWord,
+            options,
+            sourceLabel: "source.rtf",
+            targetLabel: "target.rtf");
+        var report = new RtfConversionReport();
+        report.Merge(sourceConversion.Report);
+        report.Merge(targetConversion.Report);
+        report.Add(RtfConversionSeverity.Information, "RtfWordCompareCompleted", "RTF documents were compared by OfficeIMO.Word.", RtfConversionAction.Preserved, feature: "compare");
+        return new RtfWordWorkflowResult<WordComparisonResult>(source, comparison, report);
     }
 
     private static RtfWordWorkflowResult<T> Complete<T>(
@@ -144,11 +140,4 @@ public static class WordRtfWorkflowExtensions {
         return new RtfWordWorkflowResult<T>(output.Value, workflowResult, report);
     }
 
-    private static void TryDelete(string path) {
-        try {
-            if (File.Exists(path)) File.Delete(path);
-        } catch (IOException) {
-        } catch (UnauthorizedAccessException) {
-        }
-    }
 }

--- a/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.cs
+++ b/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.cs
@@ -48,12 +48,41 @@ namespace OfficeIMO.Word {
         public static WordComparisonResult CompareStructure(string sourcePath, string targetPath, WordComparisonOptions? options) {
             if (string.IsNullOrEmpty(sourcePath)) throw new ArgumentNullException(nameof(sourcePath));
             if (string.IsNullOrEmpty(targetPath)) throw new ArgumentNullException(nameof(targetPath));
-            options ??= WordComparisonOptions.Default;
 
             using WordDocument source = WordDocument.Load(sourcePath);
             using WordDocument target = WordDocument.Load(targetPath);
+            return CompareStructureCore(source, target, sourcePath, targetPath, options);
+        }
 
-            WordComparisonResult result = new(sourcePath, targetPath);
+        /// <summary>
+        /// Compares two already-loaded documents without writing them to disk and returns a machine-readable summary.
+        /// </summary>
+        /// <param name="source">Original document.</param>
+        /// <param name="target">Modified document.</param>
+        /// <param name="options">Optional comparison switches for text normalization and feature families.</param>
+        /// <param name="sourceLabel">Logical source label included in reports.</param>
+        /// <param name="targetLabel">Logical target label included in reports.</param>
+        /// <returns>A deterministic comparison result that can be used for review reports and automation.</returns>
+        public static WordComparisonResult CompareStructure(
+            WordDocument source,
+            WordDocument target,
+            WordComparisonOptions? options = null,
+            string sourceLabel = "source",
+            string targetLabel = "target") {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (target == null) throw new ArgumentNullException(nameof(target));
+            return CompareStructureCore(source, target, sourceLabel, targetLabel, options);
+        }
+
+        private static WordComparisonResult CompareStructureCore(
+            WordDocument source,
+            WordDocument target,
+            string sourceLabel,
+            string targetLabel,
+            WordComparisonOptions? options) {
+            options ??= WordComparisonOptions.Default;
+
+            WordComparisonResult result = new(sourceLabel, targetLabel);
             var comparisonWorkBudget = new ComparisonWorkBudget(MaxComparisonTextWorkUnits);
             AnalyzeParagraphs(source, target, result, options, comparisonWorkBudget);
             if (options.CompareFields) {


### PR DESCRIPTION
This batch hardens document rendering, extraction, and conversion paths that consume untrusted content.

- bounds gradient, transform, multicolumn, flex, image, and table layout work
- normalizes huge finite angles in their native CSS unit before conversion, including deg, grad, rad, and turn
- keeps balanced-column search probes bounded without applying the final column cap before a valid layout is found
- rejects non-finite and overflow-prone CSS values before they reach drawing operations
- limits reader form traversal and structured extraction work
- makes OpenDocument style splitting safe and deterministic
- removes failed-conversion temporary files and avoids exposing temporary paths
- preserves intentional RTF hidden-HTML behavior while keeping the conversion path bounded

The accepted fixes include regression coverage for the reported crash and resource-exhaustion paths. Duplicate, already-fixed, and non-applicable findings in the same 20-item batch are dispositioned separately with evidence.

Compatibility is unchanged for valid CSS transforms and supported document inputs. Focused angle and multicolumn regressions pass on .NET 8 and .NET 10, and the affected HTML library builds for netstandard2.0 with zero warnings.