### PR TITLE
Harden PDF form, font, and Office export boundaries

### DIFF
--- a/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.Planning.cs
+++ b/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.Planning.cs
@@ -169,7 +169,8 @@ namespace OfficeIMO.Excel.Pdf {
                     return;
                 }
 
-                bool embedSystemFont = options.ResourcePolicy.AllowSystemFontEmbedding;
+                bool embedSystemFont = options.ResourcePolicy.AllowSystemFontEmbedding &&
+                    options.ResourcePolicy.AllowDocumentFontEmbedding;
                 if (embedSystemFont && pdfOptions.TryRegisterNamedOfficeFontFamily(trimmedFamilyName, out _)) {
                     return;
                 }

--- a/OfficeIMO.Excel.Tests/Excel.PerformanceReviewRegression.cs
+++ b/OfficeIMO.Excel.Tests/Excel.PerformanceReviewRegression.cs
@@ -5626,7 +5626,8 @@ namespace OfficeIMO.Tests {
                     name: "ScorePivot",
                     rowFields: new[] { "Name" },
                     dataFields: new[] { new ExcelPivotDataField("Score", DataConsolidateFunctionValues.Sum, "Total Score") },
-                    calculatedFields: new[] { new ExcelPivotCalculatedField("DoubleScore", "'Score' * 2") });
+                    calculatedFields: new[] { new ExcelPivotCalculatedField("DoubleScore", "'Score' * 2") },
+                    options: new ExcelPivotTableOptions { SaveSourceData = true });
 
                 document.Save(memory);
             }

--- a/OfficeIMO.Excel.Tests/Excel.PivotTables.cs
+++ b/OfficeIMO.Excel.Tests/Excel.PivotTables.cs
@@ -224,6 +224,36 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_PivotTableCalculatedFields_DoNotPersistSourceRowsWithoutOptIn() {
+            var filePath = Path.Combine(_directoryWithFiles, "ExcelPivotTableNoSourceCacheByDefault.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorksheet("Data");
+                sheet.CellValue(1, 1, "Region");
+                sheet.CellValue(1, 2, "Sales");
+                sheet.CellValue(2, 1, "Confidential East");
+                sheet.CellValue(2, 2, 10);
+                sheet.CellValue(3, 1, "Confidential West");
+                sheet.CellValue(3, 2, 12);
+                sheet.AddPivotTable(
+                    sourceRange: "A1:B3",
+                    destinationCell: "E2",
+                    name: "SalesPivot",
+                    rowFields: new[] { "Region" },
+                    dataFields: new[] { new ExcelPivotDataField("Sales", DataConsolidateFunctionValues.Sum, "Total Sales") },
+                    calculatedFields: new[] { new ExcelPivotCalculatedField("DoubleSales", "'Sales' * 2") });
+                document.Save();
+            }
+
+            using var spreadsheet = SpreadsheetDocument.Open(filePath, false);
+            var cachePart = spreadsheet.WorkbookPart!.PivotTableCacheDefinitionParts.Single();
+            Assert.False(cachePart.PivotCacheDefinition!.SaveData!.Value);
+            Assert.True(cachePart.PivotCacheDefinition.RefreshOnLoad!.Value);
+            var recordsPart = Assert.Single(cachePart.GetPartsOfType<PivotTableCacheRecordsPart>());
+            Assert.Equal(0U, recordsPart.PivotCacheRecords!.Count!.Value);
+        }
+
+        [Fact]
         public void Test_FluentPivotBuilder_AppliesItemAndPageFilterHelpers() {
             var filePath = Path.Combine(_directoryWithFiles, "ExcelPivotTableFluentItemFilters.xlsx");
 

--- a/OfficeIMO.Excel/ExcelPivotTableOptions.cs
+++ b/OfficeIMO.Excel/ExcelPivotTableOptions.cs
@@ -9,7 +9,8 @@ namespace OfficeIMO.Excel {
         public bool? RefreshOnOpen { get; set; }
 
         /// <summary>
-        /// Gets or sets whether source cache records should be saved in the workbook package.
+        /// Gets or sets whether source cache records should be saved in the workbook package. Defaults to false so
+        /// source rows are not duplicated into the pivot cache unless the caller explicitly opts in.
         /// </summary>
         public bool? SaveSourceData { get; set; }
 

--- a/OfficeIMO.Excel/ExcelSheet.PivotTables.CacheRecords.cs
+++ b/OfficeIMO.Excel/ExcelSheet.PivotTables.CacheRecords.cs
@@ -106,25 +106,6 @@ namespace OfficeIMO.Excel {
         private static bool ShouldCollectPivotSharedItems(int fieldIndex, IReadOnlyList<bool>? collectFieldValues)
             => collectFieldValues == null || fieldIndex < 0 || fieldIndex >= collectFieldValues.Count || collectFieldValues[fieldIndex];
 
-        private static bool ShouldEmbedPivotCacheRecords(
-            int sourceRecordCount,
-            IReadOnlyDictionary<int, ExcelPivotGrouping> groupingMap,
-            IReadOnlyList<GeneratedPivotGroupingField> generatedFields,
-            IReadOnlyList<ExcelPivotCalculatedField> calculatedFields,
-            IReadOnlyList<ExcelPivotFilter> pivotFilters,
-            IReadOnlyDictionary<int, ExcelPivotFieldOptions>? fieldOptionMap)
-        {
-            if (sourceRecordCount <= 0 || sourceRecordCount > EmbeddedPivotCacheRecordRowLimit) {
-                return false;
-            }
-
-            // Simple source-range pivots can refresh from the worksheet. Embed cache
-            // records only for bounded scenarios that introduce cache-only fields.
-            return groupingMap.Count != 0
-                || generatedFields.Count != 0
-                || calculatedFields.Count != 0;
-        }
-
         private List<PivotFieldValues> BuildGeneratedPivotFieldValueMap(
             IReadOnlyList<GeneratedPivotGroupingField> generatedFields,
             int firstDataRow,

--- a/OfficeIMO.Excel/ExcelSheet.PivotTables.cs
+++ b/OfficeIMO.Excel/ExcelSheet.PivotTables.cs
@@ -12,8 +12,6 @@ namespace OfficeIMO.Excel {
         private static readonly IReadOnlyDictionary<int, IReadOnlyList<int>> EmptyGeneratedPivotGroupingFieldMap =
             new Dictionary<int, IReadOnlyList<int>>(0);
 
-        private const int EmbeddedPivotCacheRecordRowLimit = 4096;
-
         private StylesCache? _pivotStylesCache;
 
         /// <summary>
@@ -369,14 +367,7 @@ namespace OfficeIMO.Excel {
                 ReportPivotTiming("AddPivotTable.PrepareCacheMetadata");
 
                 int sourceRecordCount = Math.Max(0, r2 - r1);
-                bool savePivotCacheRecords = ShouldEmbedPivotCacheRecords(
-                    sourceRecordCount,
-                    groupingMap,
-                    generatedGroupingFields,
-                    calculatedFieldList,
-                    pivotFilterList,
-                    fieldOptionMap);
-                bool effectiveSavePivotCacheRecords = options?.SaveSourceData ?? savePivotCacheRecords;
+                bool effectiveSavePivotCacheRecords = options?.SaveSourceData == true;
                 var cacheDefPart = workbookPart.AddNewPart<PivotTableCacheDefinitionPart>();
                 var cacheDef = new PivotCacheDefinition {
                     CacheSource = new CacheSource {

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfConverterOptionsApiTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfConverterOptionsApiTests.cs
@@ -45,6 +45,7 @@ public sealed class PdfConverterOptionsApiTests {
         Assert.False(options.IncludeImages);
         Assert.True(options.ResourcePolicy.AllowDataUris);
         Assert.True(options.ResourcePolicy.AllowLocalFileAccess);
+        Assert.True(options.ResourcePolicy.AllowDocumentFontEmbedding);
         Assert.False(options.ApplyDefaultTheme);
         Assert.Equal(MarkdownPdfFrontMatterRenderMode.Hidden, options.FrontMatterRenderMode);
     }
@@ -159,6 +160,7 @@ public sealed class PdfConverterOptionsApiTests {
 
     private static void AssertPortable(PdfResourcePolicy policy) {
         Assert.False(policy.AllowSystemFontEmbedding);
+        Assert.False(policy.AllowDocumentFontEmbedding);
         Assert.False(policy.AllowLocalFileAccess);
         Assert.False(policy.AllowRemoteResourceResolution);
         Assert.True(policy.AllowDataUris);
@@ -167,6 +169,7 @@ public sealed class PdfConverterOptionsApiTests {
 
     private static void AssertBalancedDefault(PdfResourcePolicy policy) {
         Assert.True(policy.AllowSystemFontEmbedding);
+        Assert.False(policy.AllowDocumentFontEmbedding);
         Assert.False(policy.AllowLocalFileAccess);
         Assert.False(policy.AllowRemoteResourceResolution);
         Assert.True(policy.AllowDataUris);

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfDocumentCanvasTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfDocumentCanvasTests.cs
@@ -974,6 +974,20 @@ public class PdfDocumentCanvasTests {
     }
 
     [Fact]
+    public void CanvasTable_RejectsUnboundedLogicalGridBeforeRendering() {
+        PdfDocument document = PdfDocument.Create(new PdfOptions {
+                PageWidth = 240,
+                PageHeight = 180
+            })
+            .Canvas(canvas => canvas.Table(new[] {
+                new[] { PdfTableCell.Span("Oversized", 262145) }
+            }, 30, 30, 120, 60));
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => document.ToBytes());
+        Assert.Contains("exceeding the supported limit", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void CanvasTable_RowSpanSkipsContinuationRowStripeFill() {
         byte[] bytes = PdfDocument.Create(new PdfOptions {
                 PageWidth = 240,

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfFontFamilyTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfFontFamilyTests.cs
@@ -633,6 +633,35 @@ public class PdfFontFamilyTests {
         Assert.Null(family);
     }
 
+#if NET6_0_OR_GREATER
+    [Fact]
+    public void PdfEmbeddedFontFamily_SystemFontEnumerationSkipsSymbolicLinkLoops() {
+        if (OperatingSystem.IsWindows()) {
+            return;
+        }
+
+        string root = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        string loop = Path.Combine(root, "nested", "loop");
+        try {
+            string nested = Directory.CreateDirectory(Path.Combine(root, "nested")).FullName;
+            File.WriteAllBytes(Path.Combine(nested, "safe.ttf"), new byte[] { 0, 1, 2, 3 });
+            Directory.CreateSymbolicLink(loop, root);
+
+            string[] files = PdfEmbeddedFontFamily.EnumerateTrueTypeFontFiles(root).ToArray();
+
+            Assert.Single(files);
+            Assert.EndsWith("safe.ttf", files[0], StringComparison.Ordinal);
+        } finally {
+            if (Directory.Exists(loop)) {
+                Directory.Delete(loop);
+            }
+
+            Directory.Delete(root, recursive: true);
+        }
+    }
+#endif
+
     [Fact]
     public void PdfEmbeddedFontFamily_TryFromSystemFontFilesSkipsOversizedFontFiles() {
         if (!TryFindSingleInstalledRegularFontFace(out string familyName, out string fontPath)) {

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfFontSecurityTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfFontSecurityTests.cs
@@ -73,6 +73,39 @@ endbfrange
     }
 
     [Fact]
+    public void ToUnicodeCMap_ExcludesOversizedReverseMappings() {
+        string repeatedDestination = string.Concat(Enumerable.Repeat("0041", 65));
+        byte[] cmapBytes = Encoding.ASCII.GetBytes($"""
+beginbfchar
+<01> <{repeatedDestination}>
+<02> <0041>
+endbfchar
+""");
+
+        Assert.True(ToUnicodeCMap.TryParse(cmapBytes, out ToUnicodeCMap? cmap));
+        Assert.NotNull(cmap);
+
+        Assert.True(cmap!.TryEncodeText(new string('A', 65), out string encoded));
+        Assert.Equal(string.Concat(Enumerable.Repeat("02", 65)), encoded);
+    }
+
+    [Fact]
+    public void ToUnicodeCMap_CapsCumulativeReverseIndexNodes() {
+        var cmap = new ToUnicodeCMap();
+        MethodInfo addMap = typeof(ToUnicodeCMap).GetMethod("AddMap", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        FieldInfo nodeCount = typeof(ToUnicodeCMap).GetField("_reverseMapNodeCount", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        FieldInfo budgetExhausted = typeof(ToUnicodeCMap).GetField("_reverseMapBudgetExhausted", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        for (int index = 1; index <= 2048; index++) {
+            string destination = string.Concat(Enumerable.Repeat(index.ToString("X4"), 64));
+            addMap.Invoke(cmap, new object[] { index.ToString("X4"), destination });
+        }
+
+        Assert.True((bool)budgetExhausted.GetValue(cmap)!);
+        Assert.InRange((int)nodeCount.GetValue(cmap)!, 1, 65536);
+    }
+
+    [Fact]
     public void ResourceResolver_CapsCidWidthRangeExpansion() {
         var page = new PdfDictionary();
         var resources = new PdfDictionary();
@@ -120,6 +153,24 @@ endbfrange
         Assert.Contains("cmap mapping count exceeds supported limits", exception.Message, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void OpenTypeInspectorRejectsCumulativeOverlappingFormat12CmapExpansion() {
+        byte[] fontData = CreateMinimalTrueTypeFont(CreateOverlappingFormat12Cmap());
+
+        Assert.False(PdfOpenTypeFontInspector.TryInspect(fontData, out PdfOpenTypeFontInfo? info, out string? error, "OfficeIMO Security Font"));
+        Assert.Null(info);
+        Assert.Contains("cmap mapping count exceeds supported limits", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void OpenTypeInspectorRejectsCumulativeOverlappingFormat4CmapExpansion() {
+        byte[] fontData = CreateMinimalTrueTypeFont(CreateOverlappingFormat4Cmap());
+
+        Assert.False(PdfOpenTypeFontInspector.TryInspect(fontData, out PdfOpenTypeFontInfo? info, out string? error, "OfficeIMO Security Font"));
+        Assert.Null(info);
+        Assert.Contains("cmap mapping count exceeds supported limits", error, StringComparison.Ordinal);
+    }
+
     private static byte[] CreateLargeRangeFormat12Cmap() {
         var data = new byte[40];
         WriteUInt16(data, 2, 1);
@@ -132,6 +183,56 @@ endbfrange
         WriteUInt32(data, 28, 0);
         WriteUInt32(data, 32, 0x10FFFF);
         WriteUInt32(data, 36, 1);
+        return data;
+    }
+
+    private static byte[] CreateOverlappingFormat12Cmap() {
+        const int groupCount = 3;
+        var data = new byte[12 + 16 + groupCount * 12];
+        WriteUInt16(data, 2, 1);
+        WriteUInt16(data, 4, 3);
+        WriteUInt16(data, 6, 10);
+        WriteUInt32(data, 8, 12);
+        WriteUInt16(data, 12, 12);
+        WriteUInt32(data, 16, (uint)(16 + groupCount * 12));
+        WriteUInt32(data, 24, groupCount);
+        for (int group = 0; group < groupCount; group++) {
+            int offset = 28 + group * 12;
+            WriteUInt32(data, offset, 0);
+            WriteUInt32(data, offset + 4, 0xFFFF);
+            WriteUInt32(data, offset + 8, 1);
+        }
+
+        return data;
+    }
+
+    private static byte[] CreateOverlappingFormat4Cmap() {
+        const int segmentCount = 4;
+        const int subtableLength = 16 + segmentCount * 8;
+        var data = new byte[12 + subtableLength];
+        WriteUInt16(data, 2, 1);
+        WriteUInt16(data, 4, 3);
+        WriteUInt16(data, 6, 1);
+        WriteUInt32(data, 8, 12);
+        WriteUInt16(data, 12, 4);
+        WriteUInt16(data, 14, subtableLength);
+        WriteUInt16(data, 18, segmentCount * 2);
+
+        int endCodeOffset = 26;
+        int startCodeOffset = endCodeOffset + segmentCount * 2 + 2;
+        int idDeltaOffset = startCodeOffset + segmentCount * 2;
+        int idRangeOffsetOffset = idDeltaOffset + segmentCount * 2;
+        for (int segment = 0; segment < segmentCount - 1; segment++) {
+            WriteUInt16(data, endCodeOffset + segment * 2, 0xFFFE);
+            WriteUInt16(data, startCodeOffset + segment * 2, 0);
+            WriteUInt16(data, idDeltaOffset + segment * 2, 1);
+            WriteUInt16(data, idRangeOffsetOffset + segment * 2, 0);
+        }
+
+        WriteUInt16(data, endCodeOffset + (segmentCount - 1) * 2, 0xFFFF);
+        WriteUInt16(data, startCodeOffset + (segmentCount - 1) * 2, 0xFFFF);
+        WriteUInt16(data, idDeltaOffset + (segmentCount - 1) * 2, 1);
+        WriteUInt16(data, idRangeOffsetOffset + (segmentCount - 1) * 2, 0);
         return data;
     }
 

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfFormModelSecurityTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfFormModelSecurityTests.cs
@@ -1,0 +1,122 @@
+using System.Collections;
+using System.Reflection;
+using OfficeIMO.Pdf;
+using Xunit;
+
+namespace OfficeIMO.Tests.Pdf;
+
+public class PdfFormModelSecurityTests {
+    [Fact]
+    public void PreflightCapabilityNumericContractsRemainStable() {
+        Assert.Equal(0, (int)PdfPreflightCapability.ExtractText);
+        Assert.Equal(1, (int)PdfPreflightCapability.ManipulatePages);
+        Assert.Equal(2, (int)PdfPreflightCapability.FillSimpleFormFields);
+        Assert.Equal(3, (int)PdfPreflightCapability.FlattenSimpleFormFields);
+        Assert.Equal(4, (int)PdfPreflightCapability.FillAndFlattenSimpleFormFields);
+        Assert.Equal(5, (int)PdfPreflightCapability.ExtractImages);
+        Assert.Equal(6, (int)PdfPreflightCapability.ReadLogicalObjects);
+        Assert.Equal(7, (int)PdfPreflightCapability.ExtractAttachments);
+        Assert.Equal(8, (int)PdfPreflightCapability.AppendMetadataRevision);
+        Assert.Equal(9, (int)PdfPreflightCapability.AppendFormFieldRevision);
+        Assert.Equal(10, (int)PdfPreflightCapability.PrepareExternalSignatureRevision);
+    }
+
+    [Fact]
+    public void FormFieldDerivedCollectionsRemainLinearAndPreserveOrder() {
+        var widgets = new List<PdfFormWidget>();
+        for (int pageNumber = 1; pageNumber <= 4096; pageNumber++) {
+            widgets.Add(new PdfFormWidget(pageNumber, "Choice", pageNumber, 0, 0, 10, 10, null, null));
+            widgets.Add(new PdfFormWidget(pageNumber + 4096, "Choice", pageNumber, 0, 0, 10, 10, null, null));
+        }
+
+        var values = new List<string>();
+        var options = new List<PdfFormFieldOption>();
+        for (int index = 0; index < 4096; index++) {
+            string value = "Value" + index.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            values.Add(value);
+            options.Add(new PdfFormFieldOption(value, "Display " + value));
+        }
+
+        var field = new PdfFormField(
+            objectNumber: 1,
+            name: "Choice",
+            partialName: "Choice",
+            fieldType: "Ch",
+            value: values[0],
+            alternateName: null,
+            mappingName: null,
+            flags: null,
+            values: values,
+            options: options,
+            widgets: widgets);
+
+        Assert.Equal(Enumerable.Range(1, 4096), field.PageNumbers);
+        Assert.Equal(options, field.SelectedOptions);
+    }
+
+    [Fact]
+    public void LogicalWidgetIndexBuildsEachWidgetOnceByPage() {
+        var fields = new List<PdfFormField>();
+        for (int fieldIndex = 0; fieldIndex < 1024; fieldIndex++) {
+            int pageNumber = fieldIndex % 16 + 1;
+            var widget = new PdfFormWidget(fieldIndex, "Field" + fieldIndex, pageNumber, 0, 0, 10, 10, null, null);
+            fields.Add(new PdfFormField(
+                objectNumber: fieldIndex,
+                name: "Field" + fieldIndex,
+                partialName: "Field" + fieldIndex,
+                fieldType: "Tx",
+                value: null,
+                alternateName: null,
+                mappingName: null,
+                flags: null,
+                widgets: new[] { widget }));
+        }
+
+        IReadOnlyDictionary<int, IReadOnlyList<PdfLogicalFormWidget>> index =
+            PdfLogicalDocument.IndexFormWidgetsByPageNumber(fields);
+
+        Assert.Equal(16, index.Count);
+        Assert.Equal(1024, index.Values.Sum(widgets => widgets.Count));
+        Assert.All(index, pair => Assert.All(pair.Value, widget => Assert.Equal(pair.Key, widget.PageNumber)));
+    }
+
+    [Fact]
+    public void StructuredLeaderRowsDeduplicateWithStableInsertionOrder() {
+        var page = new StructuredPage();
+        for (int index = 0; index < 4096; index++) {
+            Assert.True(page.TryAddLeaderRow("Label " + index, "Value " + index));
+        }
+
+        Assert.False(page.TryAddLeaderRow("Label 2048", "Value 2048"));
+        Assert.Equal(4096, page.LeaderRows.Count);
+        Assert.Equal(new[] { "Label 0", "Value 0" }, page.LeaderRows[0]);
+        Assert.Equal(new[] { "Label 4095", "Value 4095" }, page.LeaderRows[4095]);
+    }
+
+    [Fact]
+    public void XrefStreamRejectsOversizedFieldWidthsWithoutEnumeratingBytes() {
+        var widths = new PdfArray();
+        widths.Items.Add(new PdfNumber(int.MaxValue));
+        widths.Items.Add(new PdfNumber(int.MaxValue));
+        widths.Items.Add(new PdfNumber(3));
+        var dictionary = new PdfDictionary();
+        dictionary.Items["W"] = widths;
+        dictionary.Items["Size"] = new PdfNumber(1);
+        MethodInfo method = typeof(PdfSyntax).GetMethod(
+            "ReadXrefStreamEntries",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        var entries = (IEnumerable)method.Invoke(null, new object[] { dictionary, new byte[] { 0, 0, 0 } })!;
+
+        Assert.Empty(entries.Cast<object>());
+    }
+
+    [Fact]
+    public void LiteralStringUsesUnicodeEncodingBeforeLowBytesCanBecomePdfSyntax() {
+        string encoded = PdfSyntaxEscaper.LiteralString("\u0129 /Author \u0128Injected");
+
+        Assert.StartsWith("<", encoded, StringComparison.Ordinal);
+        Assert.EndsWith(">", encoded, StringComparison.Ordinal);
+        Assert.DoesNotContain(") /Author (", encoded, StringComparison.Ordinal);
+    }
+}

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfReaderAndFooterSupport.SingleStream.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfReaderAndFooterSupport.SingleStream.cs
@@ -49,8 +49,10 @@ public partial class PdfReaderAndFooterRegressionTests {
         return Encoding.ASCII.GetBytes(pdf);
     }
 
-    private static byte[] BuildPdfWithFontEncodingDifferences() {
-        const string streamContent = "BT\n/F1 12 Tf\n72 720 Td\n<4142434445> Tj\nET\n";
+    private static byte[] BuildPdfWithFontEncodingDifferences(
+        string differences = "65 /Z /space /Euro /uni0104 /A.alt",
+        string encodedText = "4142434445") {
+        string streamContent = "BT\n/F1 12 Tf\n72 720 Td\n<" + encodedText + "> Tj\nET\n";
         int streamLength = Encoding.ASCII.GetByteCount(streamContent);
 
         string pdf = string.Join("\n", new[] {
@@ -65,7 +67,7 @@ public partial class PdfReaderAndFooterRegressionTests {
             "<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>",
             "endobj",
             "4 0 obj",
-            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding << /BaseEncoding /WinAnsiEncoding /Differences [65 /Z /space /Euro /uni0104 /A.alt] >> >>",
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding << /BaseEncoding /WinAnsiEncoding /Differences [" + differences + "] >> >>",
             "endobj",
             "5 0 obj",
             $"<< /Length {streamLength} >>",

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfReaderAndFooterTextParserTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfReaderAndFooterTextParserTests.cs
@@ -237,6 +237,18 @@ public partial class PdfReaderAndFooterRegressionTests {
         Assert.Equal(PdfWriter.EstimateSimpleTextWidth("Z \u20AC\u0104A", PdfStandardFont.Helvetica, 12), span.Advance, 3);
     }
 
+    [Theory]
+    [InlineData("65 /uD800")]
+    [InlineData("65 /uDFFF")]
+    [InlineData("65 /uniD800")]
+    public void PdfReadPage_GetTextSpans_RejectsSurrogateGlyphNames(string differences) {
+        byte[] bytes = BuildPdfWithFontEncodingDifferences(differences, "41");
+
+        PdfTextSpan span = Assert.Single(PdfReadDocument.Open(bytes).Pages[0].GetTextSpans());
+
+        Assert.Equal("A", span.Text);
+    }
+
     [Fact]
     public void TextContentParser_AdvancesRunsThroughActiveTextMatrix() {
         const string content = "BT /F1 10 Tf 2 0 0 2 10 20 Tm (A) Tj (B) Tj ET";

--- a/OfficeIMO.Pdf/Model/PdfEmbeddedFontFamily.System.cs
+++ b/OfficeIMO.Pdf/Model/PdfEmbeddedFontFamily.System.cs
@@ -2,6 +2,8 @@ namespace OfficeIMO.Pdf;
 
 public sealed partial class PdfEmbeddedFontFamily {
     internal const int MaxSystemFontFilesToInspect = 8192;
+    internal const int MaxSystemFontDirectoriesToInspect = 512;
+    internal const int MaxSystemFontDirectoryDepth = 16;
     internal const long MaxSystemFontFileBytes = 128L * 1024L * 1024L;
     internal const int MaxSystemFontFamilyCacheEntries = 32;
     private static readonly System.Collections.Generic.Dictionary<string, System.Lazy<SystemFontFamilyCacheEntry>> SystemFontFamilyCache =
@@ -130,7 +132,9 @@ public sealed partial class PdfEmbeddedFontFamily {
 
         try {
             var fileInfo = new System.IO.FileInfo(path);
-            if (!fileInfo.Exists || fileInfo.Length > MaxSystemFontFileBytes) {
+            if (!fileInfo.Exists ||
+                (fileInfo.Attributes & System.IO.FileAttributes.ReparsePoint) != 0 ||
+                fileInfo.Length > MaxSystemFontFileBytes) {
                 return false;
             }
 
@@ -396,51 +400,93 @@ public sealed partial class PdfEmbeddedFontFamily {
         yield return "/System/Library/Fonts";
     }
 
-    private static System.Collections.Generic.IEnumerable<string> EnumerateTrueTypeFontFiles(string root) {
-        var directories = new System.Collections.Generic.Stack<string>();
-        directories.Push(root);
+    internal static System.Collections.Generic.IEnumerable<string> EnumerateTrueTypeFontFiles(string root) {
+        var directories = new System.Collections.Generic.Stack<(string Path, int Depth)>();
+        var seenDirectories = new System.Collections.Generic.HashSet<string>(System.StringComparer.OrdinalIgnoreCase);
+        directories.Push((root, 0));
+        int inspectedDirectories = 0;
 
-        while (directories.Count > 0) {
-            string current = directories.Pop();
-            string[] files;
+        while (directories.Count > 0 && inspectedDirectories < MaxSystemFontDirectoriesToInspect) {
+            (string current, int depth) = directories.Pop();
+            string canonicalPath;
             try {
-                files = GetTrueTypeFontFiles(current);
+                canonicalPath = System.IO.Path.GetFullPath(current);
+                var directoryInfo = new System.IO.DirectoryInfo(canonicalPath);
+                if (!directoryInfo.Exists ||
+                    (directoryInfo.Attributes & System.IO.FileAttributes.ReparsePoint) != 0 ||
+                    !seenDirectories.Add(canonicalPath)) {
+                    continue;
+                }
+            } catch (System.Exception exception) when (
+                exception is System.IO.IOException ||
+                exception is System.UnauthorizedAccessException ||
+                exception is System.NotSupportedException ||
+                exception is System.ArgumentException) {
+                continue;
+            }
+
+            inspectedDirectories++;
+            System.Collections.Generic.IEnumerable<string> files;
+            try {
+                files = System.IO.Directory.EnumerateFiles(canonicalPath);
+            } catch (System.Exception exception) when (
+                exception is System.IO.IOException ||
+                exception is System.UnauthorizedAccessException) {
+                files = System.Array.Empty<string>();
+            }
+
+            using (System.Collections.Generic.IEnumerator<string> enumerator = files.GetEnumerator()) {
+                while (true) {
+                    string file;
+                    try {
+                        if (!enumerator.MoveNext()) {
+                            break;
+                        }
+
+                        file = enumerator.Current;
+                    } catch (System.Exception exception) when (
+                        exception is System.IO.IOException ||
+                        exception is System.UnauthorizedAccessException) {
+                        break;
+                    }
+
+                    string extension = System.IO.Path.GetExtension(file);
+                    if (string.Equals(extension, ".ttf", System.StringComparison.OrdinalIgnoreCase) ||
+                        string.Equals(extension, ".ttc", System.StringComparison.OrdinalIgnoreCase)) {
+                        yield return file;
+                    }
+                }
+            }
+
+            if (depth >= MaxSystemFontDirectoryDepth) {
+                continue;
+            }
+
+            System.Collections.Generic.IEnumerable<string> children;
+            try {
+                children = System.IO.Directory.EnumerateDirectories(canonicalPath);
             } catch (System.Exception exception) when (
                 exception is System.IO.IOException ||
                 exception is System.UnauthorizedAccessException) {
                 continue;
             }
 
-            for (int i = 0; i < files.Length; i++) {
-                yield return files[i];
-            }
+            using (System.Collections.Generic.IEnumerator<string> enumerator = children.GetEnumerator()) {
+                while (directories.Count + inspectedDirectories < MaxSystemFontDirectoriesToInspect) {
+                    try {
+                        if (!enumerator.MoveNext()) {
+                            break;
+                        }
 
-            string[] children;
-            try {
-                children = System.IO.Directory.GetDirectories(current);
-            } catch (System.Exception exception) when (
-                exception is System.IO.IOException ||
-                exception is System.UnauthorizedAccessException) {
-                continue;
-            }
-
-            for (int i = 0; i < children.Length; i++) {
-                directories.Push(children[i]);
+                        directories.Push((enumerator.Current, depth + 1));
+                    } catch (System.Exception exception) when (
+                        exception is System.IO.IOException ||
+                        exception is System.UnauthorizedAccessException) {
+                        break;
+                    }
+                }
             }
         }
-    }
-
-    private static string[] GetTrueTypeFontFiles(string root) {
-        string[] trueTypeFiles = System.IO.Directory.GetFiles(root, "*.ttf");
-        string[] collectionFiles = System.IO.Directory.GetFiles(root, "*.ttc");
-        if (collectionFiles.Length == 0) {
-            return trueTypeFiles;
-        }
-
-        string[] files = new string[trueTypeFiles.Length + collectionFiles.Length];
-        System.Array.Copy(trueTypeFiles, 0, files, 0, trueTypeFiles.Length);
-        System.Array.Copy(collectionFiles, 0, files, trueTypeFiles.Length, collectionFiles.Length);
-        return files;
     }
 
     private static bool TryReadTrueTypeNameMetadata(byte[] data, out TrueTypeNameMetadata? metadata) {

--- a/OfficeIMO.Pdf/Model/PdfOpenTypeFontInspector.cs
+++ b/OfficeIMO.Pdf/Model/PdfOpenTypeFontInspector.cs
@@ -182,6 +182,7 @@ public static class PdfOpenTypeFontInspector {
         int idDeltaOffset = startCodeOffset + segCount * 2;
         int idRangeOffsetOffset = idDeltaOffset + segCount * 2;
         var map = new Dictionary<int, int>();
+        int processedMappings = 0;
 
         for (int segment = 0; segment < segCount; segment++) {
             int endCode = ReadUInt16(data, endCodeOffset + segment * 2);
@@ -192,6 +193,17 @@ public static class PdfOpenTypeFontInspector {
             if (startCode == 0xFFFF && endCode == 0xFFFF) {
                 continue;
             }
+
+            int mappingCount = endCode >= startCode ? endCode - startCode + 1 : 0;
+            if (mappingCount == 0) {
+                continue;
+            }
+
+            if (mappingCount > MaxUnicodeCMapMappings || processedMappings > MaxUnicodeCMapMappings - mappingCount) {
+                throw new NotSupportedException("OpenType Unicode cmap mapping count exceeds supported limits.");
+            }
+
+            processedMappings += mappingCount;
 
             for (int code = startCode; code <= endCode && code <= 0xFFFF; code++) {
                 int glyphId;
@@ -232,6 +244,7 @@ public static class PdfOpenTypeFontInspector {
         }
 
         var map = new Dictionary<int, int>();
+        int processedMappings = 0;
         int groupOffset = offset + 16;
         for (uint group = 0; group < groupCount; group++) {
             uint startCharCode = ReadUInt32(data, groupOffset);
@@ -243,9 +256,11 @@ public static class PdfOpenTypeFontInspector {
             }
 
             uint mappingCount = endCharCode - startCharCode + 1U;
-            if (mappingCount > MaxUnicodeCMapMappings || map.Count > MaxUnicodeCMapMappings - (int)mappingCount) {
+            if (mappingCount > MaxUnicodeCMapMappings || processedMappings > MaxUnicodeCMapMappings - (int)mappingCount) {
                 throw new NotSupportedException("OpenType Unicode cmap mapping count exceeds supported limits.");
             }
+
+            processedMappings += (int)mappingCount;
 
             for (uint code = startCharCode; code <= endCharCode; code++) {
                 uint glyph = startGlyphId + (code - startCharCode);

--- a/OfficeIMO.Pdf/Options/PdfResourcePolicy.cs
+++ b/OfficeIMO.Pdf/Options/PdfResourcePolicy.cs
@@ -30,6 +30,7 @@ public sealed class PdfResourcePolicy {
     /// </summary>
     public static PdfResourcePolicy CreateTrustedHost() => new PdfResourcePolicy {
         AllowSystemFontEmbedding = true,
+        AllowDocumentFontEmbedding = true,
         AllowLocalFileAccess = true,
         AllowRemoteResourceResolution = true,
         AllowDataUris = true,
@@ -38,6 +39,12 @@ public sealed class PdfResourcePolicy {
 
     /// <summary>When true, converters may load and embed installed system fonts. Enabled by the balanced default.</summary>
     public bool AllowSystemFontEmbedding { get; set; }
+
+    /// <summary>
+    /// When true, Office converters may use font family names from the source document to locate and embed installed
+    /// system fonts. Disabled by default because document-controlled names must not trigger host font disclosure.
+    /// </summary>
+    public bool AllowDocumentFontEmbedding { get; set; }
 
     /// <summary>When true, format-specific local-resource options may read files from explicitly allowed locations.</summary>
     public bool AllowLocalFileAccess { get; set; }
@@ -54,6 +61,7 @@ public sealed class PdfResourcePolicy {
     /// <summary>Creates an independent policy snapshot.</summary>
     public PdfResourcePolicy Clone() => new PdfResourcePolicy {
         AllowSystemFontEmbedding = AllowSystemFontEmbedding,
+        AllowDocumentFontEmbedding = AllowDocumentFontEmbedding,
         AllowLocalFileAccess = AllowLocalFileAccess,
         AllowRemoteResourceResolution = AllowRemoteResourceResolution,
         AllowDataUris = AllowDataUris,

--- a/OfficeIMO.Pdf/Reading/Core/PdfSyntax.Xref.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfSyntax.Xref.cs
@@ -552,8 +552,12 @@ internal static partial class PdfSyntax {
         int w0 = GetNonNegativeInt(widthsArray.Items[0]);
         int w1 = GetNonNegativeInt(widthsArray.Items[1]);
         int w2 = GetNonNegativeInt(widthsArray.Items[2]);
-        int entryWidth = w0 + w1 + w2;
-        if (entryWidth <= 0) {
+        if (w0 > sizeof(long) || w1 > sizeof(long) || w2 > sizeof(long)) {
+            yield break;
+        }
+
+        int entryWidth = checked(w0 + w1 + w2);
+        if (entryWidth <= 0 || entryWidth > data.Length) {
             yield break;
         }
 
@@ -561,7 +565,7 @@ internal static partial class PdfSyntax {
         int dataOffset = 0;
         foreach (var range in ranges) {
             for (int i = 0; i < range.Count; i++) {
-                if (dataOffset + entryWidth > data.Length) {
+                if (dataOffset > data.Length - entryWidth) {
                     yield break;
                 }
 

--- a/OfficeIMO.Pdf/Reading/Core/ResourceResolver.cs
+++ b/OfficeIMO.Pdf/Reading/Core/ResourceResolver.cs
@@ -800,7 +800,8 @@ internal static partial class ResourceResolver {
             (glyphName.Length - 3) % 4 == 0) {
             var builder = new System.Text.StringBuilder((glyphName.Length - 3) / 4);
             for (int i = 3; i < glyphName.Length; i += 4) {
-                if (!TryParseHexCodePoint(glyphName.Substring(i, 4), out int codePoint)) {
+                if (!TryParseHexCodePoint(glyphName.Substring(i, 4), out int codePoint) ||
+                    !IsValidUnicodeScalar(codePoint)) {
                     return false;
                 }
 
@@ -815,7 +816,7 @@ internal static partial class ResourceResolver {
             glyphName.Length <= 7 &&
             glyphName[0] == 'u' &&
             TryParseHexCodePoint(glyphName.Substring(1), out int scalar) &&
-            scalar <= 0x10FFFF) {
+            IsValidUnicodeScalar(scalar)) {
 #if NET5_0_OR_GREATER
             value = char.ConvertFromUtf32(scalar);
 #else
@@ -826,6 +827,9 @@ internal static partial class ResourceResolver {
 
         return false;
     }
+
+    private static bool IsValidUnicodeScalar(int value) =>
+        value >= 0 && value <= 0x10FFFF && (value < 0xD800 || value > 0xDFFF);
 
     private static bool TryParseHexCodePoint(string text, out int value) {
         value = 0;

--- a/OfficeIMO.Pdf/Reading/Font/ToUnicodeCMap.cs
+++ b/OfficeIMO.Pdf/Reading/Font/ToUnicodeCMap.cs
@@ -7,13 +7,16 @@ internal sealed class ToUnicodeCMap {
     private const int MaxRangeMappings = 4096;
     private const int MaxSourceCodeBytes = 4;
     private const int MaxDestinationTextCharacters = 4096;
+    private const int MaxReverseMappingTextCharacters = 64;
+    private const int MaxReverseMapNodes = 65536;
     private const int MaxDestinationHexCharactersWithWhitespace = MaxDestinationTextCharacters * 8;
 
     private readonly Dictionary<string, string> _map = new(StringComparer.OrdinalIgnoreCase);
-    private readonly Dictionary<string, string> _reverseMap = new(StringComparer.Ordinal);
+    private readonly ReverseMapNode _reverseMapRoot = new();
     private int _maxKeyBytes = 1;
-    private int _maxReverseTextLength = 1;
     private int _processedMappings;
+    private int _reverseMapNodeCount = 1;
+    private bool _reverseMapBudgetExhausted;
 
     public static bool TryParse(byte[] data, out ToUnicodeCMap? cmap) {
         try {
@@ -119,12 +122,16 @@ internal sealed class ToUnicodeCMap {
         // dst may be multi-codepoints; keep as UTF-16 string
         string s = HexToString(dstHex);
         _map[key] = s;
-        if (s.Length > 0) {
-            _maxReverseTextLength = Math.Max(_maxReverseTextLength, s.Length);
-        }
+        if (!_reverseMapBudgetExhausted && s.Length > 0 && s.Length <= MaxReverseMappingTextCharacters) {
+            ReverseMapNode node = _reverseMapRoot;
+            for (int index = 0; index < s.Length; index++) {
+                if (!node.TryGetOrAdd(s[index], ref _reverseMapNodeCount, MaxReverseMapNodes, out node)) {
+                    _reverseMapBudgetExhausted = true;
+                    return;
+                }
+            }
 
-        if (!_reverseMap.ContainsKey(s)) {
-            _reverseMap[s] = key;
+            node.CodeHex ??= key;
         }
     }
 
@@ -233,12 +240,16 @@ internal sealed class ToUnicodeCMap {
         for (int index = 0; index < text.Length;) {
             string? codeHex = null;
             int matchedLength = 0;
-            int maxLength = Math.Min(_maxReverseTextLength, text.Length - index);
-            for (int length = maxLength; length >= 1; length--) {
-                string candidate = text.Substring(index, length);
-                if (_reverseMap.TryGetValue(candidate, out codeHex)) {
-                    matchedLength = length;
+            ReverseMapNode node = _reverseMapRoot;
+            int maxLength = Math.Min(MaxReverseMappingTextCharacters, text.Length - index);
+            for (int length = 1; length <= maxLength; length++) {
+                if (!node.TryGet(text[index + length - 1], out node)) {
                     break;
+                }
+
+                if (node.CodeHex != null) {
+                    codeHex = node.CodeHex;
+                    matchedLength = length;
                 }
             }
 
@@ -255,16 +266,44 @@ internal sealed class ToUnicodeCMap {
         return true;
     }
 
+    private sealed class ReverseMapNode {
+        private Dictionary<char, ReverseMapNode>? _children;
+
+        internal string? CodeHex { get; set; }
+
+        internal bool TryGetOrAdd(char value, ref int nodeCount, int maximumNodes, out ReverseMapNode child) {
+            if (_children != null && _children.TryGetValue(value, out ReverseMapNode? existing)) {
+                child = existing;
+                return true;
+            }
+
+            if (nodeCount >= maximumNodes) {
+                child = null!;
+                return false;
+            }
+
+            _children ??= new Dictionary<char, ReverseMapNode>();
+            child = new ReverseMapNode();
+            _children[value] = child;
+            nodeCount++;
+            return true;
+        }
+
+        internal bool TryGet(char value, out ReverseMapNode child) {
+            if (_children != null && _children.TryGetValue(value, out ReverseMapNode? match)) {
+                child = match;
+                return true;
+            }
+
+            child = null!;
+            return false;
+        }
+    }
+
     private static string ByteSliceToHex(byte[] b, int start, int len) {
         var sb = new System.Text.StringBuilder(len * 2);
         for (int i = 0; i < len; i++) sb.Append(b[start + i].ToString("X2", System.Globalization.CultureInfo.InvariantCulture));
         return sb.ToString();
     }
 
-    private static int GetScalarLength(string value, int index) =>
-        char.IsHighSurrogate(value[index]) &&
-        index + 1 < value.Length &&
-        char.IsLowSurrogate(value[index + 1])
-            ? 2
-            : 1;
 }

--- a/OfficeIMO.Pdf/Reading/Layout/ContentStructureExtractor.cs
+++ b/OfficeIMO.Pdf/Reading/Layout/ContentStructureExtractor.cs
@@ -16,6 +16,7 @@ namespace OfficeIMO.Pdf;
 /// - Tables: simple rows detected via large X gaps (heuristic)
 /// </summary>
 public sealed class StructuredPage {
+    private readonly HashSet<(string Label, string Value)> _leaderRowKeys = new();
     /// <summary>Plain text lines in natural reading order.</summary>
     public List<string> Lines { get; } = new();
     /// <summary>TOC entries: title + page number.</summary>
@@ -24,6 +25,15 @@ public sealed class StructuredPage {
     public List<string> ListItems { get; } = new();
     /// <summary>Leader rows split into label and trailing value.</summary>
     public List<string[]> LeaderRows { get; } = new();
+
+    internal bool TryAddLeaderRow(string label, string value) {
+        if (!_leaderRowKeys.Add((label, value))) {
+            return false;
+        }
+
+        LeaderRows.Add(new[] { label, value });
+        return true;
+    }
     /// <summary>Detected list nodes with hierarchical level.</summary>
     public List<StructuredListItem> ListNodes { get; } = new();
     /// <summary>Per-line geometry details (Y, XStart, XEnd, Text, Spans).</summary>
@@ -554,15 +564,7 @@ internal static class ContentStructureExtractor {
             return;
         }
 
-        foreach (var row in page.LeaderRows) {
-            if (row.Length >= 2 &&
-                string.Equals(row[0], label, StringComparison.Ordinal) &&
-                string.Equals(row[1], value, StringComparison.Ordinal)) {
-                return;
-            }
-        }
-
-        page.LeaderRows.Add(new[] { label, value });
+        page.TryAddLeaderRow(label, value);
     }
 
     private static bool TryParseTocRow(string text, out string label, out int pageNumber) {

--- a/OfficeIMO.Pdf/Reading/Logical/PdfLogicalDocument.cs
+++ b/OfficeIMO.Pdf/Reading/Logical/PdfLogicalDocument.cs
@@ -272,15 +272,17 @@ public sealed partial class PdfLogicalDocument {
             }
 
             var grouped = new Dictionary<int, List<PdfFormField>>();
+            var memberships = new Dictionary<int, HashSet<PdfFormField>>();
             IReadOnlyList<PdfLogicalFormWidget> widgets = FormWidgets;
             for (int i = 0; i < widgets.Count; i++) {
                 PdfLogicalFormWidget widget = widgets[i];
                 if (!grouped.TryGetValue(widget.PageNumber, out List<PdfFormField>? pageFields)) {
                     pageFields = new List<PdfFormField>();
                     grouped.Add(widget.PageNumber, pageFields);
+                    memberships.Add(widget.PageNumber, new HashSet<PdfFormField>());
                 }
 
-                if (!pageFields.Contains(widget.Field)) {
+                if (memberships[widget.PageNumber].Add(widget.Field)) {
                     pageFields.Add(widget.Field);
                 }
             }
@@ -978,11 +980,14 @@ public sealed partial class PdfLogicalDocument {
         PdfDocumentOpenAction? openAction = useDocumentWideObjects
             ? document.OpenAction
             : PdfPageRangeObjectFilter.FilterOpenActionByPageNumbers(document.OpenAction, pageNumbers);
+        IReadOnlyDictionary<int, IReadOnlyList<PdfLogicalFormWidget>> formWidgetsByPageNumber =
+            IndexFormWidgetsByPageNumber(formFields);
 
         var pages = new List<PdfLogicalPage>(pageNumbers.Length);
         for (int i = 0; i < pageNumbers.Length; i++) {
             int pageNumber = pageNumbers[i];
-            pages.Add(PdfLogicalPage.From(document, document.Pages[pageNumber - 1], pageNumber, options, formFields));
+            formWidgetsByPageNumber.TryGetValue(pageNumber, out IReadOnlyList<PdfLogicalFormWidget>? pageFormWidgets);
+            pages.Add(PdfLogicalPage.From(document, document.Pages[pageNumber - 1], pageNumber, options, pageFormWidgets));
         }
 
         return new PdfLogicalDocument(
@@ -1010,6 +1015,35 @@ public sealed partial class PdfLogicalDocument {
             document.CatalogPageLayout,
             document.CatalogVersion,
             document.CatalogLanguage);
+    }
+
+    internal static IReadOnlyDictionary<int, IReadOnlyList<PdfLogicalFormWidget>> IndexFormWidgetsByPageNumber(
+        IReadOnlyList<PdfFormField> formFields) {
+        var grouped = new Dictionary<int, List<PdfLogicalFormWidget>>();
+        for (int fieldIndex = 0; fieldIndex < formFields.Count; fieldIndex++) {
+            PdfFormField field = formFields[fieldIndex];
+            for (int widgetIndex = 0; widgetIndex < field.Widgets.Count; widgetIndex++) {
+                PdfFormWidget widget = field.Widgets[widgetIndex];
+                if (!widget.PageNumber.HasValue) {
+                    continue;
+                }
+
+                int pageNumber = widget.PageNumber.Value;
+                if (!grouped.TryGetValue(pageNumber, out List<PdfLogicalFormWidget>? pageWidgets)) {
+                    pageWidgets = new List<PdfLogicalFormWidget>();
+                    grouped.Add(pageNumber, pageWidgets);
+                }
+
+                pageWidgets.Add(new PdfLogicalFormWidget(pageNumber, field, widget));
+            }
+        }
+
+        var result = new Dictionary<int, IReadOnlyList<PdfLogicalFormWidget>>();
+        foreach (var item in grouped) {
+            result.Add(item.Key, item.Value.AsReadOnly());
+        }
+
+        return new System.Collections.ObjectModel.ReadOnlyDictionary<int, IReadOnlyList<PdfLogicalFormWidget>>(result);
     }
 
     private static PdfFormFieldTextAlignment ToTextAlignment(int? quadding) {

--- a/OfficeIMO.Pdf/Reading/Logical/PdfLogicalPage.cs
+++ b/OfficeIMO.Pdf/Reading/Logical/PdfLogicalPage.cs
@@ -184,7 +184,7 @@ public sealed class PdfLogicalPage {
     /// <summary>True when the source page dictionary has page-level additional actions.</summary>
     public bool HasPageActions => PageActionCount > 0;
 
-    internal static PdfLogicalPage From(PdfReadDocument document, PdfReadPage page, int pageNumber, PdfTextLayoutOptions? options, IReadOnlyList<PdfFormField>? formFields = null) {
+    internal static PdfLogicalPage From(PdfReadDocument document, PdfReadPage page, int pageNumber, PdfTextLayoutOptions? options, IReadOnlyList<PdfLogicalFormWidget>? pageFormWidgets = null) {
         var size = page.GetPageSize();
         PdfPageGeometry geometry = page.GetGeometry();
         var structured = page.ExtractStructured(options);
@@ -250,17 +250,11 @@ public sealed class PdfLogicalPage {
             annotations.Add(readAnnotations[i].WithPageNumber(pageNumber));
         }
 
-        if (formFields is not null) {
-            for (int fieldIndex = 0; fieldIndex < formFields.Count; fieldIndex++) {
-                PdfFormField field = formFields[fieldIndex];
-                for (int widgetIndex = 0; widgetIndex < field.Widgets.Count; widgetIndex++) {
-                    PdfFormWidget widget = field.Widgets[widgetIndex];
-                    if (widget.PageNumber == pageNumber) {
-                        var logicalWidget = new PdfLogicalFormWidget(pageNumber, field, widget);
-                        formWidgets.Add(logicalWidget);
-                        elements.Add(logicalWidget);
-                    }
-                }
+        if (pageFormWidgets is not null) {
+            for (int widgetIndex = 0; widgetIndex < pageFormWidgets.Count; widgetIndex++) {
+                PdfLogicalFormWidget logicalWidget = pageFormWidgets[widgetIndex];
+                formWidgets.Add(logicalWidget);
+                elements.Add(logicalWidget);
             }
         }
 

--- a/OfficeIMO.Pdf/Reading/Model/PdfDocumentInfo.cs
+++ b/OfficeIMO.Pdf/Reading/Model/PdfDocumentInfo.cs
@@ -566,6 +566,7 @@ public sealed partial class PdfDocumentInfo {
             }
 
             var grouped = new Dictionary<int, List<PdfFormField>>();
+            var memberships = new Dictionary<int, HashSet<PdfFormField>>();
             for (int i = 0; i < FormFields.Count; i++) {
                 PdfFormField formField = FormFields[i];
                 for (int j = 0; j < formField.Widgets.Count; j++) {
@@ -577,9 +578,10 @@ public sealed partial class PdfDocumentInfo {
                     if (!grouped.TryGetValue(pageNumber.Value, out List<PdfFormField>? fields)) {
                         fields = new List<PdfFormField>();
                         grouped.Add(pageNumber.Value, fields);
+                        memberships.Add(pageNumber.Value, new HashSet<PdfFormField>());
                     }
 
-                    if (!fields.Contains(formField)) {
+                    if (memberships[pageNumber.Value].Add(formField)) {
                         fields.Add(formField);
                     }
                 }

--- a/OfficeIMO.Pdf/Reading/Model/PdfFormField.cs
+++ b/OfficeIMO.Pdf/Reading/Model/PdfFormField.cs
@@ -308,9 +308,10 @@ public sealed class PdfFormField {
             }
 
             var pages = new List<int>();
+            var seenPages = new HashSet<int>();
             for (int i = 0; i < Widgets.Count; i++) {
                 int? pageNumber = Widgets[i].PageNumber;
-                if (!pageNumber.HasValue || pages.Contains(pageNumber.Value)) {
+                if (!pageNumber.HasValue || !seenPages.Add(pageNumber.Value)) {
                     continue;
                 }
 
@@ -381,13 +382,11 @@ public sealed class PdfFormField {
         }
 
         var selected = new List<PdfFormFieldOption>();
+        var selectedValues = new HashSet<string>(values, StringComparer.Ordinal);
         for (int i = 0; i < options.Count; i++) {
             PdfFormFieldOption option = options[i];
-            for (int j = 0; j < values.Count; j++) {
-                if (string.Equals(option.ExportValue, values[j], StringComparison.Ordinal)) {
-                    selected.Add(option);
-                    break;
-                }
+            if (selectedValues.Contains(option.ExportValue)) {
+                selected.Add(option);
             }
         }
 

--- a/OfficeIMO.Pdf/Reading/Model/PdfPreflightCapability.cs
+++ b/OfficeIMO.Pdf/Reading/Model/PdfPreflightCapability.cs
@@ -5,35 +5,35 @@ namespace OfficeIMO.Pdf;
 /// </summary>
 public enum PdfPreflightCapability {
     /// <summary>Text and structured text readback operations.</summary>
-    ExtractText,
+    ExtractText = 0,
 
     /// <summary>Image XObject extraction operations.</summary>
-    ExtractImages,
+    ExtractImages = 5,
 
     /// <summary>Embedded-file and associated-file attachment extraction operations.</summary>
-    ExtractAttachments,
+    ExtractAttachments = 7,
 
     /// <summary>Page-level rewrite operations such as extract, split, merge, import, edit, stamp, and metadata updates.</summary>
-    ManipulatePages,
+    ManipulatePages = 1,
 
     /// <summary>Append-only metadata revision updates that preserve the existing PDF bytes.</summary>
-    AppendMetadataRevision,
+    AppendMetadataRevision = 8,
 
     /// <summary>Append-only AcroForm field-value revision updates that preserve the existing PDF bytes.</summary>
-    AppendFormFieldRevision,
+    AppendFormFieldRevision = 9,
 
     /// <summary>Append-only external-signature placeholder revision preparation.</summary>
-    PrepareExternalSignatureRevision,
+    PrepareExternalSignatureRevision = 10,
 
     /// <summary>Simple AcroForm value updates for named text, choice, or button fields.</summary>
-    FillSimpleFormFields,
+    FillSimpleFormFields = 2,
 
     /// <summary>Simple AcroForm flattening for named text, choice, or button widgets with page-backed rectangles.</summary>
-    FlattenSimpleFormFields,
+    FlattenSimpleFormFields = 3,
 
     /// <summary>Simple AcroForm value updates followed by simple widget flattening.</summary>
-    FillAndFlattenSimpleFormFields,
+    FillAndFlattenSimpleFormFields = 4,
 
     /// <summary>Logical object readback through <see cref="PdfLogicalDocument"/>.</summary>
-    ReadLogicalObjects
+    ReadLogicalObjects = 6
 }

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfSyntaxEscaper.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfSyntaxEscaper.cs
@@ -19,6 +19,13 @@ internal static class PdfSyntaxEscaper {
     }
 
     internal static string LiteralString(string value) {
+        Guard.NotNull(value, nameof(value));
+        for (int index = 0; index < value.Length; index++) {
+            if (value[index] > byte.MaxValue) {
+                return TextString(value);
+            }
+        }
+
         return "(" + EscapeLiteralContent(value) + ")";
     }
 

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Canvas.Table.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Canvas.Table.cs
@@ -4,6 +4,8 @@ namespace OfficeIMO.Pdf;
 
 internal static partial class PdfWriter {
     private sealed partial class LayoutContext {
+        private const long MaximumCanvasTableGridCells = 262144;
+
         private void RenderCanvasTable(PdfCanvasTableItem item) {
             ValidateCanvasBox(item.X, item.Y, item.Width, item.Height, "Canvas table");
             TableBlock table = item.Block;
@@ -11,6 +13,11 @@ internal static partial class PdfWriter {
             int rows = table.Cells.Count;
             if (columns == 0 || rows == 0) {
                 return;
+            }
+
+            long gridCells = (long)columns * rows;
+            if (gridCells > MaximumCanvasTableGridCells) {
+                throw new InvalidOperationException($"Canvas table grid contains {gridCells} logical cells, exceeding the supported limit of {MaximumCanvasTableGridCells}.");
             }
 
             PdfTableStyle style = table.Style ?? currentOpts.DefaultTableStyleSnapshot ?? TableStyles.Light();
@@ -23,6 +30,7 @@ internal static partial class PdfWriter {
             int footerStart = rows - style.FooterRowCount;
             double[] columnWidths = ResolveCanvasTableColumnWidths(style, columns, item.Width, columnGap);
             double[] rowHeights = ResolveCanvasTableRowHeights(style, rows, item.Height, rowGap);
+            System.Collections.Generic.List<TableCellLayout>[] cellLayoutsByRow = GetTableCellLayoutsByRow(table, columns);
             var rowFontSizes = new double[rows];
             var rowFontSizeScales = new double[rows];
             var rowLeadings = new double[rows];
@@ -57,7 +65,7 @@ internal static partial class PdfWriter {
                 bool[] rowFillSkips = GetRowSpanContinuationSkipColumns(table, rowIndex, columns);
                 DrawCanvasTableRowBackground(style, rowIndex, rowIsHeader, rowIsFooter, xOrigin, rowBottom, columnWidths, columnGap, rowFillSkips, rowHeights[rowIndex]);
 
-                var cells = GetTableCellLayouts(table, rowIndex, columns);
+                var cells = cellLayoutsByRow[rowIndex];
                 for (int cellIndex = 0; cellIndex < cells.Count; cellIndex++) {
                     TableCellLayout cell = cells[cellIndex];
                     double cellX = xOrigin + GetCanvasTableColumnsOffset(columnWidths, cell.Column, columnGap);
@@ -118,7 +126,7 @@ internal static partial class PdfWriter {
             }
 
             if (style.BorderColor is not null && style.BorderWidth > 0D) {
-                DrawCanvasTableGrid(table, style, columns, rows, xOrigin, topY, tableHeight, columnWidths, rowHeights, columnGap, rowGap);
+                DrawCanvasTableGrid(table, style, columns, rows, xOrigin, topY, tableHeight, columnWidths, rowHeights, columnGap, rowGap, cellLayoutsByRow);
             }
 
             if (rotated) {
@@ -378,17 +386,18 @@ internal static partial class PdfWriter {
             }
         }
 
-        private void DrawCanvasTableGrid(TableBlock table, PdfTableStyle style, int columns, int rows, double x, double topY, double height, double[] columnWidths, double[] rowHeights, double columnGap, double rowGap) {
+        private void DrawCanvasTableGrid(TableBlock table, PdfTableStyle style, int columns, int rows, double x, double topY, double height, double[] columnWidths, double[] rowHeights, double columnGap, double rowGap, System.Collections.Generic.IReadOnlyList<TableCellLayout>[] cellLayoutsByRow) {
             PdfColor color = style.BorderColor!.Value;
             double width = style.BorderWidth;
             double tableWidth = GetTableCellWidth(columnWidths, 0, columns, columnGap);
             DrawRowRect(sb, color, width, x, topY - height, tableWidth, height, true);
+            bool[][] verticalBoundarySkips = GetCanvasTableVerticalBoundarySkips(cellLayoutsByRow, rows, columns);
 
             double lineX = x;
             for (int column = 0; column < columns - 1; column++) {
                 lineX += columnWidths[column];
                 for (int row = 0; row < rows; row++) {
-                    if (IsTableBoundaryInsideSpannedCell(table, row, column, columns)) {
+                    if (verticalBoundarySkips[column][row]) {
                         continue;
                     }
 
@@ -407,6 +416,38 @@ internal static partial class PdfWriter {
                 DrawTableHorizontalLine(sb, color, width, x, columnWidths, columnGap, lineY, skips, true);
                 lineY -= rowGap;
             }
+        }
+
+        private static bool[][] GetCanvasTableVerticalBoundarySkips(System.Collections.Generic.IReadOnlyList<TableCellLayout>[] cellLayoutsByRow, int rows, int columns) {
+            var deltas = new int[Math.Max(0, columns - 1)][];
+            for (int boundary = 0; boundary < deltas.Length; boundary++) {
+                deltas[boundary] = new int[rows + 1];
+            }
+
+            for (int row = 0; row < rows; row++) {
+                System.Collections.Generic.IReadOnlyList<TableCellLayout> cells = cellLayoutsByRow[row];
+                for (int cellIndex = 0; cellIndex < cells.Count; cellIndex++) {
+                    TableCellLayout cell = cells[cellIndex];
+                    int endRow = Math.Min(rows, row + cell.RowSpan);
+                    int endBoundary = Math.Min(columns - 1, cell.Column + cell.ColumnSpan - 1);
+                    for (int boundary = cell.Column; boundary < endBoundary; boundary++) {
+                        deltas[boundary][row]++;
+                        deltas[boundary][endRow]--;
+                    }
+                }
+            }
+
+            var skips = new bool[deltas.Length][];
+            for (int boundary = 0; boundary < deltas.Length; boundary++) {
+                skips[boundary] = new bool[rows];
+                int active = 0;
+                for (int row = 0; row < rows; row++) {
+                    active += deltas[boundary][row];
+                    skips[boundary][row] = active > 0;
+                }
+            }
+
+            return skips;
         }
 
         private static double GetCanvasTableColumnsOffset(double[] columnWidths, int column, double columnGap) {

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.TableCells.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.TableCells.cs
@@ -619,6 +619,44 @@ internal static partial class PdfWriter {
         return targetCells;
     }
 
+    private static System.Collections.Generic.List<TableCellLayout>[] GetTableCellLayoutsByRow(TableBlock table, int columnCount) {
+        var layouts = new System.Collections.Generic.List<TableCellLayout>[table.Cells.Count];
+        var activeRowSpans = new int[columnCount];
+        for (int currentRow = 0; currentRow < table.Cells.Count; currentRow++) {
+            var rowLayouts = new System.Collections.Generic.List<TableCellLayout>();
+            layouts[currentRow] = rowLayouts;
+            int column = 0;
+            var row = table.Cells[currentRow];
+            for (int cellIndex = 0; cellIndex < row.Count && column < columnCount; cellIndex++) {
+                while (column < columnCount && activeRowSpans[column] > 0) {
+                    column++;
+                }
+
+                if (column >= columnCount) {
+                    break;
+                }
+
+                PdfTableCell cell = row[cellIndex];
+                int columnSpan = System.Math.Min(cell.ColumnSpan, columnCount - column);
+                int rowSpan = System.Math.Min(cell.RowSpan, table.Cells.Count - currentRow);
+                rowLayouts.Add(new TableCellLayout(column, columnSpan, rowSpan, cell.Text, cell.Runs, cell.Paragraphs, cell.LinkUri, cell.LinkDestinationName, cell.LinkContents, cell.NamedDestinationName, cell.CheckBoxes, cell.FormFields, cell.Images, cell.NoWrap));
+                for (int c = column; c < column + columnSpan; c++) {
+                    activeRowSpans[c] = System.Math.Max(activeRowSpans[c], rowSpan);
+                }
+
+                column += columnSpan;
+            }
+
+            for (int c = 0; c < activeRowSpans.Length; c++) {
+                if (activeRowSpans[c] > 0) {
+                    activeRowSpans[c]--;
+                }
+            }
+        }
+
+        return layouts;
+    }
+
     private static double GetTableCellWidth(double[] columnWidths, int column, int columnSpan, double columnGap) {
         double width = 0D;
         int lastColumn = System.Math.Min(columnWidths.Length, column + columnSpan);

--- a/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.Fonts.cs
+++ b/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.Fonts.cs
@@ -283,7 +283,8 @@ public static partial class PowerPointPdfConverterExtensions {
                 return;
             }
 
-            bool embedSystemFont = options.ResourcePolicy.AllowSystemFontEmbedding;
+            bool embedSystemFont = options.ResourcePolicy.AllowSystemFontEmbedding &&
+                options.ResourcePolicy.AllowDocumentFontEmbedding;
             if (embedSystemFont && pdfOptions.TryRegisterNamedOfficeFontFamily(trimmedFamilyName, out _)) {
                 return;
             }

--- a/OfficeIMO.PowerPoint/PowerPointSlide.InheritedShapes.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSlide.InheritedShapes.cs
@@ -18,21 +18,23 @@ namespace OfficeIMO.PowerPoint {
             SlideMasterPart? masterPart = layoutPart?.SlideMasterPart;
             List<PowerPointShape> layoutShapes = CreateInheritedShapes(layoutPart?.SlideLayout?.CommonSlideData?.ShapeTree, layoutPart);
             IReadOnlyList<PowerPointShape> slideShapes = Shapes;
+            var layoutOverrides = new PlaceholderOverrideIndex(layoutShapes);
+            var slideOverrides = new PlaceholderOverrideIndex(slideShapes);
 
             if (ShowsMasterShapes(layoutPart?.SlideLayout)) {
                 // Master placeholders define geometry and styles for concrete slide/layout
                 // placeholders. Their editing prompts are not inherited slide content.
                 foreach (PowerPointShape masterShape in CreateInheritedShapes(masterPart?.SlideMaster?.CommonSlideData?.ShapeTree, masterPart)) {
                     if (!IsStructuralPlaceholder(masterShape) &&
-                        !IsPlaceholderOverridden(masterShape, layoutShapes) &&
-                        !IsPlaceholderOverridden(masterShape, slideShapes)) {
+                        !layoutOverrides.ContainsMatch(masterShape) &&
+                        !slideOverrides.ContainsMatch(masterShape)) {
                         shapes.Add(masterShape);
                     }
                 }
             }
 
             foreach (PowerPointShape layoutShape in layoutShapes) {
-                if (!IsPlaceholderOverridden(layoutShape, slideShapes)) {
+                if (!slideOverrides.ContainsMatch(layoutShape)) {
                     shapes.Add(layoutShape);
                 }
             }
@@ -65,36 +67,68 @@ namespace OfficeIMO.PowerPoint {
         private static bool IsStructuralPlaceholder(PowerPointShape shape) =>
             TryGetPlaceholderSignature(shape, out _, out _);
 
-        private static bool IsPlaceholderOverridden(PowerPointShape inheritedShape, IReadOnlyList<PowerPointShape> overridingShapes) {
-            if (!TryGetPlaceholderSignature(inheritedShape, out PlaceholderValues? inheritedType, out uint? inheritedIndex)) {
-                return false;
-            }
-
-            foreach (PowerPointShape overridingShape in overridingShapes) {
-                if (TryGetPlaceholderSignature(overridingShape, out PlaceholderValues? overridingType, out uint? overridingIndex) &&
-                    PlaceholderSignaturesMatch(inheritedType, inheritedIndex, overridingType, overridingIndex)) {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
         private static bool TryGetPlaceholderSignature(PowerPointShape shape, out PlaceholderValues? type, out uint? index) {
             type = shape.ShapePlaceholderType;
             index = shape.ShapePlaceholderIndex;
             return type.HasValue || index.HasValue;
         }
 
-        private static bool PlaceholderSignaturesMatch(PlaceholderValues? inheritedType, uint? inheritedIndex, PlaceholderValues? overridingType, uint? overridingIndex) {
-            if (inheritedIndex.HasValue && overridingIndex.HasValue) {
-                return inheritedIndex.Value == overridingIndex.Value &&
-                    (!inheritedType.HasValue || !overridingType.HasValue || inheritedType.Value == overridingType.Value);
+        private sealed class PlaceholderOverrideIndex {
+            private readonly HashSet<uint> _indices = new();
+            private readonly HashSet<uint> _untypedIndices = new();
+            private readonly Dictionary<uint, HashSet<PlaceholderValues>> _typesByIndex = new();
+            private readonly HashSet<PlaceholderValues> _allTypes = new();
+            private readonly HashSet<PlaceholderValues> _typesWithoutIndex = new();
+
+            internal PlaceholderOverrideIndex(IReadOnlyList<PowerPointShape> shapes) {
+                for (int index = 0; index < shapes.Count; index++) {
+                    if (!TryGetPlaceholderSignature(shapes[index], out PlaceholderValues? type, out uint? placeholderIndex)) {
+                        continue;
+                    }
+
+                    if (type.HasValue) {
+                        _allTypes.Add(type.Value);
+                    }
+
+                    if (!placeholderIndex.HasValue) {
+                        if (type.HasValue) {
+                            _typesWithoutIndex.Add(type.Value);
+                        }
+
+                        continue;
+                    }
+
+                    _indices.Add(placeholderIndex.Value);
+                    if (!type.HasValue) {
+                        _untypedIndices.Add(placeholderIndex.Value);
+                    } else {
+                        if (!_typesByIndex.TryGetValue(placeholderIndex.Value, out HashSet<PlaceholderValues>? types)) {
+                            types = new HashSet<PlaceholderValues>();
+                            _typesByIndex.Add(placeholderIndex.Value, types);
+                        }
+
+                        types.Add(type.Value);
+                    }
+                }
             }
 
-            return inheritedType.HasValue &&
-                overridingType.HasValue &&
-                inheritedType.Value == overridingType.Value;
+            internal bool ContainsMatch(PowerPointShape inheritedShape) {
+                if (!TryGetPlaceholderSignature(inheritedShape, out PlaceholderValues? type, out uint? index)) {
+                    return false;
+                }
+
+                if (!index.HasValue) {
+                    return type.HasValue && _allTypes.Contains(type.Value);
+                }
+
+                if (!type.HasValue) {
+                    return _indices.Contains(index.Value);
+                }
+
+                return _typesWithoutIndex.Contains(type.Value) ||
+                    _untypedIndices.Contains(index.Value) ||
+                    (_typesByIndex.TryGetValue(index.Value, out HashSet<PlaceholderValues>? types) && types.Contains(type.Value));
+            }
         }
     }
 }

--- a/OfficeIMO.Visio.Tests/Visio.Stencils.cs
+++ b/OfficeIMO.Visio.Tests/Visio.Stencils.cs
@@ -1029,7 +1029,7 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
-        public void PackageStencilPreviewGalleryLinksSvgPreviewsWithoutInliningThem() {
+        public void PackageStencilPreviewGalleryStoresSvgPreviewsAsDownloadOnlyText() {
             string packagePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vssx");
             byte[] svg = Encoding.UTF8.GetBytes("<svg xmlns=\"http://www.w3.org/2000/svg\"><script>alert(1)</script><rect width=\"10\" height=\"10\"/></svg>");
             CreatePackageWithRawGroupMaster(packagePath, "FancyCloud", "Fancy Cloud", "svg", svg);
@@ -1052,14 +1052,15 @@ namespace OfficeIMO.Tests {
             Assert.False(entry.HasThumbnail);
             Assert.Equal(0, gallery.BrowserRenderableCount);
             Assert.Equal(0, gallery.ThumbnailCount);
-            Assert.Equal("assets/42-FancyCloud.svg", entry.RelativePath);
+            Assert.Equal("assets/42-FancyCloud.svg.txt", entry.RelativePath);
             Assert.True(File.Exists(entry.FilePath));
             Assert.Equal(svg, File.ReadAllBytes(entry.FilePath));
 
             string html = File.ReadAllText(gallery.IndexPath!);
-            Assert.Contains("assets/42-FancyCloud.svg", html);
+            Assert.Contains("<a download href=\"assets/42-FancyCloud.svg.txt\">", html);
             Assert.Contains("<div class=\"fallback\">svg</div>", html);
-            Assert.DoesNotContain("<img src=\"assets/42-FancyCloud.svg\"", html, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("href=\"assets/42-FancyCloud.svg\"", html, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("<img src=\"assets/42-FancyCloud.svg.txt\"", html, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain(".thumbnail.svg", html, StringComparison.OrdinalIgnoreCase);
         }
 

--- a/OfficeIMO.Visio.Tests/Visio.TimelineDiagramBuilder.cs
+++ b/OfficeIMO.Visio.Tests/Visio.TimelineDiagramBuilder.cs
@@ -9,6 +9,33 @@ using Xunit;
 namespace OfficeIMO.Tests {
     public class VisioTimelineDiagramBuilderTests {
         [Fact]
+        public void TimelineDiagramBuilderTracksLargeUniqueIdSetsWithoutRescanningItems() {
+            var builder = new VisioTimelineDiagramBuilder(VisioDocument.Create(), "Security Timeline");
+            DateTime date = new DateTime(2026, 1, 1);
+
+            for (int index = 0; index < 4096; index++) {
+                builder.Milestone("milestone-" + index, date, "Milestone " + index);
+            }
+
+            Assert.Throws<ArgumentException>(() => builder.Span(
+                "milestone-2048",
+                date,
+                date.AddDays(1),
+                "Duplicate"));
+        }
+
+        [Fact]
+        public void TimelineDiagramBuilderReleasesReplacedTitleId() {
+            var builder = new VisioTimelineDiagramBuilder(VisioDocument.Create(), "Security Timeline");
+            DateTime date = new DateTime(2026, 1, 1);
+
+            builder
+                .Title("Initial", id: "old-title")
+                .Title("Replacement", id: "new-title")
+                .Milestone("old-title", date, "Reused id");
+        }
+
+        [Fact]
         public void TimelineDiagramBuilderCreatesStyledRoadmapPage() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
 

--- a/OfficeIMO.Visio/Diagrams/VisioTimelineDiagramBuilder.cs
+++ b/OfficeIMO.Visio/Diagrams/VisioTimelineDiagramBuilder.cs
@@ -106,6 +106,8 @@ namespace OfficeIMO.Visio.Diagrams {
         private readonly List<SpanItem> _spans = new();
         private readonly Dictionary<string, SpanItem> _spansById = new(StringComparer.Ordinal);
         private readonly List<CalloutItem> _callouts = new();
+        private readonly HashSet<string> _shapeIds = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, int> _nextCalloutIndexByTarget = new(StringComparer.Ordinal);
         private VisioStyleTheme _theme = VisioStyleTheme.Modern();
         private VisioMeasurementUnit _unit = VisioMeasurementUnit.Inches;
         private DateTime? _startDate;
@@ -133,6 +135,9 @@ namespace OfficeIMO.Visio.Diagrams {
         internal VisioTimelineDiagramBuilder(VisioDocument document, string pageName) {
             _document = document ?? throw new ArgumentNullException(nameof(document));
             _pageName = string.IsNullOrWhiteSpace(pageName) ? "Timeline" : pageName;
+            _shapeIds.Add("timeline-axis");
+            _shapeIds.Add("timeline-start-label");
+            _shapeIds.Add("timeline-end-label");
         }
 
         /// <summary>Sets the page size used by the generated timeline page.</summary>
@@ -205,16 +210,23 @@ namespace OfficeIMO.Visio.Diagrams {
         /// <summary>Adds a centered editable title above the generated timeline.</summary>
         public VisioTimelineDiagramBuilder Title(string? text = null, string id = "title", double height = 0.45, double gap = 0.35) {
             string normalizedId = RequireId(id, nameof(id), "Title id");
-            if (IsShapeIdInUse(normalizedId)) {
+            bool replacesExistingTitle = _titleText != null;
+            if (IsShapeIdInUse(normalizedId) &&
+                (!replacesExistingTitle || !string.Equals(_titleId, normalizedId, StringComparison.Ordinal))) {
                 throw new ArgumentException($"A timeline item with shape id '{normalizedId}' already exists.", nameof(id));
             }
 
             ValidatePositive(height, nameof(height));
             ValidateNonNegative(gap, nameof(gap));
+            if (replacesExistingTitle && !string.Equals(_titleId, normalizedId, StringComparison.Ordinal)) {
+                _shapeIds.Remove(_titleId);
+            }
+
             _titleText = string.IsNullOrWhiteSpace(text) ? _pageName : text;
             _titleId = normalizedId;
             _titleHeight = height;
             _titleGap = gap;
+            _shapeIds.Add(normalizedId);
             return this;
         }
 
@@ -252,6 +264,8 @@ namespace OfficeIMO.Visio.Diagrams {
             MilestoneItem item = new(normalizedId, text ?? string.Empty, date.Date, kind, placement);
             _milestones.Add(item);
             _milestonesById.Add(normalizedId, item);
+            _shapeIds.Add(normalizedId);
+            _shapeIds.Add(GetMilestoneLabelId(normalizedId));
             return this;
         }
 
@@ -277,6 +291,7 @@ namespace OfficeIMO.Visio.Diagrams {
             SpanItem item = new(normalizedId, text ?? string.Empty, start.Date, end.Date, lane, placement);
             _spans.Add(item);
             _spansById.Add(normalizedId, item);
+            _shapeIds.Add(normalizedId);
             return this;
         }
 
@@ -303,6 +318,7 @@ namespace OfficeIMO.Visio.Diagrams {
             ValidatePositive(options.Width, nameof(options.Width));
             ValidatePositive(options.Height, nameof(options.Height));
             _callouts.Add(new CalloutItem(normalizedTargetId, normalizedId, text ?? string.Empty, pinX, pinY, options));
+            _shapeIds.Add(normalizedId);
             return this;
         }
 
@@ -329,6 +345,7 @@ namespace OfficeIMO.Visio.Diagrams {
             ValidatePositive(options.Width, nameof(options.Width));
             ValidatePositive(options.Height, nameof(options.Height));
             _callouts.Add(new CalloutItem(normalizedTargetId, normalizedId, text ?? string.Empty, placement, gap, options));
+            _shapeIds.Add(normalizedId);
             return this;
         }
 
@@ -644,38 +661,7 @@ namespace OfficeIMO.Visio.Diagrams {
             return _milestonesById.ContainsKey(id) || _spansById.ContainsKey(id);
         }
 
-        private bool IsShapeIdInUse(string id) {
-            if (!string.IsNullOrWhiteSpace(_titleText) && string.Equals(_titleId, id, StringComparison.Ordinal)) {
-                return true;
-            }
-
-            if (string.Equals(id, "timeline-axis", StringComparison.Ordinal) ||
-                string.Equals(id, "timeline-start-label", StringComparison.Ordinal) ||
-                string.Equals(id, "timeline-end-label", StringComparison.Ordinal)) {
-                return true;
-            }
-
-            foreach (MilestoneItem milestone in _milestones) {
-                if (string.Equals(milestone.Id, id, StringComparison.Ordinal) ||
-                    string.Equals(GetMilestoneLabelId(milestone.Id), id, StringComparison.Ordinal)) {
-                    return true;
-                }
-            }
-
-            foreach (SpanItem span in _spans) {
-                if (string.Equals(span.Id, id, StringComparison.Ordinal)) {
-                    return true;
-                }
-            }
-
-            foreach (CalloutItem callout in _callouts) {
-                if (string.Equals(callout.Id, id, StringComparison.Ordinal)) {
-                    return true;
-                }
-            }
-
-            return false;
-        }
+        private bool IsShapeIdInUse(string id) => _shapeIds.Contains(id);
 
         private void EnsureKnownTimelineItem(string id, string parameterName) {
             if (!_milestonesById.ContainsKey(id) && !_spansById.ContainsKey(id)) {
@@ -686,14 +672,16 @@ namespace OfficeIMO.Visio.Diagrams {
         private string CreateCalloutId(string targetId) {
             string id = targetId + "-callout";
             if (!IsShapeIdInUse(id)) {
+                _nextCalloutIndexByTarget[targetId] = 2;
                 return id;
             }
 
-            int index = 2;
+            int index = _nextCalloutIndexByTarget.TryGetValue(targetId, out int nextIndex) ? nextIndex : 2;
             while (IsShapeIdInUse(id + "-" + index)) {
                 index++;
             }
 
+            _nextCalloutIndexByTarget[targetId] = index + 1;
             return id + "-" + index;
         }
 

--- a/OfficeIMO.Visio/Stencils/VisioStencilPreviewGallery.cs
+++ b/OfficeIMO.Visio/Stencils/VisioStencilPreviewGallery.cs
@@ -147,7 +147,7 @@ namespace OfficeIMO.Visio.Stencils {
 
             List<VisioStencilPreviewGalleryEntry> entries = new();
             foreach (VisioStencilPreviewImageData image in images.OrderBy(image => image.MasterNameU, StringComparer.OrdinalIgnoreCase)) {
-                string filePath = image.SaveToDirectory(previewDirectory);
+                string filePath = SaveGalleryPreviewPayload(previewDirectory, image);
                 string relativePath = Path.Combine(options.PreviewDirectoryName, Path.GetFileName(filePath))
                     .Replace(Path.DirectorySeparatorChar, '/')
                     .Replace(Path.AltDirectorySeparatorChar, '/');
@@ -171,6 +171,19 @@ namespace OfficeIMO.Visio.Stencils {
             }
 
             return new VisioStencilPreviewGallery(fullPackagePath, fullOutputDirectory, previewDirectory, thumbnailDirectory, indexPath, entries.AsReadOnly());
+        }
+
+        private static string SaveGalleryPreviewPayload(string previewDirectory, VisioStencilPreviewImageData image) {
+            string extension = image.PreviewImage.Extension?.TrimStart('.') ?? string.Empty;
+            if (!string.Equals(extension, "svg", StringComparison.OrdinalIgnoreCase)) {
+                return image.SaveToDirectory(previewDirectory);
+            }
+
+            // Preserve the source bytes for review, but use a text extension so a gallery host cannot serve an
+            // attacker-controlled SVG as an executable top-level image document by extension alone.
+            string path = Path.Combine(previewDirectory, image.SuggestedFileName + ".txt");
+            image.Save(path);
+            return path;
         }
 
         internal static void ValidateOptions(VisioStencilPreviewGalleryOptions options) {
@@ -286,7 +299,7 @@ namespace OfficeIMO.Visio.Stencils {
             AppendDefinition(builder, "Type", entry.Image.PreviewImage.ContentType ?? string.Empty);
             AppendDefinition(builder, "Bytes", entry.Image.ByteLength.ToString(CultureInfo.InvariantCulture));
             AppendDefinition(builder, "Target", entry.Image.PreviewImage.Target);
-            builder.AppendLine("            <dt>File</dt><dd><a href=\"" + Escape(entry.RelativePath) + "\">" + Escape(Path.GetFileName(entry.FilePath)) + "</a></dd>");
+            builder.AppendLine("            <dt>File</dt><dd><a download href=\"" + Escape(entry.RelativePath) + "\">" + Escape(Path.GetFileName(entry.FilePath)) + "</a></dd>");
             if (!string.IsNullOrWhiteSpace(entry.ThumbnailRelativePath)) {
                 builder.AppendLine("            <dt>Thumb</dt><dd><a href=\"" + Escape(entry.ThumbnailRelativePath!) + "\">" + Escape(Path.GetFileName(entry.ThumbnailFilePath!)) + "</a></dd>");
             }

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.OptionsAndToc.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.OptionsAndToc.cs
@@ -26,9 +26,10 @@ namespace OfficeIMO.Word.Pdf {
             pdfOptions.PageSize = firstSection == null ? PdfCore.PageSizes.A4 : GetNativePageSize(firstSection, options);
             pdfOptions.Margins = firstSection == null ? PdfCore.PageMargins.Uniform(72) : GetNativeMargins(firstSection, options);
             bool allowSystemFontEmbedding = options?.ResourcePolicy.AllowSystemFontEmbedding == true;
-            bool preserveConfiguredFontSlots = ApplyNativeDefaultFont(document, options, pdfOptions, allowSystemFontEmbedding, nativeFontMap) ||
+            bool allowDocumentFontEmbedding = allowSystemFontEmbedding && options?.ResourcePolicy.AllowDocumentFontEmbedding == true;
+            bool preserveConfiguredFontSlots = ApplyNativeDefaultFont(document, options, pdfOptions, allowSystemFontEmbedding, allowDocumentFontEmbedding, nativeFontMap) ||
                                                 options?.PdfOptions != null;
-            HashSet<PdfCore.PdfStandardFont> registeredFontSlots = RegisterNativeDocumentFonts(document, pdfOptions, preserveConfiguredFontSlots, allowSystemFontEmbedding, nativeFontMap);
+            HashSet<PdfCore.PdfStandardFont> registeredFontSlots = RegisterNativeDocumentFonts(document, pdfOptions, preserveConfiguredFontSlots, allowDocumentFontEmbedding, nativeFontMap);
             ApplyNativeTextFallbacks(options, pdfOptions, registeredFontSlots, preserveConfiguredFontSlots, allowSystemFontEmbedding);
             pdfOptions.BackgroundColor = ParseNativeColor(document.Background?.Color);
             pdfOptions.CreateOutlineFromHeadings = true;
@@ -87,7 +88,7 @@ namespace OfficeIMO.Word.Pdf {
             return false;
         }
 
-        private static bool ApplyNativeDefaultFont(WordDocument document, PdfSaveOptions? options, PdfCore.PdfOptions pdfOptions, bool allowSystemFontEmbedding, NativeFontMap nativeFontMap) {
+        private static bool ApplyNativeDefaultFont(WordDocument document, PdfSaveOptions? options, PdfCore.PdfOptions pdfOptions, bool allowSystemFontEmbedding, bool allowDocumentFontEmbedding, NativeFontMap nativeFontMap) {
             string? optionFontFamily = options?.FontFamily;
             if (!string.IsNullOrWhiteSpace(optionFontFamily) &&
                 TryApplyNativeDefaultFontCandidate(optionFontFamily, pdfOptions, embedSystemFont: allowSystemFontEmbedding)) {
@@ -102,7 +103,7 @@ namespace OfficeIMO.Word.Pdf {
                 document.Settings.FontFamilyEastAsia,
                 document.Settings.FontFamilyComplexScript
             }) {
-                if (TryApplyNativeDefaultFontCandidate(family, pdfOptions, embedSystemFont: allowSystemFontEmbedding)) {
+                if (TryApplyNativeDefaultFontCandidate(family, pdfOptions, embedSystemFont: allowDocumentFontEmbedding)) {
                     nativeFontMap.Register(family!, pdfOptions.DefaultFont);
                     return true;
                 }


### PR DESCRIPTION
## Summary

- bound PDF form matching, page lookups, font inspection, CMap reverse indexing, cross-reference parsing, leader-row deduplication, and canvas grid work
- keep document-font embedding and local system-font discovery behind separate policies with bounded traversal
- preserve PowerPoint inheritance behavior, store SVG previews as inert downloads, and make Visio timeline ID checks linear
- persist Excel pivot source records only when `SaveSourceData` is enabled

## Security disposition

This PR fixes 18 validated Medium findings from the all-severity backlog. Two records in the same 20-item batch were already fixed on master by PRs #2102 and #1880 and were closed separately with their original merge evidence.

## Validation

- PDF parser, form, font, option, text, canvas, and table-span security suites pass on net8.0 and net10.0
- Excel pivot privacy, Visio gallery/timeline, and PowerPoint inheritance regressions pass on both targets
- affected netstandard2.0 projects build with zero warnings
- one independent read-only review plus one targeted confirmation completed; all accepted findings are fixed