### PR TITLE
Harden parser and package resource boundaries

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -954,6 +954,7 @@ jobs:
               "OfficeIMO.Tests.Markdown_Renderer",
               "OfficeIMO.Tests.Markdown_IntelligenceX",
               "OfficeIMO.Tests.MarkdownAllSeverityBatch11SecurityTests",
+              "OfficeIMO.Tests.MarkdownAllSeverityBatch12SecurityTests",
           )
 
           unassigned = [name for name in discovered if not any(partition in name for partition in markdown_partitions)]
@@ -979,7 +980,7 @@ jobs:
               ;;
             markdown-suite)
               run_markdown_tests "markdown-suite" 'FullyQualifiedName~OfficeIMO.Tests.MarkdownSuite'
-              run_markdown_tests "markdown-named" 'FullyQualifiedName~OfficeIMO.Tests.MarkdownHtmlToMarkdownCompatibilityTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownHtmlToMarkdownTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownHtmlApiContracts|FullyQualifiedName~OfficeIMO.Tests.Markdown_|FullyQualifiedName~OfficeIMO.Tests.MarkdownTranscript|FullyQualifiedName~OfficeIMO.Tests.MarkdownReaderBomTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownBlankLinesTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownDefinitionLinesTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownOrderedListsTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownStreamingPreviewTests|FullyQualifiedName~OfficeIMO.Tests.Markdown_Renderer|FullyQualifiedName~OfficeIMO.Tests.Markdown_IntelligenceX|FullyQualifiedName~OfficeIMO.Tests.MarkdownAllSeverityBatch11SecurityTests'
+              run_markdown_tests "markdown-named" 'FullyQualifiedName~OfficeIMO.Tests.MarkdownHtmlToMarkdownCompatibilityTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownHtmlToMarkdownTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownHtmlApiContracts|FullyQualifiedName~OfficeIMO.Tests.Markdown_|FullyQualifiedName~OfficeIMO.Tests.MarkdownTranscript|FullyQualifiedName~OfficeIMO.Tests.MarkdownReaderBomTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownBlankLinesTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownDefinitionLinesTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownOrderedListsTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownStreamingPreviewTests|FullyQualifiedName~OfficeIMO.Tests.Markdown_Renderer|FullyQualifiedName~OfficeIMO.Tests.Markdown_IntelligenceX|FullyQualifiedName~OfficeIMO.Tests.MarkdownAllSeverityBatch11SecurityTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownAllSeverityBatch12SecurityTests'
               ;;
             pdf-visual-inspector)
               export OFFICEIMO_REQUIRE_PDF_RASTERIZER=1

--- a/OfficeIMO.Excel.Tests/Excel.Security.AllSeverityBatch12.cs
+++ b/OfficeIMO.Excel.Tests/Excel.Security.AllSeverityBatch12.cs
@@ -1,0 +1,113 @@
+using OfficeIMO.Excel;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        public async Task LoadApisEnforceInputBudgetForPathAndStreams() {
+            byte[] workbook = CreateBatch12Workbook();
+            var restrictive = new ExcelLoadOptions {
+                MaxInputBytes = workbook.Length - 1L
+            };
+            string path = Path.Combine(Path.GetTempPath(),
+                Guid.NewGuid().ToString("N") + ".xlsx");
+            try {
+                File.WriteAllBytes(path, workbook);
+                Assert.Throws<InvalidDataException>(() =>
+                    ExcelDocument.Load(path, restrictive));
+
+                using var stream = new Batch12NonSeekableStream(workbook);
+                Assert.Throws<InvalidDataException>(() =>
+                    ExcelDocument.Load(stream, restrictive));
+
+                using var asyncStream = new Batch12NonSeekableStream(workbook);
+                await Assert.ThrowsAsync<InvalidDataException>(() =>
+                    ExcelDocument.LoadAsync(asyncStream, restrictive));
+
+                using var validStream = new MemoryStream(workbook,
+                    writable: false);
+                using ExcelDocument valid = ExcelDocument.Load(validStream,
+                    new ExcelLoadOptions { MaxInputBytes = workbook.Length });
+                Assert.Single(valid.Sheets);
+            } finally {
+                if (File.Exists(path)) File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public async Task RemoteLoadEnforcesInputBudgetDuringDownload() {
+            byte[] workbook = CreateRemoteWorkbookBytes();
+            using var handler = new FakeWorkbookHttpMessageHandler((_, _) =>
+                Task.FromResult(CreateWorkbookResponse(workbook)));
+
+            IOException exception = await Assert.ThrowsAsync<IOException>(() =>
+                ExcelDocument.LoadAsync(
+                    new Uri("https://example.test/workbook.xlsx"),
+                    new ExcelHttpLoadOptions {
+                        HttpMessageHandler = handler,
+                        MaxBytes = workbook.Length * 2L
+                    },
+                    new ExcelLoadOptions {
+                        MaxInputBytes = workbook.Length - 1L
+                    }));
+
+            Assert.Contains((workbook.Length - 1).ToString(),
+                exception.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public async Task RemoteLoadRejectsInvalidInputBudgetBeforeRequest() {
+            int requestCount = 0;
+            using var handler = new FakeWorkbookHttpMessageHandler((_, _) => {
+                requestCount++;
+                return Task.FromResult(
+                    CreateWorkbookResponse(CreateRemoteWorkbookBytes()));
+            });
+
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+                ExcelDocument.LoadAsync(
+                    new Uri("https://example.test/workbook.xlsx"),
+                    new ExcelHttpLoadOptions { HttpMessageHandler = handler },
+                    new ExcelLoadOptions { MaxInputBytes = 0 }));
+
+            Assert.Equal(0, requestCount);
+        }
+
+        private static byte[] CreateBatch12Workbook() {
+            using ExcelDocument document = ExcelDocument.Create();
+            document.AddWorksheet("Data").CellValue(1, 1, "safe");
+            return document.ToBytes();
+        }
+
+        private sealed class Batch12NonSeekableStream : Stream {
+            private readonly MemoryStream _inner;
+
+            internal Batch12NonSeekableStream(byte[] bytes) {
+                _inner = new MemoryStream(bytes, writable: false);
+            }
+
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => false;
+            public override long Length => throw new NotSupportedException();
+            public override long Position {
+                get => throw new NotSupportedException();
+                set => throw new NotSupportedException();
+            }
+            public override void Flush() { }
+            public override int Read(byte[] buffer, int offset, int count) =>
+                _inner.Read(buffer, offset, count);
+            public override long Seek(long offset, SeekOrigin origin) =>
+                throw new NotSupportedException();
+            public override void SetLength(long value) =>
+                throw new NotSupportedException();
+            public override void Write(byte[] buffer, int offset, int count) =>
+                throw new NotSupportedException();
+            protected override void Dispose(bool disposing) {
+                if (disposing) _inner.Dispose();
+                base.Dispose(disposing);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelDocument.CreateLoad.cs
+++ b/OfficeIMO.Excel/ExcelDocument.CreateLoad.cs
@@ -236,6 +236,11 @@ namespace OfficeIMO.Excel {
             if (bytes == null) throw new ArgumentNullException(nameof(bytes));
             if (options == null) throw new ArgumentNullException(nameof(options));
             OfficeDocumentLifecycle.Validate(options.AccessMode, options.PersistenceMode, "workbook");
+            long? inputLimit = ResolveInputLimit(options);
+            if (inputLimit.HasValue && bytes.LongLength > inputLimit.Value) {
+                throw new InvalidDataException(
+                    $"Workbook input contains {bytes.LongLength} bytes, exceeding MaxInputBytes ({inputLimit.Value}).");
+            }
             if (options.PackageSecurity != null) {
                 OfficePackageSecurityInspector.Validate(bytes, options.PackageSecurity);
             }
@@ -301,18 +306,36 @@ namespace OfficeIMO.Excel {
             }
         }
 
-        private static byte[] ReadAllBytes(Stream stream, OfficePackageSecurityOptions? securityOptions = null) {
-            return securityOptions == null
-                ? OfficeStreamReader.ReadAllBytes(stream)
-                : OfficePackageSecurityInspector.ReadBounded(stream, securityOptions);
+        private static byte[] ReadAllBytes(Stream stream, ExcelLoadOptions options) {
+            long? inputLimit = ResolveInputLimit(options);
+            return options.PackageSecurity != null
+                && inputLimit == options.PackageSecurity.MaxPackageBytes
+                ? OfficePackageSecurityInspector.ReadBounded(stream, options.PackageSecurity)
+                : OfficeStreamReader.ReadAllBytes(stream, inputLimit);
         }
 
         private static async Task<byte[]> ReadAllBytesAsync(Stream stream, CancellationToken cancellationToken,
-            OfficePackageSecurityOptions? securityOptions = null) {
-            return securityOptions == null
-                ? await OfficeStreamReader.ReadAllBytesAsync(stream, cancellationToken).ConfigureAwait(false)
-                : await OfficePackageSecurityInspector.ReadBoundedAsync(stream, securityOptions, cancellationToken)
+            ExcelLoadOptions options) {
+            long? inputLimit = ResolveInputLimit(options);
+            return options.PackageSecurity != null
+                && inputLimit == options.PackageSecurity.MaxPackageBytes
+                ? await OfficePackageSecurityInspector.ReadBoundedAsync(stream, options.PackageSecurity, cancellationToken)
+                    .ConfigureAwait(false)
+                : await OfficeStreamReader.ReadAllBytesAsync(stream, cancellationToken, inputLimit)
                     .ConfigureAwait(false);
+        }
+
+        private static long? ResolveInputLimit(ExcelLoadOptions options) {
+            long? configured = options.MaxInputBytes;
+            if (configured.HasValue && configured.Value < 1) {
+                throw new ArgumentOutOfRangeException(nameof(options.MaxInputBytes));
+            }
+            if (options.PackageSecurity == null) return configured;
+            long packageLimit = options.PackageSecurity.MaxPackageBytes;
+            if (packageLimit < 1) {
+                throw new ArgumentOutOfRangeException(nameof(OfficePackageSecurityOptions.MaxPackageBytes));
+            }
+            return configured.HasValue ? Math.Min(configured.Value, packageLimit) : packageLimit;
         }
 
         private static void DisposeStream(Stream? stream) {
@@ -397,7 +420,7 @@ namespace OfficeIMO.Excel {
             byte[] bytes;
             using (var source = new FileStream(filePath, FileMode.Open, FileAccess.Read,
                 FileShare.ReadWrite | FileShare.Delete)) {
-                bytes = ReadAllBytes(source, resolved.PackageSecurity);
+                bytes = ReadAllBytes(source, resolved);
             }
             return LoadFromByteArray(bytes, resolved, filePath);
         }
@@ -421,7 +444,7 @@ namespace OfficeIMO.Excel {
             byte[] encryptedBytes;
             using (var source = new FileStream(filePath, FileMode.Open, FileAccess.Read,
                 FileShare.ReadWrite | FileShare.Delete)) {
-                encryptedBytes = ReadAllBytes(source, resolved.PackageSecurity);
+                encryptedBytes = ReadAllBytes(source, resolved);
             }
             if (resolved.PackageSecurity != null) {
                 OfficePackageSecurityInspector.Validate(encryptedBytes, resolved.PackageSecurity);
@@ -448,7 +471,7 @@ namespace OfficeIMO.Excel {
             OfficeDocumentLifecycle.Validate(resolved.AccessMode, resolved.PersistenceMode, "workbook");
             OfficeDocumentLifecycle.EnsureSaveOnDisposeDestination(stream, resolved.PersistenceMode, nameof(stream));
 
-            var bytes = ReadAllBytes(stream, resolved.PackageSecurity);
+            var bytes = ReadAllBytes(stream, resolved);
             return LoadFromByteArray(
                 bytes,
                 resolved,
@@ -471,7 +494,7 @@ namespace OfficeIMO.Excel {
             ExcelLoadOptions resolved = options ?? new ExcelLoadOptions();
             EnsureEncryptedLoadUsesExplicitPersistence(resolved);
 
-            var encryptedBytes = ReadAllBytes(stream, resolved.PackageSecurity);
+            var encryptedBytes = ReadAllBytes(stream, resolved);
             if (resolved.PackageSecurity != null) {
                 OfficePackageSecurityInspector.Validate(encryptedBytes, resolved.PackageSecurity);
             }
@@ -533,7 +556,7 @@ namespace OfficeIMO.Excel {
             }
 
             ExcelLoadOptions resolved = options ?? new ExcelLoadOptions();
-            var bytes = await ReadAllBytesCompatAsync(filePath, cancellationToken, resolved.PackageSecurity)
+            var bytes = await ReadAllBytesCompatAsync(filePath, cancellationToken, resolved)
                 .ConfigureAwait(false);
             return LoadFromByteArray(bytes, resolved, filePath);
         }
@@ -555,7 +578,7 @@ namespace OfficeIMO.Excel {
                 throw new FileNotFoundException($"File '{filePath}' doesn't exist.", filePath);
             }
 
-            var encryptedBytes = await ReadAllBytesCompatAsync(filePath, cancellationToken, resolved.PackageSecurity)
+            var encryptedBytes = await ReadAllBytesCompatAsync(filePath, cancellationToken, resolved)
                 .ConfigureAwait(false);
             if (resolved.PackageSecurity != null) {
                 OfficePackageSecurityInspector.Validate(encryptedBytes, resolved.PackageSecurity);
@@ -583,7 +606,7 @@ namespace OfficeIMO.Excel {
             OfficeDocumentLifecycle.Validate(resolved.AccessMode, resolved.PersistenceMode, "workbook");
             OfficeDocumentLifecycle.EnsureSaveOnDisposeDestination(stream, resolved.PersistenceMode, nameof(stream));
 
-            var bytes = await ReadAllBytesAsync(stream, cancellationToken, resolved.PackageSecurity)
+            var bytes = await ReadAllBytesAsync(stream, cancellationToken, resolved)
                 .ConfigureAwait(false);
             return LoadFromByteArray(
                 bytes,
@@ -608,7 +631,7 @@ namespace OfficeIMO.Excel {
             ExcelLoadOptions resolved = options ?? new ExcelLoadOptions();
             EnsureEncryptedLoadUsesExplicitPersistence(resolved);
 
-            var encryptedBytes = await ReadAllBytesAsync(stream, cancellationToken, resolved.PackageSecurity)
+            var encryptedBytes = await ReadAllBytesAsync(stream, cancellationToken, resolved)
                 .ConfigureAwait(false);
             if (resolved.PackageSecurity != null) {
                 OfficePackageSecurityInspector.Validate(encryptedBytes, resolved.PackageSecurity);

--- a/OfficeIMO.Excel/ExcelDocument.Http.cs
+++ b/OfficeIMO.Excel/ExcelDocument.Http.cs
@@ -16,7 +16,11 @@ namespace OfficeIMO.Excel {
         public static async Task<ExcelDocument> LoadAsync(Uri uri, ExcelHttpLoadOptions? httpOptions = null, ExcelLoadOptions? options = null, CancellationToken cancellationToken = default) {
             ExcelLoadOptions resolved = options ?? new ExcelLoadOptions();
             ValidateRemoteLoadLifecycle(resolved);
-            byte[] bytes = await ExcelHttpWorkbookLoader.DownloadAsync(uri, httpOptions, cancellationToken).ConfigureAwait(false);
+            byte[] bytes = await ExcelHttpWorkbookLoader.DownloadAsync(
+                uri,
+                httpOptions,
+                cancellationToken,
+                ResolveInputLimit(resolved)).ConfigureAwait(false);
             return LoadFromByteArray(bytes, resolved, filePath: null);
         }
 

--- a/OfficeIMO.Excel/ExcelDocument.OpenSettings.cs
+++ b/OfficeIMO.Excel/ExcelDocument.OpenSettings.cs
@@ -16,13 +16,15 @@ namespace OfficeIMO.Excel {
     public partial class ExcelDocument : IDisposable, IAsyncDisposable {
 
         private static async Task<byte[]> ReadAllBytesCompatAsync(string path, CancellationToken ct,
-            OfficePackageSecurityOptions? securityOptions = null) {
+            ExcelLoadOptions options) {
             using (var fs = new FileStream(path, FileMode.Open, FileAccess.Read,
                 FileShare.ReadWrite | FileShare.Delete, 8192, FileOptions.Asynchronous)) {
-                return securityOptions == null
-                    ? await OfficeStreamReader.ReadAllBytesAsync(fs, ct).ConfigureAwait(false)
-                    : await OfficePackageSecurityInspector.ReadBoundedAsync(fs, securityOptions, ct)
-                        .ConfigureAwait(false);
+                long? inputLimit = ResolveInputLimit(options);
+                return options.PackageSecurity != null
+                    && inputLimit == options.PackageSecurity.MaxPackageBytes
+                    ? await OfficePackageSecurityInspector.ReadBoundedAsync(fs, options.PackageSecurity, ct)
+                        .ConfigureAwait(false)
+                    : await OfficeStreamReader.ReadAllBytesAsync(fs, ct, inputLimit).ConfigureAwait(false);
             }
         }
 

--- a/OfficeIMO.Excel/ExcelLifecycleOptions.cs
+++ b/OfficeIMO.Excel/ExcelLifecycleOptions.cs
@@ -12,6 +12,11 @@ namespace OfficeIMO.Excel {
 
     /// <summary>Controls access, persistence, and package behavior when loading an Excel workbook.</summary>
     public sealed class ExcelLoadOptions : DocumentLoadOptions {
+        /// <summary>
+        /// Maximum workbook bytes buffered by load APIs. Default: 512 MiB. Set to null to disable this compatibility guard.
+        /// </summary>
+        public long? MaxInputBytes { get; set; } = 512L * 1024L * 1024L;
+
         /// <summary>Provides optional low-level Open XML package settings.</summary>
         public OpenSettings? OpenSettings { get; set; }
 

--- a/OfficeIMO.Markdown.Tests/Markdown/Markdown_AllSeverityBatch12_Security_Tests.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown/Markdown_AllSeverityBatch12_Security_Tests.cs
@@ -1,0 +1,131 @@
+using System.Text;
+using OfficeIMO.Markdown;
+using OfficeIMO.Word.Markdown;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class MarkdownAllSeverityBatch12SecurityTests {
+    [Fact]
+    public void MarkdownReader_MixedEmphasisMarkersUseIndexedClosingRuns() {
+        string markdown = "*outer "
+            + string.Join(" ", Enumerable.Repeat("_inner", 4_000))
+            + "*";
+
+        MarkdownDoc document = MarkdownReader.Parse(markdown);
+
+        Assert.Single(document.Blocks);
+        Assert.Contains("outer", document.ToMarkdown(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MarkdownReader_RejectsDetailsBeyondConfiguredNestingDepth() {
+        string markdown = BuildNestedDetails(8);
+        var options = new MarkdownReaderOptions { MaxNestingDepth = 4 };
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(
+            () => MarkdownReader.Parse(markdown, options));
+
+        Assert.Contains("MaxNestingDepth (4)", exception.Message,
+            StringComparison.Ordinal);
+        Assert.Single(MarkdownReader.Parse(
+            BuildNestedDetails(2), options).Blocks);
+    }
+
+    [Fact]
+    public void MarkdownReader_HtmlBlockWithManyTagStartsAvoidsSuffixCopies() {
+        string markdown = "<div>" + new string('<', 50_000) + "</div>";
+
+        MarkdownDoc document = MarkdownReader.Parse(markdown);
+
+        Assert.Single(document.Blocks);
+    }
+
+    [Fact]
+    public void MarkdownToWord_RejectsDeepBlockAndInlineTrees() {
+        var blockDocument = MarkdownDoc.Create();
+        blockDocument.Add(CreateNestedDetailsBlock(8));
+        var options = new MarkdownToWordOptions { MaxNestingDepth = 4 };
+
+        InvalidDataException blockException = Assert.Throws<InvalidDataException>(
+            () => blockDocument.ToWordDocument(options));
+        Assert.Contains("block nesting", blockException.Message,
+            StringComparison.Ordinal);
+
+        var inlineDocument = MarkdownDoc.Create();
+        inlineDocument.Add(new ParagraphBlock(CreateNestedInlineSequence(8)));
+        InvalidDataException inlineException = Assert.Throws<InvalidDataException>(
+            () => inlineDocument.ToWordDocument(options));
+        Assert.Contains("inline nesting", inlineException.Message,
+            StringComparison.Ordinal);
+
+        var safeDocument = MarkdownDoc.Create();
+        safeDocument.Add(new ParagraphBlock(CreateNestedInlineSequence(2)));
+        using var converted = safeDocument.ToWordDocument(options);
+        Assert.NotNull(converted);
+    }
+
+    [Fact]
+    public void MarkdownRenderer_TableClipboardExportsNeutralizeSpreadsheetFormulas() {
+        var options = new MarkdownRenderer.MarkdownRendererOptions {
+            EnableTableCopyButtons = true
+        };
+        string shell = MarkdownRenderer.MarkdownRenderer.BuildShellHtml(
+            "Security", options);
+
+        Assert.Contains("function omdSpreadsheetSafeCell(value)", shell,
+            StringComparison.Ordinal);
+        Assert.Contains("replace(/[\\t\\r\\n]+/g, ' ')", shell,
+            StringComparison.Ordinal);
+        Assert.Contains("/^[=+\\-@]/.test(s)", shell,
+            StringComparison.Ordinal);
+        Assert.Equal(2, CountOccurrences(shell,
+            "omdSpreadsheetSafeCell(omdCellText(c))"));
+    }
+
+    private static string BuildNestedDetails(int depth) {
+        var markdown = new StringBuilder();
+        for (int index = 0; index < depth; index++) {
+            markdown.AppendLine("<details>");
+            markdown.AppendLine("<summary>Level</summary>");
+        }
+        markdown.AppendLine("safe");
+        for (int index = 0; index < depth; index++) {
+            markdown.AppendLine("</details>");
+        }
+        return markdown.ToString();
+    }
+
+    private static DetailsBlock CreateNestedDetailsBlock(int depth) {
+        IMarkdownBlock child = new ParagraphBlock(
+            new InlineSequence().Text("safe"));
+        for (int index = 0; index < depth; index++) {
+            child = new DetailsBlock(new SummaryBlock("Level"),
+                new[] { child });
+        }
+        return (DetailsBlock)child;
+    }
+
+    private static InlineSequence CreateNestedInlineSequence(int depth) {
+        InlineSequence current = new InlineSequence().Text("safe");
+        for (int index = 0; index < depth; index++) {
+            var parent = new InlineSequence();
+            parent.ReplaceItems(new IMarkdownInline[] {
+                new BoldSequenceInline(current)
+            });
+            current = parent;
+        }
+        return current;
+    }
+
+    private static int CountOccurrences(string source, string value) {
+        int count = 0;
+        int offset = 0;
+        while ((offset = source.IndexOf(value, offset,
+                   StringComparison.Ordinal)) >= 0) {
+            count++;
+            offset += value.Length;
+        }
+        return count;
+    }
+}

--- a/OfficeIMO.Markdown/Reader/MarkdownReader.Inlines.Emphasis.cs
+++ b/OfficeIMO.Markdown/Reader/MarkdownReader.Inlines.Emphasis.cs
@@ -37,6 +37,8 @@ public static partial class MarkdownReader {
         private readonly ClosingRunLengthIndex _asteriskEvenRuns;
         private readonly ClosingRunLengthIndex _underscoreOddRuns;
         private readonly ClosingRunLengthIndex _underscoreEvenRuns;
+        private readonly ClosingRunPositionIndex _asteriskPositions;
+        private readonly ClosingRunPositionIndex _underscorePositions;
 
         private EmphasisClosingRunIndex(
             byte[] asteriskSuffixSummaries,
@@ -44,13 +46,17 @@ public static partial class MarkdownReader {
             ClosingRunLengthIndex asteriskOddRuns,
             ClosingRunLengthIndex asteriskEvenRuns,
             ClosingRunLengthIndex underscoreOddRuns,
-            ClosingRunLengthIndex underscoreEvenRuns) {
+            ClosingRunLengthIndex underscoreEvenRuns,
+            ClosingRunPositionIndex asteriskPositions,
+            ClosingRunPositionIndex underscorePositions) {
             _asteriskSuffixSummaries = asteriskSuffixSummaries;
             _underscoreSuffixSummaries = underscoreSuffixSummaries;
             _asteriskOddRuns = asteriskOddRuns;
             _asteriskEvenRuns = asteriskEvenRuns;
             _underscoreOddRuns = underscoreOddRuns;
             _underscoreEvenRuns = underscoreEvenRuns;
+            _asteriskPositions = asteriskPositions;
+            _underscorePositions = underscorePositions;
         }
 
         internal static EmphasisClosingRunIndex Build(string text, bool cjkFriendlyEmphasis) {
@@ -60,6 +66,8 @@ public static partial class MarkdownReader {
             var asteriskEvenRuns = new Dictionary<int, int>();
             var underscoreOddRuns = new Dictionary<int, int>();
             var underscoreEvenRuns = new Dictionary<int, int>();
+            var asteriskPositions = new List<(int Start, int Length)>();
+            var underscorePositions = new List<(int Start, int Length)>();
 
             for (int index = text.Length - 1; index >= 0; index--) {
                 asteriskSummaries[index] = asteriskSummaries[index + 1];
@@ -79,6 +87,9 @@ public static partial class MarkdownReader {
                 if (!canClose) {
                     continue;
                 }
+
+                (marker == '*' ? asteriskPositions : underscorePositions)
+                    .Add((index, runLength));
 
                 Dictionary<int, int> runStarts;
                 if (marker == '*') {
@@ -105,7 +116,9 @@ public static partial class MarkdownReader {
                 ClosingRunLengthIndex.Create(asteriskOddRuns),
                 ClosingRunLengthIndex.Create(asteriskEvenRuns),
                 ClosingRunLengthIndex.Create(underscoreOddRuns),
-                ClosingRunLengthIndex.Create(underscoreEvenRuns));
+                ClosingRunLengthIndex.Create(underscoreEvenRuns),
+                ClosingRunPositionIndex.Create(asteriskPositions),
+                ClosingRunPositionIndex.Create(underscorePositions));
         }
 
         internal bool HasRunAtLeastTwo(int start, char marker) {
@@ -124,6 +137,20 @@ public static partial class MarkdownReader {
             }
 
             return index.GetLargestRunAtMost(maximumRunLength, start);
+        }
+
+        internal int FindFirstRun(int start, char marker, int exactRunLength) {
+            ClosingRunPositionIndex index = marker == '*'
+                ? _asteriskPositions
+                : _underscorePositions;
+            return index.FindFirst(start, exactRunLength);
+        }
+
+        internal int FindFirstRun(int start, char marker) {
+            ClosingRunPositionIndex index = marker == '*'
+                ? _asteriskPositions
+                : _underscorePositions;
+            return index.FindFirst(start, exactRunLength: 0);
         }
 
         private byte GetSummary(int start, char marker) {
@@ -203,6 +230,48 @@ public static partial class MarkdownReader {
                 return right >= 0
                     ? right
                     : FindRightmostIndex(node * 2, segmentStart, middle, queryEnd, minimumStart);
+            }
+        }
+
+        private sealed class ClosingRunPositionIndex {
+            private readonly int[] _allStarts;
+            private readonly int[] _singleStarts;
+            private readonly int[] _doubleStarts;
+
+            private ClosingRunPositionIndex(
+                int[] allStarts,
+                int[] singleStarts,
+                int[] doubleStarts) {
+                _allStarts = allStarts;
+                _singleStarts = singleStarts;
+                _doubleStarts = doubleStarts;
+            }
+
+            internal static ClosingRunPositionIndex Create(
+                List<(int Start, int Length)> descendingRuns) {
+                descendingRuns.Reverse();
+                int[] all = descendingRuns.Select(static run => run.Start).ToArray();
+                int[] singles = descendingRuns
+                    .Where(static run => run.Length == 1)
+                    .Select(static run => run.Start)
+                    .ToArray();
+                int[] doubles = descendingRuns
+                    .Where(static run => run.Length == 2)
+                    .Select(static run => run.Start)
+                    .ToArray();
+                return new ClosingRunPositionIndex(all, singles, doubles);
+            }
+
+            internal int FindFirst(int minimumStart, int exactRunLength) {
+                int[] starts = exactRunLength switch {
+                    0 => _allStarts,
+                    1 => _singleStarts,
+                    2 => _doubleStarts,
+                    _ => Array.Empty<int>()
+                };
+                int index = Array.BinarySearch(starts, minimumStart);
+                if (index < 0) index = ~index;
+                return index < starts.Length ? starts[index] : -1;
             }
         }
     }
@@ -540,7 +609,15 @@ public static partial class MarkdownReader {
         return count;
     }
 
-    private static bool ShouldTreatMixedSingleMarkerAsLiteral(string text, int start, char marker, int runLen, bool canOpen, bool canClose, Stack<InlineFrame> stack, bool cjkFriendlyEmphasis) {
+    private static bool ShouldTreatMixedSingleMarkerAsLiteral(
+        string text,
+        int start,
+        char marker,
+        int runLen,
+        bool canOpen,
+        bool canClose,
+        Stack<InlineFrame> stack,
+        EmphasisClosingRunIndex? closingRuns) {
         if (!canOpen || canClose) return false;
         if (runLen != 1) return false;
         if (marker != '*' && marker != '_') return false;
@@ -550,11 +627,12 @@ public static partial class MarkdownReader {
         var top = stack.Peek();
         if ((top.Kind != FrameKind.Italic && top.Kind != FrameKind.Bold) || (top.OpenLen != 1 && top.OpenLen != 2)) return false;
         if (top.Marker == marker) return false;
+        if (closingRuns == null) return false;
 
-        int outerClose = FindNextClosingDelimiterRunIndex(text, start + 1, top.Marker, requiredRunLength: top.OpenLen, cjkFriendlyEmphasis);
+        int outerClose = closingRuns.FindFirstRun(start + 1, top.Marker, top.OpenLen);
         if (outerClose < 0) return false;
 
-        int innerClose = FindNextClosingDelimiterIndex(text, start + 1, marker, minimumRunLength: 1, cjkFriendlyEmphasis);
+        int innerClose = closingRuns.FindFirstRun(start + 1, marker);
         return innerClose < 0 || outerClose < innerClose;
     }
 

--- a/OfficeIMO.Markdown/Reader/MarkdownReader.Inlines.cs
+++ b/OfficeIMO.Markdown/Reader/MarkdownReader.Inlines.cs
@@ -794,7 +794,7 @@ public static partial class MarkdownReader {
 
                 GetDelimiterFlags(text, pos, marker, runLen, options.CjkFriendlyEmphasis, out bool canOpen, out bool canClose);
 
-                if (ShouldTreatMixedSingleMarkerAsLiteral(text, pos, marker, runLen, canOpen, canClose, stack, options.CjkFriendlyEmphasis)) {
+                if (ShouldTreatMixedSingleMarkerAsLiteral(text, pos, marker, runLen, canOpen, canClose, stack, emphasisClosingRuns)) {
                     AddTextNode(marker.ToString(), pos, 1);
                     pos++;
                     continue;

--- a/OfficeIMO.Markdown/Reader/MarkdownReader.NestedSyntax.cs
+++ b/OfficeIMO.Markdown/Reader/MarkdownReader.NestedSyntax.cs
@@ -13,7 +13,7 @@ public static partial class MarkdownReader {
         int lineOffset) {
 
         var nestedOptions = CloneOptionsWithoutFrontMatter(options);
-        var nestedState = CloneState(state);
+        var nestedState = CreateNestedState(state, options);
         var syntaxChildren = new List<MarkdownSyntaxNode>();
         var nestedDoc = ParseInternal(markdown, nestedOptions, nestedState, allowFrontMatter: false, out _, out _, syntaxChildren, lineOffset: lineOffset, applyDocumentTransforms: false);
         return (nestedDoc.Blocks, syntaxChildren);
@@ -30,7 +30,7 @@ public static partial class MarkdownReader {
 
         var markdown = string.Join("\n", sourceLines.Select(line => line.Text ?? string.Empty));
         var nestedOptions = CloneOptionsWithoutFrontMatter(options);
-        var nestedState = CloneState(state);
+        var nestedState = CreateNestedState(state, options);
         nestedState.SourceLineAbsoluteNumbers = sourceLines.Select(line => line.AbsoluteLine).ToArray();
         nestedState.LazyQuoteContinuationLines.Clear();
         nestedState.QuoteContainerLines.Clear();
@@ -63,6 +63,25 @@ public static partial class MarkdownReader {
         SynchronizeOwnedSyntaxCaches(remappedSyntaxTree);
         MarkdownObjectTreeBinder.BindDocument(nestedDoc, remappedSyntaxTree);
         return (nestedDoc.Blocks, remappedSyntaxChildren);
+    }
+
+    private static MarkdownReaderState CreateNestedState(
+        MarkdownReaderState state,
+        MarkdownReaderOptions options) {
+        if (options.MaxNestingDepth < 1) {
+            throw new ArgumentOutOfRangeException(
+                nameof(options.MaxNestingDepth),
+                options.MaxNestingDepth,
+                "MaxNestingDepth must be greater than zero.");
+        }
+        if (state.NestedBlockDepth >= options.MaxNestingDepth) {
+            throw new InvalidDataException(
+                $"Markdown block nesting exceeds MaxNestingDepth ({options.MaxNestingDepth}).");
+        }
+
+        MarkdownReaderState nested = CloneState(state);
+        nested.NestedBlockDepth = state.NestedBlockDepth + 1;
+        return nested;
     }
 
     private static bool ShouldSuppressNestedLazySetextHeadingUnderline(

--- a/OfficeIMO.Markdown/Reader/MarkdownReader.Options.cs
+++ b/OfficeIMO.Markdown/Reader/MarkdownReader.Options.cs
@@ -80,6 +80,7 @@ public static partial class MarkdownReader {
             AllowedUrlSchemes = source.AllowedUrlSchemes,
             PreserveTrivia = source.PreserveTrivia,
             MaxInputCharacters = source.MaxInputCharacters,
+            MaxNestingDepth = source.MaxNestingDepth,
             InputNormalization = new MarkdownInputNormalizationOptions {
                 NormalizeZeroWidthSpacingArtifacts = source.InputNormalization?.NormalizeZeroWidthSpacingArtifacts ?? false,
                 NormalizeEmojiWordJoins = source.InputNormalization?.NormalizeEmojiWordJoins ?? false,
@@ -212,6 +213,7 @@ public static partial class MarkdownReader {
         clone.SuppressBlockGenericAttributes = state.SuppressBlockGenericAttributes;
         clone.SuppressHeadingGenericAttributes = state.SuppressHeadingGenericAttributes;
         clone.IsMarkdigDefinitionListBody = state.IsMarkdigDefinitionListBody;
+        clone.NestedBlockDepth = state.NestedBlockDepth;
         foreach (var line in state.LazyQuoteContinuationLines) clone.LazyQuoteContinuationLines.Add(line);
         foreach (var line in state.QuoteContainerLines) clone.QuoteContainerLines.Add(line);
         foreach (var line in state.SuppressedSetextHeadingUnderlineLines) clone.SuppressedSetextHeadingUnderlineLines.Add(line);

--- a/OfficeIMO.Markdown/Reader/MarkdownReader.cs
+++ b/OfficeIMO.Markdown/Reader/MarkdownReader.cs
@@ -267,6 +267,12 @@ public static partial class MarkdownReader {
 
     private static string PrepareMarkdownForParsing(string markdown, MarkdownReaderOptions options) {
         markdown ??= string.Empty;
+        if (options.MaxNestingDepth < 1) {
+            throw new ArgumentOutOfRangeException(
+                nameof(options.MaxNestingDepth),
+                options.MaxNestingDepth,
+                "MaxNestingDepth must be greater than zero.");
+        }
         if (markdown.Length == 0) {
             return string.Empty;
         }

--- a/OfficeIMO.Markdown/Reader/MarkdownReaderOptions.cs
+++ b/OfficeIMO.Markdown/Reader/MarkdownReaderOptions.cs
@@ -135,7 +135,8 @@ public sealed class MarkdownReaderOptions {
                 : (string[])AllowedUrlSchemes.Clone(),
             InputNormalization = CloneInputNormalizationOptions(InputNormalization),
             PreserveTrivia = PreserveTrivia,
-            MaxInputCharacters = MaxInputCharacters
+            MaxInputCharacters = MaxInputCharacters,
+            MaxNestingDepth = MaxNestingDepth
         };
 
         CopyList(FencedBlockExtensions, clone.FencedBlockExtensions);
@@ -641,6 +642,12 @@ public sealed class MarkdownReaderOptions {
     /// When set and exceeded, parsing fails fast with an <see cref="ArgumentOutOfRangeException"/>.
     /// </summary>
     public int? MaxInputCharacters { get; set; }
+
+    /// <summary>
+    /// Maximum recursive block-container depth accepted while parsing nested lists, quotes,
+    /// details, callouts, footnotes, and similar constructs. Default: 64.
+    /// </summary>
+    public int MaxNestingDepth { get; set; } = 64;
 
     /// <summary>
     /// Optional language-based fenced block factories that can produce specialized AST nodes

--- a/OfficeIMO.Markdown/Reader/MarkdownReaderState.cs
+++ b/OfficeIMO.Markdown/Reader/MarkdownReaderState.cs
@@ -120,6 +120,7 @@ public sealed class MarkdownReaderState {
     internal bool SuppressBlockGenericAttributes { get; set; }
     internal bool SuppressHeadingGenericAttributes { get; set; }
     internal bool IsMarkdigDefinitionListBody { get; set; }
+    internal int NestedBlockDepth { get; set; }
     internal MarkdownPendingGenericAttributeBlock? PendingGenericAttributeBlock { get; set; }
     internal HashSet<int> LazyQuoteContinuationLines { get; } = new HashSet<int>();
     internal HashSet<int> QuoteContainerLines { get; } = new HashSet<int>();

--- a/OfficeIMO.Markdown/Reader/Parsers/HtmlBlockParser.cs
+++ b/OfficeIMO.Markdown/Reader/Parsers/HtmlBlockParser.cs
@@ -677,14 +677,22 @@ public static partial class MarkdownReader {
             return count;
         }
 
-        private static bool TryParseTag(string line, out string tagName, out bool isClosing, out int endIndex) {
+        private static bool TryParseTag(string line, out string tagName, out bool isClosing, out int endIndex) =>
+            TryParseTagCore(line, 0, out tagName, out isClosing, out endIndex);
+
+        private static bool TryParseTagCore(
+            string line,
+            int startIndex,
+            out string tagName,
+            out bool isClosing,
+            out int endIndex) {
             tagName = string.Empty;
             isClosing = false;
             endIndex = -1;
 
-            if (line.Length < 2 || line[0] != '<') return false;
+            if (startIndex < 0 || startIndex + 1 >= line.Length || line[startIndex] != '<') return false;
 
-            int idx = 1;
+            int idx = startIndex + 1;
             if (idx < line.Length && line[idx] == '/') {
                 isClosing = true;
                 idx++;
@@ -856,12 +864,10 @@ public static partial class MarkdownReader {
 
             if (startIndex < 0 || startIndex >= line.Length || line[startIndex] != '<') return false;
 
-            string segment = line.Substring(startIndex);
-            if (!TryParseTag(segment, out tagName, out isClosing, out var localEndIndex)) {
+            if (!TryParseTagCore(line, startIndex, out tagName, out isClosing, out endIndex)) {
                 return false;
             }
 
-            endIndex = startIndex + localEndIndex;
             nextIndex = endIndex + 1;
             return true;
         }

--- a/OfficeIMO.MarkdownRenderer/MarkdownRenderer.Updates.cs
+++ b/OfficeIMO.MarkdownRenderer/MarkdownRenderer.Updates.cs
@@ -149,7 +149,12 @@ async function updateContent(newBodyHtml) {
 
   function omdCellText(cell) {
     const t = (cell && (cell.innerText || cell.textContent)) ? String(cell.innerText || cell.textContent) : '';
-    return t.replace(/\r?\n/g, ' ').trim();
+    return t.replace(/[\t\r\n]+/g, ' ').trim();
+  }
+
+  function omdSpreadsheetSafeCell(value) {
+    const s = String(value ?? '');
+    return /^[=+\-@]/.test(s) ? "'" + s : s;
   }
 
   function omdTableToTsv(table) {
@@ -159,7 +164,7 @@ async function updateContent(newBodyHtml) {
       const cells = tr.querySelectorAll('th,td');
       if (!cells || cells.length === 0) return;
       const vals = [];
-      cells.forEach(c => vals.push(omdCellText(c)));
+      cells.forEach(c => vals.push(omdSpreadsheetSafeCell(omdCellText(c))));
       rows.push(vals.join('\\t'));
     });
     return rows.join('\\n');
@@ -180,7 +185,7 @@ async function updateContent(newBodyHtml) {
       const cells = tr.querySelectorAll('th,td');
       if (!cells || cells.length === 0) return;
       const vals = [];
-      cells.forEach(c => vals.push(omdCsvEscape(omdCellText(c))));
+      cells.forEach(c => vals.push(omdCsvEscape(omdSpreadsheetSafeCell(omdCellText(c)))));
       rows.push(vals.join(','));
     });
     return rows.join('\\n');

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfReadLimitTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfReadLimitTests.cs
@@ -433,6 +433,23 @@ public class PdfReadLimitTests {
     }
 
     [Fact]
+    public void ObjectStreamDeclaredCountIsBoundedBeforePairAllocation() {
+        byte[] pdf = BuildObjectPdf(
+            "<< /Type /ObjStm /N 4294967296 /First 1 /Length 1 >>\n"
+            + "stream\n0\nendstream");
+        var options = new PdfReadOptions {
+            Limits = new PdfReadLimits { MaxIndirectObjects = 32 }
+        };
+
+        PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(
+            () => PdfReadDocument.Open(pdf, options));
+
+        Assert.Equal(PdfReadLimitKind.IndirectObjects, exception.Kind);
+        Assert.Equal(32, exception.Limit);
+        Assert.Equal(4_294_967_296L, exception.Actual);
+    }
+
+    [Fact]
     public void RawStreamBudgetStopsAllocation() {
         byte[] pdf = BuildPdf();
         var options = new PdfReadOptions {

--- a/OfficeIMO.Pdf/Reading/Core/PdfSyntax.ObjectStreams.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfSyntax.ObjectStreams.cs
@@ -25,9 +25,7 @@ internal static partial class PdfSyntax {
 
             // Decode object stream bytes (flate only for now)
             var data = Filters.StreamDecoder.Decode(s.Dictionary, s.Data, map, limits.MaxDecodedStreamBytes);
-            int n = (int)(s.Dictionary.Get<PdfNumber>("N")?.Value ?? 0);
-            int first = (int)(s.Dictionary.Get<PdfNumber>("First")?.Value ?? 0);
-            if (n <= 0 || first <= 0 || first > data.Length) continue;
+            if (!TryReadObjectStreamLayout(s.Dictionary, data.Length, limits, out int n, out int first)) continue;
             // Header: pairs of objectNumber and offset (ASCII)
             var headerBytes = new byte[first];
             Buffer.BlockCopy(data, 0, headerBytes, 0, first);
@@ -62,6 +60,38 @@ internal static partial class PdfSyntax {
         }
 
         int GetSourceOffset(int objectNumber) => parsedOffsets.TryGetValue(objectNumber, out int offset) ? offset : int.MaxValue;
+    }
+
+    private static bool TryReadObjectStreamLayout(
+        PdfDictionary dictionary,
+        int decodedLength,
+        PdfReadLimits limits,
+        out int objectCount,
+        out int firstObjectOffset) {
+        objectCount = 0;
+        firstObjectOffset = 0;
+
+        double rawObjectCount = dictionary.Get<PdfNumber>("N")?.Value ?? 0D;
+        double rawFirstOffset = dictionary.Get<PdfNumber>("First")?.Value ?? 0D;
+        if (double.IsNaN(rawObjectCount) || double.IsInfinity(rawObjectCount)
+            || rawObjectCount < 1D || rawObjectCount != Math.Truncate(rawObjectCount)) {
+            return false;
+        }
+        if (rawObjectCount > limits.MaxIndirectObjects) {
+            throw PdfReadLimitException.Create(
+                PdfReadLimitKind.IndirectObjects,
+                limits.MaxIndirectObjects,
+                rawObjectCount > long.MaxValue ? long.MaxValue : (long)rawObjectCount);
+        }
+        if (double.IsNaN(rawFirstOffset) || double.IsInfinity(rawFirstOffset)
+            || rawFirstOffset < 1D || rawFirstOffset > decodedLength
+            || rawFirstOffset != Math.Truncate(rawFirstOffset)) {
+            return false;
+        }
+
+        objectCount = (int)rawObjectCount;
+        firstObjectOffset = (int)rawFirstOffset;
+        return true;
     }
 
     private static List<(int Obj, int Off)> ParsePairs(string header, int n) {

--- a/OfficeIMO.Pdf/Reading/Core/PdfSyntax.Xref.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfSyntax.Xref.cs
@@ -737,9 +737,8 @@ internal static partial class PdfSyntax {
         }
 
         byte[] data = Filters.StreamDecoder.Decode(objectStream.Dictionary, objectStream.Data, map, limits.MaxDecodedStreamBytes);
-        int n = (int)(objectStream.Dictionary.Get<PdfNumber>("N")?.Value ?? 0);
-        int first = (int)(objectStream.Dictionary.Get<PdfNumber>("First")?.Value ?? 0);
-        if (objectStreamIndex < 0 || objectStreamIndex >= n || n <= 0 || first <= 0 || first > data.Length) {
+        if (!TryReadObjectStreamLayout(objectStream.Dictionary, data.Length, limits, out int n, out int first)
+            || objectStreamIndex < 0 || objectStreamIndex >= n) {
             return false;
         }
 

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.Security.AllSeverityBatch12.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.Security.AllSeverityBatch12.cs
@@ -1,0 +1,134 @@
+using DocumentFormat.OpenXml.Packaging;
+using OfficeIMO.PowerPoint;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class PowerPointAllSeverityBatch12SecurityTests {
+    [Fact]
+    public async Task LoadApisEnforceInputBudgetForSeekableAndNonSeekableStreams() {
+        byte[] package;
+        using (PowerPointPresentation source =
+               PowerPointPresentation.Create()) {
+            source.AddSlide().AddTextBox("safe");
+            package = source.ToBytes();
+        }
+        var restrictive = new PowerPointLoadOptions {
+            MaxInputBytes = package.Length - 1L
+        };
+
+        using var seekable = new MemoryStream(package, writable: false);
+        Assert.Throws<InvalidDataException>(() =>
+            PowerPointPresentation.Load(seekable, restrictive));
+
+        using var nonSeekable = new Batch12NonSeekableStream(package);
+        Assert.Throws<InvalidDataException>(() =>
+            PowerPointPresentation.Load(nonSeekable, restrictive));
+
+        using var asyncStream = new Batch12NonSeekableStream(package);
+        await Assert.ThrowsAsync<InvalidDataException>(() =>
+            PowerPointPresentation.LoadAsync(asyncStream, restrictive));
+
+        using var validStream = new MemoryStream(package, writable: false);
+        using PowerPointPresentation valid = PowerPointPresentation.Load(
+            validStream,
+            new PowerPointLoadOptions { MaxInputBytes = package.Length });
+        Assert.Single(valid.Slides);
+    }
+
+    [Fact]
+    public void DuplicateSlideRejectsCyclicPartRelationships() {
+        using PowerPointPresentation presentation =
+            PowerPointPresentation.Create();
+        PowerPointSlide slide = presentation.AddSlide();
+        ExtendedPart first = slide.SlidePart.AddExtendedPart(
+            "urn:officeimo:test:first",
+            "application/xml",
+            "rIdCycleFirst");
+        ExtendedPart second = first.AddExtendedPart(
+            "urn:officeimo:test:second",
+            "application/xml",
+            "rIdCycleSecond");
+        WritePart(first, "<first />");
+        WritePart(second, "<second />");
+        second.AddPart(first, "rIdCycleBack");
+        int originalSlideCount = presentation.Slides.Count;
+        int originalTopLevelPartCount = presentation.OpenXmlDocument
+            .PresentationPart!.Parts.Count();
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(
+            () => presentation.DuplicateSlide(0));
+
+        Assert.Contains("contain a cycle", exception.Message,
+            StringComparison.Ordinal);
+        Assert.Equal(originalSlideCount, presentation.Slides.Count);
+        Assert.Equal(originalTopLevelPartCount, presentation.OpenXmlDocument
+            .PresentationPart!.Parts.Count());
+    }
+
+    [Fact]
+    public void ConversionPreservesConfiguredInputBudget() {
+        string root = Path.Combine(Path.GetTempPath(),
+            "officeimo-powerpoint-conversion-" + Guid.NewGuid().ToString("N"));
+        string sourcePath = Path.Combine(root, "source.pptx");
+        string destinationPath = Path.Combine(root, "destination.pptx");
+        Directory.CreateDirectory(root);
+        try {
+            using (PowerPointPresentation presentation =
+                   PowerPointPresentation.Create(sourcePath)) {
+                presentation.AddSlide().AddTextBox("safe");
+                presentation.Save();
+            }
+            long sourceLength = new FileInfo(sourcePath).Length;
+            var options = new PowerPointPresentationConversionOptions {
+                LoadOptions = new PowerPointLoadOptions {
+                    MaxInputBytes = sourceLength - 1L
+                }
+            };
+
+            Assert.Throws<InvalidDataException>(() =>
+                PowerPointPresentation.AnalyzeConversion(
+                    sourcePath, destinationPath, options));
+        } finally {
+            if (Directory.Exists(root)) Directory.Delete(root, true);
+        }
+    }
+
+    private static void WritePart(OpenXmlPart part, string content) {
+        using Stream stream = part.GetStream(FileMode.Create,
+            FileAccess.Write);
+        using var writer = new StreamWriter(stream);
+        writer.Write(content);
+    }
+
+    private sealed class Batch12NonSeekableStream : Stream {
+        private readonly MemoryStream _inner;
+
+        internal Batch12NonSeekableStream(byte[] bytes) {
+            _inner = new MemoryStream(bytes, writable: false);
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count) =>
+            _inner.Read(buffer, offset, count);
+        public override long Seek(long offset, SeekOrigin origin) =>
+            throw new NotSupportedException();
+        public override void SetLength(long value) =>
+            throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) =>
+            throw new NotSupportedException();
+        protected override void Dispose(bool disposing) {
+            if (disposing) _inner.Dispose();
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/OfficeIMO.PowerPoint/PowerPointLifecycleOptions.cs
+++ b/OfficeIMO.PowerPoint/PowerPointLifecycleOptions.cs
@@ -9,6 +9,11 @@ namespace OfficeIMO.PowerPoint {
 
     /// <summary>Controls access, persistence, and package behavior when loading a PowerPoint presentation.</summary>
     public sealed class PowerPointLoadOptions : DocumentLoadOptions {
+        /// <summary>
+        /// Maximum presentation bytes buffered by load APIs. Default: 512 MiB. Set to null to disable this compatibility guard.
+        /// </summary>
+        public long? MaxInputBytes { get; set; } = 512L * 1024L * 1024L;
+
         /// <summary>Provides optional low-level Open XML package settings.</summary>
         public OpenSettings? OpenSettings { get; set; }
 

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.Conversion.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.Conversion.cs
@@ -405,6 +405,9 @@ public sealed partial class PowerPointPresentation {
             PersistenceMode = DocumentPersistenceMode.Explicit,
             PackageSecurity = source?.PackageSecurity,
             OpenSettings = source?.OpenSettings,
+            MaxInputBytes = source == null
+                ? 512L * 1024L * 1024L
+                : source.MaxInputBytes,
             LegacyPptImportOptions = legacy == null
                 ? new LegacyPptImportOptions { ReportUnsupportedContent = true }
                 : new LegacyPptImportOptions {

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.Input.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.Input.cs
@@ -239,13 +239,20 @@ namespace OfficeIMO.PowerPoint {
 
         private static long? ResolvePackageInputLimit(
             PowerPointLoadOptions options) {
-            if (options.PackageSecurity == null) return null;
-            long configured = options.PackageSecurity.MaxPackageBytes;
-            if (configured < 1) {
+            long? configured = options.MaxInputBytes;
+            if (configured.HasValue && configured.Value < 1) {
+                throw new ArgumentOutOfRangeException(
+                    nameof(options.MaxInputBytes));
+            }
+            if (options.PackageSecurity == null) return configured;
+            long packageLimit = options.PackageSecurity.MaxPackageBytes;
+            if (packageLimit < 1) {
                 throw new ArgumentOutOfRangeException(
                     nameof(OfficePackageSecurityOptions.MaxPackageBytes));
             }
-            return configured;
+            return configured.HasValue
+                ? Math.Min(configured.Value, packageLimit)
+                : packageLimit;
         }
 
         private static int ResolveLegacyInputLimit(

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.Parts.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.Parts.cs
@@ -13,6 +13,8 @@ using P14 = DocumentFormat.OpenXml.Office2010.PowerPoint;
 
 namespace OfficeIMO.PowerPoint {
     public sealed partial class PowerPointPresentation {
+        private const int MaxPartCloneDepth = 128;
+
         private void InitializeDefaultParts() {
             // IMPORTANT: PowerPoint requires a very specific initialization pattern to avoid the repair dialog.
             // We must create an initial blank slide with relationship ID "rId2" and then create
@@ -323,45 +325,89 @@ namespace OfficeIMO.PowerPoint {
             ICollection<ImportedPartRoot>? importedPartRoots = null,
             Func<OpenXmlPart, string, bool>?
                 shouldSkipPartRelationship = null) {
-            if (sourcePart is SlidePart sourceSlide
-                && slideResolver != null) {
-                SlidePart? targetSlide = slideResolver(sourceSlide);
-                if (targetSlide == null) {
-                    if (skipUnresolvedSlideTargets) {
-                        RemoveInternalSlideLinkMarkup(targetContainer,
-                            relationshipId);
-                        return;
+            ClonePartRecursive(sourcePart, targetContainer, relationshipId,
+                shouldShare, includeDataParts, dataPartMap, slideResolver,
+                skipUnresolvedSlideTargets, importedPartRoots,
+                shouldSkipPartRelationship, new HashSet<OpenXmlPart>(), 0);
+        }
+
+        private static void ClonePartRecursive(
+            OpenXmlPart sourcePart,
+            OpenXmlPartContainer targetContainer,
+            string relationshipId,
+            Func<OpenXmlPart, bool> shouldShare,
+            bool includeDataParts,
+            Dictionary<DataPart, MediaDataPart>? dataPartMap,
+            Func<SlidePart, SlidePart?>? slideResolver,
+            bool skipUnresolvedSlideTargets,
+            ICollection<ImportedPartRoot>? importedPartRoots,
+            Func<OpenXmlPart, string, bool>?
+                shouldSkipPartRelationship,
+            HashSet<OpenXmlPart> activeParts,
+            int depth) {
+            if (depth >= MaxPartCloneDepth) {
+                throw new InvalidDataException(
+                    $"PowerPoint part relationships exceed the supported clone depth of {MaxPartCloneDepth}.");
+            }
+            if (!activeParts.Add(sourcePart)) {
+                throw new InvalidDataException(
+                    "PowerPoint part relationships contain a cycle and cannot be cloned safely.");
+            }
+
+            OpenXmlPart? clonedPart = null;
+            try {
+                if (sourcePart is SlidePart sourceSlide
+                    && slideResolver != null) {
+                    SlidePart? targetSlide = slideResolver(sourceSlide);
+                    if (targetSlide == null) {
+                        if (skipUnresolvedSlideTargets) {
+                            RemoveInternalSlideLinkMarkup(targetContainer,
+                                relationshipId);
+                            return;
+                        }
+                        throw new InvalidDataException(
+                            "An imported internal slide target is not present in the import closure.");
                     }
-                    throw new InvalidDataException(
-                        "An imported internal slide target is not present in the import closure.");
+                    AddExistingPart(targetContainer, targetSlide, relationshipId);
+                    return;
                 }
-                AddExistingPart(targetContainer, targetSlide, relationshipId);
-                return;
-            }
-            if (shouldShare(sourcePart)) {
-                AddExistingPart(targetContainer, sourcePart, relationshipId);
-                return;
-            }
-
-            OpenXmlPart newPart = sourcePart is ExtendedPart extendedPart
-                ? targetContainer.AddExtendedPart(extendedPart.RelationshipType, extendedPart.ContentType, relationshipId)
-                : AddNewPartWithContentType(targetContainer, sourcePart, relationshipId);
-
-            CopyPartData(sourcePart, newPart);
-            importedPartRoots?.Add(new ImportedPartRoot(sourcePart,
-                newPart));
-            CloneReferenceRelationships(sourcePart, newPart, includeDataParts, dataPartMap);
-
-            foreach (var childPair in sourcePart.Parts) {
-                if (shouldSkipPartRelationship?.Invoke(sourcePart,
-                        childPair.RelationshipId) == true) {
-                    continue;
+                if (shouldShare(sourcePart)) {
+                    AddExistingPart(targetContainer, sourcePart, relationshipId);
+                    return;
                 }
-                ClonePartRecursive(childPair.OpenXmlPart, newPart,
-                    childPair.RelationshipId, shouldShare,
-                    includeDataParts, dataPartMap, slideResolver,
-                    skipUnresolvedSlideTargets, importedPartRoots,
-                    shouldSkipPartRelationship);
+
+                clonedPart = sourcePart is ExtendedPart extendedPart
+                    ? targetContainer.AddExtendedPart(extendedPart.RelationshipType, extendedPart.ContentType, relationshipId)
+                    : AddNewPartWithContentType(targetContainer, sourcePart, relationshipId);
+
+                CopyPartData(sourcePart, clonedPart);
+                importedPartRoots?.Add(new ImportedPartRoot(sourcePart,
+                    clonedPart));
+                CloneReferenceRelationships(sourcePart, clonedPart, includeDataParts, dataPartMap);
+
+                foreach (var childPair in sourcePart.Parts) {
+                    if (shouldSkipPartRelationship?.Invoke(sourcePart,
+                            childPair.RelationshipId) == true) {
+                        continue;
+                    }
+                    ClonePartRecursive(childPair.OpenXmlPart, clonedPart,
+                        childPair.RelationshipId, shouldShare,
+                        includeDataParts, dataPartMap, slideResolver,
+                        skipUnresolvedSlideTargets, importedPartRoots,
+                        shouldSkipPartRelationship, activeParts, depth + 1);
+                }
+            } catch {
+                if (clonedPart != null) {
+                    try {
+                        targetContainer.DeletePart(clonedPart);
+                    } catch {
+                        // Preserve the original clone failure; the owning
+                        // operation performs its own top-level rollback too.
+                    }
+                }
+                throw;
+            } finally {
+                activeParts.Remove(sourcePart);
             }
         }
 

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.Slides.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.Slides.cs
@@ -326,8 +326,14 @@ namespace OfficeIMO.PowerPoint {
             SlidePart slidePart = _presentationPart.AddNewPart<SlidePart>(slideRelId);
             slidePart.Slide = (Slide)sourceSlideRoot.CloneNode(true);
 
-            CloneSlidePartRelationships(sourcePart, slidePart, ShouldSharePart, includeDataParts: true);
-            RemapDuplicatedNotesSlideBacklink(sourcePart, slidePart);
+            try {
+                CloneSlidePartRelationships(sourcePart, slidePart,
+                    ShouldSharePart, includeDataParts: true);
+                RemapDuplicatedNotesSlideBacklink(sourcePart, slidePart);
+            } catch {
+                _presentationPart.DeletePart(slidePart);
+                throw;
+            }
 
             SlideIdList slideIdList = PresentationRoot.SlideIdList ??= new SlideIdList();
             SlideId slideId = new() { Id = GetNextSlideId() };

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.Slides.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.Slides.cs
@@ -331,7 +331,11 @@ namespace OfficeIMO.PowerPoint {
                     ShouldSharePart, includeDataParts: true);
                 RemapDuplicatedNotesSlideBacklink(sourcePart, slidePart);
             } catch {
-                _presentationPart.DeletePart(slidePart);
+                try {
+                    _presentationPart.DeletePart(slidePart);
+                } catch {
+                    // Preserve the original clone failure when best-effort cleanup fails.
+                }
                 throw;
             }
 

--- a/OfficeIMO.PowerPoint/PowerPointSlide.Arrange.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSlide.Arrange.cs
@@ -386,7 +386,11 @@ namespace OfficeIMO.PowerPoint {
 
                 return relationshipId;
             } catch {
-                _slidePart.DeletePart(targetChartPart);
+                try {
+                    _slidePart.DeletePart(targetChartPart);
+                } catch {
+                    // Preserve the original clone failure when best-effort cleanup fails.
+                }
                 throw;
             }
         }

--- a/OfficeIMO.PowerPoint/PowerPointSlide.Arrange.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSlide.Arrange.cs
@@ -10,6 +10,8 @@ using Dgm = DocumentFormat.OpenXml.Drawing.Diagrams;
 
 namespace OfficeIMO.PowerPoint {
     public partial class PowerPointSlide {
+        private const int MaxPartCloneDepth = 128;
+
         /// <summary>
         ///     Creates a duplicate of the provided shape and optionally offsets its position (EMUs).
         /// </summary>
@@ -368,32 +370,72 @@ namespace OfficeIMO.PowerPoint {
         private string CloneChartPart(ChartPart sourceChartPart) {
             string relationshipId = GetNextRelationshipId(_slidePart);
             ChartPart targetChartPart = (ChartPart)AddNewPartWithContentType(_slidePart, sourceChartPart, relationshipId);
-            C.ChartSpace? sourceChartSpace = sourceChartPart.ChartSpace;
-            if (sourceChartSpace != null) {
-                targetChartPart.ChartSpace = (C.ChartSpace)sourceChartSpace.CloneNode(true);
-                targetChartPart.ChartSpace.Save();
-            } else {
-                CopyPartData(sourceChartPart, targetChartPart);
-            }
-            CloneReferenceRelationships(sourceChartPart, targetChartPart);
+            try {
+                C.ChartSpace? sourceChartSpace = sourceChartPart.ChartSpace;
+                if (sourceChartSpace != null) {
+                    targetChartPart.ChartSpace = (C.ChartSpace)sourceChartSpace.CloneNode(true);
+                    targetChartPart.ChartSpace.Save();
+                } else {
+                    CopyPartData(sourceChartPart, targetChartPart);
+                }
+                CloneReferenceRelationships(sourceChartPart, targetChartPart);
 
-            foreach (IdPartPair childPair in sourceChartPart.Parts) {
-                ClonePartRecursive(childPair.OpenXmlPart, targetChartPart, childPair.RelationshipId);
-            }
+                foreach (IdPartPair childPair in sourceChartPart.Parts) {
+                    ClonePartRecursive(childPair.OpenXmlPart, targetChartPart, childPair.RelationshipId);
+                }
 
-            return relationshipId;
+                return relationshipId;
+            } catch {
+                _slidePart.DeletePart(targetChartPart);
+                throw;
+            }
         }
 
         private static void ClonePartRecursive(OpenXmlPart sourcePart, OpenXmlPartContainer targetContainer, string relationshipId) {
-            OpenXmlPart newPart = sourcePart is ExtendedPart extendedPart
-                ? targetContainer.AddExtendedPart(extendedPart.RelationshipType, extendedPart.ContentType, relationshipId)
-                : AddNewPartWithContentType(targetContainer, sourcePart, relationshipId);
+            ClonePartRecursive(sourcePart, targetContainer, relationshipId,
+                new HashSet<OpenXmlPart>(), 0);
+        }
 
-            CopyPartData(sourcePart, newPart);
-            CloneReferenceRelationships(sourcePart, newPart);
+        private static void ClonePartRecursive(
+            OpenXmlPart sourcePart,
+            OpenXmlPartContainer targetContainer,
+            string relationshipId,
+            HashSet<OpenXmlPart> activeParts,
+            int depth) {
+            if (depth >= MaxPartCloneDepth) {
+                throw new InvalidDataException(
+                    $"PowerPoint part relationships exceed the supported clone depth of {MaxPartCloneDepth}.");
+            }
+            if (!activeParts.Add(sourcePart)) {
+                throw new InvalidDataException(
+                    "PowerPoint part relationships contain a cycle and cannot be cloned safely.");
+            }
 
-            foreach (IdPartPair childPair in sourcePart.Parts) {
-                ClonePartRecursive(childPair.OpenXmlPart, newPart, childPair.RelationshipId);
+            OpenXmlPart? clonedPart = null;
+            try {
+                clonedPart = sourcePart is ExtendedPart extendedPart
+                    ? targetContainer.AddExtendedPart(extendedPart.RelationshipType, extendedPart.ContentType, relationshipId)
+                    : AddNewPartWithContentType(targetContainer, sourcePart, relationshipId);
+
+                CopyPartData(sourcePart, clonedPart);
+                CloneReferenceRelationships(sourcePart, clonedPart);
+
+                foreach (IdPartPair childPair in sourcePart.Parts) {
+                    ClonePartRecursive(childPair.OpenXmlPart, clonedPart,
+                        childPair.RelationshipId, activeParts, depth + 1);
+                }
+            } catch {
+                if (clonedPart != null) {
+                    try {
+                        targetContainer.DeletePart(clonedPart);
+                    } catch {
+                        // Preserve the original clone failure; CloneChartPart
+                        // removes the top-level chart relationship as well.
+                    }
+                }
+                throw;
+            } finally {
+                activeParts.Remove(sourcePart);
             }
         }
 

--- a/OfficeIMO.Reader.Core/DocumentReader.Path.cs
+++ b/OfficeIMO.Reader.Core/DocumentReader.Path.cs
@@ -250,18 +250,36 @@ internal static partial class DocumentReaderEngine {
 
     private static IEnumerable<string> EnumerateFilesSafeDeterministic(string folderPath, ReaderFolderOptions options, CancellationToken cancellationToken) {
         var directories = new Queue<string>();
+        int entriesInspected = 0;
         directories.Enqueue(folderPath);
         while (directories.Count > 0) {
             cancellationToken.ThrowIfCancellationRequested();
             string directory = directories.Dequeue();
-            string[] entries;
-            try { entries = Directory.GetFileSystemEntries(directory); } catch { continue; }
-            if (options.DeterministicOrder) Array.Sort(entries, StringComparer.Ordinal);
+            var entries = new List<string>();
+            try {
+                foreach (string entry in Directory.EnumerateFileSystemEntries(directory)) {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    entriesInspected++;
+                    if (entriesInspected > options.MaxTraversalEntries) {
+                        throw new InvalidDataException(
+                            $"Folder traversal exceeds MaxTraversalEntries ({options.MaxTraversalEntries}).");
+                    }
+                    entries.Add(entry);
+                }
+            } catch (InvalidDataException) {
+                throw;
+            } catch (OperationCanceledException) {
+                throw;
+            } catch {
+                continue;
+            }
+            if (options.DeterministicOrder) entries.Sort(StringComparer.Ordinal);
             foreach (string entry in entries) {
                 FileAttributes attributes;
                 try { attributes = File.GetAttributes(entry); } catch { continue; }
+                if (options.SkipReparsePoints && (attributes & FileAttributes.ReparsePoint) != 0) continue;
                 if ((attributes & FileAttributes.Directory) != 0) {
-                    if (options.Recurse && (!options.SkipReparsePoints || (attributes & FileAttributes.ReparsePoint) == 0)) directories.Enqueue(entry);
+                    if (options.Recurse) directories.Enqueue(entry);
                 } else {
                     yield return entry;
                 }

--- a/OfficeIMO.Reader.Core/DocumentReader.Registry.cs
+++ b/OfficeIMO.Reader.Core/DocumentReader.Registry.cs
@@ -92,6 +92,7 @@ internal static partial class DocumentReaderEngine {
         var clone = new ReaderFolderOptions {
             Recurse = options?.Recurse ?? true,
             MaxFiles = Math.Max(1, options?.MaxFiles ?? 500),
+            MaxTraversalEntries = Math.Max(1, options?.MaxTraversalEntries ?? 10_000),
             MaxTotalBytes = options?.MaxTotalBytes,
             Extensions = options?.Extensions == null ? null : options.Extensions.ToArray(),
             SkipReparsePoints = options?.SkipReparsePoints ?? true,

--- a/OfficeIMO.Reader.Core/ReaderOptions.cs
+++ b/OfficeIMO.Reader.Core/ReaderOptions.cs
@@ -107,6 +107,11 @@ public sealed class ReaderFolderOptions {
     public int MaxFiles { get; set; } = 500;
 
     /// <summary>
+    /// Maximum raw file-system entries inspected before filtering and deterministic sorting. Default: 10,000.
+    /// </summary>
+    public int MaxTraversalEntries { get; set; } = 10_000;
+
+    /// <summary>
     /// Optional maximum total bytes accepted for parsing across the folder operation.
     /// Files whose known size exceeds the remaining budget are skipped before their format handler runs.
     /// When source size metadata is unavailable, the cap is enforced after parsing as a best-effort fallback.
@@ -122,7 +127,7 @@ public sealed class ReaderFolderOptions {
     public IReadOnlyList<string>? Extensions { get; set; }
 
     /// <summary>
-    /// When true, directory traversal skips reparse points (junctions/symlinks). Default: true.
+    /// When true, directory traversal skips file and directory reparse points (junctions/symlinks). Default: true.
     /// </summary>
     public bool SkipReparsePoints { get; set; } = true;
 

--- a/OfficeIMO.Reader.Markdown/MarkdownReaderAdapter.cs
+++ b/OfficeIMO.Reader.Markdown/MarkdownReaderAdapter.cs
@@ -5,21 +5,34 @@ using OfficeIMO.Markdown;
 namespace OfficeIMO.Reader.Markdown;
 
 internal static class MarkdownReaderAdapter {
+    private const int MaximumDataViewColumns = 4_096;
+
     internal static ReaderMarkdownOptions Clone(ReaderMarkdownOptions? source) => new ReaderMarkdownOptions {
         ChunkByHeadings = source?.ChunkByHeadings ?? true,
         ParserOptions = (source?.ParserOptions ?? new MarkdownReaderOptions()).Clone()
     };
 
     internal static OfficeDocumentReadResult ReadDocument(string path, ReaderOptions readerOptions, ReaderMarkdownOptions options, CancellationToken cancellationToken) {
-        string text = File.ReadAllText(path);
-        return Project(text, path, readerOptions, options, cancellationToken);
+        long maxInputBytes = readerOptions.MaxInputBytes ?? OfficeDocumentReaderBuilderMarkdownExtensions.DefaultMaxInputBytes;
+        ReaderInputLimits.EnforceFileSize(path, maxInputBytes);
+        using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+        return ReadDocument(stream, path, readerOptions, options, cancellationToken);
     }
 
     internal static OfficeDocumentReadResult ReadDocument(Stream stream, string? sourceName, ReaderOptions readerOptions, ReaderMarkdownOptions options, CancellationToken cancellationToken) {
-        if (stream.CanSeek) stream.Position = 0;
-        using var reader = new StreamReader(stream, Encoding.UTF8, true, 4096, leaveOpen: true);
-        string text = reader.ReadToEnd();
-        return Project(text, string.IsNullOrWhiteSpace(sourceName) ? "document.md" : sourceName!, readerOptions, options, cancellationToken);
+        long maxInputBytes = readerOptions.MaxInputBytes ?? OfficeDocumentReaderBuilderMarkdownExtensions.DefaultMaxInputBytes;
+        Stream parseStream = ReaderInputLimits.EnsureSeekableReadStream(
+            stream,
+            maxInputBytes,
+            cancellationToken,
+            out bool ownsParseStream);
+        try {
+            using var reader = new StreamReader(parseStream, Encoding.UTF8, true, 4096, leaveOpen: true);
+            string text = reader.ReadToEnd();
+            return Project(text, string.IsNullOrWhiteSpace(sourceName) ? "document.md" : sourceName!, readerOptions, options, cancellationToken);
+        } finally {
+            if (ownsParseStream) parseStream.Dispose();
+        }
     }
 
     private static OfficeDocumentReadResult Project(string text, string sourceName, ReaderOptions readerOptions, ReaderMarkdownOptions options, CancellationToken cancellationToken) {
@@ -176,39 +189,54 @@ internal static class MarkdownReaderAdapter {
             if (root.ValueKind != JsonValueKind.Object) return false;
 
             var columns = new List<string>();
-            var rows = new List<IReadOnlyList<string>>();
+            int rowLimit = Math.Max(1, maxRows);
+            var rows = new List<IReadOnlyList<string>>(Math.Min(rowLimit, 256));
+            int totalRowCount = 0;
             if (root.TryGetProperty("columns", out JsonElement columnsElement) && columnsElement.ValueKind == JsonValueKind.Array) {
-                foreach (JsonElement value in columnsElement.EnumerateArray()) columns.Add(ReadJsonScalar(value));
+                if (!TryReadColumns(columnsElement, columns)) return false;
             }
 
             if (root.TryGetProperty("rows", out JsonElement rowsElement) && rowsElement.ValueKind == JsonValueKind.Array) {
-                JsonElement[] sourceRows = rowsElement.EnumerateArray().ToArray();
-                if (sourceRows.Length > 0 && sourceRows[0].ValueKind == JsonValueKind.Array) {
+                int sourceRowCount = rowsElement.GetArrayLength();
+                if (sourceRowCount > 0 && rowsElement[0].ValueKind == JsonValueKind.Array) {
                     bool columnsWereProvided = columns.Count > 0;
-                    IReadOnlyList<string> first = sourceRows[0].EnumerateArray().Select(ReadJsonScalar).ToArray();
-                    if (columns.Count == 0) columns.AddRange(first);
-                    for (int index = columnsWereProvided ? 0 : 1; index < sourceRows.Length; index++) {
-                        if (sourceRows[index].ValueKind == JsonValueKind.Array) rows.Add(NormalizeRow(sourceRows[index].EnumerateArray().Select(ReadJsonScalar).ToArray(), columns.Count));
+                    if (!columnsWereProvided && !TryReadColumns(rowsElement[0], columns)) return false;
+                    int firstDataRow = columnsWereProvided ? 0 : 1;
+                    for (int index = firstDataRow; index < sourceRowCount; index++) {
+                        if (rowsElement[index].ValueKind != JsonValueKind.Array) continue;
+                        totalRowCount++;
+                        if (rows.Count < rowLimit) {
+                            rows.Add(ReadBoundedRow(rowsElement[index], columns.Count));
+                        }
                     }
                 }
             } else if (root.TryGetProperty("records", out JsonElement recordsElement) && recordsElement.ValueKind == JsonValueKind.Array) {
-                JsonElement[] records = recordsElement.EnumerateArray().ToArray();
-                if (columns.Count == 0 && records.Length > 0 && records[0].ValueKind == JsonValueKind.Object) {
-                    columns.AddRange(records[0].EnumerateObject().Select(static property => property.Name));
+                int recordCount = recordsElement.GetArrayLength();
+                if (columns.Count == 0 && recordCount > 0 && recordsElement[0].ValueKind == JsonValueKind.Object) {
+                    foreach (JsonProperty property in recordsElement[0].EnumerateObject()) {
+                        if (columns.Count >= MaximumDataViewColumns) return false;
+                        columns.Add(property.Name);
+                    }
                 }
-                foreach (JsonElement record in records) {
+                for (int index = 0; index < recordCount; index++) {
+                    JsonElement record = recordsElement[index];
                     if (record.ValueKind == JsonValueKind.Object) {
-                        rows.Add(columns.Select(column => record.TryGetProperty(column, out JsonElement value) ? ReadJsonScalar(value) : string.Empty).ToArray());
+                        totalRowCount++;
+                        if (rows.Count < rowLimit) {
+                            rows.Add(columns.Select(column => record.TryGetProperty(column, out JsonElement value) ? ReadJsonScalar(value) : string.Empty).ToArray());
+                        }
                     } else if (record.ValueKind == JsonValueKind.Array) {
-                        rows.Add(NormalizeRow(record.EnumerateArray().Select(ReadJsonScalar).ToArray(), columns.Count));
+                        totalRowCount++;
+                        if (rows.Count < rowLimit) {
+                            rows.Add(ReadBoundedRow(record, columns.Count));
+                        }
                     }
                 }
             }
 
             if (columns.Count == 0) return false;
             string kind = ReadJsonString(root, "kind") ?? "ix-dataview";
-            int rowLimit = Math.Max(1, maxRows);
-            IReadOnlyList<IReadOnlyList<string>> boundedRows = rows.Take(rowLimit).ToArray();
+            IReadOnlyList<IReadOnlyList<string>> boundedRows = rows;
             table = new ReaderTable {
                 Title = ReadJsonString(root, "title") ?? kind,
                 Kind = kind,
@@ -217,8 +245,8 @@ internal static class MarkdownReaderAdapter {
                 PayloadHash = Hash(payload),
                 Columns = columns,
                 Rows = boundedRows,
-                TotalRowCount = rows.Count,
-                Truncated = rows.Count > boundedRows.Count,
+                TotalRowCount = totalRowCount,
+                Truncated = totalRowCount > boundedRows.Count,
                 ColumnProfiles = ReaderTableProfiler.CreateProfiles(columns, boundedRows),
                 Location = new ReaderLocation {
                     Path = sourceName,
@@ -238,6 +266,21 @@ internal static class MarkdownReaderAdapter {
         } catch (JsonException) {
             return false;
         }
+    }
+
+    private static bool TryReadColumns(JsonElement values, List<string> columns) {
+        if (values.GetArrayLength() > MaximumDataViewColumns) return false;
+        foreach (JsonElement value in values.EnumerateArray()) columns.Add(ReadJsonScalar(value));
+        return true;
+    }
+
+    private static IReadOnlyList<string> ReadBoundedRow(JsonElement row, int columnCount) {
+        var values = new List<string>(columnCount);
+        foreach (JsonElement value in row.EnumerateArray()) {
+            if (values.Count >= columnCount) break;
+            values.Add(ReadJsonScalar(value));
+        }
+        return NormalizeRow(values, columnCount);
     }
 
     private static IReadOnlyList<string> NormalizeRow(IReadOnlyList<string> row, int columnCount) =>

--- a/OfficeIMO.Reader.Markdown/OfficeDocumentReaderBuilderMarkdownExtensions.cs
+++ b/OfficeIMO.Reader.Markdown/OfficeDocumentReaderBuilderMarkdownExtensions.cs
@@ -5,6 +5,9 @@ public static class OfficeDocumentReaderBuilderMarkdownExtensions {
     /// <summary>Stable Markdown handler identifier.</summary>
     public const string HandlerId = "officeimo.reader.markdown";
 
+    /// <summary>Default maximum Markdown input size. Default: 64 MiB.</summary>
+    public const long DefaultMaxInputBytes = 64L * 1024L * 1024L;
+
     /// <summary>Adds Markdown and MDX text ingestion.</summary>
     public static OfficeDocumentReaderBuilder AddMarkdownHandler(
         this OfficeDocumentReaderBuilder builder,
@@ -19,6 +22,7 @@ public static class OfficeDocumentReaderBuilderMarkdownExtensions {
             Description = "OfficeIMO.Markdown AST projection with headings, tables, visuals, and source spans.",
             Kind = ReaderInputKind.Markdown,
             Extensions = new[] { ".md", ".markdown", ".mdown", ".mkd", ".mdx" },
+            DefaultMaxInputBytes = DefaultMaxInputBytes,
             ReadDocumentPath = (path, readerOptions, token) => MarkdownReaderAdapter.ReadDocument(path, readerOptions, configured, token),
             ReadDocumentStream = (stream, sourceName, readerOptions, token) => MarkdownReaderAdapter.ReadDocument(stream, sourceName, readerOptions, configured, token),
             WarningBehavior = ReaderWarningBehavior.Mixed,

--- a/OfficeIMO.Reader.Tests/Reader.AllSeverityBatch12.Security.cs
+++ b/OfficeIMO.Reader.Tests/Reader.AllSeverityBatch12.Security.cs
@@ -1,0 +1,149 @@
+using OfficeIMO.Reader;
+using OfficeIMO.Reader.Markdown;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class ReaderAllSeverityBatch12SecurityTests {
+    [Fact]
+    public void MarkdownHandler_DefaultInputLimitRejectsOversizedPath() {
+        string path = Path.Combine(Path.GetTempPath(),
+            Guid.NewGuid().ToString("N") + ".md");
+        try {
+            using (var stream = new FileStream(path, FileMode.CreateNew,
+                       FileAccess.Write, FileShare.None)) {
+                stream.SetLength(
+                    OfficeDocumentReaderBuilderMarkdownExtensions
+                        .DefaultMaxInputBytes + 1);
+            }
+            OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
+                .AddMarkdownHandler()
+                .Build();
+
+            Assert.Throws<IOException>(
+                () => reader.ReadDocument(path));
+        } finally {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void MarkdownHandler_BoundsNonSeekableStreamsBeforeParsing() {
+        byte[] payload = Encoding.UTF8.GetBytes(new string('x', 1_024));
+        using var stream = new NonSeekableReadStream(payload);
+        OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
+            .AddMarkdownHandler()
+            .Build();
+
+        Assert.Throws<IOException>(() => reader.ReadDocument(
+            stream,
+            "oversized.md",
+            new ReaderOptions { MaxInputBytes = 32 }));
+    }
+
+    [Fact]
+    public void MarkdownDataView_OnlyMaterializesConfiguredRows() {
+        var markdown = new StringBuilder(
+            "```ix-dataview\n{\"columns\":[\"Value\"],\"rows\":[");
+        const int totalRows = 5_000;
+        for (int index = 0; index < totalRows; index++) {
+            if (index > 0) markdown.Append(',');
+            markdown.Append("[\"").Append(index).Append("\"]");
+        }
+        markdown.Append("]}\n```");
+        OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
+            .AddMarkdownHandler()
+            .Build();
+
+        OfficeDocumentReadResult result = reader.ReadDocument(
+            Encoding.UTF8.GetBytes(markdown.ToString()),
+            "table.md",
+            new ReaderOptions { MaxTableRows = 2 });
+
+        ReaderTable table = Assert.Single(
+            Assert.Single(result.Chunks).Tables!);
+        Assert.Equal(2, table.Rows.Count);
+        Assert.Equal(totalRows, table.TotalRowCount);
+        Assert.True(table.Truncated);
+    }
+
+    [Fact]
+    public void MarkdownDataView_CountsOnlyProjectableRows() {
+        const string markdown = """
+            ```ix-dataview
+            {"columns":["Value"],"rows":[["one"],null,{"bad":true},["two"]]}
+            ```
+            """;
+        OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
+            .AddMarkdownHandler()
+            .Build();
+
+        OfficeDocumentReadResult result = reader.ReadDocument(
+            Encoding.UTF8.GetBytes(markdown),
+            "table.md",
+            new ReaderOptions { MaxTableRows = 2 });
+
+        ReaderTable table = Assert.Single(
+            Assert.Single(result.Chunks).Tables!);
+        Assert.Equal(2, table.Rows.Count);
+        Assert.Equal(2, table.TotalRowCount);
+        Assert.False(table.Truncated);
+    }
+
+    [Fact]
+    public void ReadFolder_RejectsEnumerationBeyondTraversalBudget() {
+        string folder = Path.Combine(Path.GetTempPath(),
+            "officeimo-reader-budget-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(folder);
+        try {
+            for (int index = 0; index < 4; index++) {
+                File.WriteAllText(Path.Combine(folder, index + ".md"),
+                    "safe");
+            }
+
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(
+                () => OfficeIMO.Reader.Tests.ReaderTestReaders.All.ReadFolder(
+                    folder,
+                    new ReaderFolderOptions {
+                        Recurse = false,
+                        MaxFiles = 1,
+                        MaxTraversalEntries = 3
+                    }).ToArray());
+
+            Assert.Contains("MaxTraversalEntries (3)", exception.Message,
+                StringComparison.Ordinal);
+        } finally {
+            if (Directory.Exists(folder)) Directory.Delete(folder, true);
+        }
+    }
+
+    [Fact]
+    public void ReadFolder_SkipsFileSymlinksByDefault() {
+#if NET6_0_OR_GREATER
+        if (OperatingSystem.IsWindows()) return;
+        string root = Path.Combine(Path.GetTempPath(),
+            "officeimo-reader-link-" + Guid.NewGuid().ToString("N"));
+        string folder = Path.Combine(root, "input");
+        string external = Path.Combine(root, "secret.md");
+        Directory.CreateDirectory(folder);
+        try {
+            File.WriteAllText(external, "outside-secret");
+            File.CreateSymbolicLink(
+                Path.Combine(folder, "linked.md"), external);
+
+            ReaderChunk[] chunks = OfficeIMO.Reader.Tests.ReaderTestReaders.All.ReadFolder(
+                folder,
+                new ReaderFolderOptions {
+                    Recurse = false,
+                    Extensions = new[] { ".md" }
+                }).ToArray();
+
+            Assert.DoesNotContain(chunks, chunk =>
+                (chunk.Text ?? string.Empty).Contains(
+                    "outside-secret", StringComparison.Ordinal));
+        } finally {
+            if (Directory.Exists(root)) Directory.Delete(root, true);
+        }
+#endif
+    }
+}

--- a/OfficeIMO.Visio.Tests/Visio.Security.AllSeverityBatch12.cs
+++ b/OfficeIMO.Visio.Tests/Visio.Security.AllSeverityBatch12.cs
@@ -1,0 +1,129 @@
+using System.IO.Compression;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using OfficeIMO.Visio;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class VisioAllSeverityBatch12SecurityTests {
+    [Fact]
+    public async Task LoadApisEnforceInputBudgetForNonSeekableStreams() {
+        VisioDocument source = VisioDocument.Create();
+        source.AddPage("Page-1");
+        byte[] package = source.ToBytes();
+        var restrictive = new VisioLoadOptions {
+            MaxInputBytes = package.Length - 1L
+        };
+
+        using var stream = new Batch12NonSeekableStream(package);
+        Assert.Throws<InvalidDataException>(() =>
+            VisioDocument.Load(stream, restrictive));
+
+        using var asyncStream = new Batch12NonSeekableStream(package);
+        await Assert.ThrowsAsync<InvalidDataException>(() =>
+            VisioDocument.LoadAsync(
+                asyncStream, CancellationToken.None, restrictive));
+
+        using var validStream = new MemoryStream(package, writable: false);
+        VisioDocument valid = VisioDocument.Load(validStream,
+            new VisioLoadOptions { MaxInputBytes = package.Length });
+        Assert.Single(valid.Pages);
+    }
+
+    [Fact]
+    public void ExtractMastersContainsHostileIdsWithinOutputFolder() {
+        string root = Path.Combine(Path.GetTempPath(),
+            "officeimo-visio-assets-" + Guid.NewGuid().ToString("N"));
+        string packagePath = Path.Combine(root, "source.vsdx");
+        string output = Path.Combine(root, "output");
+        string escaped = Path.Combine(root, "escaped-Danger.xml");
+        Directory.CreateDirectory(root);
+        try {
+            CreateMasterPackage(packagePath, "../escaped", "Danger");
+
+            VisioAssets.ExtractMasters(packagePath, output);
+
+            string extracted = Assert.Single(Directory.GetFiles(output));
+            Assert.StartsWith(Path.GetFullPath(output)
+                    + Path.DirectorySeparatorChar,
+                Path.GetFullPath(extracted),
+                StringComparison.OrdinalIgnoreCase);
+            Assert.False(File.Exists(escaped));
+            Assert.Contains("escaped-", Path.GetFileName(extracted),
+                StringComparison.Ordinal);
+#if NET6_0_OR_GREATER
+            if (!OperatingSystem.IsWindows()) {
+                File.Delete(extracted);
+                File.WriteAllText(escaped, "outside-safe");
+                File.CreateSymbolicLink(extracted, escaped);
+
+                Assert.Throws<IOException>(() =>
+                    VisioAssets.ExtractMasters(packagePath, output));
+                Assert.Equal("outside-safe", File.ReadAllText(escaped));
+            }
+#endif
+        } finally {
+            if (Directory.Exists(root)) Directory.Delete(root, true);
+        }
+    }
+
+    private static void CreateMasterPackage(
+        string path,
+        string id,
+        string name) {
+        using ZipArchive archive = ZipFile.Open(path,
+            ZipArchiveMode.Create);
+        WriteEntry(archive,
+            "visio/masters/masters.xml",
+            $"<Masters xmlns=\"http://schemas.microsoft.com/office/visio/2012/main\" xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\"><Master ID=\"{id}\" NameU=\"{name}\"><Rel r:id=\"rId1\" /></Master></Masters>");
+        WriteEntry(archive,
+            "visio/masters/_rels/masters.xml.rels",
+            "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\"><Relationship Id=\"rId1\" Type=\"urn:officeimo:test\" Target=\"master1.xml\" /></Relationships>");
+        WriteEntry(archive,
+            "visio/masters/master1.xml",
+            "<MasterContents xmlns=\"http://schemas.microsoft.com/office/visio/2012/main\" />");
+    }
+
+    private static void WriteEntry(
+        ZipArchive archive,
+        string name,
+        string content) {
+        ZipArchiveEntry entry = archive.CreateEntry(name);
+        using Stream stream = entry.Open();
+        using var writer = new StreamWriter(stream,
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        writer.Write(content);
+    }
+
+    private sealed class Batch12NonSeekableStream : Stream {
+        private readonly MemoryStream _inner;
+
+        internal Batch12NonSeekableStream(byte[] bytes) {
+            _inner = new MemoryStream(bytes, writable: false);
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count) =>
+            _inner.Read(buffer, offset, count);
+        public override long Seek(long offset, SeekOrigin origin) =>
+            throw new NotSupportedException();
+        public override void SetLength(long value) =>
+            throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) =>
+            throw new NotSupportedException();
+        protected override void Dispose(bool disposing) {
+            if (disposing) _inner.Dispose();
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/OfficeIMO.Visio/VisioAssets.cs
+++ b/OfficeIMO.Visio/VisioAssets.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
 using System.Xml;
 using System.Xml.Linq;
 using OfficeIMO.Drawing;
@@ -23,6 +25,7 @@ namespace OfficeIMO.Visio {
         public const long MaxTotalMasterRelationshipBytes = 64_000_000;
         /// <summary>Maximum number of master relationships copied from one Visio package import.</summary>
         public const int MaxMasterRelationships = 4096;
+        private const int MaxExtractedFileNameComponentLength = 64;
 
         private static readonly XmlReaderSettings PackageXmlReaderSettings = new() {
             DtdProcessing = DtdProcessing.Prohibit,
@@ -193,13 +196,66 @@ namespace OfficeIMO.Visio {
         /// Extracts masters from a VSDX file to a folder as standalone XML files (one per master).
         /// </summary>
         public static void ExtractMasters(string vsdxPath, string outputFolder, IEnumerable<string>? filterNames = null) {
-            Directory.CreateDirectory(outputFolder);
+            string outputRoot = Path.GetFullPath(outputFolder);
+            Directory.CreateDirectory(outputRoot);
+            string outputRootPrefix = outputRoot.TrimEnd(
+                Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                + Path.DirectorySeparatorChar;
             foreach (var m in LoadMasterContents(vsdxPath, filterNames)) {
-                string safeName = string.Concat(m.NameU.Select(ch => char.IsLetterOrDigit(ch) ? ch : '_'));
-                string filePath = Path.Combine(outputFolder, $"{m.Id}-{safeName}.xml");
-                using var fs = File.Create(filePath);
+                string safeId = CreateSafeFileNameComponent(m.Id, "master");
+                string safeName = CreateSafeFileNameComponent(m.NameU, "unnamed");
+                string filePath = Path.GetFullPath(Path.Combine(outputRoot,
+                    $"{safeId}-{safeName}.xml"));
+                if (!filePath.StartsWith(outputRootPrefix,
+                        StringComparison.OrdinalIgnoreCase)) {
+                    throw new InvalidDataException(
+                        "The generated Visio master filename escapes the requested output directory.");
+                }
+                using var fs = new FileStream(filePath, FileMode.CreateNew,
+                    FileAccess.Write, FileShare.None);
                 m.MasterXml.Save(fs, SaveOptions.DisableFormatting);
             }
+        }
+
+        private static string CreateSafeFileNameComponent(
+            string value,
+            string fallback) {
+            StringBuilder builder = new(MaxExtractedFileNameComponentLength);
+            bool modified = string.IsNullOrEmpty(value);
+            foreach (char character in value ?? string.Empty) {
+                char safeCharacter = char.IsLetterOrDigit(character)
+                    || character == '-'
+                    || character == '_'
+                    ? character
+                    : '_';
+                if (safeCharacter != character) modified = true;
+                if (builder.Length < MaxExtractedFileNameComponentLength) {
+                    builder.Append(safeCharacter);
+                } else {
+                    modified = true;
+                }
+            }
+
+            string safeValue = builder.Length == 0
+                ? fallback
+                : builder.ToString();
+            if (!modified) return safeValue;
+
+            string suffix = "-" + ComputeStableFileNameSuffix(value ?? string.Empty);
+            int prefixLength = Math.Min(safeValue.Length,
+                MaxExtractedFileNameComponentLength - suffix.Length);
+            return safeValue.Substring(0, prefixLength) + suffix;
+        }
+
+        private static string ComputeStableFileNameSuffix(string value) {
+            byte[] bytes = Encoding.UTF8.GetBytes(value);
+            byte[] digest;
+            using (SHA256 sha256 = SHA256.Create()) {
+                digest = sha256.ComputeHash(bytes);
+            }
+            return BitConverter.ToString(digest, 0, 6)
+                .Replace("-", string.Empty)
+                .ToLowerInvariant();
         }
 
         private static IEnumerable<MasterRelationshipContent> LoadMasterRelationships(ZipArchive zip, string masterPartPath, ref long totalRelationshipBytes, ref int totalRelationships) {

--- a/OfficeIMO.Visio/VisioDocument.Load.cs
+++ b/OfficeIMO.Visio/VisioDocument.Load.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.IO.Packaging;
+using OfficeIMO.Drawing;
 using OfficeIMO.Drawing.Internal;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,11 +19,17 @@ namespace OfficeIMO.Visio {
         /// <summary>
         /// Loads an existing .vsdx document from a stream.
         /// </summary>
-        public static VisioDocument Load(Stream stream) {
+        public static VisioDocument Load(Stream stream) => Load(stream, options: null);
+
+        /// <summary>Loads an existing .vsdx document from a stream with explicit input limits.</summary>
+        public static VisioDocument Load(Stream stream, VisioLoadOptions? options) {
             if (stream == null) throw new ArgumentNullException(nameof(stream));
             if (!stream.CanRead) throw new ArgumentException("Stream must be readable.", nameof(stream));
 
-            using var buffer = new MemoryStream(OfficeStreamReader.ReadAllBytes(stream), writable: false);
+            VisioLoadOptions resolved = options ?? new VisioLoadOptions();
+            byte[] bytes = OfficeStreamReader.ReadAllBytes(stream, ResolveInputLimit(resolved));
+            ValidatePackageSecurity(bytes, resolved);
+            using var buffer = new MemoryStream(bytes, writable: false);
 
             using Package package = Package.Open(buffer, FileMode.Open, FileAccess.Read);
             VisioDocument document = LoadCore(package, filePath: null);
@@ -33,22 +40,34 @@ namespace OfficeIMO.Visio {
         }
 
         /// <summary>Asynchronously loads an existing .vsdx file.</summary>
-        public static async Task<VisioDocument> LoadAsync(string filePath, CancellationToken cancellationToken = default) {
+        public static Task<VisioDocument> LoadAsync(string filePath, CancellationToken cancellationToken = default) =>
+            LoadAsync(filePath, cancellationToken, options: null);
+
+        /// <summary>Asynchronously loads an existing .vsdx file with explicit input limits.</summary>
+        public static async Task<VisioDocument> LoadAsync(string filePath, CancellationToken cancellationToken, VisioLoadOptions? options) {
             if (filePath == null) throw new ArgumentNullException(nameof(filePath));
             string fullPath = Path.GetFullPath(filePath);
             if (!File.Exists(fullPath)) throw new FileNotFoundException($"File '{fullPath}' doesn't exist.", fullPath);
             using var source = new FileStream(fullPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete, 81920, useAsync: true);
-            byte[] bytes = await OfficeStreamReader.ReadAllBytesAsync(source, cancellationToken).ConfigureAwait(false);
+            VisioLoadOptions resolved = options ?? new VisioLoadOptions();
+            byte[] bytes = await OfficeStreamReader.ReadAllBytesAsync(source, cancellationToken, ResolveInputLimit(resolved)).ConfigureAwait(false);
+            ValidatePackageSecurity(bytes, resolved);
             using var buffer = new MemoryStream(bytes, writable: false);
             using Package package = Package.Open(buffer, FileMode.Open, FileAccess.Read);
             return LoadCore(package, fullPath);
         }
 
         /// <summary>Asynchronously loads an existing .vsdx document from a caller-owned stream.</summary>
-        public static async Task<VisioDocument> LoadAsync(Stream stream, CancellationToken cancellationToken = default) {
+        public static Task<VisioDocument> LoadAsync(Stream stream, CancellationToken cancellationToken = default) =>
+            LoadAsync(stream, cancellationToken, options: null);
+
+        /// <summary>Asynchronously loads an existing .vsdx document from a caller-owned stream with explicit input limits.</summary>
+        public static async Task<VisioDocument> LoadAsync(Stream stream, CancellationToken cancellationToken, VisioLoadOptions? options) {
             if (stream == null) throw new ArgumentNullException(nameof(stream));
             if (!stream.CanRead) throw new ArgumentException("Stream must be readable.", nameof(stream));
-            byte[] bytes = await OfficeStreamReader.ReadAllBytesAsync(stream, cancellationToken).ConfigureAwait(false);
+            VisioLoadOptions resolved = options ?? new VisioLoadOptions();
+            byte[] bytes = await OfficeStreamReader.ReadAllBytesAsync(stream, cancellationToken, ResolveInputLimit(resolved)).ConfigureAwait(false);
+            ValidatePackageSecurity(bytes, resolved);
             using var buffer = new MemoryStream(bytes, writable: false);
             using Package package = Package.Open(buffer, FileMode.Open, FileAccess.Read);
             VisioDocument document = LoadCore(package, filePath: null);
@@ -56,6 +75,25 @@ namespace OfficeIMO.Visio {
                 stream,
                 OfficeIMO.Drawing.DocumentAccessMode.ReadWrite);
             return document;
+        }
+
+        private static long? ResolveInputLimit(VisioLoadOptions options) {
+            long? configured = options.MaxInputBytes;
+            if (configured.HasValue && configured.Value < 1) {
+                throw new ArgumentOutOfRangeException(nameof(options.MaxInputBytes));
+            }
+            if (options.PackageSecurity == null) return configured;
+            long packageLimit = options.PackageSecurity.MaxPackageBytes;
+            if (packageLimit < 1) {
+                throw new ArgumentOutOfRangeException(nameof(OfficePackageSecurityOptions.MaxPackageBytes));
+            }
+            return configured.HasValue ? Math.Min(configured.Value, packageLimit) : packageLimit;
+        }
+
+        private static void ValidatePackageSecurity(byte[] bytes, VisioLoadOptions options) {
+            if (options.PackageSecurity != null) {
+                OfficePackageSecurityInspector.Validate(bytes, options.PackageSecurity);
+            }
         }
     }
 }

--- a/OfficeIMO.Visio/VisioLoadOptions.cs
+++ b/OfficeIMO.Visio/VisioLoadOptions.cs
@@ -1,0 +1,14 @@
+using OfficeIMO.Drawing;
+
+namespace OfficeIMO.Visio {
+    /// <summary>Controls resource limits and package inspection when loading Visio documents into memory.</summary>
+    public sealed class VisioLoadOptions {
+        /// <summary>
+        /// Maximum VSDX bytes buffered by stream and asynchronous load APIs. Default: 512 MiB. Set to null to disable this compatibility guard.
+        /// </summary>
+        public long? MaxInputBytes { get; set; } = 512L * 1024L * 1024L;
+
+        /// <summary>Optional Office package resource limits and active-content policies.</summary>
+        public OfficePackageSecurityOptions? PackageSecurity { get; set; }
+    }
+}

--- a/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.BlockRenderer.cs
+++ b/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.BlockRenderer.cs
@@ -43,10 +43,15 @@ namespace OfficeIMO.Word.Markdown {
                     return;
                 }
 
-                if (block is Omd.MarkdownObject markdownObject) {
-                    Visit(markdownObject);
-                } else {
-                    RenderFallback(block);
+                _converter.EnterBlockRender(_options);
+                try {
+                    if (block is Omd.MarkdownObject markdownObject) {
+                        Visit(markdownObject);
+                    } else {
+                        RenderFallback(block);
+                    }
+                } finally {
+                    _converter.ExitBlockRender();
                 }
             }
 

--- a/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.OmdInlines.cs
+++ b/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.OmdInlines.cs
@@ -78,13 +78,20 @@ namespace OfficeIMO.Word.Markdown {
             Omd.InlineSequence? inlines,
             WordDocument document,
             InlineFormatState fmt,
-            string? defaultFont) {
+            string? defaultFont,
+            int maxNestingDepth,
+            int nestingDepth) {
             var runs = new List<WordParagraph>();
             if (inlines == null) {
                 return runs;
             }
 
-            new DetachedInlineRunBuilder(document, runs, fmt, defaultFont).Visit(inlines);
+            EnsureInlineNestingWithinLimit(maxNestingDepth, nestingDepth);
+
+            new DetachedInlineRunBuilder(
+                document, runs, fmt, defaultFont, maxNestingDepth,
+                nestingDepth + 1)
+                .Visit(inlines);
             return runs;
         }
 
@@ -105,24 +112,39 @@ namespace OfficeIMO.Word.Markdown {
             private readonly List<WordParagraph> _runs;
             private readonly InlineFormatState _fmt;
             private readonly string? _defaultFont;
+            private readonly int _maxNestingDepth;
+            private readonly int _nestingDepth;
 
             public DetachedInlineRunBuilder(
                 WordDocument document,
                 List<WordParagraph> runs,
                 InlineFormatState fmt,
-                string? defaultFont) {
+                string? defaultFont,
+                int maxNestingDepth,
+                int nestingDepth) {
                 _document = document;
                 _runs = runs;
                 _fmt = fmt;
                 _defaultFont = defaultFont;
+                _maxNestingDepth = maxNestingDepth;
+                _nestingDepth = nestingDepth;
             }
 
             private void VisitNested(Omd.MarkdownObject? node, InlineFormatState format) {
                 if (node == null) {
                     return;
                 }
+                EnsureInlineNestingWithinLimit(
+                    _maxNestingDepth, _nestingDepth);
 
-                new DetachedInlineRunBuilder(_document, _runs, format, _defaultFont).Visit(node);
+                new DetachedInlineRunBuilder(
+                    _document,
+                    _runs,
+                    format,
+                    _defaultFont,
+                    _maxNestingDepth,
+                    _nestingDepth + 1)
+                    .Visit(node);
             }
 
             protected override void VisitTextRun(Omd.TextRun inline) =>
@@ -278,7 +300,8 @@ namespace OfficeIMO.Word.Markdown {
                 defaultTextColorHex,
                 pageContentWidthPixels,
                 listLevel,
-                quoteDepth)
+                quoteDepth,
+                nestingDepth: 0)
                 .Visit(inlines);
         }
 
@@ -293,6 +316,7 @@ namespace OfficeIMO.Word.Markdown {
             private readonly double _pageContentWidthPixels;
             private readonly int _listLevel;
             private readonly int _quoteDepth;
+            private readonly int _nestingDepth;
 
             public ParagraphInlineWriter(
                 WordParagraph paragraph,
@@ -304,7 +328,8 @@ namespace OfficeIMO.Word.Markdown {
                 string? defaultTextColorHex,
                 double pageContentWidthPixels,
                 int listLevel,
-                int quoteDepth) {
+                int quoteDepth,
+                int nestingDepth) {
                 _paragraph = paragraph;
                 _options = options;
                 _document = document;
@@ -315,14 +340,29 @@ namespace OfficeIMO.Word.Markdown {
                 _pageContentWidthPixels = pageContentWidthPixels;
                 _listLevel = listLevel;
                 _quoteDepth = quoteDepth;
+                _nestingDepth = nestingDepth;
             }
 
             private void VisitNested(Omd.MarkdownObject? node, InlineFormatState format) {
                 if (node == null) {
                     return;
                 }
+                EnsureInlineNestingWithinLimit(
+                    _options.MaxNestingDepth, _nestingDepth);
 
-                new ParagraphInlineWriter(_paragraph, _options, _document, _footnoteDefs, format, _defaultFont, _defaultTextColorHex, _pageContentWidthPixels, _listLevel, _quoteDepth).Visit(node);
+                new ParagraphInlineWriter(
+                    _paragraph,
+                    _options,
+                    _document,
+                    _footnoteDefs,
+                    format,
+                    _defaultFont,
+                    _defaultTextColorHex,
+                    _pageContentWidthPixels,
+                    _listLevel,
+                    _quoteDepth,
+                    _nestingDepth + 1)
+                    .Visit(node);
             }
 
             protected override void VisitTextRun(Omd.TextRun inline) =>
@@ -344,7 +384,13 @@ namespace OfficeIMO.Word.Markdown {
                 try {
                     var uri = new Uri(inline.Url, UriKind.RelativeOrAbsolute);
                     if (inline.LabelInlines != null && inline.LabelInlines.Nodes.Count > 0) {
-                        var labelRuns = BuildLinkLabelRunsOmd(inline.LabelInlines, _document, _fmt, _defaultFont);
+                        var labelRuns = BuildLinkLabelRunsOmd(
+                            inline.LabelInlines,
+                            _document,
+                            _fmt,
+                            _defaultFont,
+                            _options.MaxNestingDepth,
+                            _nestingDepth);
                         if (labelRuns.Count > 0) {
                             ApplyHyperlinkRunFormattingOmd(labelRuns, _options);
                             WordHyperLink.AddHyperLink(_paragraph, labelRuns, uri);
@@ -494,6 +540,21 @@ namespace OfficeIMO.Word.Markdown {
                 }
 
                 base.VisitInline(inline);
+            }
+        }
+
+        private static void EnsureInlineNestingWithinLimit(
+            int maxNestingDepth,
+            int currentDepth) {
+            if (maxNestingDepth < 1) {
+                throw new ArgumentOutOfRangeException(
+                    nameof(MarkdownToWordOptions.MaxNestingDepth),
+                    maxNestingDepth,
+                    "MaxNestingDepth must be greater than zero.");
+            }
+            if (currentDepth >= maxNestingDepth) {
+                throw new System.IO.InvalidDataException(
+                    $"Markdown-to-Word inline nesting exceeds MaxNestingDepth ({maxNestingDepth}).");
             }
         }
 

--- a/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.SharedRendering.cs
+++ b/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.SharedRendering.cs
@@ -9,6 +9,27 @@ using Omd = OfficeIMO.Markdown;
 
 namespace OfficeIMO.Word.Markdown {
     internal partial class MarkdownToWordConverter {
+        private int _activeBlockRenderDepth;
+
+        private void EnterBlockRender(MarkdownToWordOptions options) {
+            if (options.MaxNestingDepth < 1) {
+                throw new ArgumentOutOfRangeException(
+                    nameof(options.MaxNestingDepth),
+                    options.MaxNestingDepth,
+                    "MaxNestingDepth must be greater than zero.");
+            }
+            if (_activeBlockRenderDepth >= options.MaxNestingDepth) {
+                throw new System.IO.InvalidDataException(
+                    $"Markdown-to-Word block nesting exceeds MaxNestingDepth ({options.MaxNestingDepth}).");
+            }
+
+            _activeBlockRenderDepth++;
+        }
+
+        private void ExitBlockRender() {
+            _activeBlockRenderDepth--;
+        }
+
         private void RenderSharedBlockOmd(
             Omd.IMarkdownBlock block,
             IWordBlockRenderHost host,

--- a/OfficeIMO.Word.Markdown/Options/MarkdownToWordOptions.cs
+++ b/OfficeIMO.Word.Markdown/Options/MarkdownToWordOptions.cs
@@ -39,6 +39,11 @@ namespace OfficeIMO.Word.Markdown {
         public Action<string>? OnWarning { get; set; }
 
         /// <summary>
+        /// Maximum nested block-rendering depth accepted by the Word converter. Default: 64.
+        /// </summary>
+        public int MaxNestingDepth { get; set; } = 64;
+
+        /// <summary>
         /// Optional default page size applied when creating new documents.
         /// </summary>
         public WordPageSize? DefaultPageSize { get; set; }

--- a/OfficeIMO.Word.Markdown/WordMarkdownConverterExtensions.cs
+++ b/OfficeIMO.Word.Markdown/WordMarkdownConverterExtensions.cs
@@ -237,6 +237,7 @@ namespace OfficeIMO.Word.Markdown {
                 FontFamily = source.FontFamily,
                 BaseUri = source.BaseUri,
                 OnWarning = source.OnWarning,
+                MaxNestingDepth = source.MaxNestingDepth,
                 DefaultPageSize = source.DefaultPageSize,
                 DefaultOrientation = source.DefaultOrientation,
                 AllowLocalImages = source.AllowLocalImages,


### PR DESCRIPTION
## Summary

- enforce configurable input, traversal, recursion, and object-count limits across Markdown, Reader, Excel, PDF, PowerPoint, and Visio paths
- prevent formula-copy, symlink traversal, path traversal, and cyclic package-clone abuse at the owning security boundaries
- make failed PowerPoint clone operations roll back partial package changes while preserving the original failure
- add focused regression coverage and include the new Markdown security class in the named CI partition

## Compatibility

Existing public entry points retain their current defaults while gaining finite safety budgets. Callers that intentionally process unusually large documents can raise the corresponding lifecycle or reader option explicitly.