### PR TITLE
Harden document processing limits and remote image loading

### DIFF
--- a/OfficeIMO.Drawing.Tests/Drawing.RemoteImages.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.RemoteImages.cs
@@ -81,7 +81,7 @@ public sealed class DrawingRemoteImageTests {
     }
 
     [Fact]
-    public void CreatePinnedRequestUsesValidatedAddressAndPreservesHostIdentity() {
+    public void LegacyPinnedRequestUsesValidatedAddressAndPreservesHostHeader() {
         using HttpRequestMessage request = OfficeRemoteImageLoader.CreatePinnedRequest(
             new Uri("https://images.example.test:8443/assets/logo.png?size=2"),
             IPAddress.Parse("203.0.113.8"));

--- a/OfficeIMO.Drawing.Tests/Drawing.RemoteImages.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.RemoteImages.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading;
@@ -19,7 +20,9 @@ public sealed class DrawingRemoteImageTests {
             $"HTTP/1.1 200 OK\r\nContent-Type: image/jpg; charset=binary\r\nContent-Length: {payload.Length}\r\nConnection: close\r\n\r\n",
             payload);
 
-        OfficeRemoteImage image = await OfficeRemoteImageLoader.LoadAsync(server.Url("logo.jpg"));
+        OfficeRemoteImage image = await OfficeRemoteImageLoader.LoadAsync(
+            server.Url("logo.jpg"),
+            new OfficeRemoteImageLoadOptions { AllowPrivateNetworkAddresses = true });
 
         Assert.Equal("image/jpeg", image.ContentType);
         Assert.Equal("logo.jpg", image.FileName);
@@ -39,7 +42,9 @@ public sealed class DrawingRemoteImageTests {
             $"HTTP/1.1 302 Found\r\nLocation: {target.Url("private.png")}\r\nConnection: close\r\n\r\n");
 
         await Assert.ThrowsAsync<InvalidDataException>(() =>
-            OfficeRemoteImageLoader.LoadAsync(redirect.Url("redirect.png")));
+            OfficeRemoteImageLoader.LoadAsync(
+                redirect.Url("redirect.png"),
+                new OfficeRemoteImageLoadOptions { AllowPrivateNetworkAddresses = true }));
         await redirect.Completion;
         await Task.Delay(100);
         Assert.Equal(0, target.RequestCount);
@@ -53,7 +58,7 @@ public sealed class DrawingRemoteImageTests {
         using var server = new SingleResponseServer(
             "HTTP/1.1 200 OK\r\nContent-Type: image/png\r\nConnection: close\r\n\r\n",
             payload);
-        var options = new OfficeRemoteImageLoadOptions { MaximumBytes = 16 };
+        var options = new OfficeRemoteImageLoadOptions { MaximumBytes = 16, AllowPrivateNetworkAddresses = true };
 
         await Assert.ThrowsAsync<InvalidDataException>(() =>
             OfficeRemoteImageLoader.LoadAsync(server.Url("large.png"), options));
@@ -67,6 +72,23 @@ public sealed class DrawingRemoteImageTests {
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
             OfficeRemoteImageLoader.LoadAsync("http://127.0.0.1:1/image.png", cancellationToken: cancellation.Token));
+    }
+
+    [Fact]
+    public async Task LoadAsyncRejectsLoopbackBeforeOpeningConnectionByDefault() {
+        await Assert.ThrowsAsync<InvalidDataException>(() =>
+            OfficeRemoteImageLoader.LoadAsync("http://127.0.0.1:6553/private.png"));
+    }
+
+    [Fact]
+    public void CreatePinnedRequestUsesValidatedAddressAndPreservesHostIdentity() {
+        using HttpRequestMessage request = OfficeRemoteImageLoader.CreatePinnedRequest(
+            new Uri("https://images.example.test:8443/assets/logo.png?size=2"),
+            IPAddress.Parse("203.0.113.8"));
+
+        Assert.Equal("203.0.113.8", request.RequestUri!.Host);
+        Assert.Equal("/assets/logo.png?size=2", request.RequestUri.PathAndQuery);
+        Assert.Equal("images.example.test:8443", request.Headers.Host);
     }
 
     private sealed class SingleResponseServer : IDisposable {

--- a/OfficeIMO.Drawing/Data/ObjectFlattener.cs
+++ b/OfficeIMO.Drawing/Data/ObjectFlattener.cs
@@ -4,6 +4,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.IO;
 using System.Reflection;
 using System.Text;
 
@@ -18,6 +19,13 @@ namespace OfficeIMO.Drawing {
         public bool IncludeFullObjects { get; set; }
         /// <summary>Maximum recursion depth when expanding nested objects.</summary>
         public int MaxDepth { get; set; } = int.MaxValue;
+        /// <summary>
+        /// Maximum number of source or expanded rows a tabular consumer may materialize.
+        /// The default matches the maximum Excel data rows available below one header row.
+        /// </summary>
+        public int MaxRows { get; set; } = 1_048_575;
+        /// <summary>Maximum number of items enumerated from one nested collection.</summary>
+        public int MaxCollectionItems { get; set; } = 1_048_575;
         /// <summary>Header casing strategy for generated column names.</summary>
         public HeaderCase HeaderCase { get; set; } = HeaderCase.Raw;
         /// <summary>Optional prefixes to trim from generated headers.</summary>
@@ -146,6 +154,7 @@ namespace OfficeIMO.Drawing {
         /// </summary>
         public Dictionary<string, object?> Flatten<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)] T>(T item, ObjectFlattenerOptions opts) {
             if (opts == null) throw new ArgumentNullException(nameof(opts));
+            ValidateCollectionLimit(opts);
             if (item == null) {
                 return new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
             }
@@ -310,7 +319,11 @@ namespace OfficeIMO.Drawing {
         private static void MapCollectionToColumns(string basePath, IEnumerable enumerable, CollectionColumnMapping map, Dictionary<string, object?> dict, ObjectFlattenerOptions opts) {
             Type? lastType = null;
             CollectionMapAccessors? lastAccessors = null;
+            int itemCount = 0;
             foreach (var item in enumerable) {
+                if (itemCount++ >= opts.MaxCollectionItems) {
+                    throw new InvalidDataException($"The collection at '{basePath}' exceeds the {opts.MaxCollectionItems}-item flattening limit.");
+                }
                 if (item == null) continue;
                 Type itemType = item.GetType();
                 var accessors = itemType == lastType
@@ -440,14 +453,14 @@ namespace OfficeIMO.Drawing {
 
         private static object? HandleCollection(string path, IEnumerable enumerable, ObjectFlattenerOptions opts) {
             if (opts.CollectionMode == CollectionMode.JoinWith) {
-                var joined = JoinCollectionValues(enumerable, opts.CollectionJoinWith);
+                var joined = JoinCollectionValues(path, enumerable, opts.CollectionJoinWith, opts.MaxCollectionItems);
                 return ApplyFormatting(path, joined, opts);
             }
             // ExpandRows handled in SheetBuilder
             return enumerable;
         }
 
-        private static string JoinCollectionValues(IEnumerable enumerable, string separator) {
+        private static string JoinCollectionValues(string path, IEnumerable enumerable, string separator, int maximumItems) {
             var enumerator = enumerable.GetEnumerator();
             try {
                 if (!enumerator.MoveNext()) {
@@ -455,12 +468,16 @@ namespace OfficeIMO.Drawing {
                 }
 
                 string first = enumerator.Current?.ToString() ?? string.Empty;
+                int itemCount = 1;
                 if (!enumerator.MoveNext()) {
                     return first;
                 }
 
                 var joined = new StringBuilder(first);
                 do {
+                    if (itemCount++ >= maximumItems) {
+                        throw new InvalidDataException($"The collection at '{path}' exceeds the {maximumItems}-item flattening limit.");
+                    }
                     joined.Append(separator);
                     joined.Append(enumerator.Current?.ToString() ?? string.Empty);
                 } while (enumerator.MoveNext());
@@ -468,6 +485,12 @@ namespace OfficeIMO.Drawing {
                 return joined.ToString();
             } finally {
                 (enumerator as IDisposable)?.Dispose();
+            }
+        }
+
+        private static void ValidateCollectionLimit(ObjectFlattenerOptions options) {
+            if (options.MaxCollectionItems <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(options.MaxCollectionItems));
             }
         }
 

--- a/OfficeIMO.Drawing/Data/ObjectFlattener.cs
+++ b/OfficeIMO.Drawing/Data/ObjectFlattener.cs
@@ -149,6 +149,38 @@ namespace OfficeIMO.Drawing {
         private static readonly ConcurrentDictionary<CollectionMapAccessorKey, CollectionMapAccessors> _collectionMapAccessorCache = new();
         private static readonly ConcurrentDictionary<Type, FieldInfo[]> _valueTupleFieldCache = new();
 
+        internal static List<T> MaterializeRowsBounded<T>(
+            IEnumerable<T> source,
+            ObjectFlattenerOptions options,
+            string consumerName) {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (options == null) throw new ArgumentNullException(nameof(options));
+            if (options.MaxRows <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(options.MaxRows),
+                    "MaxRows must be greater than zero.");
+            }
+
+            int capacity = source is IReadOnlyCollection<T> readOnly
+                ? readOnly.Count
+                : source is ICollection<T> collection
+                    ? collection.Count
+                    : 0;
+            if (capacity > options.MaxRows) {
+                throw new InvalidDataException(
+                    $"{consumerName} exceeds the {options.MaxRows}-row materialization limit.");
+            }
+
+            var rows = capacity > 0 ? new List<T>(capacity) : new List<T>();
+            foreach (T item in source) {
+                if (rows.Count >= options.MaxRows) {
+                    throw new InvalidDataException(
+                        $"{consumerName} exceeds the {options.MaxRows}-row materialization limit.");
+                }
+                rows.Add(item);
+            }
+            return rows;
+        }
+
         /// <summary>
         /// Flattens <paramref name="item"/> into a dictionary according to <paramref name="opts"/>.
         /// </summary>

--- a/OfficeIMO.Drawing/Data/ObjectFlattener.cs
+++ b/OfficeIMO.Drawing/Data/ObjectFlattener.cs
@@ -169,8 +169,14 @@ namespace OfficeIMO.Drawing {
                 throw new InvalidDataException(
                     $"{consumerName} exceeds the {options.MaxRows}-row materialization limit.");
             }
-
             var rows = capacity > 0 ? new List<T>(capacity) : new List<T>();
+            if (source is IReadOnlyList<T> readOnlyList) {
+                for (int index = 0; index < readOnlyList.Count; index++) {
+                    rows.Add(readOnlyList[index]);
+                }
+                return rows;
+            }
+
             foreach (T item in source) {
                 if (rows.Count >= options.MaxRows) {
                     throw new InvalidDataException(

--- a/OfficeIMO.Drawing/OfficeIMO.Drawing.csproj
+++ b/OfficeIMO.Drawing/OfficeIMO.Drawing.csproj
@@ -30,6 +30,8 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="OfficeIMO.Html" />
+    <InternalsVisibleTo Include="OfficeIMO.Excel" />
+    <InternalsVisibleTo Include="OfficeIMO.PowerPoint" />
     <Compile Include="..\OfficeIMO.SharedSource\Compound\*.cs" Link="Internal\Compound\%(Filename)%(Extension)" />
     <None Include="..\Assets\OfficeIMO.png">
       <Pack>True</Pack>

--- a/OfficeIMO.Drawing/OfficeRemoteImageLoadOptions.cs
+++ b/OfficeIMO.Drawing/OfficeRemoteImageLoadOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace OfficeIMO.Drawing;
 
@@ -18,6 +19,19 @@ public sealed class OfficeRemoteImageLoadOptions {
     /// <summary>Maximum number of same-origin redirects that may be followed.</summary>
     public int MaximumRedirects { get; set; } = 5;
 
+    /// <summary>
+    /// Allows loopback, private, link-local, multicast, and otherwise non-public destination
+    /// addresses. The secure default is <c>false</c>; enable this only for explicitly trusted
+    /// intranet image sources.
+    /// </summary>
+    public bool AllowPrivateNetworkAddresses { get; set; }
+
+    /// <summary>
+    /// Optional exact host allowlist. When non-empty, every initial and redirected destination
+    /// must match one of these host names (case-insensitive).
+    /// </summary>
+    public ISet<string> AllowedHosts { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
     internal Snapshot CreateSnapshot() {
         if (MaximumBytes <= 0) {
             throw new ArgumentOutOfRangeException(nameof(MaximumBytes), "MaximumBytes must be greater than zero.");
@@ -31,18 +45,30 @@ public sealed class OfficeRemoteImageLoadOptions {
             throw new ArgumentOutOfRangeException(nameof(MaximumRedirects), "MaximumRedirects cannot be negative.");
         }
 
-        return new Snapshot(MaximumBytes, Timeout, MaximumRedirects);
+        var allowedHosts = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (string host in AllowedHosts) {
+            if (string.IsNullOrWhiteSpace(host)) {
+                throw new ArgumentException("AllowedHosts cannot contain an empty host name.", nameof(AllowedHosts));
+            }
+            allowedHosts.Add(host.Trim().TrimEnd('.'));
+        }
+
+        return new Snapshot(MaximumBytes, Timeout, MaximumRedirects, AllowPrivateNetworkAddresses, allowedHosts);
     }
 
     internal sealed class Snapshot {
-        internal Snapshot(long maximumBytes, TimeSpan timeout, int maximumRedirects) {
+        internal Snapshot(long maximumBytes, TimeSpan timeout, int maximumRedirects, bool allowPrivateNetworkAddresses, HashSet<string> allowedHosts) {
             MaximumBytes = maximumBytes;
             Timeout = timeout;
             MaximumRedirects = maximumRedirects;
+            AllowPrivateNetworkAddresses = allowPrivateNetworkAddresses;
+            AllowedHosts = allowedHosts;
         }
 
         internal long MaximumBytes { get; }
         internal TimeSpan Timeout { get; }
         internal int MaximumRedirects { get; }
+        internal bool AllowPrivateNetworkAddresses { get; }
+        internal HashSet<string> AllowedHosts { get; }
     }
 }

--- a/OfficeIMO.Drawing/OfficeRemoteImageLoader.cs
+++ b/OfficeIMO.Drawing/OfficeRemoteImageLoader.cs
@@ -14,6 +14,14 @@ namespace OfficeIMO.Drawing;
 /// </summary>
 public static class OfficeRemoteImageLoader {
     private const int BufferSize = 81920;
+#if NET8_0_OR_GREATER
+    private static readonly HttpClient PublicClient = CreatePinnedClient(
+        allowPrivateNetworkAddresses: false);
+    private static readonly HttpClient PrivateClient = CreatePinnedClient(
+        allowPrivateNetworkAddresses: true);
+#else
+    private static readonly HttpClient LegacyClient = CreateClient();
+#endif
 
     /// <summary>
     /// Asynchronously retrieves an image from an HTTP or HTTPS URL.
@@ -52,9 +60,22 @@ public static class OfficeRemoteImageLoader {
 
         Uri current = uri;
         for (int redirectCount = 0; ; redirectCount++) {
-            IPAddress[] addresses = await ResolveDestinationAsync(current, snapshot, timeout.Token).ConfigureAwait(false);
-            using HttpClient client = CreateClient();
-            using HttpRequestMessage request = CreatePinnedRequest(current, addresses[0]);
+            timeout.Token.ThrowIfCancellationRequested();
+            ValidateDestinationPolicy(current, snapshot);
+#if NET8_0_OR_GREATER
+            HttpClient client = snapshot.AllowPrivateNetworkAddresses
+                ? PrivateClient
+                : PublicClient;
+            using var request = new HttpRequestMessage(HttpMethod.Get,
+                current);
+#else
+            IPAddress[] addresses = await ResolveDestinationAsync(current,
+                snapshot.AllowPrivateNetworkAddresses, timeout.Token)
+                .ConfigureAwait(false);
+            HttpClient client = LegacyClient;
+            using HttpRequestMessage request = CreatePinnedRequest(current,
+                addresses[0]);
+#endif
             using HttpResponseMessage response = await client.SendAsync(
                 request,
                 HttpCompletionOption.ResponseHeadersRead,
@@ -97,6 +118,48 @@ public static class OfficeRemoteImageLoader {
             Timeout = System.Threading.Timeout.InfiniteTimeSpan
         };
     }
+
+#if NET8_0_OR_GREATER
+    private static HttpClient CreatePinnedClient(
+        bool allowPrivateNetworkAddresses) {
+        var handler = new SocketsHttpHandler {
+            AllowAutoRedirect = false,
+            AutomaticDecompression = DecompressionMethods.GZip
+                | DecompressionMethods.Deflate,
+            PooledConnectionIdleTimeout = TimeSpan.FromMinutes(2),
+            PooledConnectionLifetime = TimeSpan.FromMinutes(5),
+            UseProxy = false
+        };
+        handler.ConnectCallback = async (context, cancellationToken) => {
+            IPAddress[] addresses = await ResolveDestinationAsync(
+                context.DnsEndPoint.Host, allowPrivateNetworkAddresses,
+                cancellationToken).ConfigureAwait(false);
+            Exception? lastFailure = null;
+            foreach (IPAddress address in addresses) {
+                var socket = new Socket(address.AddressFamily,
+                    SocketType.Stream, ProtocolType.Tcp);
+                try {
+                    await socket.ConnectAsync(address,
+                        context.DnsEndPoint.Port, cancellationToken)
+                        .ConfigureAwait(false);
+                    return new NetworkStream(socket, ownsSocket: true);
+                } catch (Exception exception) when (exception
+                           is SocketException
+                           || exception is IOException) {
+                    lastFailure = exception;
+                    socket.Dispose();
+                }
+            }
+
+            throw new HttpRequestException(
+                "No validated remote image address accepted the connection.",
+                lastFailure);
+        };
+        return new HttpClient(handler, disposeHandler: true) {
+            Timeout = System.Threading.Timeout.InfiniteTimeSpan
+        };
+    }
+#endif
 
     private static async Task<byte[]> ReadBoundedAsync(Stream input, long maximumBytes, CancellationToken cancellationToken) {
         using var output = new MemoryStream();
@@ -149,11 +212,9 @@ public static class OfficeRemoteImageLoader {
         }
     }
 
-    private static async Task<IPAddress[]> ResolveDestinationAsync(
+    private static void ValidateDestinationPolicy(
         Uri uri,
-        OfficeRemoteImageLoadOptions.Snapshot options,
-        CancellationToken cancellationToken) {
-        cancellationToken.ThrowIfCancellationRequested();
+        OfficeRemoteImageLoadOptions.Snapshot options) {
         string host = uri.IdnHost.TrimEnd('.');
         if (options.AllowedHosts.Count > 0 && !options.AllowedHosts.Contains(host)) {
             throw new InvalidDataException("The remote image host is outside the configured allowlist.");
@@ -164,6 +225,20 @@ public static class OfficeRemoteImageLoader {
             || host.EndsWith(".localhost", StringComparison.OrdinalIgnoreCase))) {
             throw new InvalidDataException("Remote images cannot target localhost or non-public network addresses.");
         }
+    }
+
+    private static Task<IPAddress[]> ResolveDestinationAsync(
+        Uri uri,
+        bool allowPrivateNetworkAddresses,
+        CancellationToken cancellationToken) => ResolveDestinationAsync(
+            uri.IdnHost.TrimEnd('.'), allowPrivateNetworkAddresses,
+            cancellationToken);
+
+    private static async Task<IPAddress[]> ResolveDestinationAsync(
+        string host,
+        bool allowPrivateNetworkAddresses,
+        CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
 
         IPAddress[] addresses;
         if (IPAddress.TryParse(host, out IPAddress? literal)) {
@@ -180,7 +255,8 @@ public static class OfficeRemoteImageLoader {
         }
 
         if (addresses.Length == 0
-            || (!options.AllowPrivateNetworkAddresses && addresses.Any(IsNonPublicAddress))) {
+            || (!allowPrivateNetworkAddresses
+                && addresses.Any(IsNonPublicAddress))) {
             throw new InvalidDataException("Remote images cannot target localhost or non-public network addresses.");
         }
 

--- a/OfficeIMO.Drawing/OfficeRemoteImageLoader.cs
+++ b/OfficeIMO.Drawing/OfficeRemoteImageLoader.cs
@@ -1,7 +1,9 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -12,7 +14,6 @@ namespace OfficeIMO.Drawing;
 /// </summary>
 public static class OfficeRemoteImageLoader {
     private const int BufferSize = 81920;
-    private static readonly HttpClient Client = CreateClient();
 
     /// <summary>
     /// Asynchronously retrieves an image from an HTTP or HTTPS URL.
@@ -51,8 +52,11 @@ public static class OfficeRemoteImageLoader {
 
         Uri current = uri;
         for (int redirectCount = 0; ; redirectCount++) {
-            using HttpResponseMessage response = await Client.GetAsync(
-                current,
+            IPAddress[] addresses = await ResolveDestinationAsync(current, snapshot, timeout.Token).ConfigureAwait(false);
+            using HttpClient client = CreateClient();
+            using HttpRequestMessage request = CreatePinnedRequest(current, addresses[0]);
+            using HttpResponseMessage response = await client.SendAsync(
+                request,
                 HttpCompletionOption.ResponseHeadersRead,
                 timeout.Token).ConfigureAwait(false);
 
@@ -140,6 +144,98 @@ public static class OfficeRemoteImageLoader {
             || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)) {
             throw new ArgumentException("Image URI must use HTTP or HTTPS.", parameterName);
         }
+        if (!string.IsNullOrEmpty(uri.UserInfo)) {
+            throw new ArgumentException("Image URI cannot contain embedded credentials.", parameterName);
+        }
+    }
+
+    private static async Task<IPAddress[]> ResolveDestinationAsync(
+        Uri uri,
+        OfficeRemoteImageLoadOptions.Snapshot options,
+        CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
+        string host = uri.IdnHost.TrimEnd('.');
+        if (options.AllowedHosts.Count > 0 && !options.AllowedHosts.Contains(host)) {
+            throw new InvalidDataException("The remote image host is outside the configured allowlist.");
+        }
+        if (!options.AllowPrivateNetworkAddresses
+            && (uri.IsLoopback
+            || string.Equals(host, "localhost", StringComparison.OrdinalIgnoreCase)
+            || host.EndsWith(".localhost", StringComparison.OrdinalIgnoreCase))) {
+            throw new InvalidDataException("Remote images cannot target localhost or non-public network addresses.");
+        }
+
+        IPAddress[] addresses;
+        if (IPAddress.TryParse(host, out IPAddress? literal)) {
+            addresses = new[] { literal };
+        } else {
+            Task<IPAddress[]> resolution = Dns.GetHostAddressesAsync(host);
+            Task completed = await Task.WhenAny(
+                resolution,
+                Task.Delay(System.Threading.Timeout.Infinite, cancellationToken)).ConfigureAwait(false);
+            if (completed != resolution) {
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+            addresses = await resolution.ConfigureAwait(false);
+        }
+
+        if (addresses.Length == 0
+            || (!options.AllowPrivateNetworkAddresses && addresses.Any(IsNonPublicAddress))) {
+            throw new InvalidDataException("Remote images cannot target localhost or non-public network addresses.");
+        }
+
+        return addresses;
+    }
+
+    internal static HttpRequestMessage CreatePinnedRequest(Uri originalUri, IPAddress address) {
+        if (originalUri == null) throw new ArgumentNullException(nameof(originalUri));
+        if (address == null) throw new ArgumentNullException(nameof(address));
+
+        var pinned = new UriBuilder(originalUri) { Host = address.ToString() }.Uri;
+        var request = new HttpRequestMessage(HttpMethod.Get, pinned);
+        string host = originalUri.IdnHost;
+        if (host.IndexOf(':') >= 0 && host[0] != '[') {
+            host = "[" + host + "]";
+        }
+        request.Headers.Host = originalUri.IsDefaultPort ? host : host + ":" + originalUri.Port;
+        return request;
+    }
+
+    private static bool IsNonPublicAddress(IPAddress address) {
+        if (address.IsIPv4MappedToIPv6) address = address.MapToIPv4();
+        if (IPAddress.IsLoopback(address)
+            || address.Equals(IPAddress.Any)
+            || address.Equals(IPAddress.IPv6Any)
+            || address.Equals(IPAddress.None)
+            || address.Equals(IPAddress.IPv6None)) {
+            return true;
+        }
+
+        byte[] bytes = address.GetAddressBytes();
+        if (address.AddressFamily == AddressFamily.InterNetwork) {
+            byte first = bytes[0];
+            byte second = bytes[1];
+            byte third = bytes[2];
+            if (first == 0 || first == 10 || first == 127 || first >= 224) return true;
+            if (first == 100 && second >= 64 && second <= 127) return true;
+            if (first == 169 && second == 254) return true;
+            if (first == 172 && second >= 16 && second <= 31) return true;
+            if (first == 192 && second == 168) return true;
+            if (first == 192 && second == 0 && third == 0) return true;
+            if (first == 192 && second == 0 && third == 2) return true;
+            if (first == 198 && (second == 18 || second == 19 || (second == 51 && third == 100))) return true;
+            if (first == 203 && second == 0 && third == 113) return true;
+            return false;
+        }
+
+        if (address.AddressFamily == AddressFamily.InterNetworkV6) {
+            return address.IsIPv6LinkLocal
+                || address.IsIPv6SiteLocal
+                || address.IsIPv6Multicast
+                || (bytes[0] & 0xFE) == 0xFC
+                || (bytes[0] == 0x20 && bytes[1] == 0x01 && bytes[2] == 0x0D && bytes[3] == 0xB8);
+        }
+        return true;
     }
 
     private static bool IsSameOrigin(Uri left, Uri right) =>

--- a/OfficeIMO.Drawing/OfficeRemoteImageLoader.cs
+++ b/OfficeIMO.Drawing/OfficeRemoteImageLoader.cs
@@ -148,6 +148,9 @@ public static class OfficeRemoteImageLoader {
                            || exception is IOException) {
                     lastFailure = exception;
                     socket.Dispose();
+                } catch {
+                    socket.Dispose();
+                    throw;
                 }
             }
 

--- a/OfficeIMO.Excel.Tests/Excel.HeadersFootersAndProperties.cs
+++ b/OfficeIMO.Excel.Tests/Excel.HeadersFootersAndProperties.cs
@@ -199,7 +199,10 @@ namespace OfficeIMO.Tests {
                 using (var doc = ExcelDocument.Create(filePath))
                 {
                     var sheet = doc.AddWorksheet("Sheet1");
-                    await sheet.SetHeaderImageFromUrlAsync(HeaderFooterPosition.Center, url);
+                    await sheet.SetHeaderImageFromUrlAsync(
+                        HeaderFooterPosition.Center,
+                        url,
+                        new OfficeRemoteImageLoadOptions { AllowPrivateNetworkAddresses = true });
                     doc.Save();
                 }
             } finally {
@@ -236,7 +239,10 @@ namespace OfficeIMO.Tests {
                 using (var doc = ExcelDocument.Create(filePath))
                 {
                     var sheet = doc.AddWorksheet("Sheet1");
-                    await sheet.SetFooterImageFromUrlAsync(HeaderFooterPosition.Center, url);
+                    await sheet.SetFooterImageFromUrlAsync(
+                        HeaderFooterPosition.Center,
+                        url,
+                        new OfficeRemoteImageLoadOptions { AllowPrivateNetworkAddresses = true });
                     doc.Save();
                 }
             } finally {

--- a/OfficeIMO.Excel.Tests/Excel.Security.AllSeverityBatch13.cs
+++ b/OfficeIMO.Excel.Tests/Excel.Security.AllSeverityBatch13.cs
@@ -96,6 +96,18 @@ public sealed class ExcelAllSeverityBatch13SecurityTests {
     }
 
     [Fact]
+    public void TableFromStopsUnboundedSourceEnumerationAtConfiguredLimit() {
+        using var stream = new MemoryStream();
+        using ExcelDocument document = ExcelDocument.Create(stream);
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(
+            () => document.Compose("Data", sheet => sheet.TableFrom(
+                InfiniteRows(), configure: options => options.MaxRows = 3)));
+
+        Assert.Contains("3-row", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void RowsFromStopsNestedExpansionAtConfiguredLimit() {
         using var stream = new MemoryStream();
         using ExcelDocument document = ExcelDocument.Create(stream);

--- a/OfficeIMO.Excel.Tests/Excel.Security.AllSeverityBatch13.cs
+++ b/OfficeIMO.Excel.Tests/Excel.Security.AllSeverityBatch13.cs
@@ -124,6 +124,23 @@ public sealed class ExcelAllSeverityBatch13SecurityTests {
     }
 
     [Fact]
+    public void RowsFromHonorsPerCollectionLimitDuringNestedExpansion() {
+        using var stream = new MemoryStream();
+        using ExcelDocument document = ExcelDocument.Create(stream);
+        var rows = new[] { new NestedEnumerableRow { Values = InfiniteValues() } };
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+            document.AsFluent().Sheet("Data", sheet =>
+                sheet.RowsFrom(rows, options => {
+                    options.MaxRows = 100;
+                    options.MaxCollectionItems = 2;
+                    options.CollectionMode = CollectionMode.ExpandRows;
+                })));
+
+        Assert.Contains("2-item", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ObjectFlattenerStopsUnboundedNestedCollectionEnumeration() {
         var flattener = new ObjectFlattener();
         var options = new ObjectFlattenerOptions { MaxCollectionItems = 2 };

--- a/OfficeIMO.Excel.Tests/Excel.Security.AllSeverityBatch13.cs
+++ b/OfficeIMO.Excel.Tests/Excel.Security.AllSeverityBatch13.cs
@@ -1,0 +1,147 @@
+using OfficeIMO.Excel;
+using OfficeIMO.Excel.Fluent;
+using OfficeIMO.Drawing;
+using System.Data;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class ExcelAllSeverityBatch13SecurityTests {
+    [Fact]
+    public async Task RemoteImageInsertionRejectsLoopbackDestinationByDefault() {
+        using var stream = new MemoryStream();
+        using ExcelDocument document = ExcelDocument.Create(stream);
+        ExcelSheet sheet = document.AddWorksheet("Data");
+
+        await Assert.ThrowsAsync<InvalidDataException>(() =>
+            sheet.AddImageFromUrlAtAsync(1, 1, "http://127.0.0.1:6553/private.png"));
+    }
+
+    [Fact]
+    public void SaveRejectsPackageMaterializationBeyondConfiguredLimit() {
+        using var source = new MemoryStream();
+        using ExcelDocument document = ExcelDocument.Create(source);
+        document.AddWorksheet("Data").CellValue(1, 1, new string('x', 1024));
+        using var destination = new MemoryStream();
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+            document.Save(destination, new ExcelSaveOptions {
+                DisableFastPackageWriter = true,
+                MaxInMemoryPackageBytes = 64
+            }));
+
+        Assert.Contains("in-memory save limit", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UnchangedSaveFastPathHonorsConfiguredMaterializationLimit() {
+        byte[] package;
+        using (var source = new MemoryStream())
+        using (ExcelDocument created = ExcelDocument.Create(source)) {
+            created.AddWorksheet("Data").CellValue(1, 1, "value");
+            package = created.ToBytes();
+        }
+
+        using ExcelDocument document = ExcelDocument.Load(new MemoryStream(package, writable: false));
+        using var destination = new MemoryStream();
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+            document.Save(destination, new ExcelSaveOptions { MaxInMemoryPackageBytes = 64 }));
+
+        Assert.Contains("in-memory save limit", exception.Message, StringComparison.Ordinal);
+        Assert.Equal(0, destination.Length);
+    }
+
+    [Fact]
+    public void SimpleFastSaveChecksLimitBeforeGrowingToBytesMemoryStream() {
+        using var backing = new MemoryStream();
+        using ExcelDocument document = ExcelDocument.Create(backing);
+        document.AddWorksheet("Data").CellValue(1, 1, new string('x', 1024));
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+            document.ToBytes(options: new ExcelSaveOptions { MaxInMemoryPackageBytes = 64 }));
+
+        Assert.Contains("in-memory save limit", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DirectDataSetFastSaveChecksLimitBeforeGrowingToBytesMemoryStream() {
+        var table = new DataTable("Data");
+        table.Columns.Add("Value", typeof(string));
+        table.Rows.Add(new string('x', 1024));
+        var dataSet = new DataSet("Export");
+        dataSet.Tables.Add(table);
+
+        using var backing = new MemoryStream();
+        using ExcelDocument document = ExcelDocument.Create(backing);
+        document.InsertDataSet(dataSet, autoFit: false);
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+            document.ToBytes(options: new ExcelSaveOptions { MaxInMemoryPackageBytes = 64 }));
+
+        Assert.Contains("in-memory save limit", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RowsFromStopsUnboundedSourceEnumerationAtConfiguredLimit() {
+        using var stream = new MemoryStream();
+        using ExcelDocument document = ExcelDocument.Create(stream);
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+            document.AsFluent().Sheet("Data", sheet =>
+                sheet.RowsFrom(InfiniteRows(), options => options.MaxRows = 3)));
+
+        Assert.Contains("3-row", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RowsFromStopsNestedExpansionAtConfiguredLimit() {
+        using var stream = new MemoryStream();
+        using ExcelDocument document = ExcelDocument.Create(stream);
+        var rows = new[] { new NestedRow { Name = "item", Values = new[] { 1, 2, 3 } } };
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+            document.AsFluent().Sheet("Data", sheet =>
+                sheet.RowsFrom(rows, options => {
+                    options.MaxRows = 2;
+                    options.CollectionMode = CollectionMode.ExpandRows;
+                })));
+
+        Assert.Contains("nested expansion", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ObjectFlattenerStopsUnboundedNestedCollectionEnumeration() {
+        var flattener = new ObjectFlattener();
+        var options = new ObjectFlattenerOptions { MaxCollectionItems = 2 };
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+            flattener.Flatten(new NestedEnumerableRow { Values = InfiniteValues() }, options));
+
+        Assert.Contains("2-item", exception.Message, StringComparison.Ordinal);
+    }
+
+    private static IEnumerable<SimpleRow> InfiniteRows() {
+        int index = 0;
+        while (true) yield return new SimpleRow { Value = index++ };
+    }
+
+    private static IEnumerable<int> InfiniteValues() {
+        int index = 0;
+        while (true) yield return index++;
+    }
+
+    private sealed class SimpleRow {
+        public int Value { get; set; }
+    }
+
+    private sealed class NestedRow {
+        public string Name { get; set; } = string.Empty;
+        public int[] Values { get; set; } = Array.Empty<int>();
+    }
+
+    private sealed class NestedEnumerableRow {
+        public IEnumerable<int> Values { get; set; } = Array.Empty<int>();
+    }
+}

--- a/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Package.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Package.cs
@@ -130,10 +130,14 @@ namespace OfficeIMO.Excel {
                 ct.ThrowIfCancellationRequested();
             }
 
-            PrepareDestinationStreamForWrite(destination);
-            DirectDataSetWorkbookWriter.Write(destination, packageModel, ct);
-            try { destination.Flush(); } catch (NotSupportedException) { }
-            if (destination.CanSeek) {
+            using FileStream? stagedPackage = CreateBoundedPackageStagingStream(destination, options);
+            Stream writeTarget = stagedPackage ?? destination;
+            PrepareDestinationStreamForWrite(writeTarget);
+            DirectDataSetWorkbookWriter.Write(writeTarget, packageModel, ct);
+            try { writeTarget.Flush(); } catch (NotSupportedException) { }
+            if (stagedPackage != null) {
+                CommitStagedPackageToStream(stagedPackage, destination, options);
+            } else if (destination.CanSeek) {
                 destination.Seek(0, SeekOrigin.Begin);
             }
 
@@ -668,6 +672,7 @@ namespace OfficeIMO.Excel {
                     }
                 }
 
+                ThrowIfPackageMaterializationExceedsLimit(new FileInfo(temporaryPath).Length, options);
                 packageBytes = File.ReadAllBytes(temporaryPath);
 
                 try { _spreadSheetDocument.Dispose(); } catch { }
@@ -680,6 +685,8 @@ namespace OfficeIMO.Excel {
                 LastSaveDiagnostics = ExcelSaveDiagnostics.DirectDataSetPackage();
                 return true;
             } catch (OperationCanceledException) {
+                throw;
+            } catch (InvalidDataException ex) when (IsPackageMaterializationLimitException(ex)) {
                 throw;
             } catch (Exception ex) {
                 skipReason = "Direct DataSet package writer failed: " + ex.Message;

--- a/OfficeIMO.Excel/ExcelDocument.FastPackage.cs
+++ b/OfficeIMO.Excel/ExcelDocument.FastPackage.cs
@@ -60,11 +60,17 @@ namespace OfficeIMO.Excel {
             }
 
             ct.ThrowIfCancellationRequested();
-            PrepareDestinationStreamForWrite(destination);
-            FastWorkbookPackageWriter.Write(destination, model, ct);
+            using FileStream? stagedPackage = CreateBoundedPackageStagingStream(destination, options);
+            Stream writeTarget = stagedPackage ?? destination;
+            PrepareDestinationStreamForWrite(writeTarget);
+            FastWorkbookPackageWriter.Write(writeTarget, model, ct);
 
-            destination.Flush();
-            destination.Seek(0, SeekOrigin.Begin);
+            writeTarget.Flush();
+            if (stagedPackage != null) {
+                CommitStagedPackageToStream(stagedPackage, destination, options);
+            } else {
+                destination.Seek(0, SeekOrigin.Begin);
+            }
             if (updateDocumentState) {
                 _packageDirty = false;
                 _packagePropertiesDirty = false;
@@ -152,9 +158,10 @@ namespace OfficeIMO.Excel {
 
             ct.ThrowIfCancellationRequested();
             bool destinationBacksOpenPackage = ReferenceEquals(destination, _packageStream);
-            using MemoryStream? stagedPackage = !destination.CanSeek || destinationBacksOpenPackage
-                ? new MemoryStream()
-                : null;
+            using FileStream? stagedPackage = CreateBoundedPackageStagingStream(
+                destination,
+                options,
+                forceStaging: !destination.CanSeek || destinationBacksOpenPackage);
             Stream writeTarget = stagedPackage ?? destination;
 
             PrepareDestinationStreamForWrite(writeTarget);
@@ -164,15 +171,12 @@ namespace OfficeIMO.Excel {
 
             writeTarget.Flush();
             if (destinationBacksOpenPackage) {
-                ReloadFromBytes(stagedPackage!.ToArray(), simplePackageContentKnown: true, reusablePackageStream: destination);
+                stagedPackage!.Position = 0;
+                byte[] packageBytes = ReadPackageBytes(stagedPackage, options);
+                ReloadFromBytes(packageBytes, simplePackageContentKnown: true, reusablePackageStream: destination);
                 destination.Seek(0, SeekOrigin.Begin);
             } else if (stagedPackage != null) {
-                stagedPackage.Position = 0;
-                stagedPackage.CopyTo(destination);
-                destination.Flush();
-                if (destination.CanSeek) {
-                    destination.Seek(0, SeekOrigin.Begin);
-                }
+                CommitStagedPackageToStream(stagedPackage, destination, options);
             } else {
                 destination.Seek(0, SeekOrigin.Begin);
             }

--- a/OfficeIMO.Excel/ExcelDocument.Save.Package.cs
+++ b/OfficeIMO.Excel/ExcelDocument.Save.Package.cs
@@ -116,11 +116,16 @@ namespace OfficeIMO.Excel {
 
             PackagePropertiesSnapshot propertiesSnapshot = PackagePropertiesSnapshot.Capture(_spreadSheetDocument);
 
-            using var snapshot = new MemoryStream();
+            using FileStream snapshot = OfficeTemporaryFile.Create(
+                "OfficeIMO.Excel-Save-",
+                ".tmp",
+                FileOptions.SequentialScan,
+                out _);
             using (_spreadSheetDocument.Clone(snapshot)) { }
+            snapshot.Flush();
+            ThrowIfPackageMaterializationExceedsLimit(snapshot.Length, options);
             snapshot.Position = 0;
-
-            var packageBytes = snapshot.ToArray();
+            byte[] packageBytes = ReadPackageBytes(snapshot, options);
 
             if (closeDocument) {
                 try { _spreadSheetDocument.Dispose(); } catch { }
@@ -138,11 +143,41 @@ namespace OfficeIMO.Excel {
             destination.SetLength(0);
         }
 
+        private static FileStream? CreateBoundedPackageStagingStream(
+            Stream destination,
+            ExcelSaveOptions? options,
+            bool forceStaging = false) {
+            long? maximumBytes = GetPackageMaterializationLimit(options);
+            if (!forceStaging && (!(destination is MemoryStream) || !maximumBytes.HasValue)) {
+                return null;
+            }
+
+            return OfficeTemporaryFile.Create(
+                "OfficeIMO.Excel-FastSave-",
+                ".tmp",
+                FileOptions.SequentialScan,
+                out _);
+        }
+
+        private static void CommitStagedPackageToStream(
+            FileStream stagedPackage,
+            Stream destination,
+            ExcelSaveOptions? options) {
+            stagedPackage.Flush();
+            ThrowIfPackageMaterializationExceedsLimit(stagedPackage.Length, options);
+            stagedPackage.Position = 0;
+            PrepareDestinationStreamForWrite(destination);
+            stagedPackage.CopyTo(destination);
+            try { destination.Flush(); } catch (NotSupportedException) { }
+            if (destination.CanSeek) destination.Seek(0, SeekOrigin.Begin);
+        }
+
         private bool TryWriteUnchangedPackageToStream(Stream destination, ExcelSaveOptions? options) {
             if (!CanUseUnchangedPackageFastPath(options) || _unchangedPackageBytes == null) {
                 return false;
             }
 
+            ThrowIfPackageMaterializationExceedsLimit(_unchangedPackageBytes.LongLength, options);
             PrepareDestinationStreamForWrite(destination);
             destination.Write(_unchangedPackageBytes, 0, _unchangedPackageBytes.Length);
             try { destination.Flush(); } catch (NotSupportedException) { }
@@ -154,6 +189,7 @@ namespace OfficeIMO.Excel {
                 return false;
             }
 
+            ThrowIfPackageMaterializationExceedsLimit(_unchangedPackageBytes.LongLength, options);
             PrepareDestinationStreamForWrite(destination);
             await destination.WriteAsync(_unchangedPackageBytes, 0, _unchangedPackageBytes.Length, cancellationToken).ConfigureAwait(false);
             try { await destination.FlushAsync(cancellationToken).ConfigureAwait(false); } catch (NotSupportedException) { }
@@ -208,6 +244,7 @@ namespace OfficeIMO.Excel {
                 }
 
                 ct.ThrowIfCancellationRequested();
+                ThrowIfPackageMaterializationExceedsLimit(new FileInfo(temporaryPath).Length, options);
                 packageBytes = File.ReadAllBytes(temporaryPath);
 
                 try { _spreadSheetDocument.Dispose(); } catch { }
@@ -219,6 +256,8 @@ namespace OfficeIMO.Excel {
                 LastSaveDiagnostics = ExcelSaveDiagnostics.SimplePackage();
                 return true;
             } catch (OperationCanceledException) {
+                throw;
+            } catch (InvalidDataException ex) when (IsPackageMaterializationLimitException(ex)) {
                 throw;
             } catch (Exception ex) {
                 skipReason = "Simple package writer failed: " + ex.Message;
@@ -245,6 +284,7 @@ namespace OfficeIMO.Excel {
                 }
 
                 ct.ThrowIfCancellationRequested();
+                ThrowIfPackageMaterializationExceedsLimit(new FileInfo(temporaryPath).Length, options);
                 packageBytes = File.ReadAllBytes(temporaryPath);
 
                 try { _spreadSheetDocument.Dispose(); } catch { }
@@ -256,6 +296,8 @@ namespace OfficeIMO.Excel {
                 LastSaveDiagnostics = ExcelSaveDiagnostics.ExtendedPackage();
                 return true;
             } catch (OperationCanceledException) {
+                throw;
+            } catch (InvalidDataException ex) when (IsPackageMaterializationLimitException(ex)) {
                 throw;
             } catch (Exception ex) {
                 skipReason = "Extended package writer failed: " + ex.Message;
@@ -348,7 +390,7 @@ namespace OfficeIMO.Excel {
             ExcelChartAxisIdGenerator.Initialize(_spreadSheetDocument);
         }
 
-        private static byte[] NormalizePackageBytes(byte[] packageBytes) {
+        private static byte[] NormalizePackageBytes(byte[] packageBytes, ExcelSaveOptions? options) {
             using (var probe = new MemoryStream(packageBytes, writable: false)) {
                 try {
                     if (!ExcelPackageUtilities.NeedsContentTypeNormalization(probe)) {
@@ -358,29 +400,82 @@ namespace OfficeIMO.Excel {
                 }
             }
 
-            var working = new MemoryStream(packageBytes.Length + StreamBufferSize);
+            using FileStream working = OfficeTemporaryFile.Create(
+                "OfficeIMO.Excel-Normalize-",
+                ".tmp",
+                FileOptions.None,
+                out _);
             working.Write(packageBytes, 0, packageBytes.Length);
             working.Position = 0;
 
             try {
                 ExcelPackageUtilities.NormalizeContentTypes(working, leaveOpen: true);
+            } catch (InvalidDataException ex) when (IsPackageMaterializationLimitException(ex)) {
+                throw;
             } catch {
             }
 
-            if (working.CanSeek) {
-                working.Position = 0;
-            }
-
-            return working.ToArray();
+            ThrowIfPackageMaterializationExceedsLimit(working.Length, options);
+            working.Position = 0;
+            return ReadPackageBytes(working, options);
         }
 
-        private static byte[] FinalizePackageBytes(SavePayload payload) {
+        private static byte[] FinalizePackageBytes(SavePayload payload, ExcelSaveOptions? options) {
+            ThrowIfPackageMaterializationExceedsLimit(payload.PackageBytes.LongLength, options);
             var withProperties = payload.ApplyPackageProperties
-                ? payload.Properties.ApplyTo(payload.PackageBytes)
+                ? payload.Properties.ApplyTo(payload.PackageBytes, options)
                 : payload.PackageBytes;
-            return payload.NormalizeContentTypes
-                ? NormalizePackageBytes(withProperties)
+            ThrowIfPackageMaterializationExceedsLimit(withProperties.LongLength, options);
+            byte[] finalized = payload.NormalizeContentTypes
+                ? NormalizePackageBytes(withProperties, options)
                 : withProperties;
+            ThrowIfPackageMaterializationExceedsLimit(finalized.LongLength, options);
+            return finalized;
+        }
+
+        private static void ThrowIfPackageMaterializationExceedsLimit(long byteCount, ExcelSaveOptions? options) {
+            long? maximumBytes = GetPackageMaterializationLimit(options);
+            if (maximumBytes.HasValue && byteCount > maximumBytes.Value) {
+                throw CreatePackageMaterializationLimitException($"The Excel package exceeds the {maximumBytes.Value}-byte in-memory save limit.");
+            }
+        }
+
+        private static long? GetPackageMaterializationLimit(ExcelSaveOptions? options) {
+            long? maximumBytes = options == null
+                ? ExcelSaveOptions.DefaultMaxInMemoryPackageBytes
+                : options.MaxInMemoryPackageBytes;
+            if (maximumBytes.HasValue && maximumBytes.Value <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(options.MaxInMemoryPackageBytes));
+            }
+            return maximumBytes;
+        }
+
+        private static byte[] ReadPackageBytes(Stream stream, ExcelSaveOptions? options) {
+            ThrowIfPackageMaterializationExceedsLimit(stream.Length, options);
+            if (stream.Length > int.MaxValue) {
+                throw CreatePackageMaterializationLimitException("The Excel package is too large to materialize as one byte array.");
+            }
+
+            var bytes = new byte[(int)stream.Length];
+            int offset = 0;
+            while (offset < bytes.Length) {
+                int read = stream.Read(bytes, offset, bytes.Length - offset);
+                if (read == 0) throw new EndOfStreamException("The staged Excel package ended unexpectedly.");
+                offset += read;
+            }
+            return bytes;
+        }
+
+        private const string PackageMaterializationLimitMarker = "OfficeIMO.Excel.PackageMaterializationLimit";
+
+        private static InvalidDataException CreatePackageMaterializationLimitException(string message) {
+            var exception = new InvalidDataException(message);
+            exception.Data[PackageMaterializationLimitMarker] = true;
+            return exception;
+        }
+
+        private static bool IsPackageMaterializationLimitException(InvalidDataException exception) {
+            return exception.Data[PackageMaterializationLimitMarker] is bool marked && marked;
         }
 
         private static void ThrowIfOpenXmlValidationFails(byte[] finalizedBytes, ExcelSaveOptions? options) {

--- a/OfficeIMO.Excel/ExcelDocument.Save.Properties.cs
+++ b/OfficeIMO.Excel/ExcelDocument.Save.Properties.cs
@@ -96,12 +96,16 @@ namespace OfficeIMO.Excel {
                 }
             }
 
-            public byte[] ApplyTo(byte[] packageBytes) {
+            public byte[] ApplyTo(byte[] packageBytes, ExcelSaveOptions? options) {
                 if (packageBytes == null) throw new ArgumentNullException(nameof(packageBytes));
                 if (packageBytes.Length == 0) return packageBytes;
 
                 try {
-                    using var working = new MemoryStream(packageBytes.Length + StreamBufferSize);
+                    using FileStream working = OfficeTemporaryFile.Create(
+                        "OfficeIMO.Excel-Properties-",
+                        ".tmp",
+                        FileOptions.None,
+                        out _);
                     working.Write(packageBytes, 0, packageBytes.Length);
                     working.Position = 0;
 
@@ -120,11 +124,11 @@ namespace OfficeIMO.Excel {
                         dst.LastPrinted = _lastPrinted;
                     }
 
-                    if (working.CanSeek) {
-                        working.Position = 0;
-                    }
-
-                    return working.ToArray();
+                    ThrowIfPackageMaterializationExceedsLimit(working.Length, options);
+                    working.Position = 0;
+                    return ReadPackageBytes(working, options);
+                } catch (InvalidDataException ex) when (IsPackageMaterializationLimitException(ex)) {
+                    throw;
                 } catch {
                     return packageBytes;
                 }

--- a/OfficeIMO.Excel/ExcelDocument.Save.Public.cs
+++ b/OfficeIMO.Excel/ExcelDocument.Save.Public.cs
@@ -159,7 +159,7 @@ namespace OfficeIMO.Excel {
 
             var payload = PreparePackageForSave(options);
             try {
-                var finalizedBytes = FinalizePackageBytes(payload);
+                var finalizedBytes = FinalizePackageBytes(payload, options);
                 ThrowIfOpenXmlValidationFails(finalizedBytes, options);
                 CommitPreparedPackageToFile(path, finalizedBytes);
                 ReloadFromBytes(finalizedBytes);
@@ -196,7 +196,7 @@ namespace OfficeIMO.Excel {
 
             var payload = PreparePackageForSave(saveOptions);
             try {
-                var finalizedBytes = FinalizePackageBytes(payload);
+                var finalizedBytes = FinalizePackageBytes(payload, saveOptions);
                 ThrowIfOpenXmlValidationFails(finalizedBytes, saveOptions);
                 var encryptedBytes = OfficeEncryption.EncryptPackage(finalizedBytes, password);
                 CommitPreparedPackageToFile(path, encryptedBytes);
@@ -307,7 +307,7 @@ namespace OfficeIMO.Excel {
 
             var payload = PreparePackageForSave(options);
             try {
-                var finalizedBytes = FinalizePackageBytes(payload);
+                var finalizedBytes = FinalizePackageBytes(payload, options);
                 ThrowIfOpenXmlValidationFails(finalizedBytes, options);
                 await CommitPreparedPackageToFileAsync(target, finalizedBytes, cancellationToken).ConfigureAwait(false);
                 ReloadFromBytes(finalizedBytes);
@@ -422,7 +422,7 @@ namespace OfficeIMO.Excel {
 
             var payload = PreparePackageForSave(options, closeDocument: false);
             try {
-                var finalizedBytes = FinalizePackageBytes(payload);
+                var finalizedBytes = FinalizePackageBytes(payload, options);
                 ThrowIfOpenXmlValidationFails(finalizedBytes, options);
                 PrepareDestinationStreamForWrite(destination);
                 destination.Write(finalizedBytes, 0, finalizedBytes.Length);
@@ -449,6 +449,7 @@ namespace OfficeIMO.Excel {
             EnsureLegacyXlsSaveDoesNotDropImportedContent(saveOptions);
 
             if (CanUseUnchangedPackageFastPath(saveOptions) && _unchangedPackageBytes != null) {
+                ThrowIfPackageMaterializationExceedsLimit(_unchangedPackageBytes.LongLength, saveOptions);
                 OfficeEncryption.EncryptPackageToStream(_unchangedPackageBytes, password, destination);
                 LastSaveDiagnostics = ExcelSaveDiagnostics.UnchangedPackage();
                 return;
@@ -456,7 +457,7 @@ namespace OfficeIMO.Excel {
 
             var payload = PreparePackageForSave(saveOptions, closeDocument: false);
             try {
-                var finalizedBytes = FinalizePackageBytes(payload);
+                var finalizedBytes = FinalizePackageBytes(payload, saveOptions);
                 ThrowIfOpenXmlValidationFails(finalizedBytes, saveOptions);
                 OfficeEncryption.EncryptPackageToStream(finalizedBytes, password, destination);
                 LastSaveDiagnostics = ExcelSaveDiagnostics.Standard("Encrypted saves use the standard package finalization path.");
@@ -561,7 +562,7 @@ namespace OfficeIMO.Excel {
 
             var payload = PreparePackageForSave(options, closeDocument: false);
             try {
-                var finalizedBytes = FinalizePackageBytes(payload);
+                var finalizedBytes = FinalizePackageBytes(payload, options);
                 ThrowIfOpenXmlValidationFails(finalizedBytes, options);
                 PrepareDestinationStreamForWrite(destination);
                 await destination.WriteAsync(finalizedBytes, 0, finalizedBytes.Length, cancellationToken).ConfigureAwait(false);

--- a/OfficeIMO.Excel/ExcelSaveOptions.cs
+++ b/OfficeIMO.Excel/ExcelSaveOptions.cs
@@ -17,6 +17,15 @@ namespace OfficeIMO.Excel {
     /// robustness and CI validation.
     /// </summary>
     public sealed class ExcelSaveOptions {
+        /// <summary>Default maximum package size materialized by save operations: 256 MiB.</summary>
+        public const long DefaultMaxInMemoryPackageBytes = 256L * 1024L * 1024L;
+
+        /// <summary>
+        /// Maximum package size that may be materialized in memory while saving. The default is
+        /// 256 MiB. Set to <c>null</c> only for explicitly trusted, intentionally larger workbooks.
+        /// </summary>
+        public long? MaxInMemoryPackageBytes { get; set; } = DefaultMaxInMemoryPackageBytes;
+
         /// <summary>
         /// When true, attempts to repair common defined-name issues (duplicates, out-of-range LocalSheetId, #REF!) before save.
         /// </summary>
@@ -78,7 +87,11 @@ namespace OfficeIMO.Excel {
         public static ExcelSaveOptions Default => new ExcelSaveOptions();
 
         internal ExcelSaveOptions WithLossPolicy(ExcelConversionLossPolicy lossPolicy) {
+            if (MaxInMemoryPackageBytes.HasValue && MaxInMemoryPackageBytes.Value <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(MaxInMemoryPackageBytes));
+            }
             return new ExcelSaveOptions {
+                MaxInMemoryPackageBytes = MaxInMemoryPackageBytes,
                 SafeRepairDefinedNames = SafeRepairDefinedNames,
                 ValidateOpenXml = ValidateOpenXml,
                 SafePreflight = SafePreflight,

--- a/OfficeIMO.Excel/ExcelSheet.HeadersFooters.cs
+++ b/OfficeIMO.Excel/ExcelSheet.HeadersFooters.cs
@@ -560,9 +560,24 @@ namespace OfficeIMO.Excel {
         /// </summary>
         public async Task SetHeaderImageFromUrlAsync(HeaderFooterPosition position, string url, double? widthPoints = null,
             double? heightPoints = null, CancellationToken cancellationToken = default) {
+            await SetHeaderImageFromUrlCoreAsync(position, url, null, widthPoints, heightPoints, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>Downloads a header image using an explicit remote-network policy.</summary>
+        public Task SetHeaderImageFromUrlAsync(HeaderFooterPosition position, string url,
+            OfficeRemoteImageLoadOptions remoteImageOptions, double? widthPoints = null,
+            double? heightPoints = null, CancellationToken cancellationToken = default) {
+            if (remoteImageOptions == null) throw new ArgumentNullException(nameof(remoteImageOptions));
+            return SetHeaderImageFromUrlCoreAsync(position, url, remoteImageOptions, widthPoints, heightPoints, cancellationToken);
+        }
+
+        private async Task SetHeaderImageFromUrlCoreAsync(HeaderFooterPosition position, string url,
+            OfficeRemoteImageLoadOptions? remoteImageOptions, double? widthPoints, double? heightPoints,
+            CancellationToken cancellationToken) {
             OfficeRemoteImage remote = await OfficeRemoteImageLoader.LoadAsync(
                 url,
-                cancellationToken: cancellationToken).ConfigureAwait(false);
+                remoteImageOptions,
+                cancellationToken).ConfigureAwait(false);
             SetHeaderImage(position, remote.ToBytes(), remote.ContentType, widthPoints, heightPoints);
         }
 
@@ -584,9 +599,24 @@ namespace OfficeIMO.Excel {
         /// </summary>
         public async Task SetFooterImageFromUrlAsync(HeaderFooterPosition position, string url, double? widthPoints = null,
             double? heightPoints = null, CancellationToken cancellationToken = default) {
+            await SetFooterImageFromUrlCoreAsync(position, url, null, widthPoints, heightPoints, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>Downloads a footer image using an explicit remote-network policy.</summary>
+        public Task SetFooterImageFromUrlAsync(HeaderFooterPosition position, string url,
+            OfficeRemoteImageLoadOptions remoteImageOptions, double? widthPoints = null,
+            double? heightPoints = null, CancellationToken cancellationToken = default) {
+            if (remoteImageOptions == null) throw new ArgumentNullException(nameof(remoteImageOptions));
+            return SetFooterImageFromUrlCoreAsync(position, url, remoteImageOptions, widthPoints, heightPoints, cancellationToken);
+        }
+
+        private async Task SetFooterImageFromUrlCoreAsync(HeaderFooterPosition position, string url,
+            OfficeRemoteImageLoadOptions? remoteImageOptions, double? widthPoints, double? heightPoints,
+            CancellationToken cancellationToken) {
             OfficeRemoteImage remote = await OfficeRemoteImageLoader.LoadAsync(
                 url,
-                cancellationToken: cancellationToken).ConfigureAwait(false);
+                remoteImageOptions,
+                cancellationToken).ConfigureAwait(false);
             SetFooterImage(position, remote.ToBytes(), remote.ContentType, widthPoints, heightPoints);
         }
 

--- a/OfficeIMO.Excel/ExcelSheet.Images.Placement.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Images.Placement.cs
@@ -70,9 +70,54 @@ namespace OfficeIMO.Excel {
             double? scalePercent = null, int offsetXPixels = 0, int offsetYPixels = 0, string? name = null, string? altText = null,
             string? title = null, bool lockAspectRatio = true, double rotationDegrees = 0,
             CancellationToken cancellationToken = default) {
+            return await AddImageFromUrlPlacementCoreAsync(row, column, url, null, widthPixels, heightPixels,
+                scalePercent, offsetXPixels, offsetYPixels, name, altText, title, lockAspectRatio,
+                rotationDegrees, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Downloads and scales an image using an explicit remote-network policy.
+        /// </summary>
+        public Task<ExcelImage> AddImageFromUrlScaledAsync(
+            int row,
+            int column,
+            string url,
+            double scalePercent,
+            OfficeRemoteImageLoadOptions remoteImageOptions,
+            int offsetXPixels = 0,
+            int offsetYPixels = 0,
+            string? name = null,
+            string? altText = null,
+            string? title = null,
+            bool lockAspectRatio = true,
+            double rotationDegrees = 0,
+            CancellationToken cancellationToken = default) {
+            if (remoteImageOptions == null) throw new ArgumentNullException(nameof(remoteImageOptions));
+            return AddImageFromUrlPlacementCoreAsync(row, column, url, remoteImageOptions, null, null,
+                scalePercent, offsetXPixels, offsetYPixels, name, altText, title, lockAspectRatio,
+                rotationDegrees, cancellationToken);
+        }
+
+        private async Task<ExcelImage> AddImageFromUrlPlacementCoreAsync(
+            int row,
+            int column,
+            string url,
+            OfficeRemoteImageLoadOptions? remoteImageOptions,
+            int? widthPixels,
+            int? heightPixels,
+            double? scalePercent,
+            int offsetXPixels,
+            int offsetYPixels,
+            string? name,
+            string? altText,
+            string? title,
+            bool lockAspectRatio,
+            double rotationDegrees,
+            CancellationToken cancellationToken) {
             OfficeRemoteImage remote = await OfficeRemoteImageLoader.LoadAsync(
                 url,
-                cancellationToken: cancellationToken).ConfigureAwait(false);
+                remoteImageOptions,
+                cancellationToken).ConfigureAwait(false);
             byte[] bytes = remote.ToBytes();
             OfficeImageReader.TryIdentify(bytes, remote.FileName, out OfficeImageInfo info);
             var (resolvedWidth, resolvedHeight) = ResolveImageSize(info, widthPixels, heightPixels, scalePercent);
@@ -275,9 +320,54 @@ namespace OfficeIMO.Excel {
             int endOffsetXPixels = 0, int endOffsetYPixels = 0, string? name = null, string? altText = null, string? title = null,
             bool lockAspectRatio = true, ExcelImagePlacement placement = ExcelImagePlacement.MoveAndSize, double rotationDegrees = 0,
             CancellationToken cancellationToken = default) {
+            return await AddImageFromUrlToRangeCoreAsync(range, url, null, offsetXPixels, offsetYPixels,
+                endOffsetXPixels, endOffsetYPixels, name, altText, title, lockAspectRatio, placement,
+                rotationDegrees, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Downloads an image with an explicit remote-network policy and anchors it to a range.
+        /// </summary>
+        public Task<ExcelImage> AddImageFromUrlToRangeAsync(
+            string range,
+            string url,
+            OfficeRemoteImageLoadOptions remoteImageOptions,
+            int offsetXPixels = 0,
+            int offsetYPixels = 0,
+            int endOffsetXPixels = 0,
+            int endOffsetYPixels = 0,
+            string? name = null,
+            string? altText = null,
+            string? title = null,
+            bool lockAspectRatio = true,
+            ExcelImagePlacement placement = ExcelImagePlacement.MoveAndSize,
+            double rotationDegrees = 0,
+            CancellationToken cancellationToken = default) {
+            if (remoteImageOptions == null) throw new ArgumentNullException(nameof(remoteImageOptions));
+            return AddImageFromUrlToRangeCoreAsync(range, url, remoteImageOptions, offsetXPixels, offsetYPixels,
+                endOffsetXPixels, endOffsetYPixels, name, altText, title, lockAspectRatio, placement,
+                rotationDegrees, cancellationToken);
+        }
+
+        private async Task<ExcelImage> AddImageFromUrlToRangeCoreAsync(
+            string range,
+            string url,
+            OfficeRemoteImageLoadOptions? remoteImageOptions,
+            int offsetXPixels,
+            int offsetYPixels,
+            int endOffsetXPixels,
+            int endOffsetYPixels,
+            string? name,
+            string? altText,
+            string? title,
+            bool lockAspectRatio,
+            ExcelImagePlacement placement,
+            double rotationDegrees,
+            CancellationToken cancellationToken) {
             OfficeRemoteImage remote = await OfficeRemoteImageLoader.LoadAsync(
                 url,
-                cancellationToken: cancellationToken).ConfigureAwait(false);
+                remoteImageOptions,
+                cancellationToken).ConfigureAwait(false);
             byte[] bytes = remote.ToBytes();
             OfficeImageReader.TryIdentify(bytes, remote.FileName, out OfficeImageInfo info);
             return AddImageToRange(range, bytes, ResolveImageContentType(remote.ContentType, info), offsetXPixels,

--- a/OfficeIMO.Excel/ExcelSheet.Images.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Images.cs
@@ -159,14 +159,69 @@ namespace OfficeIMO.Excel {
                 cancellationToken: cancellationToken);
 
         /// <summary>
+        /// Asynchronously downloads an image with an explicit remote-network policy and anchors it to a cell.
+        /// </summary>
+        public Task<ExcelImage> AddImageFromUrlAtAsync(
+            int row,
+            int column,
+            string url,
+            OfficeRemoteImageLoadOptions remoteImageOptions,
+            int widthPixels = 96,
+            int heightPixels = 32,
+            int offsetXPixels = 0,
+            int offsetYPixels = 0,
+            CancellationToken cancellationToken = default) =>
+            AddImageFromUrlWithOptionsAsync(row, column, url, remoteImageOptions, widthPixels, heightPixels,
+                offsetXPixels, offsetYPixels, cancellationToken: cancellationToken);
+
+        /// <summary>
         /// Asynchronously downloads an image from a URL and returns a wrapper for setting metadata and sizing.
         /// </summary>
         public async Task<ExcelImage> AddImageFromUrlAsync(int row, int column, string url, int widthPixels = 96, int heightPixels = 32,
             int offsetXPixels = 0, int offsetYPixels = 0, string? name = null, string? altText = null, bool lockAspectRatio = true,
             CancellationToken cancellationToken = default) {
+            return await AddImageFromUrlCoreAsync(row, column, url, null, widthPixels, heightPixels, offsetXPixels,
+                offsetYPixels, name, altText, lockAspectRatio, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously downloads an image with an explicit remote-network policy and returns its wrapper.
+        /// </summary>
+        public Task<ExcelImage> AddImageFromUrlWithOptionsAsync(
+            int row,
+            int column,
+            string url,
+            OfficeRemoteImageLoadOptions remoteImageOptions,
+            int widthPixels = 96,
+            int heightPixels = 32,
+            int offsetXPixels = 0,
+            int offsetYPixels = 0,
+            string? name = null,
+            string? altText = null,
+            bool lockAspectRatio = true,
+            CancellationToken cancellationToken = default) {
+            if (remoteImageOptions == null) throw new ArgumentNullException(nameof(remoteImageOptions));
+            return AddImageFromUrlCoreAsync(row, column, url, remoteImageOptions, widthPixels, heightPixels,
+                offsetXPixels, offsetYPixels, name, altText, lockAspectRatio, cancellationToken);
+        }
+
+        private async Task<ExcelImage> AddImageFromUrlCoreAsync(
+            int row,
+            int column,
+            string url,
+            OfficeRemoteImageLoadOptions? remoteImageOptions,
+            int widthPixels,
+            int heightPixels,
+            int offsetXPixels,
+            int offsetYPixels,
+            string? name,
+            string? altText,
+            bool lockAspectRatio,
+            CancellationToken cancellationToken) {
             OfficeRemoteImage remote = await OfficeRemoteImageLoader.LoadAsync(
                 url,
-                cancellationToken: cancellationToken).ConfigureAwait(false);
+                remoteImageOptions,
+                cancellationToken).ConfigureAwait(false);
             byte[] bytes = remote.ToBytes();
             OfficeImageReader.TryIdentify(bytes, remote.FileName, out OfficeImageInfo info);
             return AddImage(row, column, bytes, contentType: ResolveImageContentType(remote.ContentType, info), widthPixels: widthPixels,

--- a/OfficeIMO.Excel/ExcelTemplate.cs
+++ b/OfficeIMO.Excel/ExcelTemplate.cs
@@ -131,9 +131,28 @@ namespace OfficeIMO.Excel {
         public static async Task<ExcelTemplateImage> FromUrlAsync(string url, int widthPixels = 96, int heightPixels = 32,
             int offsetXPixels = 0, int offsetYPixels = 0, string? name = null, string? altText = null,
             bool lockAspectRatio = true, CancellationToken cancellationToken = default) {
+            return await FromUrlCoreAsync(url, null, widthPixels, heightPixels, offsetXPixels, offsetYPixels,
+                name, altText, lockAspectRatio, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>Creates a template image using an explicit remote-network policy.</summary>
+        public static Task<ExcelTemplateImage> FromUrlAsync(string url, OfficeRemoteImageLoadOptions remoteImageOptions,
+            int widthPixels = 96, int heightPixels = 32, int offsetXPixels = 0, int offsetYPixels = 0,
+            string? name = null, string? altText = null, bool lockAspectRatio = true,
+            CancellationToken cancellationToken = default) {
+            if (remoteImageOptions == null) throw new ArgumentNullException(nameof(remoteImageOptions));
+            return FromUrlCoreAsync(url, remoteImageOptions, widthPixels, heightPixels, offsetXPixels,
+                offsetYPixels, name, altText, lockAspectRatio, cancellationToken);
+        }
+
+        private static async Task<ExcelTemplateImage> FromUrlCoreAsync(string url,
+            OfficeRemoteImageLoadOptions? remoteImageOptions, int widthPixels, int heightPixels,
+            int offsetXPixels, int offsetYPixels, string? name, string? altText, bool lockAspectRatio,
+            CancellationToken cancellationToken) {
             OfficeRemoteImage remote = await OfficeRemoteImageLoader.LoadAsync(
                 url,
-                cancellationToken: cancellationToken).ConfigureAwait(false);
+                remoteImageOptions,
+                cancellationToken).ConfigureAwait(false);
             return FromBytes(remote.ToBytes(), remote.ContentType, widthPixels, heightPixels, offsetXPixels, offsetYPixels,
                 name, altText, lockAspectRatio);
         }

--- a/OfficeIMO.Excel/Fluent/ExcelSheet.HeaderFooter.Fluent.cs
+++ b/OfficeIMO.Excel/Fluent/ExcelSheet.HeaderFooter.Fluent.cs
@@ -1,5 +1,6 @@
 using System.Threading;
 using System.Threading.Tasks;
+using OfficeIMO.Drawing;
 
 namespace OfficeIMO.Excel {
     public partial class ExcelSheet {
@@ -22,6 +23,18 @@ namespace OfficeIMO.Excel {
                                   CancellationToken cancellationToken = default) {
             SetHeaderFooter(leftText, centerText, rightText);
             await SetHeaderImageFromUrlAsync(position, url, widthPoints, heightPoints, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>Sets a header logo using an explicit remote-network policy.</summary>
+        public async Task HeaderLogoFromUrlAsync(string url, OfficeRemoteImageLoadOptions remoteImageOptions,
+                                  HeaderFooterPosition position = HeaderFooterPosition.Right,
+                                  double? widthPoints = null, double? heightPoints = null,
+                                  string? leftText = null, string? centerText = null, string? rightText = null,
+                                  CancellationToken cancellationToken = default) {
+            if (remoteImageOptions == null) throw new ArgumentNullException(nameof(remoteImageOptions));
+            SetHeaderFooter(leftText, centerText, rightText);
+            await SetHeaderImageFromUrlAsync(position, url, remoteImageOptions, widthPoints, heightPoints,
+                cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/OfficeIMO.Excel/Fluent/SheetBuilder.cs
+++ b/OfficeIMO.Excel/Fluent/SheetBuilder.cs
@@ -90,7 +90,8 @@ namespace OfficeIMO.Excel.Fluent {
                             options.DefaultValues,
                             collectionPath,
                             coll,
-                            maximumDataRows - dataRows);
+                            maximumDataRows - dataRows,
+                            options.MaxCollectionItems);
                         continue;
                     }
                 }
@@ -147,9 +148,13 @@ namespace OfficeIMO.Excel.Fluent {
             IReadOnlyDictionary<string, object?> defaultValues,
             string collectionPath,
             IEnumerable collection,
-            int maximumRows) {
+            int maximumRows,
+            int maximumCollectionItems) {
             int added = 0;
             foreach (object? element in collection) {
+                if (added >= maximumCollectionItems) {
+                    throw new InvalidDataException($"RowsFrom nested collection exceeds the {maximumCollectionItems}-item flattening limit.");
+                }
                 if (added >= maximumRows) {
                     throw new InvalidDataException($"RowsFrom nested expansion exceeds the configured row materialization limit.");
                 }

--- a/OfficeIMO.Excel/Fluent/SheetBuilder.cs
+++ b/OfficeIMO.Excel/Fluent/SheetBuilder.cs
@@ -56,13 +56,12 @@ namespace OfficeIMO.Excel.Fluent {
             if (Sheet == null) throw new InvalidOperationException("Sheet not initialized");
             if (data == null) throw new ArgumentNullException(nameof(data));
 
-            ObjectFlattenerOptions? options = null;
-            if (configure != null) {
-                options = new ObjectFlattenerOptions();
-                configure(options);
-            }
+            var options = new ObjectFlattenerOptions();
+            configure?.Invoke(options);
+            if (options.MaxRows <= 0) throw new ArgumentOutOfRangeException(nameof(options.MaxRows));
+            int maximumDataRows = Math.Min(options.MaxRows, Math.Max(0, A1.MaxRows - _currentRow));
 
-            var rows = data as IReadOnlyList<T> ?? data.ToList();
+            var rows = MaterializeRowsBounded(data, maximumDataRows);
             if (rows.Count == 0) return this;
 
             int startRow = _currentRow;
@@ -70,7 +69,6 @@ namespace OfficeIMO.Excel.Fluent {
                 return this;
             }
 
-            options ??= new ObjectFlattenerOptions();
             var flattener = new ObjectFlattener();
             var paths = options.Columns?.ToList() ?? flattener.GetPaths(typeof(T), options);
             if (options.Columns != null) {
@@ -85,11 +83,21 @@ namespace OfficeIMO.Excel.Fluent {
                 if (options.CollectionMode == CollectionMode.ExpandRows) {
                     var collectionPath = paths.FirstOrDefault(p => dict.TryGetValue(p, out var val) && val is IEnumerable && val is not string);
                     if (collectionPath != null && dict[collectionPath] is IEnumerable coll) {
-                        dataRows += AddExpandedRowsFromCollection(rowValues, paths, dict, options.DefaultValues, collectionPath, coll);
+                        dataRows += AddExpandedRowsFromCollection(
+                            rowValues,
+                            paths,
+                            dict,
+                            options.DefaultValues,
+                            collectionPath,
+                            coll,
+                            maximumDataRows - dataRows);
                         continue;
                     }
                 }
 
+                if (dataRows >= maximumDataRows) {
+                    throw new InvalidDataException($"RowsFrom exceeds the {maximumDataRows}-row materialization limit.");
+                }
                 rowValues.Add(ProjectRowsFromValues(paths, dict, options.DefaultValues));
                 dataRows++;
             }
@@ -114,20 +122,45 @@ namespace OfficeIMO.Excel.Fluent {
             return this;
         }
 
+        private static IReadOnlyList<T> MaterializeRowsBounded<T>(IEnumerable<T> data, int maximumRows) {
+            if (data is IReadOnlyList<T> rows) {
+                if (rows.Count > maximumRows) {
+                    throw new InvalidDataException($"RowsFrom exceeds the {maximumRows}-row materialization limit.");
+                }
+                return rows;
+            }
+
+            var materialized = new List<T>(Math.Min(maximumRows, 4096));
+            foreach (T item in data) {
+                if (materialized.Count >= maximumRows) {
+                    throw new InvalidDataException($"RowsFrom exceeds the {maximumRows}-row materialization limit.");
+                }
+                materialized.Add(item);
+            }
+            return materialized;
+        }
+
         private static int AddExpandedRowsFromCollection(
             List<object?[]> rowValues,
             IReadOnlyList<string> paths,
             Dictionary<string, object?> values,
             IReadOnlyDictionary<string, object?> defaultValues,
             string collectionPath,
-            IEnumerable collection) {
+            IEnumerable collection,
+            int maximumRows) {
             int added = 0;
             foreach (object? element in collection) {
+                if (added >= maximumRows) {
+                    throw new InvalidDataException($"RowsFrom nested expansion exceeds the configured row materialization limit.");
+                }
                 rowValues.Add(ProjectRowsFromValues(paths, values, defaultValues, collectionPath, element));
                 added++;
             }
 
             if (added == 0) {
+                if (maximumRows <= 0) {
+                    throw new InvalidDataException("RowsFrom nested expansion exceeds the configured row materialization limit.");
+                }
                 rowValues.Add(ProjectRowsFromValues(paths, values, defaultValues: null));
                 return 1;
             }

--- a/OfficeIMO.Excel/Fluent/SheetComposer.HeaderFooter.cs
+++ b/OfficeIMO.Excel/Fluent/SheetComposer.HeaderFooter.cs
@@ -27,6 +27,27 @@ namespace OfficeIMO.Excel.Fluent {
             return this;
         }
 
+        /// <summary>Sets a header logo using an explicit remote-network policy.</summary>
+        public async Task<SheetComposer> HeaderLogoFromUrlAsync(string url, OfficeRemoteImageLoadOptions remoteImageOptions,
+                                           HeaderFooterPosition position = HeaderFooterPosition.Right,
+                                           double? widthPoints = null, double? heightPoints = null,
+                                           string? leftText = null, string? centerText = null, string? rightText = null,
+                                           CancellationToken cancellationToken = default) {
+            if (remoteImageOptions == null) throw new ArgumentNullException(nameof(remoteImageOptions));
+            OfficeRemoteImage remote = await OfficeRemoteImageLoader.LoadAsync(url, remoteImageOptions, cancellationToken).ConfigureAwait(false);
+            HeaderFooter(h => {
+                if (!string.IsNullOrEmpty(leftText)) h.Left(leftText!);
+                if (!string.IsNullOrEmpty(centerText)) h.Center(centerText!);
+                if (!string.IsNullOrEmpty(rightText)) h.Right(rightText!);
+                switch (position) {
+                    case HeaderFooterPosition.Left: h.LeftImage(remote.ToBytes(), remote.ContentType, widthPoints, heightPoints); break;
+                    case HeaderFooterPosition.Center: h.CenterImage(remote.ToBytes(), remote.ContentType, widthPoints, heightPoints); break;
+                    default: h.RightImage(remote.ToBytes(), remote.ContentType, widthPoints, heightPoints); break;
+                }
+            });
+            return this;
+        }
+
         /// <summary>
         /// Asynchronously sets a footer logo from a URL and optional footer text.
         /// </summary>
@@ -37,6 +58,27 @@ namespace OfficeIMO.Excel.Fluent {
             OfficeRemoteImage remote = await OfficeRemoteImageLoader.LoadAsync(
                 url,
                 cancellationToken: cancellationToken).ConfigureAwait(false);
+            HeaderFooter(h => {
+                if (!string.IsNullOrEmpty(leftText)) h.FooterLeft(leftText!);
+                if (!string.IsNullOrEmpty(centerText)) h.FooterCenter(centerText!);
+                if (!string.IsNullOrEmpty(rightText)) h.FooterRight(rightText!);
+                switch (position) {
+                    case HeaderFooterPosition.Left: h.FooterLeftImage(remote.ToBytes(), remote.ContentType, widthPoints, heightPoints); break;
+                    case HeaderFooterPosition.Center: h.FooterCenterImage(remote.ToBytes(), remote.ContentType, widthPoints, heightPoints); break;
+                    default: h.FooterRightImage(remote.ToBytes(), remote.ContentType, widthPoints, heightPoints); break;
+                }
+            });
+            return this;
+        }
+
+        /// <summary>Sets a footer logo using an explicit remote-network policy.</summary>
+        public async Task<SheetComposer> FooterLogoFromUrlAsync(string url, OfficeRemoteImageLoadOptions remoteImageOptions,
+                                           HeaderFooterPosition position = HeaderFooterPosition.Right,
+                                           double? widthPoints = null, double? heightPoints = null,
+                                           string? leftText = null, string? centerText = null, string? rightText = null,
+                                           CancellationToken cancellationToken = default) {
+            if (remoteImageOptions == null) throw new ArgumentNullException(nameof(remoteImageOptions));
+            OfficeRemoteImage remote = await OfficeRemoteImageLoader.LoadAsync(url, remoteImageOptions, cancellationToken).ConfigureAwait(false);
             HeaderFooter(h => {
                 if (!string.IsNullOrEmpty(leftText)) h.FooterLeft(leftText!);
                 if (!string.IsNullOrEmpty(centerText)) h.FooterCenter(centerText!);

--- a/OfficeIMO.Excel/Fluent/SheetComposer.Images.cs
+++ b/OfficeIMO.Excel/Fluent/SheetComposer.Images.cs
@@ -1,5 +1,6 @@
 using System.Threading;
 using System.Threading.Tasks;
+using OfficeIMO.Drawing;
 
 namespace OfficeIMO.Excel.Fluent {
     /// <summary>
@@ -38,6 +39,16 @@ namespace OfficeIMO.Excel.Fluent {
             CancellationToken cancellationToken = default) {
             await Sheet.AddImageFromUrlAtAsync(row, column, url, widthPixels, heightPixels, offsetXPixels,
                 offsetYPixels, cancellationToken).ConfigureAwait(false);
+            return this;
+        }
+
+        /// <summary>Downloads an image with an explicit remote-network policy and inserts it at a cell.</summary>
+        public async Task<SheetComposer> ImageFromUrlAtAsync(int row, int column, string url,
+            OfficeRemoteImageLoadOptions remoteImageOptions, int widthPixels = 96, int heightPixels = 32,
+            int offsetXPixels = 0, int offsetYPixels = 0, CancellationToken cancellationToken = default) {
+            if (remoteImageOptions == null) throw new ArgumentNullException(nameof(remoteImageOptions));
+            await Sheet.AddImageFromUrlAtAsync(row, column, url, remoteImageOptions, widthPixels, heightPixels,
+                offsetXPixels, offsetYPixels, cancellationToken).ConfigureAwait(false);
             return this;
         }
     }

--- a/OfficeIMO.Excel/Fluent/SheetComposer.Table.cs
+++ b/OfficeIMO.Excel/Fluent/SheetComposer.Table.cs
@@ -157,22 +157,11 @@ namespace OfficeIMO.Excel.Fluent {
                 return new List<System.Collections.Generic.Dictionary<string, object?>>();
             }
 
-            if (items is IReadOnlyList<T> indexedItems) {
-                var rows = new List<System.Collections.Generic.Dictionary<string, object?>>(indexedItems.Count);
-                for (int i = 0; i < indexedItems.Count; i++) {
-                    rows.Add(flattener.Flatten(indexedItems[i], options));
-                }
-
-                return rows;
-            }
-
-            int capacity = items is IReadOnlyCollection<T> readOnlyCollection
-                ? readOnlyCollection.Count
-                : items is ICollection<T> collection ? collection.Count : 0;
-            var materializedRows = capacity > 0
-                ? new List<System.Collections.Generic.Dictionary<string, object?>>(capacity)
-                : new List<System.Collections.Generic.Dictionary<string, object?>>();
-            foreach (var item in items) {
+            List<T> boundedItems = ObjectFlattener.MaterializeRowsBounded(
+                items, options, "TableFrom");
+            var materializedRows = new List<System.Collections.Generic.Dictionary<string, object?>>(
+                boundedItems.Count);
+            foreach (T item in boundedItems) {
                 materializedRows.Add(flattener.Flatten(item, options));
             }
 

--- a/OfficeIMO.Html.Tests/Html.Security.AllSeverityBatch13.cs
+++ b/OfficeIMO.Html.Tests/Html.Security.AllSeverityBatch13.cs
@@ -1,0 +1,103 @@
+using System.Reflection;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class HtmlAllSeverityBatch13SecurityTests {
+    [Fact]
+    public void HtmlToWordRejectsImageTraversalOutsideBasePath() {
+        string root = Path.Combine(Path.GetTempPath(), "officeimo-html-image-" + Guid.NewGuid().ToString("N"));
+        string basePath = Path.Combine(root, "content");
+        string outside = Path.Combine(root, "outside.png");
+        Directory.CreateDirectory(basePath);
+        File.Copy(Path.Combine(AppContext.BaseDirectory, "Images", "EvotecLogo.png"), outside);
+        try {
+            var options = HtmlToWordOptions.CreateTrustedDocumentProfile();
+            options.BasePath = basePath;
+            using WordDocument document = OfficeIMO.Html.HtmlConversionDocument
+                .Parse("<img src='../outside.png' alt='blocked'>")
+                .ToWordDocument(options);
+
+            Assert.Empty(document.Images);
+        } finally {
+            Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void WordToHtmlNormalizesUntrustedStyleIdentifiersInClassesAndCss() {
+        const string hostileStyle = "x} body { background:url(javascript:alert(1))";
+        using WordDocument document = WordDocument.Create();
+        StyleDefinitionsPart stylePart = document._wordprocessingDocument.MainDocumentPart!.StyleDefinitionsPart
+            ?? document._wordprocessingDocument.MainDocumentPart.AddNewPart<StyleDefinitionsPart>();
+        stylePart.Styles ??= new Styles();
+        stylePart.Styles.Append(new Style(
+            new StyleRunProperties(
+                new RunFonts { Ascii = "Evil</style><style>body{background:url(https://attacker.test/)}" },
+                new Color { Val = "00ff00; background:url(https://attacker.test/)" })) {
+            Type = StyleValues.Paragraph,
+            StyleId = hostileStyle
+        });
+        document.AddParagraph("safe").SetStyleId(hostileStyle);
+        document.AddParagraph().AddText("run-safe").SetCharacterStyleId(hostileStyle);
+
+        string html = document.ToHtml(new WordToHtmlOptions {
+            IncludeParagraphClasses = true,
+            IncludeRunClasses = true
+        });
+
+        Assert.DoesNotContain(hostileStyle, html, StringComparison.Ordinal);
+        Assert.DoesNotContain("attacker.test", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("</style><style>", html, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("word-style-", html, StringComparison.Ordinal);
+        Assert.Contains("safe", html, StringComparison.Ordinal);
+        Assert.Contains("run-safe", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WordToHtmlTraversesEachNestedTableOnceAndEnforcesDepth() {
+        using WordDocument document = WordDocument.Create();
+        WordTable outer = document.AddTable(1, 1);
+        WordTable middle = outer.Rows[0].Cells[0].AddTable(1, 1);
+        middle.Rows[0].Cells[0].AddTable(1, 1);
+
+        string html = document.ToHtml();
+        Assert.Equal(3, CountOccurrences(html, "<table"));
+        Assert.Throws<InvalidDataException>(() =>
+            document.ToHtml(new WordToHtmlOptions { MaxTableNestingDepth = 2 }));
+    }
+
+    [Fact]
+    public void WordToHtmlRejectsHostileListLevelBeforeGrowingStacks() {
+        using WordDocument document = WordDocument.Create();
+        WordList list = document.AddList(WordListStyle.Bulleted);
+        list.AddItem("item");
+        WordParagraph paragraph = document.Paragraphs.Single(item => item.IsListItem);
+        paragraph.ListItemLevel = int.MaxValue;
+
+        Assert.Throws<InvalidDataException>(() =>
+            document.ToHtml(new WordToHtmlOptions { MaxListNestingDepth = 8 }));
+    }
+
+    [Fact]
+    public void HtmlStylesheetCacheIsScopedToOneConverterInstance() {
+        Type converter = typeof(HtmlToWordOptions).Assembly.GetType("OfficeIMO.Word.Html.HtmlToWordConverter", throwOnError: true)!;
+        FieldInfo cache = converter.GetField("_stylesheetCache", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+        Assert.False(cache.IsStatic);
+    }
+
+    private static int CountOccurrences(string value, string token) {
+        int count = 0;
+        int start = 0;
+        while ((start = value.IndexOf(token, start, StringComparison.OrdinalIgnoreCase)) >= 0) {
+            count++;
+            start += token.Length;
+        }
+        return count;
+    }
+}

--- a/OfficeIMO.Html.Tests/Html.StylesheetCache.cs
+++ b/OfficeIMO.Html.Tests/Html.StylesheetCache.cs
@@ -1,10 +1,7 @@
 using System;
-using System.Collections;
 using System.IO;
 using System.Net;
 using System.Net.Http;
-using System.Reflection;
-using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
 using OfficeIMO.Word.Html;
@@ -12,33 +9,19 @@ using Xunit;
 
 namespace OfficeIMO.Tests {
     public partial class Html {
-        private static IDictionary GetCache() {
-            var assembly = typeof(HtmlToWordOptions).Assembly;
-            var converterType = assembly.GetType("OfficeIMO.Word.Html.HtmlToWordConverter", true)!;
-            var field = converterType.GetField("_stylesheetCache", BindingFlags.NonPublic | BindingFlags.Static)!;
-            return (IDictionary)field.GetValue(null)!;
-        }
-
-        private static string ComputeHash(string css) {
-            using var sha = SHA256.Create();
-            var bytes = sha.ComputeHash(Encoding.UTF8.GetBytes(css));
-            return BitConverter.ToString(bytes).Replace("-", "");
-        }
-
         [Fact]
-        public void HtmlToWord_StylesheetCache_Reused_ForPathContent() {
+        public void HtmlToWord_StylesheetCache_LoadsPathContent() {
             var path = Path.GetTempFileName();
             const string css = "p { color:#111111; }";
             File.WriteAllText(path, css);
             try {
-                var cache = GetCache();
-                var key = ComputeHash(css);
-                cache.Remove(key);
                 var html = $"<link rel=\"stylesheet\" href=\"{path}\" /><p>Test</p>";
-                OfficeIMO.Html.HtmlConversionDocument.Parse(html).ToWordDocument(new HtmlToWordOptions { AllowDocumentStylesheetLinks = true });
-                var first = cache[key];
-                OfficeIMO.Html.HtmlConversionDocument.Parse(html).ToWordDocument(new HtmlToWordOptions { AllowDocumentStylesheetLinks = true });
-                Assert.Same(first, cache[key]);
+                using var document = OfficeIMO.Html.HtmlConversionDocument
+                    .Parse(html).ToWordDocument(new HtmlToWordOptions {
+                        AllowDocumentStylesheetLinks = true
+                    });
+                Assert.Equal("111111",
+                    document.Paragraphs[0].GetRuns().First().ColorHex);
             } finally {
                 File.Delete(path);
             }
@@ -87,16 +70,13 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
-        public void HtmlToWord_StylesheetCache_Reused_ForContent() {
+        public void HtmlToWord_StylesheetCache_LoadsInlineContent() {
             const string css = "p { color:#222222; }";
-            var key = ComputeHash(css);
-            var cache = GetCache();
-            cache.Remove(key);
             var html = $"<style>{css}</style><p>Test</p>";
-            OfficeIMO.Html.HtmlConversionDocument.Parse(html).ToWordDocument(new HtmlToWordOptions());
-            var first = cache[key];
-            OfficeIMO.Html.HtmlConversionDocument.Parse(html).ToWordDocument(new HtmlToWordOptions());
-            Assert.Same(first, cache[key]);
+            using var document = OfficeIMO.Html.HtmlConversionDocument
+                .Parse(html).ToWordDocument(new HtmlToWordOptions());
+            Assert.Equal("222222",
+                document.Paragraphs[0].GetRuns().First().ColorHex);
         }
     }
 }

--- a/OfficeIMO.OpenDocument.Converters.Tests/OpenDocumentConversionLossReports.cs
+++ b/OfficeIMO.OpenDocument.Converters.Tests/OpenDocumentConversionLossReports.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Xml.Linq;
 using OfficeIMO.Excel;
 using OfficeIMO.Excel.OpenDocument;
+using OfficeIMO.Drawing;
 using OfficeIMO.OpenDocument;
 using OfficeIMO.PowerPoint;
 using OfficeIMO.PowerPoint.OpenDocument;
@@ -261,7 +262,9 @@ public sealed class OpenDocumentConversionLossReportTests {
     public void WordAutomaticColorsAndUnsupportedImagesDoNotAbortConversion() {
         using WordDocument source = WordDocument.Create();
         source.AddParagraph("Automatic color").ColorHex = "auto";
-        using var tiff = new MemoryStream(new byte[] { 0x49, 0x49, 0x2A, 0x00, 0x00, 0x00, 0x00, 0x00 });
+        byte[] tiffBytes = OfficeTiffCodec.Encode(new OfficeRasterImage(
+            1, 1, OfficeColor.FromRgb(12, 34, 56)));
+        using var tiff = new MemoryStream(tiffBytes, writable: false);
         source.AddParagraph().AddImage(tiff, "unsupported.tiff", 10, 10);
 
         OdfConversionResult<OdtDocument> conversion = source.ToOpenDocumentResult();

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.Security.AllSeverityBatch13.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.Security.AllSeverityBatch13.cs
@@ -1,0 +1,59 @@
+using OfficeIMO.Drawing;
+using OfficeIMO.PowerPoint;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class PowerPointAllSeverityBatch13SecurityTests {
+    [Fact]
+    public void AddTableStopsUnboundedSourceEnumerationAtConfiguredLimit() {
+        using PowerPointPresentation presentation = PowerPointPresentation
+            .Create();
+        PowerPointSlide slide = presentation.AddSlide();
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(
+            () => slide.AddTable(InfiniteRows(),
+                options => options.MaxRows = 3));
+
+        Assert.Contains("3-row", exception.Message,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AddTableStopsUnboundedNestedExpansionAtConfiguredLimit() {
+        using PowerPointPresentation presentation = PowerPointPresentation
+            .Create();
+        PowerPointSlide slide = presentation.AddSlide();
+        var rows = new[] {
+            new NestedRow { Name = "item", Values = InfiniteValues() }
+        };
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(
+            () => slide.AddTable(rows, options => {
+                options.MaxRows = 3;
+                options.CollectionMode = CollectionMode.ExpandRows;
+            }));
+
+        Assert.Contains("nested expansion", exception.Message,
+            StringComparison.Ordinal);
+    }
+
+    private static IEnumerable<SimpleRow> InfiniteRows() {
+        int value = 0;
+        while (true) yield return new SimpleRow { Value = value++ };
+    }
+
+    private static IEnumerable<int> InfiniteValues() {
+        int value = 0;
+        while (true) yield return value++;
+    }
+
+    private sealed class SimpleRow {
+        public int Value { get; set; }
+    }
+
+    private sealed class NestedRow {
+        public string Name { get; set; } = string.Empty;
+        public IEnumerable<int> Values { get; set; } = Array.Empty<int>();
+    }
+}

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.Security.AllSeverityBatch13.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.Security.AllSeverityBatch13.cs
@@ -38,6 +38,22 @@ public sealed class PowerPointAllSeverityBatch13SecurityTests {
             StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void AddTableHonorsPerCollectionLimitDuringNestedExpansion() {
+        using PowerPointPresentation presentation = PowerPointPresentation.Create();
+        PowerPointSlide slide = presentation.AddSlide();
+        var rows = new[] { new NestedRow { Name = "item", Values = InfiniteValues() } };
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+            slide.AddTable(rows, options => {
+                options.MaxRows = 100;
+                options.MaxCollectionItems = 2;
+                options.CollectionMode = CollectionMode.ExpandRows;
+            }));
+
+        Assert.Contains("2-item", exception.Message, StringComparison.Ordinal);
+    }
+
     private static IEnumerable<SimpleRow> InfiniteRows() {
         int value = 0;
         while (true) yield return new SimpleRow { Value = value++ };

--- a/OfficeIMO.PowerPoint/PowerPointSlide.Tables.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSlide.Tables.cs
@@ -177,7 +177,8 @@ namespace OfficeIMO.PowerPoint {
             configure?.Invoke(options);
             var flattener = new ObjectFlattener();
 
-            var items = data.ToList();
+            List<T> items = ObjectFlattener.MaterializeRowsBounded(data,
+                options, "PowerPoint AddTable");
             var paths = options.Columns?.ToList() ?? flattener.GetPaths(typeof(T), options);
             if (options.Columns != null) {
                 paths = flattener.ResolvePaths(paths, options);
@@ -196,22 +197,34 @@ namespace OfficeIMO.PowerPoint {
                     var collectionPath = paths.FirstOrDefault(p =>
                         dict.TryGetValue(p, out var val) && val is IEnumerable && val is not string);
                     if (collectionPath != null && dict[collectionPath] is IEnumerable coll) {
-                        var list = coll.Cast<object?>().ToList();
-                        if (list.Count == 0) {
+                        bool expanded = false;
+                        foreach (object? element in coll) {
+                            if (rowsData.Count >= options.MaxRows) {
+                                throw new InvalidDataException(
+                                    $"PowerPoint AddTable nested expansion exceeds the {options.MaxRows}-row materialization limit.");
+                            }
+                            expanded = true;
+                            var rowValues = paths.Select(p => p == collectionPath ? element :
+                                dict.TryGetValue(p, out var v) ? v :
+                                (options.DefaultValues.TryGetValue(p, out var d) ? d : null)).ToArray();
+                            rowsData.Add(rowValues);
+                        }
+                        if (!expanded) {
+                            if (rowsData.Count >= options.MaxRows) {
+                                throw new InvalidDataException(
+                                    $"PowerPoint AddTable exceeds the {options.MaxRows}-row materialization limit.");
+                            }
                             rowsData.Add(paths.Select(p => dict.TryGetValue(p, out var v) ? v :
                                 (options.DefaultValues.TryGetValue(p, out var d) ? d : null)).ToArray());
-                        } else {
-                            foreach (var element in list) {
-                                var rowValues = paths.Select(p => p == collectionPath ? element :
-                                    dict.TryGetValue(p, out var v) ? v :
-                                    (options.DefaultValues.TryGetValue(p, out var d) ? d : null)).ToArray();
-                                rowsData.Add(rowValues);
-                            }
                         }
                         continue;
                     }
                 }
 
+                if (rowsData.Count >= options.MaxRows) {
+                    throw new InvalidDataException(
+                        $"PowerPoint AddTable exceeds the {options.MaxRows}-row materialization limit.");
+                }
                 rowsData.Add(paths.Select(p => dict.TryGetValue(p, out var v) ? v :
                     (options.DefaultValues.TryGetValue(p, out var d) ? d : null)).ToArray());
             }

--- a/OfficeIMO.PowerPoint/PowerPointSlide.Tables.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSlide.Tables.cs
@@ -198,7 +198,12 @@ namespace OfficeIMO.PowerPoint {
                         dict.TryGetValue(p, out var val) && val is IEnumerable && val is not string);
                     if (collectionPath != null && dict[collectionPath] is IEnumerable coll) {
                         bool expanded = false;
+                        int collectionItems = 0;
                         foreach (object? element in coll) {
+                            if (collectionItems >= options.MaxCollectionItems) {
+                                throw new InvalidDataException(
+                                    $"PowerPoint AddTable nested collection exceeds the {options.MaxCollectionItems}-item flattening limit.");
+                            }
                             if (rowsData.Count >= options.MaxRows) {
                                 throw new InvalidDataException(
                                     $"PowerPoint AddTable nested expansion exceeds the {options.MaxRows}-row materialization limit.");
@@ -208,6 +213,7 @@ namespace OfficeIMO.PowerPoint {
                                 dict.TryGetValue(p, out var v) ? v :
                                 (options.DefaultValues.TryGetValue(p, out var d) ? d : null)).ToArray();
                             rowsData.Add(rowValues);
+                            collectionItems++;
                         }
                         if (!expanded) {
                             if (rowsData.Count >= options.MaxRows) {

--- a/OfficeIMO.Rtf.Tests/Rtf/WordRtfConverterTests.NotesBookmarksAndFields.cs
+++ b/OfficeIMO.Rtf.Tests/Rtf/WordRtfConverterTests.NotesBookmarksAndFields.cs
@@ -270,6 +270,6 @@ public partial class WordRtfConverterTests {
     }
 
     private static byte[] CreateOnePixelPng() {
-        return Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==");
+        return Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=");
     }
 }

--- a/OfficeIMO.Visio.Tests/Visio.Security.AllSeverityBatch13.cs
+++ b/OfficeIMO.Visio.Tests/Visio.Security.AllSeverityBatch13.cs
@@ -1,0 +1,86 @@
+using System.IO.Compression;
+using OfficeIMO.Visio;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class VisioAllSeverityBatch13SecurityTests {
+    [Fact]
+    public void ValidatorRejectsOversizedEntryBeforeExtraction() {
+        string root = Path.Combine(Path.GetTempPath(), "officeimo-vsdx-limit-" + Guid.NewGuid().ToString("N"));
+        string package = Path.Combine(root, "oversized.vsdx");
+        Directory.CreateDirectory(root);
+        try {
+            using (ZipArchive archive = ZipFile.Open(package, ZipArchiveMode.Create)) {
+                ZipArchiveEntry entry = archive.CreateEntry("visio/document.xml", CompressionLevel.NoCompression);
+                using Stream output = entry.Open();
+                output.Write(new byte[32], 0, 32);
+            }
+            var validator = new VsdxPackageValidator(new VsdxPackageValidationLimits {
+                MaxEntryBytes = 16,
+                MaxTotalBytes = 64
+            });
+
+            Assert.False(validator.ValidateFile(package));
+            Assert.Contains(validator.Errors, error => error.Contains("16-byte", StringComparison.Ordinal));
+            Assert.False(validator.ValidateFileStreaming(package));
+            Assert.Contains(validator.Errors, error => error.Contains("16-byte", StringComparison.Ordinal));
+
+            string fixedPackage = Path.Combine(root, "fixed.vsdx");
+            Assert.False(validator.FixFileStreaming(package, fixedPackage));
+            Assert.Contains(validator.Errors, error => error.Contains("16-byte", StringComparison.Ordinal));
+            Assert.False(File.Exists(fixedPackage));
+        } finally {
+            Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void ValidatorEnforcesAggregateLimitAcrossDecompressedEntries() {
+        string root = Path.Combine(Path.GetTempPath(), "officeimo-vsdx-aggregate-" + Guid.NewGuid().ToString("N"));
+        string package = Path.Combine(root, "aggregate.vsdx");
+        Directory.CreateDirectory(root);
+        try {
+            using (ZipArchive archive = ZipFile.Open(package, ZipArchiveMode.Create)) {
+                for (int index = 0; index < 2; index++) {
+                    ZipArchiveEntry entry = archive.CreateEntry("visio/entry" + index + ".bin", CompressionLevel.NoCompression);
+                    using Stream output = entry.Open();
+                    output.Write(new byte[12], 0, 12);
+                }
+            }
+            var validator = new VsdxPackageValidator(new VsdxPackageValidationLimits {
+                MaxEntryBytes = 16,
+                MaxTotalBytes = 20
+            });
+
+            Assert.False(validator.ValidateFileStreaming(package));
+            Assert.Contains(validator.Errors, error => error.Contains("20-byte aggregate", StringComparison.Ordinal));
+        } finally {
+            Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void ValidatorRejectsTraversalEntryWithoutWritingOutsideTempRoot() {
+        string root = Path.Combine(Path.GetTempPath(), "officeimo-vsdx-traversal-" + Guid.NewGuid().ToString("N"));
+        string package = Path.Combine(root, "traversal.vsdx");
+        string escapedName = "escaped-" + Guid.NewGuid().ToString("N") + ".txt";
+        string escapedPath = Path.Combine(Path.GetTempPath(), escapedName);
+        Directory.CreateDirectory(root);
+        try {
+            using (ZipArchive archive = ZipFile.Open(package, ZipArchiveMode.Create)) {
+                ZipArchiveEntry entry = archive.CreateEntry("../" + escapedName);
+                using var writer = new StreamWriter(entry.Open());
+                writer.Write("blocked");
+            }
+            var validator = new VsdxPackageValidator();
+
+            Assert.False(validator.ValidateFile(package));
+            Assert.Contains(validator.Errors, error => error.Contains("escapes", StringComparison.Ordinal));
+            Assert.False(File.Exists(escapedPath));
+        } finally {
+            if (File.Exists(escapedPath)) File.Delete(escapedPath);
+            Directory.Delete(root, true);
+        }
+    }
+}

--- a/OfficeIMO.Visio/VsdxPackageValidationLimits.cs
+++ b/OfficeIMO.Visio/VsdxPackageValidationLimits.cs
@@ -1,0 +1,40 @@
+namespace OfficeIMO.Visio {
+    /// <summary>Resource limits applied while validating or repairing VSDX packages.</summary>
+    public sealed class VsdxPackageValidationLimits {
+        /// <summary>Maximum number of ZIP entries. Default: 4096.</summary>
+        public int MaxEntries { get; set; } = 4096;
+
+        /// <summary>Maximum uncompressed size of one entry. Default: 64 MiB.</summary>
+        public long MaxEntryBytes { get; set; } = 64L * 1024L * 1024L;
+
+        /// <summary>Maximum aggregate uncompressed size. Default: 256 MiB.</summary>
+        public long MaxTotalBytes { get; set; } = 256L * 1024L * 1024L;
+
+        /// <summary>Maximum uncompressed-to-compressed ratio for a non-empty entry. Default: 200.</summary>
+        public double MaxCompressionRatio { get; set; } = 200d;
+
+        internal Snapshot CreateSnapshot() {
+            if (MaxEntries <= 0) throw new ArgumentOutOfRangeException(nameof(MaxEntries));
+            if (MaxEntryBytes <= 0) throw new ArgumentOutOfRangeException(nameof(MaxEntryBytes));
+            if (MaxTotalBytes <= 0) throw new ArgumentOutOfRangeException(nameof(MaxTotalBytes));
+            if (MaxCompressionRatio <= 0 || double.IsNaN(MaxCompressionRatio) || double.IsInfinity(MaxCompressionRatio)) {
+                throw new ArgumentOutOfRangeException(nameof(MaxCompressionRatio));
+            }
+            return new Snapshot(MaxEntries, MaxEntryBytes, MaxTotalBytes, MaxCompressionRatio);
+        }
+
+        internal readonly struct Snapshot {
+            internal Snapshot(int maxEntries, long maxEntryBytes, long maxTotalBytes, double maxCompressionRatio) {
+                MaxEntries = maxEntries;
+                MaxEntryBytes = maxEntryBytes;
+                MaxTotalBytes = maxTotalBytes;
+                MaxCompressionRatio = maxCompressionRatio;
+            }
+
+            internal int MaxEntries { get; }
+            internal long MaxEntryBytes { get; }
+            internal long MaxTotalBytes { get; }
+            internal double MaxCompressionRatio { get; }
+        }
+    }
+}

--- a/OfficeIMO.Visio/VsdxPackageValidator.cs
+++ b/OfficeIMO.Visio/VsdxPackageValidator.cs
@@ -218,14 +218,16 @@ namespace OfficeIMO.Visio {
         }
 
         private static bool IsLinkEntry(ZipArchiveEntry entry) {
-            // ExternalAttributes is unavailable in the netstandard2.0 reference surface,
-            // even though modern runtime implementations expose it. The extractor always
-            // copies entry bytes into a newly created regular file; use the metadata when
-            // available to reject link-marked entries as an additional defense.
-            object? value = entry.GetType().GetProperty("ExternalAttributes")?.GetValue(entry);
-            if (!(value is int attributes)) return false;
+            // ExternalAttributes is unavailable in the netstandard2.0 reference surface.
+            // Older targets still copy bytes into newly created regular files; modern targets
+            // can reject link metadata before extraction without reflection or trim warnings.
+#if NET8_0_OR_GREATER
+            int attributes = entry.ExternalAttributes;
             int unixType = (attributes >> 16) & 0xF000;
             return unixType == 0xA000 || (attributes & (int)FileAttributes.ReparsePoint) != 0;
+#else
+            return false;
+#endif
         }
 
         private void ValidateArchiveLimits(ZipArchive archive) {

--- a/OfficeIMO.Visio/VsdxPackageValidator.cs
+++ b/OfficeIMO.Visio/VsdxPackageValidator.cs
@@ -31,6 +31,16 @@ namespace OfficeIMO.Visio {
         private readonly List<string> _errors = new();
         private readonly List<string> _warnings = new();
         private readonly List<string> _fixes = new();
+        private readonly VsdxPackageValidationLimits.Snapshot _limits;
+
+        /// <summary>Creates a validator with default resource limits.</summary>
+        public VsdxPackageValidator() : this(null) { }
+
+        /// <summary>Creates a validator with caller-supplied resource limits.</summary>
+        /// <param name="limits">Limits to snapshot for this validator instance.</param>
+        public VsdxPackageValidator(VsdxPackageValidationLimits? limits) {
+            _limits = (limits ?? new VsdxPackageValidationLimits()).CreateSnapshot();
+        }
 
         /// <summary>
         /// Gets the list of validation errors.
@@ -62,12 +72,18 @@ namespace OfficeIMO.Visio {
                 return false;
             }
 
-            var tempPath = ExtractToTemp(inputPath);
+            string? tempPath = null;
             try {
+                tempPath = ExtractToTemp(inputPath);
                 ValidatePackageStructure(tempPath);
                 return _errors.Count == 0;
+            } catch (InvalidDataException ex) {
+                _errors.Add(ex.Message);
+                return false;
             } finally {
-                try { Directory.Delete(tempPath, recursive: true); } catch { /* ignore cleanup errors */ }
+                if (tempPath != null) {
+                    try { Directory.Delete(tempPath, recursive: true); } catch { /* ignore cleanup errors */ }
+                }
             }
         }
 
@@ -87,8 +103,9 @@ namespace OfficeIMO.Visio {
                 return false;
             }
 
-            var tempPath = ExtractToTemp(inputPath);
+            string? tempPath = null;
             try {
+                tempPath = ExtractToTemp(inputPath);
                 ValidateAndFix(tempPath);
                 _errors.Clear();
                 _warnings.Clear();
@@ -103,8 +120,13 @@ namespace OfficeIMO.Visio {
 
                 ZipFile.CreateFromDirectory(tempPath, outputPath, CompressionLevel.Optimal, includeBaseDirectory: false);
                 return true;
+            } catch (InvalidDataException ex) {
+                _errors.Add(ex.Message);
+                return false;
             } finally {
-                try { Directory.Delete(tempPath, recursive: true); } catch { /* ignore cleanup errors */ }
+                if (tempPath != null) {
+                    try { Directory.Delete(tempPath, recursive: true); } catch { /* ignore cleanup errors */ }
+                }
             }
         }
 
@@ -113,8 +135,133 @@ namespace OfficeIMO.Visio {
             var rnd = Path.GetRandomFileName();
             var tempPath = Path.Combine(tempBase, $"VsdxValidator_{rnd}");
             Directory.CreateDirectory(tempPath);
-            ZipFile.ExtractToDirectory(inputPath, tempPath);
-            return tempPath;
+            try {
+                using ZipArchive archive = ZipFile.OpenRead(inputPath);
+                ValidateArchiveLimits(archive);
+                ValidateArchiveContents(archive);
+
+                string root = Path.GetFullPath(tempPath) + Path.DirectorySeparatorChar;
+                long totalBytes = 0;
+                long copiedBytes = 0;
+                foreach (ZipArchiveEntry entry in archive.Entries) {
+                    if (IsLinkEntry(entry)) {
+                        throw new InvalidDataException($"The VSDX package contains a link entry: {entry.FullName}");
+                    }
+                    if (entry.Length > _limits.MaxEntryBytes) {
+                        throw new InvalidDataException($"The VSDX entry '{entry.FullName}' exceeds the {_limits.MaxEntryBytes}-byte limit.");
+                    }
+                    if (entry.Length > 0 && (entry.CompressedLength <= 0 || entry.Length / (double)entry.CompressedLength > _limits.MaxCompressionRatio)) {
+                        throw new InvalidDataException($"The VSDX entry '{entry.FullName}' exceeds the {_limits.MaxCompressionRatio:0.##}:1 compression-ratio limit.");
+                    }
+                    totalBytes = checked(totalBytes + entry.Length);
+                    if (totalBytes > _limits.MaxTotalBytes) {
+                        throw new InvalidDataException($"The VSDX package exceeds the {_limits.MaxTotalBytes}-byte aggregate extraction limit.");
+                    }
+
+                    string relative = entry.FullName.Replace('\\', '/').Replace('/', Path.DirectorySeparatorChar);
+                    string target = Path.GetFullPath(Path.Combine(tempPath, relative));
+                    if (!target.StartsWith(root, StringComparison.Ordinal)) {
+                        throw new InvalidDataException($"The VSDX entry '{entry.FullName}' escapes the extraction directory.");
+                    }
+
+                    if (string.IsNullOrEmpty(entry.Name)) {
+                        Directory.CreateDirectory(target);
+                        continue;
+                    }
+                    string? parent = Path.GetDirectoryName(target);
+                    if (!string.IsNullOrEmpty(parent)) Directory.CreateDirectory(parent);
+                    using Stream input = entry.Open();
+                    using var output = new FileStream(target, FileMode.CreateNew, FileAccess.Write, FileShare.None);
+                    CopyEntryBounded(input, output, entry.FullName, entry.CompressedLength, ref copiedBytes);
+                }
+                return tempPath;
+            } catch {
+                try { Directory.Delete(tempPath, recursive: true); } catch { }
+                throw;
+            }
+        }
+
+        private void CopyEntryBounded(
+            Stream input,
+            Stream output,
+            string entryName,
+            long compressedBytes,
+            ref long aggregateBytes) {
+            var buffer = new byte[81920];
+            long total = 0;
+            while (true) {
+                int read = input.Read(buffer, 0, buffer.Length);
+                if (read == 0) break;
+                total = checked(total + read);
+                aggregateBytes = checked(aggregateBytes + read);
+                if (total > _limits.MaxEntryBytes) {
+                    throw new InvalidDataException($"The VSDX entry '{entryName}' exceeds the {_limits.MaxEntryBytes}-byte limit.");
+                }
+                if (aggregateBytes > _limits.MaxTotalBytes) {
+                    throw new InvalidDataException($"The VSDX package exceeds the {_limits.MaxTotalBytes}-byte aggregate limit.");
+                }
+                if (total > 0
+                    && (compressedBytes <= 0 || total / (double)compressedBytes > _limits.MaxCompressionRatio)) {
+                    throw new InvalidDataException($"The VSDX entry '{entryName}' exceeds the {_limits.MaxCompressionRatio:0.##}:1 compression-ratio limit.");
+                }
+                output.Write(buffer, 0, read);
+            }
+        }
+
+        private void ValidateArchiveContents(ZipArchive archive) {
+            long aggregateBytes = 0;
+            foreach (ZipArchiveEntry entry in archive.Entries) {
+                if (string.IsNullOrEmpty(entry.Name)) continue;
+                using Stream input = entry.Open();
+                CopyEntryBounded(input, Stream.Null, entry.FullName, entry.CompressedLength, ref aggregateBytes);
+            }
+        }
+
+        private static bool IsLinkEntry(ZipArchiveEntry entry) {
+            // ExternalAttributes is unavailable in the netstandard2.0 reference surface,
+            // even though modern runtime implementations expose it. The extractor always
+            // copies entry bytes into a newly created regular file; use the metadata when
+            // available to reject link-marked entries as an additional defense.
+            object? value = entry.GetType().GetProperty("ExternalAttributes")?.GetValue(entry);
+            if (!(value is int attributes)) return false;
+            int unixType = (attributes >> 16) & 0xF000;
+            return unixType == 0xA000 || (attributes & (int)FileAttributes.ReparsePoint) != 0;
+        }
+
+        private void ValidateArchiveLimits(ZipArchive archive) {
+            if (archive.Entries.Count > _limits.MaxEntries) {
+                throw new InvalidDataException($"The VSDX package exceeds the {_limits.MaxEntries}-entry limit.");
+            }
+
+            long totalBytes = 0;
+            foreach (ZipArchiveEntry entry in archive.Entries) {
+                ValidateEntryName(entry.FullName);
+                if (IsLinkEntry(entry)) {
+                    throw new InvalidDataException($"The VSDX package contains a link entry: {entry.FullName}");
+                }
+                if (entry.Length > _limits.MaxEntryBytes) {
+                    throw new InvalidDataException($"The VSDX entry '{entry.FullName}' exceeds the {_limits.MaxEntryBytes}-byte limit.");
+                }
+                if (entry.Length > 0
+                    && (entry.CompressedLength <= 0
+                        || entry.Length / (double)entry.CompressedLength > _limits.MaxCompressionRatio)) {
+                    throw new InvalidDataException($"The VSDX entry '{entry.FullName}' exceeds the {_limits.MaxCompressionRatio:0.##}:1 compression-ratio limit.");
+                }
+                totalBytes = checked(totalBytes + entry.Length);
+                if (totalBytes > _limits.MaxTotalBytes) {
+                    throw new InvalidDataException($"The VSDX package exceeds the {_limits.MaxTotalBytes}-byte aggregate limit.");
+                }
+            }
+        }
+
+        private static void ValidateEntryName(string entryName) {
+            string normalized = entryName.Replace('\\', '/');
+            if (normalized.Length == 0
+                || normalized[0] == '/'
+                || (normalized.Length >= 2 && normalized[1] == ':')
+                || normalized.Split('/').Any(part => part == "..")) {
+                throw new InvalidDataException($"The VSDX entry '{entryName}' escapes the package root.");
+            }
         }
 
         private void ValidatePackageStructure(string tempPath) {
@@ -147,10 +294,17 @@ namespace OfficeIMO.Visio {
                 return false;
             }
 
-            using ZipArchive zip = ZipFile.OpenRead(inputPath);
-            ValidateStreamingPhase1(zip);
-            ValidateStreamingPhase2(zip);
-            return _errors.Count == 0;
+            try {
+                using ZipArchive zip = ZipFile.OpenRead(inputPath);
+                ValidateArchiveLimits(zip);
+                ValidateArchiveContents(zip);
+                ValidateStreamingPhase1(zip);
+                ValidateStreamingPhase2(zip);
+                return _errors.Count == 0;
+            } catch (InvalidDataException ex) {
+                _errors.Add(ex.Message);
+                return false;
+            }
         }
 
         private void ValidateStreamingPhase1(ZipArchive zip) {
@@ -307,8 +461,12 @@ namespace OfficeIMO.Visio {
             if (!string.IsNullOrEmpty(outDir) && !Directory.Exists(outDir)) Directory.CreateDirectory(outDir);
             if (File.Exists(outputPath)) File.Delete(outputPath);
 
-            using (ZipArchive src = ZipFile.OpenRead(inputPath))
-            using (ZipArchive dst = ZipFile.Open(outputPath, ZipArchiveMode.Create)) {
+            try {
+                using (ZipArchive src = ZipFile.OpenRead(inputPath))
+                using (ZipArchive dst = ZipFile.Open(outputPath, ZipArchiveMode.Create)) {
+                ValidateArchiveLimits(src);
+                ValidateArchiveContents(src);
+                long copiedBytes = 0;
                 // Copy all entries except those we will recreate
                 var skip = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
                     "[Content_Types].xml",
@@ -322,7 +480,7 @@ namespace OfficeIMO.Visio {
                     var ne = dst.CreateEntry(name, CompressionLevel.Optimal);
                     using var s = e.Open();
                     using var t = ne.Open();
-                    s.CopyTo(t);
+                    CopyEntryBounded(s, t, name, e.CompressedLength, ref copiedBytes);
                 }
 
                 // Build and write [Content_Types].xml
@@ -390,10 +548,15 @@ namespace OfficeIMO.Visio {
                 var pagesRels = new XDocument(relsRoot);
                 SaveZipXml(dst, "visio/pages/_rels/pages.xml.rels", pagesRels);
                 _fixes.Add("Rebuilt /visio/pages/_rels/pages.xml.rels");
-            }
+                }
 
-            // Run streaming validation on the output
-            return ValidateFileStreaming(outputPath);
+                // Run streaming validation on the output
+                return ValidateFileStreaming(outputPath);
+            } catch (InvalidDataException ex) {
+                try { if (File.Exists(outputPath)) File.Delete(outputPath); } catch { }
+                _errors.Add(ex.Message);
+                return false;
+            }
         }
     }
 }

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Images.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Images.cs
@@ -762,7 +762,16 @@ namespace OfficeIMO.Word.Html {
             }
 
             if (!string.IsNullOrEmpty(options.BasePath)) {
-                return Path.Combine(options.BasePath, source);
+                string root = Path.GetFullPath(options.BasePath);
+                string relative = source.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);
+                string candidate = Path.GetFullPath(Path.Combine(root, relative));
+                string rootPrefix = root.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal)
+                    ? root
+                    : root + Path.DirectorySeparatorChar;
+                if (!candidate.StartsWith(rootPrefix, StringComparison.Ordinal)) {
+                    return string.Empty;
+                }
+                return candidate;
             }
 
             if (TryGetUsableDocumentBaseUri(img.BaseUrl?.Href, out var baseUri)) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
@@ -7,7 +7,6 @@ using AngleSharp.Html.Dom;
 using AngleSharp.Io;
 using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Html;
-using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Http;
 using System.Security.Cryptography;
@@ -38,7 +37,9 @@ namespace OfficeIMO.Word.Html {
         private readonly Dictionary<string, byte[]> _remoteImageBytesCache = new(StringComparer.Ordinal);
         private readonly Dictionary<string, Exception> _remoteImageFailureCache = new(StringComparer.Ordinal);
         private readonly Dictionary<string, WordParagraphStyles> _cssClassStyles = new(StringComparer.OrdinalIgnoreCase);
-        private static readonly ConcurrentDictionary<string, ICssStyleRule[]> _stylesheetCache = new(StringComparer.OrdinalIgnoreCase);
+        // A converter instance is scoped to one conversion. Keeping parsed sheets here avoids
+        // retaining attacker-controlled stylesheet identities for the lifetime of the process.
+        private readonly Dictionary<string, ICssStyleRule[]> _stylesheetCache = new(StringComparer.OrdinalIgnoreCase);
         private IBrowsingContext? _context;
         private int _suppressAutoLinksDepth;
         private bool _pendingTopBookmark;
@@ -88,6 +89,7 @@ namespace OfficeIMO.Word.Html {
             _remoteImageBytesCache.Clear();
             _remoteImageFailureCache.Clear();
             _cssClassStyles.Clear();
+            _stylesheetCache.Clear();
             _pendingTopBookmark = false;
             _imageBytesUsed = 0;
             _remoteImageBytesFetched = 0;
@@ -146,6 +148,7 @@ namespace OfficeIMO.Word.Html {
             _remoteImageBytesCache.Clear();
             _remoteImageFailureCache.Clear();
             _cssClassStyles.Clear();
+            _stylesheetCache.Clear();
             _pendingTopBookmark = false;
             _imageBytesUsed = 0;
             _remoteImageBytesFetched = 0;
@@ -201,6 +204,7 @@ namespace OfficeIMO.Word.Html {
             _remoteImageBytesCache.Clear();
             _remoteImageFailureCache.Clear();
             _cssClassStyles.Clear();
+            _stylesheetCache.Clear();
             _pendingTopBookmark = false;
             _imageBytesUsed = 0;
             _remoteImageBytesFetched = 0;

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.Equations.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.Equations.cs
@@ -102,7 +102,7 @@ namespace OfficeIMO.Word.Html {
             }
             if (options.IncludeRunClasses && !string.IsNullOrEmpty(run.CharacterStyleId) && !handledHtmlStyle) {
                 var span = htmlDocument.CreateElement("span");
-                span.SetAttribute("class", run.CharacterStyleId);
+                span.SetAttribute("class", GetSafeStyleClassName(run.CharacterStyleId));
                 span.AppendChild(node);
                 node = span;
                 runStyles.Add(run.CharacterStyleId!);

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.StyleDefinitions.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.StyleDefinitions.cs
@@ -1,6 +1,7 @@
 using AngleSharp.Dom;
 using DocumentFormat.OpenXml.Wordprocessing;
 using System.Text;
+using System.Security.Cryptography;
 using System.Threading;
 
 namespace OfficeIMO.Word.Html {
@@ -66,7 +67,8 @@ namespace OfficeIMO.Word.Html {
                         }
                         var colorVal = rPr.Color?.Val?.Value;
                         if (!string.IsNullOrEmpty(colorVal) &&
-                            !string.Equals(colorVal, "auto", StringComparison.OrdinalIgnoreCase)) {
+                            !string.Equals(colorVal, "auto", StringComparison.OrdinalIgnoreCase) &&
+                            IsSixDigitHexColor(colorVal!)) {
                             var cv = colorVal!;
                             props["color"] = "#" + cv.ToLowerInvariant();
                         }
@@ -76,8 +78,7 @@ namespace OfficeIMO.Word.Html {
                         }
                         var font = rPr.RunFonts?.Ascii?.Value;
                         if (!string.IsNullOrEmpty(font)) {
-                            var value = font!;
-                            props["font-family"] = value.Contains(' ') ? $"\"{value}\"" : value;
+                            props["font-family"] = QuoteCssString(font!);
                         }
                     }
                 }
@@ -93,15 +94,75 @@ namespace OfficeIMO.Word.Html {
             foreach (var s in paragraphStyles) {
                 cancellationToken.ThrowIfCancellationRequested();
                 var css = BuildCss(s);
-                sb.Append('.').Append(s).Append(" { ").Append(css).Append(" }\n");
+                sb.Append('.').Append(GetSafeStyleClassName(s)).Append(" { ").Append(css).Append(" }\n");
             }
             foreach (var s in runStyles) {
                 cancellationToken.ThrowIfCancellationRequested();
                 var css = BuildCss(s);
-                sb.Append('.').Append(s).Append(" { ").Append(css).Append(" }\n");
+                sb.Append('.').Append(GetSafeStyleClassName(s)).Append(" { ").Append(css).Append(" }\n");
             }
             styleElement.TextContent = sb.ToString();
             head.AppendChild(styleElement);
         }
+
+        private static bool IsSixDigitHexColor(string value) {
+            if (value.Length != 6) return false;
+            for (int i = 0; i < value.Length; i++) {
+                char character = value[i];
+                if (!((character >= '0' && character <= '9')
+                    || (character >= 'A' && character <= 'F')
+                    || (character >= 'a' && character <= 'f'))) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private static string QuoteCssString(string value) {
+            var escaped = new StringBuilder(value.Length + 2);
+            escaped.Append('"');
+            foreach (char character in value) {
+                if ((character >= 'A' && character <= 'Z')
+                    || (character >= 'a' && character <= 'z')
+                    || (character >= '0' && character <= '9')
+                    || character == ' '
+                    || character == '-'
+                    || character == '_') {
+                    escaped.Append(character);
+                } else {
+                    escaped.Append('\\')
+                        .Append(((int)character).ToString("x", System.Globalization.CultureInfo.InvariantCulture))
+                        .Append(' ');
+                }
+            }
+            return escaped.Append('"').ToString();
+        }
+
+        private static string GetSafeStyleClassName(string? styleId) {
+            if (styleId != null
+                && styleId.Length > 0
+                && IsSafeStyleClassStart(styleId[0])
+                && styleId.All(IsSafeStyleClassCharacter)) {
+                return styleId;
+            }
+
+            using SHA256 sha256 = SHA256.Create();
+            byte[] digest = sha256.ComputeHash(Encoding.UTF8.GetBytes(styleId ?? string.Empty));
+            var suffix = new StringBuilder(24);
+            for (int i = 0; i < 12; i++) {
+                suffix.Append(digest[i].ToString("x2", System.Globalization.CultureInfo.InvariantCulture));
+            }
+            return "word-style-" + suffix;
+        }
+
+        private static bool IsSafeStyleClassStart(char character) =>
+            (character >= 'A' && character <= 'Z')
+            || (character >= 'a' && character <= 'z')
+            || character == '_';
+
+        private static bool IsSafeStyleClassCharacter(char character) =>
+            IsSafeStyleClassStart(character)
+            || (character >= '0' && character <= '9')
+            || character == '-';
     }
 }

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
@@ -471,7 +471,7 @@ namespace OfficeIMO.Word.Html {
 
                     if (options.IncludeRunClasses && !string.IsNullOrEmpty(run.CharacterStyleId) && !handledHtmlStyle) {
                         var spanClass = htmlDoc.CreateElement("span");
-                        spanClass.SetAttribute("class", run.CharacterStyleId);
+                        spanClass.SetAttribute("class", GetSafeStyleClassName(run.CharacterStyleId));
                         spanClass.AppendChild(node);
                         node = spanClass;
                         runStyles.Add(run.CharacterStyleId!);
@@ -548,7 +548,7 @@ namespace OfficeIMO.Word.Html {
                 }
                 ApplyBookmarkId(element, para);
                 if (options.IncludeParagraphClasses && !string.IsNullOrEmpty(para.StyleId)) {
-                    element.SetAttribute("class", para.StyleId);
+                    element.SetAttribute("class", GetSafeStyleClassName(para.StyleId));
                     paragraphStyles.Add(para.StyleId!);
                 }
                 if (para.BiDi) {
@@ -627,14 +627,20 @@ namespace OfficeIMO.Word.Html {
                     caption.SetAttribute("dir", "rtl");
                 }
                 if (options.IncludeParagraphClasses && !string.IsNullOrEmpty(captionParagraph.StyleId)) {
-                    caption.SetAttribute("class", captionParagraph.StyleId);
+                    caption.SetAttribute("class", GetSafeStyleClassName(captionParagraph.StyleId));
                     paragraphStyles.Add(captionParagraph.StyleId!);
                 }
                 AppendRuns(caption, captionParagraph);
                 tableElement.AppendChild(caption);
             }
 
-            void AppendTable(IElement parent, WordTable table, WordParagraph? captionParagraph = null) {
+            void AppendTable(IElement parent, WordTable table, WordParagraph? captionParagraph = null, int nestingDepth = 0) {
+                if (options.MaxTableNestingDepth <= 0) {
+                    throw new ArgumentOutOfRangeException(nameof(options.MaxTableNestingDepth));
+                }
+                if (nestingDepth >= options.MaxTableNestingDepth) {
+                    throw new InvalidDataException($"The Word table nesting exceeds the {options.MaxTableNestingDepth}-level HTML conversion limit.");
+                }
                 var tableEl = htmlDoc.CreateElement("table");
                 var tableStyles = new List<string>();
                 var tableWidth = GetWidthCss(table.WidthType, table.Width);
@@ -802,9 +808,9 @@ namespace OfficeIMO.Word.Html {
                         }
 
                         if (cell.HasNestedTables) {
-                            foreach (var nested in cell.NestedTables) {
+                            foreach (var nested in cell.DirectNestedTables) {
                                 cancellationToken.ThrowIfCancellationRequested();
-                                AppendTable(cellElement, nested);
+                                AppendTable(cellElement, nested, nestingDepth: nestingDepth + 1);
                             }
                         }
 
@@ -918,6 +924,12 @@ namespace OfficeIMO.Word.Html {
                 Stack<IElement> items,
                 Stack<int> numberIds) {
                 int level = listInfo.Level;
+                if (options.MaxListNestingDepth <= 0) {
+                    throw new ArgumentOutOfRangeException(nameof(options.MaxListNestingDepth));
+                }
+                if (level < 0 || level >= options.MaxListNestingDepth) {
+                    throw new InvalidDataException($"The Word list level {level} exceeds the {options.MaxListNestingDepth}-level HTML conversion limit.");
+                }
                 int desiredListDepth = level + 1;
 
                 while (lists.Count > desiredListDepth) {
@@ -1042,7 +1054,7 @@ namespace OfficeIMO.Word.Html {
                                 AppendRuns(figure, paragraph);
                                 var figCap = htmlDoc.CreateElement("figcaption");
                                 if (options.IncludeParagraphClasses && !string.IsNullOrEmpty(captionPara.StyleId)) {
-                                    figCap.SetAttribute("class", captionPara.StyleId);
+                                    figCap.SetAttribute("class", GetSafeStyleClassName(captionPara.StyleId));
                                     paragraphStyles.Add(captionPara.StyleId!);
                                 }
                                 AppendRuns(figCap, captionPara);
@@ -1055,7 +1067,7 @@ namespace OfficeIMO.Word.Html {
                                 ApplyBookmarkId(figure, imagePara);
                                 var figCap = htmlDoc.CreateElement("figcaption");
                                 if (options.IncludeParagraphClasses && !string.IsNullOrEmpty(paragraph.StyleId)) {
-                                    figCap.SetAttribute("class", paragraph.StyleId);
+                                    figCap.SetAttribute("class", GetSafeStyleClassName(paragraph.StyleId));
                                     paragraphStyles.Add(paragraph.StyleId!);
                                 }
                                 AppendRuns(figCap, paragraph);

--- a/OfficeIMO.Word.Html/Options/WordToHtmlOptions.cs
+++ b/OfficeIMO.Word.Html/Options/WordToHtmlOptions.cs
@@ -4,6 +4,16 @@ namespace OfficeIMO.Word.Html {
     /// </summary>
     public class WordToHtmlOptions {
         /// <summary>
+        /// Maximum nested table depth exported from a Word document. The default is 128.
+        /// </summary>
+        public int MaxTableNestingDepth { get; set; } = 128;
+
+        /// <summary>
+        /// Maximum list nesting depth exported from a Word document. The default is 128.
+        /// </summary>
+        public int MaxListNestingDepth { get; set; } = 128;
+
+        /// <summary>
         /// Optional font family applied to created runs during conversion.
         /// </summary>
         public string? FontFamily { get; set; }

--- a/OfficeIMO.Word.Markdown/Converters/WordToMarkdownConverter.Ast.cs
+++ b/OfficeIMO.Word.Markdown/Converters/WordToMarkdownConverter.Ast.cs
@@ -19,6 +19,7 @@ using OmdTableCell = OfficeIMO.Markdown.TableCell;
 namespace OfficeIMO.Word.Markdown {
     internal partial class WordToMarkdownConverter {
         private int _visualFallbackResourceIndex;
+        private readonly HashSet<string> _exportedImageFileNames = new(StringComparer.OrdinalIgnoreCase);
 
         private sealed class PendingListFrame {
             public PendingListFrame(int level, bool ordered, IMarkdownListBlock block) {
@@ -47,6 +48,7 @@ namespace OfficeIMO.Word.Markdown {
 
         private void BuildMarkdownDocument(WordDocument document, MarkdownDoc markdown, WordToMarkdownOptions options, CancellationToken cancellationToken) {
             _visualFallbackResourceIndex = 0;
+            _exportedImageFileNames.Clear();
             var listIndices = DocumentTraversal.BuildListIndices(document);
             int sectionIndex = 0;
             foreach (var section in DocumentTraversal.EnumerateSections(document)) {
@@ -177,7 +179,7 @@ namespace OfficeIMO.Word.Markdown {
                 paragraphBlocks = extendedBlocks;
             }
 
-            EnsureListFrame(addRootBlock, listStack, listInfo, GetListStartForCurrentItem(paragraph, listInfo, listIndices));
+            EnsureListFrame(addRootBlock, listStack, listInfo, GetListStartForCurrentItem(paragraph, listInfo, listIndices), options.MaxListNestingDepth);
             var item = CreateListItem(paragraphBlocks, listInfo.Level, hasCheckbox, checkboxChecked);
             listStack[listStack.Count - 1].AddItem(item);
         }
@@ -237,8 +239,10 @@ namespace OfficeIMO.Word.Markdown {
             return block is HorizontalRuleBlock;
         }
 
-        private static void EnsureListFrame(Action<IMarkdownBlock> addRootBlock, List<PendingListFrame> listStack, DocumentTraversal.ListInfo listInfo, int start) {
-            int targetDepth = Math.Max(0, listInfo.Level) + 1;
+        private static void EnsureListFrame(Action<IMarkdownBlock> addRootBlock, List<PendingListFrame> listStack, DocumentTraversal.ListInfo listInfo, int start, int maximumDepth) {
+            int boundedLevel = ValidateListLevel(listInfo.Level, maximumDepth);
+
+            int targetDepth = boundedLevel + 1;
 
             while (listStack.Count > targetDepth) {
                 listStack.RemoveAt(listStack.Count - 1);
@@ -270,6 +274,16 @@ namespace OfficeIMO.Word.Markdown {
 
                 listStack.Add(new PendingListFrame(listStack.Count, ordered, block));
             }
+        }
+
+        private static int ValidateListLevel(int level, int maximumDepth) {
+            if (maximumDepth <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(WordToMarkdownOptions.MaxListNestingDepth), "MaxListNestingDepth must be greater than zero.");
+            }
+            if (level < 0 || level >= maximumDepth) {
+                throw new InvalidDataException($"The Word list level exceeds the {maximumDepth}-level Markdown nesting limit.");
+            }
+            return level;
         }
 
         private static OmdListItem CreateListItem(
@@ -343,16 +357,14 @@ namespace OfficeIMO.Word.Markdown {
                         hasRuns = false;
                     }
 
-                    ResolveParagraphCheckboxState(paragraph, out bool hasCheckbox, out bool checkboxChecked);
-                    int backscan = i - 1;
-                    while (backscan >= 0 && elements[backscan] is WordParagraph previous && previous.Equals(paragraph)) {
-                        ResolveParagraphCheckboxState(previous, out bool previousHasCheckbox, out bool previousCheckboxChecked);
-                        if (previousHasCheckbox) {
-                            hasCheckbox = true;
-                            checkboxChecked = previousCheckboxChecked;
-                        }
-                        backscan--;
+                    // A paragraph with runs is represented once per run. Only its first run needs
+                    // conversion; skipping the remaining wrappers before grouping avoids repeatedly
+                    // rescanning an attacker-controlled run group.
+                    if (hasRuns && !paragraph.IsFirstRun) {
+                        continue;
                     }
+
+                    ResolveParagraphCheckboxState(paragraph, out bool hasCheckbox, out bool checkboxChecked);
 
                     int scan = i + 1;
                     while (scan < elements.Count && elements[scan] is WordParagraph sibling && sibling.Equals(paragraph)) {
@@ -362,10 +374,6 @@ namespace OfficeIMO.Word.Markdown {
                             checkboxChecked = siblingCheckboxChecked;
                         }
                         scan++;
-                    }
-
-                    if (hasRuns && !paragraph.IsFirstRun) {
-                        continue;
                     }
 
                     var listInfo = DocumentTraversal.GetListInfo(paragraph);
@@ -505,7 +513,7 @@ namespace OfficeIMO.Word.Markdown {
                 if (allowQuoteHeuristic &&
                     paragraph.IndentationBefore.HasValue &&
                     paragraph.IndentationBefore.Value > 0) {
-                    int depth = (int)Math.Round(paragraph.IndentationBefore.Value / 720d);
+                    int depth = GetBoundedBlockquoteDepth(paragraph.IndentationBefore.Value);
                     if (depth > 0) {
                         block = WrapQuotedBlock(block, depth);
                     }
@@ -877,7 +885,7 @@ namespace OfficeIMO.Word.Markdown {
                 : new ParagraphBlock(inlines);
 
             if (allowQuoteHeuristic && paragraph.IndentationBefore.HasValue && paragraph.IndentationBefore.Value > 0) {
-                int depth = (int)Math.Round(paragraph.IndentationBefore.Value / 720d);
+                int depth = GetBoundedBlockquoteDepth(paragraph.IndentationBefore.Value);
                 if (depth > 0) {
                     block = WrapQuotedBlock(block, depth);
                 }
@@ -1664,25 +1672,15 @@ namespace OfficeIMO.Word.Markdown {
                     fileExtension = ".png";
                 }
 
-                string fileName = string.IsNullOrEmpty(image.FileName)
-                    ? Guid.NewGuid().ToString("N") + fileExtension
-                    : image.FileName!;
-                if (string.IsNullOrEmpty(Path.GetExtension(fileName))) {
-                    fileName += fileExtension;
-                }
+                string fileName = BuildSafeImageFileName(image.FileName, fileExtension);
 
                 string targetPath = Path.Combine(directory, fileName);
-
-                if (!string.IsNullOrEmpty(image.FilePath) && File.Exists(image.FilePath)) {
-                    File.Copy(image.FilePath, targetPath, true);
-                } else {
-                    OfficeFileCommit.WriteAllBytes(targetPath, image.ToBytes());
-                }
+                WriteImageFile(image, targetPath);
 
                 return fileName;
             }
 
-            byte[] bytes = image.ToBytes();
+            byte[] bytes = ReadEmbeddedImageBytes(image, options);
             string imageExtension = Path.GetExtension(image.FilePath);
             string mime = imageExtension switch {
                 ".jpg" => "image/jpeg",

--- a/OfficeIMO.Word.Markdown/Converters/WordToMarkdownConverter.Ast.cs
+++ b/OfficeIMO.Word.Markdown/Converters/WordToMarkdownConverter.Ast.cs
@@ -366,16 +366,6 @@ namespace OfficeIMO.Word.Markdown {
 
                     ResolveParagraphCheckboxState(paragraph, out bool hasCheckbox, out bool checkboxChecked);
 
-                    int scan = i + 1;
-                    while (scan < elements.Count && elements[scan] is WordParagraph sibling && sibling.Equals(paragraph)) {
-                        ResolveParagraphCheckboxState(sibling, out bool siblingHasCheckbox, out bool siblingCheckboxChecked);
-                        if (siblingHasCheckbox) {
-                            hasCheckbox = true;
-                            checkboxChecked = siblingCheckboxChecked;
-                        }
-                        scan++;
-                    }
-
                     var listInfo = DocumentTraversal.GetListInfo(paragraph);
                     if (listInfo != null) {
                         AddListParagraph(addRootBlock, listStack, paragraph, listInfo.Value, options, listIndices, hasCheckbox, checkboxChecked, trimBoundaryWhitespace);

--- a/OfficeIMO.Word.Markdown/Converters/WordToMarkdownConverter.Paragraphs.cs
+++ b/OfficeIMO.Word.Markdown/Converters/WordToMarkdownConverter.Paragraphs.cs
@@ -20,7 +20,7 @@ namespace OfficeIMO.Word.Markdown {
             var sb = new StringBuilder();
 
             if (paragraph.IndentationBefore.HasValue && paragraph.IndentationBefore.Value > 0) {
-                int depth = (int)Math.Round(paragraph.IndentationBefore.Value / 720d);
+                int depth = GetBoundedBlockquoteDepth(paragraph.IndentationBefore.Value);
                 if (depth > 0) {
                     sb.Append(string.Join(" ", Enumerable.Repeat(">", depth))).Append(' ');
                 }
@@ -35,8 +35,8 @@ namespace OfficeIMO.Word.Markdown {
 
             var listInfo = DocumentTraversal.GetListInfo(paragraph);
             if (listInfo != null) {
-                int level = listInfo.Value.Level;
-                sb.Append(new string(' ', level * 2));
+                int level = ValidateListLevel(listInfo.Value.Level, options.MaxListNestingDepth);
+                sb.Append(new string(' ', checked(level * 2)));
                 sb.Append(listInfo.Value.Ordered ? "1. " : "- ");
                 // Task list (checkbox) mapping — look across all runs in the underlying paragraph
                 bool hasCheckbox = hasCheckboxOverride ?? paragraph.IsCheckBox;
@@ -218,24 +218,14 @@ namespace OfficeIMO.Word.Markdown {
                 if (string.IsNullOrEmpty(extension)) {
                     extension = ".png";
                 }
-                string fileName = string.IsNullOrEmpty(image.FileName)
-                    ? Guid.NewGuid().ToString("N") + extension
-                    : image.FileName!;
-                if (string.IsNullOrEmpty(Path.GetExtension(fileName))) {
-                    fileName += extension;
-                }
+                string fileName = BuildSafeImageFileName(image.FileName, extension);
 
                 string targetPath = Path.Combine(directory, fileName);
-
-                if (!string.IsNullOrEmpty(image.FilePath) && File.Exists(image.FilePath)) {
-                    File.Copy(image.FilePath, targetPath, true);
-                } else {
-                    OfficeFileCommit.WriteAllBytes(targetPath, image.ToBytes());
-                }
+                WriteImageFile(image, targetPath);
 
                 return $"![{alt}]({fileName})";
             } else {
-                byte[] bytes = image.ToBytes();
+                byte[] bytes = ReadEmbeddedImageBytes(image, options);
                 string extension = Path.GetExtension(image.FilePath);
                 string mime = extension switch {
                     ".jpg" => "image/jpeg",
@@ -247,6 +237,92 @@ namespace OfficeIMO.Word.Markdown {
                 string base64 = System.Convert.ToBase64String(bytes);
                 return $"![{alt}](data:{mime};base64,{base64})";
             }
+        }
+
+        private const int MaximumBlockquoteDepth = 64;
+
+        private static int GetBoundedBlockquoteDepth(double indentationBefore) {
+            double computed = Math.Round(indentationBefore / 720d);
+            if (double.IsNaN(computed) || computed <= 0) {
+                return 0;
+            }
+
+            return computed >= MaximumBlockquoteDepth
+                ? MaximumBlockquoteDepth
+                : (int)computed;
+        }
+
+        private string BuildSafeImageFileName(string? suppliedName, string extension) {
+            string normalized = (suppliedName ?? string.Empty).Replace('\\', '/');
+            int separator = normalized.LastIndexOf('/');
+            if (separator >= 0) {
+                normalized = normalized.Substring(separator + 1);
+            }
+
+            normalized = Path.GetFileName(normalized);
+            var invalid = Path.GetInvalidFileNameChars();
+            var safe = new StringBuilder(normalized.Length);
+            foreach (char character in normalized) {
+                safe.Append(character < ' ' || invalid.Contains(character) ? '_' : character);
+            }
+
+            string fileName = safe.ToString().Trim();
+            if (string.IsNullOrEmpty(fileName) || fileName == "." || fileName == "..") {
+                fileName = Guid.NewGuid().ToString("N");
+            }
+
+            if (string.IsNullOrEmpty(Path.GetExtension(fileName))) {
+                fileName += extension;
+            }
+
+            if (_exportedImageFileNames.Add(fileName)) {
+                return fileName;
+            }
+
+            string baseName = Path.GetFileNameWithoutExtension(fileName);
+            string fileExtension = Path.GetExtension(fileName);
+            for (int suffix = 2; ; suffix++) {
+                string candidate = baseName + "-" + suffix.ToString(System.Globalization.CultureInfo.InvariantCulture) + fileExtension;
+                if (_exportedImageFileNames.Add(candidate)) {
+                    return candidate;
+                }
+            }
+        }
+
+        private static byte[] ReadEmbeddedImageBytes(WordImage image, WordToMarkdownOptions options) {
+            long maximumBytes = options.MaxEmbeddedImageBytes;
+            if (maximumBytes <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(options.MaxEmbeddedImageBytes), "MaxEmbeddedImageBytes must be greater than zero.");
+            }
+
+            using Stream input = image.OpenRead();
+            if (input.CanSeek && input.Length > maximumBytes) {
+                throw new InvalidDataException($"The embedded image exceeds the {maximumBytes}-byte Markdown limit.");
+            }
+
+            using var output = new MemoryStream();
+            var buffer = new byte[81920];
+            long total = 0;
+            while (true) {
+                int read = input.Read(buffer, 0, buffer.Length);
+                if (read == 0) break;
+                total += read;
+                if (total > maximumBytes) {
+                    throw new InvalidDataException($"The embedded image exceeds the {maximumBytes}-byte Markdown limit.");
+                }
+                output.Write(buffer, 0, read);
+            }
+
+            return output.ToArray();
+        }
+
+        private static void WriteImageFile(WordImage image, string targetPath) {
+            OfficeFileCommit.Write(targetPath, output => {
+                using Stream input = !string.IsNullOrEmpty(image.FilePath) && File.Exists(image.FilePath)
+                    ? File.OpenRead(image.FilePath)
+                    : image.OpenRead();
+                input.CopyTo(output);
+            });
         }
     }
 }

--- a/OfficeIMO.Word.Markdown/Options/WordToMarkdownOptions.cs
+++ b/OfficeIMO.Word.Markdown/Options/WordToMarkdownOptions.cs
@@ -32,6 +32,18 @@ namespace OfficeIMO.Word.Markdown {
         public string? ImageDirectory { get; set; }
 
         /// <summary>
+        /// Maximum number of image bytes that may be materialized for one base64 data URI.
+        /// The default is 32 MiB. Set a different positive value for trusted documents that
+        /// intentionally contain larger embedded images.
+        /// </summary>
+        public long MaxEmbeddedImageBytes { get; set; } = 32L * 1024L * 1024L;
+
+        /// <summary>
+        /// Maximum Word list nesting level materialized during conversion. The default is 128.
+        /// </summary>
+        public int MaxListNestingDepth { get; set; } = 128;
+
+        /// <summary>
         /// Emits externally linked images as Markdown image references instead of failing extraction.
         /// This keeps existing documents with linked or cid-based images convertible even when the
         /// binary image payload is not stored in the package.

--- a/OfficeIMO.Word.Markdown/WordMarkdownConverterExtensions.cs
+++ b/OfficeIMO.Word.Markdown/WordMarkdownConverterExtensions.cs
@@ -109,6 +109,8 @@ namespace OfficeIMO.Word.Markdown {
                 EnableHighlight = source.EnableHighlight,
                 ImageExportMode = source.ImageExportMode,
                 ImageDirectory = source.ImageDirectory,
+                MaxEmbeddedImageBytes = source.MaxEmbeddedImageBytes,
+                MaxListNestingDepth = source.MaxListNestingDepth,
                 FallbackExternalImagesToLinks = source.FallbackExternalImagesToLinks,
                 PageBreakMode = source.PageBreakMode,
                 UnsupportedContentMode = source.UnsupportedContentMode,

--- a/OfficeIMO.Word.Tests/Word.AddImageFromUrl.cs
+++ b/OfficeIMO.Word.Tests/Word.AddImageFromUrl.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading.Tasks;
+using OfficeIMO.Drawing;
 using OfficeIMO.Word;
 using Xunit;
 
@@ -28,7 +29,11 @@ namespace OfficeIMO.Tests {
             });
 
             using (var document = WordDocument.Create(filePath)) {
-                var img = await document.AddImageFromUrlAsync($"http://localhost:{port}/", 40, 40);
+                var img = await document.AddImageFromUrlAsync(
+                    $"http://localhost:{port}/",
+                    40,
+                    40,
+                    new OfficeRemoteImageLoadOptions { AllowPrivateNetworkAddresses = true });
                 Assert.NotNull(img);
                 document.Save();
             }

--- a/OfficeIMO.Word.Tests/Word.Fluent.ImageBuilder.cs
+++ b/OfficeIMO.Word.Tests/Word.Fluent.ImageBuilder.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO;
+using OfficeIMO.Drawing;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Fluent;
 using Xunit;
@@ -39,7 +40,9 @@ namespace OfficeIMO.Tests {
                     })
                     .Image(i => i.Add(bytes, "bytes.jpg").Size(70, 70).Align(HorizontalAlignment.Left));
                 await fluent.ImageAsync(async i => {
-                    await i.AddFromUrlAsync($"http://localhost:{port}/");
+                    await i.AddFromUrlAsync(
+                        $"http://localhost:{port}/",
+                        new OfficeRemoteImageLoadOptions { AllowPrivateNetworkAddresses = true });
                     i.Size(80, 80).Align(HorizontalAlignment.Center);
                 });
                 fluent.End();
@@ -108,7 +111,9 @@ namespace OfficeIMO.Tests {
 
             await Assert.ThrowsAsync<InvalidDataException>(async () => {
                 await document.AsFluent().ImageAsync(async i => {
-                    await i.AddFromUrlAsync($"http://localhost:{port}/");
+                    await i.AddFromUrlAsync(
+                        $"http://localhost:{port}/",
+                        new OfficeRemoteImageLoadOptions { AllowPrivateNetworkAddresses = true });
                 });
             });
 

--- a/OfficeIMO.Word.Tests/Word.Security.AllSeverityBatch13.cs
+++ b/OfficeIMO.Word.Tests/Word.Security.AllSeverityBatch13.cs
@@ -1,0 +1,170 @@
+using System.Diagnostics;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Fluent;
+using OfficeIMO.Word.Markdown;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class WordAllSeverityBatch13SecurityTests {
+    [Fact]
+    public void MarkdownConversionProcessesEqualRunGroupsInLinearTime() {
+        using WordDocument document = WordDocument.Create();
+        WordParagraph paragraph = document.AddParagraph();
+        for (int index = 0; index < 3000; index++) {
+            paragraph.AddText("x");
+        }
+
+        var stopwatch = Stopwatch.StartNew();
+        string markdown = document.ToMarkdown();
+        stopwatch.Stop();
+
+        Assert.Equal(3000, markdown.Count(character => character == 'x'));
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(10), $"Conversion took {stopwatch.Elapsed}.");
+    }
+
+    [Fact]
+    public void MarkdownConversionCapsBlockquoteDepth() {
+        using WordDocument document = WordDocument.Create();
+        WordParagraph paragraph = document.AddParagraph("bounded");
+        paragraph.IndentationBefore = int.MaxValue;
+
+        string markdown = document.ToMarkdown();
+
+        Assert.Equal(64, markdown.TakeWhile(character => character == '>' || character == ' ').Count(character => character == '>'));
+        Assert.Contains("bounded", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MarkdownImageExportSanitizesHostileFileNames() {
+        string imagePath = Path.Combine(AppContext.BaseDirectory, "Images", "Kulek.jpg");
+        string root = Path.Combine(Path.GetTempPath(), "officeimo-md-image-" + Guid.NewGuid().ToString("N"));
+        string output = Path.Combine(root, "images");
+        string escaped = Path.Combine(root, "logo.jpg");
+        Directory.CreateDirectory(output);
+        try {
+            using WordDocument source = WordDocument.Create();
+            source.AddParagraph().AddImage(imagePath, 16, 16);
+            source.AddParagraph().AddImage(imagePath, 16, 16);
+            using WordDocument document = WordDocument.Load(new MemoryStream(source.ToBytes(), writable: false));
+            WordImage[] images = document.Images.ToArray();
+            images[0].FileName = "../a/logo.jpg";
+            images[1].FileName = "../b/logo.jpg";
+
+            string markdown = document.ToMarkdown(new WordToMarkdownOptions {
+                ImageExportMode = ImageExportMode.File,
+                ImageDirectory = output
+            });
+
+            Assert.False(File.Exists(escaped));
+            string[] exported = Directory.GetFiles(output);
+            Assert.Equal(2, exported.Length);
+            Assert.Equal(2, exported.Select(Path.GetFileName).Distinct(StringComparer.OrdinalIgnoreCase).Count());
+            Assert.All(exported, path => Assert.StartsWith(
+                Path.GetFullPath(output) + Path.DirectorySeparatorChar,
+                Path.GetFullPath(path),
+                StringComparison.Ordinal));
+            Assert.Contains("logo.jpg", markdown, StringComparison.Ordinal);
+            Assert.Contains("logo-2.jpg", markdown, StringComparison.Ordinal);
+            Assert.DoesNotContain("..", markdown, StringComparison.Ordinal);
+        } finally {
+            if (Directory.Exists(root)) Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void MarkdownBase64EmbeddingEnforcesImageByteLimitBeforeMaterialization() {
+        string imagePath = Path.Combine(AppContext.BaseDirectory, "Images", "Kulek.jpg");
+        using WordDocument source = WordDocument.Create();
+        source.AddParagraph().AddImage(imagePath, 16, 16);
+        using WordDocument document = WordDocument.Load(new MemoryStream(source.ToBytes(), writable: false));
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+            document.ToMarkdown(new WordToMarkdownOptions { MaxEmbeddedImageBytes = 1 }));
+
+        Assert.Contains("embedded image", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void FluentRegexSearchHonorsPerMatchTimeout() {
+        using WordDocument document = WordDocument.Create();
+        document.AddParagraph(new string('a', 50_000) + "!");
+
+        Assert.Throws<RegexMatchTimeoutException>(() =>
+            document.AsFluent().FindRegex("^(a+)+$", TimeSpan.FromMilliseconds(1), _ => { }));
+    }
+
+    [Fact]
+    public void ListTraversalRejectsHostileNumberingLevels() {
+        using var stream = new MemoryStream();
+        using (WordprocessingDocument package = WordprocessingDocument.Create(stream, WordprocessingDocumentType.Document)) {
+            MainDocumentPart main = package.AddMainDocumentPart();
+            main.Document = new Document(new Body(
+                new Paragraph(
+                    new ParagraphProperties(
+                        new NumberingProperties(
+                            new NumberingLevelReference { Val = int.MaxValue },
+                            new NumberingId { Val = 1 })),
+                    new Run(new Text("item")))));
+            main.Document.Save();
+
+            Assert.Throws<InvalidDataException>(() => WordListTraversal.Traverse(package, 8).ToList());
+        }
+
+        stream.Position = 0;
+        using WordDocument document = WordDocument.Load(stream);
+        Assert.Throws<InvalidDataException>(() =>
+            document.ToMarkdown(new WordToMarkdownOptions { MaxListNestingDepth = 8 }));
+        Assert.Throws<InvalidDataException>(() =>
+            document.ExtractMarkdownChunks(
+                new WordToMarkdownOptions { MaxListNestingDepth = 8 }).ToList());
+    }
+
+    [Fact]
+    public void AddImageVmlRejectsNonImagePayloadWithoutAddingAnImagePart() {
+        string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".png");
+        File.WriteAllText(path, "not an image");
+        try {
+            using WordDocument document = WordDocument.Create();
+            WordParagraph paragraph = document.AddParagraph();
+
+            Assert.Throws<InvalidDataException>(() => paragraph.AddImageVml(path, 16, 16));
+            Assert.Empty(document.Images);
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void MacroParserStopsOnCyclicDirectorySectorChain() {
+        byte[] compound = CreateCyclicCompoundFile();
+        Type parser = typeof(WordMacro).GetNestedType("Parser", BindingFlags.NonPublic)!;
+        MethodInfo method = parser.GetMethod("GetModuleNames", BindingFlags.Static | BindingFlags.NonPublic)!;
+        using var stream = new MemoryStream(compound, writable: false);
+
+        var modules = (IReadOnlyList<string>)method.Invoke(null, new object[] { stream })!;
+
+        Assert.Empty(modules);
+    }
+
+    private static byte[] CreateCyclicCompoundFile() {
+        const int sectorSize = 512;
+        byte[] data = new byte[sectorSize * 3];
+        BitConverter.GetBytes(0xE11AB1A1E011CFD0UL).CopyTo(data, 0);
+        BitConverter.GetBytes((ushort)9).CopyTo(data, 0x1E);
+        BitConverter.GetBytes(1).CopyTo(data, 0x30);
+        for (int index = 0; index < 109; index++) {
+            BitConverter.GetBytes(-1).CopyTo(data, 0x4C + index * 4);
+        }
+        BitConverter.GetBytes(0).CopyTo(data, 0x4C);
+        int fatOffset = sectorSize;
+        BitConverter.GetBytes(unchecked((int)0xFFFFFFFD)).CopyTo(data, fatOffset);
+        BitConverter.GetBytes(1).CopyTo(data, fatOffset + 4);
+        return data;
+    }
+}

--- a/OfficeIMO.Word/Fluent/ImageBuilder.cs
+++ b/OfficeIMO.Word/Fluent/ImageBuilder.cs
@@ -69,6 +69,18 @@ namespace OfficeIMO.Word.Fluent {
         }
 
         /// <summary>
+        /// Asynchronously downloads and adds an image using an explicit remote-network policy.
+        /// </summary>
+        public async Task<ImageBuilder> AddFromUrlAsync(
+            string url,
+            OfficeRemoteImageLoadOptions remoteImageOptions,
+            CancellationToken cancellationToken = default) {
+            if (remoteImageOptions == null) throw new ArgumentNullException(nameof(remoteImageOptions));
+            OfficeRemoteImage image = await OfficeRemoteImageLoader.LoadAsync(url, remoteImageOptions, cancellationToken).ConfigureAwait(false);
+            return Add(image.ToBytes(), image.FileName);
+        }
+
+        /// <summary>
         /// Sets the size of the image in pixels.
         /// </summary>
         /// <param name="width">Image width in pixels.</param>

--- a/OfficeIMO.Word/Fluent/WordFluentDocument.cs
+++ b/OfficeIMO.Word/Fluent/WordFluentDocument.cs
@@ -320,6 +320,19 @@ namespace OfficeIMO.Word.Fluent {
         }
 
         /// <summary>
+        /// Finds runs matching the specified regular expression pattern using a caller-supplied match timeout.
+        /// </summary>
+        /// <param name="pattern">Regular expression pattern.</param>
+        /// <param name="matchTimeout">Maximum time allowed for one regex match.</param>
+        /// <param name="action">Action executed for each matching run.</param>
+        public WordFluentDocument FindRegex(string pattern, TimeSpan matchTimeout, Action<ParagraphBuilder> action) {
+            foreach (var run in Document.FindRunsRegex(pattern, matchTimeout)) {
+                action(new ParagraphBuilder(this, run));
+            }
+            return this;
+        }
+
+        /// <summary>
         /// Selects paragraphs that match the specified predicate.
         /// </summary>
         /// <param name="predicate">Filter predicate.</param>

--- a/OfficeIMO.Word/Helpers/ImageEmbedder.cs
+++ b/OfficeIMO.Word/Helpers/ImageEmbedder.cs
@@ -32,9 +32,29 @@ namespace OfficeIMO.Word {
             MainDocumentPart mainPart,
             string src,
             CancellationToken cancellationToken = default) {
+            return await CreateImageRunCoreAsync(mainPart, src, null, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Creates an image run using an explicit policy for HTTP and HTTPS sources.
+        /// </summary>
+        public static Task<Run> CreateImageRunAsync(
+            MainDocumentPart mainPart,
+            string src,
+            OfficeRemoteImageLoadOptions remoteImageOptions,
+            CancellationToken cancellationToken = default) {
+            if (remoteImageOptions == null) throw new ArgumentNullException(nameof(remoteImageOptions));
+            return CreateImageRunCoreAsync(mainPart, src, remoteImageOptions, cancellationToken);
+        }
+
+        private static async Task<Run> CreateImageRunCoreAsync(
+            MainDocumentPart mainPart,
+            string src,
+            OfficeRemoteImageLoadOptions? remoteImageOptions,
+            CancellationToken cancellationToken) {
             if (Uri.TryCreate(src, UriKind.Absolute, out Uri? uri)
                 && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps)) {
-                OfficeRemoteImage image = await OfficeRemoteImageLoader.LoadAsync(src, cancellationToken: cancellationToken).ConfigureAwait(false);
+                OfficeRemoteImage image = await OfficeRemoteImageLoader.LoadAsync(src, remoteImageOptions, cancellationToken).ConfigureAwait(false);
                 return CreateImageRun(mainPart, image.ToBytes());
             }
 

--- a/OfficeIMO.Word/WordDocument.Enumerators.cs
+++ b/OfficeIMO.Word/WordDocument.Enumerators.cs
@@ -5,6 +5,7 @@ namespace OfficeIMO.Word {
     /// Provides enumerators for traversing document content.
     /// </summary>
     public partial class WordDocument {
+        private static readonly TimeSpan DefaultRegexMatchTimeout = TimeSpan.FromSeconds(2);
         internal IEnumerable<WordParagraph> EnumerateBodyParagraphs() {
             foreach (var paragraph in this.Paragraphs) {
                 yield return paragraph;
@@ -59,7 +60,15 @@ namespace OfficeIMO.Word {
         }
 
         internal IEnumerable<WordParagraph> FindRunsRegex(string pattern) {
-            var regex = new Regex(pattern);
+            return FindRunsRegex(pattern, DefaultRegexMatchTimeout);
+        }
+
+        internal IEnumerable<WordParagraph> FindRunsRegex(string pattern, TimeSpan matchTimeout) {
+            var regex = new Regex(pattern, RegexOptions.None, matchTimeout);
+            return FindRunsRegex(regex);
+        }
+
+        private IEnumerable<WordParagraph> FindRunsRegex(Regex regex) {
             foreach (var paragraph in EnumerateAllParagraphs()) {
                 foreach (var run in paragraph.GetRuns()) {
                     if (run.Text != null && regex.IsMatch(run.Text)) {

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -154,7 +154,29 @@ namespace OfficeIMO.Word {
             double? width = null,
             double? height = null,
             CancellationToken cancellationToken = default) {
-            OfficeRemoteImage image = await OfficeRemoteImageLoader.LoadAsync(url, cancellationToken: cancellationToken).ConfigureAwait(false);
+            return await AddImageFromUrlCoreAsync(url, width, height, null, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Downloads an image with explicit remote-network policy and inserts it into the document.
+        /// </summary>
+        public Task<WordImage> AddImageFromUrlAsync(
+            string url,
+            double? width,
+            double? height,
+            OfficeRemoteImageLoadOptions remoteImageOptions,
+            CancellationToken cancellationToken = default) {
+            if (remoteImageOptions == null) throw new ArgumentNullException(nameof(remoteImageOptions));
+            return AddImageFromUrlCoreAsync(url, width, height, remoteImageOptions, cancellationToken);
+        }
+
+        private async Task<WordImage> AddImageFromUrlCoreAsync(
+            string url,
+            double? width,
+            double? height,
+            OfficeRemoteImageLoadOptions? remoteImageOptions,
+            CancellationToken cancellationToken) {
+            OfficeRemoteImage image = await OfficeRemoteImageLoader.LoadAsync(url, remoteImageOptions, cancellationToken).ConfigureAwait(false);
             using var ms = image.ToStream();
             var paragraph = AddParagraph();
             paragraph.AddImage(ms, image.FileName, width, height);

--- a/OfficeIMO.Word/WordImage.Content.cs
+++ b/OfficeIMO.Word/WordImage.Content.cs
@@ -281,11 +281,10 @@ namespace OfficeIMO.Word {
                 // if widht/height are not set we check ourselves
                 // but probably will need better way
                 var imageCharacteristics = Helpers.GetImageCharacteristics(preparedImageStream, fileName);
+                if (imageCharacteristics.Width <= 0 || imageCharacteristics.Height <= 0) {
+                    throw new InvalidDataException("The stream does not contain a supported image payload.");
+                }
                 if (width == null || height == null) {
-                    if (imageCharacteristics.Width == 0 || imageCharacteristics.Height == 0) {
-                        throw new ArgumentException("Width and height must be provided for this image type.");
-                    }
-
                     if (width != null) {
                         height = imageCharacteristics.Height * width.Value / imageCharacteristics.Width;
                     } else if (height != null) {

--- a/OfficeIMO.Word/WordListTraversal.cs
+++ b/OfficeIMO.Word/WordListTraversal.cs
@@ -61,6 +61,9 @@ namespace OfficeIMO.Word {
     /// Provides utilities to traverse list structures within a document.
     /// </summary>
     public static class WordListTraversal {
+        /// <summary>Default maximum number of nested Word list levels.</summary>
+        public const int DefaultMaximumNestingDepth = 128;
+
         /// <summary>
         /// Traverses the body of the provided document emitting events for list structures
         /// and standalone paragraphs. This helper enables converters to reuse list handling
@@ -69,8 +72,22 @@ namespace OfficeIMO.Word {
         /// <param name="document">Document to traverse.</param>
         /// <returns>Sequence of events describing lists and paragraphs.</returns>
         public static IEnumerable<WordListEvent> Traverse(WordprocessingDocument document) {
+            return Traverse(document, DefaultMaximumNestingDepth);
+        }
+
+        /// <summary>
+        /// Traverses document lists while rejecting numbering levels that would require an
+        /// excessive amount of synthetic stack work.
+        /// </summary>
+        /// <param name="document">Document to traverse.</param>
+        /// <param name="maximumNestingDepth">Maximum allowed list nesting depth.</param>
+        /// <returns>Sequence of events describing lists and paragraphs.</returns>
+        public static IEnumerable<WordListEvent> Traverse(WordprocessingDocument document, int maximumNestingDepth) {
             if (document == null) {
                 throw new ArgumentNullException(nameof(document));
+            }
+            if (maximumNestingDepth <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(maximumNestingDepth));
             }
 
             Dictionary<int, bool> listTypes = GetListTypes(document);
@@ -90,6 +107,9 @@ namespace OfficeIMO.Word {
                 NumberingProperties? numProps = paragraph.ParagraphProperties?.NumberingProperties;
                 if (numProps != null) {
                     int level = numProps.NumberingLevelReference?.Val ?? 0;
+                    if (level < 0 || level >= maximumNestingDepth) {
+                        throw new InvalidDataException($"The Word list level {level} exceeds the {maximumNestingDepth}-level traversal limit.");
+                    }
                     int numId = numProps.NumberingId?.Val ?? 0;
                     bool ordered = listTypes.ContainsKey(numId) && listTypes[numId];
 

--- a/OfficeIMO.Word/WordMacro.cs
+++ b/OfficeIMO.Word/WordMacro.cs
@@ -245,16 +245,19 @@ namespace OfficeIMO.Word {
                 if (BitConverter.ToUInt64(header, 0) != Signature) return modules;
 
                 ushort sectorShift = BitConverter.ToUInt16(header, 0x1E);
+                if (!stream.CanSeek || (sectorShift != 9 && sectorShift != 12)) return modules;
                 int sectorSize = 1 << sectorShift;
+                int maximumSectorCount = GetMaximumSectorCount(stream, sectorSize);
+                if (maximumSectorCount <= 0) return modules;
                 int dirStart = BitConverter.ToInt32(header, 0x30);
 
                 var fatSectors = new List<int>();
                 for (int i = 0; i < 109; i++) {
                     int s = BitConverter.ToInt32(header, 0x4C + i * 4);
-                    if (s >= 0) fatSectors.Add(s);
+                    if (s >= 0 && s < maximumSectorCount) fatSectors.Add(s);
                 }
-                var fat = ReadFat(stream, reader, fatSectors, sectorSize);
-                byte[] dirData = ReadChain(stream, reader, dirStart, sectorSize, fat);
+                var fat = ReadFat(stream, reader, fatSectors, sectorSize, maximumSectorCount);
+                byte[] dirData = ReadChain(stream, reader, dirStart, sectorSize, fat, maximumSectorCount);
                 if (dirData.Length == 0) return modules;
 
                 var entries = ParseDirectory(dirData);
@@ -299,19 +302,28 @@ namespace OfficeIMO.Word {
                 if (BitConverter.ToUInt64(header, 0) != Signature) return false;
 
                 ushort sectorShift = BitConverter.ToUInt16(header, 0x1E);
+                if (!stream.CanSeek || (sectorShift != 9 && sectorShift != 12)) return false;
                 int sectorSize = 1 << sectorShift;
+                int maximumSectorCount = GetMaximumSectorCount(stream, sectorSize);
+                if (maximumSectorCount <= 0) return false;
                 int dirStart = BitConverter.ToInt32(header, 0x30);
 
                 var fatSectors = new List<int>();
                 for (int i = 0; i < 109; i++) {
                     int s = BitConverter.ToInt32(header, 0x4C + i * 4);
-                    if (s >= 0) fatSectors.Add(s);
+                    if (s >= 0 && s < maximumSectorCount) fatSectors.Add(s);
                 }
-                var fat = ReadFat(stream, reader, fatSectors, sectorSize);
+                var fat = ReadFat(stream, reader, fatSectors, sectorSize, maximumSectorCount);
                 int perSector = sectorSize / 128;
                 int sector = dirStart;
-                while (sector != EndOfChain && sector >= 0 && sector < fat.Count) {
+                var visitedSectors = new HashSet<int>();
+                while (sector != EndOfChain
+                    && sector >= 0
+                    && sector < fat.Count
+                    && sector < maximumSectorCount
+                    && visitedSectors.Add(sector)) {
                     long sectorPos = (long)(sector + 1) * sectorSize;
+                    if (sectorPos < 0 || sectorPos > stream.Length - sectorSize) return false;
                     stream.Position = sectorPos;
                     byte[] buffer = reader.ReadBytes(sectorSize);
                     bool modified = false;
@@ -319,7 +331,7 @@ namespace OfficeIMO.Word {
                         int offset = i * 128;
                         if (offset + 128 > buffer.Length) break;
                         ushort nameLen = BitConverter.ToUInt16(buffer, offset + 64);
-                        if (nameLen <= 2) continue;
+                        if (nameLen <= 2 || nameLen > 64 || (nameLen & 1) != 0) continue;
                         string name = Encoding.Unicode.GetString(buffer, offset, nameLen - 2);
                         byte type = buffer[offset + 66];
                         if (type == 2 && !IsReserved(name) && string.Equals(name, moduleName, StringComparison.OrdinalIgnoreCase)) {
@@ -345,12 +357,14 @@ namespace OfficeIMO.Word {
             /// <summary>
             /// Reads the File Allocation Table sectors.
             /// </summary>
-            private static List<int> ReadFat(Stream stream, BinaryReader reader, List<int> fatSectors, int sectorSize) {
+            private static List<int> ReadFat(Stream stream, BinaryReader reader, List<int> fatSectors, int sectorSize, int maximumSectorCount) {
                 var fat = new List<int>();
                 int perSector = sectorSize / 4;
                 foreach (int sec in fatSectors) {
-                    if (sec < 0) continue;
-                    stream.Position = (long)(sec + 1) * sectorSize;
+                    if (sec < 0 || sec >= maximumSectorCount) continue;
+                    long sectorPosition = (long)(sec + 1) * sectorSize;
+                    if (sectorPosition < 0 || sectorPosition > stream.Length - sectorSize) continue;
+                    stream.Position = sectorPosition;
                     for (int i = 0; i < perSector; i++) fat.Add(reader.ReadInt32());
                 }
                 return fat;
@@ -359,17 +373,32 @@ namespace OfficeIMO.Word {
             /// <summary>
             /// Reads a chain of sectors from the compound file.
             /// </summary>
-            private static byte[] ReadChain(Stream stream, BinaryReader reader, int start, int sectorSize, List<int> fat) {
+            private static byte[] ReadChain(Stream stream, BinaryReader reader, int start, int sectorSize, List<int> fat, int maximumSectorCount) {
                 if (start < 0) return Array.Empty<byte>();
                 using var ms = new MemoryStream();
                 int sector = start;
-                while (sector != EndOfChain && sector >= 0 && sector < fat.Count) {
-                    stream.Position = (long)(sector + 1) * sectorSize;
+                var visited = new HashSet<int>();
+                while (sector != EndOfChain
+                    && sector >= 0
+                    && sector < fat.Count
+                    && sector < maximumSectorCount
+                    && visited.Add(sector)) {
+                    long sectorPosition = (long)(sector + 1) * sectorSize;
+                    if (sectorPosition < 0 || sectorPosition > stream.Length - sectorSize) break;
+                    stream.Position = sectorPosition;
                     byte[] buffer = reader.ReadBytes(sectorSize);
+                    if (buffer.Length != sectorSize) break;
                     ms.Write(buffer, 0, buffer.Length);
                     sector = fat[sector];
                 }
                 return ms.ToArray();
+            }
+
+            private static int GetMaximumSectorCount(Stream stream, int sectorSize) {
+                long dataBytes = stream.Length - 512L;
+                if (dataBytes < sectorSize) return 0;
+                long sectors = dataBytes / sectorSize;
+                return sectors > int.MaxValue ? int.MaxValue : (int)sectors;
             }
 
             /// <summary>
@@ -379,7 +408,9 @@ namespace OfficeIMO.Word {
                 var list = new List<DirEntry>(data.Length / 128);
                 for (int offset = 0; offset + 128 <= data.Length; offset += 128) {
                     ushort nameLen = BitConverter.ToUInt16(data, offset + 64);
-                    string name = nameLen > 0 ? Encoding.Unicode.GetString(data, offset, nameLen - 2) : string.Empty;
+                    string name = nameLen >= 2 && nameLen <= 64 && (nameLen & 1) == 0
+                        ? Encoding.Unicode.GetString(data, offset, nameLen - 2)
+                        : string.Empty;
                     byte type = data[offset + 66];
                     int left = BitConverter.ToInt32(data, offset + 68);
                     int right = BitConverter.ToInt32(data, offset + 72);

--- a/OfficeIMO.Word/WordParagraph.PublicMethods.Shapes.cs
+++ b/OfficeIMO.Word/WordParagraph.PublicMethods.Shapes.cs
@@ -20,13 +20,15 @@ namespace OfficeIMO.Word {
         /// </summary>
         public WordParagraph AddImageVml(string filePathImage, double? width = null, double? height = null) {
             var run = this.VerifyRun();
-            MainDocumentPart mainPart = _document._wordprocessingDocument.MainDocumentPart!;
-
-            var imagePart = mainPart.AddImagePart(ImagePartType.Png);
-            using (var fs = File.OpenRead(filePathImage)) {
-                imagePart.FeedData(fs);
-            }
-            var relId = mainPart.GetIdOfPart(imagePart);
+            using var fs = File.OpenRead(filePathImage);
+            WordImageLocation imageLocation = WordImage.AddImageToLocation(
+                _document,
+                this,
+                fs,
+                Path.GetFileName(filePathImage),
+                width,
+                height);
+            string relId = imageLocation.RelationshipId;
 
             string style = "mso-wrap-style:square";
             if (width.HasValue) style = $"width:{width}pt;" + style;


### PR DESCRIPTION
This batch resolves 16 validated Codex Security findings across Word, Excel, HTML, Drawing, and Visio.

- reject private-network image URLs by default while providing an explicit trusted-intranet opt-in
- bound Excel package materialization, Visio archive expansion, Word list/field traversal, Markdown nesting and embedded images, and VBA project parsing
- sanitize generated HTML styles and Markdown export names, and prevent output-path collisions
- keep large Excel save transforms disk-backed instead of materializing them in memory
- add regression coverage for each security boundary

Private or loopback image sources now require an explicit option:

```csharp
new OfficeRemoteImageLoadOptions {
    AllowPrivateNetworkAddresses = true
}
```

Existing public-network image calls retain their current API shape and use the secure default.