### PR TITLE
Harden parser resource boundaries

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -953,6 +953,7 @@ jobs:
               "OfficeIMO.Tests.MarkdownStreamingPreviewTests",
               "OfficeIMO.Tests.Markdown_Renderer",
               "OfficeIMO.Tests.Markdown_IntelligenceX",
+              "OfficeIMO.Tests.MarkdownAllSeverityBatch11SecurityTests",
           )
 
           unassigned = [name for name in discovered if not any(partition in name for partition in markdown_partitions)]
@@ -978,7 +979,7 @@ jobs:
               ;;
             markdown-suite)
               run_markdown_tests "markdown-suite" 'FullyQualifiedName~OfficeIMO.Tests.MarkdownSuite'
-              run_markdown_tests "markdown-named" 'FullyQualifiedName~OfficeIMO.Tests.MarkdownHtmlToMarkdownCompatibilityTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownHtmlToMarkdownTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownHtmlApiContracts|FullyQualifiedName~OfficeIMO.Tests.Markdown_|FullyQualifiedName~OfficeIMO.Tests.MarkdownTranscript|FullyQualifiedName~OfficeIMO.Tests.MarkdownReaderBomTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownBlankLinesTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownDefinitionLinesTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownOrderedListsTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownStreamingPreviewTests|FullyQualifiedName~OfficeIMO.Tests.Markdown_Renderer|FullyQualifiedName~OfficeIMO.Tests.Markdown_IntelligenceX'
+              run_markdown_tests "markdown-named" 'FullyQualifiedName~OfficeIMO.Tests.MarkdownHtmlToMarkdownCompatibilityTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownHtmlToMarkdownTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownHtmlApiContracts|FullyQualifiedName~OfficeIMO.Tests.Markdown_|FullyQualifiedName~OfficeIMO.Tests.MarkdownTranscript|FullyQualifiedName~OfficeIMO.Tests.MarkdownReaderBomTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownBlankLinesTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownDefinitionLinesTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownOrderedListsTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownStreamingPreviewTests|FullyQualifiedName~OfficeIMO.Tests.Markdown_Renderer|FullyQualifiedName~OfficeIMO.Tests.Markdown_IntelligenceX|FullyQualifiedName~OfficeIMO.Tests.MarkdownAllSeverityBatch11SecurityTests'
               ;;
             pdf-visual-inspector)
               export OFFICEIMO_REQUIRE_PDF_RASTERIZER=1

--- a/OfficeIMO.Excel.Tests/Excel.HttpLoading.cs
+++ b/OfficeIMO.Excel.Tests/Excel.HttpLoading.cs
@@ -96,6 +96,24 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public async Task ExcelHttpReaderHonorsTheStricterReadInputLimitBeforeCopying() {
+            byte[] workbookBytes = CreateRemoteWorkbookBytes();
+            using var handler = new FakeWorkbookHttpMessageHandler((_, _) =>
+                Task.FromResult(CreateWorkbookResponse(workbookBytes)));
+
+            var ex = await Assert.ThrowsAsync<IOException>(() =>
+                ExcelDocumentReader.OpenAsync(
+                    new Uri("https://example.test/workbook.xlsx"),
+                    new ExcelReadOptions { MaxInputBytes = workbookBytes.Length - 1 },
+                    new ExcelHttpLoadOptions {
+                        HttpMessageHandler = handler,
+                        MaxBytes = workbookBytes.Length * 2L
+                    }));
+
+            Assert.Contains((workbookBytes.Length - 1).ToString(), ex.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public async Task ExcelHttpLoadRejectsResponseThatExceedsLimitDuringCopy() {
             byte[] workbookBytes = CreateRemoteWorkbookBytes();
             using var handler = new FakeWorkbookHttpMessageHandler((_, _) => {

--- a/OfficeIMO.Excel.Tests/Excel.Security.AllSeverityBatch11.cs
+++ b/OfficeIMO.Excel.Tests/Excel.Security.AllSeverityBatch11.cs
@@ -1,0 +1,146 @@
+using System.Data;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        public void Reader_RejectsWorkbookBufferBeyondConfiguredInputLimit() {
+            using var stream = new MemoryStream(new byte[32], writable: false);
+
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+                ExcelDocumentReader.Open(stream, new ExcelReadOptions { MaxInputBytes = 16 }));
+
+            Assert.Contains("configured maximum size", exception.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void PivotTable_RejectsSharedItemDiscoveryBeyondAbsoluteScanBudget() {
+            using var stream = new MemoryStream();
+            using ExcelDocument document = ExcelDocument.Create(stream);
+            ExcelSheet sheet = document.AddWorksheet("Data");
+            sheet.CellValue(1, 1, "First");
+            sheet.CellValue(1, 2, "Second");
+            sheet.CellValue(1, 3, "Value");
+
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+                sheet.AddPivotTable(
+                    sourceRange: "A1:C1048576",
+                    destinationCell: "E2",
+                    rowFields: new[] { "First", "Second" },
+                    dataFields: new[] { new ExcelPivotDataField("Value", DataConsolidateFunctionValues.Sum) }));
+
+            Assert.Contains("shared-item discovery", exception.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void AppendDataTable_ScansOutOfOrderRowsAndRejectsStyleOnlyTargetCells() {
+            using var stream = new MemoryStream();
+            using ExcelDocument document = ExcelDocument.Create(stream);
+            ExcelSheet sheet = document.AddWorksheet("Sales");
+            sheet.InsertDataTableAsTable(CreateSalesTable(), tableName: "SalesTable");
+
+            SheetData sheetData = sheet.WorksheetPart.Worksheet.GetFirstChild<SheetData>()!;
+            sheetData.Append(new Row { RowIndex = uint.MaxValue });
+            sheetData.Append(new Row(new Cell { CellReference = "A3", StyleIndex = 0U }) { RowIndex = 3U });
+
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+                sheet.AppendDataTableToTable(CreateAppendTable(), "SalesTable"));
+
+            Assert.Contains("A3", exception.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void AppendDataTable_UsesExplicitCellReferencesWhenRowMetadataIsHostile() {
+            AssertAppendRejectsExplicitTargetCell(null);
+            AssertAppendRejectsExplicitTargetCell(uint.MaxValue);
+            AssertAppendRejectsExplicitTargetCell(99U);
+        }
+
+        [Fact]
+        public void AppendDataTable_RejectsTargetRangeMetadataWithoutMaterializedCells() {
+            using var stream = new MemoryStream();
+            using ExcelDocument document = ExcelDocument.Create(stream);
+            ExcelSheet sheet = document.AddWorksheet("Sales");
+            sheet.InsertDataTableAsTable(CreateSalesTable(), tableName: "SalesTable");
+            sheet.WorksheetPart.Worksheet.AppendChild(new Hyperlinks(new Hyperlink { Reference = "A3" }));
+
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+                sheet.AppendDataTableToTable(CreateAppendTable(), "SalesTable"));
+
+            Assert.Contains("hyperlink", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Save_IgnoresOutOfRangeDeclaredRowsWhenRebuildingWorksheetDimension() {
+            string filePath = Path.Combine(_directoryWithFiles, "SecurityBatch11.InvalidDimensionRow.xlsx");
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorksheet("Data");
+                sheet.CellValue(1, 1, "safe");
+                SheetData sheetData = sheet.WorksheetPart.Worksheet.GetFirstChild<SheetData>()!;
+                sheetData.Append(new Row(new Cell(new CellValue("attacker"))) { RowIndex = uint.MaxValue });
+                document.Save();
+            }
+
+            using SpreadsheetDocument package = SpreadsheetDocument.Open(filePath, false);
+            Assert.Equal("A1", package.WorkbookPart!.WorksheetParts.Single().Worksheet.GetFirstChild<SheetDimension>()!.Reference!.Value);
+        }
+
+        [Fact]
+        public void SharedStringCleanup_ConvertsOutOfRangeIndexesWithoutExpandingTheTable() {
+            using var stream = new MemoryStream();
+            using ExcelDocument document = ExcelDocument.Create(stream);
+            ExcelSheet sheet = document.AddWorksheet("Data");
+            sheet.CellValue(1, 1, "safe");
+            Cell cell = sheet.WorksheetPart.Worksheet.Descendants<Cell>().Single();
+            cell.DataType = CellValues.SharedString;
+            cell.CellValue = new CellValue(int.MaxValue.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+            document.CleanupStyleAndSharedStringArtifacts(save: false);
+
+            Assert.Equal(CellValues.InlineString, cell.DataType!.Value);
+            SharedStringTable sharedStrings = document.WorkbookPartRoot.SharedStringTablePart!.SharedStringTable!;
+            Assert.Single(sharedStrings.Elements<SharedStringItem>());
+            Assert.Equal("safe", sharedStrings.Elements<SharedStringItem>().Single().InnerText);
+        }
+
+        private static DataTable CreateSalesTable() {
+            var table = new DataTable();
+            table.Columns.Add("Region", typeof(string));
+            table.Columns.Add("Revenue", typeof(int));
+            table.Rows.Add("NA", 100);
+            return table;
+        }
+
+        private static DataTable CreateAppendTable() {
+            var table = new DataTable();
+            table.Columns.Add("Region", typeof(string));
+            table.Columns.Add("Revenue", typeof(int));
+            table.Rows.Add("EU", 200);
+            return table;
+        }
+
+        private static void AssertAppendRejectsExplicitTargetCell(uint? declaredRowIndex) {
+            using var stream = new MemoryStream();
+            using ExcelDocument document = ExcelDocument.Create(stream);
+            ExcelSheet sheet = document.AddWorksheet("Sales");
+            sheet.InsertDataTableAsTable(CreateSalesTable(), tableName: "SalesTable");
+
+            var hostileRow = new Row(new Cell {
+                CellReference = "A3",
+                CellFormula = new CellFormula("1+1")
+            });
+            if (declaredRowIndex.HasValue) {
+                hostileRow.RowIndex = declaredRowIndex.Value;
+            }
+            sheet.WorksheetPart.Worksheet.GetFirstChild<SheetData>()!.Append(hostileRow);
+
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+                sheet.AppendDataTableToTable(CreateAppendTable(), "SalesTable"));
+
+            Assert.Contains("A3", exception.Message, StringComparison.Ordinal);
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelDocument.StyleAndSharedStringCleanup.cs
+++ b/OfficeIMO.Excel/ExcelDocument.StyleAndSharedStringCleanup.cs
@@ -76,9 +76,9 @@ namespace OfficeIMO.Excel {
 
         private void CleanupSharedStringArtifacts(WorkbookPart workbookPart) {
             SharedStringTablePart? sharedStringTablePart = workbookPart.SharedStringTablePart;
-            bool sawSharedStringCell = false;
+            var sharedStringTable = sharedStringTablePart?.SharedStringTable;
+            int itemCount = sharedStringTable?.Elements<SharedStringItem>().Count() ?? 0;
             int sharedStringCellCount = 0;
-            int maxSharedStringIndex = -1;
             bool sharedStringTableChanged = false;
 
             foreach (var worksheetPart in workbookPart.WorksheetParts) {
@@ -93,7 +93,8 @@ namespace OfficeIMO.Excel {
                             }
 
                             string rawValue = cell.CellValue?.Text ?? cell.InnerText ?? string.Empty;
-                            if (!TryParseSharedStringIndex(rawValue, out int sharedStringIndex)) {
+                            if (!TryParseSharedStringIndex(rawValue, out int sharedStringIndex)
+                                || sharedStringIndex >= itemCount) {
                                 cell.DataType = CellValues.InlineString;
                                 cell.RemoveAllChildren<CellValue>();
                                 cell.RemoveAllChildren<InlineString>();
@@ -102,11 +103,7 @@ namespace OfficeIMO.Excel {
                                 continue;
                             }
 
-                            sawSharedStringCell = true;
                             sharedStringCellCount++;
-                            if (sharedStringIndex > maxSharedStringIndex) {
-                                maxSharedStringIndex = sharedStringIndex;
-                            }
                         }
                     }
                 }
@@ -116,25 +113,11 @@ namespace OfficeIMO.Excel {
                 }
             }
 
-            if (sharedStringTablePart == null && !sawSharedStringCell) {
+            if (sharedStringTablePart == null) {
                 return;
             }
 
-            if (sharedStringTablePart == null) {
-                sharedStringTablePart = workbookPart.AddNewPart<SharedStringTablePart>();
-                sharedStringTablePart.SharedStringTable = new SharedStringTable();
-                _sharedStringTablePart = sharedStringTablePart;
-                sharedStringTableChanged = true;
-            }
-
-            var sharedStringTable = sharedStringTablePart.SharedStringTable ??= new SharedStringTable();
-            int itemCount = sharedStringTable.Elements<SharedStringItem>().Count();
-            while (itemCount <= maxSharedStringIndex) {
-                sharedStringTable.AppendChild(new SharedStringItem(new Text(string.Empty)));
-                itemCount++;
-                _sharedStringTableCount = itemCount;
-                sharedStringTableChanged = true;
-            }
+            sharedStringTable ??= sharedStringTablePart.SharedStringTable = new SharedStringTable();
 
             uint expectedCount = (uint)Math.Max(sharedStringCellCount, itemCount);
             uint expectedUniqueCount = (uint)itemCount;

--- a/OfficeIMO.Excel/ExcelDocument.StyleAndSharedStringCleanup.cs
+++ b/OfficeIMO.Excel/ExcelDocument.StyleAndSharedStringCleanup.cs
@@ -4,6 +4,8 @@ using System.Globalization;
 
 namespace OfficeIMO.Excel {
     public partial class ExcelDocument {
+        private const int MaximumSharedStringRepairItems = 65_536;
+
         internal void CleanupStyleAndSharedStringArtifacts(bool save = true) {
             var workbookPart = WorkbookPartRoot;
 
@@ -94,7 +96,22 @@ namespace OfficeIMO.Excel {
 
                             string rawValue = cell.CellValue?.Text ?? cell.InnerText ?? string.Empty;
                             if (!TryParseSharedStringIndex(rawValue, out int sharedStringIndex)
-                                || sharedStringIndex >= itemCount) {
+                                || sharedStringIndex >= MaximumSharedStringRepairItems) {
+                                cell.DataType = CellValues.InlineString;
+                                cell.RemoveAllChildren<CellValue>();
+                                cell.RemoveAllChildren<InlineString>();
+                                cell.AppendChild(new InlineString(new Text(rawValue)));
+                                worksheetChanged = true;
+                                continue;
+                            }
+
+                            while (sharedStringTable != null && itemCount <= sharedStringIndex) {
+                                sharedStringTable.AppendChild(new SharedStringItem(new Text(string.Empty)));
+                                itemCount++;
+                                sharedStringTableChanged = true;
+                            }
+
+                            if (sharedStringIndex >= itemCount) {
                                 cell.DataType = CellValues.InlineString;
                                 cell.RemoveAllChildren<CellValue>();
                                 cell.RemoveAllChildren<InlineString>();

--- a/OfficeIMO.Excel/ExcelHttpWorkbookLoader.cs
+++ b/OfficeIMO.Excel/ExcelHttpWorkbookLoader.cs
@@ -11,10 +11,14 @@ namespace OfficeIMO.Excel {
         private const int BufferSize = 81920;
         private const int MaxRedirects = 10;
 
-        internal static async Task<byte[]> DownloadAsync(Uri uri, ExcelHttpLoadOptions? options, CancellationToken cancellationToken = default) {
+        internal static async Task<byte[]> DownloadAsync(
+            Uri uri,
+            ExcelHttpLoadOptions? options,
+            CancellationToken cancellationToken = default,
+            long? maximumBytes = null) {
             if (uri == null) throw new ArgumentNullException(nameof(uri));
 
-            var snapshot = ExcelHttpLoadOptionsSnapshot.Create(options);
+            var snapshot = ExcelHttpLoadOptionsSnapshot.Create(options, maximumBytes);
             ValidateScheme(uri, snapshot.SchemePolicy);
             ValidateHost(uri, snapshot);
             ValidateLimits(snapshot);
@@ -305,12 +309,15 @@ namespace OfficeIMO.Excel {
             internal IProgress<ExcelHttpLoadProgress>? Progress { get; }
             internal HttpMessageHandler? HttpMessageHandler { get; }
 
-            internal static ExcelHttpLoadOptionsSnapshot Create(ExcelHttpLoadOptions? options) {
+            internal static ExcelHttpLoadOptionsSnapshot Create(ExcelHttpLoadOptions? options, long? maximumBytes) {
                 options ??= new ExcelHttpLoadOptions();
+                long maxBytes = maximumBytes.HasValue
+                    ? Math.Min(options.MaxBytes, maximumBytes.Value)
+                    : options.MaxBytes;
 
                 return new ExcelHttpLoadOptionsSnapshot(
                     options.SchemePolicy,
-                    options.MaxBytes,
+                    maxBytes,
                     options.Timeout,
                     options.UserAgent,
                     new Dictionary<string, string>(options.Headers, StringComparer.OrdinalIgnoreCase),

--- a/OfficeIMO.Excel/ExcelSheet.DataTable.Tables.cs
+++ b/OfficeIMO.Excel/ExcelSheet.DataTable.Tables.cs
@@ -377,56 +377,113 @@ namespace OfficeIMO.Excel {
             }
 
             var sheetData = WorksheetRoot.GetFirstChild<SheetData>();
-            if (sheetData == null) {
-                return;
+            foreach (Row rowElement in sheetData?.Elements<Row>() ?? Enumerable.Empty<Row>()) {
+                int ordinalColumnIndex = 0;
+                foreach (Cell cell in rowElement.Elements<Cell>()) {
+                    ordinalColumnIndex++;
+                    string? reference = cell.CellReference?.Value;
+                    int rowIndex;
+                    int columnIndex;
+                    if (!string.IsNullOrEmpty(reference)) {
+                        (rowIndex, columnIndex) = A1.ParseCellRef(reference!);
+                    } else {
+                        uint rawRowIndex = rowElement.RowIndex?.Value ?? 0U;
+                        rowIndex = rawRowIndex <= A1.MaxRows ? (int)rawRowIndex : 0;
+                        columnIndex = ordinalColumnIndex;
+                    }
+
+                    if (rowIndex < startRow || rowIndex > endRow
+                        || columnIndex < startColumn || columnIndex > endColumn) {
+                        continue;
+                    }
+
+                    string location = string.IsNullOrEmpty(reference)
+                        ? A1.ColumnIndexToLetters(columnIndex) + rowIndex.ToString(CultureInfo.InvariantCulture)
+                        : reference!;
+                    throw new InvalidOperationException($"Cannot append to table '{tableName}' because cell {location} already contains worksheet data or formatting.");
+                }
             }
 
-            foreach (Row rowElement in sheetData.Elements<Row>()) {
-                if (rowElement.RowIndex == null) {
-                    continue;
+            EnsureAppendTargetHasNoRangeMetadata(startRow, endRow, startColumn, endColumn, tableName);
+        }
+
+        private void EnsureAppendTargetHasNoRangeMetadata(int startRow, int endRow, int startColumn, int endColumn, string tableName) {
+            foreach (Hyperlink hyperlink in WorksheetRoot.Descendants<Hyperlink>()) {
+                if (AppendTargetIntersectsReference(hyperlink.Reference?.Value, startRow, endRow, startColumn, endColumn)) {
+                    throw new InvalidOperationException($"Cannot append to table '{tableName}' because the target range contains a hyperlink.");
                 }
+            }
 
-                int rowIndex = (int)rowElement.RowIndex.Value;
-                if (rowIndex < startRow) {
-                    continue;
+            foreach (MergeCell mergeCell in WorksheetRoot.Descendants<MergeCell>()) {
+                if (AppendTargetIntersectsReference(mergeCell.Reference?.Value, startRow, endRow, startColumn, endColumn)) {
+                    throw new InvalidOperationException($"Cannot append to table '{tableName}' because the target range intersects a merged cell.");
                 }
+            }
 
-                if (rowIndex > endRow) {
-                    break;
+            foreach (DataValidation validation in WorksheetRoot.Descendants<DataValidation>()) {
+                if (AppendTargetIntersectsReferences(validation.SequenceOfReferences?.InnerText, startRow, endRow, startColumn, endColumn)) {
+                    throw new InvalidOperationException($"Cannot append to table '{tableName}' because the target range contains data validation.");
                 }
+            }
 
-                foreach (Cell cell in rowElement.Elements<Cell>()) {
-                    string? reference = cell.CellReference?.Value;
-                    if (string.IsNullOrEmpty(reference)) {
-                        continue;
-                    }
+            foreach (ConditionalFormatting formatting in WorksheetRoot.Descendants<ConditionalFormatting>()) {
+                if (AppendTargetIntersectsReferences(formatting.SequenceOfReferences?.InnerText, startRow, endRow, startColumn, endColumn)) {
+                    throw new InvalidOperationException($"Cannot append to table '{tableName}' because the target range contains conditional formatting.");
+                }
+            }
 
-                    int columnIndex = A1.ParseColumnIndexFromCellReference(reference!);
-                    if (columnIndex < startColumn || columnIndex > endColumn) {
-                        continue;
-                    }
-
-                    if (CellHasContent(cell)) {
-                        throw new InvalidOperationException($"Cannot append to table '{tableName}' because cell {reference} already contains data.");
+            var comments = _worksheetPart.WorksheetCommentsPart?.Comments?.CommentList;
+            if (comments != null) {
+                foreach (Comment comment in comments.Elements<Comment>()) {
+                    if (AppendTargetIntersectsReference(comment.Reference?.Value, startRow, endRow, startColumn, endColumn)) {
+                        throw new InvalidOperationException($"Cannot append to table '{tableName}' because the target range contains a comment.");
                     }
                 }
             }
         }
 
-        private static bool CellHasContent(Cell cell) {
-            if (cell.CellFormula != null) {
-                return true;
+        private static bool AppendTargetIntersectsReferences(string? references, int startRow, int endRow, int startColumn, int endColumn) {
+            if (string.IsNullOrWhiteSpace(references)) {
+                return false;
             }
 
-            if (cell.CellValue != null && !string.IsNullOrEmpty(cell.CellValue.Text)) {
-                return true;
-            }
-
-            if (cell.InlineString != null) {
-                return true;
+            string[] tokens = references!.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+            for (int index = 0; index < tokens.Length; index++) {
+                if (AppendTargetIntersectsReference(tokens[index], startRow, endRow, startColumn, endColumn)) {
+                    return true;
+                }
             }
 
             return false;
         }
+
+        private static bool AppendTargetIntersectsReference(string? reference, int startRow, int endRow, int startColumn, int endColumn) {
+            if (string.IsNullOrWhiteSpace(reference)) {
+                return false;
+            }
+
+            string normalized = reference!.Replace("$", string.Empty).Trim();
+            int rangeStartRow;
+            int rangeStartColumn;
+            int rangeEndRow;
+            int rangeEndColumn;
+            if (normalized.IndexOf(':') >= 0) {
+                if (!A1.TryParseRange(normalized, out rangeStartRow, out rangeStartColumn, out rangeEndRow, out rangeEndColumn)) {
+                    return false;
+                }
+            } else {
+                (rangeStartRow, rangeStartColumn) = A1.ParseCellRef(normalized);
+                rangeEndRow = rangeStartRow;
+                rangeEndColumn = rangeStartColumn;
+            }
+
+            return rangeStartRow > 0
+                && rangeStartColumn > 0
+                && rangeStartRow <= endRow
+                && rangeEndRow >= startRow
+                && rangeStartColumn <= endColumn
+                && rangeEndColumn >= startColumn;
+        }
+
     }
 }

--- a/OfficeIMO.Excel/ExcelSheet.Dimension.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Dimension.cs
@@ -18,10 +18,12 @@ namespace OfficeIMO.Excel {
                 rowOrdinal++;
                 if (!row.HasChildren) continue;
 
-                int rowIndex = checked((int)(row.RowIndex?.Value ?? (uint)rowOrdinal));
-                if (rowIndex <= 0) {
-                    rowIndex = rowOrdinal;
-                }
+                uint? declaredRowIndex = row.RowIndex?.Value;
+                int rowIndex = declaredRowIndex.HasValue
+                    ? declaredRowIndex.Value >= 1U && declaredRowIndex.Value <= A1.MaxRows
+                        ? (int)declaredRowIndex.Value
+                        : 0
+                    : rowOrdinal <= A1.MaxRows ? rowOrdinal : 0;
 
                 int cellOrdinal = 0;
                 foreach (var cell in row.Elements<Cell>()) {
@@ -42,7 +44,7 @@ namespace OfficeIMO.Excel {
                         resolvedCol = cellOrdinal;
                     }
 
-                    if (resolvedRow <= 0 || resolvedCol <= 0) continue;
+                    if (resolvedRow <= 0 || resolvedRow > A1.MaxRows || resolvedCol <= 0 || resolvedCol > A1.MaxColumns) continue;
 
                     if (resolvedRow < minRow) minRow = resolvedRow;
                     if (resolvedRow > maxRow) maxRow = resolvedRow;

--- a/OfficeIMO.Excel/ExcelSheet.PivotTables.CacheRecords.cs
+++ b/OfficeIMO.Excel/ExcelSheet.PivotTables.CacheRecords.cs
@@ -8,6 +8,22 @@ using System.Text;
 
 namespace OfficeIMO.Excel {
     public partial class ExcelSheet {
+        private const long MaximumPivotFieldScanCells = 1_000_000L;
+
+        private static void ValidatePivotFieldScanBudget(int firstDataRow, int lastDataRow, IReadOnlyList<bool> collectFieldValues, int generatedFieldCount) {
+            long rowCount = Math.Max(0L, (long)lastDataRow - firstDataRow + 1L);
+            int collectedFields = generatedFieldCount;
+            for (int field = 0; field < collectFieldValues.Count; field++) {
+                if (collectFieldValues[field]) {
+                    collectedFields++;
+                }
+            }
+
+            long scanCells = rowCount * collectedFields;
+            if (scanCells > MaximumPivotFieldScanCells) {
+                throw new InvalidOperationException($"Pivot shared-item discovery would inspect {scanCells} cells, exceeding the supported limit of {MaximumPivotFieldScanCells}.");
+            }
+        }
 
         private List<PivotFieldValues> BuildPivotFieldValueMap(int fieldCount, int firstDataRow, int lastDataRow, int firstColumn,
             IReadOnlyDictionary<int, ExcelPivotGrouping> groupingMap, IReadOnlyList<bool>? collectFieldValues = null) {

--- a/OfficeIMO.Excel/ExcelSheet.PivotTables.cs
+++ b/OfficeIMO.Excel/ExcelSheet.PivotTables.cs
@@ -340,6 +340,7 @@ namespace OfficeIMO.Excel {
                     pivotFilterList,
                     headerIndex,
                     fieldOptionMap);
+                ValidatePivotFieldScanBudget(r1 + 1, r2, sourceSharedItemRequirements, generatedGroupingFields.Count);
 
                 var workbookPart = WorkbookPartRoot;
                 var workbook = workbookPart.Workbook ??= new Workbook();

--- a/OfficeIMO.Excel/Read/ExcelDocumentReader.Http.cs
+++ b/OfficeIMO.Excel/Read/ExcelDocumentReader.Http.cs
@@ -13,10 +13,15 @@ namespace OfficeIMO.Excel {
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>Workbook reader.</returns>
         public static async Task<ExcelDocumentReader> OpenAsync(Uri uri, ExcelReadOptions? options = null, ExcelHttpLoadOptions? httpOptions = null, CancellationToken cancellationToken = default) {
-            byte[] bytes = await ExcelHttpWorkbookLoader.DownloadAsync(uri, httpOptions, cancellationToken).ConfigureAwait(false);
+            var effectiveOptions = options ?? new ExcelReadOptions();
+            byte[] bytes = await ExcelHttpWorkbookLoader.DownloadAsync(
+                uri,
+                httpOptions,
+                cancellationToken,
+                effectiveOptions.MaxInputBytes).ConfigureAwait(false);
             return OpenFromBytes(
                 bytes,
-                options,
+                effectiveOptions,
                 normalizeContentTypes: false,
                 contextMessage: $"Failed to open remote workbook '{uri}' after normalizing package content types. The package may declare an invalid content type for '/docProps/app.xml'.");
         }

--- a/OfficeIMO.Excel/Read/ExcelDocumentReader.cs
+++ b/OfficeIMO.Excel/Read/ExcelDocumentReader.cs
@@ -1,6 +1,7 @@
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using DocumentFormat.OpenXml;
+using OfficeIMO.Drawing.Internal;
 using OfficeIMO.Excel.Utilities;
 using System.IO;
 using System.IO.Packaging;
@@ -44,9 +45,15 @@ namespace OfficeIMO.Excel {
                 throw new FileNotFoundException($"File '{path}' doesn't exist.", path);
             }
 
+            var effectiveOptions = options ?? new ExcelReadOptions();
+            byte[] bytes;
+            using (var stream = File.OpenRead(path)) {
+                bytes = OfficeStreamReader.ReadAllBytes(stream, effectiveOptions.MaxInputBytes);
+            }
+
             return OpenFromBytes(
-                File.ReadAllBytes(path),
-                options,
+                bytes,
+                effectiveOptions,
                 normalizeContentTypes: false,
                 contextMessage: $"Failed to open '{path}' after normalizing package content types. The package may declare an invalid content type for '/docProps/app.xml'.");
         }
@@ -58,9 +65,10 @@ namespace OfficeIMO.Excel {
             if (stream == null) throw new ArgumentNullException(nameof(stream));
             if (!stream.CanRead) throw new ArgumentException("Stream must be readable.", nameof(stream));
 
+            var effectiveOptions = options ?? new ExcelReadOptions();
             return OpenFromBytes(
-                ReadAllBytes(stream),
-                options,
+                OfficeStreamReader.ReadAllBytes(stream, effectiveOptions.MaxInputBytes),
+                effectiveOptions,
                 normalizeContentTypes: false,
                 contextMessage: "Failed to open workbook stream after normalizing package content types. The package may declare an invalid content type for '/docProps/app.xml'.");
         }
@@ -72,9 +80,14 @@ namespace OfficeIMO.Excel {
         public static ExcelDocumentReader Open(byte[] bytes, ExcelReadOptions? options = null) {
             if (bytes == null) throw new ArgumentNullException(nameof(bytes));
 
+            var effectiveOptions = options ?? new ExcelReadOptions();
+            if (bytes.LongLength > effectiveOptions.MaxInputBytes) {
+                throw new InvalidDataException($"Workbook input contains {bytes.LongLength} bytes, exceeding the configured limit of {effectiveOptions.MaxInputBytes} bytes.");
+            }
+
             return OpenFromBytes(
                 bytes,
-                options,
+                effectiveOptions,
                 normalizeContentTypes: false,
                 contextMessage: "Failed to open workbook bytes after normalizing package content types. The package may declare an invalid content type for '/docProps/app.xml'.");
         }
@@ -406,6 +419,11 @@ namespace OfficeIMO.Excel {
         }
 
         private static ExcelDocumentReader OpenFromBytes(byte[] bytes, ExcelReadOptions? options, bool normalizeContentTypes, string contextMessage) {
+            var effectiveOptions = options ?? new ExcelReadOptions();
+            if (bytes.LongLength > effectiveOptions.MaxInputBytes) {
+                throw new InvalidDataException($"Workbook input contains {bytes.LongLength} bytes, exceeding the configured limit of {effectiveOptions.MaxInputBytes} bytes.");
+            }
+
             MemoryStream? packageStream = null;
             Package? package = null;
             try {
@@ -421,11 +439,11 @@ namespace OfficeIMO.Excel {
 
                 package = Package.Open(packageStream, FileMode.Open, FileAccess.Read);
                 var doc = SpreadsheetDocument.Open(package);
-                return new ExcelDocumentReader(doc, options ?? new ExcelReadOptions(), owns: true, package, packageStream);
+                return new ExcelDocumentReader(doc, effectiveOptions, owns: true, package, packageStream);
             } catch (Exception ex) when (!normalizeContentTypes && IsRecoverableOpenException(ex)) {
                 package?.Close();
                 packageStream?.Dispose();
-                return OpenFromBytes(bytes, options, normalizeContentTypes: true, contextMessage);
+                return OpenFromBytes(bytes, effectiveOptions, normalizeContentTypes: true, contextMessage);
             } catch (Exception ex) when (IsRecoverableOpenException(ex)) {
                 package?.Close();
                 packageStream?.Dispose();
@@ -441,40 +459,5 @@ namespace OfficeIMO.Excel {
             return ex is InvalidDataException || ex is OpenXmlPackageException || ex is XmlException;
         }
 
-        private static byte[] ReadAllBytes(Stream stream) {
-            if (stream is MemoryStream memoryStream) {
-                return memoryStream.ToArray();
-            }
-
-            if (stream.CanSeek) {
-                stream.Seek(0, SeekOrigin.Begin);
-                long length = stream.Length;
-                if (length > int.MaxValue) {
-                    throw new IOException("Workbook stream is too large to read into memory.");
-                }
-
-                var bytes = new byte[(int)length];
-                int offset = 0;
-                while (offset < bytes.Length) {
-                    int read = stream.Read(bytes, offset, bytes.Length - offset);
-                    if (read == 0) {
-                        break;
-                    }
-
-                    offset += read;
-                }
-
-                if (offset == bytes.Length) {
-                    return bytes;
-                }
-
-                Array.Resize(ref bytes, offset);
-                return bytes;
-            }
-
-            using var buffer = new MemoryStream();
-            stream.CopyTo(buffer);
-            return buffer.ToArray();
-        }
     }
 }

--- a/OfficeIMO.Excel/Read/ExcelReadOptions.cs
+++ b/OfficeIMO.Excel/Read/ExcelReadOptions.cs
@@ -8,6 +8,19 @@ namespace OfficeIMO.Excel {
         private int _maxSharedStringItems = 1_000_000;
         private int _maxSharedStringItemCharacters = 32_767;
         private long _maxSharedStringCharacters = 64L * 1024L * 1024L;
+        private long _maxInputBytes = 512L * 1024L * 1024L;
+
+        /// <summary>Maximum workbook bytes buffered by <see cref="ExcelDocumentReader"/>. Default: 512 MiB.</summary>
+        public long MaxInputBytes {
+            get => _maxInputBytes;
+            set {
+                if (value <= 0) {
+                    throw new ArgumentOutOfRangeException(nameof(value), "Workbook input limit must be greater than zero.");
+                }
+
+                _maxInputBytes = value;
+            }
+        }
 
         /// <summary>Maximum columns exposed by one range data reader.</summary>
         public int MaxDataReaderColumns { get; set; } = 16_384;

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.Structured.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.Structured.cs
@@ -39,7 +39,15 @@ internal sealed partial class HtmlToMarkdownConverter {
                 return;
             }
 
+            long groupExpansionCount = (long)pendingTerms.Count * pendingDefinitions.Count;
+            long totalExpansionCount = context.DefinitionListEntryExpansionCount + groupExpansionCount;
+            if (totalExpansionCount > context.Options.MaxDefinitionListEntryExpansions) {
+                throw new InvalidOperationException(
+                    $"HTML definition lists exceed the configured entry expansion limit of {context.Options.MaxDefinitionListEntryExpansions}.");
+            }
+
             list.AddGroup(new DefinitionListGroup(pendingTerms, pendingDefinitions));
+            context.DefinitionListEntryExpansionCount = (int)totalExpansionCount;
             pendingTerms.Clear();
             pendingDefinitions = null;
             hasDefinitionsForCurrentGroup = false;

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.cs
@@ -66,17 +66,7 @@ internal sealed partial class HtmlToMarkdownConverter {
     }
 
     private static bool ShouldTreatAsBlockElement(IElement element, ConversionContext context) {
-        if (context.Footnotes.TryGetDefinitionLabel(element, out _)
-            || context.Footnotes.ShouldConvertContainer(element)
-            || HtmlAccessibilitySemantics.TryGetHeadingLevel(element, out _)) {
-            return true;
-        }
-
-        if (IsBlockElement(element, context)) {
-            return true;
-        }
-
-        if (CanConvertAnchorToLinkedImageBlock(element, context)) {
+        if (ShouldTreatAsIntrinsicBlockElement(element, context)) {
             return true;
         }
 
@@ -84,6 +74,10 @@ internal sealed partial class HtmlToMarkdownConverter {
             return true;
         }
 
+        return ShouldTreatAsNonIntrinsicBlockElement(element, context);
+    }
+
+    private static bool ShouldTreatAsNonIntrinsicBlockElement(IElement element, ConversionContext context) {
         if (!IsInlineElement(element, context)) {
             if (IsVisualContractElement(element)
                 || (context.Options.PreserveUnsupportedBlocks
@@ -100,6 +94,13 @@ internal sealed partial class HtmlToMarkdownConverter {
 
         return false;
     }
+
+    private static bool ShouldTreatAsIntrinsicBlockElement(IElement element, ConversionContext context) =>
+        context.Footnotes.TryGetDefinitionLabel(element, out _)
+        || context.Footnotes.ShouldConvertContainer(element)
+        || HtmlAccessibilitySemantics.TryGetHeadingLevel(element, out _)
+        || IsBlockElement(element, context)
+        || CanConvertAnchorToLinkedImageBlock(element, context);
 
     private static bool IsVisualContractElement(IElement element) {
         if (element == null) {
@@ -172,13 +173,42 @@ internal sealed partial class HtmlToMarkdownConverter {
     }
 
     private static bool HasDirectBlockChildren(IElement element, ConversionContext context) {
-        foreach (var child in element.Children) {
-            if (ShouldTreatAsBlockElement(child, context)) {
-                return true;
-            }
+        if (context.BlockDescendantCache.TryGetValue(element, out bool cached)) {
+            return cached;
         }
 
-        return false;
+        var pending = new Stack<(IElement Element, bool Expanded)>();
+        pending.Push((element, false));
+        while (pending.Count > 0) {
+            var current = pending.Pop();
+            if (context.BlockDescendantCache.ContainsKey(current.Element)) {
+                continue;
+            }
+
+            if (!current.Expanded) {
+                pending.Push((current.Element, true));
+                foreach (var child in current.Element.Children) {
+                    if (!context.BlockDescendantCache.ContainsKey(child)) {
+                        pending.Push((child, false));
+                    }
+                }
+                continue;
+            }
+
+            bool containsBlock = false;
+            foreach (var child in current.Element.Children) {
+                if (ShouldTreatAsIntrinsicBlockElement(child, context)
+                    || (context.BlockDescendantCache.TryGetValue(child, out bool childContainsBlock) && childContainsBlock)
+                    || ShouldTreatAsNonIntrinsicBlockElement(child, context)) {
+                    containsBlock = true;
+                    break;
+                }
+            }
+
+            context.BlockDescendantCache[current.Element] = containsBlock;
+        }
+
+        return context.BlockDescendantCache.TryGetValue(element, out bool result) && result;
     }
 
     private static IEnumerable<IMarkdownBlock> ConvertElementToBlocks(IElement element, ConversionContext context) {

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.cs
@@ -16,7 +16,9 @@ internal sealed partial class HtmlToMarkdownConverter {
 
         public HtmlToMarkdownOptions Options { get; }
         public int SavedBase64ImageCount { get; set; }
+        public int DefinitionListEntryExpansionCount { get; set; }
         public Dictionary<string, string> SavedBase64ImagesBySource { get; } = new(StringComparer.Ordinal);
+        internal Dictionary<IElement, bool> BlockDescendantCache { get; } = new();
         internal HtmlFootnoteConversionState Footnotes { get; set; } = HtmlFootnoteConversionState.Empty;
     }
 

--- a/OfficeIMO.Markdown.Html/Options/HtmlToMarkdownOptions.cs
+++ b/OfficeIMO.Markdown.Html/Options/HtmlToMarkdownOptions.cs
@@ -8,6 +8,7 @@ using OfficeIMO.Html;
 /// </summary>
 public sealed class HtmlToMarkdownOptions {
     private int _maxTableExpandedColumns = TableBlock.MaxEffectiveColumnCount;
+    private int _maxDefinitionListEntryExpansions = 10_000;
     private readonly HashSet<string> _appliedPluginIds = new(StringComparer.OrdinalIgnoreCase);
     private readonly HashSet<string> _appliedFeaturePackIds = new(StringComparer.OrdinalIgnoreCase);
 
@@ -152,6 +153,21 @@ public sealed class HtmlToMarkdownOptions {
     }
 
     /// <summary>
+    /// Maximum number of term/definition entry pairs materialized while converting HTML definition lists.
+    /// Values must be between 1 and 1,000,000.
+    /// </summary>
+    public int MaxDefinitionListEntryExpansions {
+        get => _maxDefinitionListEntryExpansions;
+        set {
+            if (value < 1 || value > 1_000_000) {
+                throw new ArgumentOutOfRangeException(nameof(MaxDefinitionListEntryExpansions), value, "MaxDefinitionListEntryExpansions must be between 1 and 1,000,000.");
+            }
+
+            _maxDefinitionListEntryExpansions = value;
+        }
+    }
+
+    /// <summary>
     /// Optional ordered post-conversion document transforms applied to the intermediate <see cref="MarkdownDoc"/>.
     /// </summary>
     /// <example>
@@ -272,7 +288,8 @@ public sealed class HtmlToMarkdownOptions {
             ListingCardMetadataMode = ListingCardMetadataMode,
             MarkdownWriteOptions = MarkdownWriteOptions?.Clone(),
             MaxInputCharacters = MaxInputCharacters,
-            MaxTableExpandedColumns = MaxTableExpandedColumns
+            MaxTableExpandedColumns = MaxTableExpandedColumns,
+            MaxDefinitionListEntryExpansions = MaxDefinitionListEntryExpansions
         };
 
         for (var i = 0; i < DocumentTransforms.Count; i++) {

--- a/OfficeIMO.Markdown.Tests/Markdown/Markdown_AllSeverityBatch11_Security_Tests.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown/Markdown_AllSeverityBatch11_Security_Tests.cs
@@ -44,6 +44,16 @@ public sealed class MarkdownAllSeverityBatch11SecurityTests {
         Assert.Contains("safe", document.ToMarkdown(), StringComparison.Ordinal);
     }
 
+    [Theory]
+    [InlineData("<u><sup>x</u></sup>")]
+    [InlineData("<q><ins>x</q></ins>")]
+    public void MarkdownReader_CrossedInlineHtmlWrappers_StayWithinTheCurrentSlice(string markdown) {
+        MarkdownDoc document = MarkdownReader.Parse(markdown);
+
+        Assert.Single(document.Blocks);
+        Assert.Contains("x", document.ToMarkdown(), StringComparison.Ordinal);
+    }
+
     [Fact]
     public void MarkdownReader_ManyUnmatchedInlineHtmlOpeners_AreHandledWithoutRepeatedSuffixScans() {
         string markdown = string.Join(" ", Enumerable.Repeat("<u>", 4_000));

--- a/OfficeIMO.Markdown.Tests/Markdown/Markdown_AllSeverityBatch11_Security_Tests.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown/Markdown_AllSeverityBatch11_Security_Tests.cs
@@ -1,0 +1,141 @@
+using System.Text;
+using OfficeIMO.Markdown;
+using OfficeIMO.Markdown.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class MarkdownAllSeverityBatch11SecurityTests {
+    [Fact]
+    public void MarkdownReader_DeeplyNestedImageAlt_DoesNotRecursivelyMaterializeImages() {
+        var markdown = new StringBuilder();
+        for (int i = 0; i < 512; i++) markdown.Append("![");
+        markdown.Append("safe");
+        for (int i = 0; i < 512; i++) markdown.Append("](https://example.com/image.png)");
+
+        MarkdownDoc document = MarkdownReader.Parse(markdown.ToString());
+
+        var image = Assert.IsType<ImageBlock>(Assert.Single(document.Blocks));
+        Assert.Contains("safe", image.PlainAlt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MarkdownVisualContract_RejectsOversizedOrMismatchedPayloadsBeforeDecoding() {
+        string oversized = new('A', ((MarkdownVisualElementContract.MaxDecodedPayloadBytes + 2) / 3 * 4) + 1);
+        Assert.True(MarkdownVisualElementContract.TryParse(CreateVisualAttributes(oversized), out MarkdownVisualElement? element));
+        Assert.Null(MarkdownVisualElementContract.TryDecodePayload(element));
+
+        var wrongVersion = CreateVisualAttributes(Convert.ToBase64String(Encoding.UTF8.GetBytes("{}")));
+        wrongVersion[MarkdownVisualElementContract.AttributeVisualContract] = "v2";
+        Assert.True(MarkdownVisualElementContract.TryParse(wrongVersion, out element));
+        Assert.Null(MarkdownVisualElementContract.TryDecodePayload(element));
+    }
+
+    [Fact]
+    public void MarkdownReader_DeepInlineHtmlWrappers_UseBoundedIndexedMatching() {
+        var markdown = new StringBuilder();
+        for (int i = 0; i < 512; i++) markdown.Append("<u>");
+        markdown.Append("safe");
+        for (int i = 0; i < 512; i++) markdown.Append("</u>");
+
+        MarkdownDoc document = MarkdownReader.Parse(markdown.ToString());
+
+        Assert.Single(document.Blocks);
+        Assert.Contains("safe", document.ToMarkdown(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MarkdownReader_ManyUnmatchedInlineHtmlOpeners_AreHandledWithoutRepeatedSuffixScans() {
+        string markdown = string.Join(" ", Enumerable.Repeat("<u>", 4_000));
+
+        MarkdownDoc document = MarkdownReader.Parse(markdown);
+
+        Assert.Single(document.Blocks);
+    }
+
+    [Fact]
+    public void MarkdownReader_BlockImageAltWithManyUnmatchedInlineHtmlOpeners_UsesOneWrapperIndex() {
+        string alt = string.Join(" ", Enumerable.Repeat("<u>", 4_000));
+        string markdown = "![" + alt + "](https://example.com/image.png)";
+
+        MarkdownDoc document = MarkdownReader.Parse(markdown);
+
+        Assert.IsType<ImageBlock>(Assert.Single(document.Blocks));
+    }
+
+    [Fact]
+    public void MarkdownReader_LongSetextHeading_IsParsedFromOneUnderlineScan() {
+        string markdown = string.Join("\n", Enumerable.Repeat("heading", 2_000)) + "\n====";
+
+        MarkdownDoc document = MarkdownReader.Parse(markdown);
+
+        var heading = Assert.IsType<HeadingBlock>(Assert.Single(document.Blocks));
+        Assert.Equal(1, heading.Level);
+        Assert.StartsWith("heading", heading.Text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MarkdownReader_OddEmphasisCloserSelection_PreservesFormattingWithManyRuns() {
+        string markdown = "***content* " + string.Join(" ", Enumerable.Repeat("***x*", 2_000));
+
+        MarkdownDoc document = MarkdownReader.Parse(markdown);
+
+        Assert.Single(document.Blocks);
+        Assert.Contains("content", document.ToMarkdown(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MarkdownReader_RepeatedShortEmphasisOpeners_UseIndexedClosingRunLookups() {
+        string markdown = string.Join(" ", Enumerable.Repeat("**x ", 4_000));
+
+        MarkdownDoc document = MarkdownReader.Parse(markdown);
+
+        Assert.Single(document.Blocks);
+    }
+
+    [Fact]
+    public void MarkdownListRendering_LargeTaskAndLooseScopes_PreserveExpectedHtml() {
+        string markdown = string.Join("\n", Enumerable.Range(0, 4_000).Select(index =>
+            index % 2 == 0 ? $"- [ ] item {index}" : $"- item {index}"));
+        var options = new MarkdownReaderOptions { TaskLists = true };
+
+        string html = MarkdownReader.Parse(markdown, options).ToHtmlFragment();
+
+        Assert.Contains("contains-task-list", html, StringComparison.Ordinal);
+        Assert.Contains("item 3999", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HtmlToMarkdown_DeepInlineContainers_AvoidRecursiveBlockClassification() {
+        var html = new StringBuilder();
+        const int depthWithinUntrustedInputBudget = 240;
+        for (int i = 0; i < depthWithinUntrustedInputBudget; i++) html.Append("<span>");
+        html.Append("<div>safe</div>");
+        for (int i = 0; i < depthWithinUntrustedInputBudget; i++) html.Append("</span>");
+
+        string markdown = OfficeIMO.Html.HtmlConversionDocument.Parse(html.ToString()).ToMarkdown();
+
+        Assert.Contains("safe", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HtmlToMarkdown_DefinitionListExpansion_EnforcesConfiguredAggregateBudget() {
+        const string html = "<dl><dt>a</dt><dt>b</dt><dt>c</dt><dd>one</dd><dd>two</dd></dl>";
+        var options = new HtmlToMarkdownOptions { MaxDefinitionListEntryExpansions = 5 };
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+            OfficeIMO.Html.HtmlConversionDocument.Parse(html).ToMarkdownDocument(options));
+
+        Assert.Contains("entry expansion limit", exception.Message, StringComparison.Ordinal);
+    }
+
+    private static Dictionary<string, string?> CreateVisualAttributes(string payload) => new(StringComparer.Ordinal) {
+        [MarkdownVisualElementContract.AttributeVisualContract] = MarkdownVisualElementContract.ContractVersion,
+        [MarkdownVisualElementContract.AttributeVisualKind] = "chart",
+        [MarkdownVisualElementContract.AttributeFenceLanguage] = "chart",
+        [MarkdownVisualElementContract.AttributeVisualHash] = "hash",
+        [MarkdownVisualElementContract.AttributeConfigFormat] = MarkdownVisualElementContract.ConfigFormatJson,
+        [MarkdownVisualElementContract.AttributeConfigEncoding] = MarkdownVisualElementContract.ConfigEncodingBase64Utf8,
+        [MarkdownVisualElementContract.AttributeConfigBase64] = payload
+    };
+}

--- a/OfficeIMO.Markdown/Blocks/MarkdownListRendering.cs
+++ b/OfficeIMO.Markdown/Blocks/MarkdownListRendering.cs
@@ -40,24 +40,32 @@ internal static class MarkdownListRendering {
         var sb = new System.Text.StringBuilder();
         renderItemAttributes = renderItemAttributes || HtmlRenderContext.RenderListItemAttributes;
 
-        bool ContainsTasksInScope(int startIndex, int level) {
-            for (int i = startIndex; i < items.Count; i++) {
-                var it = items[i];
-                if (it.Level < level) break;
-                if (it.Level == level && it.IsTask) return true;
+        var scopeStarts = new List<int>();
+        var taskScopes = new HashSet<(int StartIndex, int Level)>();
+        var looseScopes = new HashSet<(int StartIndex, int Level)>();
+        for (int index = 0; index < items.Count; index++) {
+            int level = Math.Max(0, items[index].Level);
+            if (scopeStarts.Count > level + 1) {
+                scopeStarts.RemoveRange(level + 1, scopeStarts.Count - level - 1);
             }
-            return false;
+
+            while (scopeStarts.Count <= level) {
+                scopeStarts.Add(index);
+            }
+
+            var scopeKey = (scopeStarts[level], level);
+            if (items[index].IsTask) {
+                taskScopes.Add(scopeKey);
+            }
+
+            if (items[index].RequiresLooseListRendering()) {
+                looseScopes.Add(scopeKey);
+            }
         }
 
-        bool IsLooseInScope(int startIndex, int level) {
-            for (int i = startIndex; i < items.Count; i++) {
-                var it = items[i];
-                if (it.Level < level) break;
-                if (it.Level != level) continue;
-                if (it.RequiresLooseListRendering()) return true;
-            }
-            return false;
-        }
+        bool ContainsTasksInScope(int startIndex, int level) => taskScopes.Contains((startIndex, level));
+
+        bool IsLooseInScope(int startIndex, int level) => looseScopes.Contains((startIndex, level));
 
         void AppendOpenList(int startIndex, int level, bool isTopLevel) {
             var options = HtmlRenderContext.Options;

--- a/OfficeIMO.Markdown/Reader/MarkdownReader.Blocks.Paragraphs.cs
+++ b/OfficeIMO.Markdown/Reader/MarkdownReader.Blocks.Paragraphs.cs
@@ -935,11 +935,24 @@ public static partial class MarkdownReader {
         int maxPrefixLength = firstBlank >= 0 ? firstBlank : lines.Count;
         if (maxPrefixLength < 2) return false;
 
-        for (int prefixLength = 2; prefixLength <= maxPrefixLength; prefixLength++) {
-            var candidate = lines.GetRange(0, prefixLength);
-            if (!TryParseSetextHeadingParagraphLines(candidate, options, out level, out headingText)) continue;
+        for (int underlineIndex = 1; underlineIndex < maxPrefixLength; underlineIndex++) {
+            if (!TryGetSetextHeadingUnderlineLevel(lines[underlineIndex] ?? string.Empty, out level)) {
+                continue;
+            }
 
-            headingLineCount = prefixLength;
+            var contentLines = lines.GetRange(0, underlineIndex);
+            if (contentLines.TrueForAll(string.IsNullOrWhiteSpace)) {
+                level = 0;
+                return false;
+            }
+
+            headingText = JoinParagraphLines(contentLines, options).Trim();
+            if (headingText.Length == 0) {
+                level = 0;
+                return false;
+            }
+
+            headingLineCount = underlineIndex + 1;
             return true;
         }
 

--- a/OfficeIMO.Markdown/Reader/MarkdownReader.Inlines.Emphasis.cs
+++ b/OfficeIMO.Markdown/Reader/MarkdownReader.Inlines.Emphasis.cs
@@ -28,6 +28,185 @@ public static partial class MarkdownReader {
         public int OpenIndex { get; }
     }
 
+    private sealed class EmphasisClosingRunIndex {
+        private const byte HasRunOfAtLeastTwo = 1 << 2;
+        private const byte SingleRunCountMask = 0x03;
+        private readonly byte[] _asteriskSuffixSummaries;
+        private readonly byte[] _underscoreSuffixSummaries;
+        private readonly ClosingRunLengthIndex _asteriskOddRuns;
+        private readonly ClosingRunLengthIndex _asteriskEvenRuns;
+        private readonly ClosingRunLengthIndex _underscoreOddRuns;
+        private readonly ClosingRunLengthIndex _underscoreEvenRuns;
+
+        private EmphasisClosingRunIndex(
+            byte[] asteriskSuffixSummaries,
+            byte[] underscoreSuffixSummaries,
+            ClosingRunLengthIndex asteriskOddRuns,
+            ClosingRunLengthIndex asteriskEvenRuns,
+            ClosingRunLengthIndex underscoreOddRuns,
+            ClosingRunLengthIndex underscoreEvenRuns) {
+            _asteriskSuffixSummaries = asteriskSuffixSummaries;
+            _underscoreSuffixSummaries = underscoreSuffixSummaries;
+            _asteriskOddRuns = asteriskOddRuns;
+            _asteriskEvenRuns = asteriskEvenRuns;
+            _underscoreOddRuns = underscoreOddRuns;
+            _underscoreEvenRuns = underscoreEvenRuns;
+        }
+
+        internal static EmphasisClosingRunIndex Build(string text, bool cjkFriendlyEmphasis) {
+            var asteriskSummaries = new byte[text.Length + 1];
+            var underscoreSummaries = new byte[text.Length + 1];
+            var asteriskOddRuns = new Dictionary<int, int>();
+            var asteriskEvenRuns = new Dictionary<int, int>();
+            var underscoreOddRuns = new Dictionary<int, int>();
+            var underscoreEvenRuns = new Dictionary<int, int>();
+
+            for (int index = text.Length - 1; index >= 0; index--) {
+                asteriskSummaries[index] = asteriskSummaries[index + 1];
+                underscoreSummaries[index] = underscoreSummaries[index + 1];
+
+                char marker = text[index];
+                if ((marker != '*' && marker != '_') || (index > 0 && text[index - 1] == marker)) {
+                    continue;
+                }
+
+                int runLength = 1;
+                while (index + runLength < text.Length && text[index + runLength] == marker) {
+                    runLength++;
+                }
+
+                GetDelimiterFlags(text, index, marker, runLength, cjkFriendlyEmphasis, out _, out bool canClose);
+                if (!canClose) {
+                    continue;
+                }
+
+                Dictionary<int, int> runStarts;
+                if (marker == '*') {
+                    runStarts = (runLength & 1) == 0 ? asteriskEvenRuns : asteriskOddRuns;
+                } else {
+                    runStarts = (runLength & 1) == 0 ? underscoreEvenRuns : underscoreOddRuns;
+                }
+                if (!runStarts.TryGetValue(runLength, out int currentMaximumStart) || index > currentMaximumStart) {
+                    runStarts[runLength] = index;
+                }
+
+                byte[] summaries = marker == '*' ? asteriskSummaries : underscoreSummaries;
+                if (runLength >= 2) {
+                    summaries[index] |= HasRunOfAtLeastTwo;
+                } else {
+                    int singleCount = Math.Min(2, (summaries[index] & SingleRunCountMask) + 1);
+                    summaries[index] = (byte)((summaries[index] & ~SingleRunCountMask) | singleCount);
+                }
+            }
+
+            return new EmphasisClosingRunIndex(
+                asteriskSummaries,
+                underscoreSummaries,
+                ClosingRunLengthIndex.Create(asteriskOddRuns),
+                ClosingRunLengthIndex.Create(asteriskEvenRuns),
+                ClosingRunLengthIndex.Create(underscoreOddRuns),
+                ClosingRunLengthIndex.Create(underscoreEvenRuns));
+        }
+
+        internal bool HasRunAtLeastTwo(int start, char marker) {
+            byte summary = GetSummary(start, marker);
+            return (summary & HasRunOfAtLeastTwo) != 0;
+        }
+
+        internal int CountSingleRuns(int start, char marker) => GetSummary(start, marker) & SingleRunCountMask;
+
+        internal int GetLargestRunAtMost(int start, char marker, int maximumRunLength, bool odd) {
+            ClosingRunLengthIndex index;
+            if (marker == '*') {
+                index = odd ? _asteriskOddRuns : _asteriskEvenRuns;
+            } else {
+                index = odd ? _underscoreOddRuns : _underscoreEvenRuns;
+            }
+
+            return index.GetLargestRunAtMost(maximumRunLength, start);
+        }
+
+        private byte GetSummary(int start, char marker) {
+            byte[] summaries = marker == '*' ? _asteriskSuffixSummaries : _underscoreSuffixSummaries;
+            int index = Math.Max(0, Math.Min(start, summaries.Length - 1));
+            return summaries[index];
+        }
+
+        private sealed class ClosingRunLengthIndex {
+            private readonly int[] _runLengths;
+            private readonly int[] _maximumStarts;
+            private readonly int _leafOffset;
+
+            private ClosingRunLengthIndex(int[] runLengths, int[] maximumStarts, int leafOffset) {
+                _runLengths = runLengths;
+                _maximumStarts = maximumStarts;
+                _leafOffset = leafOffset;
+            }
+
+            internal static ClosingRunLengthIndex Create(Dictionary<int, int> maximumStartsByRunLength) {
+                int[] runLengths = maximumStartsByRunLength.Keys.ToArray();
+                Array.Sort(runLengths);
+
+                int leafOffset = 1;
+                while (leafOffset < runLengths.Length) {
+                    leafOffset <<= 1;
+                }
+
+                var maximumStarts = new int[leafOffset * 2];
+                for (int index = 0; index < maximumStarts.Length; index++) {
+                    maximumStarts[index] = -1;
+                }
+                for (int index = 0; index < runLengths.Length; index++) {
+                    maximumStarts[leafOffset + index] = maximumStartsByRunLength[runLengths[index]];
+                }
+                for (int index = leafOffset - 1; index > 0; index--) {
+                    maximumStarts[index] = Math.Max(maximumStarts[index * 2], maximumStarts[(index * 2) + 1]);
+                }
+
+                return new ClosingRunLengthIndex(runLengths, maximumStarts, leafOffset);
+            }
+
+            internal int GetLargestRunAtMost(int maximumRunLength, int minimumStart) {
+                if (_runLengths.Length == 0 || maximumRunLength <= 0) {
+                    return 0;
+                }
+
+                int maximumIndex = Array.BinarySearch(_runLengths, maximumRunLength);
+                if (maximumIndex < 0) {
+                    maximumIndex = ~maximumIndex - 1;
+                }
+                if (maximumIndex < 0) {
+                    return 0;
+                }
+
+                int matchingIndex = FindRightmostIndex(
+                    node: 1,
+                    segmentStart: 0,
+                    segmentEnd: _leafOffset - 1,
+                    queryEnd: maximumIndex,
+                    minimumStart);
+                return matchingIndex >= 0 && matchingIndex < _runLengths.Length
+                    ? _runLengths[matchingIndex]
+                    : 0;
+            }
+
+            private int FindRightmostIndex(int node, int segmentStart, int segmentEnd, int queryEnd, int minimumStart) {
+                if (segmentStart > queryEnd || _maximumStarts[node] < minimumStart) {
+                    return -1;
+                }
+                if (segmentStart == segmentEnd) {
+                    return segmentStart;
+                }
+
+                int middle = segmentStart + ((segmentEnd - segmentStart) / 2);
+                int right = FindRightmostIndex((node * 2) + 1, middle + 1, segmentEnd, queryEnd, minimumStart);
+                return right >= 0
+                    ? right
+                    : FindRightmostIndex(node * 2, segmentStart, middle, queryEnd, minimumStart);
+            }
+        }
+    }
+
     private static bool TryCloseFrame(
         Stack<InlineFrame> stack,
         char marker,
@@ -261,14 +440,21 @@ public static partial class MarkdownReader {
         return top.Marker == marker && top.Kind == FrameKind.Italic;
     }
 
-    private static bool ShouldSplitDoubleUnderscoreToLiteralAndItalic(string text, int start, int runLen, bool canOpen, bool canClose) {
+    private static bool ShouldSplitDoubleUnderscoreToLiteralAndItalic(
+        string text,
+        int start,
+        int runLen,
+        bool canOpen,
+        bool canClose,
+        EmphasisClosingRunIndex? closingRuns) {
         if (!canOpen || canClose) return false;
         if (runLen != 2) return false;
         if (string.IsNullOrEmpty(text) || start < 0 || start >= text.Length) return false;
         if (text[start] != '_') return false;
+        if (closingRuns == null) return false;
 
-        return !HasFutureClosingDelimiterRun(text, start + 2, '_', minimumRunLength: 2, cjkFriendlyEmphasis: false) &&
-               CountFutureClosingDelimiterRuns(text, start + 2, '_', requiredRunLength: 1, maximumCount: 2, cjkFriendlyEmphasis: false) == 1;
+        return !closingRuns.HasRunAtLeastTwo(start + 2, '_') &&
+               closingRuns.CountSingleRuns(start + 2, '_') == 1;
     }
 
     private static bool ShouldSplitDoubleRunIntoRootDualItalic(
@@ -279,40 +465,36 @@ public static partial class MarkdownReader {
         bool canOpen,
         bool canClose,
         Stack<InlineFrame> stack,
-        bool cjkFriendlyEmphasis) {
+        EmphasisClosingRunIndex? closingRuns) {
         if (!canOpen || canClose) return false;
         if (runLen != 2) return false;
         if (marker != '*' && marker != '_') return false;
         if (string.IsNullOrEmpty(text) || start < 0 || start >= text.Length) return false;
         if (stack == null || stack.Count != 1) return false;
-        if (HasFutureClosingDelimiterRun(text, start + 2, marker, minimumRunLength: 2, cjkFriendlyEmphasis)) return false;
+        if (closingRuns == null || closingRuns.HasRunAtLeastTwo(start + 2, marker)) return false;
 
-        return CountFutureClosingDelimiterRuns(text, start + 2, marker, requiredRunLength: 1, maximumCount: 2, cjkFriendlyEmphasis) >= 2;
+        return closingRuns.CountSingleRuns(start + 2, marker) >= 2;
     }
 
-    private static int GetLiteralPrefixLengthForOddCloser(string text, int start, char marker, int runLen, bool canOpen, bool canClose, bool cjkFriendlyEmphasis) {
+    private static int GetLiteralPrefixLengthForOddCloser(
+        string text,
+        int start,
+        char marker,
+        int runLen,
+        bool canOpen,
+        bool canClose,
+        EmphasisClosingRunIndex? closingRuns) {
         if (!canOpen || canClose) return 0;
         if (runLen < 2 || (runLen % 2) != 0) return 0;
         if (marker != '*' && marker != '_') return 0;
         if (string.IsNullOrEmpty(text) || start < 0 || start >= text.Length) return 0;
+        if (closingRuns == null) return 0;
 
-        for (int candidate = runLen - 1; candidate >= 1; candidate -= 2) {
-            if (FindNextClosingDelimiterRunIndex(text, start + runLen, marker, requiredRunLength: candidate, cjkFriendlyEmphasis) < 0) continue;
+        int suffixStart = start + runLen;
+        int largestOddCloser = closingRuns.GetLargestRunAtMost(suffixStart, marker, runLen, odd: true);
+        int largestEvenCloser = closingRuns.GetLargestRunAtMost(suffixStart, marker, runLen, odd: false);
 
-            bool hasSameOrLongerEvenCloser = false;
-            for (int even = runLen; even >= candidate + 1; even -= 2) {
-                if (FindNextClosingDelimiterRunIndex(text, start + runLen, marker, requiredRunLength: even, cjkFriendlyEmphasis) >= 0) {
-                    hasSameOrLongerEvenCloser = true;
-                    break;
-                }
-            }
-
-            if (!hasSameOrLongerEvenCloser) {
-                return runLen - candidate;
-            }
-        }
-
-        return 0;
+        return largestOddCloser > largestEvenCloser ? runLen - largestOddCloser : 0;
     }
 
     private static bool HasFutureClosingDelimiterRun(string text, int start, char marker, int minimumRunLength, bool cjkFriendlyEmphasis) {

--- a/OfficeIMO.Markdown/Reader/MarkdownReader.Inlines.Html.cs
+++ b/OfficeIMO.Markdown/Reader/MarkdownReader.Inlines.Html.cs
@@ -93,6 +93,11 @@ public static partial class MarkdownReader {
         }
 
         int openLength = tagName.Length + 2;
+        int closingLength = tagName.Length + 3;
+        if (closingStart < start + openLength || closingStart > text.Length - closingLength) {
+            return false;
+        }
+
         string inner = text.Substring(start + openLength, closingStart - (start + openLength));
         var inlines = ParseInlinesInternal(
             inner,
@@ -123,6 +128,12 @@ public static partial class MarkdownReader {
 
         matches ??= BuildInlineHtmlWrapperMatchIndex(text);
         if (!matches.TryGet(start, out string tagName, out int closingStart)) {
+            return false;
+        }
+
+        int openLength = tagName.Length + 2;
+        int closingLength = tagName.Length + 3;
+        if (closingStart < start + openLength || closingStart > text.Length - closingLength) {
             return false;
         }
 

--- a/OfficeIMO.Markdown/Reader/MarkdownReader.Inlines.Html.cs
+++ b/OfficeIMO.Markdown/Reader/MarkdownReader.Inlines.Html.cs
@@ -2,6 +2,71 @@ namespace OfficeIMO.Markdown;
 
 public static partial class MarkdownReader {
     private static readonly string[] SupportedInlineHtmlWrapperTags = { "u", "sup", "sub", "ins", "q" };
+    private const int MaximumInlineHtmlWrapperDepth = 32;
+
+    private sealed class InlineHtmlWrapperMatchIndex {
+        private readonly Dictionary<int, (string TagName, int ClosingStart)> _matches;
+        private readonly int _baseOffset;
+
+        internal InlineHtmlWrapperMatchIndex(Dictionary<int, (string TagName, int ClosingStart)> matches, int baseOffset = 0) {
+            _matches = matches;
+            _baseOffset = baseOffset;
+        }
+
+        internal InlineHtmlWrapperMatchIndex Slice(int relativeOffset) =>
+            new(_matches, checked(_baseOffset + relativeOffset));
+
+        internal bool TryGet(int relativeStart, out string tagName, out int closingStart) {
+            if (_matches.TryGetValue(checked(_baseOffset + relativeStart), out var match)) {
+                tagName = match.TagName;
+                closingStart = match.ClosingStart - _baseOffset;
+                return true;
+            }
+
+            tagName = string.Empty;
+            closingStart = -1;
+            return false;
+        }
+    }
+
+    private static InlineHtmlWrapperMatchIndex BuildInlineHtmlWrapperMatchIndex(string text) {
+        var matches = new Dictionary<int, (string TagName, int ClosingStart)>();
+        if (string.IsNullOrEmpty(text)) {
+            return new InlineHtmlWrapperMatchIndex(matches);
+        }
+
+        var openingsByTag = new Dictionary<string, Stack<int>>(StringComparer.OrdinalIgnoreCase);
+        for (int i = 0; i < SupportedInlineHtmlWrapperTags.Length; i++) {
+            openingsByTag[SupportedInlineHtmlWrapperTags[i]] = new Stack<int>();
+        }
+
+        for (int position = 0; position < text.Length; position++) {
+            if (text[position] != '<') {
+                continue;
+            }
+
+            for (int tagIndex = 0; tagIndex < SupportedInlineHtmlWrapperTags.Length; tagIndex++) {
+                string tagName = SupportedInlineHtmlWrapperTags[tagIndex];
+                if (StartsWithExactHtmlTag(text, position, tagName, opening: true)) {
+                    openingsByTag[tagName].Push(position);
+                    position += tagName.Length + 1;
+                    break;
+                }
+
+                if (StartsWithExactHtmlTag(text, position, tagName, opening: false)) {
+                    var openings = openingsByTag[tagName];
+                    if (openings.Count > 0) {
+                        matches[openings.Pop()] = (tagName, position);
+                    }
+
+                    position += tagName.Length + 2;
+                    break;
+                }
+            }
+        }
+
+        return new InlineHtmlWrapperMatchIndex(matches);
+    }
 
     private static bool TryParseSupportedInlineHtmlTag(
         string text,
@@ -11,6 +76,8 @@ public static partial class MarkdownReader {
         MarkdownInlineSourceMap? sourceMap,
         bool allowLinks,
         bool allowImages,
+        InlineHtmlWrapperMatchIndex matches,
+        int wrapperDepth,
         out int consumed,
         out IMarkdownInline htmlNode) {
         consumed = 0;
@@ -20,122 +87,47 @@ public static partial class MarkdownReader {
             return false;
         }
 
-        for (int i = 0; i < SupportedInlineHtmlWrapperTags.Length; i++) {
-            if (!TryParseInlineHtmlWrapper(text, start, SupportedInlineHtmlWrapperTags[i], options, state, sourceMap, allowLinks, allowImages, out consumed, out var inlines)) {
-                continue;
-            }
-
-            var htmlTag = new HtmlTagSequenceInline(SupportedInlineHtmlWrapperTags[i], inlines);
-            SetInlineHtmlTagMarkerSpans(htmlTag, sourceMap, start, consumed);
-            htmlNode = htmlTag;
-            return true;
-        }
-
-        return false;
-    }
-
-    private static bool TryParseInlineHtmlWrapper(
-        string text,
-        int start,
-        string tagName,
-        MarkdownReaderOptions options,
-        MarkdownReaderState? state,
-        MarkdownInlineSourceMap? sourceMap,
-        bool allowLinks,
-        bool allowImages,
-        out int consumed,
-        out InlineSequence inlines) {
-        consumed = 0;
-        inlines = new InlineSequence();
-
-        if (!StartsWithExactHtmlTag(text, start, tagName, opening: true)) {
+        if (wrapperDepth >= MaximumInlineHtmlWrapperDepth
+            || !matches.TryGet(start, out string tagName, out int closingStart)) {
             return false;
         }
 
         int openLength = tagName.Length + 2;
-        int scan = start + openLength;
-        int depth = 1;
-
-        while (scan < text.Length) {
-            if (StartsWithExactHtmlTag(text, scan, tagName, opening: false)) {
-                depth--;
-                if (depth == 0) {
-                    string inner = text.Substring(start + openLength, scan - (start + openLength));
-                    inlines = ParseInlinesInternal(
-                        inner,
-                        options,
-                        state,
-                        allowLinks,
-                        allowImages,
-                        sourceMap?.Slice(start + openLength, inner.Length));
-                    DecodeHtmlEntitiesInTextRuns(inlines);
-                    consumed = (scan - start) + tagName.Length + 3;
-                    return true;
-                }
-
-                scan += tagName.Length + 3;
-                continue;
-            }
-
-            if (StartsWithExactHtmlTag(text, scan, tagName, opening: true)) {
-                depth++;
-                scan += openLength;
-                continue;
-            }
-
-            scan++;
-        }
-
-        return false;
+        string inner = text.Substring(start + openLength, closingStart - (start + openLength));
+        var inlines = ParseInlinesInternal(
+            inner,
+            options,
+            state,
+            allowLinks,
+            allowImages,
+            sourceMap?.Slice(start + openLength, inner.Length),
+            matches.Slice(start + openLength),
+            wrapperDepth + 1);
+        DecodeHtmlEntitiesInTextRuns(inlines);
+        consumed = (closingStart - start) + tagName.Length + 3;
+        var htmlTag = new HtmlTagSequenceInline(tagName, inlines);
+        SetInlineHtmlTagMarkerSpans(htmlTag, sourceMap, start, consumed);
+        htmlNode = htmlTag;
+        return true;
     }
 
-    private static bool TryConsumeSupportedInlineHtmlWrapperSpan(string text, int start, out int consumed) {
+    private static bool TryConsumeSupportedInlineHtmlWrapperSpan(
+        string text,
+        int start,
+        out int consumed,
+        InlineHtmlWrapperMatchIndex? matches = null) {
         consumed = 0;
         if (string.IsNullOrEmpty(text) || start < 0 || start >= text.Length || text[start] != '<') {
             return false;
         }
 
-        for (int i = 0; i < SupportedInlineHtmlWrapperTags.Length; i++) {
-            if (TryConsumeSupportedInlineHtmlWrapperSpan(text, start, SupportedInlineHtmlWrapperTags[i], out consumed)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private static bool TryConsumeSupportedInlineHtmlWrapperSpan(string text, int start, string tagName, out int consumed) {
-        consumed = 0;
-        if (!StartsWithExactHtmlTag(text, start, tagName, opening: true)) {
+        matches ??= BuildInlineHtmlWrapperMatchIndex(text);
+        if (!matches.TryGet(start, out string tagName, out int closingStart)) {
             return false;
         }
 
-        int openLength = tagName.Length + 2;
-        int scan = start + openLength;
-        int depth = 1;
-
-        while (scan < text.Length) {
-            if (StartsWithExactHtmlTag(text, scan, tagName, opening: false)) {
-                depth--;
-                if (depth == 0) {
-                    consumed = (scan - start) + tagName.Length + 3;
-                    return true;
-                }
-
-                scan += tagName.Length + 3;
-                continue;
-            }
-
-            if (StartsWithExactHtmlTag(text, scan, tagName, opening: true)) {
-                depth++;
-                scan += openLength;
-                continue;
-            }
-
-            scan++;
-        }
-
-        return false;
+        consumed = (closingStart - start) + tagName.Length + 3;
+        return true;
     }
 
     private static void SetInlineHtmlTagMarkerSpans(

--- a/OfficeIMO.Markdown/Reader/MarkdownReader.Inlines.Images.cs
+++ b/OfficeIMO.Markdown/Reader/MarkdownReader.Inlines.Images.cs
@@ -1,9 +1,19 @@
 namespace OfficeIMO.Markdown;
 
 public static partial class MarkdownReader {
-    private static string ExtractImageAltPlainText(string altMarkdown, MarkdownReaderOptions options, MarkdownReaderState? state) {
+    private const int MaxImageAltNestingDepth = 32;
+
+    private static string ExtractImageAltPlainText(
+        string altMarkdown,
+        MarkdownReaderOptions options,
+        MarkdownReaderState? state,
+        int imageAltDepth = 0) {
         if (string.IsNullOrEmpty(altMarkdown)) {
             return string.Empty;
+        }
+
+        if (imageAltDepth >= MaxImageAltNestingDepth) {
+            return altMarkdown;
         }
 
         var altSequence = ParseInlinesInternal(
@@ -11,14 +21,15 @@ public static partial class MarkdownReader {
             options,
             state,
             allowLinks: true,
-            allowImages: true);
+            allowImages: true,
+            imageAltDepth: imageAltDepth + 1);
         return InlinePlainText.Extract(altSequence);
     }
 
-    private static bool TryConsumeLiteralInlineImage(string text, int start, out int consumed) {
+    private static bool TryConsumeLiteralInlineImage(string text, int start, out int consumed, InlineHtmlWrapperMatchIndex? inlineHtmlWrapperMatches = null) {
         consumed = 0;
         if (start + 1 >= text.Length || text[start] != '!' || text[start + 1] != '[') return false;
-        int altEnd = FindMatchingBracket(text, start + 1);
+        int altEnd = FindMatchingBracket(text, start + 1, inlineHtmlWrapperMatches: inlineHtmlWrapperMatches);
         if (altEnd < 0) return false;
         if (altEnd + 1 >= text.Length || text[altEnd + 1] != '(') return false;
         int parenClose = FindMatchingParen(text, altEnd + 1);
@@ -49,14 +60,15 @@ public static partial class MarkdownReader {
         out int hrefStart,
         out int hrefLength,
         out int? hrefTitleStart,
-        out int? hrefTitleLength) {
+        out int? hrefTitleLength,
+        InlineHtmlWrapperMatchIndex? inlineHtmlWrapperMatches = null) {
         consumed = 0; alt = img = href = string.Empty; imgTitle = hrefTitle = null;
         altStart = altLength = imgStart = imgLength = hrefStart = hrefLength = 0;
         imgTitleStart = imgTitleLength = hrefTitleStart = hrefTitleLength = null;
         if (start >= text.Length || text[start] != '[') return false;
         if (start + 1 >= text.Length || text[start + 1] != '!') return false;
         if (start + 2 >= text.Length || text[start + 2] != '[') return false;
-        int altEnd = FindMatchingBracket(text, start + 2);
+        int altEnd = FindMatchingBracket(text, start + 2, inlineHtmlWrapperMatches: inlineHtmlWrapperMatches);
         if (altEnd < 0) return false;
         if (altEnd + 1 >= text.Length || text[altEnd + 1] != '(') return false;
         int imgClose = FindMatchingParen(text, altEnd + 1);
@@ -141,7 +153,8 @@ public static partial class MarkdownReader {
         out int srcStart,
         out int srcLength,
         out int? titleStart,
-        out int? titleLength) {
+        out int? titleLength,
+        InlineHtmlWrapperMatchIndex? inlineHtmlWrapperMatches = null) {
         return TryParseInlineImage(
             text,
             start,
@@ -155,7 +168,8 @@ public static partial class MarkdownReader {
             out srcStart,
             out srcLength,
             out titleStart,
-            out titleLength);
+            out titleLength,
+            inlineHtmlWrapperMatches);
     }
 
     private static bool TryParseInlineImage(
@@ -171,14 +185,15 @@ public static partial class MarkdownReader {
         out int srcStart,
         out int srcLength,
         out int? titleStart,
-        out int? titleLength) {
+        out int? titleLength,
+        InlineHtmlWrapperMatchIndex? inlineHtmlWrapperMatches = null) {
         consumed = 0;
         alt = src = string.Empty;
         title = null;
         altStart = altLength = srcStart = srcLength = 0;
         titleStart = titleLength = null;
         if (start + 1 >= text.Length || text[start] != '!' || text[start + 1] != '[') return false;
-        int altEnd = FindMatchingBracket(text, start + 1);
+        int altEnd = FindMatchingBracket(text, start + 1, inlineHtmlWrapperMatches: inlineHtmlWrapperMatches);
         if (altEnd < 0) return false;
         if (altEnd + 1 >= text.Length || text[altEnd + 1] != '(') return false;
         int parenClose = FindMatchingParen(text, altEnd + 1);
@@ -221,12 +236,13 @@ public static partial class MarkdownReader {
         out string alt,
         out string label,
         out int altStart,
-        out int altLength) {
+        out int altLength,
+        InlineHtmlWrapperMatchIndex? inlineHtmlWrapperMatches = null) {
         consumed = 0;
         alt = label = string.Empty;
         altStart = altLength = 0;
         if (start + 1 >= text.Length || text[start] != '!' || text[start + 1] != '[') return false;
-        int altEnd = FindMatchingBracket(text, start + 1);
+        int altEnd = FindMatchingBracket(text, start + 1, inlineHtmlWrapperMatches: inlineHtmlWrapperMatches);
         if (altEnd < 0) return false;
 
         altStart = start + 2;
@@ -238,7 +254,7 @@ public static partial class MarkdownReader {
 
         // Full or collapsed reference: ![alt][label] or ![alt][]
         if (altEnd + 1 < text.Length && text[altEnd + 1] == '[') {
-            int labelEnd = FindMatchingBracket(text, altEnd + 1);
+            int labelEnd = FindMatchingBracket(text, altEnd + 1, inlineHtmlWrapperMatches: inlineHtmlWrapperMatches);
             if (labelEnd < 0) return false;
             label = text.Substring(altEnd + 2, labelEnd - (altEnd + 2));
             if (string.IsNullOrEmpty(label)) label = alt;

--- a/OfficeIMO.Markdown/Reader/MarkdownReader.Inlines.Links.cs
+++ b/OfficeIMO.Markdown/Reader/MarkdownReader.Inlines.Links.cs
@@ -1,11 +1,16 @@
 namespace OfficeIMO.Markdown;
 
 public static partial class MarkdownReader {
-    private static int FindMatchingBracket(string text, int openIndex, MarkdownReaderOptions? options = null) {
+    private static int FindMatchingBracket(
+        string text,
+        int openIndex,
+        MarkdownReaderOptions? options = null,
+        InlineHtmlWrapperMatchIndex? inlineHtmlWrapperMatches = null) {
         if (string.IsNullOrEmpty(text) || openIndex < 0 || openIndex >= text.Length || text[openIndex] != '[') return -1;
 
         int depth = 0;
         bool escaped = false;
+        var effectiveInlineHtmlWrapperMatches = inlineHtmlWrapperMatches;
         for (int i = openIndex; i < text.Length; i++) {
             char c = text[i];
             if (escaped) {
@@ -18,7 +23,11 @@ public static partial class MarkdownReader {
                 continue;
             }
 
-            if (TrySkipLinkLabelInlineSpan(text, i, options, out int spanConsumed)) {
+            if (c == '<' && effectiveInlineHtmlWrapperMatches == null && options?.InlineHtml != false) {
+                effectiveInlineHtmlWrapperMatches = BuildInlineHtmlWrapperMatchIndex(text);
+            }
+
+            if (TrySkipLinkLabelInlineSpan(text, i, options, out int spanConsumed, effectiveInlineHtmlWrapperMatches)) {
                 i += spanConsumed - 1;
                 continue;
             }
@@ -37,7 +46,12 @@ public static partial class MarkdownReader {
         return -1;
     }
 
-    private static bool TrySkipLinkLabelInlineSpan(string text, int start, MarkdownReaderOptions? options, out int consumed) {
+    private static bool TrySkipLinkLabelInlineSpan(
+        string text,
+        int start,
+        MarkdownReaderOptions? options,
+        out int consumed,
+        InlineHtmlWrapperMatchIndex? inlineHtmlWrapperMatches = null) {
         consumed = 0;
         if (string.IsNullOrEmpty(text) || start < 0 || start >= text.Length) return false;
 
@@ -47,7 +61,7 @@ public static partial class MarkdownReader {
 
         if (text[start] == '<') {
             bool inlineHtml = options?.InlineHtml != false;
-            if (inlineHtml && TryConsumeSupportedInlineHtmlWrapperSpan(text, start, out consumed)) {
+            if (inlineHtml && TryConsumeSupportedInlineHtmlWrapperSpan(text, start, out consumed, inlineHtmlWrapperMatches)) {
                 return true;
             }
 
@@ -165,31 +179,31 @@ public static partial class MarkdownReader {
         return UnescapeMarkdownBackslashEscapes(value);
     }
 
-    private static bool TryParseRefLink(string text, int start, MarkdownReaderOptions? options, out int consumed, out string label, out string refLabel) {
+    private static bool TryParseRefLink(string text, int start, MarkdownReaderOptions? options, out int consumed, out string label, out string refLabel, InlineHtmlWrapperMatchIndex? inlineHtmlWrapperMatches = null) {
         consumed = 0; label = refLabel = string.Empty;
         if (start >= text.Length || text[start] != '[') return false;
-        int rb = FindMatchingBracket(text, start, options); if (rb < 0) return false;
+        int rb = FindMatchingBracket(text, start, options, inlineHtmlWrapperMatches); if (rb < 0) return false;
         if (rb + 1 >= text.Length || text[rb + 1] != '[') return false;
-        int rb2 = FindMatchingBracket(text, rb + 1, options); if (rb2 < 0) return false;
+        int rb2 = FindMatchingBracket(text, rb + 1, options, inlineHtmlWrapperMatches); if (rb2 < 0) return false;
         label = text.Substring(start + 1, rb - (start + 1));
         refLabel = text.Substring(rb + 2, rb2 - (rb + 2));
         consumed = rb2 - start + 1; return true;
     }
 
-    private static bool TryParseCollapsedRef(string text, int start, MarkdownReaderOptions? options, out int consumed, out string label) {
+    private static bool TryParseCollapsedRef(string text, int start, MarkdownReaderOptions? options, out int consumed, out string label, InlineHtmlWrapperMatchIndex? inlineHtmlWrapperMatches = null) {
         consumed = 0; label = string.Empty;
         if (start >= text.Length || text[start] != '[') return false;
-        int rb = FindMatchingBracket(text, start, options); if (rb < 0) return false;
+        int rb = FindMatchingBracket(text, start, options, inlineHtmlWrapperMatches); if (rb < 0) return false;
         if (rb + 2 >= text.Length || text[rb + 1] != '[' || text[rb + 2] != ']') return false;
         label = text.Substring(start + 1, rb - (start + 1));
         consumed = rb + 3 - start;
         return true;
     }
 
-    private static bool TryParseShortcutRef(string text, int start, MarkdownReaderOptions? options, out int consumed, out string label) {
+    private static bool TryParseShortcutRef(string text, int start, MarkdownReaderOptions? options, out int consumed, out string label, InlineHtmlWrapperMatchIndex? inlineHtmlWrapperMatches = null) {
         consumed = 0; label = string.Empty;
         if (start >= text.Length || text[start] != '[') return false;
-        int rb = FindMatchingBracket(text, start, options); if (rb < 0) return false;
+        int rb = FindMatchingBracket(text, start, options, inlineHtmlWrapperMatches); if (rb < 0) return false;
         if (rb + 1 < text.Length && text[rb + 1] == '[') return false;
         label = text.Substring(start + 1, rb - (start + 1));
         consumed = rb + 1 - start;
@@ -198,9 +212,10 @@ public static partial class MarkdownReader {
 
     private static bool ContainsResolvedLinkInLabel(string label, MarkdownReaderOptions? options, MarkdownReaderState? state) {
         if (string.IsNullOrEmpty(label)) return false;
+        var inlineHtmlWrapperMatches = BuildInlineHtmlWrapperMatchIndex(label);
 
         for (int i = 0; i < label.Length; i++) {
-            if (TrySkipLinkLabelInlineSpan(label, i, options, out int spanConsumed)) {
+            if (TrySkipLinkLabelInlineSpan(label, i, options, out int spanConsumed, inlineHtmlWrapperMatches)) {
                 i += spanConsumed - 1;
                 continue;
             }
@@ -226,7 +241,8 @@ public static partial class MarkdownReader {
                 out _,
                 out _,
                 out _,
-                out _)) {
+                out _,
+                inlineHtmlWrapperMatches)) {
                 return true;
             }
 
@@ -234,17 +250,17 @@ public static partial class MarkdownReader {
                 continue;
             }
 
-            if (TryParseRefLink(label, i, options, out _, out _, out var referenceLabel)
+            if (TryParseRefLink(label, i, options, out _, out _, out var referenceLabel, inlineHtmlWrapperMatches)
                 && state.LinkRefs.ContainsKey(NormalizeReferenceLabel(referenceLabel))) {
                 return true;
             }
 
-            if (TryParseCollapsedRef(label, i, options, out _, out var collapsedLabel)
+            if (TryParseCollapsedRef(label, i, options, out _, out var collapsedLabel, inlineHtmlWrapperMatches)
                 && state.LinkRefs.ContainsKey(NormalizeReferenceLabel(collapsedLabel))) {
                 return true;
             }
 
-            if (TryParseShortcutRef(label, i, options, out _, out var shortcutLabel)
+            if (TryParseShortcutRef(label, i, options, out _, out var shortcutLabel, inlineHtmlWrapperMatches)
                 && state.LinkRefs.ContainsKey(NormalizeReferenceLabel(shortcutLabel))) {
                 return true;
             }
@@ -266,11 +282,12 @@ public static partial class MarkdownReader {
         out int hrefStart,
         out int hrefLength,
         out int? titleStart,
-        out int? titleLength) {
+        out int? titleLength,
+        InlineHtmlWrapperMatchIndex? inlineHtmlWrapperMatches = null) {
         consumed = 0; label = href = string.Empty; title = null;
         hrefStart = 0; hrefLength = 0; titleStart = null; titleLength = null;
         if (start >= text.Length || text[start] != '[') return false;
-        int labelEnd = FindMatchingBracket(text, start, options);
+        int labelEnd = FindMatchingBracket(text, start, options, inlineHtmlWrapperMatches);
         if (labelEnd < 0) return false;
         int parenOpen = (labelEnd + 1 < text.Length && text[labelEnd + 1] == '(') ? labelEnd + 1 : -1;
         if (parenOpen < 0) return false;

--- a/OfficeIMO.Markdown/Reader/MarkdownReader.Inlines.cs
+++ b/OfficeIMO.Markdown/Reader/MarkdownReader.Inlines.cs
@@ -12,10 +12,26 @@ public static partial class MarkdownReader {
         return sequence;
     }
 
-    private static InlineSequence ParseInlinesInternal(string text, MarkdownReaderOptions options, MarkdownReaderState? state, bool allowLinks, bool allowImages, MarkdownInlineSourceMap? sourceMap = null) {
+    private static InlineSequence ParseInlinesInternal(
+        string text,
+        MarkdownReaderOptions options,
+        MarkdownReaderState? state,
+        bool allowLinks,
+        bool allowImages,
+        MarkdownInlineSourceMap? sourceMap = null,
+        InlineHtmlWrapperMatchIndex? inlineHtmlWrapperMatches = null,
+        int inlineHtmlWrapperDepth = 0,
+        int imageAltDepth = 0) {
         var root = new InlineSequence { AutoSpacing = false };
         if (string.IsNullOrEmpty(text)) return root;
         var inlineParserExtensions = BuildEffectiveInlineParserExtensions(options);
+        inlineHtmlWrapperMatches ??= BuildInlineHtmlWrapperMatchIndex(text);
+        EmphasisClosingRunIndex? emphasisClosingRuns = text.IndexOf('*') >= 0 || text.IndexOf('_') >= 0
+            ? EmphasisClosingRunIndex.Build(text, options.CjkFriendlyEmphasis)
+            : null;
+        EmphasisClosingRunIndex? standardEmphasisClosingRuns = options.CjkFriendlyEmphasis && text.IndexOf('_') >= 0
+            ? EmphasisClosingRunIndex.Build(text, cjkFriendlyEmphasis: false)
+            : emphasisClosingRuns;
 
         // We parse emphasis/strong/strikethrough using a simple stack of open frames so that nesting like
         // "*a **b** c*" behaves intuitively. This is not a full spec implementation, but it's materially
@@ -329,7 +345,10 @@ public static partial class MarkdownReader {
                 state,
                 nestedAllowLinks,
                 nestedAllowImages,
-                SliceMap(relativeStart, safeLength));
+                SliceMap(relativeStart, safeLength),
+                inlineHtmlWrapperMatches.Slice(relativeStart),
+                inlineHtmlWrapperDepth,
+                imageAltDepth);
         }
 
         int pos = 0;
@@ -447,7 +466,7 @@ public static partial class MarkdownReader {
                 if (rb > pos + 2) { var lab = text.Substring(pos + 2, rb - (pos + 2)); AddFootnoteRefNode(lab, pos, rb + 1 - pos); pos = rb + 1; continue; }
             }
 
-            if (TryParseImageLink(
+            if (allowImages && TryParseImageLink(
                 text,
                 pos,
                 sourceMap,
@@ -466,15 +485,16 @@ public static partial class MarkdownReader {
                 out int imageLinkHrefStart,
                 out int imageLinkHrefLength,
                 out int? imageLinkHrefTitleStart,
-                out int? imageLinkHrefTitleLength)) {
+                out int? imageLinkHrefTitleLength,
+                inlineHtmlWrapperMatches)) {
                 if (allowLinks && allowImages) {
                     var imgResolved = ResolveUrl(img2, options);
                     var hrefResolved = ResolveUrl(href2, options);
                     if (imgResolved is null || hrefResolved is null) {
                         // Unsafe URLs: keep content as plain text instead of a clickable linked image.
-                        AddTextNode(string.IsNullOrEmpty(alt2) ? "image" : ExtractImageAltPlainText(alt2, options, state), pos, consumed);
+                        AddTextNode(string.IsNullOrEmpty(alt2) ? "image" : ExtractImageAltPlainText(alt2, options, state, imageAltDepth), pos, consumed);
                     } else {
-                        var plainAlt2 = ExtractImageAltPlainText(alt2, options, state);
+                        var plainAlt2 = ExtractImageAltPlainText(alt2, options, state, imageAltDepth);
                         var imageLink = new ImageLinkInline(alt2, imgResolved!, hrefResolved!, imgTitle2, hrefTitle2, plainAlt2);
                         AddRawNode(imageLink, pos, consumed);
                         int outerSeparatorStart = FindLinkedImageOuterSeparatorStart(pos, consumed, imageLinkHrefStart);
@@ -521,14 +541,15 @@ public static partial class MarkdownReader {
                         out var altRef,
                         out var refLabel,
                         out int altRefStart,
-                        out int altRefLength)) {
+                        out int altRefLength,
+                        inlineHtmlWrapperMatches)) {
                         var key = NormalizeReferenceLabel(refLabel);
                         if (state.LinkRefs.TryGetValue(key, out var defImg)) {
                             var resolved = ResolveUrl(defImg.Url, options);
                             if (resolved is null) {
-                                AddTextNode(string.IsNullOrEmpty(altRef) ? "image" : ExtractImageAltPlainText(altRef, options, state), pos, consumedRefImg);
+                                AddTextNode(string.IsNullOrEmpty(altRef) ? "image" : ExtractImageAltPlainText(altRef, options, state, imageAltDepth), pos, consumedRefImg);
                             } else {
-                                var plainAltRef = ExtractImageAltPlainText(altRef, options, state);
+                                var plainAltRef = ExtractImageAltPlainText(altRef, options, state, imageAltDepth);
                                 AddReferenceImageNode(
                                     altRef,
                                     resolved!,
@@ -562,12 +583,13 @@ public static partial class MarkdownReader {
                         out int srcStartImg,
                         out int srcLengthImg,
                         out int? titleStartImg,
-                        out int? titleLengthImg)) {
+                        out int? titleLengthImg,
+                        inlineHtmlWrapperMatches)) {
                         var srcResolved = ResolveUrl(srcImg, options);
                         if (srcResolved is null) {
-                            AddTextNode(string.IsNullOrEmpty(altImg) ? "image" : ExtractImageAltPlainText(altImg, options, state), pos, consumedImg);
+                            AddTextNode(string.IsNullOrEmpty(altImg) ? "image" : ExtractImageAltPlainText(altImg, options, state, imageAltDepth), pos, consumedImg);
                         } else {
-                            var plainAltImg = ExtractImageAltPlainText(altImg, options, state);
+                            var plainAltImg = ExtractImageAltPlainText(altImg, options, state, imageAltDepth);
                             AddInlineImageNode(
                                 altImg,
                                 srcResolved!,
@@ -585,7 +607,7 @@ public static partial class MarkdownReader {
                         pos += consumedImg; continue;
                     }
 
-                    if (TryConsumeLiteralInlineImage(text, pos, out int literalImageLength)) {
+                    if (TryConsumeLiteralInlineImage(text, pos, out int literalImageLength, inlineHtmlWrapperMatches)) {
                         AddTextNode(text.Substring(pos, literalImageLength), pos, literalImageLength);
                         pos += literalImageLength; continue;
                     }
@@ -618,8 +640,8 @@ public static partial class MarkdownReader {
             }
             if (text[pos] == '[') {
                 if (allowLinks) {
-                    if (TryParseLink(text, pos, options, sourceMap, state, out int consumed2, out var label2, out var href3, out var title2, out int hrefStart2, out int hrefLength2, out int? titleStart2, out int? titleLength2)) {
-                        var labelSeq = ParseInlinesInternal(label2, options, state, allowLinks: false, allowImages: true, SliceMap(pos + 1, label2.Length));
+                    if (TryParseLink(text, pos, options, sourceMap, state, out int consumed2, out var label2, out var href3, out var title2, out int hrefStart2, out int hrefLength2, out int? titleStart2, out int? titleLength2, inlineHtmlWrapperMatches)) {
+                        var labelSeq = ParseInlinesInternal(label2, options, state, allowLinks: false, allowImages, SliceMap(pos + 1, label2.Length), inlineHtmlWrapperMatches.Slice(pos + 1), inlineHtmlWrapperDepth, imageAltDepth);
 
                         // Allow empty href: commonly used as placeholder or to be filled by the host.
                         if (string.IsNullOrWhiteSpace(href3)) {
@@ -636,7 +658,7 @@ public static partial class MarkdownReader {
                         pos += consumed2; continue;
                     }
 
-                    if (state != null && TryParseCollapsedRef(text, pos, options, out int consumedC, out var lbl2)) {
+                    if (state != null && TryParseCollapsedRef(text, pos, options, out int consumedC, out var lbl2, inlineHtmlWrapperMatches)) {
                         var key = NormalizeReferenceLabel(lbl2);
                         if (ContainsResolvedLinkInLabel(lbl2, options, state)) {
                             AddTextNode("[", pos, 1);
@@ -644,7 +666,7 @@ public static partial class MarkdownReader {
                             continue;
                         }
 
-                        var labelSeq = ParseInlinesInternal(lbl2, options, state, allowLinks: false, allowImages: true, SliceMap(pos + 1, lbl2.Length));
+                        var labelSeq = ParseInlinesInternal(lbl2, options, state, allowLinks: false, allowImages, SliceMap(pos + 1, lbl2.Length), inlineHtmlWrapperMatches.Slice(pos + 1), inlineHtmlWrapperDepth, imageAltDepth);
                         if (state.LinkRefs.TryGetValue(key, out var def2)) {
                             var resolved = ResolveUrl(def2.Url, options);
                             if (resolved is null) {
@@ -658,7 +680,7 @@ public static partial class MarkdownReader {
                         AddTextNode(text.Substring(pos, consumedC), pos, consumedC);
                         pos += consumedC; continue;
                     }
-                    if (state != null && TryParseRefLink(text, pos, options, out int consumedR, out var lbl, out var refLabel)) {
+                    if (state != null && TryParseRefLink(text, pos, options, out int consumedR, out var lbl, out var refLabel, inlineHtmlWrapperMatches)) {
                         var key = NormalizeReferenceLabel(refLabel);
                         if (ContainsResolvedLinkInLabel(lbl, options, state)) {
                             AddTextNode("[", pos, 1);
@@ -666,7 +688,7 @@ public static partial class MarkdownReader {
                             continue;
                         }
 
-                        var labelSeq = ParseInlinesInternal(lbl, options, state, allowLinks: false, allowImages: true, SliceMap(pos + 1, lbl.Length));
+                        var labelSeq = ParseInlinesInternal(lbl, options, state, allowLinks: false, allowImages, SliceMap(pos + 1, lbl.Length), inlineHtmlWrapperMatches.Slice(pos + 1), inlineHtmlWrapperDepth, imageAltDepth);
                         if (state.LinkRefs.TryGetValue(key, out var def)) {
                             var resolved = ResolveUrl(def.Url, options);
                             if (resolved is null) {
@@ -677,7 +699,7 @@ public static partial class MarkdownReader {
                             pos += consumedR; continue;
                         }
                     }
-                    if (state != null && TryParseShortcutRef(text, pos, options, out int consumedS, out var lbl3)) {
+                    if (state != null && TryParseShortcutRef(text, pos, options, out int consumedS, out var lbl3, inlineHtmlWrapperMatches)) {
                         var key = NormalizeReferenceLabel(lbl3);
                         if (ContainsResolvedLinkInLabel(lbl3, options, state)) {
                             AddTextNode("[", pos, 1);
@@ -685,7 +707,7 @@ public static partial class MarkdownReader {
                             continue;
                         }
 
-                        var labelSeq = ParseInlinesInternal(lbl3, options, state, allowLinks: false, allowImages: true, SliceMap(pos + 1, lbl3.Length));
+                        var labelSeq = ParseInlinesInternal(lbl3, options, state, allowLinks: false, allowImages, SliceMap(pos + 1, lbl3.Length), inlineHtmlWrapperMatches.Slice(pos + 1), inlineHtmlWrapperDepth, imageAltDepth);
                         if (state.LinkRefs.TryGetValue(key, out var def3)) {
                             var resolved = ResolveUrl(def3.Url, options);
                             if (resolved is null) {
@@ -798,9 +820,9 @@ public static partial class MarkdownReader {
                 }
 
                 bool preferInnerBold = ShouldPreferInnerBold(stack, marker, remaining, canOpen, canClose);
-                bool splitDoubleUnderscoreOpener = ShouldSplitDoubleUnderscoreToLiteralAndItalic(text, pos, remaining, canOpen, canClose);
-                bool splitDoubleRunIntoRootDualItalic = ShouldSplitDoubleRunIntoRootDualItalic(text, pos, marker, remaining, canOpen, canClose, stack, options.CjkFriendlyEmphasis);
-                int literalPrefixForOddCloser = GetLiteralPrefixLengthForOddCloser(text, pos, marker, remaining, canOpen, canClose, options.CjkFriendlyEmphasis);
+                bool splitDoubleUnderscoreOpener = ShouldSplitDoubleUnderscoreToLiteralAndItalic(text, pos, remaining, canOpen, canClose, standardEmphasisClosingRuns);
+                bool splitDoubleRunIntoRootDualItalic = ShouldSplitDoubleRunIntoRootDualItalic(text, pos, marker, remaining, canOpen, canClose, stack, emphasisClosingRuns);
+                int literalPrefixForOddCloser = GetLiteralPrefixLengthForOddCloser(text, pos, marker, remaining, canOpen, canClose, emphasisClosingRuns);
 
                 if (canClose && !preferInnerBold) {
                     while (remaining > 0) {
@@ -892,7 +914,7 @@ public static partial class MarkdownReader {
             }
 
             if (options.InlineHtml && text[pos] == '<') {
-                if (TryParseSupportedInlineHtmlTag(text, pos, options, state, sourceMap, allowLinks, allowImages, out int consumedHtmlTag, out var htmlNode)) {
+                if (TryParseSupportedInlineHtmlTag(text, pos, options, state, sourceMap, allowLinks, allowImages, inlineHtmlWrapperMatches, inlineHtmlWrapperDepth, out int consumedHtmlTag, out var htmlNode)) {
                     AddRawNode(htmlNode, pos, consumedHtmlTag);
                     pos += consumedHtmlTag;
                     continue;

--- a/OfficeIMO.Markdown/Visuals/MarkdownVisualElement.cs
+++ b/OfficeIMO.Markdown/Visuals/MarkdownVisualElement.cs
@@ -6,6 +6,9 @@ namespace OfficeIMO.Markdown;
 /// Neutral metadata contract for renderer-produced visual host elements such as charts, networks, and data views.
 /// </summary>
 public static class MarkdownVisualElementContract {
+    /// <summary>Maximum decoded visual payload accepted from an HTML contract host. Default: 4 MiB.</summary>
+    public const int MaxDecodedPayloadBytes = 4 * 1024 * 1024;
+
     /// <summary>Current shared visual contract version.</summary>
     public const string ContractVersion = "v1";
 
@@ -96,12 +99,23 @@ public static class MarkdownVisualElementContract {
             return null;
         }
 
-        if (!string.Equals(element.ConfigEncoding, ConfigEncodingBase64Utf8, StringComparison.OrdinalIgnoreCase)) {
+        if (!string.Equals(element.ContractVersion, ContractVersion, StringComparison.Ordinal)
+            || !string.Equals(element.ConfigFormat, ConfigFormatJson, StringComparison.OrdinalIgnoreCase)
+            || !string.Equals(element.ConfigEncoding, ConfigEncodingBase64Utf8, StringComparison.OrdinalIgnoreCase)) {
+            return null;
+        }
+
+        int maximumEncodedCharacters = ((MaxDecodedPayloadBytes + 2) / 3) * 4;
+        if (element.ConfigBase64.Length > maximumEncodedCharacters) {
             return null;
         }
 
         try {
             var bytes = Convert.FromBase64String(element.ConfigBase64);
+            if (bytes.Length > MaxDecodedPayloadBytes) {
+                return null;
+            }
+
             return Encoding.UTF8.GetString(bytes);
         } catch (FormatException) {
             return null;

--- a/OfficeIMO.Reader.Csv/CsvReadOptions.cs
+++ b/OfficeIMO.Reader.Csv/CsvReadOptions.cs
@@ -5,6 +5,11 @@ namespace OfficeIMO.Reader.Csv;
 /// </summary>
 public sealed class CsvReadOptions {
     /// <summary>
+    /// Maximum columns accepted from one CSV record. Default: 4,096.
+    /// </summary>
+    public int MaxColumns { get; set; } = 4_096;
+
+    /// <summary>
     /// Rows per emitted chunk.
     /// </summary>
     public int ChunkRows { get; set; } = 200;

--- a/OfficeIMO.Reader.Csv/CsvReaderAdapter.cs
+++ b/OfficeIMO.Reader.Csv/CsvReaderAdapter.cs
@@ -82,6 +82,9 @@ internal static class CsvReaderAdapter {
 
         foreach (var record in records) {
             cancellationToken.ThrowIfCancellationRequested();
+            if (record.Count > options.MaxColumns) {
+                throw new InvalidDataException($"CSV record contains {record.Count} columns, exceeding the configured limit of {options.MaxColumns}.");
+            }
 
             var values = record.Select(static value => value ?? string.Empty).ToArray();
             if (headers == null && options.HeadersInFirstRow) {
@@ -286,6 +289,7 @@ internal static class CsvReaderAdapter {
         var source = options ?? new CsvReadOptions();
 
         var normalized = new CsvReadOptions {
+            MaxColumns = source.MaxColumns,
             ChunkRows = source.ChunkRows,
             HeadersInFirstRow = source.HeadersInFirstRow,
             IncludeMarkdown = source.IncludeMarkdown
@@ -293,6 +297,10 @@ internal static class CsvReaderAdapter {
 
         if (normalized.ChunkRows < 1) {
             normalized.ChunkRows = 1;
+        }
+
+        if (normalized.MaxColumns < 1) {
+            throw new ArgumentOutOfRangeException(nameof(CsvReadOptions.MaxColumns), normalized.MaxColumns, "CSV column limit must be greater than zero.");
         }
 
         return normalized;

--- a/OfficeIMO.Reader.Csv/OfficeDocumentReaderBuilderCsvExtensions.cs
+++ b/OfficeIMO.Reader.Csv/OfficeDocumentReaderBuilderCsvExtensions.cs
@@ -48,6 +48,7 @@ public static class OfficeDocumentReaderBuilderCsvExtensions {
         if (options == null) return null;
 
         return new CsvReadOptions {
+            MaxColumns = options.MaxColumns,
             ChunkRows = options.ChunkRows,
             HeadersInFirstRow = options.HeadersInFirstRow,
             IncludeMarkdown = options.IncludeMarkdown

--- a/OfficeIMO.Reader.Tests/Reader.Csv.Security.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Csv.Security.cs
@@ -1,0 +1,20 @@
+using System.Text;
+using OfficeIMO.Reader.Csv;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class ReaderCsvSecurityTests {
+    [Fact]
+    public void CsvReaderAdapter_RejectsRecordsBeyondConfiguredColumnBudgetBeforeNormalization() {
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes("a,b,c,d,e\n1,2,3,4,5\n"), writable: false);
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+            CsvReaderAdapter.Read(
+                stream,
+                sourceName: "wide.csv",
+                csvOptions: new CsvReadOptions { MaxColumns = 4 }).ToList());
+
+        Assert.Contains("5 columns", exception.Message, StringComparison.Ordinal);
+    }
+}

--- a/OfficeIMO.Word.Tests/Word.Inspection.Security.cs
+++ b/OfficeIMO.Word.Tests/Word.Inspection.Security.cs
@@ -1,0 +1,45 @@
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void InspectionSnapshot_BoundsRecursiveFootnoteAndEndnoteReferences() {
+            string filePath = Path.Combine(_directoryWithFiles, "InspectionRecursiveNotes.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Footnote anchor").AddFootNote("Footnote body");
+                document.AddParagraph("Endnote anchor").AddEndNote("Endnote body");
+                document.Save();
+            }
+
+            using (WordprocessingDocument package = WordprocessingDocument.Open(filePath, true)) {
+                Footnote footnote = package.MainDocumentPart!.FootnotesPart!.Footnotes!
+                    .Elements<Footnote>()
+                    .Single(note => note.Id?.Value > 0);
+                Paragraph footnoteBody = footnote.Elements<Paragraph>().Last();
+                footnoteBody.Append(new Run(new Text(" recursive "), new FootnoteReference { Id = footnote.Id }));
+                package.MainDocumentPart.FootnotesPart.Footnotes.Save();
+
+                Endnote endnote = package.MainDocumentPart.EndnotesPart!.Endnotes!
+                    .Elements<Endnote>()
+                    .Single(note => note.Id?.Value > 0);
+                Paragraph endnoteBody = endnote.Elements<Paragraph>().Last();
+                endnoteBody.Append(new Run(new Text(" recursive "), new EndnoteReference { Id = endnote.Id }));
+                package.MainDocumentPart.EndnotesPart.Endnotes.Save();
+            }
+
+            using WordDocument loaded = WordDocument.Load(filePath);
+            WordDocumentSnapshot snapshot = loaded.CreateInspectionSnapshot();
+
+            Assert.Single(snapshot.Sections);
+            var runs = snapshot.Sections[0].Elements
+                .OfType<WordParagraphSnapshot>()
+                .SelectMany(paragraph => paragraph.Runs)
+                .ToList();
+            Assert.Contains(runs, run => run.Footnote != null);
+            Assert.Contains(runs, run => run.Endnote != null);
+        }
+    }
+}

--- a/OfficeIMO.Word/WordDocument.Inspection.cs
+++ b/OfficeIMO.Word/WordDocument.Inspection.cs
@@ -5,7 +5,14 @@ using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word {
     public partial class WordDocument {
+        private const int MaximumInspectionNoteDepth = 32;
+
+        private sealed class InspectionExpansionContext {
+            internal HashSet<string> ActiveNoteKeys { get; } = new(StringComparer.Ordinal);
+        }
+
         public WordDocumentSnapshot CreateInspectionSnapshot() {
+            var expansionContext = new InspectionExpansionContext();
             var snapshot = new WordDocumentSnapshot {
                 FilePath = string.IsNullOrWhiteSpace(FilePath) ? null : FilePath,
                 Title = BuiltinDocumentProperties?.Title,
@@ -36,12 +43,12 @@ namespace OfficeIMO.Word {
                     FooterCount = CountFooterParts(section.Footer),
                     DifferentFirstPage = section.DifferentFirstPage,
                     DifferentOddAndEvenPages = section.DifferentOddAndEvenPages,
-                    DefaultHeader = BuildHeaderFooterSnapshot(section.Header?.Default, "header", "default"),
-                    DefaultFooter = BuildHeaderFooterSnapshot(section.Footer?.Default, "footer", "default"),
-                    FirstHeader = BuildHeaderFooterSnapshot(section.Header?.First, "header", "first"),
-                    FirstFooter = BuildHeaderFooterSnapshot(section.Footer?.First, "footer", "first"),
-                    EvenHeader = BuildHeaderFooterSnapshot(section.Header?.Even, "header", "even"),
-                    EvenFooter = BuildHeaderFooterSnapshot(section.Footer?.Even, "footer", "even"),
+                    DefaultHeader = BuildHeaderFooterSnapshot(section.Header?.Default, "header", "default", expansionContext),
+                    DefaultFooter = BuildHeaderFooterSnapshot(section.Footer?.Default, "footer", "default", expansionContext),
+                    FirstHeader = BuildHeaderFooterSnapshot(section.Header?.First, "header", "first", expansionContext),
+                    FirstFooter = BuildHeaderFooterSnapshot(section.Footer?.First, "footer", "first", expansionContext),
+                    EvenHeader = BuildHeaderFooterSnapshot(section.Header?.Even, "header", "even", expansionContext),
+                    EvenFooter = BuildHeaderFooterSnapshot(section.Footer?.Even, "footer", "even", expansionContext),
                 };
 
                 int order = 0;
@@ -55,11 +62,11 @@ namespace OfficeIMO.Word {
                             elementIndex++;
                         }
 
-                        var paragraphSnapshot = BuildParagraphSnapshot(new WordParagraph(this, paragraphPart._paragraph));
+                        var paragraphSnapshot = BuildParagraphSnapshot(new WordParagraph(this, paragraphPart._paragraph), expansionContext);
                         paragraphSnapshot.Order = order++;
                         sectionSnapshot.AddElement(paragraphSnapshot);
                     } else if (element is WordTable table) {
-                        var tableSnapshot = BuildTableSnapshot(table);
+                        var tableSnapshot = BuildTableSnapshot(table, expansionContext);
                         tableSnapshot.Order = order++;
                         sectionSnapshot.AddElement(tableSnapshot);
                     }
@@ -108,7 +115,8 @@ namespace OfficeIMO.Word {
         private WordHeaderFooterSnapshot? BuildHeaderFooterSnapshot(
             WordHeaderFooter? headerFooter,
             string kind,
-            string variant) {
+            string variant,
+            InspectionExpansionContext expansionContext) {
             if (headerFooter == null) {
                 return null;
             }
@@ -123,12 +131,12 @@ namespace OfficeIMO.Word {
             foreach (var child in EnumerateHeaderFooterBlocks(headerFooter)) {
                 switch (child) {
                     case Paragraph paragraph:
-                        var paragraphSnapshot = BuildParagraphSnapshot(new WordParagraph(this, paragraph));
+                        var paragraphSnapshot = BuildParagraphSnapshot(new WordParagraph(this, paragraph), expansionContext);
                         paragraphSnapshot.Order = order++;
                         snapshot.AddElement(paragraphSnapshot);
                         break;
                     case Table table:
-                        var tableSnapshot = BuildTableSnapshot(new WordTable(this, table));
+                        var tableSnapshot = BuildTableSnapshot(new WordTable(this, table), expansionContext);
                         tableSnapshot.Order = order++;
                         snapshot.AddElement(tableSnapshot);
                         break;
@@ -138,7 +146,7 @@ namespace OfficeIMO.Word {
             return snapshot;
         }
 
-        private WordParagraphSnapshot BuildParagraphSnapshot(WordParagraph paragraph) {
+        private WordParagraphSnapshot BuildParagraphSnapshot(WordParagraph paragraph, InspectionExpansionContext expansionContext) {
             var bookmark = paragraph.Bookmark;
             var bookmarkStart = paragraph._paragraph.ChildElements.OfType<BookmarkStart>().FirstOrDefault();
             var snapshot = new WordParagraphSnapshot {
@@ -208,8 +216,8 @@ namespace OfficeIMO.Word {
                     IsHyperlink = hyperlink != null,
                     HyperlinkUri = hyperlink?.Uri?.ToString(),
                     HyperlinkAnchor = hyperlink?.Anchor,
-                    Footnote = BuildFootnoteSnapshot(run.FootNote),
-                    Endnote = BuildEndnoteSnapshot(run.EndNote),
+                    Footnote = BuildFootnoteSnapshot(run.FootNote, expansionContext),
+                    Endnote = BuildEndnoteSnapshot(run.EndNote, expansionContext),
                     InlineImage = image == null ? null : new WordInlineImageSnapshot {
                         FilePath = string.IsNullOrWhiteSpace(image.FilePath) ? null : image.FilePath,
                         FileName = image.FileName,
@@ -236,7 +244,7 @@ namespace OfficeIMO.Word {
             return snapshot;
         }
 
-        private WordTableSnapshot BuildTableSnapshot(WordTable table) {
+        private WordTableSnapshot BuildTableSnapshot(WordTable table, InspectionExpansionContext expansionContext) {
             var snapshot = new WordTableSnapshot {
                 RowCount = table.Rows.Count,
                 ColumnCount = table.Rows.Count == 0 ? 0 : table.Rows.Max(row => row.CellsCount),
@@ -294,7 +302,7 @@ namespace OfficeIMO.Word {
                     snapshot.HasVerticalMerges |= cell.HasVerticalMerge;
 
                     foreach (var paragraphGroup in GroupParagraphs(cell.Paragraphs)) {
-                        cellSnapshot.AddParagraph(BuildParagraphSnapshot(paragraphGroup));
+                        cellSnapshot.AddParagraph(BuildParagraphSnapshot(paragraphGroup, expansionContext));
                     }
 
                     rowSnapshot.AddCell(cellSnapshot);
@@ -306,46 +314,66 @@ namespace OfficeIMO.Word {
             return snapshot;
         }
 
-        private WordFootnoteSnapshot? BuildFootnoteSnapshot(WordFootNote? footNote) {
+        private WordFootnoteSnapshot? BuildFootnoteSnapshot(WordFootNote? footNote, InspectionExpansionContext expansionContext) {
             if (footNote == null) {
                 return null;
             }
 
-            var paragraphs = footNote.Paragraphs;
-            if (paragraphs == null || paragraphs.Count == 0) {
+            string noteKey = "F:" + (footNote.ReferenceId?.ToString() ?? "unknown");
+            if (expansionContext.ActiveNoteKeys.Count >= MaximumInspectionNoteDepth
+                || !expansionContext.ActiveNoteKeys.Add(noteKey)) {
                 return null;
             }
 
-            var snapshot = new WordFootnoteSnapshot {
-                ReferenceId = footNote.ReferenceId,
-            };
+            try {
+                var paragraphs = footNote.Paragraphs;
+                if (paragraphs == null || paragraphs.Count == 0) {
+                    return null;
+                }
 
-            foreach (var paragraphGroup in GroupParagraphs(paragraphs).Where(paragraph => paragraph.GetRuns().Any(run => run.FootNote == null))) {
-                snapshot.AddParagraph(BuildParagraphSnapshot(paragraphGroup));
+                var snapshot = new WordFootnoteSnapshot {
+                    ReferenceId = footNote.ReferenceId,
+                };
+
+                foreach (var paragraphGroup in GroupParagraphs(paragraphs).Where(paragraph => paragraph.GetRuns().Any(run => run.FootNote == null))) {
+                    snapshot.AddParagraph(BuildParagraphSnapshot(paragraphGroup, expansionContext));
+                }
+
+                return snapshot.Paragraphs.Count > 0 ? snapshot : null;
+            } finally {
+                expansionContext.ActiveNoteKeys.Remove(noteKey);
             }
-
-            return snapshot.Paragraphs.Count > 0 ? snapshot : null;
         }
 
-        private WordEndnoteSnapshot? BuildEndnoteSnapshot(WordEndNote? endnote) {
+        private WordEndnoteSnapshot? BuildEndnoteSnapshot(WordEndNote? endnote, InspectionExpansionContext expansionContext) {
             if (endnote == null) {
                 return null;
             }
 
-            var paragraphs = endnote.Paragraphs;
-            if (paragraphs == null || paragraphs.Count == 0) {
+            string noteKey = "E:" + (endnote.ReferenceId?.ToString() ?? "unknown");
+            if (expansionContext.ActiveNoteKeys.Count >= MaximumInspectionNoteDepth
+                || !expansionContext.ActiveNoteKeys.Add(noteKey)) {
                 return null;
             }
 
-            var snapshot = new WordEndnoteSnapshot {
-                ReferenceId = endnote.ReferenceId,
-            };
+            try {
+                var paragraphs = endnote.Paragraphs;
+                if (paragraphs == null || paragraphs.Count == 0) {
+                    return null;
+                }
 
-            foreach (var paragraphGroup in GroupParagraphs(paragraphs).Where(paragraph => paragraph.GetRuns().Any(run => run.EndNote == null))) {
-                snapshot.AddParagraph(BuildParagraphSnapshot(paragraphGroup));
+                var snapshot = new WordEndnoteSnapshot {
+                    ReferenceId = endnote.ReferenceId,
+                };
+
+                foreach (var paragraphGroup in GroupParagraphs(paragraphs).Where(paragraph => paragraph.GetRuns().Any(run => run.EndNote == null))) {
+                    snapshot.AddParagraph(BuildParagraphSnapshot(paragraphGroup, expansionContext));
+                }
+
+                return snapshot.Paragraphs.Count > 0 ? snapshot : null;
+            } finally {
+                expansionContext.ActiveNoteKeys.Remove(noteKey);
             }
-
-            return snapshot.Paragraphs.Count > 0 ? snapshot : null;
         }
 
         private static double? ResolveIndentFirstLinePoints(WordParagraph paragraph) {


### PR DESCRIPTION
## Summary

- enforce bounded Excel input, worksheet, pivot, append, and shared-string processing, including remote workbook downloads
- cap CSV normalization and recursive Word note inspection
- replace recursive or repeated-scan Markdown and HTML paths with bounded, indexed processing, slice-local wrapper matching, and capped visual payload decoding

These changes address the 16 valid findings in all-severity security batch 11. Four other records in the batch were already closed by earlier merged fixes.

## Compatibility

No public API is removed. Existing defaults remain permissive for normal documents. Small missing shared-string entries are repaired within a fixed ceiling; hostile inputs fail or are normalized at explicit resource boundaries.

## Validation

- full Markdown suite: 2,933/2,933 on .NET 8 and .NET 10
- batch Markdown security regressions: 13/13 on .NET 8 and .NET 10
- focused Excel shared-string regressions: 3/3 on .NET 8 and .NET 10
- focused Excel and HTTP security suite: 8/8 on .NET 8 and .NET 10
- focused CSV and Word regressions pass on .NET 8 and .NET 10
- affected netstandard2.0 projects build without warnings