### PR TITLE
Harden conversion and rendering boundaries

### DIFF
--- a/OfficeIMO.CSV.Tests/CsvDocumentBasicsTests.cs
+++ b/OfficeIMO.CSV.Tests/CsvDocumentBasicsTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -648,6 +649,28 @@ public class CsvDocumentBasicsTests
     }
 
     [Fact]
+    public void Delimiterless_Comment_With_Unmatched_Quote_Does_Not_Force_Lookahead()
+    {
+        var lines = new List<string> { "# note \"unterminated" };
+        for (int index = 0; index < CsvLoadOptions.DefaultMaxCommentContinuationLines; index++)
+        {
+            lines.Add("continuation-" + index.ToString(CultureInfo.InvariantCulture));
+        }
+        lines.Add("must not be read");
+
+        using var reader = new ReadLimitedTextReader(
+            lines,
+            maximumReads: CsvLoadOptions.DefaultMaxCommentContinuationLines + 1);
+
+        string[] first = CsvDocument.ReadRecords(reader, new CsvLoadOptions {
+            SkipCommentRows = true
+        }).First();
+
+        Assert.Equal(new[] { "continuation-0" }, first);
+        Assert.Equal(CsvLoadOptions.DefaultMaxCommentContinuationLines + 1, reader.ReadCount);
+    }
+
+    [Fact]
     public void Can_Treat_Leading_Comment_As_Header_When_Requested()
     {
         var parsed = CsvDocument.Parse(
@@ -983,4 +1006,42 @@ public class CsvDocumentBasicsTests
         public override string ToString() => _value;
     }
 #endif
+
+    private sealed class ReadLimitedTextReader : TextReader
+    {
+        private readonly IReadOnlyList<string> _lines;
+        private readonly int _maximumReads;
+        private int _index;
+
+        internal ReadLimitedTextReader(IReadOnlyList<string> lines, int maximumReads)
+        {
+            _lines = lines;
+            _maximumReads = maximumReads;
+        }
+
+        internal int ReadCount { get; private set; }
+
+        public override int Read(char[] buffer, int index, int count)
+        {
+            ReadCount++;
+            if (ReadCount > _maximumReads)
+            {
+                throw new InvalidOperationException("Parser read past the bounded record prefix.");
+            }
+
+            if (_index >= _lines.Count)
+            {
+                return 0;
+            }
+
+            string line = _lines[_index++] + "\n";
+            if (line.Length > count)
+            {
+                throw new InvalidOperationException("Test line exceeds the supplied reader buffer.");
+            }
+
+            line.CopyTo(0, buffer, index, line.Length);
+            return line.Length;
+        }
+    }
 }

--- a/OfficeIMO.CSV.Tests/CsvSaveApiTests.cs
+++ b/OfficeIMO.CSV.Tests/CsvSaveApiTests.cs
@@ -135,6 +135,25 @@ public class CsvSaveApiTests
     }
 
     [Fact]
+    public void CreateTextWriter_NoClobberClaimsDestinationAtomically()
+    {
+        string path = Path.Combine(Path.GetTempPath(), "OfficeIMO.CSV.NoClobber." + Guid.NewGuid().ToString("N") + ".csv");
+        try
+        {
+            File.WriteAllText(path, "existing");
+
+            Assert.Throws<IOException>(() =>
+                CsvFile.CreateTextWriter(path, new CsvSaveOptions { NoClobber = true }));
+
+            Assert.Equal("existing", File.ReadAllText(path));
+        }
+        finally
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    [Fact]
     public async Task SaveAsync_Append_Creates_Missing_Parent_Directory()
     {
         string directory = CreateMissingDirectoryPath();

--- a/OfficeIMO.CSV/CsvDocument.DelimiterDetection.cs
+++ b/OfficeIMO.CSV/CsvDocument.DelimiterDetection.cs
@@ -60,7 +60,8 @@ public sealed partial class CsvDocument
         using var records = ReadLogicalDelimiterDetectionRecords(
             reader,
             line => ShouldSkipCommentDuringDelimiterDetection(line, options, useHeaderDiscovery, allowPreHeaderCommentSkip),
-            line => IsDelimiterDetectionHeaderCandidate(line, options, candidates)).GetEnumerator();
+            line => IsDelimiterDetectionHeaderCandidate(line, options, candidates),
+            options.MaxCommentContinuationLines).GetEnumerator();
         while (records.MoveNext())
         {
             var record = records.Current;
@@ -123,8 +124,14 @@ public sealed partial class CsvDocument
     private static IEnumerable<string> ReadLogicalDelimiterDetectionRecords(
         TextReader reader,
         Func<string, bool> shouldSkipRawCommentRecord,
-        Func<string, bool> isHeaderCandidate)
+        Func<string, bool> isHeaderCandidate,
+        int maxCommentContinuationLines)
     {
+        if (maxCommentContinuationLines <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxCommentContinuationLines));
+        }
+
         var pendingLines = new Queue<string>();
         while (TryReadDelimiterDetectionLine(reader, pendingLines, out var line))
         {
@@ -132,7 +139,12 @@ public sealed partial class CsvDocument
             UpdateLogicalDelimiterDetectionQuoteState(line, ref inQuotes);
             if (shouldSkipRawCommentRecord(line) && inQuotes)
             {
-                SkipRawDelimiterDetectionCommentRecord(reader, pendingLines, line, isHeaderCandidate);
+                SkipRawDelimiterDetectionCommentRecord(
+                    reader,
+                    pendingLines,
+                    line,
+                    isHeaderCandidate,
+                    maxCommentContinuationLines);
                 continue;
             }
 
@@ -181,12 +193,13 @@ public sealed partial class CsvDocument
         TextReader reader,
         Queue<string> pendingLines,
         string firstLine,
-        Func<string, bool> isHeaderCandidate)
+        Func<string, bool> isHeaderCandidate,
+        int maxCommentContinuationLines)
     {
         var continuations = new List<string>();
         var inQuotes = false;
         UpdateLogicalDelimiterDetectionQuoteState(firstLine, ref inQuotes);
-        while (reader.ReadLine() is { } next)
+        while (continuations.Count < maxCommentContinuationLines && reader.ReadLine() is { } next)
         {
             continuations.Add(next);
             UpdateLogicalDelimiterDetectionQuoteState(next, ref inQuotes);

--- a/OfficeIMO.CSV/CsvDocument.cs
+++ b/OfficeIMO.CSV/CsvDocument.cs
@@ -200,11 +200,7 @@ public sealed partial class CsvDocument
             throw new IOException($"The file '{fullPath}' already exists.");
         }
 
-        var directory = Path.GetDirectoryName(fullPath);
-        if (!string.IsNullOrEmpty(directory))
-        {
-            Directory.CreateDirectory(directory);
-        }
+        OfficeFileCommit.EnsureTargetDirectory(fullPath);
 
         if (options.Append)
         {
@@ -213,9 +209,7 @@ public sealed partial class CsvDocument
             return;
         }
 
-        var temporaryPath = Path.Combine(
-            string.IsNullOrEmpty(directory) ? Environment.CurrentDirectory : directory,
-            "." + Path.GetFileName(fullPath) + "." + Guid.NewGuid().ToString("N") + ".tmp");
+        var temporaryPath = OfficeFileCommit.CreateTemporaryPath(fullPath);
 
         try
         {
@@ -224,23 +218,17 @@ public sealed partial class CsvDocument
                 WriteObjects(writer, items, options);
             }
 
-            if (File.Exists(fullPath))
-            {
-                File.Replace(temporaryPath, fullPath, destinationBackupFileName: null, ignoreMetadataErrors: true);
-            }
-            else
-            {
-                File.Move(temporaryPath, fullPath);
-            }
+            OfficeFileCommit.CommitTemporaryFile(
+                temporaryPath,
+                fullPath,
+                options.NoClobber
+                    ? OfficeFileCommit.ConflictPolicy.FailIfExists
+                    : OfficeFileCommit.ConflictPolicy.Replace);
+            temporaryPath = string.Empty;
         }
-        catch
+        finally
         {
-            if (File.Exists(temporaryPath))
-            {
-                File.Delete(temporaryPath);
-            }
-
-            throw;
+            OfficeFileCommit.DeleteIfExists(temporaryPath);
         }
     }
 

--- a/OfficeIMO.CSV/CsvFile.cs
+++ b/OfficeIMO.CSV/CsvFile.cs
@@ -178,8 +178,25 @@ public static class CsvFile
         }
     }
 
-    private static Stream CreateWriteStream(string path, CsvSaveOptions options, bool append, int bufferSize) =>
-        CreateWriteStream(path, ResolveCompression(options.CompressionType, path), options.CompressionLevel, append, bufferSize);
+    private static Stream CreateWriteStream(string path, CsvSaveOptions options, bool append, int bufferSize)
+    {
+        CsvCompressionType compressionType = ResolveCompression(options.CompressionType, path);
+        EnsureCompressionSupported(compressionType);
+        EnsureCompressionLevelSupported(compressionType, options.CompressionLevel);
+        if (append && compressionType != CsvCompressionType.None)
+        {
+            throw new NotSupportedException("Appending to compressed CSV files is not supported.");
+        }
+
+        if (!options.NoClobber)
+        {
+            return CreateWriteStream(path, compressionType, options.CompressionLevel, append, bufferSize);
+        }
+
+        var fileStream = new FileStream(path, FileMode.CreateNew, FileAccess.Write, FileShare.Read,
+            bufferSize, FileOptions.SequentialScan);
+        return WrapWriteStream(fileStream, compressionType, options.CompressionLevel);
+    }
 
     private static Stream CreateWriteStream(string path, CsvCompressionType compressionType, CompressionLevel compressionLevel, bool append, int bufferSize)
     {

--- a/OfficeIMO.CSV/CsvLoadOptions.cs
+++ b/OfficeIMO.CSV/CsvLoadOptions.cs
@@ -16,6 +16,9 @@ public sealed class CsvLoadOptions
     /// <summary>Default maximum complete stream input size (256 MiB).</summary>
     public const long DefaultMaxInputBytes = 256L * 1024L * 1024L;
 
+    /// <summary>Default maximum physical lines inspected while deciding whether a quoted comment continues.</summary>
+    public const int DefaultMaxCommentContinuationLines = 64;
+
     /// <summary>
     /// Gets or sets whether the first record in the file represents the header row. Default is <c>true</c>.
     /// Ignored when <see cref="Header"/> is provided; in that case the first record is treated as data.
@@ -43,6 +46,13 @@ public sealed class CsvLoadOptions
     /// Comment rows are identified by <see cref="CommentCharacter"/>.
     /// </summary>
     public bool SkipCommentRows { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum number of physical continuation lines inspected for a quoted comment record.
+    /// Once the limit is reached, buffered lines are replayed as ordinary input instead of being retained while
+    /// searching for a closing quote. Defaults to <see cref="DefaultMaxCommentContinuationLines"/>.
+    /// </summary>
+    public int MaxCommentContinuationLines { get; set; } = DefaultMaxCommentContinuationLines;
 
     /// <summary>
     /// Gets or sets the character that identifies a comment row when it appears at the start of a record. Default is <c>#</c>.

--- a/OfficeIMO.CSV/CsvParser.cs
+++ b/OfficeIMO.CSV/CsvParser.cs
@@ -878,7 +878,13 @@ internal static partial class CsvParser
         var continuations = new List<CsvLine>();
         var state = new QuotedRecordState();
         UpdateQuotedRecordState(firstLine, delimiter, options.TrimWhitespace, ref state);
-        while (true)
+        int continuationLimit = options.MaxCommentContinuationLines;
+        if (continuationLimit <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(options), "MaxCommentContinuationLines must be greater than zero.");
+        }
+
+        while (continuations.Count < continuationLimit)
         {
             var next = ReadLineWithSeparator(reader, pendingLines, out var nextSeparator);
             if (next == null)
@@ -901,6 +907,9 @@ internal static partial class CsvParser
                 return true;
             }
         }
+
+        EnqueueContinuations(pendingLines, continuations);
+        return true;
     }
 
     private static void EnqueueContinuations(Queue<CsvLine> pendingLines, List<CsvLine> continuations)

--- a/OfficeIMO.Drawing.Tests/Drawing.Tests.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.Tests.cs
@@ -22,6 +22,37 @@ public partial class DrawingTests {
     };
 
     [Fact]
+    public void DeferredBehindContentOrderingRestoresStablePaintOrderInOnePass() {
+        var drawing = new OfficeDrawing(100, 60);
+        OfficeShape background = OfficeShape.Rectangle(100, 60);
+        background.FillColor = OfficeColor.White;
+        background.StrokeWidth = 0D;
+        drawing.AddShape(background, 0, 0);
+        drawing.AddText("foreground-one", 5, 5, 50, 10);
+
+        OfficeShape blue = OfficeShape.Rectangle(10, 10);
+        blue.FillColor = OfficeColor.Blue;
+        OfficeShape red = OfficeShape.Rectangle(10, 10);
+        red.FillColor = OfficeColor.Red;
+        using (drawing.DeferBehindContentOrdering()) {
+            for (int index = 0; index < 5000; index++) {
+                drawing.AddShapeBehindContent(index % 2 == 0 ? blue : red, 10, 10);
+                if (index == 2499) {
+                    drawing.AddText("foreground-two", 5, 20, 50, 10);
+                }
+            }
+        }
+
+        Assert.Equal(5003, drawing.Elements.Count);
+        Assert.Equal(5001, drawing.Shapes.Count);
+        Assert.Equal(OfficeColor.White, Assert.IsType<OfficeDrawingShape>(drawing.Elements[0]).Shape.FillColor);
+        Assert.Equal(OfficeColor.Blue, Assert.IsType<OfficeDrawingShape>(drawing.Elements[1]).Shape.FillColor);
+        Assert.Equal(OfficeColor.Red, Assert.IsType<OfficeDrawingShape>(drawing.Elements[5000]).Shape.FillColor);
+        Assert.Equal("foreground-one", Assert.IsType<OfficeDrawingText>(drawing.Elements[5001]).Text);
+        Assert.Equal("foreground-two", Assert.IsType<OfficeDrawingText>(drawing.Elements[5002]).Text);
+    }
+
+    [Fact]
     public void OfficeImageExportBuilder_AppliesSharedFluentPresets() {
         var options = new TestImageExportOptions();
         var builder = new TestImageExportBuilder(options);

--- a/OfficeIMO.Drawing/OfficeDrawing.cs
+++ b/OfficeIMO.Drawing/OfficeDrawing.cs
@@ -18,6 +18,7 @@ public sealed partial class OfficeDrawing {
     private readonly List<OfficeDrawingElement> _elements = new List<OfficeDrawingElement>();
     private readonly ReadOnlyCollection<OfficeDrawingElement> _elementsView;
     private readonly HashSet<OfficeDrawingElement> _behindContentElements = new HashSet<OfficeDrawingElement>();
+    private int _behindContentBatchDepth;
 
     /// <summary>Drawing width in the caller's layout unit.</summary>
     public double Width { get; }
@@ -77,7 +78,11 @@ public sealed partial class OfficeDrawing {
         }
 
         int elementIndex = AddBehindContentElement(item);
-        _shapes.Insert(GetTypedElementInsertIndex<OfficeDrawingShape>(elementIndex), item);
+        if (_behindContentBatchDepth > 0) {
+            _shapes.Add(item);
+        } else {
+            _shapes.Insert(GetTypedElementInsertIndex<OfficeDrawingShape>(elementIndex), item);
+        }
         return this;
     }
 
@@ -242,7 +247,11 @@ public sealed partial class OfficeDrawing {
         }
 
         int elementIndex = AddBehindContentElement(item);
-        _images.Insert(GetTypedElementInsertIndex<OfficeDrawingImage>(elementIndex), item);
+        if (_behindContentBatchDepth > 0) {
+            _images.Add(item);
+        } else {
+            _images.Insert(GetTypedElementInsertIndex<OfficeDrawingImage>(elementIndex), item);
+        }
         return this;
     }
 
@@ -569,9 +578,79 @@ public sealed partial class OfficeDrawing {
 
     private int AddBehindContentElement(OfficeDrawingElement item) {
         _behindContentElements.Add(item);
+        if (_behindContentBatchDepth > 0) {
+            _elements.Add(item);
+            return _elements.Count - 1;
+        }
+
         int index = GetBehindContentInsertIndex();
         _elements.Insert(index, item);
         return index;
+    }
+
+    /// <summary>
+    /// Defers behind-content ordering so importers can add many background elements in linear time.
+    /// Paint order is restored when the returned scope is disposed.
+    /// </summary>
+    internal IDisposable DeferBehindContentOrdering() {
+        _behindContentBatchDepth++;
+        return new BehindContentOrderingScope(this);
+    }
+
+    private void EndBehindContentOrdering() {
+        if (_behindContentBatchDepth <= 0) return;
+        _behindContentBatchDepth--;
+        if (_behindContentBatchDepth != 0) return;
+
+        int backgroundIndex = GetPageBackgroundIndex();
+        var ordered = new List<OfficeDrawingElement>(_elements.Count);
+        if (backgroundIndex >= 0) ordered.Add(_elements[backgroundIndex]);
+        for (int index = 0; index < _elements.Count; index++) {
+            if (index != backgroundIndex && _behindContentElements.Contains(_elements[index])) {
+                ordered.Add(_elements[index]);
+            }
+        }
+        for (int index = 0; index < _elements.Count; index++) {
+            if (index != backgroundIndex && !_behindContentElements.Contains(_elements[index])) {
+                ordered.Add(_elements[index]);
+            }
+        }
+
+        _elements.Clear();
+        _elements.AddRange(ordered);
+        _shapes.Clear();
+        _images.Clear();
+        for (int index = 0; index < _elements.Count; index++) {
+            if (_elements[index] is OfficeDrawingShape shape) _shapes.Add(shape);
+            if (_elements[index] is OfficeDrawingImage image) _images.Add(image);
+        }
+    }
+
+    private int GetPageBackgroundIndex() {
+        if (_elements.Count == 0) return -1;
+        return _elements[0] is OfficeDrawingShape shape
+            && shape.X == 0D
+            && shape.Y == 0D
+            && shape.Shape.Kind == OfficeShapeKind.Rectangle
+            && shape.Shape.Width == Width
+            && shape.Shape.Height == Height
+            && shape.Shape.StrokeWidth <= 0D
+            ? 0
+            : -1;
+    }
+
+    private sealed class BehindContentOrderingScope : IDisposable {
+        private OfficeDrawing? _owner;
+
+        internal BehindContentOrderingScope(OfficeDrawing owner) {
+            _owner = owner;
+        }
+
+        public void Dispose() {
+            OfficeDrawing? owner = _owner;
+            _owner = null;
+            owner?.EndBehindContentOrdering();
+        }
     }
 
     private int GetTypedElementInsertIndex<T>(int elementIndex) where T : OfficeDrawingElement {

--- a/OfficeIMO.Excel.Html/HtmlExcelConverterExtensions.cs
+++ b/OfficeIMO.Excel.Html/HtmlExcelConverterExtensions.cs
@@ -766,9 +766,25 @@ public static partial class HtmlExcelConverterExtensions {
         double top = NormalizeCrop(item, "data-officeimo-crop-top", budget, result);
         double right = NormalizeCrop(item, "data-officeimo-crop-right", budget, result);
         double bottom = NormalizeCrop(item, "data-officeimo-crop-bottom", budget, result);
+        NormalizeCropPair(ref left, ref right, result, "horizontal");
+        NormalizeCropPair(ref top, ref bottom, result, "vertical");
         if (left > 0D || top > 0D || right > 0D || bottom > 0D) {
             image.SetCropRatio(left, top, right, bottom);
         }
+    }
+
+    private static void NormalizeCropPair(
+        ref double first,
+        ref double second,
+        HtmlToExcelResult result,
+        string axis) {
+        if (first + second < 1D) return;
+        first = 0D;
+        second = 0D;
+        AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.SemanticValueInvalid,
+            "Invalid image " + axis + " crop metadata used the zero fallback.",
+            lossKind: HtmlConversionLossKind.Approximation,
+            source: "image crop " + axis);
     }
 
     private static double NormalizeCrop(IElement item, string attributeName, HtmlImportBudget budget, HtmlToExcelResult result) {

--- a/OfficeIMO.Excel.Tests/Excel.ImageExport.HeaderFooter.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ImageExport.HeaderFooter.cs
@@ -31,6 +31,32 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void ExcelWorksheet_SvgHeaderFooterDoesNotSerializeClippedTextOrOversizedFontNames() {
+            using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet sheet = document.AddWorksheet("Report");
+            FillPageBreakGrid(sheet);
+            string visiblePrefix = new string('V', 600);
+            string oversizedFont = new string('F', 10000);
+            sheet.SetHeaderFooter(
+                headerLeft: visiblePrefix + "PLAIN-SECRET-TAIL",
+                headerCenter: "&B" + visiblePrefix + "RICH-SECRET-TAIL",
+                footerRight: "&\"" + oversizedFont + ",Bold\"FONT-SECRET-TAIL");
+
+            OfficeImageExportResult result = Assert.Single(sheet.ExportImages(
+                OfficeImageExportFormat.Svg,
+                new ExcelWorksheetImageExportOptions {
+                    Range = "A1:B2",
+                    ShowGridlines = false
+                }));
+            string svg = Encoding.UTF8.GetString(result.Bytes);
+
+            Assert.DoesNotContain("PLAIN-SECRET-TAIL", svg, StringComparison.Ordinal);
+            Assert.DoesNotContain("RICH-SECRET-TAIL", svg, StringComparison.Ordinal);
+            Assert.DoesNotContain("FONT-SECRET-TAIL", svg, StringComparison.Ordinal);
+            Assert.DoesNotContain(oversizedFont, svg, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void ExcelWorksheet_PageSlicedSvgExportRendersSupportedHeaderFooterFields() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
             using ExcelDocument document = ExcelDocument.Create(filePath);
@@ -96,7 +122,7 @@ namespace OfficeIMO.Tests {
             sheet.AddManualRowPageBreak(2, save: false);
 
             IReadOnlyList<OfficeImageExportResult> results = sheet.ExportImages(OfficeImageExportFormat.Svg, new ExcelWorksheetImageExportOptions {
-                Range = "A1:H4",
+                Range = "A1:P4",
                 SplitByManualPageBreaks = true,
                 ShowGridlines = false,
                 HeaderFooterDateTime = headerFooterDateTime
@@ -193,7 +219,7 @@ namespace OfficeIMO.Tests {
             sheet.AddManualRowPageBreak(2, save: false);
 
             IReadOnlyList<OfficeImageExportResult> results = sheet.ExportImages(OfficeImageExportFormat.Svg, new ExcelWorksheetImageExportOptions {
-                Range = "A1:D4",
+                Range = "A1:P4",
                 SplitByManualPageBreaks = true,
                 ShowGridlines = false
             });
@@ -217,7 +243,7 @@ namespace OfficeIMO.Tests {
             sheet.AddManualRowPageBreak(2, save: false);
 
             IReadOnlyList<OfficeImageExportResult> results = sheet.ExportImages(OfficeImageExportFormat.Svg, new ExcelWorksheetImageExportOptions {
-                Range = "A1:D4",
+                Range = "A1:P4",
                 SplitByManualPageBreaks = true,
                 ShowGridlines = false
             });
@@ -299,7 +325,7 @@ namespace OfficeIMO.Tests {
             sheet.AddManualRowPageBreak(2, save: false);
 
             IReadOnlyList<OfficeImageExportResult> results = sheet.ExportImages(OfficeImageExportFormat.Svg, new ExcelWorksheetImageExportOptions {
-                Range = "A1:D4",
+                Range = "A1:P4",
                 SplitByManualPageBreaks = true,
                 ShowGridlines = false,
                 HeaderFooterDateTime = headerFooterDateTime
@@ -331,7 +357,7 @@ namespace OfficeIMO.Tests {
             sheet.AddManualRowPageBreak(4, save: false);
 
             IReadOnlyList<OfficeImageExportResult> results = sheet.ExportImages(OfficeImageExportFormat.Svg, new ExcelWorksheetImageExportOptions {
-                Range = "A1:D6",
+                Range = "A1:P6",
                 SplitByManualPageBreaks = true,
                 ShowGridlines = false
             });

--- a/OfficeIMO.Excel.Tests/Excel.ImageExport.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ImageExport.cs
@@ -285,6 +285,7 @@ namespace OfficeIMO.Tests {
             Assert.Equal("01/05/26", ExcelNumberFormatDisplay.FormatNumericText(new DateTime(2026, 1, 5).ToOADate(), 1U, "mm/dd/yy", "46027"));
             Assert.Equal("January 5, 2026", ExcelNumberFormatDisplay.FormatNumericText(new DateTime(2026, 1, 5).ToOADate(), 1U, "mmmm d, yyyy", "46027"));
             Assert.Equal("Monday, January 5", ExcelNumberFormatDisplay.FormatNumericText(new DateTime(2026, 1, 5).ToOADate(), 1U, "dddd, mmmm d", "46027"));
+            Assert.Equal("46027", ExcelNumberFormatDisplay.FormatNumericText(46027D, 1U, "mmmm d \"%\"", "46027"));
             Assert.Equal("5%", ExcelNumberFormatDisplay.FormatNumericText(5D, 1U, "0\"%\"", "5"));
             Assert.Equal("500%", ExcelNumberFormatDisplay.FormatNumericText(5D, 1U, "0%", "5"));
             Assert.Equal("1234%%", ExcelNumberFormatDisplay.FormatNumericText(0.1234D, 1U, "0%%", "0.1234"));
@@ -299,6 +300,7 @@ namespace OfficeIMO.Tests {
             Assert.Equal("\u20AC1,234.50", ExcelNumberFormatDisplay.FormatNumericText(1234.5D, 1U, "[$\u20AC-407]#,##0.00", "1234.5"));
             Assert.Equal("90:00", ExcelNumberFormatDisplay.FormatNumericText(TimeSpan.FromMinutes(90).TotalDays, 1U, "[mm]:ss", "0.0625"));
             Assert.Equal("5400", ExcelNumberFormatDisplay.FormatNumericText(TimeSpan.FromMinutes(90).TotalDays, 1U, "[ss]", "0.0625"));
+            Assert.Equal("1E+20", ExcelNumberFormatDisplay.FormatNumericText(1E20D, 1U, "[ss]", "1E+20"));
             Assert.Equal(string.Empty, ExcelNumberFormatDisplay.FormatNumericText(0D, 1U, "0;-0;;@", "0"));
             Assert.Equal(string.Empty, ExcelNumberFormatDisplay.FormatNumericText(0D, 1U, "#", "0"));
             Assert.Equal(string.Empty, ExcelNumberFormatDisplay.FormatNumericText(0D, 1U, "#,###", "0"));
@@ -1263,6 +1265,39 @@ namespace OfficeIMO.Tests {
                 Assert.Contains(snapshot.ConditionalIcons, icon => icon.Row == 2 && icon.Kind == ExcelConditionalIconKind.RedCircle);
                 Assert.Contains(snapshot.ConditionalIcons, icon => icon.Row == 3 && icon.Kind == ExcelConditionalIconKind.YellowCircle);
                 Assert.Contains(snapshot.ConditionalIcons, icon => icon.Row == 4 && icon.Kind == ExcelConditionalIconKind.GreenCircle);
+            }
+        }
+
+        [Fact]
+        public void ExcelRange_ImageExportRejectsNonFiniteIconSetPercentiles() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+            try {
+                using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                    ExcelSheet sheet = document.AddWorksheet("IconPercentiles");
+                    sheet.CellValue(1, 1, 1);
+                    sheet.CellValue(2, 1, 2);
+                    sheet.CellValue(3, 1, 3);
+                    sheet.AddConditionalIconSet("A1:A3", IconSetValues.ThreeTrafficLights1,
+                        showValue: true, reverseIconOrder: false);
+                    document.Save();
+                }
+
+                using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true)) {
+                    Worksheet worksheet = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet;
+                    IconSet iconSet = worksheet.Elements<ConditionalFormatting>()
+                        .First().Elements<ConditionalFormattingRule>().First().GetFirstChild<IconSet>()!;
+                    ConditionalFormatValueObject threshold = iconSet.Elements<ConditionalFormatValueObject>().ElementAt(1);
+                    threshold.Type = ConditionalFormatValueObjectValues.Percentile;
+                    threshold.Val = "NaN";
+                    worksheet.Save();
+                }
+
+                using ExcelDocument reopened = ExcelDocument.Load(filePath);
+                ExcelRangeVisualSnapshot snapshot = reopened.Sheets.Single().Range("A1:A3").CreateVisualSnapshot();
+
+                Assert.Equal(3, snapshot.ConditionalIcons.Count);
+            } finally {
+                if (File.Exists(filePath)) File.Delete(filePath);
             }
         }
 

--- a/OfficeIMO.Excel.Tests/Excel.LegacyXls.ExternalCellCache.cs
+++ b/OfficeIMO.Excel.Tests/Excel.LegacyXls.ExternalCellCache.cs
@@ -1,6 +1,8 @@
 using OfficeIMO.Excel.LegacyXls;
 using OfficeIMO.Excel.LegacyXls.Diagnostics;
 using OfficeIMO.Excel.LegacyXls.Model;
+using OfficeIMO.Excel;
+using DocumentFormat.OpenXml.Packaging;
 using Xunit;
 
 namespace OfficeIMO.Tests {
@@ -11,7 +13,8 @@ namespace OfficeIMO.Tests {
             byte[] compound = LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFile(workbookStream);
 
             LegacyXlsWorkbook workbook = LegacyXlsWorkbook.Load(compound, new LegacyXlsImportOptions {
-                ReportUnsupportedContent = true
+                ReportUnsupportedContent = true,
+                PreserveExternalWorkbookLinks = true
             });
             LegacyXlsImportReport report = workbook.CreateImportReport();
 
@@ -117,6 +120,29 @@ namespace OfficeIMO.Tests {
                 && diagnostic.DetailCode == "ExternalReference:ExternalWorkbook"
                 && diagnostic.RecordType == 0x01ae);
             Assert.DoesNotContain(workbook.UnsupportedFeatures, feature => feature.RecordType == 0x0059 || feature.RecordType == 0x005a);
+        }
+
+        [Fact]
+        public void LegacyXls_Load_DoesNotActivateExternalWorkbookLinksByDefault() {
+            byte[] workbookStream = LegacyXlsTestWorkbookBuilder.CreateExternalCellCacheWorkbookStream();
+            byte[] compound = LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFile(workbookStream);
+
+            LegacyXlsWorkbook workbook = LegacyXlsWorkbook.Load(compound);
+            using ExcelDocument document = ExcelDocument.LoadLegacyXls(new MemoryStream(compound));
+
+            Assert.Contains(workbook.UnsupportedFeatures, feature =>
+                feature.Kind == LegacyXlsUnsupportedFeatureKind.ExternalReference
+                && feature.DetailCode == "ExternalReference:ExternalWorkbook");
+            Assert.DoesNotContain(document.WorkbookPartRoot.Parts,
+                pair => pair.OpenXmlPart is ExternalWorkbookPart);
+
+            byte[] consolidationStream = LegacyXlsTestWorkbookBuilder.CreatePhase5ExternalReferencesWorkbookStream();
+            byte[] consolidationCompound = LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFile(consolidationStream);
+            using ExcelDocument consolidationDocument = ExcelDocument.LoadLegacyXls(new MemoryStream(consolidationCompound));
+            Assert.All(consolidationDocument.WorkbookPartRoot.WorksheetParts, worksheetPart =>
+                Assert.DoesNotContain(worksheetPart.ExternalRelationships,
+                    relationship => relationship.RelationshipType ==
+                        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/externalLinkPath"));
         }
 
         [Fact]

--- a/OfficeIMO.Excel.Tests/Excel.LegacyXls.Formulas.cs
+++ b/OfficeIMO.Excel.Tests/Excel.LegacyXls.Formulas.cs
@@ -138,6 +138,29 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void LegacyXls_Load_DropsExternalWorkbookFormulasByDefaultButKeepsCachedValues() {
+            byte[] workbookStream = LegacyXlsTestWorkbookBuilder.CreateFormulaExternalWorkbookReferenceWorkbookStream();
+            byte[] compound = LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFile(workbookStream);
+
+            using ExcelDocument document = ExcelDocument.LoadLegacyXls(new MemoryStream(compound));
+            using var output = new MemoryStream();
+            document.Save(output, new ExcelSaveOptions {
+                LossPolicy = ExcelConversionLossPolicy.Allow
+            });
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(new MemoryStream(output.ToArray()), false);
+
+            WorkbookPart workbookPart = spreadsheet.WorkbookPart!;
+            Assert.Empty(workbookPart.GetPartsOfType<ExternalWorkbookPart>());
+            Cell[] cells = workbookPart.WorksheetParts.Single().Worksheet.Descendants<Cell>()
+                .OrderBy(cell => cell.CellReference!.Value, StringComparer.Ordinal)
+                .ToArray();
+            Assert.Equal(2, cells.Length);
+            Assert.All(cells, cell => Assert.Null(cell.CellFormula));
+            Assert.Equal("15", cells[0].CellValue!.Text);
+            Assert.Equal("42", cells[1].CellValue!.Text);
+        }
+
+        [Fact]
         public void LegacyXls_Load_ImportsFormulaExternalDefinedNames() {
             byte[] workbookStream = LegacyXlsTestWorkbookBuilder.CreateFormulaExternalDefinedNameWorkbookStream();
             byte[] compound = LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFile(workbookStream);
@@ -178,6 +201,25 @@ namespace OfficeIMO.Tests {
             WorksheetPart worksheetPart = workbookPart.WorksheetParts.Single();
             Cell projectedFormula = worksheetPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference!.Value == "A1");
             Assert.Equal("'Budget.xls'!TaxRate", projectedFormula.CellFormula!.Text);
+        }
+
+        [Fact]
+        public void LegacyXls_Load_DropsExternalDefinedNameFormulasByDefaultButKeepsCachedValue() {
+            byte[] workbookStream = LegacyXlsTestWorkbookBuilder.CreateFormulaExternalDefinedNameWorkbookStream();
+            byte[] compound = LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFile(workbookStream);
+
+            using ExcelDocument document = ExcelDocument.LoadLegacyXls(new MemoryStream(compound));
+            using var output = new MemoryStream();
+            document.Save(output, new ExcelSaveOptions {
+                LossPolicy = ExcelConversionLossPolicy.Allow
+            });
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(new MemoryStream(output.ToArray()), false);
+
+            WorkbookPart workbookPart = spreadsheet.WorkbookPart!;
+            Assert.Empty(workbookPart.GetPartsOfType<ExternalWorkbookPart>());
+            Cell cell = Assert.Single(workbookPart.WorksheetParts.Single().Worksheet.Descendants<Cell>());
+            Assert.Null(cell.CellFormula);
+            Assert.Equal("0.25", cell.CellValue!.Text);
         }
 
         [Fact]

--- a/OfficeIMO.Excel.Tests/Excel.LegacyXls.Formulas.cs
+++ b/OfficeIMO.Excel.Tests/Excel.LegacyXls.Formulas.cs
@@ -89,7 +89,8 @@ namespace OfficeIMO.Tests {
             byte[] compound = LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFile(workbookStream);
 
             LegacyXlsWorkbook legacy = LegacyXlsWorkbook.Load(compound, new LegacyXlsImportOptions {
-                ReportUnsupportedContent = true
+                ReportUnsupportedContent = true,
+                PreserveExternalWorkbookLinks = true
             });
 
             Assert.DoesNotContain(legacy.Diagnostics, d => d.Severity == LegacyXlsDiagnosticSeverity.Error);
@@ -110,7 +111,8 @@ namespace OfficeIMO.Tests {
             Assert.Equal("SUM('[Budget.xls]Jan'!A1:A2)", areaFormula.FormulaText);
 
             using ExcelDocument document = ExcelDocument.LoadLegacyXls(new MemoryStream(compound), new LegacyXlsImportOptions {
-                ReportUnsupportedContent = true
+                ReportUnsupportedContent = true,
+                PreserveExternalWorkbookLinks = true
             });
 
             using var output = new MemoryStream();
@@ -141,7 +143,8 @@ namespace OfficeIMO.Tests {
             byte[] compound = LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFile(workbookStream);
 
             LegacyXlsWorkbook legacy = LegacyXlsWorkbook.Load(compound, new LegacyXlsImportOptions {
-                ReportUnsupportedContent = true
+                ReportUnsupportedContent = true,
+                PreserveExternalWorkbookLinks = true
             });
 
             Assert.DoesNotContain(legacy.Diagnostics, d => d.Severity == LegacyXlsDiagnosticSeverity.Error);
@@ -158,7 +161,8 @@ namespace OfficeIMO.Tests {
             Assert.Equal("'Budget.xls'!TaxRate", formula.FormulaText);
 
             using ExcelDocument document = ExcelDocument.LoadLegacyXls(new MemoryStream(compound), new LegacyXlsImportOptions {
-                ReportUnsupportedContent = true
+                ReportUnsupportedContent = true,
+                PreserveExternalWorkbookLinks = true
             });
 
             using var output = new MemoryStream();

--- a/OfficeIMO.Excel.Tests/Excel.LegacyXls.Formulas.cs
+++ b/OfficeIMO.Excel.Tests/Excel.LegacyXls.Formulas.cs
@@ -161,6 +161,39 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void LegacyXls_Load_DropsExternalFormulaWhenWorkbookNameContainsApostrophe() {
+            byte[] workbookStream = LegacyXlsTestWorkbookBuilder.CreateFormulaExternalWorkbookReferenceWorkbookStream("C:\\Data\\O'Brien.xls");
+            byte[] compound = LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFile(workbookStream);
+
+            using ExcelDocument document = ExcelDocument.LoadLegacyXls(new MemoryStream(compound));
+            using var output = new MemoryStream();
+            document.Save(output, new ExcelSaveOptions { LossPolicy = ExcelConversionLossPolicy.Allow });
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(new MemoryStream(output.ToArray()), false);
+
+            Cell[] cells = spreadsheet.WorkbookPart!.WorksheetParts.Single().Worksheet.Descendants<Cell>()
+                .OrderBy(cell => cell.CellReference!.Value, StringComparer.Ordinal)
+                .ToArray();
+            Assert.All(cells, cell => Assert.Null(cell.CellFormula));
+            Assert.Empty(spreadsheet.WorkbookPart.GetPartsOfType<ExternalWorkbookPart>());
+        }
+
+        [Fact]
+        public void LegacyXls_Load_PreservesLocalFormulaWhoseStringLiteralMentionsExternalWorkbook() {
+            byte[] workbookStream = LegacyXlsTestWorkbookBuilder.CreateFormulaStringLiteralMatchingExternalWorkbookStream();
+            byte[] compound = LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFile(workbookStream);
+
+            using ExcelDocument document = ExcelDocument.LoadLegacyXls(new MemoryStream(compound));
+            using var output = new MemoryStream();
+            document.Save(output, new ExcelSaveOptions { LossPolicy = ExcelConversionLossPolicy.Allow });
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(new MemoryStream(output.ToArray()), false);
+
+            WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.Single();
+            Cell formulaCell = worksheetPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference!.Value == "B1");
+            Assert.Equal("\"[Budget.xls]Jan\"&A1", formulaCell.CellFormula!.Text);
+            Assert.Empty(spreadsheet.WorkbookPart.GetPartsOfType<ExternalWorkbookPart>());
+        }
+
+        [Fact]
         public void LegacyXls_Load_ImportsFormulaExternalDefinedNames() {
             byte[] workbookStream = LegacyXlsTestWorkbookBuilder.CreateFormulaExternalDefinedNameWorkbookStream();
             byte[] compound = LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFile(workbookStream);
@@ -1459,12 +1492,15 @@ namespace OfficeIMO.Tests {
                 return bytes;
             }
 
-            internal static byte[] CreateFormulaExternalWorkbookReferenceWorkbookStream() {
+            internal static byte[] CreateFormulaExternalWorkbookReferenceWorkbookStream() =>
+                CreateFormulaExternalWorkbookReferenceWorkbookStream("C:\\Data\\Budget.xls");
+
+            internal static byte[] CreateFormulaExternalWorkbookReferenceWorkbookStream(string target) {
                 using var stream = new MemoryStream();
                 WriteRecord(stream, 0x0809, new byte[] { 0x00, 0x06, 0x05, 0x00, 0xdb, 0x0b, 0xcc, 0x07 });
                 long boundSheetPosition = stream.Position;
                 WriteRecord(stream, 0x0085, BuildBoundSheetPayload(0, "ExternalFormula"));
-                WriteRecord(stream, 0x01ae, BuildSupBookExternalWorkbookPayload("C:\\Data\\Budget.xls", "Jan", "Feb"));
+                WriteRecord(stream, 0x01ae, BuildSupBookExternalWorkbookPayload(target, "Jan", "Feb"));
                 WriteRecord(stream, 0x0017, BuildExternSheetPayload((0, 0, 0)));
                 WriteRecord(stream, 0x000a, Array.Empty<byte>());
 
@@ -1472,6 +1508,29 @@ namespace OfficeIMO.Tests {
                 WriteRecord(stream, 0x0809, new byte[] { 0x00, 0x06, 0x10, 0x00, 0xdb, 0x0b, 0xcc, 0x07 });
                 WriteRecord(stream, 0x0006, BuildFormulaNumberPayload(0, 0, 15d, formulaTokens: Build3dReferenceAdditionFormulaTokens(0, 0, 0, 5)));
                 WriteRecord(stream, 0x0006, BuildFormulaNumberPayload(1, 0, 42d, formulaTokens: BuildSum3dAreaFormulaTokens(0, 0, 0, 1, 0)));
+                WriteRecord(stream, 0x000a, Array.Empty<byte>());
+
+                byte[] bytes = stream.ToArray();
+                Buffer.BlockCopy(BitConverter.GetBytes(sheetOffset), 0, bytes, checked((int)boundSheetPosition + 4), 4);
+                return bytes;
+            }
+
+            internal static byte[] CreateFormulaStringLiteralMatchingExternalWorkbookStream() {
+                using var stream = new MemoryStream();
+                WriteRecord(stream, 0x0809, new byte[] { 0x00, 0x06, 0x05, 0x00, 0xdb, 0x0b, 0xcc, 0x07 });
+                long boundSheetPosition = stream.Position;
+                WriteRecord(stream, 0x0085, BuildBoundSheetPayload(0, "StringLiteral"));
+                WriteRecord(stream, 0x01ae, BuildSupBookExternalWorkbookPayload("C:\\Data\\Budget.xls", "Jan"));
+                WriteRecord(stream, 0x000a, Array.Empty<byte>());
+
+                int sheetOffset = checked((int)stream.Position);
+                WriteRecord(stream, 0x0809, new byte[] { 0x00, 0x06, 0x10, 0x00, 0xdb, 0x0b, 0xcc, 0x07 });
+                WriteRecord(stream, 0x0204, BuildLabelPayload(0, 0, "Local"));
+                WriteRecord(stream, 0x0006, BuildFormulaStringResultPayload(
+                    0,
+                    1,
+                    BuildStringLiteralConcatFormulaTokens("[Budget.xls]Jan", 0, 0)));
+                WriteRecord(stream, 0x0207, BuildFormulaStringPayload("[Budget.xls]JanLocal"));
                 WriteRecord(stream, 0x000a, Array.Empty<byte>());
 
                 byte[] bytes = stream.ToArray();

--- a/OfficeIMO.Excel.Tests/Excel.LegacyXls.Formulas.cs
+++ b/OfficeIMO.Excel.Tests/Excel.LegacyXls.Formulas.cs
@@ -178,6 +178,23 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void LegacyXls_Load_DropsExternalFormulaWhenSupBookTargetContainsControlCharacters() {
+            byte[] workbookStream = LegacyXlsTestWorkbookBuilder.CreateFormulaExternalWorkbookReferenceWorkbookStream("\u0001Budget.xls");
+            byte[] compound = LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFile(workbookStream);
+
+            using ExcelDocument document = ExcelDocument.LoadLegacyXls(new MemoryStream(compound));
+            using var output = new MemoryStream();
+            document.Save(output, new ExcelSaveOptions { LossPolicy = ExcelConversionLossPolicy.Allow });
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(new MemoryStream(output.ToArray()), false);
+
+            Cell[] cells = spreadsheet.WorkbookPart!.WorksheetParts.Single().Worksheet.Descendants<Cell>()
+                .OrderBy(cell => cell.CellReference!.Value, StringComparer.Ordinal)
+                .ToArray();
+            Assert.All(cells, cell => Assert.Null(cell.CellFormula));
+            Assert.Empty(spreadsheet.WorkbookPart.GetPartsOfType<ExternalWorkbookPart>());
+        }
+
+        [Fact]
         public void LegacyXls_Load_PreservesLocalFormulaWhoseStringLiteralMentionsExternalWorkbook() {
             byte[] workbookStream = LegacyXlsTestWorkbookBuilder.CreateFormulaStringLiteralMatchingExternalWorkbookStream();
             byte[] compound = LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFile(workbookStream);

--- a/OfficeIMO.Excel.Tests/Excel.LegacyXls.NativeWrite.DataConsolidation.cs
+++ b/OfficeIMO.Excel.Tests/Excel.LegacyXls.NativeWrite.DataConsolidation.cs
@@ -318,7 +318,9 @@ namespace OfficeIMO.Tests {
                     document.Save(xlsOutputPath);
                 }
 
-                using LegacyXlsLoadResult result = ExcelDocument.LoadLegacyXlsWithReport(xlsOutputPath);
+                using LegacyXlsLoadResult result = ExcelDocument.LoadLegacyXlsWithReport(
+                    xlsOutputPath,
+                    new LegacyXlsImportOptions { PreserveExternalWorkbookLinks = true });
                 Assert.False(result.HasImportErrors);
                 Assert.False(result.HasUnsupportedFeatures, FormatUnsupportedFeatures(result.UnsupportedFeatures));
 
@@ -376,7 +378,9 @@ namespace OfficeIMO.Tests {
                     document.Save(xlsOutputPath);
                 }
 
-                using LegacyXlsLoadResult result = ExcelDocument.LoadLegacyXlsWithReport(xlsOutputPath);
+                using LegacyXlsLoadResult result = ExcelDocument.LoadLegacyXlsWithReport(
+                    xlsOutputPath,
+                    new LegacyXlsImportOptions { PreserveExternalWorkbookLinks = true });
                 Assert.False(result.HasImportErrors);
                 Assert.False(result.HasUnsupportedFeatures, FormatUnsupportedFeatures(result.UnsupportedFeatures));
 

--- a/OfficeIMO.Excel.Tests/Excel.LegacyXls.NativeWrite.DefinedNames.cs
+++ b/OfficeIMO.Excel.Tests/Excel.LegacyXls.NativeWrite.DefinedNames.cs
@@ -224,7 +224,9 @@ namespace OfficeIMO.Tests {
                     document.Save(xlsOutputPath);
                 }
 
-                using LegacyXlsLoadResult result = ExcelDocument.LoadLegacyXlsWithReport(xlsOutputPath);
+                using LegacyXlsLoadResult result = ExcelDocument.LoadLegacyXlsWithReport(
+                    xlsOutputPath,
+                    new LegacyXlsImportOptions { PreserveExternalWorkbookLinks = true });
                 result.EnsureNoImportErrors();
                 LegacyXlsExternalReference externalReference = Assert.Single(
                     result.Workbook.ExternalReferences,
@@ -263,7 +265,9 @@ namespace OfficeIMO.Tests {
                     document.Save(xlsOutputPath);
                 }
 
-                using LegacyXlsLoadResult result = ExcelDocument.LoadLegacyXlsWithReport(xlsOutputPath);
+                using LegacyXlsLoadResult result = ExcelDocument.LoadLegacyXlsWithReport(
+                    xlsOutputPath,
+                    new LegacyXlsImportOptions { PreserveExternalWorkbookLinks = true });
                 result.EnsureNoImportErrors();
                 LegacyXlsExternalReference externalReference = Assert.Single(
                     result.Workbook.ExternalReferences,
@@ -341,7 +345,9 @@ namespace OfficeIMO.Tests {
                     document.Save(xlsOutputPath);
                 }
 
-                using LegacyXlsLoadResult result = ExcelDocument.LoadLegacyXlsWithReport(xlsOutputPath);
+                using LegacyXlsLoadResult result = ExcelDocument.LoadLegacyXlsWithReport(
+                    xlsOutputPath,
+                    new LegacyXlsImportOptions { PreserveExternalWorkbookLinks = true });
                 result.EnsureNoImportErrors();
 
                 LegacyXlsExternalReference externalReference = Assert.Single(

--- a/OfficeIMO.Excel.Tests/Excel.LegacyXls.WorkbookFeatures.cs
+++ b/OfficeIMO.Excel.Tests/Excel.LegacyXls.WorkbookFeatures.cs
@@ -1237,7 +1237,8 @@ namespace OfficeIMO.Tests {
             byte[] compound = LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFile(workbookStream);
 
             LegacyXlsWorkbook legacy = LegacyXlsWorkbook.Load(compound, new LegacyXlsImportOptions {
-                ReportUnsupportedContent = true
+                ReportUnsupportedContent = true,
+                PreserveExternalWorkbookLinks = true
             });
 
             Assert.DoesNotContain(legacy.Diagnostics, d => d.Severity == LegacyXlsDiagnosticSeverity.Error);

--- a/OfficeIMO.Excel/ExcelDocument.Conversion.cs
+++ b/OfficeIMO.Excel/ExcelDocument.Conversion.cs
@@ -229,7 +229,9 @@ namespace OfficeIMO.Excel {
         private static LegacyXlsImportOptions CreateConversionImportOptions(LegacyXlsImportOptions options) {
             return new LegacyXlsImportOptions {
                 MaxInputBytes = options.MaxInputBytes,
+                MaxDecodedImageBytes = options.MaxDecodedImageBytes,
                 Password = options.Password,
+                PreserveExternalWorkbookLinks = options.PreserveExternalWorkbookLinks,
                 // Conversion loss policy depends on complete unsupported-content discovery.
                 ReportUnsupportedContent = true
             };

--- a/OfficeIMO.Excel/ExcelSheet.CellValue.Overloads.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellValue.Overloads.cs
@@ -423,8 +423,13 @@ namespace OfficeIMO.Excel {
         }
 
         /// <summary>
-        /// Sets a formula in the specified cell.
+        /// Sets a formula in the specified cell while preserving any existing value as its cached result.
         /// </summary>
+        /// <remarks>
+        /// Cached formula values are part of the workbook contract and are intentionally retained. This method is
+        /// not a secure-erasure or redaction API; callers removing sensitive historic content should rebuild the
+        /// workbook from approved data rather than relying on an in-place formula mutation.
+        /// </remarks>
         /// <param name="row">The 1-based row index.</param>
         /// <param name="column">The 1-based column index.</param>
         /// <param name="formula">The formula expression.</param>

--- a/OfficeIMO.Excel/Imaging/ExcelConditionalVisualEvaluator.IconSets.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelConditionalVisualEvaluator.IconSets.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using OfficeIMO.Drawing;
 
 namespace OfficeIMO.Excel {
@@ -140,19 +139,19 @@ namespace OfficeIMO.Excel {
                 ExcelConditionalIconSetThreshold threshold = thresholds[index];
                 if (string.Equals(threshold.Type, "num", StringComparison.OrdinalIgnoreCase) ||
                     string.Equals(threshold.Type, "Number", StringComparison.OrdinalIgnoreCase)) {
-                    if (double.TryParse(threshold.Value, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out double numeric)) {
+                    if (ExcelConditionalFormatThresholds.TryParseThresholdNumber(threshold.Value, out double numeric)) {
                         return numeric;
                     }
                 }
 
                 if ((string.Equals(threshold.Type, "percent", StringComparison.OrdinalIgnoreCase) ||
                     string.Equals(threshold.Type, "Percent", StringComparison.OrdinalIgnoreCase)) &&
-                    double.TryParse(threshold.Value, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out double percent)) {
+                    ExcelConditionalFormatThresholds.TryParseThresholdNumber(threshold.Value, out double percent)) {
                     return min + ((max - min) * Math.Max(0D, Math.Min(100D, percent)) / 100D);
                 }
 
                 if (string.Equals(threshold.Type, "percentile", StringComparison.OrdinalIgnoreCase) &&
-                    double.TryParse(threshold.Value, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out double percentile)) {
+                    ExcelConditionalFormatThresholds.TryParseThresholdNumber(threshold.Value, out double percentile)) {
                     return ExcelConditionalFormatThresholds.CalculatePercentile(values, Math.Max(0D, Math.Min(100D, percentile)));
                 }
             }

--- a/OfficeIMO.Excel/Imaging/ExcelSheet.Imaging.HeaderFooter.Text.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelSheet.Imaging.HeaderFooter.Text.cs
@@ -4,6 +4,8 @@ using OfficeIMO.Drawing;
 
 namespace OfficeIMO.Excel {
     public partial class ExcelSheet {
+        private const int MaximumHeaderFooterFontFamilyCharacters = 256;
+
         private bool TryResolveHeaderFooterText(string? text, int pageNumber, int pageCount, DateTime headerFooterDateTime, out HeaderFooterTextSection normalized) {
             normalized = HeaderFooterTextSection.Empty;
             if (string.IsNullOrWhiteSpace(text)) {
@@ -180,6 +182,10 @@ namespace OfficeIMO.Excel {
 
             int end = text.IndexOf('"', openingQuoteIndex + 1);
             if (end < 0) {
+                return false;
+            }
+
+            if (end - openingQuoteIndex - 1 > MaximumHeaderFooterFontFamilyCharacters) {
                 return false;
             }
 

--- a/OfficeIMO.Excel/Imaging/ExcelSheet.Imaging.HeaderFooter.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelSheet.Imaging.HeaderFooter.cs
@@ -500,8 +500,14 @@ namespace OfficeIMO.Excel {
                 AppendHeaderFooterSvgRichLine(builder, section, zone, baseline, fontSize, fontFamily, lineHeight, alignment, measure);
             } else {
                 if (!string.IsNullOrWhiteSpace(section.Text)) {
-                    builder.AppendSvgTextElement(
+                    string displayText = ResolveHeaderFooterZoneText(
                         section.Text,
+                        fontSize,
+                        zone.Width,
+                        (text, size) => measure(text, size, fontFamily),
+                        alignment);
+                    builder.AppendSvgTextElement(
+                        displayText,
                         zone.AnchorX,
                         baseline,
                         lineHeight,
@@ -534,7 +540,7 @@ namespace OfficeIMO.Excel {
                 wrap: false,
                 shrinkToFit: false,
                 minimumFontSize: 1D,
-                OfficeTextOverflowBehavior.Clip);
+                OfficeTextOverflowBehavior.Ellipsis);
             if (layout.Lines.Count == 0) {
                 return;
             }

--- a/OfficeIMO.Excel/LegacyXls/Biff/BiffFormulaReferenceFormatter.cs
+++ b/OfficeIMO.Excel/LegacyXls/Biff/BiffFormulaReferenceFormatter.cs
@@ -287,7 +287,7 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
             return true;
         }
 
-        private static string NormalizeExternalWorkbookTarget(string? target) {
+        internal static string NormalizeExternalWorkbookTarget(string? target) {
             if (string.IsNullOrWhiteSpace(target)) {
                 return "ExternalWorkbook";
             }

--- a/OfficeIMO.Excel/LegacyXls/Biff/LegacyBiffWorkbookParser.cs
+++ b/OfficeIMO.Excel/LegacyXls/Biff/LegacyBiffWorkbookParser.cs
@@ -4,7 +4,9 @@ using OfficeIMO.Excel.LegacyXls.Model;
 namespace OfficeIMO.Excel.LegacyXls.Biff {
     internal static class LegacyBiffWorkbookParser {
         internal static LegacyXlsWorkbook Parse(byte[] workbookStream, LegacyXlsImportOptions options) {
-            var workbook = new LegacyXlsWorkbook();
+            var workbook = new LegacyXlsWorkbook {
+                PreserveExternalWorkbookLinks = options.PreserveExternalWorkbookLinks
+            };
             var decodedImageBudget = new LegacyXlsDecodedImageBudget(options.MaxDecodedImageBytes);
             IReadOnlyList<BiffRecord> records = ReadWorkbookGlobalRecords(workbookStream, workbook.MutableDiagnostics);
             var sharedStrings = new List<BiffStringReader.BiffStringValue>();
@@ -476,7 +478,9 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
 
             workbook.MutableExternalReferences.Add(reference!);
             bool unsupportedExternalReference = reference!.Kind == LegacyXlsExternalReferenceKind.AddIn
-                || reference.Kind == LegacyXlsExternalReferenceKind.DdeOrOle;
+                || reference.Kind == LegacyXlsExternalReferenceKind.DdeOrOle
+                || (reference.Kind == LegacyXlsExternalReferenceKind.ExternalWorkbook
+                    && !options.PreserveExternalWorkbookLinks);
             if (unsupportedExternalReference) {
                 LegacyXlsUnsupportedFeature feature = BiffUnsupportedRecordDiagnostics.CreateExternalReferenceFeature(record, reference);
                 workbook.MutableUnsupportedFeatures.Add(feature);

--- a/OfficeIMO.Excel/LegacyXls/LegacyXlsImportOptions.cs
+++ b/OfficeIMO.Excel/LegacyXls/LegacyXlsImportOptions.cs
@@ -17,6 +17,12 @@ namespace OfficeIMO.Excel.LegacyXls {
         public bool ReportUnsupportedContent { get; set; } = true;
 
         /// <summary>
+        /// Preserves external-workbook relationships as active Open XML links. Disabled by default because
+        /// opening the projected workbook may cause a spreadsheet client to contact an attacker-controlled target.
+        /// </summary>
+        public bool PreserveExternalWorkbookLinks { get; set; }
+
+        /// <summary>
         /// Optional password used to decrypt password-to-open encrypted legacy XLS workbooks.
         /// </summary>
         public string? Password { get; set; }

--- a/OfficeIMO.Excel/LegacyXls/Model/LegacyXlsWorkbook.cs
+++ b/OfficeIMO.Excel/LegacyXls/Model/LegacyXlsWorkbook.cs
@@ -47,6 +47,9 @@ namespace OfficeIMO.Excel.LegacyXls.Model {
         /// <summary>Gets whether the workbook stream was successfully decrypted from password-to-open protection.</summary>
         public bool WasEncryptedSource { get; internal set; }
 
+        /// <summary>Gets whether projection may recreate active external-workbook relationships.</summary>
+        internal bool PreserveExternalWorkbookLinks { get; set; }
+
         internal LegacyXlsWorkbook() {
         }
 

--- a/OfficeIMO.Excel/LegacyXls/Projection/LegacyXlsWorkbookProjector.cs
+++ b/OfficeIMO.Excel/LegacyXls/Projection/LegacyXlsWorkbookProjector.cs
@@ -1159,6 +1159,10 @@ namespace OfficeIMO.Excel.LegacyXls.Projection {
                         Reference = reference.CellRange,
                     };
                     if (reference.SourceKind == LegacyXlsDataConsolidationSourceKind.ExternalVirtualPath) {
+                        if (!workbook.PreserveExternalWorkbookLinks) {
+                            continue;
+                        }
+
                         string? relationshipId = AddExternalDataConsolidationRelationship(sheet, reference.Source);
                         if (relationshipId == null) {
                             continue;
@@ -1183,6 +1187,10 @@ namespace OfficeIMO.Excel.LegacyXls.Projection {
                         Name = name.Name
                     };
                     if (name.SourceKind == LegacyXlsDataConsolidationSourceKind.ExternalVirtualPath) {
+                        if (!workbook.PreserveExternalWorkbookLinks) {
+                            continue;
+                        }
+
                         string? relationshipId = AddExternalDataConsolidationRelationship(sheet, name.Source);
                         if (relationshipId == null) {
                             continue;
@@ -1667,6 +1675,10 @@ namespace OfficeIMO.Excel.LegacyXls.Projection {
         }
 
         private static void ProjectExternalReferences(LegacyXlsWorkbook workbook, ExcelDocument document) {
+            if (!workbook.PreserveExternalWorkbookLinks) {
+                return;
+            }
+
             WorkbookPart workbookPart = document.WorkbookPartRoot;
             Workbook workbookRoot = workbookPart.Workbook ?? throw new InvalidOperationException("Workbook is null.");
 

--- a/OfficeIMO.Excel/LegacyXls/Projection/LegacyXlsWorkbookProjector.cs
+++ b/OfficeIMO.Excel/LegacyXls/Projection/LegacyXlsWorkbookProjector.cs
@@ -1,6 +1,7 @@
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Excel.LegacyXls.Biff;
 using OfficeIMO.Excel.LegacyXls.Model;
 using System.Globalization;
 
@@ -939,9 +940,7 @@ namespace OfficeIMO.Excel.LegacyXls.Projection {
                     continue;
                 }
 
-                string normalizedTarget = reference.Target!.Replace('\\', '/');
-                int separator = normalizedTarget.LastIndexOf('/');
-                string fileName = separator >= 0 ? normalizedTarget.Substring(separator + 1) : normalizedTarget;
+                string fileName = BiffFormulaReferenceFormatter.NormalizeExternalWorkbookTarget(reference.Target);
                 if (fileName.Length == 0) continue;
                 string escapedFileName = fileName.Replace("'", "''");
                 if (ContainsFormulaTokenOutsideStringLiteral(formulaText, "[" + escapedFileName + "]") ||

--- a/OfficeIMO.Excel/LegacyXls/Projection/LegacyXlsWorkbookProjector.cs
+++ b/OfficeIMO.Excel/LegacyXls/Projection/LegacyXlsWorkbookProjector.cs
@@ -943,11 +943,37 @@ namespace OfficeIMO.Excel.LegacyXls.Projection {
                 int separator = normalizedTarget.LastIndexOf('/');
                 string fileName = separator >= 0 ? normalizedTarget.Substring(separator + 1) : normalizedTarget;
                 if (fileName.Length == 0) continue;
-                if (formulaText.IndexOf("[" + fileName + "]", StringComparison.OrdinalIgnoreCase) >= 0 ||
-                    formulaText.IndexOf("'" + fileName + "'!", StringComparison.OrdinalIgnoreCase) >= 0 ||
-                    formulaText.IndexOf(fileName + "!", StringComparison.OrdinalIgnoreCase) >= 0) {
+                string escapedFileName = fileName.Replace("'", "''");
+                if (ContainsFormulaTokenOutsideStringLiteral(formulaText, "[" + escapedFileName + "]") ||
+                    ContainsFormulaTokenOutsideStringLiteral(formulaText, "'" + escapedFileName + "'!") ||
+                    ContainsFormulaTokenOutsideStringLiteral(formulaText, escapedFileName + "!")) {
                     return true;
                 }
+            }
+
+            return false;
+        }
+
+        private static bool ContainsFormulaTokenOutsideStringLiteral(string formulaText, string token) {
+            bool inStringLiteral = false;
+            for (int index = 0; index < formulaText.Length;) {
+                if (formulaText[index] == '"') {
+                    if (inStringLiteral && index + 1 < formulaText.Length && formulaText[index + 1] == '"') {
+                        index += 2;
+                        continue;
+                    }
+
+                    inStringLiteral = !inStringLiteral;
+                    index++;
+                    continue;
+                }
+
+                if (!inStringLiteral && index <= formulaText.Length - token.Length &&
+                    string.Compare(formulaText, index, token, 0, token.Length, StringComparison.OrdinalIgnoreCase) == 0) {
+                    return true;
+                }
+
+                index++;
             }
 
             return false;

--- a/OfficeIMO.Excel/LegacyXls/Projection/LegacyXlsWorkbookProjector.cs
+++ b/OfficeIMO.Excel/LegacyXls/Projection/LegacyXlsWorkbookProjector.cs
@@ -674,7 +674,9 @@ namespace OfficeIMO.Excel.LegacyXls.Projection {
                         currentSheet.CellValue(cell.Row, cell.Column, value);
                     }
 
-                    if (cell.IsFormula && !string.IsNullOrWhiteSpace(cell.FormulaText)) {
+                    if (cell.IsFormula &&
+                        !string.IsNullOrWhiteSpace(cell.FormulaText) &&
+                        ShouldProjectFormula(workbook, cell.FormulaText!)) {
                         currentSheet.CellFormula(cell.Row, cell.Column, cell.FormulaText!);
                     }
 
@@ -686,7 +688,8 @@ namespace OfficeIMO.Excel.LegacyXls.Projection {
                         cell.Row == arrayFormula.FirstRow
                         && cell.Column == arrayFormula.FirstColumn
                         && cell.IsFormula
-                        && !string.IsNullOrWhiteSpace(cell.FormulaText));
+                        && !string.IsNullOrWhiteSpace(cell.FormulaText)
+                        && ShouldProjectFormula(workbook, cell.FormulaText!));
                     if (formulaCell != null) {
                         currentSheet.SetLegacyArrayFormula(arrayFormula.Range, formulaCell.FormulaText!);
                     }
@@ -902,8 +905,8 @@ namespace OfficeIMO.Excel.LegacyXls.Projection {
                     AllowSort = permissions?.AllowSort ?? false,
                     AllowAutoFilter = permissions?.AllowAutoFilter ?? false,
                     AllowPivotTables = permissions?.AllowPivotTables ?? false
-                });
-            }
+            });
+        }
 
             ProjectProtectedRanges(legacySheet, sheet);
             ProjectPageSetup(legacySheet, sheet);
@@ -924,6 +927,30 @@ namespace OfficeIMO.Excel.LegacyXls.Projection {
             } else if (legacySheet.Visibility != 0) {
                 sheet.SetHidden(true);
             }
+        }
+
+        private static bool ShouldProjectFormula(LegacyXlsWorkbook workbook, string formulaText) =>
+            workbook.PreserveExternalWorkbookLinks || !ReferencesExternalWorkbook(workbook, formulaText);
+
+        private static bool ReferencesExternalWorkbook(LegacyXlsWorkbook workbook, string formulaText) {
+            foreach (LegacyXlsExternalReference reference in workbook.ExternalReferences) {
+                if (reference.Kind != LegacyXlsExternalReferenceKind.ExternalWorkbook ||
+                    string.IsNullOrWhiteSpace(reference.Target)) {
+                    continue;
+                }
+
+                string normalizedTarget = reference.Target!.Replace('\\', '/');
+                int separator = normalizedTarget.LastIndexOf('/');
+                string fileName = separator >= 0 ? normalizedTarget.Substring(separator + 1) : normalizedTarget;
+                if (fileName.Length == 0) continue;
+                if (formulaText.IndexOf("[" + fileName + "]", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                    formulaText.IndexOf("'" + fileName + "'!", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                    formulaText.IndexOf(fileName + "!", StringComparison.OrdinalIgnoreCase) >= 0) {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private static void ProjectTableDefinitions(LegacyXlsWorkbook workbook, LegacyXlsWorksheet legacySheet, ExcelSheet sheet) {
@@ -1564,6 +1591,9 @@ namespace OfficeIMO.Excel.LegacyXls.Projection {
         private static void ProjectDefinedNames(LegacyXlsWorkbook workbook, ExcelDocument document) {
             IReadOnlyDictionary<int, int> worksheetIndexByProjectedSheetIndex = CreateWorksheetIndexByProjectedSheetIndex(workbook);
             foreach (LegacyXlsDefinedName definedName in workbook.DefinedNames) {
+                if (!workbook.PreserveExternalWorkbookLinks && ReferencesExternalWorkbook(workbook, definedName.Reference)) {
+                    continue;
+                }
                 ExcelSheet? scope = definedName.LocalSheetIndex.HasValue
                     && worksheetIndexByProjectedSheetIndex.TryGetValue(definedName.LocalSheetIndex.Value, out int worksheetIndex)
                     && worksheetIndex < document.Sheets.Count

--- a/OfficeIMO.Excel/Utilities/ExcelNumberFormatDisplay.cs
+++ b/OfficeIMO.Excel/Utilities/ExcelNumberFormatDisplay.cs
@@ -83,8 +83,12 @@ namespace OfficeIMO.Excel {
                 return false;
             }
 
-            sample = new DateTime(2099, 12, 31, 23, 59, 59).ToString(TranslateDateFormat(formatCode!), CultureInfo.InvariantCulture);
-            return true;
+            try {
+                sample = new DateTime(2099, 12, 31, 23, 59, 59).ToString(TranslateDateFormat(formatCode!), CultureInfo.InvariantCulture);
+                return true;
+            } catch (FormatException) {
+                return false;
+            }
         }
 
         private static string FormatDateValue(double value, uint numberFormatId, string formatCode, ExcelDateSystem dateSystem) {
@@ -99,20 +103,24 @@ namespace OfficeIMO.Excel {
                 return value.ToString(CultureInfo.InvariantCulture);
             }
 
-            switch (numberFormatId) {
-                case 14: return date.ToString("M/d/yyyy", CultureInfo.InvariantCulture);
-                case 15: return date.ToString("d-MMM-yy", CultureInfo.InvariantCulture);
-                case 16: return date.ToString("d-MMM", CultureInfo.InvariantCulture);
-                case 17: return date.ToString("MMM-yy", CultureInfo.InvariantCulture);
-                case 18: return date.ToString("h:mm tt", CultureInfo.InvariantCulture);
-                case 19: return date.ToString("h:mm:ss tt", CultureInfo.InvariantCulture);
-                case 20: return date.ToString("H:mm", CultureInfo.InvariantCulture);
-                case 21: return date.ToString("H:mm:ss", CultureInfo.InvariantCulture);
-                case 22: return date.ToString("M/d/yyyy H:mm", CultureInfo.InvariantCulture);
-                case 45: return date.ToString("mm:ss", CultureInfo.InvariantCulture);
-                case 47: return date.ToString("mm:ss.0", CultureInfo.InvariantCulture);
-                default:
-                    return date.ToString(TranslateDateFormat(formatCode), CultureInfo.InvariantCulture);
+            try {
+                switch (numberFormatId) {
+                    case 14: return date.ToString("M/d/yyyy", CultureInfo.InvariantCulture);
+                    case 15: return date.ToString("d-MMM-yy", CultureInfo.InvariantCulture);
+                    case 16: return date.ToString("d-MMM", CultureInfo.InvariantCulture);
+                    case 17: return date.ToString("MMM-yy", CultureInfo.InvariantCulture);
+                    case 18: return date.ToString("h:mm tt", CultureInfo.InvariantCulture);
+                    case 19: return date.ToString("h:mm:ss tt", CultureInfo.InvariantCulture);
+                    case 20: return date.ToString("H:mm", CultureInfo.InvariantCulture);
+                    case 21: return date.ToString("H:mm:ss", CultureInfo.InvariantCulture);
+                    case 22: return date.ToString("M/d/yyyy H:mm", CultureInfo.InvariantCulture);
+                    case 45: return date.ToString("mm:ss", CultureInfo.InvariantCulture);
+                    case 47: return date.ToString("mm:ss.0", CultureInfo.InvariantCulture);
+                    default:
+                        return date.ToString(TranslateDateFormat(formatCode), CultureInfo.InvariantCulture);
+                }
+            } catch (FormatException) {
+                return value.ToString(CultureInfo.InvariantCulture);
             }
         }
 
@@ -320,9 +328,18 @@ namespace OfficeIMO.Excel {
                 return false;
             }
 
-            TimeSpan duration = TimeSpan.FromDays(value);
+            TimeSpan duration;
+            TimeSpan absolute;
+            try {
+                duration = TimeSpan.FromDays(value);
+                absolute = duration.Duration();
+            } catch (ArgumentException) {
+                return false;
+            } catch (OverflowException) {
+                return false;
+            }
+
             bool negative = duration.Ticks < 0;
-            TimeSpan absolute = duration.Duration();
             string sign = negative ? "-" : string.Empty;
 
             if (hasHours) {

--- a/OfficeIMO.Html.Tests/Html.ArtifactGallery.cs
+++ b/OfficeIMO.Html.Tests/Html.ArtifactGallery.cs
@@ -119,4 +119,31 @@ public partial class Html {
         Assert.Contains("HtmlCommentSkipped", manifestJson, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("WordOpenXmlPackageValid", manifestJson, StringComparison.OrdinalIgnoreCase);
     }
+
+    [Fact]
+    public void HtmlArtifactGallery_DefaultImportBlocksLocalFileResources() {
+        string artifactDirectory = Path.Combine(Path.GetTempPath(), "OfficeIMO.HtmlArtifactGallery.Security." + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(artifactDirectory);
+        string localImagePath = Path.Combine(artifactDirectory, "local-secret.png");
+        File.WriteAllBytes(localImagePath, Convert.FromBase64String(
+            "iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAABFSURBVEhLY1BNfv2flpgBXYDaeBhaILCzkSKMbt6oBRgY3bxRCzAwunmjFmBgdPNGLcDA6OaNWoCB0c3DsIDaeNQCghgAFxBXzP1LTe4AAAAASUVORK5CYII="));
+        string html = "<html><body><h1>Gallery</h1><img src=\"" + new Uri(localImagePath).AbsoluteUri + "\" alt=\"Local secret\"></body></html>";
+
+        try {
+            HtmlCapabilityGalleryManifest manifest = HtmlConversionDocument.Parse(html, new HtmlConversionDocumentOptions {
+                Profile = HtmlConversionProfile.Document,
+                Trust = HtmlInputTrust.Trusted
+            }).SaveHtmlCapabilityGallery(artifactDirectory, new WordHtmlCapabilityGalleryOptions {
+                ScenarioId = "offline-default",
+                Title = "Offline Default"
+            });
+
+            Assert.Contains(manifest.Result.Diagnostics.Diagnostics,
+                diagnostic => diagnostic.Code == "ImageSkippedByPolicy");
+            Assert.Contains(manifest.ResourceManifest.Resources,
+                resource => resource.Source == new Uri(localImagePath).AbsoluteUri && !resource.IsAllowed);
+        } finally {
+            Directory.Delete(artifactDirectory, recursive: true);
+        }
+    }
 }

--- a/OfficeIMO.Html.Tests/Html.OfficeAdapters.cs
+++ b/OfficeIMO.Html.Tests/Html.OfficeAdapters.cs
@@ -866,8 +866,8 @@ public class HtmlOfficeAdapters {
         string html = presentation.ToHtml(new PowerPointHtmlSaveOptions {
             Profile = OfficeHtmlConversionProfile.PowerPointSemanticSlides
         });
-        html = html.Replace("<td>10</td>", "<td data-officeimo-x=\"1\">10</td>", StringComparison.Ordinal)
-            .Replace("<td>20</td>", string.Empty, StringComparison.Ordinal);
+        html = html.Replace("<td>10</td>", "<td data-officeimo-x=\"1\">10</td>")
+            .Replace("<td>20</td>", string.Empty);
 
         HtmlToPowerPointResult result = HtmlConversionDocument.Parse(html).ToPowerPointPresentationResult();
         using PowerPointPresentation imported = result.Value;

--- a/OfficeIMO.Html.Tests/Html.OfficeAdapters.cs
+++ b/OfficeIMO.Html.Tests/Html.OfficeAdapters.cs
@@ -296,6 +296,31 @@ public class HtmlOfficeAdapters {
     }
 
     [Fact]
+    public void ExcelHtml_RejectsCropPairsThatConsumeTheWholeImage() {
+        using ExcelDocument workbook = ExcelDocument.Create(new MemoryStream());
+        ExcelSheet sheet = workbook.AddWorksheet("Drawings");
+        sheet.CellValue(1, 1, "Seed");
+        sheet.AddImageAbsolute(10, 10, OnePixelPng, widthPixels: 40, heightPixels: 30)
+            .SetCropRatio(0.1D, 0D, 0.1D, 0D);
+        string html = workbook.ToHtml(new ExcelHtmlSaveOptions {
+            Profile = OfficeHtmlConversionProfile.ExcelSemanticTables
+        });
+        html = System.Text.RegularExpressions.Regex.Replace(
+            html, "data-officeimo-crop-left=\"[^\"]*\"", "data-officeimo-crop-left=\"0.75\"");
+        html = System.Text.RegularExpressions.Regex.Replace(
+            html, "data-officeimo-crop-right=\"[^\"]*\"", "data-officeimo-crop-right=\"0.75\"");
+
+        HtmlToExcelResult result = HtmlConversionDocument.Parse(html).ToExcelDocumentResult();
+        using ExcelDocument imported = result.Value;
+        ExcelImage image = Assert.Single(imported.Sheets.Single().Images);
+
+        Assert.Equal(0D, image.CropLeftRatio);
+        Assert.Equal(0D, image.CropRightRatio);
+        Assert.Contains(result.Report.Diagnostics,
+            diagnostic => diagnostic.Code == HtmlConversionDiagnosticCodes.SemanticValueInvalid);
+    }
+
+    [Fact]
     public void ExcelHtml_RoundTripsTwoCellImageAnchors() {
         using ExcelDocument workbook = ExcelDocument.Create(new MemoryStream());
         ExcelSheet sheet = workbook.AddWorksheet("Anchors");
@@ -830,6 +855,33 @@ public class HtmlOfficeAdapters {
     }
 
     [Fact]
+    public void PowerPointHtml_RejectsXValuesOnMismatchedNonScatterSeries() {
+        using PowerPointPresentation presentation = PowerPointPresentation.Create(new MemoryStream());
+        PowerPointSlide slide = presentation.AddSlide();
+        var data = new OfficeChartData(new[] { "A", "B" }, new[] {
+            new OfficeChartSeries("Actual", new[] { 10D, 20D })
+        });
+        slide.AddChartPoints(OfficeChartKind.ColumnClustered, data, 72, 96, 240, 140).SetTitle("Columns");
+
+        string html = presentation.ToHtml(new PowerPointHtmlSaveOptions {
+            Profile = OfficeHtmlConversionProfile.PowerPointSemanticSlides
+        });
+        html = html.Replace("<td>10</td>", "<td data-officeimo-x=\"1\">10</td>", StringComparison.Ordinal)
+            .Replace("<td>20</td>", string.Empty, StringComparison.Ordinal);
+
+        HtmlToPowerPointResult result = HtmlConversionDocument.Parse(html).ToPowerPointPresentationResult();
+        using PowerPointPresentation imported = result.Value;
+        PowerPointChart importedChart = Assert.Single(imported.Slides[0].Charts);
+
+        Assert.True(importedChart.TryGetOfficeSnapshot(out OfficeChartSnapshot snapshot));
+        OfficeChartSeries series = Assert.Single(snapshot.Data.Series);
+        Assert.Equal(2, series.Values.Count);
+        Assert.Null(series.XValues);
+        Assert.Contains(result.Report.Diagnostics,
+            diagnostic => diagnostic.Code == HtmlConversionDiagnosticCodes.ContentApproximated);
+    }
+
+    [Fact]
     public void PowerPointHtml_RoundTripsVariableLengthScatterSeriesInSemanticChartData() {
         using PowerPointPresentation presentation = PowerPointPresentation.Create(new MemoryStream());
         PowerPointSlide slide = presentation.AddSlide();
@@ -1231,6 +1283,32 @@ public class HtmlOfficeAdapters {
         Assert.Equal(0.2D, importedPicture.CropTopRatio, 3);
         Assert.Equal(0.05D, importedPicture.CropRightRatio, 3);
         Assert.Equal(0.15D, importedPicture.CropBottomRatio, 3);
+    }
+
+    [Fact]
+    public void PowerPointHtml_RejectsCropPairsThatConsumeTheWholePicture() {
+        using PowerPointPresentation presentation = PowerPointPresentation.Create(new MemoryStream());
+        PowerPointSlide slide = presentation.AddSlide();
+        using (var image = new MemoryStream(OnePixelPng)) {
+            slide.AddPicturePoints(image, OfficeIMO.PowerPoint.ImagePartType.Png, 40, 40, 80, 60)
+                .Crop(10D, 0D, 10D, 0D);
+        }
+        string html = presentation.ToHtml(new PowerPointHtmlSaveOptions {
+            Profile = OfficeHtmlConversionProfile.PowerPointSemanticSlides
+        });
+        html = System.Text.RegularExpressions.Regex.Replace(
+            html, "data-officeimo-crop-left=\"[^\"]*\"", "data-officeimo-crop-left=\"0.75\"");
+        html = System.Text.RegularExpressions.Regex.Replace(
+            html, "data-officeimo-crop-right=\"[^\"]*\"", "data-officeimo-crop-right=\"0.75\"");
+
+        HtmlToPowerPointResult result = HtmlConversionDocument.Parse(html).ToPowerPointPresentationResult();
+        using PowerPointPresentation imported = result.Value;
+        PowerPointPicture picture = Assert.Single(imported.Slides[0].Pictures);
+
+        Assert.Equal(0D, picture.CropLeftRatio);
+        Assert.Equal(0D, picture.CropRightRatio);
+        Assert.Contains(result.Report.Diagnostics,
+            diagnostic => diagnostic.Code == HtmlConversionDiagnosticCodes.SemanticValueInvalid);
     }
 
     [Fact]

--- a/OfficeIMO.Markdown.Tests/Markdown/Markdown_Renderer_RawHtmlHandling_Tests.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown/Markdown_Renderer_RawHtmlHandling_Tests.cs
@@ -6,6 +6,49 @@ namespace OfficeIMO.Tests.MarkdownSuite;
 
 public class Markdown_Renderer_RawHtmlHandling_Tests {
     [Fact]
+    public void GenericAttributes_DoNotBypassSanitizedHtmlAttributePolicy() {
+        const string markdown = "Safe {onclick=\"alert(1)\" style=\"display:none\" href=\"javascript:alert(2)\" srcdoc=\"<script>x</script>\" data-safe=\"yes\" title=\"kept\"}\n\n![safe](/safe.png){srcset=\"https://attacker.test/leak.png 2x\" imagesrcset=\"https://attacker.test/preload.png 1x\"}";
+        var readerOptions = new MarkdownReaderOptions { GenericAttributes = true };
+        var htmlOptions = new HtmlOptions {
+            Style = HtmlStyle.Plain,
+            CssDelivery = CssDelivery.None,
+            BodyClass = null,
+            RawHtmlHandling = RawHtmlHandling.Sanitize
+        };
+
+        string html = OfficeIMO.Markdown.MarkdownReader.Parse(markdown, readerOptions)
+            .ToHtmlFragment(htmlOptions);
+
+        Assert.DoesNotContain("onclick", html, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("style=", html, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("href=", html, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("srcdoc", html, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("srcset", html, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("imagesrcset", html, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("data-safe=\"yes\"", html, StringComparison.Ordinal);
+        Assert.Contains("title=\"kept\"", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GenericAttributes_PreserveTrustedAllowRendering() {
+        const string markdown = "Trusted {style=\"color:red\" href=\"https://example.test\" onclick=\"trusted()\"}";
+        var readerOptions = new MarkdownReaderOptions { GenericAttributes = true };
+        var htmlOptions = new HtmlOptions {
+            Style = HtmlStyle.Plain,
+            CssDelivery = CssDelivery.None,
+            BodyClass = null,
+            RawHtmlHandling = RawHtmlHandling.Allow
+        };
+
+        string html = OfficeIMO.Markdown.MarkdownReader.Parse(markdown, readerOptions)
+            .ToHtmlFragment(htmlOptions);
+
+        Assert.Contains("style=\"color:red\"", html, StringComparison.Ordinal);
+        Assert.Contains("href=\"https://example.test\"", html, StringComparison.Ordinal);
+        Assert.Contains("onclick=\"trusted()\"", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void HtmlOptions_Can_Strip_RawHtml_Blocks() {
         var md = "<div>hi</div>\n\nParagraph";
         var opts = new HtmlOptions { Style = HtmlStyle.Plain, CssDelivery = CssDelivery.None, BodyClass = null, RawHtmlHandling = RawHtmlHandling.Strip };

--- a/OfficeIMO.Markdown/Utilities/MarkdownHtmlAttributes.cs
+++ b/OfficeIMO.Markdown/Utilities/MarkdownHtmlAttributes.cs
@@ -13,14 +13,15 @@ internal static class MarkdownHtmlAttributes {
             return string.Empty;
         }
 
+        var effectiveOptions = options ?? HtmlRenderContext.Options;
         var builder = new StringBuilder();
-        AppendId(builder, attributes?.ElementId ?? fallbackElementId, options);
+        AppendId(builder, attributes?.ElementId ?? fallbackElementId, effectiveOptions);
         if (attributes != null || additionalClasses != null) {
-            AppendClasses(builder, attributes?.Classes, additionalClasses, options, additionalClassesFirst);
+            AppendClasses(builder, attributes?.Classes, additionalClasses, effectiveOptions, additionalClassesFirst);
         }
 
         if (attributes != null) {
-            AppendAttributes(builder, attributes, options);
+            AppendAttributes(builder, attributes, effectiveOptions);
         }
 
         return builder.ToString();
@@ -86,7 +87,7 @@ internal static class MarkdownHtmlAttributes {
             if (string.IsNullOrWhiteSpace(attribute.Key)
                 || string.Equals(attribute.Key, "id", StringComparison.OrdinalIgnoreCase)
                 || string.Equals(attribute.Key, "class", StringComparison.OrdinalIgnoreCase)
-                || !IsSafeAttributeName(attribute.Key)) {
+                || !IsSafeAttributeName(attribute.Key, options)) {
                 continue;
             }
 
@@ -99,7 +100,7 @@ internal static class MarkdownHtmlAttributes {
         }
     }
 
-    private static bool IsSafeAttributeName(string name) {
+    private static bool IsSafeAttributeName(string name, HtmlOptions? options) {
         var trimmed = name.Trim();
         if (trimmed.Length == 0) {
             return false;
@@ -116,6 +117,33 @@ internal static class MarkdownHtmlAttributes {
             }
 
             return false;
+        }
+
+        if ((options?.RawHtmlHandling ?? RawHtmlHandling.Allow) == RawHtmlHandling.Allow) {
+            return true;
+        }
+
+        if (trimmed.StartsWith("on", StringComparison.OrdinalIgnoreCase)
+            || trimmed.StartsWith("xmlns", StringComparison.OrdinalIgnoreCase)) {
+            return false;
+        }
+
+        switch (trimmed.ToLowerInvariant()) {
+            case "action":
+            case "background":
+            case "data":
+            case "formaction":
+            case "href":
+            case "imagesrcset":
+            case "manifest":
+            case "ping":
+            case "poster":
+            case "src":
+            case "srcdoc":
+            case "srcset":
+            case "style":
+            case "xlink:href":
+                return false;
         }
 
         return true;

--- a/OfficeIMO.Markup.PowerPoint/MarkupToPowerPointOptions.cs
+++ b/OfficeIMO.Markup.PowerPoint/MarkupToPowerPointOptions.cs
@@ -22,7 +22,10 @@ public sealed class MarkupToPowerPointOptions {
     public string? TemporaryDirectory { get; set; }
     /// <summary>Maximum Mermaid renderer execution time in milliseconds.</summary>
     public int MermaidRenderTimeoutMilliseconds { get; set; } = 30000;
-    /// <summary>Optional deck preflight rules applied after conversion.</summary>
+    /// <summary>
+    /// Optional deck preflight rules applied after conversion. When omitted, bounded preflight runs with
+    /// pairwise shape-collision detection disabled; trusted callers can opt into that diagnostic explicitly.
+    /// </summary>
     public PowerPointDeckPreflightOptions? PreflightOptions { get; set; }
     /// <summary>Whether preflight findings should fail the conversion.</summary>
     public bool FailOnPreflightFindings { get; set; }

--- a/OfficeIMO.Markup.PowerPoint/OfficeMarkupPowerPointExporter.cs
+++ b/OfficeIMO.Markup.PowerPoint/OfficeMarkupPowerPointExporter.cs
@@ -73,7 +73,11 @@ internal sealed partial class OfficeMarkupPowerPointExporter {
             }
 
             PowerPointDeckPreflightOptions preflightOptions = options.PreflightOptions?.Clone()
-                ?? new PowerPointDeckPreflightOptions();
+                ?? new PowerPointDeckPreflightOptions {
+                    // Markup can expand into many peer shapes. Callers may opt into collision diagnostics,
+                    // but the default export path must not perform a quadratic pairwise scan.
+                    DetectShapeCollisions = false
+                };
             PowerPointDeckPreflightReport preflightReport = presentation.InspectPreflight(preflightOptions);
             if (options.FailOnPreflightFindings) {
                 preflightReport.ThrowIfFindings(preflightOptions.FailureSeverity);

--- a/OfficeIMO.Markup.Tests/OfficeMarkupPowerPointPreflightTests.cs
+++ b/OfficeIMO.Markup.Tests/OfficeMarkupPowerPointPreflightTests.cs
@@ -10,6 +10,47 @@ namespace OfficeIMO.Markup.Tests;
 
 public class OfficeMarkupPowerPointPreflightTests {
     [Fact]
+    public void DefaultMarkupPreflightSkipsPairwiseCollisionScanUnlessExplicitlyRequested() {
+        const string markup = """
+---
+profile: presentation
+---
+
+# Collision policy
+
+@slide {
+  layout: blank
+}
+
+::textbox x=10% y=20% w=55% h=20%
+First overlapping box
+
+::textbox x=20% y=25% w=55% h=20%
+Second overlapping box
+""";
+        OfficeMarkupParseResult parsed = OfficeMarkupParser.Parse(markup);
+
+        OfficeMarkupPowerPointConversionResult bounded = parsed.Document.ToPowerPointPresentationResult(
+            new MarkupToPowerPointOptions { RenderMermaidDiagrams = false });
+        OfficeMarkupPowerPointConversionResult explicitCollisionScan = parsed.Document.ToPowerPointPresentationResult(
+            new MarkupToPowerPointOptions {
+                RenderMermaidDiagrams = false,
+                PreflightOptions = new PowerPointDeckPreflightOptions {
+                    DetectShapeCollisions = true,
+                    IncludeVisualSnapshotDiagnostics = false
+                }
+            });
+
+        using (bounded.Value)
+        using (explicitCollisionScan.Value) {
+            Assert.DoesNotContain(bounded.Report.Preflight.Findings,
+                finding => finding.Code == "Layout.ShapeCollision");
+            Assert.Contains(explicitCollisionScan.Report.Preflight.Findings,
+                finding => finding.Code == "Layout.ShapeCollision");
+        }
+    }
+
+    [Fact]
     public void SaveAsPowerPoint_ReturnsSharedPreflightThatCanBePersistedSeparately() {
         const string markup = """
 ---

--- a/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.cs
+++ b/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.cs
@@ -181,9 +181,12 @@ public static partial class HtmlPowerPointConverterExtensions {
         }
 
         using (reservation) {
-            bool restoredFromSemanticData = TryReadChartData(item, out PptCore.PowerPointChartData? semanticData);
-            PptCore.PowerPointChartData data = semanticData ?? CreatePlaceholderChartDataFromInventory(item);
             string chartKind = ReadChartKind(item);
+            bool restoredFromSemanticData = TryReadChartData(
+                item,
+                chartKind.Equals("Scatter", StringComparison.OrdinalIgnoreCase),
+                out PptCore.PowerPointChartData? semanticData);
+            PptCore.PowerPointChartData data = semanticData ?? CreatePlaceholderChartDataFromInventory(item);
             ReadChartGeometry(item, 500D, fallbackTop, 320D, 180D, budget, result, out double left, out double chartTop, out double width, out double height);
             if (!TryAddChartByKind(slide, chartKind, data, left, chartTop, width, height, out PptCore.PowerPointChart? chart, out string? fallbackMessage) || chart == null) {
                 AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.ContentOmitted,
@@ -259,7 +262,7 @@ public static partial class HtmlPowerPointConverterExtensions {
         return new PptCore.PowerPointChartData(categories, series);
     }
 
-    private static bool TryReadChartData(IElement item, out PptCore.PowerPointChartData? data) {
+    private static bool TryReadChartData(IElement item, bool allowXValues, out PptCore.PowerPointChartData? data) {
         data = null;
         IElement? table = item.QuerySelector("table.officeimo-chart-data");
         if (table == null) {
@@ -285,6 +288,10 @@ public static partial class HtmlPowerPointConverterExtensions {
             var values = new double[valueCells.Count];
             var xValues = new double[valueCells.Count];
             bool hasXValues = valueCells.Any(cell => cell.GetAttribute("data-officeimo-x") != null);
+            if (hasXValues && !allowXValues) {
+                return false;
+            }
+
             for (int i = 0; i < valueCells.Count; i++) {
                 IElement cell = valueCells[i];
                 string text = PreserveText(cell.TextContent);
@@ -393,9 +400,25 @@ public static partial class HtmlPowerPointConverterExtensions {
         top = NormalizeRange(top, 0D, 0D, 1D, budget, result, "picture crop top");
         right = NormalizeRange(right, 0D, 0D, 1D, budget, result, "picture crop right");
         bottom = NormalizeRange(bottom, 0D, 0D, 1D, budget, result, "picture crop bottom");
+        NormalizeCropPair(ref left, ref right, result, "horizontal");
+        NormalizeCropPair(ref top, ref bottom, result, "vertical");
         if (left > 0D || top > 0D || right > 0D || bottom > 0D) {
             picture.Crop(left * 100D, top * 100D, right * 100D, bottom * 100D);
         }
+    }
+
+    private static void NormalizeCropPair(
+        ref double first,
+        ref double second,
+        HtmlToPowerPointResult result,
+        string axis) {
+        if (first + second < 1D) return;
+        first = 0D;
+        second = 0D;
+        AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.SemanticValueInvalid,
+            "Invalid picture " + axis + " crop metadata used the zero fallback.",
+            lossKind: HtmlConversionLossKind.Approximation,
+            source: "picture crop " + axis);
     }
 
     private static void ApplyShapeTransforms(IElement item, PptCore.PowerPointShape shape, HtmlImportBudget budget, HtmlToPowerPointResult result) {

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.ImageExport.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.ImageExport.cs
@@ -3012,6 +3012,23 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void PowerPointSlide_SkipsChartFramesTooSmallForSafeRendering() {
+            using var stream = new MemoryStream();
+            using PowerPointPresentation presentation = PowerPointPresentation.Create(stream);
+            presentation.SlideSize.SetSizePoints(120, 80);
+            PowerPointSlide slide = presentation.AddSlide();
+            var data = new PowerPointChartData(
+                new[] { "A", "B" },
+                new[] { new PowerPointChartSeries("Series", new[] { 1D, 2D }) });
+            slide.AddChartPoints(data, 10, 10, 1, 1);
+
+            PowerPointSlideVisualSnapshot snapshot = slide.CreateVisualSnapshot();
+
+            Assert.Contains(snapshot.Diagnostics, diagnostic =>
+                diagnostic.Code == PowerPointImageExportDiagnosticCodes.UnsupportedShape);
+        }
+
+        [Fact]
         public void PowerPointSlide_RendersComboChartsThroughSharedDrawingChartRenderer() {
             using var stream = new MemoryStream();
             using PowerPointPresentation presentation = PowerPointPresentation.Create(stream);

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.Templates.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.Templates.cs
@@ -212,6 +212,29 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void CreateFromTemplate_DoesNotExposeCopiedTemplateWhenRetentionValidationFails() {
+            string templatePath = CreateTemplatePresentation();
+            string outputPath = TempPath(".pptx");
+            try {
+                var options = new PowerPointTemplateCreationOptions {
+                    SlideRetention = PowerPointTemplateSlideRetention.Selected
+                };
+                options.SourceSlideIndexes.Add(99);
+
+                Assert.Throws<ArgumentOutOfRangeException>(() =>
+                    PowerPointTemplate.CreatePresentation(templatePath, outputPath, options));
+
+                Assert.False(File.Exists(outputPath));
+                string directory = Path.GetDirectoryName(outputPath)!;
+                string prefix = "." + Path.GetFileNameWithoutExtension(outputPath) + ".";
+                Assert.DoesNotContain(Directory.EnumerateFiles(directory), path =>
+                    Path.GetFileName(path).StartsWith(prefix, StringComparison.Ordinal));
+            } finally {
+                Delete(templatePath, outputPath);
+            }
+        }
+
+        [Fact]
         public void CreateFromTemplate_ConvertsPotxToEditablePptx() {
             string sourcePptx = CreateTemplatePresentation();
             string sourcePotx = TempPath(".potx");

--- a/OfficeIMO.PowerPoint/Imaging/PowerPointSlideImageRenderer.Charts.cs
+++ b/OfficeIMO.PowerPoint/Imaging/PowerPointSlideImageRenderer.Charts.cs
@@ -15,22 +15,24 @@ namespace OfficeIMO.PowerPoint {
                 return;
             }
 
-            OfficeChartSnapshot drawingSnapshot = CreateOfficeChartSnapshot(snapshot, width, height);
-            OfficeDrawing chartDrawing = OfficeChartDrawingRenderer.Render(drawingSnapshot, useMinimumCanvas: false);
-            if (chartDrawing.Width > width || chartDrawing.Height > height) {
-                AddUnsupportedShapeDiagnostic(diagnostics, chart, "Skipped a PowerPoint chart because the shared chart renderer requires a larger drawing area than the chart frame.");
-                return;
-            }
-
             try {
+                OfficeChartSnapshot drawingSnapshot = CreateOfficeChartSnapshot(snapshot, width, height);
+                OfficeDrawing chartDrawing = OfficeChartDrawingRenderer.Render(drawingSnapshot, useMinimumCanvas: false);
+                if (chartDrawing.Width > width || chartDrawing.Height > height) {
+                    AddUnsupportedShapeDiagnostic(diagnostics, chart, "Skipped a PowerPoint chart because the shared chart renderer requires a larger drawing area than the chart frame.");
+                    return;
+                }
+
                 OfficeImageFrameTransform transform = CreateChartFrameTransform(chart, left, top, width, height);
                 if (transform.HasTransform) {
                     drawing.AddDrawing(chartDrawing, left, top, transform);
                 } else {
                     drawing.AddDrawing(chartDrawing, left, top);
                 }
-            } catch (ArgumentOutOfRangeException) {
-                AddUnsupportedShapeDiagnostic(diagnostics, chart, "Skipped a PowerPoint chart because the rendered Drawing chart would exceed the slide canvas.");
+            } catch (ArgumentException) {
+                AddUnsupportedShapeDiagnostic(diagnostics, chart, "Skipped a PowerPoint chart because its frame is too small for safe rendering.");
+            } catch (InvalidOperationException) {
+                AddUnsupportedShapeDiagnostic(diagnostics, chart, "Skipped a PowerPoint chart because its cached layout could not be rendered safely.");
             }
         }
 

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.Templates.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.Templates.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Presentation;
+using OfficeIMO.Drawing.Internal;
 
 namespace OfficeIMO.PowerPoint {
     /// <summary>Controls which source slides remain in a presentation created from a template.</summary>
@@ -64,23 +65,32 @@ namespace OfficeIMO.PowerPoint {
             }
 
             PowerPointTemplateCreationOptions resolved = options ?? new PowerPointTemplateCreationOptions();
-            string? directory = Path.GetDirectoryName(destination);
-            if (!string.IsNullOrWhiteSpace(directory)) Directory.CreateDirectory(directory!);
-            File.Copy(source, destination, resolved.Overwrite);
-
-            if (string.Equals(sourceExtension, ".potx", StringComparison.OrdinalIgnoreCase)) {
-                using PresentationDocument document = PresentationDocument.Open(destination, true);
-                document.ChangeDocumentType(PresentationDocumentType.Presentation);
-                document.Save();
-            }
-
-            PowerPointPresentation presentation = Load(destination);
+            OfficeFileCommit.EnsureTargetDirectory(destination);
+            string stagingPath = OfficeFileCommit.CreateStagingPath(destination);
             try {
-                presentation.ApplyTemplateSlideRetention(resolved);
-                return presentation;
-            } catch {
-                presentation.Dispose();
-                throw;
+                File.Copy(source, stagingPath, overwrite: false);
+
+                if (string.Equals(sourceExtension, ".potx", StringComparison.OrdinalIgnoreCase)) {
+                    using PresentationDocument document = PresentationDocument.Open(stagingPath, true);
+                    document.ChangeDocumentType(PresentationDocumentType.Presentation);
+                    document.Save();
+                }
+
+                using (PowerPointPresentation presentation = Load(stagingPath)) {
+                    presentation.ApplyTemplateSlideRetention(resolved);
+                    presentation.Save();
+                }
+
+                OfficeFileCommit.CommitTemporaryFile(
+                    stagingPath,
+                    destination,
+                    resolved.Overwrite
+                        ? OfficeFileCommit.ConflictPolicy.Replace
+                        : OfficeFileCommit.ConflictPolicy.FailIfExists);
+                stagingPath = string.Empty;
+                return Load(destination);
+            } finally {
+                OfficeFileCommit.DeleteIfExists(stagingPath);
             }
         }
 

--- a/OfficeIMO.TestAssets/Documents/LegacyXlsCorpus/excel-com-generated/external-links.import-report.md
+++ b/OfficeIMO.TestAssets/Documents/LegacyXlsCorpus/excel-com-generated/external-links.import-report.md
@@ -53,11 +53,17 @@ Worksheet metadata records: 7
 Worksheet future metadata records: 1
 Unsupported sheet metadata records: 0
 Unsupported sheet future metadata records: 0
-Unsupported features: 0
+Unsupported features: 1
 Unsupported projection gaps: 0
-Preserved feature records: 0
+Preserved feature records: 1
 Errors: 0
 Warnings: 0
+
+## Diagnostics By Code
+
+| Key | Count |
+| --- | --- |
+| XLS-BIFF-FEATURE-EXTERNAL-REFERENCE-UNSUPPORTED | 1 |
 
 ## Formula Tokens By Name
 
@@ -241,6 +247,36 @@ Warnings: 0
 | Key | Count |
 | --- | --- |
 | Missing | 1 |
+
+## Unsupported Features By Code
+
+| Key | Count |
+| --- | --- |
+| XLS-BIFF-FEATURE-EXTERNAL-REFERENCE-UNSUPPORTED | 1 |
+
+## Unsupported Features By Kind
+
+| Key | Count |
+| --- | --- |
+| ExternalReference | 1 |
+
+## Unsupported Feature Record Types
+
+| Key | Count |
+| --- | --- |
+| ExternalReference\|XLS-BIFF-FEATURE-EXTERNAL-REFERENCE-UNSUPPORTED\|0x01AE | 1 |
+
+## Unsupported Feature Details
+
+| Key | Count |
+| --- | --- |
+| ExternalReference\|XLS-BIFF-FEATURE-EXTERNAL-REFERENCE-UNSUPPORTED\|ExternalReference:ExternalWorkbook | 1 |
+
+## Unsupported Feature Locations
+
+| Key | Count |
+| --- | --- |
+| XLS-BIFF-FEATURE-EXTERNAL-REFERENCE-UNSUPPORTED\|(workbook) | 1 |
 
 ## File Format States
 
@@ -1067,3 +1103,15 @@ Warnings: 0
 | Key | Count |
 | --- | --- |
 | Bytes:4 | 1 |
+
+## Preserved Feature Records By Kind
+
+| Key | Count |
+| --- | --- |
+| ExternalReference | 1 |
+
+## Preserved Feature Record Details
+
+| Key | Count |
+| --- | --- |
+| ExternalReference\|XLS-BIFF-FEATURE-EXTERNAL-REFERENCE-UNSUPPORTED\|ExternalReference:ExternalWorkbook | 1 |

--- a/OfficeIMO.TestAssets/Documents/LegacyXlsCorpus/openpreserve-format-corpus/MonteCarlo.import-report.md
+++ b/OfficeIMO.TestAssets/Documents/LegacyXlsCorpus/openpreserve-format-corpus/MonteCarlo.import-report.md
@@ -53,11 +53,17 @@ Worksheet metadata records: 41
 Worksheet future metadata records: 0
 Unsupported sheet metadata records: 0
 Unsupported sheet future metadata records: 0
-Unsupported features: 0
+Unsupported features: 1
 Unsupported projection gaps: 0
-Preserved feature records: 0
+Preserved feature records: 1
 Errors: 0
 Warnings: 0
+
+## Diagnostics By Code
+
+| Key | Count |
+| --- | --- |
+| XLS-BIFF-FEATURE-EXTERNAL-REFERENCE-UNSUPPORTED | 1 |
 
 ## Formula Tokens By Name
 
@@ -455,6 +461,36 @@ Warnings: 0
 | Key | Count |
 | --- | --- |
 | Missing | 7 |
+
+## Unsupported Features By Code
+
+| Key | Count |
+| --- | --- |
+| XLS-BIFF-FEATURE-EXTERNAL-REFERENCE-UNSUPPORTED | 1 |
+
+## Unsupported Features By Kind
+
+| Key | Count |
+| --- | --- |
+| ExternalReference | 1 |
+
+## Unsupported Feature Record Types
+
+| Key | Count |
+| --- | --- |
+| ExternalReference\|XLS-BIFF-FEATURE-EXTERNAL-REFERENCE-UNSUPPORTED\|0x01AE | 1 |
+
+## Unsupported Feature Details
+
+| Key | Count |
+| --- | --- |
+| ExternalReference\|XLS-BIFF-FEATURE-EXTERNAL-REFERENCE-UNSUPPORTED\|ExternalReference:ExternalWorkbook | 1 |
+
+## Unsupported Feature Locations
+
+| Key | Count |
+| --- | --- |
+| XLS-BIFF-FEATURE-EXTERNAL-REFERENCE-UNSUPPORTED\|(workbook) | 1 |
 
 ## File Format States
 
@@ -2428,3 +2464,15 @@ Warnings: 0
 | RowBlockIndex | 7 |
 | Selection | 7 |
 | SheetOptions | 7 |
+
+## Preserved Feature Records By Kind
+
+| Key | Count |
+| --- | --- |
+| ExternalReference | 1 |
+
+## Preserved Feature Record Details
+
+| Key | Count |
+| --- | --- |
+| ExternalReference\|XLS-BIFF-FEATURE-EXTERNAL-REFERENCE-UNSUPPORTED\|ExternalReference:ExternalWorkbook | 1 |

--- a/OfficeIMO.TestAssets/Documents/LegacyXlsCorpus/openpreserve-format-corpus/valid.import-report.md
+++ b/OfficeIMO.TestAssets/Documents/LegacyXlsCorpus/openpreserve-format-corpus/valid.import-report.md
@@ -53,9 +53,9 @@ Worksheet metadata records: 67
 Worksheet future metadata records: 0
 Unsupported sheet metadata records: 0
 Unsupported sheet future metadata records: 0
-Unsupported features: 0
+Unsupported features: 2
 Unsupported projection gaps: 0
-Preserved feature records: 0
+Preserved feature records: 2
 Errors: 0
 Warnings: 0
 
@@ -63,6 +63,7 @@ Warnings: 0
 
 | Key | Count |
 | --- | --- |
+| XLS-BIFF-FEATURE-EXTERNAL-REFERENCE-UNSUPPORTED | 2 |
 | XLS-BIFF-SORT-RESERVED-BYTES | 1 |
 
 ## Formula Tokens By Name
@@ -890,6 +891,36 @@ Warnings: 0
 | Sheet5 | 1 |
 | Sheet6 | 1 |
 | Sheet8 | 1 |
+
+## Unsupported Features By Code
+
+| Key | Count |
+| --- | --- |
+| XLS-BIFF-FEATURE-EXTERNAL-REFERENCE-UNSUPPORTED | 2 |
+
+## Unsupported Features By Kind
+
+| Key | Count |
+| --- | --- |
+| ExternalReference | 2 |
+
+## Unsupported Feature Record Types
+
+| Key | Count |
+| --- | --- |
+| ExternalReference\|XLS-BIFF-FEATURE-EXTERNAL-REFERENCE-UNSUPPORTED\|0x01AE | 2 |
+
+## Unsupported Feature Details
+
+| Key | Count |
+| --- | --- |
+| ExternalReference\|XLS-BIFF-FEATURE-EXTERNAL-REFERENCE-UNSUPPORTED\|ExternalReference:ExternalWorkbook | 2 |
+
+## Unsupported Feature Locations
+
+| Key | Count |
+| --- | --- |
+| XLS-BIFF-FEATURE-EXTERNAL-REFERENCE-UNSUPPORTED\|(workbook) | 2 |
 
 ## File Format States
 
@@ -3172,3 +3203,15 @@ Warnings: 0
 | Selection | 10 |
 | SheetOptions | 10 |
 | Sort | 1 |
+
+## Preserved Feature Records By Kind
+
+| Key | Count |
+| --- | --- |
+| ExternalReference | 2 |
+
+## Preserved Feature Record Details
+
+| Key | Count |
+| --- | --- |
+| ExternalReference\|XLS-BIFF-FEATURE-EXTERNAL-REFERENCE-UNSUPPORTED\|ExternalReference:ExternalWorkbook | 2 |

--- a/OfficeIMO.Word.Html/WordHtmlCapabilityGalleryExtensions.cs
+++ b/OfficeIMO.Word.Html/WordHtmlCapabilityGalleryExtensions.cs
@@ -57,7 +57,10 @@ namespace OfficeIMO.Word.Html {
 
             HtmlRoundTripScore score = HtmlRoundTripScorer.Compare(source.SourceHtml, roundTripHtml);
             HtmlResourceManifest resourceManifest = HtmlResourcePipeline.BuildManifest(source.SourceHtml, new HtmlResourcePipelineOptions {
-                ResourceUrlPolicy = options.ResourceUrlPolicy ?? HtmlUrlPolicy.CreateOfficeIMOProfile()
+                ResourceUrlPolicy = options.ResourceUrlPolicy
+                    ?? (options.ImportOptions == null
+                        ? HtmlUrlPolicy.CreateEmbeddedResourceProfile()
+                        : importOptions.ResourceUrlPolicy)
             });
             var manifest = new HtmlCapabilityGalleryManifest(
                 result,
@@ -76,7 +79,7 @@ namespace OfficeIMO.Word.Html {
         }
 
         private static HtmlToWordOptions CreateImportOptions(HtmlToWordOptions? options) {
-            HtmlToWordOptions importOptions = options?.Clone() ?? HtmlToWordOptions.CreateTrustedDocumentProfile();
+            HtmlToWordOptions importOptions = options?.Clone() ?? HtmlToWordOptions.CreateUntrustedHtmlProfile();
             importOptions.EnableAccessibilityDiagnostics = true;
             return importOptions;
         }

--- a/OfficeIMO.Word/Imaging/WordDocumentImageRenderer.HeadersFooters.cs
+++ b/OfficeIMO.Word/Imaging/WordDocumentImageRenderer.HeadersFooters.cs
@@ -202,7 +202,9 @@ namespace OfficeIMO.Word {
                 sectionPageCount: sectionPageCount,
                 pageNumberValue: pageNumberValue,
                 pageNumberText: pageNumberText);
-            AddHeaderFooterContent(headerFooter, measurementContext, new List<OfficeImageExportDiagnostic>(), "header-footer");
+            using (measurementDrawing.DeferBehindContentOrdering()) {
+                AddHeaderFooterContent(headerFooter, measurementContext, new List<OfficeImageExportDiagnostic>(), "header-footer");
+            }
             return Math.Max(DefaultHeaderFooterLineHeightPoints, measurementContext.Y);
         }
 

--- a/OfficeIMO.Word/Imaging/WordDocumentImageRenderer.cs
+++ b/OfficeIMO.Word/Imaging/WordDocumentImageRenderer.cs
@@ -136,6 +136,7 @@ namespace OfficeIMO.Word {
             AddBackgroundRectangle(drawing, options.BackgroundColor);
 
             if (options.IncludeDocumentContent) {
+                using var behindContentBatch = drawing.DeferBehindContentOrdering();
                 IReadOnlyDictionary<OpenXmlElement, WordImageSourceBlock> sourceBlocks =
                     BuildImageSourceBlocks(document, cancellationToken);
                 int totalPageCount = Math.Max(1, sectionPageCounts.Sum());
@@ -242,29 +243,31 @@ namespace OfficeIMO.Word {
                 sectionIndex,
                 cancellationToken);
             IReadOnlyList<OpenXmlElement> bodyChildren = bodyEntries.Select(entry => entry.Element).ToList();
-            for (int index = 0; index < bodyChildren.Count; index++) {
-                cancellationToken.ThrowIfCancellationRequested();
-                WordSectionBodyElement entry = bodyEntries[index];
-                OpenXmlElement element = entry.Element;
-                if (entry.SectionIndex != sectionIndex) {
-                    int mergedSectionPageCount = ResolveSectionPageCountForFieldContext(sectionPageCounts, entry.SectionIndex, sectionPageCount);
-                    context.UpdateSectionContext(entry.SectionIndex + 1, mergedSectionPageCount);
-                }
+            using (drawing.DeferBehindContentOrdering()) {
+                for (int index = 0; index < bodyChildren.Count; index++) {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    WordSectionBodyElement entry = bodyEntries[index];
+                    OpenXmlElement element = entry.Element;
+                    if (entry.SectionIndex != sectionIndex) {
+                        int mergedSectionPageCount = ResolveSectionPageCountForFieldContext(sectionPageCounts, entry.SectionIndex, sectionPageCount);
+                        context.UpdateSectionContext(entry.SectionIndex + 1, mergedSectionPageCount);
+                    }
 
-                TryAdvanceForKeepWithNext(document, bodyChildren, index, context, listMarkers);
-                if (context.PastTargetPage || context.StoppedForPagination) {
-                    break;
-                }
+                    TryAdvanceForKeepWithNext(document, bodyChildren, index, context, listMarkers);
+                    if (context.PastTargetPage || context.StoppedForPagination) {
+                        break;
+                    }
 
-                bool added = AddBodyElementContent(document, element, context, diagnostics, listMarkers);
+                    bool added = AddBodyElementContent(document, element, context, diagnostics, listMarkers);
 
-                if (context.PastTargetPage || context.StoppedForPagination) {
-                    break;
-                }
+                    if (context.PastTargetPage || context.StoppedForPagination) {
+                        break;
+                    }
 
-                if (context.IsTargetPage && !added && element is Paragraph) {
-                    context.ClearParagraphSpacingState();
-                    context.Y += ParagraphGapPoints;
+                    if (context.IsTargetPage && !added && element is Paragraph) {
+                        context.ClearParagraphSpacingState();
+                        context.Y += ParagraphGapPoints;
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary

- stage template saves and CSV no-clobber writes atomically
- disable expensive PowerPoint preflight work by default and bound shape and chart rendering edge cases
- reject unsafe legacy XLS external links unless explicitly requested, including workbook formulas, external defined-name formulas, and data-consolidation relationships
- normalize legacy workbook targets exactly as the BIFF formula formatter does, covering path prefixes, control characters, and Excel's escaped apostrophe syntax while ignoring workbook-like text inside formula string literals
- keep cached legacy XLS formula values when external formulas are suppressed, while preserving internal formulas normally
- prevent clipped Excel and Word SVG text, oversized font metadata, malformed crop and format values, and dangerous Markdown generic attributes from escaping their rendering boundaries
- make behind-content ordering linear across body, headers, and footers
- use untrusted resource profiles for generated HTML galleries
- disposition exported all-severity findings 121–140: 16 fixed here, three already fixed by earlier aggregate or indexing limits, and one formula-cache report classified not applicable

## Compatibility notes

- legacy XLS external workbook relationships and formulas are opt-in through PreserveExternalWorkbookLinks; ordinary external hyperlinks, string literals, and internal formulas are unaffected
- cached Excel formula results remain available when an unsafe external formula is removed
- trusted Markdown rendering with RawHtmlHandling.Allow retains prior generic attributes, while strict modes reject event, style, namespace, and URL-bearing attributes
- delimiterless multiline CSV comments remain supported with a bounded continuation lookahead

Focused regressions pass on net8.0 and net10.0 across the affected libraries, including canonical SupBook target normalization, escaped workbook names, quoted formula strings, and the explicit opt-in and safe-default legacy XLS paths. The affected netstandard2.0 libraries build with zero warnings.