### PR TITLE
Harden document parsing and export boundaries

### DIFF
--- a/OfficeIMO.Pdf.Tests/Pdf/PdfConversionScenarioManifestTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfConversionScenarioManifestTests.cs
@@ -885,7 +885,7 @@ public sealed class PdfConversionScenarioManifestTests {
     }
 
     [Fact]
-    public void PdfReaderPageChunks_DoNotRepeatDocumentCatalogActions() {
+    public void PdfReaderPageChunks_RetainDocumentCatalogActionsOnlyOnce() {
         byte[] pdf = CreateCatalogActionsMultiPagePdf();
 
         List<ReaderChunk> pageChunks = PdfReaderAdapter.Read(
@@ -894,12 +894,14 @@ public sealed class PdfConversionScenarioManifestTests {
             readerOptions: new ReaderOptions { MaxChars = 8_000 }).ToList();
 
         Assert.Equal(2, pageChunks.Count);
+        Assert.Equal(2, pageChunks[0].Actions!.Count(action => action.Scope == ReaderActionScope.Catalog));
+        Assert.DoesNotContain(pageChunks[1].Actions ?? Array.Empty<ReaderActionSummary>(), action => action.Scope == ReaderActionScope.Catalog);
         Assert.All(pageChunks, chunk => {
-            Assert.DoesNotContain(chunk.Actions ?? Array.Empty<ReaderActionSummary>(), action => action.Scope == ReaderActionScope.Catalog);
-            Assert.DoesNotContain(chunk.Actions ?? Array.Empty<ReaderActionSummary>(), action => action.Scope == ReaderActionScope.DocumentOpen);
             Assert.NotNull(chunk.Diagnostics);
             Assert.Equal(2, chunk.Diagnostics!.CatalogActionCount);
             Assert.True(chunk.Diagnostics.HasCatalogActions);
+            Assert.Equal(2, chunk.Diagnostics.PotentiallyUnsafeActionCount);
+            Assert.Equal(2, chunk.Diagnostics.JavaScriptActionCount);
         });
 
         ReaderChunk documentChunk = Assert.Single(PdfReaderAdapter.Read(

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfDocumentVisualQualityFlowKeepRowColumnTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfDocumentVisualQualityFlowKeepRowColumnTests.cs
@@ -255,6 +255,38 @@ public partial class PdfDocumentVisualQualityTests {
     }
 
     [Fact]
+    public void RowColumnParagraph_LongKeepWithNextChainRendersWithBoundedMeasurement() {
+        byte[] bytes = PdfDocument.Create(new PdfOptions {
+                PageWidth = 300,
+                PageHeight = 400,
+                MarginLeft = 30,
+                MarginRight = 30,
+                MarginTop = 30,
+                MarginBottom = 30,
+                DefaultFont = PdfStandardFont.Helvetica,
+                DefaultFontSize = 8
+            })
+            .Compose(document =>
+                document.Page(page =>
+                    page.Content(content =>
+                        content.Row(row =>
+                            row.Column(100, column => {
+                                for (int i = 0; i < 768; i++) {
+                                    column.Paragraph(
+                                        paragraph => paragraph.Text("Keep" + i.ToString(CultureInfo.InvariantCulture)),
+                                        style: new PdfParagraphStyle { KeepWithNext = true });
+                                }
+
+                                column.Paragraph(paragraph => paragraph.Text("KeepChainTail"));
+                            })))))
+            .ToBytes();
+
+        using var pdf = PdfPigDocument.Open(new MemoryStream(bytes));
+        Assert.True(pdf.NumberOfPages > 1);
+        Assert.Contains("KeepChainTail", pdf.GetPage(pdf.NumberOfPages).Text);
+    }
+
+    [Fact]
     public void RowColumnHeading_KeepsWithFollowingParagraph() {
         var options = new PdfOptions {
             PageWidth = 260,

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfDocumentVisualQualityTableSecurityTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfDocumentVisualQualityTableSecurityTests.cs
@@ -1,0 +1,103 @@
+using System.Collections.Generic;
+using System.Linq;
+using OfficeIMO.Pdf;
+using PdfPigDocument = UglyToad.PdfPig.PdfDocument;
+using Xunit;
+
+namespace OfficeIMO.Tests.Pdf;
+
+public partial class PdfDocumentVisualQualityTests {
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ExactHeightTableRowsDoNotEmitClippedHiddenText(bool rowColumn) {
+        var options = new PdfOptions {
+            PageWidth = 260,
+            PageHeight = 180,
+            MarginLeft = 30,
+            MarginRight = 30,
+            MarginTop = 30,
+            MarginBottom = 30,
+            DefaultFont = PdfStandardFont.Helvetica,
+            DefaultFontSize = 9
+        };
+        var style = TableStyles.Minimal();
+        style.HeaderRowCount = 0;
+        style.CellPaddingX = 0;
+        style.CellPaddingY = 0;
+        style.ColumnWidthPoints = new List<double?> { 120 };
+        style.FixedRowHeights = new List<double?> { 18 };
+        PdfTableCell[][] rows = {
+            new[] {
+                PdfTableCell.RichTextCell(new[] {
+                    TextRun.Normal("VisibleLine"),
+                    TextRun.LineBreak(),
+                    TextRun.Normal("ClippedSecret")
+                })
+            }
+        };
+
+        PdfDocument document = PdfDocument.Create(options);
+        if (rowColumn) {
+            document.Compose(compose =>
+                compose.Page(page =>
+                    page.Content(content =>
+                        content.Row(row =>
+                            row.Column(100, column => column.Table(rows, style: style))))));
+        } else {
+            document.Table(rows, style: style);
+        }
+
+        byte[] bytes = document.ToBytes();
+        using PdfPigDocument pdf = PdfPigDocument.Open(bytes);
+        string text = string.Concat(pdf.GetPages().Select(page => page.Text));
+
+        Assert.Contains("VisibleLine", text);
+        Assert.DoesNotContain("ClippedSecret", text);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void NoWrapTableRunLinksStayInsideCellClip(bool rowColumn) {
+        const string uri = "https://example.com/no-wrap";
+        var options = new PdfOptions {
+            PageWidth = 260,
+            PageHeight = 180,
+            MarginLeft = 30,
+            MarginRight = 30,
+            MarginTop = 30,
+            MarginBottom = 30,
+            DefaultFont = PdfStandardFont.Helvetica,
+            DefaultFontSize = 9
+        };
+        var style = TableStyles.Minimal();
+        style.HeaderRowCount = 0;
+        style.CellPaddingX = 0;
+        style.CellPaddingY = 0;
+        style.ColumnWidthPoints = new List<double?> { 80 };
+        PdfTableCell[][] rows = {
+            new[] {
+                PdfTableCell.RichTextCell(new[] {
+                    TextRun.Link(new string('W', 256), uri)
+                }).WithNoWrap()
+            }
+        };
+
+        PdfDocument document = PdfDocument.Create(options);
+        if (rowColumn) {
+            document.Compose(compose =>
+                compose.Page(page =>
+                    page.Content(content =>
+                        content.Row(row =>
+                            row.Column(100, column => column.Table(rows, style: style))))));
+        } else {
+            document.Table(rows, style: style);
+        }
+
+        PdfLinkAnnotation link = Assert.Single(PdfInspector.Inspect(document.ToBytes()).LinkAnnotations, annotation => annotation.Uri == uri);
+
+        Assert.InRange(link.X1, 29.5D, 31D);
+        Assert.InRange(link.X2, 30D, 112.5D);
+    }
+}

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfSignatureValidatorTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfSignatureValidatorTests.cs
@@ -22,6 +22,41 @@ public class PdfSignatureValidatorTests {
     }
 
     [Fact]
+    public void Validate_RejectsSignatureMarkersWithoutReadableSignatureDictionary() {
+        byte[] pdf = Encoding.ASCII.GetBytes(string.Join("\n", new[] {
+            "%PDF-1.7",
+            "1 0 obj",
+            "<< /Type /Catalog /Pages 2 0 R /AcroForm 4 0 R >>",
+            "endobj",
+            "2 0 obj",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "endobj",
+            "3 0 obj",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] >>",
+            "endobj",
+            "4 0 obj",
+            "<< /Fields [5 0 R] /SigFlags 1 >>",
+            "endobj",
+            "5 0 obj",
+            "<< /FT /Sig /T (Malformed) >>",
+            "endobj",
+            "trailer",
+            "<< /Root 1 0 R /Size 6 >>",
+            "startxref",
+            "123",
+            "%%EOF"
+        }));
+
+        PdfSignatureValidationReport report = PdfSignatureValidator.Validate(pdf);
+
+        Assert.True(report.HasSignatures);
+        Assert.Equal(0, report.SignatureCount);
+        Assert.True(report.HasErrors);
+        Assert.False(report.IsStructurallyValid);
+        Assert.Contains(report.Findings, finding => finding.Code == "UnreadableSignature");
+    }
+
+    [Fact]
     public void Validate_ReportsSignatureStructureAndPreservationMarkers() {
         PdfSignatureValidationReport report = PdfSignatureValidator.Validate(BuildSignedIncrementalPdf());
 

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Row.Items.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Row.Items.cs
@@ -307,30 +307,48 @@ internal static partial class PdfWriter {
         }
 
         private double MeasureColKeepWithNextChainHeight(System.Collections.Generic.List<ColItem> items, int startIndex) {
-            double total = 0D;
-            for (int itemIndex = startIndex; itemIndex < items.Count; itemIndex++) {
+            if ((uint)startIndex >= (uint)items.Count) {
+                return 0D;
+            }
+
+            if (!rowColumnKeepChainHeights.TryGetValue(items, out double[]? heights)) {
+                heights = BuildColKeepWithNextChainHeights(items);
+                rowColumnKeepChainHeights.Add(items, heights);
+            }
+
+            return heights[startIndex];
+        }
+
+        private double[] BuildColKeepWithNextChainHeights(System.Collections.Generic.List<ColItem> items) {
+            var heights = new double[items.Count];
+            for (int itemIndex = items.Count - 1; itemIndex >= 0; itemIndex--) {
                 ColItem item = items[itemIndex];
                 if (item is ColBookmark) {
+                    heights[itemIndex] = itemIndex + 1 < items.Count ? heights[itemIndex + 1] : 0D;
                     continue;
                 }
 
                 bool keepWithNext = ColItemKeepsWithNext(item);
+                int nextItemIndex = itemIndex + 1;
+                double itemHeight;
                 if (keepWithNext && item is ColListItem listItem && listItem.IsFirstInKeepWithNextGroup) {
-                    double spacingBefore = ResolveColumnSpacingBefore(listItem.SpacingBefore, total + 1D);
-                    total += listItem.KeepWithNextGroupHeight - listItem.SpacingBefore + spacingBefore;
-                    itemIndex += Math.Max(0, listItem.KeepWithNextGroupItemCount - 1);
+                    double spacingBefore = ResolveColumnSpacingBefore(listItem.SpacingBefore, 1D);
+                    itemHeight = listItem.KeepWithNextGroupHeight - listItem.SpacingBefore + spacingBefore;
+                    nextItemIndex += Math.Max(0, listItem.KeepWithNextGroupItemCount - 1);
                 } else {
-                    total += keepWithNext
-                        ? MeasureColItemFullHeight(item, total + 1D)
+                    itemHeight = keepWithNext
+                        ? MeasureColItemFullHeight(item, 1D)
                         : MeasureColItemFirstVisualHeight(item);
                 }
 
-                if (!keepWithNext) {
-                    break;
+                if (keepWithNext && nextItemIndex < items.Count) {
+                    itemHeight += heights[nextItemIndex];
                 }
+
+                heights[itemIndex] = itemHeight;
             }
 
-            return total;
+            return heights;
         }
 
         private bool ColItemKeepsWithNext(ColItem item) {

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Row.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Row.cs
@@ -800,11 +800,11 @@ internal static partial class PdfWriter {
                                     TableCellTextLayout lines = table.RowLines[rowIndex][c];
                                     int sourceStartLine = wholeRowSegment && cell.RowSpan > 1 ? 0 : startLine;
                                     int requestedLineCount = wholeRowSegment && cell.RowSpan > 1 ? lines.LineCount : lineCount;
-                                    int visibleLineCount = Math.Max(0, Math.Min(requestedLineCount, lines.LineCount - sourceStartLine));
+                                    double availableTextHeight = Math.Max(0, cellHeight - cellPadTop - cellPadBottom);
+                                    int visibleLineCount = LimitTableCellLineCountToHeight(lines, sourceStartLine, requestedLineCount, rowLeading, availableTextHeight);
                                     double verticalOffset = 0;
                                     double visibleTextHeight = 0D;
                                     if (visibleLineCount > 0) {
-                                        double availableTextHeight = Math.Max(0, cellHeight - cellPadTop - cellPadBottom);
                                         visibleTextHeight = MeasureTableCellTextHeight(lines, sourceStartLine, visibleLineCount, rowLeading);
                                         double visibleContentHeight = MeasureTableCellContentHeight(cell, lines, sourceStartLine, visibleLineCount, rowLeading, innerW);
                                         double unusedTextHeight = Math.Max(0, availableTextHeight - visibleContentHeight);

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Table.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Table.cs
@@ -539,11 +539,11 @@ internal static partial class PdfWriter {
                     TableCellTextLayout lines = rowLines[rowIndex][c];
                     int sourceStartLine = wholeRowSegment && cell.RowSpan > 1 ? 0 : startLine;
                     int requestedLineCount = wholeRowSegment && cell.RowSpan > 1 ? lines.LineCount : lineCount;
-                    int visibleLineCount = Math.Max(0, Math.Min(requestedLineCount, lines.LineCount - sourceStartLine));
+                    double availableTextHeight = Math.Max(0, cellHeight - cellPadTop - cellPadBottom);
+                    int visibleLineCount = LimitTableCellLineCountToHeight(lines, sourceStartLine, requestedLineCount, rowLeading, availableTextHeight);
                     double verticalOffset = 0;
                     double visibleTextHeight = 0D;
                     if (visibleLineCount > 0) {
-                        double availableTextHeight = Math.Max(0, cellHeight - cellPadTop - cellPadBottom);
                         visibleTextHeight = MeasureTableCellTextHeight(lines, sourceStartLine, visibleLineCount, rowLeading);
                         double visibleContentHeight = MeasureTableCellContentHeight(cell, lines, sourceStartLine, visibleLineCount, rowLeading, innerW);
                         double unusedTextHeight = Math.Max(0, availableTextHeight - visibleContentHeight);

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.cs
@@ -17,6 +17,7 @@ internal static partial class PdfWriter {
         private readonly System.Collections.Generic.IReadOnlyDictionary<string, int> sectionPageNumbers;
         private readonly System.Collections.Generic.Dictionary<FlowMaterializationKey, System.Collections.Generic.IReadOnlyList<IPdfBlock>> deferredMaterializations;
         private readonly System.Collections.Generic.List<SectionBlock> encounteredSectionDefinitions = new System.Collections.Generic.List<SectionBlock>();
+        private readonly System.Collections.Generic.Dictionary<System.Collections.Generic.List<ColItem>, double[]> rowColumnKeepChainHeights = new System.Collections.Generic.Dictionary<System.Collections.Generic.List<ColItem>, double[]>();
         private bool encounteredTableOfContents;
         private PdfOptions currentOpts;
         private int currentPageGroupId;

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.TableCells.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.TableCells.cs
@@ -661,7 +661,7 @@ internal static partial class PdfWriter {
     private static TableCellTextLayout CreateTableCellTextLayout(TableCellLayout cell, double innerWidth, PdfStandardFont baseFont, double fontSize, double leading, PdfOptions? options, double runFontSizeScale = 1D, double minimumShrinkFontSize = 0D) {
         double wrapWidth = GetTableCellWrapWidth(innerWidth, cell.NoWrap);
         if (cell.Paragraphs.Count > 0) {
-            return CreateTableCellParagraphTextLayout(ScaleTableCellParagraphsForShrink(cell.Paragraphs, runFontSizeScale, minimumShrinkFontSize), wrapWidth, baseFont, fontSize, leading, options);
+            return CreateTableCellParagraphTextLayout(ScaleTableCellParagraphsForShrink(cell.Paragraphs, runFontSizeScale, minimumShrinkFontSize), wrapWidth, innerWidth, baseFont, fontSize, leading, options);
         }
 
         var wrap = WrapRichRunsCore(ScaleTableRunsForShrink(cell.Runs, runFontSizeScale, minimumShrinkFontSize), wrapWidth, fontSize, baseFont, leading, null, DefaultParagraphTabStopWidth, options);
@@ -744,7 +744,7 @@ internal static partial class PdfWriter {
     private static double GetTableCellWrapWidth(double innerWidth, bool noWrap) =>
         noWrap ? TableCellNoWrapWidth : innerWidth;
 
-    private static TableCellTextLayout CreateTableCellParagraphTextLayout(System.Collections.Generic.IReadOnlyList<PdfTableCellParagraph> paragraphs, double innerWidth, PdfStandardFont baseFont, double fontSize, double leading, PdfOptions? options) {
+    private static TableCellTextLayout CreateTableCellParagraphTextLayout(System.Collections.Generic.IReadOnlyList<PdfTableCellParagraph> paragraphs, double wrapWidth, double cellInnerWidth, PdfStandardFont baseFont, double fontSize, double leading, PdfOptions? options) {
         var lines = new System.Collections.Generic.List<System.Collections.Generic.List<RichSeg>>();
         var lineHeights = new System.Collections.Generic.List<double>();
         var lineAlignments = new System.Collections.Generic.List<PdfAlign?>();
@@ -752,9 +752,9 @@ internal static partial class PdfWriter {
         var lineWidths = new System.Collections.Generic.List<double>();
         for (int paragraphIndex = 0; paragraphIndex < paragraphs.Count; paragraphIndex++) {
             PdfTableCellParagraph paragraph = paragraphs[paragraphIndex];
-            PdfParagraphStyle paragraphStyle = CreateTableCellParagraphStyle(paragraph);
+            PdfParagraphStyle paragraphStyle = CreateTableCellParagraphStyle(paragraph, cellInnerWidth);
             double paragraphLeading = paragraphStyle.LineHeight.HasValue ? GetParagraphLeading(paragraphStyle, fontSize) : leading;
-            var paragraphFrame = GetParagraphTextFrame(paragraphStyle, 0D, innerWidth);
+            var paragraphFrame = GetParagraphTextFrame(paragraphStyle, 0D, wrapWidth);
             var wrap = WrapRichRunsCoreWithFirstLineOrigin(
                 paragraph.Runs,
                 paragraphFrame.Width,
@@ -803,18 +803,26 @@ internal static partial class PdfWriter {
             lineHeights.Add(leading);
             lineAlignments.Add(null);
             lineXOffsets.Add(0D);
-            lineWidths.Add(innerWidth);
+            lineWidths.Add(wrapWidth);
         }
 
         return new TableCellTextLayout(lines, lineHeights, lineAlignments, lineXOffsets, lineWidths);
     }
 
-    private static PdfParagraphStyle CreateTableCellParagraphStyle(PdfTableCellParagraph paragraph) {
+    private static PdfParagraphStyle CreateTableCellParagraphStyle(PdfTableCellParagraph paragraph, double availableWidth) {
+        const double minimumTextWidth = 0.001D;
+        double safeWidth = double.IsNaN(availableWidth) || double.IsInfinity(availableWidth)
+            ? minimumTextWidth
+            : System.Math.Max(minimumTextWidth, availableWidth);
+        double leftIndent = System.Math.Min(paragraph.LeftIndent, System.Math.Max(0D, safeWidth - minimumTextWidth));
+        double rightIndent = System.Math.Min(paragraph.RightIndent, System.Math.Max(0D, safeWidth - leftIndent - minimumTextWidth));
+        double textWidth = System.Math.Max(minimumTextWidth, safeWidth - leftIndent - rightIndent);
+        double firstLineIndent = System.Math.Max(-leftIndent, System.Math.Min(paragraph.FirstLineIndent, textWidth - minimumTextWidth));
         var style = new PdfParagraphStyle {
             LineHeight = paragraph.LineHeight,
-            LeftIndent = paragraph.LeftIndent,
-            RightIndent = paragraph.RightIndent,
-            FirstLineIndent = paragraph.FirstLineIndent,
+            LeftIndent = leftIndent,
+            RightIndent = rightIndent,
+            FirstLineIndent = firstLineIndent,
             DefaultTabStopWidth = paragraph.DefaultTabStopWidth
         };
 
@@ -840,6 +848,23 @@ internal static partial class PdfWriter {
 
     private static double GetRichLineHeight(System.Collections.Generic.IReadOnlyList<double> heights, int lineIndex, double fallbackLeading) =>
         lineIndex >= 0 && lineIndex < heights.Count ? heights[lineIndex] : fallbackLeading;
+
+    private static int LimitTableCellLineCountToHeight(TableCellTextLayout lines, int startLine, int requestedLineCount, double fallbackLeading, double availableHeight) {
+        int maximumLineCount = System.Math.Max(0, System.Math.Min(requestedLineCount, lines.LineCount - startLine));
+        double consumedHeight = 0D;
+        int visibleLineCount = 0;
+        for (int offset = 0; offset < maximumLineCount; offset++) {
+            double lineHeight = GetRichLineHeight(lines.LineHeights, startLine + offset, fallbackLeading);
+            if (consumedHeight + lineHeight > availableHeight + 0.001D) {
+                break;
+            }
+
+            consumedHeight += lineHeight;
+            visibleLineCount++;
+        }
+
+        return visibleLineCount;
+    }
 
     private static double MeasureRichLinesHeight(System.Collections.Generic.IReadOnlyList<double> heights, int lineCount, double fallbackLeading) {
         double height = 0D;

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Text.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Text.cs
@@ -2162,6 +2162,9 @@ internal static partial class PdfWriter {
     }
 
     private static void WriteClippedRichParagraph(StringBuilder sb, RichParagraphBlock block, System.Collections.Generic.List<System.Collections.Generic.List<RichSeg>> lines, System.Collections.Generic.List<double> lineHeights, PdfOptions opts, double startY, double fontSize, double defaultLeading, System.Collections.Generic.List<LinkAnnotation> annots, double clipX, double clipY, double clipWidth, double clipHeight, double? xOverride = null, double? widthOverride = null, double? firstLineXOverride = null, double? firstLineWidthOverride = null, string? structureType = null, int? markedContentId = null, LayoutResult.Page? structurePage = null, System.Collections.Generic.IReadOnlyList<PdfAlign?>? lineAlignments = null, System.Collections.Generic.IReadOnlyList<double>? lineXOffsets = null, System.Collections.Generic.IReadOnlyList<double>? lineWidths = null) {
+        // Prevent link coalescing from extending a newly clipped annotation into a prior text frame.
+        annots.Add(new LinkAnnotation());
+        int annotationStart = annots.Count;
         new ContentStreamBuilder(sb)
             .SaveState()
             .Rectangle(clipX, clipY, clipWidth, clipHeight)
@@ -2169,9 +2172,32 @@ internal static partial class PdfWriter {
             .EndPath();
 
         WriteRichParagraph(sb, block, lines, lineHeights, opts, startY, fontSize, defaultLeading, annots, xOverride, widthOverride, firstLineXOverride, firstLineWidthOverride, structureType, markedContentId, structurePage, lineAlignments, lineXOffsets, lineWidths);
+        ClipLinkAnnotations(annots, annotationStart, clipX, clipY, clipWidth, clipHeight);
+        annots.RemoveAt(annotationStart - 1);
 
         new ContentStreamBuilder(sb)
             .RestoreState();
+    }
+
+    private static void ClipLinkAnnotations(System.Collections.Generic.List<LinkAnnotation> annots, int annotationStart, double clipX, double clipY, double clipWidth, double clipHeight) {
+        double clipRight = clipX + Math.Max(0D, clipWidth);
+        double clipTop = clipY + Math.Max(0D, clipHeight);
+        for (int index = annots.Count - 1; index >= annotationStart; index--) {
+            LinkAnnotation annotation = annots[index];
+            double x1 = Math.Max(annotation.X1, clipX);
+            double y1 = Math.Max(annotation.Y1, clipY);
+            double x2 = Math.Min(annotation.X2, clipRight);
+            double y2 = Math.Min(annotation.Y2, clipTop);
+            if (x2 <= x1 || y2 <= y1) {
+                annots.RemoveAt(index);
+                continue;
+            }
+
+            annotation.X1 = x1;
+            annotation.Y1 = y1;
+            annotation.X2 = x2;
+            annotation.Y2 = y2;
+        }
     }
 
 }

--- a/OfficeIMO.Pdf/Signatures/PdfSignatureValidator.cs
+++ b/OfficeIMO.Pdf/Signatures/PdfSignatureValidator.cs
@@ -53,6 +53,11 @@ internal static class PdfSignatureValidator {
                 PdfDiagnosticSeverity.Info,
                 "NoSignatures",
                 "No PDF signature fields, signature values, or /ByteRange markers were detected."));
+        } else if (security.Signatures.Count == 0) {
+            findings.Add(new PdfSignatureValidationFinding(
+                PdfDiagnosticSeverity.Error,
+                "UnreadableSignature",
+                "PDF signature markers were detected, but no complete signature dictionary could be validated."));
         }
 
         var signatureResults = new List<PdfSignatureValidationResult>(security.Signatures.Count);

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.FeatureReport.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.FeatureReport.cs
@@ -7,6 +7,7 @@ using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Presentation;
 using A = DocumentFormat.OpenXml.Drawing;
 using C = DocumentFormat.OpenXml.Drawing.Charts;
+using S = DocumentFormat.OpenXml.Spreadsheet;
 using OfficeIMO.PowerPoint;
 using Xunit;
 
@@ -182,6 +183,51 @@ namespace OfficeIMO.Tests {
 
                     Assert.Empty(report.FindFeatures("Images"));
                     Assert.Same(report, report.EnsureNoFeatures("Images"));
+                }
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void PowerPointFeatureReport_EmptySlideBackgroundPropertiesDoNotHideInheritedImage() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string imagePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Images", "BackgroundImage.png");
+
+            try {
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                    presentation.AddSlide().AddTextBox("Inherited background image");
+                    presentation.Save();
+                }
+
+                using (PresentationDocument document = PresentationDocument.Open(filePath, true)) {
+                    SlidePart slidePart = document.PresentationPart!.SlideParts.Single();
+                    SlideMasterPart masterPart = slidePart.SlideLayoutPart!.SlideMasterPart!;
+                    ImagePart imagePart = masterPart.AddImagePart(DocumentFormat.OpenXml.Packaging.ImagePartType.Png);
+                    using (FileStream stream = File.OpenRead(imagePath)) {
+                        imagePart.FeedData(stream);
+                    }
+
+                    string relationshipId = masterPart.GetIdOfPart(imagePart);
+                    masterPart.SlideMaster!.CommonSlideData!.Background = new Background(
+                        new BackgroundProperties(
+                            new A.BlipFill(
+                                new A.Blip { Embed = relationshipId },
+                                new A.Stretch(new A.FillRectangle()))));
+                    masterPart.SlideMaster.Save();
+
+                    slidePart.Slide.CommonSlideData!.Background = new Background(new BackgroundProperties());
+                    slidePart.Slide.Save();
+                }
+
+                using (PowerPointPresentation presentation = PowerPointPresentation.Load(filePath, new PowerPointLoadOptions { AccessMode = OfficeIMO.Drawing.DocumentAccessMode.ReadOnly })) {
+                    PowerPointFeatureReport report = presentation.InspectFeatures();
+                    PowerPointFeatureFinding images = Assert.Single(report.FindFeatures("Images"));
+
+                    Assert.Equal(1, images.Count);
+                    Assert.Throws<InvalidOperationException>(() => report.EnsureNoFeatures("Images"));
                 }
             } finally {
                 if (File.Exists(filePath)) {
@@ -1000,6 +1046,214 @@ namespace OfficeIMO.Tests {
                         && feature.Details.Any(detail => detail.Contains("Microsoft_Excel_Worksheet", StringComparison.OrdinalIgnoreCase)));
                     Assert.DoesNotContain(report.PreservedFeatures, feature => feature.Name == "Embedded packages");
                     Assert.False(report.HasAdvancedFeatures);
+                }
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void PowerPointFeatureReport_TreatsUnsafeChartOwnedPackageAsAdvanced() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                    presentation.AddSlide().AddChart();
+                    presentation.Save();
+                }
+
+                using (PresentationDocument document = PresentationDocument.Open(filePath, true)) {
+                    ChartPart chartPart = document.PresentationPart!.SlideParts.Single().ChartParts.Single();
+                    if (chartPart.EmbeddedPackagePart is EmbeddedPackagePart existingPackage) {
+                        chartPart.DeletePart(existingPackage);
+                    }
+                    EmbeddedPackagePart package = chartPart.AddEmbeddedPackagePart("application/vnd.ms-excel.sheet.macroEnabled.12");
+                    using var content = new MemoryStream(new byte[] { 1, 2, 3, 4 });
+                    package.FeedData(content);
+                }
+
+                using (PowerPointPresentation presentation = PowerPointPresentation.Load(filePath, new PowerPointLoadOptions { AccessMode = OfficeIMO.Drawing.DocumentAccessMode.ReadOnly })) {
+                    PowerPointFeatureReport report = presentation.InspectFeatures();
+                    PowerPointFeatureFinding embedded = Assert.Single(report.FindFeatures("Embedded packages"));
+
+                    Assert.Equal(PowerPointFeatureSupportLevel.Preserved, embedded.SupportLevel);
+                    Assert.Equal(1, embedded.Count);
+                    Assert.Throws<InvalidOperationException>(() => report.EnsureNoAdvancedFeatures());
+                }
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void PowerPointFeatureReport_TreatsUnreferencedChartWorkbookAsAdvanced() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                    presentation.AddSlide().AddChart();
+                    presentation.Save();
+                }
+
+                using (PresentationDocument document = PresentationDocument.Open(filePath, true)) {
+                    ChartPart chartPart = document.PresentationPart!.SlideParts.Single().ChartParts.Single();
+                    chartPart.ChartSpace!.RemoveAllChildren<C.ExternalData>();
+                    chartPart.ChartSpace.Save();
+                }
+
+                using (PowerPointPresentation presentation = PowerPointPresentation.Load(filePath, new PowerPointLoadOptions { AccessMode = OfficeIMO.Drawing.DocumentAccessMode.ReadOnly })) {
+                    PowerPointFeatureReport report = presentation.InspectFeatures();
+                    PowerPointFeatureFinding embedded = Assert.Single(report.FindFeatures("Embedded packages"));
+
+                    Assert.Equal(1, embedded.Count);
+                    Assert.Throws<InvalidOperationException>(() => report.EnsureNoAdvancedFeatures());
+                }
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void PowerPointFeatureReport_TreatsMalformedChartWorkbookAsAdvanced() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                    presentation.AddSlide().AddChart();
+                    presentation.Save();
+                }
+
+                using (PresentationDocument document = PresentationDocument.Open(filePath, true)) {
+                    ChartPart chartPart = document.PresentationPart!.SlideParts.Single().ChartParts.Single();
+                    EmbeddedPackagePart package = Assert.Single(chartPart.GetPartsOfType<EmbeddedPackagePart>());
+                    using var content = new MemoryStream(new byte[] { 1, 2, 3, 4 });
+                    package.FeedData(content);
+                }
+
+                using (PowerPointPresentation presentation = PowerPointPresentation.Load(filePath, new PowerPointLoadOptions { AccessMode = OfficeIMO.Drawing.DocumentAccessMode.ReadOnly })) {
+                    PowerPointFeatureReport report = presentation.InspectFeatures();
+                    PowerPointFeatureFinding embedded = Assert.Single(report.FindFeatures("Embedded packages"));
+
+                    Assert.Equal(1, embedded.Count);
+                    Assert.Throws<InvalidOperationException>(() => report.EnsureNoAdvancedFeatures());
+                }
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void PowerPointFeatureReport_TreatsChartWorkbookWithExternalRelationshipAsAdvanced() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                    presentation.AddSlide().AddChart();
+                    presentation.Save();
+                }
+
+                using (PresentationDocument document = PresentationDocument.Open(filePath, true)) {
+                    ChartPart chartPart = document.PresentationPart!.SlideParts.Single().ChartParts.Single();
+                    EmbeddedPackagePart package = Assert.Single(chartPart.GetPartsOfType<EmbeddedPackagePart>());
+                    using Stream workbookStream = package.GetStream(FileMode.Open, FileAccess.ReadWrite);
+                    using SpreadsheetDocument workbook = SpreadsheetDocument.Open(workbookStream, true);
+                    workbook.WorkbookPart!.AddExternalRelationship(
+                        "urn:officeimo:test-external-workbook",
+                        new Uri("https://example.invalid/linked.xlsx"),
+                        "rIdUnsafeExternalWorkbook");
+                }
+
+                using (PowerPointPresentation presentation = PowerPointPresentation.Load(filePath, new PowerPointLoadOptions { AccessMode = OfficeIMO.Drawing.DocumentAccessMode.ReadOnly })) {
+                    PowerPointFeatureReport report = presentation.InspectFeatures();
+                    PowerPointFeatureFinding embedded = Assert.Single(report.FindFeatures("Embedded packages"));
+
+                    Assert.Equal(1, embedded.Count);
+                    Assert.Throws<InvalidOperationException>(() => report.EnsureNoAdvancedFeatures());
+                }
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void PowerPointFeatureReport_TreatsChartWorkbookWithNestedSharedStringPartAsAdvanced() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                    presentation.AddSlide().AddChart();
+                    presentation.Save();
+                }
+
+                using (PresentationDocument document = PresentationDocument.Open(filePath, true)) {
+                    ChartPart chartPart = document.PresentationPart!.SlideParts.Single().ChartParts.Single();
+                    EmbeddedPackagePart package = Assert.Single(chartPart.GetPartsOfType<EmbeddedPackagePart>());
+                    using Stream workbookStream = package.GetStream(FileMode.Open, FileAccess.ReadWrite);
+                    using SpreadsheetDocument workbook = SpreadsheetDocument.Open(workbookStream, true);
+                    SharedStringTablePart sharedStrings = Assert.Single(workbook.WorkbookPart!.GetPartsOfType<SharedStringTablePart>());
+                    AddExtendedPart(
+                        sharedStrings,
+                        "urn:officeimo:test-nested-shared-string-part",
+                        "application/octet-stream",
+                        "bin",
+                        new byte[] { 1, 2, 3, 4 });
+                }
+
+                using (PowerPointPresentation presentation = PowerPointPresentation.Load(filePath, new PowerPointLoadOptions { AccessMode = OfficeIMO.Drawing.DocumentAccessMode.ReadOnly })) {
+                    PowerPointFeatureReport report = presentation.InspectFeatures();
+                    PowerPointFeatureFinding embedded = Assert.Single(report.FindFeatures("Embedded packages"));
+
+                    Assert.Equal(1, embedded.Count);
+                    Assert.Throws<InvalidOperationException>(() => report.EnsureNoAdvancedFeatures());
+                }
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void PowerPointFeatureReport_TreatsOversizedCompressedChartWorksheetAsAdvanced() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                    presentation.AddSlide().AddChart();
+                    presentation.Save();
+                }
+
+                using (PresentationDocument document = PresentationDocument.Open(filePath, true)) {
+                    ChartPart chartPart = document.PresentationPart!.SlideParts.Single().ChartParts.Single();
+                    EmbeddedPackagePart package = Assert.Single(chartPart.GetPartsOfType<EmbeddedPackagePart>());
+                    using Stream workbookStream = package.GetStream(FileMode.Open, FileAccess.ReadWrite);
+                    using SpreadsheetDocument workbook = SpreadsheetDocument.Open(workbookStream, true);
+                    WorksheetPart worksheetPart = Assert.Single(workbook.WorkbookPart!.GetPartsOfType<WorksheetPart>());
+                    S.SheetData sheetData = worksheetPart.Worksheet.GetFirstChild<S.SheetData>()!;
+                    sheetData.Append(new S.Row(
+                        new S.Cell {
+                            DataType = S.CellValues.String,
+                            CellValue = new S.CellValue(new string('A', 3 * 1024 * 1024))
+                        }));
+                    worksheetPart.Worksheet.Save();
+                }
+
+                using (PowerPointPresentation presentation = PowerPointPresentation.Load(filePath, new PowerPointLoadOptions { AccessMode = OfficeIMO.Drawing.DocumentAccessMode.ReadOnly })) {
+                    PowerPointFeatureReport report = presentation.InspectFeatures();
+                    PowerPointFeatureFinding embedded = Assert.Single(report.FindFeatures("Embedded packages"));
+
+                    Assert.Equal(1, embedded.Count);
+                    Assert.Throws<InvalidOperationException>(() => report.EnsureNoAdvancedFeatures());
                 }
             } finally {
                 if (File.Exists(filePath)) {

--- a/OfficeIMO.PowerPoint/PowerPointFeatureReport.cs
+++ b/OfficeIMO.PowerPoint/PowerPointFeatureReport.cs
@@ -9,6 +9,7 @@ using DocumentFormat.OpenXml.Presentation;
 using A = DocumentFormat.OpenXml.Drawing;
 using C = DocumentFormat.OpenXml.Drawing.Charts;
 using Dgm = DocumentFormat.OpenXml.Drawing.Diagrams;
+using S = DocumentFormat.OpenXml.Spreadsheet;
 
 namespace OfficeIMO.PowerPoint {
     /// <summary>
@@ -316,7 +317,8 @@ namespace OfficeIMO.PowerPoint {
             var tableMetadataDetails = DescribeTableMetadata();
             var chartDetails = DescribePartsByType<ChartPart>(allParts);
             var diagramDetails = DescribeDiagramParts(allParts);
-            var chartWorkbookDetails = DescribeChartWorkbookParts(allParts);
+            var safeChartWorkbookParts = GetSafeChartWorkbookParts(allParts);
+            var chartWorkbookDetails = DescribeChartWorkbookParts(safeChartWorkbookParts);
             var chartCompanionDetails = DescribePartsByUriOrContentType(allParts, "chartStyle")
                 .Concat(DescribePartsByUriOrContentType(allParts, "chartColorStyle"))
                 .Concat(chartWorkbookDetails)
@@ -398,7 +400,7 @@ namespace OfficeIMO.PowerPoint {
                 editableOleObjects.Select(ole =>
                     (OpenXmlPart)ole.EmbeddedPart));
             var embeddedPackageDetails = DescribeNonChartEmbeddedPackageParts(
-                allParts, editableOleParts);
+                allParts, editableOleParts, safeChartWorkbookParts);
             var linkedOleDetails = LegacyPptLinkedOleDetails.ToList();
             var activeXControlDetails = DescribeActiveXControlParts(allParts)
                 .Concat(LegacyPptActiveXDetails)
@@ -602,22 +604,28 @@ namespace OfficeIMO.PowerPoint {
             Background? slideBackground = slide.SlidePart.Slide?.CommonSlideData?.Background;
             if (slideBackground != null) {
                 BackgroundProperties? slideProperties = slideBackground.BackgroundProperties;
-                if (slideProperties != null) {
+                if (slideProperties?.HasChildren == true) {
                     yield return slideProperties;
+                    yield break;
                 }
 
-                yield break;
+                if (slideBackground.BackgroundStyleReference != null) {
+                    yield break;
+                }
             }
 
             SlideLayoutPart? layoutPart = slide.SlidePart.SlideLayoutPart;
             Background? layoutBackground = layoutPart?.SlideLayout?.CommonSlideData?.Background;
             if (layoutBackground != null) {
                 BackgroundProperties? layoutProperties = layoutBackground.BackgroundProperties;
-                if (layoutProperties != null) {
+                if (layoutProperties?.HasChildren == true) {
                     yield return layoutProperties;
+                    yield break;
                 }
 
-                yield break;
+                if (layoutBackground.BackgroundStyleReference != null) {
+                    yield break;
+                }
             }
 
             BackgroundProperties? masterProperties = layoutPart?.SlideMasterPart?.SlideMaster?.CommonSlideData?.Background?.BackgroundProperties;
@@ -1107,10 +1115,8 @@ namespace OfficeIMO.PowerPoint {
                 .ToList();
         }
 
-        private static List<string> DescribeChartWorkbookParts(IEnumerable<OpenXmlPart> parts) {
-            return parts
-                .OfType<ChartPart>()
-                .SelectMany(chartPart => chartPart.GetPartsOfType<EmbeddedPackagePart>())
+        private static List<string> DescribeChartWorkbookParts(ISet<OpenXmlPart> safeChartWorkbookParts) {
+            return safeChartWorkbookParts
                 .Select(DescribePart)
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .OrderBy(detail => detail, StringComparer.OrdinalIgnoreCase)
@@ -1119,19 +1125,146 @@ namespace OfficeIMO.PowerPoint {
 
         private static List<string> DescribeNonChartEmbeddedPackageParts(
             IEnumerable<OpenXmlPart> parts,
-            ISet<OpenXmlPart> editableOleParts) {
-            var chartWorkbooks = new HashSet<OpenXmlPart>(
-                parts.OfType<ChartPart>().SelectMany(chartPart => chartPart.GetPartsOfType<EmbeddedPackagePart>()));
-
+            ISet<OpenXmlPart> editableOleParts,
+            ISet<OpenXmlPart> safeChartWorkbookParts) {
             return parts
                 .Where(part => part is EmbeddedPackagePart || part is EmbeddedObjectPart)
-                .Where(part => !chartWorkbooks.Contains(part))
+                .Where(part => !safeChartWorkbookParts.Contains(part))
                 .Where(part => !editableOleParts.Contains(part))
                 .Select(DescribePart)
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .OrderBy(detail => detail, StringComparer.OrdinalIgnoreCase)
                 .ToList();
         }
+
+        private static HashSet<OpenXmlPart> GetSafeChartWorkbookParts(IEnumerable<OpenXmlPart> parts) {
+            var result = new HashSet<OpenXmlPart>();
+            foreach (ChartPart chartPart in parts.OfType<ChartPart>()) {
+                foreach (EmbeddedPackagePart packagePart in chartPart.GetPartsOfType<EmbeddedPackagePart>()) {
+                    if (IsSafeChartWorkbookPart(chartPart, packagePart)) {
+                        result.Add(packagePart);
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        private static bool IsSafeChartWorkbookPart(ChartPart chartPart, EmbeddedPackagePart part) {
+            if (!string.Equals(
+                    part.ContentType,
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    StringComparison.OrdinalIgnoreCase)) {
+                return false;
+            }
+
+            string relationshipId = chartPart.GetIdOfPart(part);
+            bool isReferenced = chartPart.ChartSpace?
+                .Descendants<C.ExternalData>()
+                .Any(externalData => string.Equals(externalData.Id?.Value, relationshipId, StringComparison.Ordinal)) == true;
+            if (!isReferenced) {
+                return false;
+            }
+
+            try {
+                using Stream stream = part.GetStream(FileMode.Open, FileAccess.Read);
+                byte[] workbookBytes = ReadChartWorkbookBytes(stream);
+                OfficePackageSecurityInspector.Validate(workbookBytes, CreateChartWorkbookSecurityOptions());
+                using var workbookStream = new MemoryStream(workbookBytes, writable: false);
+                using SpreadsheetDocument workbook = SpreadsheetDocument.Open(workbookStream, false);
+                return IsSafeGeneratedChartWorkbook(workbook);
+            } catch (FileFormatException) {
+                return false;
+            } catch (OpenXmlPackageException) {
+                return false;
+            } catch (InvalidDataException) {
+                return false;
+            } catch (IOException) {
+                return false;
+            }
+        }
+
+        private static OfficePackageSecurityOptions CreateChartWorkbookSecurityOptions() =>
+            new OfficePackageSecurityOptions {
+                MaxPackageBytes = 8L * 1024L * 1024L,
+                MaxPartCount = 64,
+                MaxPartUncompressedBytes = 2L * 1024L * 1024L,
+                MaxTotalUncompressedBytes = 8L * 1024L * 1024L,
+                MaxCompressionRatio = 100D,
+                Macros = OfficePackageContentPolicy.Reject,
+                EmbeddedPayloads = OfficePackageContentPolicy.Reject,
+                ActiveX = OfficePackageContentPolicy.Reject,
+                ExternalRelationships = OfficePackageContentPolicy.Reject
+            };
+
+        private static byte[] ReadChartWorkbookBytes(Stream stream) {
+            const int maximumBytes = 8 * 1024 * 1024;
+            using var buffer = new MemoryStream();
+            var chunk = new byte[81920];
+            int totalBytes = 0;
+            while (true) {
+                int read = stream.Read(chunk, 0, Math.Min(chunk.Length, maximumBytes + 1 - totalBytes));
+                if (read == 0) {
+                    return buffer.ToArray();
+                }
+
+                totalBytes = checked(totalBytes + read);
+                if (totalBytes > maximumBytes) {
+                    throw new InvalidDataException(
+                        $"Embedded chart workbook exceeds the configured maximum of {maximumBytes} bytes.");
+                }
+
+                buffer.Write(chunk, 0, read);
+            }
+        }
+
+        private static bool IsSafeGeneratedChartWorkbook(SpreadsheetDocument workbook) {
+            WorkbookPart? workbookPart = workbook.WorkbookPart;
+            if (workbook.DocumentType != SpreadsheetDocumentType.Workbook
+                || workbookPart?.Workbook == null
+                || workbookPart.VbaProjectPart != null
+                || workbook.Parts.Count() != 1
+                || workbook.Parts.Any(pair => pair.OpenXmlPart is not WorkbookPart)
+                || workbook.ExternalRelationships.Any()) {
+                return false;
+            }
+
+            WorksheetPart[] worksheets = workbookPart.GetPartsOfType<WorksheetPart>().ToArray();
+            SharedStringTablePart[] sharedStrings = workbookPart.GetPartsOfType<SharedStringTablePart>().ToArray();
+            if (worksheets.Length != 1
+                || sharedStrings.Length != 1
+                || workbookPart.Parts.Count() != 2
+                || workbookPart.Parts.Any(pair => pair.OpenXmlPart is not WorksheetPart && pair.OpenXmlPart is not SharedStringTablePart)
+                || HasUnsupportedChartWorkbookRelationships(workbookPart)) {
+                return false;
+            }
+
+            WorksheetPart worksheetPart = worksheets[0];
+            S.Worksheet? worksheet = worksheetPart.Worksheet;
+            if (worksheet == null
+                || worksheetPart.Parts.Any()
+                || sharedStrings[0].Parts.Any()
+                || HasUnsupportedChartWorkbookRelationships(worksheetPart)
+                || HasUnsupportedChartWorkbookRelationships(sharedStrings[0])
+                || worksheet.Descendants<S.CellFormula>().Any()
+                || worksheet.Descendants<S.Hyperlinks>().Any()
+                || worksheet.Descendants<S.OleObjects>().Any()
+                || worksheet.Descendants<S.Controls>().Any()) {
+                return false;
+            }
+
+            S.Sheets? sheets = workbookPart.Workbook.Sheets;
+            S.Sheet? sheet = sheets?.Elements<S.Sheet>().SingleOrDefault();
+            return sheet?.Id?.Value != null
+                && string.Equals(sheet.Id.Value, workbookPart.GetIdOfPart(worksheetPart), StringComparison.Ordinal)
+                && workbookPart.Workbook.DefinedNames == null
+                && workbookPart.Workbook.ExternalReferences == null;
+        }
+
+        private static bool HasUnsupportedChartWorkbookRelationships(OpenXmlPart part) =>
+            part.ExternalRelationships.Any()
+            || part.HyperlinkRelationships.Any()
+            || part.DataPartReferenceRelationships.Any();
 
         private static List<string> DescribeDiagramParts(IEnumerable<OpenXmlPart> parts) {
             return DescribePartsByType<DiagramDataPart>(parts)

--- a/OfficeIMO.Reader.Pdf/PdfReaderAdapter.Actions.cs
+++ b/OfficeIMO.Reader.Pdf/PdfReaderAdapter.Actions.cs
@@ -3,11 +3,12 @@ using OfficeIMO.Pdf;
 namespace OfficeIMO.Reader.Pdf;
 
 internal static partial class PdfReaderAdapter {
-    private static IReadOnlyList<ReaderActionSummary>? BuildActions(PdfLogicalDocument document, IReadOnlyList<PdfLogicalPage> selectedPages, PdfLogicalPage? page) {
+    private static IReadOnlyList<ReaderActionSummary>? BuildActions(PdfLogicalDocument document, IReadOnlyList<PdfLogicalPage> selectedPages, PdfLogicalPage? page, bool includeDocumentActions) {
         IReadOnlyList<PdfLogicalPage> scope = page is null ? selectedPages : new[] { page };
-        bool includeDocumentActions = ShouldIncludeDocumentLevelActions(selectedPages, page);
         PdfDocumentOpenAction? scopedOpenAction = includeDocumentActions ? GetScopedOpenAction(document.OpenAction, scope) : null;
-        IReadOnlyList<PdfCatalogAction> catalogActions = GetScopedCatalogActions(document, selectedPages, page);
+        IReadOnlyList<PdfCatalogAction> catalogActions = includeDocumentActions
+            ? GetScopedCatalogActions(document)
+            : Array.Empty<PdfCatalogAction>();
         bool hasOpenAction = scopedOpenAction is not null;
         bool hasCatalogActions = catalogActions.Count > 0;
         int selectedPageActionCount = CountPageActions(scope);
@@ -39,35 +40,8 @@ internal static partial class PdfReaderAdapter {
         return actions.Count == 0 ? null : actions.AsReadOnly();
     }
 
-    private static IReadOnlyList<PdfCatalogAction> GetScopedCatalogActions(PdfLogicalDocument document, IReadOnlyList<PdfLogicalPage> selectedPages, PdfLogicalPage? page) {
-        if (!ShouldIncludeDocumentLevelActions(selectedPages, page)) {
-            return Array.Empty<PdfCatalogAction>();
-        }
-
-        return AreAllDocumentPagesSelected(document, selectedPages)
-            ? document.CatalogActions
-            : Array.Empty<PdfCatalogAction>();
-    }
-
-    private static bool ShouldIncludeDocumentLevelActions(IReadOnlyList<PdfLogicalPage> selectedPages, PdfLogicalPage? page) {
-        return page is null || selectedPages.Count == 1;
-    }
-
-    private static bool AreAllDocumentPagesSelected(PdfLogicalDocument document, IReadOnlyList<PdfLogicalPage> selectedPages) {
-        if (document.PageCount == 0 || selectedPages.Count != document.PageCount) {
-            return false;
-        }
-
-        var seen = new HashSet<int>();
-        for (int i = 0; i < selectedPages.Count; i++) {
-            int pageNumber = selectedPages[i].PageNumber;
-            if (pageNumber < 1 || pageNumber > document.PageCount || !seen.Add(pageNumber)) {
-                return false;
-            }
-        }
-
-        return seen.Count == document.PageCount;
-    }
+    private static IReadOnlyList<PdfCatalogAction> GetScopedCatalogActions(PdfLogicalDocument document) =>
+        document.CatalogActions;
 
     private static PdfDocumentOpenAction? GetScopedOpenAction(PdfDocumentOpenAction? openAction, IReadOnlyList<PdfLogicalPage> scope) {
         if (openAction is null) {

--- a/OfficeIMO.Reader.Pdf/PdfReaderAdapter.Document.Metadata.cs
+++ b/OfficeIMO.Reader.Pdf/PdfReaderAdapter.Document.Metadata.cs
@@ -610,7 +610,7 @@ internal static partial class PdfReaderAdapter {
     }
 
     private static void AddActionMetadata(List<OfficeDocumentMetadataEntry> entries, PdfLogicalDocument document, IReadOnlyList<PdfLogicalPage> selectedPages) {
-        IReadOnlyList<ReaderActionSummary>? actions = BuildActions(document, selectedPages, page: null);
+        IReadOnlyList<ReaderActionSummary>? actions = BuildActions(document, selectedPages, page: null, includeDocumentActions: true);
         if (actions == null || actions.Count == 0) {
             return;
         }

--- a/OfficeIMO.Reader.Pdf/PdfReaderAdapter.cs
+++ b/OfficeIMO.Reader.Pdf/PdfReaderAdapter.cs
@@ -96,7 +96,7 @@ internal static partial class PdfReaderAdapter {
             var documentTables = BuildTables(documentTableExtractions);
             var documentVisuals = BuildVisuals(pages);
             var documentFormFields = BuildFormFields(document, pages, page: null);
-            var documentActions = BuildActions(document, pages, page: null);
+            var documentActions = BuildActions(document, pages, page: null, includeDocumentActions: true);
             ReaderChunkDiagnostics documentDiagnostics = BuildChunkDiagnostics(document, pages, page: null, documentTableExtractions, documentActions);
             foreach (var chunk in BuildChunksFromText(
                 markdown,
@@ -133,7 +133,7 @@ internal static partial class PdfReaderAdapter {
             var pageTables = BuildTables(pageTableExtractions, pageIndex);
             var pageVisuals = BuildVisuals(new[] { page }, pageIndex);
             var pageFormFields = BuildFormFields(document, pages, page);
-            var pageActions = BuildActions(document, pages, page);
+            var pageActions = BuildActions(document, pages, page, includeDocumentActions: pageIndex == 0);
             ReaderChunkDiagnostics pageDiagnostics = BuildChunkDiagnostics(document, pages, page, pageTableExtractions, pageActions);
             foreach (var chunk in BuildChunksFromText(
                 markdown,
@@ -258,7 +258,7 @@ internal static partial class PdfReaderAdapter {
         IReadOnlyList<PdfLogicalPage> scope = page is null ? selectedPages : new[] { page };
         PdfDocumentSecurityInfo security = document.Security;
         bool hasScopedOpenAction = GetScopedOpenAction(document.OpenAction, scope) is not null;
-        int selectedCatalogActionCount = GetScopedCatalogActions(document, selectedPages, page: null).Count;
+        int selectedCatalogActionCount = GetScopedCatalogActions(document).Count;
         int selectedPageActionCount = CountPageActions(scope);
         int selectedAnnotationActionCount = CountAnnotationActions(scope);
         int imageCount = CountImages(scope);
@@ -267,7 +267,7 @@ internal static partial class PdfReaderAdapter {
         int selectedFormWidgetCount = CountFormWidgets(scope);
         int selectedFormWidgetAppearanceStateCount = CountFormWidgetAppearanceStates(scope);
         TableDiagnosticSummary tableSummary = SummarizeTables(tableExtractions);
-        ActionDiagnosticSummary actionSummary = SummarizeActions(actions);
+        ActionDiagnosticSummary actionSummary = SummarizeActions(actions, document.CatalogActions);
         PdfTaggedContentInfo? taggedContent = document.TaggedContent;
         PdfOptionalContentProperties? optionalContent = document.OptionalContent;
         return new ReaderChunkDiagnostics {
@@ -379,8 +379,8 @@ internal static partial class PdfReaderAdapter {
         public int ImportDataCount { get; }
     }
 
-    private static ActionDiagnosticSummary SummarizeActions(IReadOnlyList<ReaderActionSummary>? actions) {
-        if (actions == null || actions.Count == 0) {
+    private static ActionDiagnosticSummary SummarizeActions(IReadOnlyList<ReaderActionSummary>? actions, IReadOnlyList<PdfCatalogAction> catalogActions) {
+        if ((actions == null || actions.Count == 0) && catalogActions.Count == 0) {
             return new ActionDiagnosticSummary(0, 0, 0, 0, 0);
         }
 
@@ -389,24 +389,39 @@ internal static partial class PdfReaderAdapter {
         int launchCount = 0;
         int submitFormCount = 0;
         int importDataCount = 0;
-        for (int i = 0; i < actions.Count; i++) {
-            ReaderActionSummary action = actions[i];
-            if (action.IsPotentiallyUnsafe) {
-                potentiallyUnsafeCount++;
-            }
+        if (actions != null) {
+            for (int i = 0; i < actions.Count; i++) {
+                ReaderActionSummary action = actions[i];
+                if (action.Scope == ReaderActionScope.Catalog) {
+                    continue;
+                }
 
-            if (string.Equals(action.ActionType, "JavaScript", StringComparison.Ordinal)) {
-                javaScriptCount++;
-            } else if (string.Equals(action.ActionType, "Launch", StringComparison.Ordinal)) {
-                launchCount++;
-            } else if (string.Equals(action.ActionType, "SubmitForm", StringComparison.Ordinal)) {
-                submitFormCount++;
-            } else if (string.Equals(action.ActionType, "ImportData", StringComparison.Ordinal)) {
-                importDataCount++;
+                CountActionType(action.ActionType, action.IsPotentiallyUnsafe);
             }
         }
 
+        for (int i = 0; i < catalogActions.Count; i++) {
+            PdfCatalogAction action = catalogActions[i];
+            CountActionType(action.ActionType, IsPotentiallyUnsafeActionType(action.ActionType));
+        }
+
         return new ActionDiagnosticSummary(potentiallyUnsafeCount, javaScriptCount, launchCount, submitFormCount, importDataCount);
+
+        void CountActionType(string actionType, bool isPotentiallyUnsafe) {
+            if (isPotentiallyUnsafe) {
+                potentiallyUnsafeCount++;
+            }
+
+            if (string.Equals(actionType, "JavaScript", StringComparison.Ordinal)) {
+                javaScriptCount++;
+            } else if (string.Equals(actionType, "Launch", StringComparison.Ordinal)) {
+                launchCount++;
+            } else if (string.Equals(actionType, "SubmitForm", StringComparison.Ordinal)) {
+                submitFormCount++;
+            } else if (string.Equals(actionType, "ImportData", StringComparison.Ordinal)) {
+                importDataCount++;
+            }
+        }
     }
 
     private readonly struct TableDiagnosticSummary {

--- a/OfficeIMO.Reader.Tests/Reader.Pdf.Modular.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Pdf.Modular.cs
@@ -1119,7 +1119,7 @@ public sealed class ReaderPdfModularTests {
     }
 
     [Fact]
-    public void DocumentReaderPdf_ReadPdfLogicalDocument_RangedReadOmitsCatalogActions() {
+    public void DocumentReaderPdf_ReadPdfLogicalDocument_RangedReadRetainsCatalogActions() {
         PdfLogicalDocument logical = PdfLogicalDocument.Load(BuildTwoPageCatalogActionsPdf());
 
         ReaderChunk chunk = Assert.Single(PdfReaderAdapter.Read(
@@ -1134,12 +1134,38 @@ public sealed class ReaderPdfModularTests {
 
         Assert.Equal(2, chunk.Location.Page);
         Assert.NotNull(chunk.Diagnostics);
-        Assert.False(chunk.Diagnostics!.HasCatalogActions);
-        Assert.False(chunk.Diagnostics.HasActiveContent);
-        Assert.Equal(0, chunk.Diagnostics.CatalogActionCount);
-        Assert.Null(chunk.Actions);
+        Assert.True(chunk.Diagnostics!.HasCatalogActions);
+        Assert.True(chunk.Diagnostics.HasActiveContent);
+        Assert.Equal(1, chunk.Diagnostics.CatalogActionCount);
+        Assert.NotNull(chunk.Actions);
+        Assert.Contains(chunk.Actions!, action => action.Scope == ReaderActionScope.Catalog && action.IsPotentiallyUnsafe);
         Assert.Contains("Second catalog-safe page", chunk.Markdown ?? chunk.Text, StringComparison.Ordinal);
         Assert.DoesNotContain("First catalog page", chunk.Markdown ?? chunk.Text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DocumentReaderPdf_ReadPdfLogicalDocument_DuplicateRangesRetainCatalogActionsOnlyOnce() {
+        PdfLogicalDocument logical = PdfLogicalDocument.Load(BuildTwoPageCatalogActionsPdf());
+
+        List<ReaderChunk> chunks = PdfReaderAdapter.Read(
+            logical,
+            sourceName: "catalog-actions-duplicate-ranges.pdf",
+            pdfOptions: new ReaderPdfOptions {
+                PageRanges = new[] {
+                    PdfPageRange.From(2, 2),
+                    PdfPageRange.From(2, 2)
+                }
+            }).ToList();
+
+        Assert.Equal(2, chunks.Count);
+        Assert.Contains(chunks[0].Actions!, action => action.Scope == ReaderActionScope.Catalog);
+        Assert.DoesNotContain(chunks[1].Actions ?? Array.Empty<ReaderActionSummary>(), action => action.Scope == ReaderActionScope.Catalog);
+        Assert.All(chunks, chunk => {
+            Assert.NotNull(chunk.Diagnostics);
+            Assert.Equal(1, chunk.Diagnostics!.CatalogActionCount);
+            Assert.Equal(1, chunk.Diagnostics.PotentiallyUnsafeActionCount);
+            Assert.Equal(1, chunk.Diagnostics.JavaScriptActionCount);
+        });
     }
 
     [Fact]

--- a/OfficeIMO.Reader.Tests/Reader.Yaml.Modular.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Yaml.Modular.cs
@@ -246,7 +246,7 @@ public sealed class ReaderYamlModularTests {
     }
 
     [Fact]
-    public void DocumentReaderYaml_ReadYamlStream_EmitsNodeLimitRow() {
+    public void DocumentReaderYaml_ReadYamlStream_EnforcesNodeLimitBeforeModelLoad() {
         const string yaml = "root:\n  child:\n    value: 1\n";
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(yaml), writable: false);
 
@@ -259,8 +259,8 @@ public sealed class ReaderYamlModularTests {
                 IncludeMarkdown = false
             }));
 
-        Assert.Contains("node-limit", chunk.Text ?? string.Empty, StringComparison.Ordinal);
-        Assert.Contains("(max nodes reached)", chunk.Text ?? string.Empty, StringComparison.Ordinal);
+        Assert.Contains("YAML parse limit exceeded", chunk.Text ?? string.Empty, StringComparison.Ordinal);
+        Assert.Contains("maximum node count reached", chunk.Text ?? string.Empty, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -286,7 +286,7 @@ public sealed class ReaderYamlModularTests {
 
     [Fact]
     public void DocumentReaderYaml_ReadYamlStream_EnforcesScalarLengthBeforeModelLoad() {
-        string yaml = "value: " + new string('a', 32) + "\n";
+        string yaml = "value: \"" + new string('a', 32) + "\"\n";
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(yaml), writable: false);
 
         var chunk = Assert.Single(YamlReaderAdapter.Read(
@@ -302,13 +302,12 @@ public sealed class ReaderYamlModularTests {
     }
 
     [Fact]
-    public void DocumentReaderYaml_ReadYamlStream_CountsDepthLimitedChildrenAgainstNodeLimit() {
+    public void DocumentReaderYaml_ReadYamlStream_EnforcesDepthLimitBeforeModelLoad() {
         const string yaml =
             "root:\n" +
-            "  - one\n" +
-            "  - two\n" +
-            "  - three\n" +
-            "  - four\n";
+            "  child:\n" +
+            "    grandchild:\n" +
+            "      value: one\n";
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(yaml), writable: false);
 
         var chunk = Assert.Single(YamlReaderAdapter.Read(
@@ -316,13 +315,13 @@ public sealed class ReaderYamlModularTests {
             sourceName: "depth-limited.yaml",
             yamlOptions: new YamlReadOptions {
                 MaxDepth = 1,
-                MaxNodes = 4,
+                MaxNodes = 100,
                 ChunkRows = 10,
                 IncludeMarkdown = false
             }));
 
-        Assert.Contains("depth-limit", chunk.Text ?? string.Empty, StringComparison.Ordinal);
-        Assert.Contains("node-limit", chunk.Text ?? string.Empty, StringComparison.Ordinal);
+        Assert.Contains("YAML parse limit exceeded", chunk.Text ?? string.Empty, StringComparison.Ordinal);
+        Assert.Contains("maximum depth reached", chunk.Text ?? string.Empty, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -341,6 +340,7 @@ public sealed class ReaderYamlModularTests {
                 IncludeMarkdown = false
             }));
 
-        Assert.Contains("node-limit", chunk.Text ?? string.Empty, StringComparison.Ordinal);
+        Assert.Contains("YAML parse limit exceeded", chunk.Text ?? string.Empty, StringComparison.Ordinal);
+        Assert.Contains("maximum node count reached", chunk.Text ?? string.Empty, StringComparison.Ordinal);
     }
 }

--- a/OfficeIMO.Reader.Tests/Reader.Yaml.Modular.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Yaml.Modular.cs
@@ -325,6 +325,28 @@ public sealed class ReaderYamlModularTests {
     }
 
     [Fact]
+    public void DocumentReaderYaml_ReadYamlStream_EnforcesScalarDepthBeforeModelLoad() {
+        const string yaml =
+            "root:\n" +
+            "  child:\n" +
+            "    value: one\n";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(yaml), writable: false);
+
+        var chunk = Assert.Single(YamlReaderAdapter.Read(
+            stream,
+            sourceName: "scalar-depth-limited.yaml",
+            yamlOptions: new YamlReadOptions {
+                MaxDepth = 1,
+                MaxNodes = 100,
+                ChunkRows = 10,
+                IncludeMarkdown = false
+            }));
+
+        Assert.Contains("YAML parse limit exceeded", chunk.Text ?? string.Empty, StringComparison.Ordinal);
+        Assert.Contains("maximum depth reached", chunk.Text ?? string.Empty, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void DocumentReaderYaml_ReadYamlStream_BoundsComplexMappingKeysWithNodeLimit() {
         const string yaml =
             "? [one, two, three, four]\n" +

--- a/OfficeIMO.Reader.Yaml/YamlReadOptions.cs
+++ b/OfficeIMO.Reader.Yaml/YamlReadOptions.cs
@@ -10,12 +10,12 @@ public sealed class YamlReadOptions {
     public int ChunkRows { get; set; } = 200;
 
     /// <summary>
-    /// Maximum node traversal depth.
+    /// Maximum node depth accepted by the streaming preflight before the representation model is loaded.
     /// </summary>
     public int MaxDepth { get; set; } = 32;
 
     /// <summary>
-    /// Maximum number of YAML nodes visited before traversal emits a node-limit row and stops.
+    /// Maximum number of YAML nodes accepted by the streaming preflight before the representation model is loaded.
     /// </summary>
     public int MaxNodes { get; set; } = 20_000;
 

--- a/OfficeIMO.Reader.Yaml/YamlReaderAdapter.cs
+++ b/OfficeIMO.Reader.Yaml/YamlReaderAdapter.cs
@@ -142,6 +142,10 @@ internal static class YamlReaderAdapter {
                 case Scalar:
                 case AnchorAlias:
                     nodes++;
+                    if (containerDepth > options.MaxDepth) {
+                        limitError = "YAML parse limit exceeded: maximum depth reached.";
+                        return false;
+                    }
                     break;
             }
 

--- a/OfficeIMO.Reader.Yaml/YamlReaderAdapter.cs
+++ b/OfficeIMO.Reader.Yaml/YamlReaderAdapter.cs
@@ -116,10 +116,37 @@ internal static class YamlReaderAdapter {
         limitError = null;
         var parser = new Parser(reader);
         int events = 0;
+        int nodes = 0;
+        int containerDepth = 0;
         while (parser.MoveNext()) {
             events++;
             if (events > options.MaxParseEvents) {
                 limitError = "YAML parse limit exceeded: maximum parse event count reached.";
+                return false;
+            }
+
+            switch (parser.Current) {
+                case MappingStart:
+                case SequenceStart:
+                    nodes++;
+                    containerDepth++;
+                    if (containerDepth > options.MaxDepth + 1) {
+                        limitError = "YAML parse limit exceeded: maximum depth reached.";
+                        return false;
+                    }
+                    break;
+                case MappingEnd:
+                case SequenceEnd:
+                    containerDepth = Math.Max(0, containerDepth - 1);
+                    break;
+                case Scalar:
+                case AnchorAlias:
+                    nodes++;
+                    break;
+            }
+
+            if (nodes > options.MaxNodes) {
+                limitError = "YAML parse limit exceeded: maximum node count reached.";
                 return false;
             }
 

--- a/OfficeIMO.Rtf.Markdown/RtfToMarkdownConverter.cs
+++ b/OfficeIMO.Rtf.Markdown/RtfToMarkdownConverter.cs
@@ -15,6 +15,7 @@ internal static class RtfToMarkdownConverter {
         RtfTableTraversalGuard.ValidateDocument(document);
         var blocks = new List<IMarkdownBlock>(document.Blocks.Count + document.Notes.Count + 1);
         int imageIndex = 0;
+        var listStartLookup = new ListStartLookup(document);
         context.NoteRegistry = new RtfMarkdownNoteRegistry();
 
         try {
@@ -23,7 +24,7 @@ internal static class RtfToMarkdownConverter {
                 switch (block) {
                     case RtfParagraph paragraph:
                         if (paragraph.ListKind != RtfListKind.None) {
-                            i = ConvertListRun(document, context, blocks, i, ref imageIndex);
+                            i = ConvertListRun(document, listStartLookup, context, blocks, i, ref imageIndex);
                         } else if (TryConvertCodeBlockRun(document, blocks, i, out int codeBlockEndIndex)) {
                             i = codeBlockEndIndex;
                         } else {
@@ -56,7 +57,7 @@ internal static class RtfToMarkdownConverter {
         }
     }
 
-    private static int ConvertListRun(RtfDocument document, RtfToMarkdownConversionContext context, ICollection<IMarkdownBlock> blocks, int startIndex, ref int imageIndex) {
+    private static int ConvertListRun(RtfDocument document, ListStartLookup listStartLookup, RtfToMarkdownConversionContext context, ICollection<IMarkdownBlock> blocks, int startIndex, ref int imageIndex) {
         var first = (RtfParagraph)document.Blocks[startIndex];
         int? firstListId = first.ListId;
         int? firstListDefinitionId = first.ListDefinitionId;
@@ -90,15 +91,15 @@ internal static class RtfToMarkdownConverter {
             paragraphs.Add(paragraph);
         }
 
-        blocks.Add(ConvertListParagraphs(document, context, paragraphs, ref imageIndex));
+        blocks.Add(ConvertListParagraphs(listStartLookup, context, paragraphs, ref imageIndex));
         return i - 1;
     }
 
-    private static IMarkdownBlock ConvertListParagraphs(RtfDocument document, RtfToMarkdownConversionContext context, IReadOnlyList<RtfParagraph> paragraphs, ref int imageIndex) {
+    private static IMarkdownBlock ConvertListParagraphs(ListStartLookup listStartLookup, RtfToMarkdownConversionContext context, IReadOnlyList<RtfParagraph> paragraphs, ref int imageIndex) {
         RtfParagraph first = paragraphs[0];
-        IMarkdownListBlock root = CreateMarkdownListBlock(document, first);
+        IMarkdownListBlock root = CreateMarkdownListBlock(listStartLookup, first);
         var frames = new List<ListFrame> {
-            CreateListFrame(document, first, 0, NormalizeListKind(first.ListKind), root)
+            CreateListFrame(listStartLookup, first, 0, NormalizeListKind(first.ListKind), root)
         };
 
         for (int i = 0; i < paragraphs.Count; i++) {
@@ -113,7 +114,7 @@ internal static class RtfToMarkdownConverter {
             InlineSequence inlines = ConvertParagraphInlines(paragraph, context, ref imageIndex);
             ListItem item = CreateListItem(inlines);
 
-            ListFrame frame = GetOrCreateListFrame(document, frames, paragraph, level, kind);
+            ListFrame frame = GetOrCreateListFrame(listStartLookup, frames, paragraph, level, kind);
             AddListItem(frame.List, item);
             frame.LastItem = item;
         }
@@ -212,7 +213,7 @@ internal static class RtfToMarkdownConverter {
         return true;
     }
 
-    private static ListFrame GetOrCreateListFrame(RtfDocument document, List<ListFrame> frames, RtfParagraph paragraph, int level, RtfListKind kind) {
+    private static ListFrame GetOrCreateListFrame(ListStartLookup listStartLookup, List<ListFrame> frames, RtfParagraph paragraph, int level, RtfListKind kind) {
         if (level <= 0) {
             while (frames.Count > 1) {
                 frames.RemoveAt(frames.Count - 1);
@@ -223,7 +224,7 @@ internal static class RtfToMarkdownConverter {
 
         while (frames.Count > 0) {
             ListFrame current = frames[frames.Count - 1];
-            if (current.Level < level || MatchesListFrame(document, current, paragraph, level, kind)) {
+            if (current.Level < level || MatchesListFrame(listStartLookup, current, paragraph, level, kind)) {
                 break;
             }
 
@@ -231,7 +232,7 @@ internal static class RtfToMarkdownConverter {
         }
 
         ListFrame last = frames[frames.Count - 1];
-        if (MatchesListFrame(document, last, paragraph, level, kind)) {
+        if (MatchesListFrame(listStartLookup, last, paragraph, level, kind)) {
             return last;
         }
 
@@ -239,33 +240,33 @@ internal static class RtfToMarkdownConverter {
             return frames[0];
         }
 
-        IMarkdownListBlock childList = CreateMarkdownListBlock(document, paragraph);
+        IMarkdownListBlock childList = CreateMarkdownListBlock(listStartLookup, paragraph);
         last.LastItem.NestedBlocks.Add((IMarkdownBlock)childList);
-        var childFrame = CreateListFrame(document, paragraph, level, kind, childList);
+        var childFrame = CreateListFrame(listStartLookup, paragraph, level, kind, childList);
         frames.Add(childFrame);
         return childFrame;
     }
 
-    private static ListFrame CreateListFrame(RtfDocument document, RtfParagraph paragraph, int level, RtfListKind kind, IMarkdownListBlock list) =>
+    private static ListFrame CreateListFrame(ListStartLookup listStartLookup, RtfParagraph paragraph, int level, RtfListKind kind, IMarkdownListBlock list) =>
         new ListFrame(
             level,
             kind,
             list,
             paragraph.ListId,
             paragraph.ListDefinitionId,
-            kind == RtfListKind.Decimal ? ResolveListStart(document, paragraph) : 1);
+            kind == RtfListKind.Decimal ? ResolveListStart(listStartLookup, paragraph) : 1);
 
-    private static bool MatchesListFrame(RtfDocument document, ListFrame frame, RtfParagraph paragraph, int level, RtfListKind kind) =>
+    private static bool MatchesListFrame(ListStartLookup listStartLookup, ListFrame frame, RtfParagraph paragraph, int level, RtfListKind kind) =>
         frame.Level == level &&
         frame.Kind == kind &&
         frame.ListId == paragraph.ListId &&
         frame.ListDefinitionId == paragraph.ListDefinitionId &&
-        (kind != RtfListKind.Decimal || frame.Start == ResolveListStart(document, paragraph));
+        (kind != RtfListKind.Decimal || frame.Start == ResolveListStart(listStartLookup, paragraph));
 
-    private static IMarkdownListBlock CreateMarkdownListBlock(RtfDocument document, RtfParagraph paragraph) {
+    private static IMarkdownListBlock CreateMarkdownListBlock(ListStartLookup listStartLookup, RtfParagraph paragraph) {
         RtfListKind kind = NormalizeListKind(paragraph.ListKind);
         return kind == RtfListKind.Decimal
-            ? new OrderedListBlock { Start = ResolveListStart(document, paragraph) }
+            ? new OrderedListBlock { Start = ResolveListStart(listStartLookup, paragraph) }
             : new UnorderedListBlock();
     }
 
@@ -281,10 +282,10 @@ internal static class RtfToMarkdownConverter {
         return kind == RtfListKind.Decimal ? RtfListKind.Decimal : RtfListKind.Bullet;
     }
 
-    private static int ResolveListStart(RtfDocument document, RtfParagraph paragraph) {
+    private static int ResolveListStart(ListStartLookup listStartLookup, RtfParagraph paragraph) {
         int levelIndex = Math.Max(0, paragraph.ListLevel ?? 0);
         if (paragraph.ListId.HasValue) {
-            RtfListOverride? listOverride = document.ListOverrides.FirstOrDefault(item => item.Id == paragraph.ListId.Value);
+            listStartLookup.Overrides.TryGetValue(paragraph.ListId.Value, out RtfListOverride? listOverride);
             RtfListLevelOverride? levelOverride = listOverride?.LevelOverrides.ElementAtOrDefault(levelIndex);
             if (levelOverride?.OverrideStartAt == true && levelOverride.StartAt.HasValue) {
                 return Math.Max(1, levelOverride.StartAt.Value);
@@ -292,7 +293,7 @@ internal static class RtfToMarkdownConverter {
         }
 
         if (paragraph.ListDefinitionId.HasValue) {
-            RtfListDefinition? definition = document.ListDefinitions.FirstOrDefault(item => item.Id == paragraph.ListDefinitionId.Value);
+            listStartLookup.Definitions.TryGetValue(paragraph.ListDefinitionId.Value, out RtfListDefinition? definition);
             RtfListLevel? level = definition?.Levels.FirstOrDefault(item => item.LevelIndex == levelIndex);
             if (level?.StartAt.HasValue == true) {
                 return Math.Max(1, level.StartAt.Value);
@@ -300,6 +301,25 @@ internal static class RtfToMarkdownConverter {
         }
 
         return Math.Max(1, paragraph.LegacyNumbering.StartAt ?? 1);
+    }
+
+    private sealed class ListStartLookup {
+        internal Dictionary<int, RtfListOverride> Overrides { get; } = new();
+        internal Dictionary<int, RtfListDefinition> Definitions { get; } = new();
+
+        internal ListStartLookup(RtfDocument document) {
+            foreach (RtfListOverride item in document.ListOverrides) {
+                if (!Overrides.ContainsKey(item.Id)) {
+                    Overrides.Add(item.Id, item);
+                }
+            }
+
+            foreach (RtfListDefinition item in document.ListDefinitions) {
+                if (!Definitions.ContainsKey(item.Id)) {
+                    Definitions.Add(item.Id, item);
+                }
+            }
+        }
     }
 
     private static IMarkdownBlock ConvertParagraph(RtfDocument document, RtfParagraph paragraph, RtfToMarkdownConversionContext context, ref int imageIndex) {

--- a/OfficeIMO.Rtf.Tests/Rtf/RtfMarkdownConverterTests.cs
+++ b/OfficeIMO.Rtf.Tests/Rtf/RtfMarkdownConverterTests.cs
@@ -886,6 +886,26 @@ public class RtfMarkdownConverterTests {
     }
 
     [Fact]
+    public void RtfDocumentToMarkdownResolvesManyDistinctListIdsWithoutRepeatedTableScans() {
+        const int listCount = 1024;
+        RtfDocument document = RtfDocument.Create();
+        for (int index = 1; index <= listCount; index++) {
+            int definitionId = 10_000 + index;
+            RtfListDefinition definition = document.AddListDefinition(definitionId);
+            definition.AddLevel(RtfListKind.Decimal).StartAt = index;
+            document.AddListOverride(index, definitionId);
+            document.AddParagraph("Item " + index)
+                .SetList(listId: index, level: 0, kind: RtfListKind.Decimal)
+                .ListDefinitionId = definitionId;
+        }
+
+        string markdown = document.ToMarkdown();
+
+        Assert.Contains("1. Item 1", markdown, StringComparison.Ordinal);
+        Assert.Contains(listCount + ". Item " + listCount, markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void RtfDocumentToMarkdownPreservesListStartsAndDoesNotPromoteDataRows() {
         RtfDocument document = RtfDocument.Create();
         RtfListDefinition definition = document.AddListDefinition(100);

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.Charts.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.Charts.cs
@@ -14,8 +14,10 @@ namespace OfficeIMO.Word.Pdf {
         private const double NativeEmusPerPoint = 12700D;
         private const int MaxNativeWordChartSeries = 256;
         private const int MaxNativeWordChartPoints = 4096;
-        private const double MaxNativeWordChartWidthPoints = 1440D;
-        private const double MaxNativeWordChartHeightPoints = 1080D;
+        private const double MinNativeWordChartWidthPoints = 240D;
+        private const double MaxNativeWordChartWidthPoints = 420D;
+        private const double MinNativeWordChartHeightPoints = 150D;
+        private const double MaxNativeWordChartHeightPoints = 260D;
         private const double NativeWordChartTitleTopPadding = 31D;
         private const double NativeWordChartSpacingAfter = NativeDefaultParagraphSpacingAfter;
 
@@ -72,6 +74,11 @@ namespace OfficeIMO.Word.Pdf {
             List<OpenXmlElement> allChartElements = plotArea.ChildElements
                 .Where(IsNativeWordChartElement)
                 .ToList();
+            if (allChartElements.Count > 1) {
+                warning = "Word combo charts are not partially exported because omitting a plot can misrepresent the source data.";
+                return false;
+            }
+
             List<OpenXmlElement> chartElements = allChartElements
                 .Where(IsNativeSupportedWordChartElement)
                 .ToList();
@@ -81,12 +88,6 @@ namespace OfficeIMO.Word.Pdf {
             }
 
             OpenXmlElement chartElement = chartElements[0];
-            if (allChartElements.Count > 1) {
-                warning = "Word combo chart contains " + allChartElements.Count.ToString(CultureInfo.InvariantCulture) +
-                    " plot types; exported the first supported '" + chartElement.LocalName +
-                    "' plot and omitted the additional plot types.";
-            }
-
             if (!TryMapNativeWordChartKind(chartElement, out OfficeChartKind chartKind)) {
                 warning = "Word chart type '" + chartElement.LocalName + "' is not supported by the shared OfficeIMO chart renderer.";
                 return false;
@@ -515,8 +516,8 @@ namespace OfficeIMO.Word.Pdf {
             long? cy = chart.Drawing?.Inline?.Extent?.Cy?.Value ?? chart.Drawing?.Anchor?.Extent?.Cy?.Value;
             double width = cx.HasValue && cx.Value > 0 ? cx.Value / NativeEmusPerPoint : 360D;
             double height = cy.HasValue && cy.Value > 0 ? cy.Value / NativeEmusPerPoint : 216D;
-            width = Math.Min(MaxNativeWordChartWidthPoints, width);
-            height = Math.Min(MaxNativeWordChartHeightPoints, height);
+            width = Math.Min(MaxNativeWordChartWidthPoints, Math.Max(MinNativeWordChartWidthPoints, width));
+            height = Math.Min(MaxNativeWordChartHeightPoints, Math.Max(MinNativeWordChartHeightPoints, height));
             return (width, height);
         }
 

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.DocumentDefaults.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.DocumentDefaults.cs
@@ -117,7 +117,8 @@ namespace OfficeIMO.Word.Pdf {
 
         private static double? ConvertNativeLineHundredthsToPoints(Int32Value? value, double fontSize, double lineHeight) {
             if (value == null ||
-                value.Value < 0 ||
+                !int.TryParse(value.InnerText, NumberStyles.Integer, CultureInfo.InvariantCulture, out int lineHundredths) ||
+                lineHundredths < 0 ||
                 fontSize <= 0D ||
                 lineHeight <= 0D ||
                 double.IsNaN(fontSize) ||
@@ -127,7 +128,7 @@ namespace OfficeIMO.Word.Pdf {
                 return null;
             }
 
-            return (value.Value / 100D) * fontSize * lineHeight;
+            return (lineHundredths / 100D) * fontSize * lineHeight;
         }
 
         private static bool IsNativeOnOffTrue(OnOffValue? value) =>

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.ParagraphStyleDefaults.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.ParagraphStyleDefaults.cs
@@ -64,6 +64,12 @@ namespace OfficeIMO.Word.Pdf {
         }
 
         private static NativeParagraphStyleDefaults GetNativeParagraphStyleDefaults(WordParagraph paragraph) {
+            NativeStyleLookupCache? cache = GetNativeStyleLookupCache(paragraph._document);
+            string? resolvedStyleId = cache?.ResolveParagraphStyleId(paragraph.StyleId);
+            if (cache != null && !string.IsNullOrWhiteSpace(resolvedStyleId) && cache.ParagraphDefaults.TryGetValue(resolvedStyleId!, out NativeParagraphStyleDefaults cachedDefaults)) {
+                return cachedDefaults;
+            }
+
             IReadOnlyList<W.Style> styleChain = GetNativeParagraphStyleChain(paragraph._document, paragraph.StyleId);
             if (styleChain.Count == 0) {
                 return NativeParagraphStyleDefaults.Empty;
@@ -156,7 +162,7 @@ namespace OfficeIMO.Word.Pdf {
                 }
             }
 
-            return new NativeParagraphStyleDefaults(
+            var result = new NativeParagraphStyleDefaults(
                 fontSize,
                 fontFamily,
                 bold,
@@ -184,41 +190,46 @@ namespace OfficeIMO.Word.Pdf {
                 contextualSpacing,
                 shadingFillColorHex,
                 borders);
+            if (cache != null && !string.IsNullOrWhiteSpace(resolvedStyleId)) {
+                cache.ParagraphDefaults[resolvedStyleId!] = result;
+            }
+
+            return result;
         }
 
         private static IReadOnlyList<W.Style> GetNativeParagraphStyleChain(WordDocument? document, string? styleId) {
-            W.Styles? styles = document?._wordprocessingDocument?.MainDocumentPart?.StyleDefinitionsPart?.Styles;
-            if (styles == null) {
+            NativeStyleLookupCache? cache = GetNativeStyleLookupCache(document);
+            string? resolvedStyleId = cache?.ResolveParagraphStyleId(styleId);
+            if (cache == null || string.IsNullOrWhiteSpace(resolvedStyleId)) {
                 return Array.Empty<W.Style>();
             }
 
-            Dictionary<string, W.Style> paragraphStyles = styles
-                .Elements<W.Style>()
-                .Where(style => IsNativeParagraphStyle(style) && !string.IsNullOrEmpty(style.StyleId?.Value))
-                .ToDictionary(style => style.StyleId!.Value!, style => style, StringComparer.Ordinal);
-
-            if (string.IsNullOrWhiteSpace(styleId)) {
-                styleId = paragraphStyles.Values.FirstOrDefault(style => style.Default?.Value == true)?.StyleId?.Value;
-            }
-
-            if (string.IsNullOrWhiteSpace(styleId)) {
-                return Array.Empty<W.Style>();
+            if (cache.ParagraphChains.TryGetValue(resolvedStyleId!, out IReadOnlyList<W.Style>? cachedChain)) {
+                return cachedChain;
             }
 
             var chain = new List<W.Style>();
             var visited = new HashSet<string>(StringComparer.Ordinal);
-            string? currentStyleId = styleId;
-            while (!string.IsNullOrWhiteSpace(currentStyleId) && visited.Add(currentStyleId!) && paragraphStyles.TryGetValue(currentStyleId!, out W.Style? style)) {
+            string? currentStyleId = resolvedStyleId;
+            while (!string.IsNullOrWhiteSpace(currentStyleId) && visited.Add(currentStyleId!) && cache.ParagraphStyles.TryGetValue(currentStyleId!, out W.Style? style)) {
+                cache.RecordStyleChainReference(chain.Count + 1);
                 chain.Add(style);
                 currentStyleId = style.BasedOn?.Val?.Value;
             }
 
             chain.Reverse();
-            return chain;
+            IReadOnlyList<W.Style> result = chain.ToArray();
+            cache.ParagraphChains[resolvedStyleId!] = result;
+            return result;
         }
 
         private static NativeCharacterStyleDefaults GetNativeCharacterStyleDefaults(WordDocument? document, W.RunProperties? runProperties) {
             string? styleId = runProperties?.RunStyle?.Val?.Value;
+            NativeStyleLookupCache? cache = GetNativeStyleLookupCache(document);
+            if (cache != null && !string.IsNullOrWhiteSpace(styleId) && cache.CharacterDefaults.TryGetValue(styleId!, out NativeCharacterStyleDefaults cachedDefaults)) {
+                return cachedDefaults;
+            }
+
             IReadOnlyList<W.Style> styleChain = GetNativeCharacterStyleChain(document, styleId);
             if (styleChain.Count == 0) {
                 return NativeCharacterStyleDefaults.Empty;
@@ -251,7 +262,7 @@ namespace OfficeIMO.Word.Pdf {
                 highlight = styleRunProperties?.GetFirstChild<W.Highlight>()?.Val?.Value ?? highlight;
             }
 
-            return new NativeCharacterStyleDefaults(
+            var result = new NativeCharacterStyleDefaults(
                 fontSize,
                 fontFamily,
                 bold,
@@ -263,29 +274,36 @@ namespace OfficeIMO.Word.Pdf {
                 baseline,
                 colorHex,
                 highlight);
+            if (cache != null && !string.IsNullOrWhiteSpace(styleId)) {
+                cache.CharacterDefaults[styleId!] = result;
+            }
+
+            return result;
         }
 
         private static IReadOnlyList<W.Style> GetNativeCharacterStyleChain(WordDocument? document, string? styleId) {
-            W.Styles? styles = document?._wordprocessingDocument?.MainDocumentPart?.StyleDefinitionsPart?.Styles;
-            if (styles == null || string.IsNullOrWhiteSpace(styleId)) {
+            NativeStyleLookupCache? cache = GetNativeStyleLookupCache(document);
+            if (cache == null || string.IsNullOrWhiteSpace(styleId)) {
                 return Array.Empty<W.Style>();
             }
 
-            Dictionary<string, W.Style> characterStyles = styles
-                .Elements<W.Style>()
-                .Where(style => IsNativeCharacterStyle(style) && !string.IsNullOrEmpty(style.StyleId?.Value))
-                .ToDictionary(style => style.StyleId!.Value!, style => style, StringComparer.Ordinal);
+            if (cache.CharacterChains.TryGetValue(styleId!, out IReadOnlyList<W.Style>? cachedChain)) {
+                return cachedChain;
+            }
 
             var chain = new List<W.Style>();
             var visited = new HashSet<string>(StringComparer.Ordinal);
             string? currentStyleId = styleId;
-            while (!string.IsNullOrWhiteSpace(currentStyleId) && visited.Add(currentStyleId!) && characterStyles.TryGetValue(currentStyleId!, out W.Style? style)) {
+            while (!string.IsNullOrWhiteSpace(currentStyleId) && visited.Add(currentStyleId!) && cache.CharacterStyles.TryGetValue(currentStyleId!, out W.Style? style)) {
+                cache.RecordStyleChainReference(chain.Count + 1);
                 chain.Add(style);
                 currentStyleId = style.BasedOn?.Val?.Value;
             }
 
             chain.Reverse();
-            return chain;
+            IReadOnlyList<W.Style> result = chain.ToArray();
+            cache.CharacterChains[styleId!] = result;
+            return result;
         }
 
         private static IReadOnlyList<WordTabStop> GetNativeParagraphEffectiveTabStops(WordParagraph paragraph) {

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.ParagraphStyles.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.ParagraphStyles.cs
@@ -11,6 +11,8 @@ using PdfCore = OfficeIMO.Pdf;
 
 namespace OfficeIMO.Word.Pdf {
     public static partial class WordPdfConverterExtensions {
+        private const double MaxNativeParagraphBorderSpacingPoints = 31D;
+
         private static PdfCore.PdfParagraphStyle CreateNativeParagraphStyle(WordParagraph paragraph) =>
             CreateNativeParagraphStyle(paragraph, GetNativeDocumentDefaults(paragraph._document));
 
@@ -386,7 +388,9 @@ namespace OfficeIMO.Word.Pdf {
                 return defaultPadding;
             }
 
-            return Math.Max(left.GetValueOrDefault(), right.GetValueOrDefault());
+            return Math.Min(
+                Math.Max(left.GetValueOrDefault(), right.GetValueOrDefault()),
+                MaxNativeParagraphBorderSpacingPoints);
         }
 
         private static double ResolveNativeParagraphPanelPaddingY(NativeParagraphBorders borders, double defaultPadding) {
@@ -396,7 +400,9 @@ namespace OfficeIMO.Word.Pdf {
                 return defaultPadding;
             }
 
-            return Math.Max(top.GetValueOrDefault(), bottom.GetValueOrDefault());
+            return Math.Min(
+                Math.Max(top.GetValueOrDefault(), bottom.GetValueOrDefault()),
+                MaxNativeParagraphBorderSpacingPoints);
         }
 
         private static bool HasNativeOnlyBottomParagraphBorder(NativeParagraphBorders borders) =>

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.StyleLookupCache.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.StyleLookupCache.cs
@@ -1,0 +1,103 @@
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using W = DocumentFormat.OpenXml.Wordprocessing;
+
+namespace OfficeIMO.Word.Pdf {
+    public static partial class WordPdfConverterExtensions {
+        private const int MaxNativeIndexedStyles = 4_096;
+        private const int MaxNativeStyleChainDepth = 256;
+        private const int MaxNativeCachedStyleReferences = 8_192;
+        private static readonly ConditionalWeakTable<WordDocument, NativeStyleLookupCache> NativeStyleLookupCaches = new();
+
+        private sealed class NativeStyleLookupCache {
+            internal Dictionary<string, W.Style> ParagraphStyles { get; } = new(StringComparer.Ordinal);
+            internal Dictionary<string, W.Style> CharacterStyles { get; } = new(StringComparer.Ordinal);
+            internal Dictionary<string, W.Style> TableStyles { get; } = new(StringComparer.Ordinal);
+            internal Dictionary<string, IReadOnlyList<W.Style>> ParagraphChains { get; } = new(StringComparer.Ordinal);
+            internal Dictionary<string, IReadOnlyList<W.Style>> CharacterChains { get; } = new(StringComparer.Ordinal);
+            internal Dictionary<string, IReadOnlyList<W.Style>> TableChains { get; } = new(StringComparer.Ordinal);
+            internal Dictionary<string, NativeParagraphStyleDefaults> ParagraphDefaults { get; } = new(StringComparer.Ordinal);
+            internal Dictionary<string, NativeCharacterStyleDefaults> CharacterDefaults { get; } = new(StringComparer.Ordinal);
+            internal string? DefaultParagraphStyleId { get; }
+            internal string? DefaultTableStyleId { get; }
+            private int _indexedStyleCount;
+            private int _cachedStyleReferenceCount;
+
+            internal NativeStyleLookupCache(W.Styles? styles) {
+                if (styles == null) {
+                    return;
+                }
+
+                string? defaultParagraphStyleId = null;
+                string? defaultTableStyleId = null;
+                foreach (W.Style style in styles.Elements<W.Style>()) {
+                    string? styleId = style.StyleId?.Value;
+                    if (string.IsNullOrEmpty(styleId)) {
+                        continue;
+                    }
+
+                    if (IsNativeParagraphStyle(style)) {
+                        if (!ParagraphStyles.ContainsKey(styleId!)) {
+                            RecordIndexedStyle();
+                            ParagraphStyles.Add(styleId!, style);
+                            if (defaultParagraphStyleId == null && style.Default?.Value == true) {
+                                defaultParagraphStyleId = styleId;
+                            }
+                        }
+                    } else if (IsNativeCharacterStyle(style) && !CharacterStyles.ContainsKey(styleId!)) {
+                        RecordIndexedStyle();
+                        CharacterStyles.Add(styleId!, style);
+                    } else if (style.Type?.Value == W.StyleValues.Table && !TableStyles.ContainsKey(styleId!)) {
+                        RecordIndexedStyle();
+                        TableStyles.Add(styleId!, style);
+                        if (defaultTableStyleId == null && style.Default?.Value == true) {
+                            defaultTableStyleId = styleId;
+                        }
+                    }
+                }
+
+                DefaultParagraphStyleId = defaultParagraphStyleId;
+                DefaultTableStyleId = defaultTableStyleId;
+            }
+
+            internal void RecordStyleChainReference(int depth) {
+                if (depth > MaxNativeStyleChainDepth) {
+                    throw new System.IO.InvalidDataException($"Word style inheritance depth exceeds the native PDF limit of {MaxNativeStyleChainDepth}.");
+                }
+
+                if (_cachedStyleReferenceCount >= MaxNativeCachedStyleReferences) {
+                    throw new System.IO.InvalidDataException($"Word style inheritance work exceeds the native PDF limit of {MaxNativeCachedStyleReferences} cached references.");
+                }
+
+                _cachedStyleReferenceCount++;
+            }
+
+            private void RecordIndexedStyle() {
+                if (_indexedStyleCount >= MaxNativeIndexedStyles) {
+                    throw new System.IO.InvalidDataException($"Word style count exceeds the native PDF limit of {MaxNativeIndexedStyles}.");
+                }
+
+                _indexedStyleCount++;
+            }
+
+            internal string? ResolveParagraphStyleId(string? styleId) =>
+                string.IsNullOrWhiteSpace(styleId) ? DefaultParagraphStyleId : styleId;
+
+            internal string? ResolveTableStyleId(string? styleId) =>
+                string.IsNullOrWhiteSpace(styleId) ? DefaultTableStyleId : styleId;
+        }
+
+        private static NativeStyleLookupCache? GetNativeStyleLookupCache(WordDocument? document) {
+            if (document == null) {
+                return null;
+            }
+
+            return NativeStyleLookupCaches.GetValue(
+                document,
+                current => new NativeStyleLookupCache(current._wordprocessingDocument?.MainDocumentPart?.StyleDefinitionsPart?.Styles));
+        }
+
+        private static void ResetNativeStyleLookupCache(WordDocument document) =>
+            NativeStyleLookupCaches.Remove(document);
+    }
+}

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.TableCells.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.TableCells.cs
@@ -365,6 +365,9 @@ namespace OfficeIMO.Word.Pdf {
             double leftIndent = paragraph.IndentationBeforePoints ?? styleDefaults.LeftIndent ?? tableStyleDefaults.ParagraphLeftIndent ?? 0D;
             double rightIndent = paragraph.IndentationAfterPoints ?? styleDefaults.RightIndent ?? tableStyleDefaults.ParagraphRightIndent ?? 0D;
             double firstLineIndent = paragraph.IndentationFirstLinePoints ?? styleDefaults.FirstLineIndent ?? tableStyleDefaults.ParagraphFirstLineIndent ?? 0D;
+            leftIndent = NormalizeNativeTableCellIndent(leftIndent);
+            rightIndent = NormalizeNativeTableCellIndent(rightIndent);
+            firstLineIndent = double.IsNaN(firstLineIndent) || double.IsInfinity(firstLineIndent) ? 0D : firstLineIndent;
 
             if (paragraph.IndentationHangingPoints.HasValue) {
                 double hangingIndent = paragraph.IndentationHangingPoints.Value;
@@ -379,6 +382,9 @@ namespace OfficeIMO.Word.Pdf {
 
             return (leftIndent, rightIndent, firstLineIndent);
         }
+
+        private static double NormalizeNativeTableCellIndent(double value) =>
+            value < 0D || double.IsNaN(value) || double.IsInfinity(value) ? 0D : value;
 
         private static double? ResolveNativeTableCellParagraphLineHeight(WordParagraph paragraph, NativeDocumentDefaults nativeDefaults, NativeTableStyleDefaults tableStyleDefaults) {
             NativeParagraphStyleDefaults styleDefaults = GetNativeParagraphStyleDefaults(paragraph);

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.TableStyleDefaults.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.TableStyleDefaults.cs
@@ -354,34 +354,29 @@ namespace OfficeIMO.Word.Pdf {
         }
 
         private static IReadOnlyList<W.Style> GetNativeTableStyleChain(WordDocument document, string? styleId) {
-            W.Styles? styles = document._wordprocessingDocument?.MainDocumentPart?.StyleDefinitionsPart?.Styles;
-            if (styles == null) {
+            NativeStyleLookupCache? cache = GetNativeStyleLookupCache(document);
+            string? resolvedStyleId = cache?.ResolveTableStyleId(styleId);
+            if (cache == null || string.IsNullOrWhiteSpace(resolvedStyleId)) {
                 return Array.Empty<W.Style>();
             }
 
-            Dictionary<string, W.Style> tableStyles = styles
-                .Elements<W.Style>()
-                .Where(style => style.Type?.Value == W.StyleValues.Table && !string.IsNullOrEmpty(style.StyleId?.Value))
-                .ToDictionary(style => style.StyleId!.Value!, style => style, StringComparer.Ordinal);
-
-            if (string.IsNullOrWhiteSpace(styleId)) {
-                styleId = tableStyles.Values.FirstOrDefault(style => style.Default?.Value == true)?.StyleId?.Value;
-            }
-
-            if (string.IsNullOrWhiteSpace(styleId)) {
-                return Array.Empty<W.Style>();
+            if (cache.TableChains.TryGetValue(resolvedStyleId!, out IReadOnlyList<W.Style>? cachedChain)) {
+                return cachedChain;
             }
 
             var chain = new List<W.Style>();
             var visited = new HashSet<string>(StringComparer.Ordinal);
-            string? currentStyleId = styleId;
-            while (!string.IsNullOrWhiteSpace(currentStyleId) && visited.Add(currentStyleId!) && tableStyles.TryGetValue(currentStyleId!, out W.Style? style)) {
+            string? currentStyleId = resolvedStyleId;
+            while (!string.IsNullOrWhiteSpace(currentStyleId) && visited.Add(currentStyleId!) && cache.TableStyles.TryGetValue(currentStyleId!, out W.Style? style)) {
+                cache.RecordStyleChainReference(chain.Count + 1);
                 chain.Add(style);
                 currentStyleId = style.BasedOn?.Val?.Value;
             }
 
             chain.Reverse();
-            return chain;
+            IReadOnlyList<W.Style> result = chain.ToArray();
+            cache.TableChains[resolvedStyleId!] = result;
+            return result;
         }
 
         private static string? GetNativeTableStyleId(WordTable table) =>

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.Tables.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.Tables.cs
@@ -379,10 +379,43 @@ namespace OfficeIMO.Word.Pdf {
         private static void SuppressNativeTableRoleBoundariesCrossedByRowSpans(PdfCore.PdfTableStyle style, TableLayout layout) {
             if (style.HeaderRowCount > 0 && HasNativeCellSpanningRowBoundary(layout, style.HeaderRowCount)) {
                 // A repeated or semantic header cannot contain only part of a vertically merged Word cell.
-                // Conditional formatting has already been projected into the per-cell style maps above.
+                // Preserve fill formatting that otherwise depends on the header role before clearing it.
+                ProjectNativeHeaderFillToCells(style, layout, style.HeaderRowCount);
                 style.HeaderRowCount = 0;
                 style.RepeatHeaderRowCount = 0;
             }
+        }
+
+        private static void ProjectNativeHeaderFillToCells(PdfCore.PdfTableStyle style, TableLayout layout, int headerRowCount) {
+            if (!style.HeaderFill.HasValue || headerRowCount <= 0) {
+                return;
+            }
+
+            var cellFills = style.CellFills == null
+                ? new Dictionary<(int Row, int Column), PdfCore.PdfColor>()
+                : new Dictionary<(int Row, int Column), PdfCore.PdfColor>(style.CellFills);
+            int projectedRowCount = System.Math.Min(headerRowCount, layout.Rows.Count);
+            for (int rowIndex = 0; rowIndex < projectedRowCount; rowIndex++) {
+                IReadOnlyList<WordTableCell> row = layout.Rows[rowIndex];
+                int logicalColumnIndex = GetNativeTableRowStartColumn(layout, rowIndex);
+                foreach (WordTableCell cell in row) {
+                    if (IsNativeHorizontalMergeContinuation(cell)) {
+                        continue;
+                    }
+
+                    int columnSpan = GetNativeCellColumnSpan(cell);
+                    if (!IsNativeVerticalMergeContinuation(cell)) {
+                        (int Row, int Column) key = (rowIndex, logicalColumnIndex);
+                        if (!cellFills.ContainsKey(key)) {
+                            cellFills[key] = style.HeaderFill.Value;
+                        }
+                    }
+
+                    logicalColumnIndex += columnSpan;
+                }
+            }
+
+            style.CellFills = cellFills;
         }
 
         private static bool HasNativeCellSpanningRowBoundary(TableLayout layout, int boundaryRowIndex) {

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.Tables.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.Tables.cs
@@ -309,13 +309,14 @@ namespace OfficeIMO.Word.Pdf {
                 style,
                 usesConfiguredDefaultStyle,
                 ShouldApplyNativeTableStyleCellPadding(table) ? tableStyleDefaults : NativeTableStyleDefaults.Empty);
-            ApplyNativeTableConditionalStyles(table, style, tableStyleDefaults, rowCount);
+            ApplyNativeTableConditionalStyles(table, style, tableStyleDefaults, rowCount, layout);
             ApplyNativeTableBandingStyles(table, layout, style, tableStyleDefaults);
             ApplyNativeTableConditionalColumnFills(table, layout, tableStyleDefaults, style);
             ApplyNativeTableConditionalBorders(table, layout, tableStyleDefaults, style);
             ApplyNativeTableConditionalPaddings(table, layout, tableStyleDefaults, style);
             ApplyNativeTableLayoutOptions(table, layout, style, contentWidth, tableStyleDefaults);
             ApplyNativeTableRowOptions(table, style);
+            SuppressNativeTableRoleBoundariesCrossedByRowSpans(style, layout);
             return style;
         }
 
@@ -351,9 +352,9 @@ namespace OfficeIMO.Word.Pdf {
             };
         }
 
-        private static void ApplyNativeTableConditionalStyles(WordTable table, PdfCore.PdfTableStyle style, NativeTableStyleDefaults tableStyleDefaults, int rowCount) {
+        private static void ApplyNativeTableConditionalStyles(WordTable table, PdfCore.PdfTableStyle style, NativeTableStyleDefaults tableStyleDefaults, int rowCount, TableLayout layout) {
             ApplyNativeFirstRowConditionalStyle(table, style, tableStyleDefaults);
-            ApplyNativeLastRowConditionalStyle(table, style, tableStyleDefaults, rowCount);
+            ApplyNativeLastRowConditionalStyle(table, style, tableStyleDefaults, rowCount, layout);
         }
 
         private static void ApplyNativeFirstRowConditionalStyle(WordTable table, PdfCore.PdfTableStyle style, NativeTableStyleDefaults tableStyleDefaults) {
@@ -364,13 +365,40 @@ namespace OfficeIMO.Word.Pdf {
             ApplyNativeHeaderConditionalStyle(style, tableStyleDefaults.FirstRowStyle);
         }
 
-        private static void ApplyNativeLastRowConditionalStyle(WordTable table, PdfCore.PdfTableStyle style, NativeTableStyleDefaults tableStyleDefaults, int rowCount) {
+        private static void ApplyNativeLastRowConditionalStyle(WordTable table, PdfCore.PdfTableStyle style, NativeTableStyleDefaults tableStyleDefaults, int rowCount, TableLayout layout) {
             if (table.ConditionalFormattingLastRow != true || rowCount <= style.HeaderRowCount) {
                 return;
             }
 
-            style.FooterRowCount = 1;
+            if (!HasNativeCellSpanningRowBoundary(layout, rowCount - 1)) {
+                style.FooterRowCount = 1;
+            }
             ApplyNativeFooterConditionalStyle(style, tableStyleDefaults.LastRowStyle);
+        }
+
+        private static void SuppressNativeTableRoleBoundariesCrossedByRowSpans(PdfCore.PdfTableStyle style, TableLayout layout) {
+            if (style.HeaderRowCount > 0 && HasNativeCellSpanningRowBoundary(layout, style.HeaderRowCount)) {
+                // A repeated or semantic header cannot contain only part of a vertically merged Word cell.
+                // Conditional formatting has already been projected into the per-cell style maps above.
+                style.HeaderRowCount = 0;
+                style.RepeatHeaderRowCount = 0;
+            }
+        }
+
+        private static bool HasNativeCellSpanningRowBoundary(TableLayout layout, int boundaryRowIndex) {
+            for (int rowIndex = 0; rowIndex < boundaryRowIndex && rowIndex < layout.Rows.Count; rowIndex++) {
+                foreach (WordTableCell cell in layout.Rows[rowIndex]) {
+                    if (IsNativeHorizontalMergeContinuation(cell) || IsNativeVerticalMergeContinuation(cell)) {
+                        continue;
+                    }
+
+                    if (rowIndex + GetNativeCellRowSpan(cell) > boundaryRowIndex) {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
 
         private static void ApplyNativeHeaderConditionalStyle(PdfCore.PdfTableStyle style, NativeTableConditionalStyleDefaults conditionalStyle) {

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.cs
@@ -204,6 +204,9 @@ namespace OfficeIMO.Word.Pdf {
                 sectionIndex = sectionGroupEnd;
             }
 
+            // The lookup cache is conversion-scoped. Releasing it here preserves the pre-existing
+            // post-conversion behavior and prevents disposed document state from being reused.
+            ResetNativeStyleLookupCache(document);
             return pdf;
         }
 

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.cs
@@ -110,6 +110,7 @@ namespace OfficeIMO.Word.Pdf {
         };
 
         private static PdfCore.PdfDocument CreateOfficeIMOPdfDocument(WordDocument document, PdfSaveOptions? options) {
+            ResetNativeStyleLookupCache(document);
             BuiltinDocumentProperties properties = document.BuiltinDocumentProperties;
             var nativeFontMap = new NativeFontMap(options?.Report);
             PdfCore.PdfDocument pdf = PdfCore.PdfDocument.Create(CreateNativeOptions(document, options, nativeFontMap))

--- a/OfficeIMO.Word.Tests/Pdf/Word.SaveAsPdf.ParagraphFormatting.cs
+++ b/OfficeIMO.Word.Tests/Pdf/Word.SaveAsPdf.ParagraphFormatting.cs
@@ -597,6 +597,34 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void SaveAsPdf_OfficeIMOEngine_Clamps_Untrusted_Paragraph_Border_Space() {
+            string docPath = Path.Combine(_directoryWithFiles, "PdfNativeParagraphBorderSpaceLimit.docx");
+            string pdfPath = Path.Combine(_directoryWithFiles, "PdfNativeParagraphBorderSpaceLimit.pdf");
+
+            using (WordDocument document = WordDocument.Create(docPath)) {
+                WordParagraph paragraph = document.AddParagraph("BoundedBorderSpace");
+                paragraph.Borders.LeftStyle = BorderValues.Single;
+                paragraph.Borders.RightStyle = BorderValues.Single;
+                paragraph.Borders.TopStyle = BorderValues.Single;
+                paragraph.Borders.BottomStyle = BorderValues.Single;
+                paragraph.Borders.LeftSpace = uint.MaxValue;
+                paragraph.Borders.RightSpace = uint.MaxValue;
+                paragraph.Borders.TopSpace = uint.MaxValue;
+                paragraph.Borders.BottomSpace = uint.MaxValue;
+
+                document.Save();
+                document.SaveAsPdf(pdfPath, new PdfSaveOptions {
+                    IncludePageNumbers = false,
+                    PageSize = new OfficeIMO.Pdf.PageSize(360, 220),
+                    Margins = OfficeIMO.Pdf.PageMargins.Uniform(30),
+                    FontFamily = "Helvetica"
+                });
+            }
+
+            Assert.Contains("BoundedBorderSpace", PdfTextExtractor.ExtractAllText(pdfPath));
+        }
+
+        [Fact]
         public void SaveAsPdf_OfficeIMOEngine_Renders_Paragraph_Tab_Leaders() {
             string docPath = Path.Combine(_directoryWithFiles, "PdfNativeParagraphTabs.docx");
             string pdfPath = Path.Combine(_directoryWithFiles, "PdfNativeParagraphTabs.pdf");

--- a/OfficeIMO.Word.Tests/Pdf/Word.SaveAsPdf.Security.AllSeverityBatch09.cs
+++ b/OfficeIMO.Word.Tests/Pdf/Word.SaveAsPdf.Security.AllSeverityBatch09.cs
@@ -1,0 +1,141 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Pdf;
+using System.IO;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public partial class Word {
+    [Fact]
+    public void SaveAsPdf_OfficeIMOEngine_ToleratesDuplicateNumberingAndStyleIds() {
+        string docPath = Path.Combine(_directoryWithFiles, "PdfNativeDuplicateNumberingAndStyles.docx");
+        string pdfPath = Path.Combine(_directoryWithFiles, "PdfNativeDuplicateNumberingAndStyles.pdf");
+
+        using (WordDocument document = WordDocument.Create(docPath)) {
+            Styles styles = document._wordprocessingDocument.MainDocumentPart!.StyleDefinitionsPart!.Styles!;
+            styles.Append(
+                new Style(new StyleName { Val = "First paragraph style" }) { Type = StyleValues.Paragraph, StyleId = "DuplicateParagraphStyle", CustomStyle = true },
+                new Style(new StyleName { Val = "Second paragraph style" }) { Type = StyleValues.Paragraph, StyleId = "DuplicateParagraphStyle", CustomStyle = true },
+                new Style(new StyleName { Val = "First character style" }) { Type = StyleValues.Character, StyleId = "DuplicateCharacterStyle", CustomStyle = true },
+                new Style(new StyleName { Val = "Second character style" }) { Type = StyleValues.Character, StyleId = "DuplicateCharacterStyle", CustomStyle = true },
+                new Style(new StyleName { Val = "First table style" }) { Type = StyleValues.Table, StyleId = "DuplicateTableStyle", CustomStyle = true },
+                new Style(new StyleName { Val = "Second table style" }) { Type = StyleValues.Table, StyleId = "DuplicateTableStyle", CustomStyle = true });
+
+            document.AddParagraph("Duplicate paragraph style survives").SetStyleId("DuplicateParagraphStyle");
+            document.AddParagraph().AddText("Duplicate character style survives").SetCharacterStyleId("DuplicateCharacterStyle");
+            WordTable table = document.AddTable(1, 1);
+            table._tableProperties!.TableStyle = new TableStyle { Val = "DuplicateTableStyle" };
+            table.Rows[0].Cells[0].Paragraphs[0].Text = "Duplicate table style survives";
+
+            MainDocumentPart mainPart = document._wordprocessingDocument.MainDocumentPart!;
+            NumberingDefinitionsPart numberingPart = mainPart.NumberingDefinitionsPart ?? mainPart.AddNewPart<NumberingDefinitionsPart>();
+            numberingPart.Numbering ??= new Numbering();
+            numberingPart.Numbering.Append(
+                new AbstractNum(
+                    new Level(new StartNumberingValue { Val = 1 }) { LevelIndex = 0 },
+                    new Level(new StartNumberingValue { Val = 2 }) { LevelIndex = 0 }) { AbstractNumberId = 42 },
+                new AbstractNum(new Level { LevelIndex = 0 }) { AbstractNumberId = 42 },
+                new NumberingInstance(
+                    new AbstractNumId { Val = 42 },
+                    new LevelOverride(new StartOverrideNumberingValue { Val = 3 }) { LevelIndex = 0 },
+                    new LevelOverride(new StartOverrideNumberingValue { Val = 4 }) { LevelIndex = 0 }) { NumberID = 7 });
+
+            document.Save();
+            document.SaveAsPdf(pdfPath, new PdfSaveOptions { IncludePageNumbers = false });
+        }
+
+        Assert.True(File.Exists(pdfPath));
+    }
+
+    [Fact]
+    public void SaveAsPdf_OfficeIMOEngine_IgnoresMalformedLineHundredths() {
+        string docPath = Path.Combine(_directoryWithFiles, "PdfNativeMalformedLineHundredths.docx");
+        string pdfPath = Path.Combine(_directoryWithFiles, "PdfNativeMalformedLineHundredths.pdf");
+
+        using (WordDocument document = WordDocument.Create(docPath)) {
+            WordParagraph paragraph = document.AddParagraph("Malformed line spacing survives");
+            paragraph._paragraph.ParagraphProperties ??= new ParagraphProperties();
+            var spacing = new SpacingBetweenLines();
+            spacing.SetAttribute(new OpenXmlAttribute(
+                "w",
+                "beforeLines",
+                "http://schemas.openxmlformats.org/wordprocessingml/2006/main",
+                "not-an-integer"));
+            paragraph._paragraph.ParagraphProperties.Append(spacing);
+
+            document.SaveAsPdf(pdfPath, new PdfSaveOptions { IncludePageNumbers = false });
+        }
+
+        Assert.True(File.Exists(pdfPath));
+    }
+
+    [Fact]
+    public void SaveAsPdf_OfficeIMOEngine_ClampsExtremeTableCellParagraphIndents() {
+        string docPath = Path.Combine(_directoryWithFiles, "PdfNativeExtremeTableCellIndents.docx");
+        string pdfPath = Path.Combine(_directoryWithFiles, "PdfNativeExtremeTableCellIndents.pdf");
+
+        using (WordDocument document = WordDocument.Create(docPath)) {
+            WordParagraph paragraph = document.AddTable(1, 1).Rows[0].Cells[0].Paragraphs[0];
+            paragraph.Text = "Extreme cell indentation survives";
+            paragraph._paragraph.ParagraphProperties ??= new ParagraphProperties();
+            paragraph._paragraph.ParagraphProperties.Indentation = new Indentation {
+                Left = "2147483647",
+                Right = "2147483647",
+                FirstLine = "2147483647"
+            };
+
+            document.SaveAsPdf(pdfPath, new PdfSaveOptions { IncludePageNumbers = false });
+        }
+
+        Assert.True(File.Exists(pdfPath));
+    }
+
+    [Fact]
+    public void SaveAsPdf_OfficeIMOEngine_AllowsConditionalRowFormattingAcrossVerticalMerge() {
+        string docPath = Path.Combine(_directoryWithFiles, "PdfNativeLastRowVerticalMerge.docx");
+        string pdfPath = Path.Combine(_directoryWithFiles, "PdfNativeLastRowVerticalMerge.pdf");
+
+        using (WordDocument document = WordDocument.Create(docPath)) {
+            WordTable table = document.AddTable(2, 1);
+            table.Rows[0].Cells[0].Paragraphs[0].Text = "Merged across final row";
+            table.Rows[0].Cells[0].MergeVertically(1);
+            table.ConditionalFormattingFirstRow = true;
+            table.ConditionalFormattingLastRow = true;
+
+            document.SaveAsPdf(pdfPath, new PdfSaveOptions { IncludePageNumbers = false });
+        }
+
+        Assert.True(File.Exists(pdfPath));
+    }
+
+    [Fact]
+    public void SaveAsPdf_OfficeIMOEngine_RejectsAggregateStyleInheritanceAmplification() {
+        string docPath = Path.Combine(_directoryWithFiles, "PdfNativeStyleInheritanceBudget.docx");
+        string pdfPath = Path.Combine(_directoryWithFiles, "PdfNativeStyleInheritanceBudget.pdf");
+
+        using WordDocument document = WordDocument.Create(docPath);
+        Styles styles = document._wordprocessingDocument.MainDocumentPart!.StyleDefinitionsPart!.Styles!;
+        string? parentStyleId = null;
+        for (int index = 0; index < 128; index++) {
+            string styleId = "SecurityStyle" + index.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            var style = new Style(new StyleName { Val = styleId }) {
+                Type = StyleValues.Paragraph,
+                StyleId = styleId,
+                CustomStyle = true
+            };
+            if (parentStyleId != null) {
+                style.Append(new BasedOn { Val = parentStyleId });
+            }
+
+            styles.Append(style);
+            document.AddParagraph("Bounded style " + index.ToString(System.Globalization.CultureInfo.InvariantCulture)).SetStyleId(styleId);
+            parentStyleId = styleId;
+        }
+
+        document.Save();
+        Assert.Throws<InvalidDataException>(() => document.SaveAsPdf(pdfPath, new PdfSaveOptions { IncludePageNumbers = false }));
+    }
+}

--- a/OfficeIMO.Word.Tests/Pdf/Word.SaveAsPdf.StructuredBlocks.cs
+++ b/OfficeIMO.Word.Tests/Pdf/Word.SaveAsPdf.StructuredBlocks.cs
@@ -1242,6 +1242,29 @@ public partial class Word {
         Assert.Contains("0.184 0.435 0.243 rg", rawPdf, StringComparison.Ordinal);
     }
 
+    [Theory]
+    [InlineData(1L, 1L)]
+    [InlineData(long.MaxValue, long.MaxValue)]
+    public void SaveAsPdf_OfficeIMOEngine_NormalizesUntrustedWordChartExtents(long cx, long cy) {
+        string suffix = cx == 1L ? "Tiny" : "Huge";
+        string docPath = Path.Combine(_directoryWithFiles, "PdfNativeWordChart" + suffix + "Extent.docx");
+        string pdfPath = Path.Combine(_directoryWithFiles, "PdfNativeWordChart" + suffix + "Extent.pdf");
+
+        using (WordDocument document = WordDocument.Create(docPath)) {
+            WordChart chart = document.AddChart("Untrusted Word chart extent", false, 360, 220);
+            chart.AddPie("Passed", 3);
+            chart.AddPie("Failed", 1);
+            DW.Extent extent = chart.Drawing!.Inline?.Extent ?? chart.Drawing.Anchor!.Extent!;
+            extent.Cx = cx;
+            extent.Cy = cy;
+            document.AddParagraph("After normalized chart extent");
+
+            document.SaveAsPdf(pdfPath, new PdfSaveOptions { IncludePageNumbers = false });
+        }
+
+        Assert.Contains("After normalized chart extent", PdfTextExtractor.ExtractAllText(pdfPath));
+    }
+
     [Fact]
     public void SaveAsPdf_OfficeIMOEngine_Renders_Inline_Word_Charts_After_Text_Run() {
         string docPath = Path.Combine(_directoryWithFiles, "PdfNativeInlineWordChart.docx");
@@ -1495,7 +1518,7 @@ public partial class Word {
     }
 
     [Fact]
-    public void SaveAsPdf_OfficeIMOEngine_Renders_Primary_Word_Chart_From_Mixed_Combo() {
+    public void SaveAsPdf_OfficeIMOEngine_Rejects_Partial_Word_Combo_Chart_Export() {
         string docPath = Path.Combine(_directoryWithFiles, "PdfNativeWordMixedUnsupportedChart.docx");
         string pdfPath = Path.Combine(_directoryWithFiles, "PdfNativeWordMixedUnsupportedChart.pdf");
         var options = new PdfSaveOptions {
@@ -1511,34 +1534,30 @@ public partial class Word {
             ChartPart chartPart = (ChartPart)typeof(WordChart)
                 .GetProperty("ChartPart", BindingFlags.NonPublic | BindingFlags.Instance)!
                 .GetValue(chart)!;
-            chartPart.ChartSpace!.Descendants<PlotArea>().First().Append(new BubbleChart());
+            PlotArea plotArea = chartPart.ChartSpace!.Descendants<PlotArea>().First();
+            plotArea.InsertBefore(new BubbleChart(), plotArea.GetFirstChild<BarChart>()!);
 
             MethodInfo method = typeof(WordPdfConverterExtensions).GetMethod("TryCreateNativeWordChartSnapshot", BindingFlags.NonPublic | BindingFlags.Static)!;
             object?[] arguments = { chart, null, null };
             bool result = (bool)method.Invoke(null, arguments)!;
 
-            Assert.True(result, (string?)arguments[2]);
-            object snapshot = arguments[1]!;
-            Assert.Equal(OfficeChartKind.BarClustered, snapshot.GetType().GetProperty("ChartKind")!.GetValue(snapshot));
-            Assert.Contains("omitted the additional plot types", (string?)arguments[2], StringComparison.OrdinalIgnoreCase);
+            Assert.False(result);
+            Assert.Null(arguments[1]);
+            Assert.Contains("not partially exported", (string?)arguments[2], StringComparison.OrdinalIgnoreCase);
 
             document.Save();
             PdfDocumentConversionResult conversion = document.ToPdfDocumentResult(options);
             conversion.Save(pdfPath);
 
-            Assert.DoesNotContain(conversion.Warnings, warning => warning.Code == "NativeBodyChartUnsupported");
-            PdfConversionWarning simplified = Assert.Single(conversion.Warnings, warning => warning.Code == "NativeBodyChartSimplified");
-            Assert.Contains("omitted the additional plot types", simplified.Message, StringComparison.OrdinalIgnoreCase);
+            PdfConversionWarning unsupported = Assert.Single(conversion.Warnings, warning => warning.Code == "NativeBodyChartUnsupported");
+            Assert.Contains("not partially exported", unsupported.Message, StringComparison.OrdinalIgnoreCase);
         }
 
         string text = PdfTextExtractor.ExtractAllText(pdfPath);
         Assert.Contains("After mixed chart", text);
-        Assert.Contains("Word PDF Mixed Chart", text);
-        Assert.Contains("Q1", text);
-        Assert.Contains("Q2", text);
-
-        string rawPdf = Encoding.ASCII.GetString(File.ReadAllBytes(pdfPath));
-        Assert.Contains("0.267 0.447 0.769 rg", rawPdf, StringComparison.Ordinal);
+        Assert.DoesNotContain("Word PDF Mixed Chart", text);
+        Assert.DoesNotContain("Q1", text);
+        Assert.DoesNotContain("Q2", text);
     }
 
     [Fact]

--- a/OfficeIMO.Word.Tests/Pdf/Word.SaveAsPdf.TableStyleMapping.cs
+++ b/OfficeIMO.Word.Tests/Pdf/Word.SaveAsPdf.TableStyleMapping.cs
@@ -236,6 +236,32 @@ public partial class Word {
     }
 
     [Fact]
+    public void SaveAsPdf_OfficeIMOEngine_Preserves_First_Row_Fill_When_Vertical_Merge_Suppresses_Header_Role() {
+        using WordDocument document = WordDocument.Create(Path.Combine(_directoryWithFiles, "PdfNativeTableStyleMergedFirstRow.docx"));
+        Styles styles = document._wordprocessingDocument.MainDocumentPart!.StyleDefinitionsPart!.Styles!;
+        styles.Append(new Style(
+            new StyleName { Val = "Merged First Row Table" },
+            new TableStyleProperties(
+                new TableStyleConditionalFormattingTableCellProperties(
+                    new Shading { Val = ShadingPatternValues.Clear, Fill = "112233" }))
+            { Type = TableStyleOverrideValues.FirstRow })
+        { Type = StyleValues.Table, StyleId = "MergedFirstRowTable" });
+
+        WordTable table = document.AddTable(2, 2);
+        table._tableProperties!.TableStyle = new TableStyle { Val = "MergedFirstRowTable" };
+        table.ConditionalFormattingFirstRow = true;
+        table.Rows[0].Cells[0].MergeVertically(1);
+
+        PdfCore.PdfTableStyle style = CreateNativeTableStyleForTest(table);
+
+        Assert.Equal(0, style.HeaderRowCount);
+        Assert.Equal(0, style.RepeatHeaderRowCount);
+        Assert.NotNull(style.CellFills);
+        Assert.Equal(PdfCore.PdfColor.FromRgb(17, 34, 51), style.CellFills![(0, 0)]);
+        Assert.Equal(PdfCore.PdfColor.FromRgb(17, 34, 51), style.CellFills[(0, 1)]);
+    }
+
+    [Fact]
     public void SaveAsPdf_OfficeIMOEngine_Maps_Table_Style_Last_Row_Conditional_Formatting() {
         using WordDocument document = WordDocument.Create(Path.Combine(_directoryWithFiles, "PdfNativeTableStyleLastRowConditional.docx"));
         Styles styles = document._wordprocessingDocument.MainDocumentPart!.StyleDefinitionsPart!.Styles!;

--- a/OfficeIMO.Word/Converters/DocumentTraversal.cs
+++ b/OfficeIMO.Word/Converters/DocumentTraversal.cs
@@ -259,9 +259,12 @@ namespace OfficeIMO.Word {
                 return result;
             }
 
-            Dictionary<int, AbstractNum> abstracts = numbering.Elements<AbstractNum>()
-                .Where(abstractNum => abstractNum.AbstractNumberId?.Value != null)
-                .ToDictionary(abstractNum => abstractNum.AbstractNumberId!.Value, abstractNum => abstractNum);
+            var abstracts = new Dictionary<int, AbstractNum>();
+            foreach (AbstractNum abstractNum in numbering.Elements<AbstractNum>()) {
+                if (abstractNum.AbstractNumberId?.HasValue == true && !abstracts.ContainsKey(abstractNum.AbstractNumberId.Value)) {
+                    abstracts.Add(abstractNum.AbstractNumberId.Value, abstractNum);
+                }
+            }
 
             foreach (NumberingInstance instance in numbering.Elements<NumberingInstance>()) {
                 if (instance.NumberID?.Value == null) {
@@ -281,22 +284,25 @@ namespace OfficeIMO.Word {
                         return startOverrideValue?.Val?.HasValue == true && startOverrideValue.Val.Value == 1;
                     });
 
-                Dictionary<int, int> startOverrides = overrides
-                    .Where(levelOverride => levelOverride.LevelIndex?.Value != null)
-                    .Select(levelOverride => new {
-                        Level = levelOverride.LevelIndex!.Value,
-                        Start = levelOverride.GetFirstChild<StartOverrideNumberingValue>()?.Val
-                    })
-                    .Where(item => item.Start?.HasValue == true)
-                    .ToDictionary(item => item.Level, item => item.Start!.Value);
+                var startOverrides = new Dictionary<int, int>();
+                foreach (LevelOverride levelOverride in overrides) {
+                    StartOverrideNumberingValue? start = levelOverride.GetFirstChild<StartOverrideNumberingValue>();
+                    if (levelOverride.LevelIndex?.HasValue == true && start?.Val?.HasValue == true && !startOverrides.ContainsKey(levelOverride.LevelIndex.Value)) {
+                        startOverrides.Add(levelOverride.LevelIndex.Value, start.Val.Value);
+                    }
+                }
 
-                Dictionary<int, ListLevelDefinition> levels = abstractNum?.Elements<Level>()
-                    .Where(level => level.LevelIndex?.Value != null)
-                    .Select(level => {
+                var levels = new Dictionary<int, ListLevelDefinition>();
+                if (abstractNum != null) {
+                    foreach (Level level in abstractNum.Elements<Level>()) {
+                        if (level.LevelIndex?.HasValue != true || levels.ContainsKey(level.LevelIndex.Value)) {
+                            continue;
+                        }
+
                         var indentation = level.GetFirstChild<PreviousParagraphProperties>()?.GetFirstChild<Indentation>();
                         NumberingSymbolRunProperties? markerProperties = level.GetFirstChild<NumberingSymbolRunProperties>();
-                        return new ListLevelDefinition(
-                            level: level.LevelIndex!.Value,
+                        var definition = new ListLevelDefinition(
+                            level: level.LevelIndex.Value,
                             start: level.StartNumberingValue?.Val?.Value ?? 1,
                             numberFormat: level.NumberingFormat?.Val?.Value,
                             levelText: level.LevelText?.Val?.Value,
@@ -309,8 +315,9 @@ namespace OfficeIMO.Word {
                             markerFontSize: ResolveListMarkerFontSize(markerProperties),
                             levelJustification: level.LevelJustification?.Val?.Value,
                             levelSuffix: level.LevelSuffix?.Val?.Value);
-                    })
-                    .ToDictionary(level => level.Level, level => level) ?? new Dictionary<int, ListLevelDefinition>();
+                        levels.Add(definition.Level, definition);
+                    }
+                }
 
                 result[numberId] = new ListNumberingDefinition(
                     numberId,
@@ -525,4 +532,3 @@ namespace OfficeIMO.Word {
         }
     }
 }
-


### PR DESCRIPTION
## Summary

- bounds malformed PDF signature, layout, table, link-annotation, and keep-chain processing before attacker-controlled document data can amplify work
- makes Word-to-PDF style, table-role, indent, border, and chart handling bounded and cache-backed while keeping the style cache scoped to one conversion
- preserves first-row conditional fill when a vertical merge prevents a Word row from remaining a semantic or repeated PDF header
- keeps PDF reader catalog actions consistent across ranged page reads without repeating document-level actions
- applies YAML stream, scalar, hashing, node, event, and effective-depth limits before loading the representation model
- linearizes RTF list lookup and treats only tightly bounded OfficeIMO-generated chart workbooks as safe PowerPoint chart data
- dispositions exported all-severity findings 161–180: 19 fixed here and one YAML finding already fixed by earlier merged package-security work

## Compatibility

No public API signatures change. PDF page chunks expose document catalog actions only once while retaining the same security diagnostics on every chunk. Standard OfficeIMO-generated chart workbooks remain recognized as chart data; externally linked, malformed, oversized, or structurally extended workbooks are reported as advanced embedded content.