### PR TITLE
Harden metadata handling and document conversion boundaries

### DIFF
--- a/OfficeIMO.Email.Tests/Mime/EmailMimeMetadataTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailMimeMetadataTests.cs
@@ -112,7 +112,7 @@ public sealed class EmailMimeMetadataTests {
     }
 
     [Fact]
-    public void RetainsMetadataHeadersThatCannotBeProjected() {
+    public void DoesNotRetainRawMetadataHeadersThatCannotBeProjected() {
         byte[] eml = Encoding.ASCII.GetBytes(
             "Importance: critical\r\nPriority: immediate\r\nX-Unsent: maybe\r\n" +
             "Content-Type: text/plain; charset=utf-8\r\n\r\nBody\r\n");
@@ -122,8 +122,29 @@ public sealed class EmailMimeMetadataTests {
         using var stream = new MemoryStream(output);
         MimeMessage message = MimeMessage.Load(stream);
 
-        Assert.Equal("critical", message.Headers["Importance"]);
-        Assert.Equal("immediate", message.Headers["Priority"]);
-        Assert.Equal("maybe", message.Headers["X-Unsent"]);
+        Assert.Null(message.Headers["Importance"]);
+        Assert.Null(message.Headers["Priority"]);
+        Assert.Null(message.Headers["X-Unsent"]);
+    }
+
+    [Fact]
+    public void ClearingTypedMetadataDoesNotResurrectRetainedRawHeaders() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Importance: high\r\nPriority: urgent\r\nX-Unsent: 1\r\n" +
+            "Keywords: Secret Project\r\nContent-Type: text/plain; charset=utf-8\r\n\r\nBody\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+        document.MessageMetadata.Importance = null;
+        document.MessageMetadata.Priority = null;
+        document.MessageMetadata.IsDraft = false;
+        document.MessageMetadata.Categories.Clear();
+
+        using var stream = new MemoryStream(new EmailDocumentWriter().ToBytes(document, EmailFileFormat.Eml));
+        MimeMessage message = MimeMessage.Load(stream);
+
+        Assert.Null(message.Headers["Importance"]);
+        Assert.Null(message.Headers["X-Priority"]);
+        Assert.Null(message.Headers["Priority"]);
+        Assert.Null(message.Headers["X-Unsent"]);
+        Assert.Null(message.Headers["Keywords"]);
     }
 }

--- a/OfficeIMO.Email/Mime/MimeWriter.cs
+++ b/OfficeIMO.Email/Mime/MimeWriter.cs
@@ -4,7 +4,8 @@ internal static class MimeWriter {
     private static readonly HashSet<string> ManagedHeaders = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
         "Subject", "From", "Sender", "To", "Cc", "Bcc", "Reply-To", "Date", "Message-ID",
         "References", "In-Reply-To", "MIME-Version", "Content-Type", "Content-Transfer-Encoding",
-        "Content-Disposition"
+        "Content-Disposition", "Disposition-Notification-To", "Return-Receipt-To", "X-Unsent",
+        "Sensitivity", "Status", "Keywords", "Importance", "X-Priority", "Priority"
     };
 
     internal static byte[] Write(EmailDocument document, EmailWriterOptions options, IList<EmailDiagnostic> diagnostics) {

--- a/OfficeIMO.Excel.Tests/Excel.ImageExport.HeaderFooter.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ImageExport.HeaderFooter.cs
@@ -98,7 +98,8 @@ namespace OfficeIMO.Tests {
             IReadOnlyList<OfficeImageExportResult> results = sheet.ExportImages(OfficeImageExportFormat.Svg, new ExcelWorksheetImageExportOptions {
                 Range = "A1:AZ4",
                 SplitByManualPageBreaks = true,
-                ShowGridlines = false
+                ShowGridlines = false,
+                IncludeWorkbookPathInHeaderFooter = true
             });
 
             string svg = Encoding.UTF8.GetString(results[1].Bytes);

--- a/OfficeIMO.Excel.Tests/Excel.Security.AllSeverityBatch14.cs
+++ b/OfficeIMO.Excel.Tests/Excel.Security.AllSeverityBatch14.cs
@@ -1,0 +1,104 @@
+using System.Data;
+using System.Text;
+using DocumentFormat.OpenXml.CustomProperties;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.VariantTypes;
+using OfficeIMO.Drawing;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class ExcelAllSeverityBatch14SecurityTests {
+    [Fact]
+    public void DirectDataSetFastSaveHonorsSignedWorkbookMutationPolicy() {
+        var table = new DataTable("Data");
+        table.Columns.Add("Value", typeof(string));
+        table.Rows.Add("safe");
+        var dataSet = new DataSet("Export");
+        dataSet.Tables.Add(table);
+
+        using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+        document.InsertDataSet(dataSet, autoFit: false);
+        document._spreadSheetDocument.AddDigitalSignatureOriginPart();
+
+        Assert.Throws<ExcelSignedWorkbookMutationException>(() => document.ToBytes());
+    }
+
+    [Fact]
+    public void CustomFormulaDoesNotInvokeCallbackForNonFiniteArguments() {
+        using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+        int callbackCount = 0;
+        document.Calculation.RegisterCustomFunction("ECHOFINITE", (_, arguments) => {
+            callbackCount++;
+            return arguments[0];
+        });
+        ExcelSheet sheet = document.AddWorksheet("Data");
+        sheet.CellFormula(1, 1, "ECHOFINITE(1E309)");
+
+        Exception? exception = Record.Exception(() => document.Calculate());
+
+        Assert.Null(exception);
+        Assert.Equal(0, callbackCount);
+    }
+
+    [Fact]
+    public void HeaderFooterPathFieldsRequireExplicitExportOptIn() {
+        string root = Path.Combine(Path.GetTempPath(), "officeimo-header-path-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        string workbookPath = Path.Combine(root, "report.xlsx");
+        try {
+            using ExcelDocument document = ExcelDocument.Create(workbookPath);
+            ExcelSheet sheet = document.AddWorksheet("Report");
+            sheet.CellValue(1, 1, "body");
+            sheet.SetHeaderFooter(headerLeft: "Path &[Path] &Z");
+
+            string defaultSvg = Encoding.UTF8.GetString(Assert.Single(sheet.ExportImages(
+                OfficeImageExportFormat.Svg,
+                new ExcelWorksheetImageExportOptions {
+                    Range = "A1:AZ2",
+                    SplitByManualPageBreaks = true
+                })).Bytes);
+            string optedInSvg = Encoding.UTF8.GetString(Assert.Single(sheet.ExportImages(
+                OfficeImageExportFormat.Svg,
+                new ExcelWorksheetImageExportOptions {
+                    Range = "A1:AZ2",
+                    SplitByManualPageBreaks = true,
+                    IncludeWorkbookPathInHeaderFooter = true
+                })).Bytes);
+
+            Assert.DoesNotContain(root, defaultSvg, StringComparison.Ordinal);
+            Assert.Contains(root, optedInSvg, StringComparison.Ordinal);
+        } finally {
+            if (Directory.Exists(root)) Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void LoadSkipsMalformedCustomPropertiesAndRetainsValidOnes() {
+        string path = Path.Combine(Path.GetTempPath(), "officeimo-custom-property-" + Guid.NewGuid().ToString("N") + ".xlsx");
+        try {
+            using (ExcelDocument document = ExcelDocument.Create(path)) {
+                document.SetCustomDocumentProperty("Valid", "retained");
+                document.AddWorksheet("Data").CellValue(1, 1, "body");
+                document.Save();
+            }
+
+            using (SpreadsheetDocument package = SpreadsheetDocument.Open(path, true)) {
+                CustomFilePropertiesPart part = package.CustomFilePropertiesPart!;
+                part.Properties!.Append(new CustomDocumentProperty(new VTInt32("not-an-integer")) {
+                    FormatId = "{D5CDD505-2E9C-101B-9397-08002B2CF9AE}",
+                    PropertyId = 99,
+                    Name = "Malformed"
+                });
+                part.Properties.Save();
+            }
+
+            using ExcelDocument loaded = ExcelDocument.Load(path);
+            Assert.Equal("retained", loaded.CustomDocumentProperties["Valid"].Text);
+            Assert.False(loaded.CustomDocumentProperties.ContainsKey("Malformed"));
+        } finally {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelDocument.CustomDocumentProperties.cs
+++ b/OfficeIMO.Excel/ExcelDocument.CustomDocumentProperties.cs
@@ -60,7 +60,13 @@ namespace OfficeIMO.Excel {
                     continue;
                 }
 
-                loadedProperties[property.Name!.Value!] = new ExcelCustomProperty(property);
+                try {
+                    loadedProperties[property.Name!.Value!] = new ExcelCustomProperty(property);
+                } catch (Exception exception) when (exception is FormatException
+                                                     || exception is OverflowException
+                                                     || exception is ArgumentException) {
+                    // Malformed optional metadata must not prevent the workbook itself from loading.
+                }
             }
 
             CustomDocumentProperties.ReplaceWith(loadedProperties);

--- a/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Package.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Package.cs
@@ -100,6 +100,8 @@ namespace OfficeIMO.Excel {
                 return false;
             }
 
+            ApplySignatureMutationPolicy(options);
+
             DirectDataSetWorkbookModel packageModel;
             if (_materializedDirectDataSetFastSaveModel != null) {
                 if (!CanWriteMaterializedDirectDataSetPackage(_materializedDirectDataSetFastSaveModel)) {

--- a/OfficeIMO.Excel/ExcelSheet.Formulas.Custom.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Formulas.Custom.cs
@@ -19,7 +19,9 @@ namespace OfficeIMO.Excel {
 
             var customArguments = new ExcelFormulaValue[arguments.Count];
             for (int index = 0; index < arguments.Count; index++) {
-                customArguments[index] = ToCustomFormulaValue(arguments[index]);
+                if (!TryConvertFormulaArgumentToCustomValue(arguments[index], out customArguments[index])) {
+                    return false;
+                }
             }
 
             var context = new ExcelCustomFormulaFunctionContext(
@@ -31,18 +33,36 @@ namespace OfficeIMO.Excel {
             return customResult.HasValue && TryConvertCustomFormulaValue(customResult.Value, out result);
         }
 
-        private static ExcelFormulaValue ToCustomFormulaValue(FormulaArgumentValue value) {
+        private static bool TryConvertFormulaArgumentToCustomValue(
+            FormulaArgumentValue value,
+            out ExcelFormulaValue result) {
             if (value.IsError) {
-                return ExcelFormulaValue.FromError(value.ErrorCode ?? "#VALUE!");
+                string errorCode = (value.ErrorCode ?? "#VALUE!").Trim();
+                if (errorCode.Length == 0 || errorCode.Length > 255 || errorCode[0] != '#'
+                    || errorCode.Any(char.IsWhiteSpace)) {
+                    result = default;
+                    return false;
+                }
+
+                result = ExcelFormulaValue.FromError(errorCode);
+                return true;
             }
 
             if (value.Number.HasValue) {
-                return ExcelFormulaValue.FromNumber(value.Number.Value);
+                double number = value.Number.Value;
+                if (double.IsNaN(number) || double.IsInfinity(number)) {
+                    result = default;
+                    return false;
+                }
+
+                result = ExcelFormulaValue.FromNumber(number);
+                return true;
             }
 
-            return value.Text == null
+            result = value.Text == null
                 ? ExcelFormulaValue.Blank
                 : ExcelFormulaValue.FromText(value.Text);
+            return true;
         }
 
         private static bool TryConvertCustomFormulaValue(ExcelFormulaValue value, out FormulaArgumentValue result) {

--- a/OfficeIMO.Excel/Imaging/ExcelImageExportOptions.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelImageExportOptions.cs
@@ -66,6 +66,13 @@ namespace OfficeIMO.Excel {
         public bool ShowCommentBodies { get; set; }
 
         /// <summary>
+        /// Whether workbook directory paths referenced by header/footer <c>&amp;Z</c> and <c>&amp;[Path]</c>
+        /// fields may be included in rendered images. The default is <see langword="false"/> to avoid
+        /// exposing local or server filesystem paths in exported artifacts.
+        /// </summary>
+        public bool IncludeWorkbookPathInHeaderFooter { get; set; }
+
+        /// <summary>
         /// Default column width in pixels when a column has no explicit width.
         /// </summary>
         public double DefaultColumnWidthPixels { get; set; } = 64D;
@@ -108,6 +115,7 @@ namespace OfficeIMO.Excel {
             target.ConditionalFormattingDate = ConditionalFormattingDate;
             target.ShowHyperlinkHints = ShowHyperlinkHints;
             target.ShowCommentBodies = ShowCommentBodies;
+            target.IncludeWorkbookPathInHeaderFooter = IncludeWorkbookPathInHeaderFooter;
             target.DefaultColumnWidthPixels = DefaultColumnWidthPixels;
             target.DefaultRowHeightPixels = DefaultRowHeightPixels;
             target.MaximumRenderedCells = MaximumRenderedCells;

--- a/OfficeIMO.Excel/Imaging/ExcelSheet.Imaging.HeaderFooter.Text.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelSheet.Imaging.HeaderFooter.Text.cs
@@ -6,7 +6,13 @@ namespace OfficeIMO.Excel {
     public partial class ExcelSheet {
         private const int MaximumHeaderFooterFontFamilyCharacters = 256;
 
-        private bool TryResolveHeaderFooterText(string? text, int pageNumber, int pageCount, DateTime headerFooterDateTime, out HeaderFooterTextSection normalized) {
+        private bool TryResolveHeaderFooterText(
+            string? text,
+            int pageNumber,
+            int pageCount,
+            DateTime headerFooterDateTime,
+            bool includeWorkbookPath,
+            out HeaderFooterTextSection normalized) {
             normalized = HeaderFooterTextSection.Empty;
             if (string.IsNullOrWhiteSpace(text)) {
                 return true;
@@ -117,6 +123,10 @@ namespace OfficeIMO.Excel {
                 } else if (token == 'G') {
                     FlushHeaderFooterTextRun(runs, builder, bold, italic, underline, strikethrough, color, fontSize, fontFamily);
                 } else if (token == 'Z') {
+                    if (!includeWorkbookPath) {
+                        continue;
+                    }
+
                     if (!TryGetWorkbookPathPrefix(out string pathPrefix)) {
                         return false;
                     }
@@ -129,7 +139,7 @@ namespace OfficeIMO.Excel {
                     }
 
                     string fieldName = text.Substring(i + 1, end - i - 1);
-                    if (!TryAppendHeaderFooterField(builder, fieldName, pageNumber, pageCount, headerFooterDateTime)) {
+                    if (!TryAppendHeaderFooterField(builder, fieldName, pageNumber, pageCount, headerFooterDateTime, includeWorkbookPath)) {
                         return false;
                     }
 
@@ -249,7 +259,13 @@ namespace OfficeIMO.Excel {
             return false;
         }
 
-        private bool TryAppendHeaderFooterField(StringBuilder builder, string fieldName, int pageNumber, int pageCount, DateTime headerFooterDateTime) {
+        private bool TryAppendHeaderFooterField(
+            StringBuilder builder,
+            string fieldName,
+            int pageNumber,
+            int pageCount,
+            DateTime headerFooterDateTime,
+            bool includeWorkbookPath) {
             if (string.Equals(fieldName, "Page", StringComparison.OrdinalIgnoreCase)) {
                 builder.Append(pageNumber.ToString(CultureInfo.InvariantCulture));
                 return true;
@@ -285,6 +301,10 @@ namespace OfficeIMO.Excel {
             }
 
             if (string.Equals(fieldName, "Path", StringComparison.OrdinalIgnoreCase)) {
+                if (!includeWorkbookPath) {
+                    return true;
+                }
+
                 if (!TryGetWorkbookPathPrefix(out string pathPrefix)) {
                     return false;
                 }

--- a/OfficeIMO.Excel/Imaging/ExcelSheet.Imaging.HeaderFooter.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelSheet.Imaging.HeaderFooter.cs
@@ -22,7 +22,13 @@ namespace OfficeIMO.Excel {
             ref ExcelRasterRenderState rasterState) {
             DateTime headerFooterDateTime = options.HeaderFooterDateTime ?? DateTime.Now;
             if (headerFooterSnapshot == null ||
-                !TryCreateHeaderFooterTextChrome(headerFooterSnapshot, pageNumber, pageCount, headerFooterDateTime, out HeaderFooterTextChrome chrome)) {
+                !TryCreateHeaderFooterTextChrome(
+                    headerFooterSnapshot,
+                    pageNumber,
+                    pageCount,
+                    headerFooterDateTime,
+                    options.IncludeWorkbookPathInHeaderFooter,
+                    out HeaderFooterTextChrome chrome)) {
                 return content;
             }
 
@@ -170,7 +176,7 @@ namespace OfficeIMO.Excel {
             return canvasHeight - headerHeight - footerHeight;
         }
 
-        private bool CanRenderHeaderFooterTextChrome(DateTime headerFooterDateTime) {
+        private bool CanRenderHeaderFooterTextChrome(DateTime headerFooterDateTime, bool includeWorkbookPath) {
             if (!HasHeaderFooterContent()) {
                 return true;
             }
@@ -187,6 +193,7 @@ namespace OfficeIMO.Excel {
                 3,
                 3,
                 headerFooterDateTime,
+                includeWorkbookPath,
                 out _)) {
                 return false;
             }
@@ -202,6 +209,7 @@ namespace OfficeIMO.Excel {
                     1,
                     3,
                     headerFooterDateTime,
+                    includeWorkbookPath,
                     out _)) {
                 return false;
             }
@@ -217,6 +225,7 @@ namespace OfficeIMO.Excel {
                     2,
                     3,
                     headerFooterDateTime,
+                    includeWorkbookPath,
                     out _)) {
                 return false;
             }
@@ -261,7 +270,13 @@ namespace OfficeIMO.Excel {
             }
         }
 
-        private bool TryCreateHeaderFooterTextChrome(HeaderFooterSnapshot snapshot, int pageNumber, int pageCount, DateTime headerFooterDateTime, out HeaderFooterTextChrome chrome) {
+        private bool TryCreateHeaderFooterTextChrome(
+            HeaderFooterSnapshot snapshot,
+            int pageNumber,
+            int pageCount,
+            DateTime headerFooterDateTime,
+            bool includeWorkbookPath,
+            out HeaderFooterTextChrome chrome) {
             chrome = default;
 
             HeaderFooterVariantText selected = SelectHeaderFooterVariantText(snapshot, pageNumber);
@@ -275,6 +290,7 @@ namespace OfficeIMO.Excel {
                 pageNumber,
                 pageCount,
                 headerFooterDateTime,
+                includeWorkbookPath,
                 out HeaderFooterTextChrome textChrome)) {
                 return false;
             }
@@ -299,14 +315,15 @@ namespace OfficeIMO.Excel {
             int pageNumber,
             int pageCount,
             DateTime headerFooterDateTime,
+            bool includeWorkbookPath,
             out HeaderFooterTextChrome chrome) {
             chrome = default;
-            if (!TryResolveHeaderFooterText(headerLeftSource, pageNumber, pageCount, headerFooterDateTime, out HeaderFooterTextSection headerLeft) ||
-                !TryResolveHeaderFooterText(headerCenterSource, pageNumber, pageCount, headerFooterDateTime, out HeaderFooterTextSection headerCenter) ||
-                !TryResolveHeaderFooterText(headerRightSource, pageNumber, pageCount, headerFooterDateTime, out HeaderFooterTextSection headerRight) ||
-                !TryResolveHeaderFooterText(footerLeftSource, pageNumber, pageCount, headerFooterDateTime, out HeaderFooterTextSection footerLeft) ||
-                !TryResolveHeaderFooterText(footerCenterSource, pageNumber, pageCount, headerFooterDateTime, out HeaderFooterTextSection footerCenter) ||
-                !TryResolveHeaderFooterText(footerRightSource, pageNumber, pageCount, headerFooterDateTime, out HeaderFooterTextSection footerRight)) {
+            if (!TryResolveHeaderFooterText(headerLeftSource, pageNumber, pageCount, headerFooterDateTime, includeWorkbookPath, out HeaderFooterTextSection headerLeft) ||
+                !TryResolveHeaderFooterText(headerCenterSource, pageNumber, pageCount, headerFooterDateTime, includeWorkbookPath, out HeaderFooterTextSection headerCenter) ||
+                !TryResolveHeaderFooterText(headerRightSource, pageNumber, pageCount, headerFooterDateTime, includeWorkbookPath, out HeaderFooterTextSection headerRight) ||
+                !TryResolveHeaderFooterText(footerLeftSource, pageNumber, pageCount, headerFooterDateTime, includeWorkbookPath, out HeaderFooterTextSection footerLeft) ||
+                !TryResolveHeaderFooterText(footerCenterSource, pageNumber, pageCount, headerFooterDateTime, includeWorkbookPath, out HeaderFooterTextSection footerCenter) ||
+                !TryResolveHeaderFooterText(footerRightSource, pageNumber, pageCount, headerFooterDateTime, includeWorkbookPath, out HeaderFooterTextSection footerRight)) {
                 return false;
             }
 

--- a/OfficeIMO.Excel/Imaging/ExcelSheet.Imaging.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelSheet.Imaging.cs
@@ -228,7 +228,9 @@ namespace OfficeIMO.Excel {
 
             IReadOnlyList<OfficeImageExportDiagnostic> pageDiagnostics = BuildPageLevelUnsupportedDiagnostics(
                 includePrintTitlesUnsupported: !allowMultipleResults,
-                includeHeaderFooterUnsupported: !allowMultipleResults || !CanRenderHeaderFooterTextChrome(options.HeaderFooterDateTime ?? DateTime.Now));
+                includeHeaderFooterUnsupported: !allowMultipleResults || !CanRenderHeaderFooterTextChrome(
+                    options.HeaderFooterDateTime ?? DateTime.Now,
+                    options.IncludeWorkbookPathInHeaderFooter));
             if (!allowMultipleResults) {
                 return ranges
                     .Select(range => range

--- a/OfficeIMO.Html.Tests/Html.Security.AllSeverityBatch14.cs
+++ b/OfficeIMO.Html.Tests/Html.Security.AllSeverityBatch14.cs
@@ -1,0 +1,19 @@
+using OfficeIMO.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class HtmlAllSeverityBatch14SecurityTests {
+    [Fact]
+    public void SemanticProjectionDoesNotExposeIgnoredDescendantText() {
+        HtmlSemanticDocument semantic = HtmlConversionDocument.Parse(
+            "<p>visible<style>STYLE-SECRET</style><script>SCRIPT-SECRET</script>tail</p>"
+        ).SemanticDocument;
+
+        string text = string.Join(" ", semantic.Sections.SelectMany(section => section.Blocks).Select(block => block.Text));
+        Assert.Contains("visible", text, StringComparison.Ordinal);
+        Assert.Contains("tail", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("STYLE-SECRET", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("SCRIPT-SECRET", text, StringComparison.Ordinal);
+    }
+}

--- a/OfficeIMO.Html/Engine/HtmlGenericDocumentProjector.cs
+++ b/OfficeIMO.Html/Engine/HtmlGenericDocumentProjector.cs
@@ -43,7 +43,7 @@ internal static class HtmlGenericDocumentProjector {
         List<HtmlGenericSectionProjection> result) {
         var pending = new List<IElement>();
         foreach (IElement child in GetChildBlocks(container)) {
-            if (IgnoredElements.Contains(child.LocalName)) continue;
+            if (IsIgnoredElement(child)) continue;
             if (Is(child, "section") || Is(child, "article")) {
                 AppendImplicitSections(document, pending, result);
                 pending.Clear();
@@ -177,7 +177,7 @@ internal static class HtmlGenericDocumentProjector {
         || HtmlAccessibilitySemantics.HasRole(element, "doc-endnote");
 
     private static IEnumerable<IElement> EnumerateBlocks(IElement element) {
-        if (IgnoredElements.Contains(element.LocalName)) yield break;
+        if (IsIgnoredElement(element)) yield break;
         if (IsTextBlock(element) || IsTable(element) || IsImage(element)
             || IsMedia(element) || IsForm(element) || IsNote(element)) {
             yield return element;
@@ -197,7 +197,7 @@ internal static class HtmlGenericDocumentProjector {
                 continue;
             }
 
-            if (node is not IElement element || IgnoredElements.Contains(element.LocalName)) continue;
+            if (node is not IElement element || IsIgnoredElement(element)) continue;
             FlushTextBlock(container, text, result);
             result.Add(element);
         }
@@ -215,7 +215,7 @@ internal static class HtmlGenericDocumentProjector {
     }
 
     private static bool IsInlineTextContainer(IElement element) {
-        if (IgnoredElements.Contains(element.LocalName)
+        if (IsIgnoredElement(element)
             || IsSemanticBlockBoundary(element) || IsImage(element)
             || Normalize(element.TextContent).Length == 0) {
             return false;
@@ -235,10 +235,12 @@ internal static class HtmlGenericDocumentProjector {
         || IsNote(element) || IsExplicitGroupingElement(element);
 
     private static bool IsContainerBoundary(IElement element) =>
-        IsSemanticBlockBoundary(element)
+        IsIgnoredElement(element) || IsSemanticBlockBoundary(element)
         || Is(element, "div") || Is(element, "header") || Is(element, "footer")
         || Is(element, "aside") || Is(element, "figure") || Is(element, "figcaption")
         || Is(element, "hr") || Is(element, "li") || Is(element, "dt") || Is(element, "dd");
+
+    internal static bool IsIgnoredElement(IElement element) => IgnoredElements.Contains(element.LocalName);
 
     private static string GetSectionTitle(IHtmlDocument document, IElement section, int index) {
         string title = Normalize(section.GetAttribute("aria-label"));

--- a/OfficeIMO.Html/Semantics/HtmlSemanticDocumentBuilder.cs
+++ b/OfficeIMO.Html/Semantics/HtmlSemanticDocumentBuilder.cs
@@ -212,6 +212,7 @@ internal static class HtmlSemanticDocumentBuilder {
             return;
         }
         if (!(node is IElement element)) return;
+        if (!isRoot && HtmlGenericDocumentProjector.IsIgnoredElement(element)) return;
         if (!isRoot && skipNestedLists && (Is(element, "ul") || Is(element, "ol") || Is(element, "dl"))) return;
         if (Is(element, "br")) {
             runs.Add(new HtmlSemanticRun("\n", state.Hyperlink, state.Bold, state.Italic,

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.Layouts.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.Layouts.cs
@@ -585,6 +585,61 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void ImportedOrdinaryLayoutUnsupportedPicture_IsLossBlocked() {
+            byte[] sourceBytes;
+            using (PowerPointPresentation source =
+                   PowerPointPresentation.Create()) {
+                source.AddSlide(P.SlideLayoutValues.Blank);
+                sourceBytes = source.ToBytes(PowerPointFileFormat.Ppt);
+            }
+
+            using var input = new MemoryStream(sourceBytes,
+                writable: false);
+            using PowerPointPresentation imported = PowerPointPresentation
+                .Load(input);
+            SlideLayoutPart layoutPart = imported.Slides[0].SlidePart
+                .SlideLayoutPart!;
+            ImagePart imagePart = layoutPart.AddImagePart(
+                DocumentFormat.OpenXml.Packaging.ImagePartType.Png);
+            using (var image = new MemoryStream(
+                       OfficeIMO.Tests.Pdf.PdfPngTestImages.CreateRgbPng(
+                           30, 60, 90), writable: false)) {
+                imagePart.FeedData(image);
+            }
+            layoutPart.SlideLayout!.CommonSlideData!.ShapeTree!.Append(
+                new P.Picture(
+                    new P.NonVisualPictureProperties(
+                        new P.NonVisualDrawingProperties {
+                            Id = 700U,
+                            Name = "Unsupported materialized picture"
+                        },
+                        new P.NonVisualPictureDrawingProperties(),
+                        new P.ApplicationNonVisualDrawingProperties()),
+                    new P.BlipFill(
+                        new A.Blip {
+                            Embed = layoutPart.GetIdOfPart(imagePart)
+                        },
+                        new A.Stretch(new A.FillRectangle())),
+                    new P.ShapeProperties(
+                        new A.Transform2D(
+                            new A.Offset { X = 300000L, Y = 400000L },
+                            new A.Extents {
+                                Cx = 1200000L,
+                                Cy = 900000L
+                            }),
+                        new A.PresetGeometry(new A.AdjustValueList()) {
+                            Preset = A.ShapeTypeValues.Rectangle
+                        })));
+
+            LegacyPptWritePreflightReport preflight = imported
+                .AnalyzeLegacyPptWrite();
+
+            Assert.False(preflight.CanWrite);
+            Assert.Contains(preflight.Findings, finding =>
+                finding.Code == "PPT-WRITE-IMPORT-LOSS");
+        }
+
+        [Fact]
         public void ImportedOrdinaryLayoutBaselineShapeMutation_IsLossBlocked() {
             byte[] sourceBytes;
             using (PowerPointPresentation source =

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.RoundTripThemes.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.RoundTripThemes.cs
@@ -310,6 +310,39 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void ImportedSlideThemeEdit_WithMalformedSlideAtom_IsLossBlocked() {
+            byte[] sourceBytes = CreateSlideThemeOverrideBytes(
+                accent5: "ABCDEF", accent1: "123456");
+            using var input = new MemoryStream(sourceBytes,
+                writable: false);
+            using PowerPointPresentation imported = PowerPointPresentation
+                .Load(input);
+            PowerPointSlide slide = imported.Slides[0];
+            Assert.True(imported.LegacyPptProjectionMap!.TryGetSlide(slide,
+                out LegacyPptSlideProjection? projection));
+            LegacyPptPersistObject persistObject = imported.LegacyPptPackage!
+                .PersistObjects[projection!.PersistId];
+            LegacyPptRecord record = LegacyPptRecordReader.ReadSingle(
+                persistObject.RecordBytes, 0, new LegacyPptImportOptions());
+            LegacyPptRecord slideAtom = Assert.Single(record.Children,
+                child => child.Type == 0x03EF && child.PayloadLength >= 22);
+            System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(
+                persistObject.RecordBytes.AsSpan(slideAtom.Offset + 2, 2),
+                0x03EE);
+            A.ThemeOverride theme = Assert.IsType<A.ThemeOverride>(slide
+                .SlidePart.ThemeOverridePart?.ThemeOverride);
+            SetThemeOverrideColor<A.Accent5Color>(theme, "5A6B7C");
+            SetThemeOverrideColor<A.Accent1Color>(theme, "102938");
+
+            LegacyPptWritePreflightReport preflight = imported
+                .AnalyzeLegacyPptWrite();
+
+            Assert.False(preflight.CanWrite);
+            Assert.Contains(preflight.Findings, finding =>
+                finding.Code == "PPT-WRITE-IMPORT-LOSS");
+        }
+
+        [Fact]
         public void ImportedLayoutThemeEdit_MaterializesIntoAffectedSlides() {
             byte[] sourceBytes;
             using (PowerPointPresentation created =

--- a/OfficeIMO.PowerPoint/LegacyPpt/Write/LegacyPptPreservingWriter.ChangePlan.cs
+++ b/OfficeIMO.PowerPoint/LegacyPpt/Write/LegacyPptPreservingWriter.ChangePlan.cs
@@ -680,7 +680,9 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Write {
                 return true;
             } catch (Exception exception) when (exception is InvalidDataException
                                                 || exception is OverflowException
-                                                || exception is ArgumentException) {
+                                                || exception is ArgumentException
+                                                || exception is InvalidOperationException
+                                                || exception is NotSupportedException) {
                 rewritten.Clear();
                 return false;
             }

--- a/OfficeIMO.Reader.Core/ReaderHierarchicalChunker.cs
+++ b/OfficeIMO.Reader.Core/ReaderHierarchicalChunker.cs
@@ -51,16 +51,23 @@ public static partial class ReaderHierarchicalChunker {
         bool enforceSingleSourceIdentity) {
         var state = new ChunkingState(options, cancellationToken, enforceSingleSourceIdentity);
         int inputIndex = 0;
+        int? knownInputCount = source is ICollection<ReaderChunk> collection
+            ? collection.Count
+            : source is IReadOnlyCollection<ReaderChunk> readOnlyCollection
+                ? readOnlyCollection.Count
+                : null;
         using IEnumerator<ReaderChunk> enumerator = source.GetEnumerator();
         while (!state.OutputLimitReached) {
             cancellationToken.ThrowIfCancellationRequested();
+            if (inputIndex >= options.MaxInputChunks) {
+                if (!knownInputCount.HasValue || knownInputCount.Value > options.MaxInputChunks) {
+                    state.AddLimitDiagnostic("hierarchical-input-chunk-limit", options.MaxInputChunks, "input chunks");
+                }
+                break;
+            }
             if (!enumerator.MoveNext()) break;
             ReaderChunk? chunk = enumerator.Current;
             if (ReferenceEquals(chunk, FallbackInputLimitMarker)) {
-                state.AddLimitDiagnostic("hierarchical-input-chunk-limit", options.MaxInputChunks, "input chunks");
-                break;
-            }
-            if (inputIndex >= options.MaxInputChunks) {
                 state.AddLimitDiagnostic("hierarchical-input-chunk-limit", options.MaxInputChunks, "input chunks");
                 break;
             }

--- a/OfficeIMO.Reader.Core/ReaderHierarchicalChunker.cs
+++ b/OfficeIMO.Reader.Core/ReaderHierarchicalChunker.cs
@@ -21,12 +21,17 @@ public static partial class ReaderHierarchicalChunker {
         CancellationToken cancellationToken = default) {
         if (document == null) throw new ArgumentNullException(nameof(document));
         ReaderHierarchicalChunkingOptions normalized = Normalize(options);
+        int? knownInputCount = document.Chunks != null && document.Chunks.Count > 0
+            ? document.Chunks.Count
+            : null;
         return ChunkCore(
             GetSourceChunks(document, normalized.MaxInputChunks, cancellationToken),
             document.Source ?? new OfficeDocumentSource(),
             normalized,
             cancellationToken,
-            enforceSingleSourceIdentity: false);
+            enforceSingleSourceIdentity: false,
+            knownInputCount: knownInputCount,
+            inspectInternalBoundaryMarker: true);
     }
 
     /// <summary>Chunks an existing source-ordered collection.</summary>
@@ -48,10 +53,12 @@ public static partial class ReaderHierarchicalChunker {
         OfficeDocumentSource sourceInfo,
         ReaderHierarchicalChunkingOptions options,
         CancellationToken cancellationToken,
-        bool enforceSingleSourceIdentity) {
+        bool enforceSingleSourceIdentity,
+        int? knownInputCount = null,
+        bool inspectInternalBoundaryMarker = false) {
         var state = new ChunkingState(options, cancellationToken, enforceSingleSourceIdentity);
         int inputIndex = 0;
-        int? knownInputCount = source is ICollection<ReaderChunk> collection
+        knownInputCount ??= source is ICollection<ReaderChunk> collection
             ? collection.Count
             : source is IReadOnlyCollection<ReaderChunk> readOnlyCollection
                 ? readOnlyCollection.Count
@@ -60,7 +67,10 @@ public static partial class ReaderHierarchicalChunker {
         while (!state.OutputLimitReached) {
             cancellationToken.ThrowIfCancellationRequested();
             if (inputIndex >= options.MaxInputChunks) {
-                if (!knownInputCount.HasValue || knownInputCount.Value > options.MaxInputChunks) {
+                bool truncated = knownInputCount.HasValue
+                    ? knownInputCount.Value > options.MaxInputChunks
+                    : !inspectInternalBoundaryMarker || enumerator.MoveNext();
+                if (truncated) {
                     state.AddLimitDiagnostic("hierarchical-input-chunk-limit", options.MaxInputChunks, "input chunks");
                 }
                 break;

--- a/OfficeIMO.Reader.Pdf/PdfReaderAdapter.Actions.cs
+++ b/OfficeIMO.Reader.Pdf/PdfReaderAdapter.Actions.cs
@@ -70,10 +70,10 @@ internal static partial class PdfReaderAdapter {
             IsPotentiallyUnsafe = IsPotentiallyUnsafeActionType(action.ActionType),
             DestinationPageNumber = action.PageNumber,
             DestinationMode = action.DestinationMode?.ToString(),
-            DestinationTop = action.DestinationTop,
-            DestinationLeft = action.DestinationLeft,
-            DestinationBottom = action.DestinationBottom,
-            DestinationRight = action.DestinationRight
+            DestinationTop = NormalizeFiniteCoordinate(action.DestinationTop),
+            DestinationLeft = NormalizeFiniteCoordinate(action.DestinationLeft),
+            DestinationBottom = NormalizeFiniteCoordinate(action.DestinationBottom),
+            DestinationRight = NormalizeFiniteCoordinate(action.DestinationRight)
         };
     }
 

--- a/OfficeIMO.Reader.Pdf/PdfReaderAdapter.Document.cs
+++ b/OfficeIMO.Reader.Pdf/PdfReaderAdapter.Document.cs
@@ -408,19 +408,19 @@ internal static partial class PdfReaderAdapter {
                     DestinationName = link.DestinationName,
                     DestinationPageNumber = link.DestinationPageNumber,
                     DestinationMode = link.DestinationMode?.ToString(),
-                    DestinationTop = link.DestinationTop,
-                    DestinationLeft = link.DestinationLeft,
-                    DestinationBottom = link.DestinationBottom,
-                    DestinationRight = link.DestinationRight,
+                    DestinationTop = NormalizeFiniteCoordinate(link.DestinationTop),
+                    DestinationLeft = NormalizeFiniteCoordinate(link.DestinationLeft),
+                    DestinationBottom = NormalizeFiniteCoordinate(link.DestinationBottom),
+                    DestinationRight = NormalizeFiniteCoordinate(link.DestinationRight),
                     NamedAction = link.NamedAction,
                     RemoteFile = link.RemoteFile,
                     RemoteDestinationName = link.RemoteDestinationName,
                     RemoteDestinationPageNumber = link.RemoteDestinationPageNumber,
                     RemoteDestinationMode = link.RemoteDestinationMode?.ToString(),
-                    RemoteDestinationTop = link.RemoteDestinationTop,
-                    RemoteDestinationLeft = link.RemoteDestinationLeft,
-                    RemoteDestinationBottom = link.RemoteDestinationBottom,
-                    RemoteDestinationRight = link.RemoteDestinationRight,
+                    RemoteDestinationTop = NormalizeFiniteCoordinate(link.RemoteDestinationTop),
+                    RemoteDestinationLeft = NormalizeFiniteCoordinate(link.RemoteDestinationLeft),
+                    RemoteDestinationBottom = NormalizeFiniteCoordinate(link.RemoteDestinationBottom),
+                    RemoteDestinationRight = NormalizeFiniteCoordinate(link.RemoteDestinationRight),
                     Text = link.Contents,
                     Location = BuildLocation(source, page.PageNumber, pageIndex, "link", "page-" + page.PageNumber.ToString(CultureInfo.InvariantCulture) + "-selection-" + pageIndex.ToString("D4", CultureInfo.InvariantCulture) + "-link-" + linkIndex.ToString(CultureInfo.InvariantCulture)),
                     Region = new OfficeDocumentRegion {
@@ -620,10 +620,16 @@ internal static partial class PdfReaderAdapter {
     }
 
     private static void AddAttribute(Dictionary<string, string> attributes, string name, double? value) {
-        if (value.HasValue) {
-            attributes[name] = value.Value.ToString("R", CultureInfo.InvariantCulture);
+        double? normalized = NormalizeFiniteCoordinate(value);
+        if (normalized.HasValue) {
+            attributes[name] = normalized.Value.ToString("R", CultureInfo.InvariantCulture);
         }
     }
+
+    private static double? NormalizeFiniteCoordinate(double? value) =>
+        value.HasValue && !double.IsNaN(value.Value) && !double.IsInfinity(value.Value)
+            ? value
+            : null;
 
     private static void AddAttribute(Dictionary<string, string> attributes, string name, string? value) {
         if (!string.IsNullOrWhiteSpace(value)) {

--- a/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
+++ b/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
@@ -309,6 +309,32 @@ public sealed class ReaderHierarchicalChunkingTests {
     }
 
     [Fact]
+    public void Chunk_DocumentPreservesKnownInputCountAtLimit() {
+        var options = new ReaderHierarchicalChunkingOptions {
+            MaxTokens = 10,
+            OverlapTokens = 0,
+            MaxInputChunks = 1,
+            IncludeContextInText = false,
+            TokenCounter = WordCounter
+        };
+        var exactDocument = new OfficeDocumentReadResult {
+            Chunks = new[] { CreateChunk("first", "first block") }
+        };
+        var truncatedDocument = new OfficeDocumentReadResult {
+            Chunks = new[] {
+                CreateChunk("first", "first block"),
+                CreateChunk("second", "second block")
+            }
+        };
+
+        ReaderChunkHierarchyResult exact = ReaderHierarchicalChunker.Chunk(exactDocument, options);
+        ReaderChunkHierarchyResult truncated = ReaderHierarchicalChunker.Chunk(truncatedDocument, options);
+
+        Assert.DoesNotContain(exact.Diagnostics, diagnostic => diagnostic.Code == "hierarchical-input-chunk-limit");
+        Assert.Contains(truncated.Diagnostics, diagnostic => diagnostic.Code == "hierarchical-input-chunk-limit");
+    }
+
+    [Fact]
     public void Chunk_DoesNotAdvanceLazySourceBeyondInputLimit() {
         var options = new ReaderHierarchicalChunkingOptions {
             MaxTokens = 10,

--- a/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
+++ b/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
@@ -309,6 +309,27 @@ public sealed class ReaderHierarchicalChunkingTests {
     }
 
     [Fact]
+    public void Chunk_DoesNotAdvanceLazySourceBeyondInputLimit() {
+        var options = new ReaderHierarchicalChunkingOptions {
+            MaxTokens = 10,
+            OverlapTokens = 0,
+            MaxInputChunks = 1,
+            IncludeContextInText = false,
+            TokenCounter = WordCounter
+        };
+
+        ReaderChunkHierarchyResult result = ReaderHierarchicalChunker.Chunk(ThrowAfterFirstChunk(), options);
+
+        Assert.Single(result.Chunks);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "hierarchical-input-chunk-limit");
+    }
+
+    private static IEnumerable<ReaderChunk> ThrowAfterFirstChunk() {
+        yield return CreateChunk("first", "first block");
+        throw new InvalidOperationException("The chunker advanced beyond MaxInputChunks.");
+    }
+
+    [Fact]
     public void Chunk_BoundsFallbackInspectionWhenSourceBlocksAreDuplicates() {
         var duplicate = new OfficeDocumentBlock { Id = "duplicate", Text = "body" };
         var blocks = new CountingBlockList(duplicate, 1000);

--- a/OfficeIMO.Reader.Tests/Reader.Pdf.Modular.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Pdf.Modular.cs
@@ -960,8 +960,7 @@ public sealed class ReaderPdfModularTests {
         string source = Encoding.ASCII.GetString(BuildInternalDestinationLinkPdf());
         byte[] malformed = Encoding.ASCII.GetBytes(source.Replace(
             "/XYZ 24 144 1",
-            "/XYZ 1e309 144 1",
-            StringComparison.Ordinal));
+            "/XYZ 1e309 144 1"));
 
         OfficeDocumentReadResult result = PdfReaderAdapter.ReadDocument(
             new MemoryStream(malformed, writable: false),

--- a/OfficeIMO.Reader.Tests/Reader.Pdf.Modular.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Pdf.Modular.cs
@@ -956,6 +956,24 @@ public sealed class ReaderPdfModularTests {
     }
 
     [Fact]
+    public void DocumentReaderPdf_NormalizesNonFiniteLinkCoordinatesBeforeJsonSerialization() {
+        string source = Encoding.ASCII.GetString(BuildInternalDestinationLinkPdf());
+        byte[] malformed = Encoding.ASCII.GetBytes(source.Replace(
+            "/XYZ 24 144 1",
+            "/XYZ 1e309 144 1",
+            StringComparison.Ordinal));
+
+        OfficeDocumentReadResult result = PdfReaderAdapter.ReadDocument(
+            new MemoryStream(malformed, writable: false),
+            sourceName: "non-finite-link.pdf");
+
+        OfficeDocumentLink link = Assert.Single(result.Links);
+        Assert.Null(link.DestinationLeft);
+        using JsonDocument json = JsonDocument.Parse(result.ToJson());
+        Assert.False(json.RootElement.GetProperty("links")[0].TryGetProperty("destinationLeft", out _));
+    }
+
+    [Fact]
     public void DocumentReaderPdf_ReadPdfDocument_ExposesAttachmentMetadata() {
         byte[] invoiceXml = Encoding.UTF8.GetBytes("<invoice>42</invoice>");
         byte[] sourceBytes = Encoding.UTF8.GetBytes("Source payload");

--- a/OfficeIMO.Reader.Tests/Reader.Web.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Web.cs
@@ -78,6 +78,29 @@ public sealed class ReaderWebTests {
     }
 
     [Fact]
+    public async Task WebReader_DoesNotHashQuerySecretsIntoSourceIdentity() {
+        int responseIndex = 0;
+        var handler = new DelegateHttpHandler((request, cancellationToken) => {
+            int current = Interlocked.Increment(ref responseIndex);
+            HttpResponseMessage response = TextResponse("same body", "text/plain");
+            response.RequestMessage = new HttpRequestMessage(
+                HttpMethod.Get,
+                "https://cdn.example/report.txt?token=secret-" + current.ToString(CultureInfo.InvariantCulture));
+            return Task.FromResult(response);
+        });
+        using var httpClient = new HttpClient(handler);
+        OfficeDocumentWebReader webReader = OfficeIMO.Reader.Tests.ReaderTestReaders.All.CreateWebReader(httpClient);
+
+        OfficeDocumentReadResult first = await webReader.ReadDocumentAsync(new Uri("https://example.test/report"));
+        OfficeDocumentReadResult second = await webReader.ReadDocumentAsync(new Uri("https://example.test/report"));
+
+        Assert.Equal(first.Source.SourceId, second.Source.SourceId);
+        Assert.DoesNotContain("secret", first.Source.SourceId, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(first.Metadata, item => item.Value.Contains("secret", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(second.Metadata, item => item.Value.Contains("secret", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public async Task WebReader_UsesTheRichPipelineForMarkdownConvenience() {
         var handler = new DelegateHttpHandler((request, cancellationToken) =>
             Task.FromResult(TextResponse("# Remote note\n\nBody", "text/markdown")));

--- a/OfficeIMO.Reader.Web/ReaderWebTransport.cs
+++ b/OfficeIMO.Reader.Web/ReaderWebTransport.cs
@@ -265,7 +265,7 @@ internal sealed class ReaderWebDownload : IDisposable {
         ReaderWebOptions options,
         bool computeHashes) {
         string sourceId = DocumentReaderEngine.BuildPortableSourceId(
-            "web:" + FormatUri(ResponseUri, includeQuery: true));
+            "web:" + FormatUri(ResponseUri, includeQuery: false));
         DocumentReaderEngine.ApplyExternalSourceMetadata(
             result,
             sourceId,

--- a/OfficeIMO.Rtf.Tests/Rtf/RtfEditingWorkflowTests.cs
+++ b/OfficeIMO.Rtf.Tests/Rtf/RtfEditingWorkflowTests.cs
@@ -76,6 +76,29 @@ public class RtfEditingWorkflowTests {
     }
 
     [Fact]
+    public void Semantic_Clone_Separates_Header_References_From_Detached_Notes() {
+        RtfDocument source = RtfDocument.Create();
+        RtfNote headerNote = source.AddNote(RtfNoteKind.Footnote);
+        headerNote.AddParagraph("Header note");
+        source.AddHeader().AddParagraph("Header").AddNoteReference(headerNote, "H");
+        RtfNote detached = source.AddNote(RtfNoteKind.Endnote);
+        detached.AddParagraph("Detached note");
+        RtfNote bodyNote = source.AddNote(RtfNoteKind.Footnote);
+        bodyNote.AddParagraph("Body note");
+        source.AddParagraph("Body").AddNoteReference(bodyNote, "B");
+
+        RtfDocument clone = source.Clone();
+
+        RtfGeneratedText headerReference = Assert.Single(clone.HeaderFooters[0].Paragraphs[0].Inlines.OfType<RtfGeneratedText>());
+        Assert.Equal("Header note", headerReference.Note?.ToPlainText());
+        RtfGeneratedText bodyReference = Assert.Single(clone.Paragraphs[0].Inlines.OfType<RtfGeneratedText>());
+        Assert.Equal("Body note", bodyReference.Note?.ToPlainText());
+        RtfNote detachedClone = Assert.Single(clone.Notes, note => note.ToPlainText() == "Detached note");
+        Assert.DoesNotContain(clone.Paragraphs.SelectMany(paragraph => paragraph.Inlines), inline =>
+            inline is RtfGeneratedText generated && generated.Note == detachedClone);
+    }
+
+    [Fact]
     public void Semantic_ReplaceText_Replaces_Visible_Text_In_Inline_Results_And_Shapes() {
         RtfDocument document = RtfDocument.Create();
         RtfParagraph paragraph = document.AddParagraph("Body ");

--- a/OfficeIMO.Rtf.Tests/Rtf/RtfEditingWorkflowTests.cs
+++ b/OfficeIMO.Rtf.Tests/Rtf/RtfEditingWorkflowTests.cs
@@ -99,6 +99,31 @@ public class RtfEditingWorkflowTests {
     }
 
     [Fact]
+    public void Semantic_Clone_Separates_Nested_Header_Notes_From_Detached_Notes() {
+        RtfDocument source = RtfDocument.Create();
+        RtfNote nestedHeaderNote = source.AddNote(RtfNoteKind.Footnote);
+        nestedHeaderNote.AddParagraph("Nested header note");
+        RtfNote headerNote = source.AddNote(RtfNoteKind.Footnote);
+        headerNote.AddParagraph("Header note").AddNoteReference(nestedHeaderNote, "N");
+        source.AddHeader().AddParagraph("Header").AddNoteReference(headerNote, "H");
+        RtfNote detached = source.AddNote(RtfNoteKind.Endnote);
+        detached.AddParagraph("Detached note");
+        source.AddParagraph("Body");
+
+        RtfDocument clone = source.Clone();
+
+        RtfNote detachedClone = Assert.Single(clone.Notes, note => note.ToPlainText() == "Detached note");
+        Assert.DoesNotContain(clone.Paragraphs.SelectMany(paragraph => paragraph.Inlines), inline =>
+            inline is RtfGeneratedText generated && generated.Note == detachedClone);
+        RtfGeneratedText headerReference = Assert.Single(
+            clone.HeaderFooters[0].Paragraphs[0].Inlines.OfType<RtfGeneratedText>());
+        Assert.Equal("Header note", headerReference.Note?.ToPlainText());
+        RtfGeneratedText nestedReference = Assert.Single(
+            headerReference.Note!.Paragraphs.SelectMany(paragraph => paragraph.Inlines).OfType<RtfGeneratedText>());
+        Assert.Equal("Nested header note", nestedReference.Note?.ToPlainText());
+    }
+
+    [Fact]
     public void Semantic_ReplaceText_Replaces_Visible_Text_In_Inline_Results_And_Shapes() {
         RtfDocument document = RtfDocument.Create();
         RtfParagraph paragraph = document.AddParagraph("Body ");

--- a/OfficeIMO.Rtf/Model/RtfDocument.Editing.cs
+++ b/OfficeIMO.Rtf/Model/RtfDocument.Editing.cs
@@ -6,10 +6,11 @@ public sealed partial class RtfDocument {
     public RtfDocument Clone() {
         HashSet<RtfNote> referencedNotes = RtfNoteReferenceCollector.Collect(this);
         int detachedNoteCount = _notes.Count(note => !referencedNotes.Contains(note));
+        int headerFooterReferenceCount = RtfNoteReferenceCollector.CountHeaderFooterReferences(this);
         RtfDocument clone = Read(ToRtf(new RtfWriteOptions { IncludeGenerator = false })).Document;
         if (detachedNoteCount == 0) return clone;
 
-        var detachedClones = new HashSet<RtfNote>(clone.Notes.Take(detachedNoteCount));
+        var detachedClones = new HashSet<RtfNote>(clone.Notes.Skip(headerFooterReferenceCount).Take(detachedNoteCount));
         var paragraphs = new List<RtfParagraph>();
         CollectParagraphsInOrder(clone.Blocks, paragraphs);
         foreach (RtfParagraph paragraph in paragraphs) paragraph.RemoveGeneratedNoteReferences(detachedClones);

--- a/OfficeIMO.Rtf/Model/RtfNoteReferenceCollector.cs
+++ b/OfficeIMO.Rtf/Model/RtfNoteReferenceCollector.cs
@@ -13,6 +13,18 @@ internal static class RtfNoteReferenceCollector {
         return notes;
     }
 
+    public static int CountHeaderFooterReferences(RtfDocument document) {
+        if (document == null) throw new ArgumentNullException(nameof(document));
+        int count = 0;
+        foreach (RtfHeaderFooter headerFooter in document.HeaderFooters) {
+            foreach (RtfParagraph paragraph in headerFooter.Paragraphs) {
+                count += CountParagraphReferences(paragraph);
+            }
+        }
+
+        return count;
+    }
+
     private static void CollectBlocks(IEnumerable<IRtfBlock> blocks, ISet<RtfNote> notes) {
         foreach (IRtfBlock block in blocks) {
             switch (block) {
@@ -54,5 +66,30 @@ internal static class RtfNoteReferenceCollector {
                     break;
             }
         }
+    }
+
+    private static int CountParagraphReferences(RtfParagraph paragraph) {
+        int count = 0;
+        foreach (IRtfInline inline in paragraph.Inlines) {
+            switch (inline) {
+                case RtfRun run when run.Note != null:
+                case RtfGeneratedText { Note: not null }:
+                    count++;
+                    break;
+                case RtfField field:
+                    count += CountParagraphReferences(field.Result);
+                    break;
+                case RtfObject rtfObject:
+                    count += CountParagraphReferences(rtfObject.Result);
+                    break;
+                case RtfShape shape:
+                    foreach (RtfParagraph shapeParagraph in shape.TextBoxParagraphs) {
+                        count += CountParagraphReferences(shapeParagraph);
+                    }
+                    break;
+            }
+        }
+
+        return count;
     }
 }

--- a/OfficeIMO.Rtf/Model/RtfNoteReferenceCollector.cs
+++ b/OfficeIMO.Rtf/Model/RtfNoteReferenceCollector.cs
@@ -50,10 +50,10 @@ internal static class RtfNoteReferenceCollector {
         foreach (IRtfInline inline in paragraph.Inlines) {
             switch (inline) {
                 case RtfRun run when run.Note != null:
-                    notes.Add(run.Note);
+                    CollectNote(run.Note, notes);
                     break;
                 case RtfGeneratedText generatedText when generatedText.Note != null:
-                    notes.Add(generatedText.Note);
+                    CollectNote(generatedText.Note, notes);
                     break;
                 case RtfField field:
                     CollectParagraph(field.Result, notes);
@@ -68,13 +68,22 @@ internal static class RtfNoteReferenceCollector {
         }
     }
 
+    private static void CollectNote(RtfNote note, ISet<RtfNote> notes) {
+        if (!notes.Add(note)) return;
+        foreach (RtfParagraph paragraph in note.Paragraphs) {
+            CollectParagraph(paragraph, notes);
+        }
+    }
+
     private static int CountParagraphReferences(RtfParagraph paragraph) {
         int count = 0;
         foreach (IRtfInline inline in paragraph.Inlines) {
             switch (inline) {
                 case RtfRun run when run.Note != null:
-                case RtfGeneratedText { Note: not null }:
-                    count++;
+                    count += CountSerializedNoteSequence(run.Note);
+                    break;
+                case RtfGeneratedText generatedText when generatedText.Note != null:
+                    count += CountSerializedNoteSequence(generatedText.Note);
                     break;
                 case RtfField field:
                     count += CountParagraphReferences(field.Result);
@@ -90,6 +99,45 @@ internal static class RtfNoteReferenceCollector {
             }
         }
 
+        return count;
+    }
+
+    private static int CountSerializedNoteSequence(RtfNote note) =>
+        CountSerializedNoteSequence(note, new HashSet<RtfNote>());
+
+    private static int CountSerializedNoteSequence(RtfNote note, ISet<RtfNote> activeNotes) {
+        if (!activeNotes.Add(note)) return 0;
+        int count = 1;
+        foreach (RtfParagraph paragraph in note.Paragraphs) {
+            count += CountParagraphReferences(paragraph, activeNotes);
+        }
+        activeNotes.Remove(note);
+        return count;
+    }
+
+    private static int CountParagraphReferences(RtfParagraph paragraph, ISet<RtfNote> activeNotes) {
+        int count = 0;
+        foreach (IRtfInline inline in paragraph.Inlines) {
+            switch (inline) {
+                case RtfRun run when run.Note != null:
+                    count += CountSerializedNoteSequence(run.Note, activeNotes);
+                    break;
+                case RtfGeneratedText generatedText when generatedText.Note != null:
+                    count += CountSerializedNoteSequence(generatedText.Note, activeNotes);
+                    break;
+                case RtfField field:
+                    count += CountParagraphReferences(field.Result, activeNotes);
+                    break;
+                case RtfObject rtfObject:
+                    count += CountParagraphReferences(rtfObject.Result, activeNotes);
+                    break;
+                case RtfShape shape:
+                    foreach (RtfParagraph shapeParagraph in shape.TextBoxParagraphs) {
+                        count += CountParagraphReferences(shapeParagraph, activeNotes);
+                    }
+                    break;
+            }
+        }
         return count;
     }
 }

--- a/OfficeIMO.Visio.Tests/Visio.Security.AllSeverityBatch14.cs
+++ b/OfficeIMO.Visio.Tests/Visio.Security.AllSeverityBatch14.cs
@@ -20,4 +20,30 @@ public sealed class VisioAllSeverityBatch14SecurityTests {
             Directory.Delete(parent, true);
         }
     }
+
+#if NET8_0_OR_GREATER
+    [Fact]
+    public void ShowcaseSummaryRejectsSymlinkedArtifactsAndParentDirectories() {
+        string parent = Path.Combine(Path.GetTempPath(), "officeimo-showcase-symlink-" + Guid.NewGuid().ToString("N"));
+        string root = Path.Combine(parent, "root");
+        string outsideDirectory = Path.Combine(parent, "outside");
+        Directory.CreateDirectory(root);
+        Directory.CreateDirectory(outsideDirectory);
+        string outside = Path.Combine(outsideDirectory, "outside.vsdx");
+        File.WriteAllText(outside, "outside");
+        string fileLink = Path.Combine(root, "file-link.vsdx");
+        string directoryLink = Path.Combine(root, "directory-link");
+        try {
+            File.CreateSymbolicLink(fileLink, outside);
+            Directory.CreateSymbolicLink(directoryLink, outsideDirectory);
+
+            Assert.Throws<ArgumentException>(() =>
+                VisioShowcaseSummary.Create(root, new[] { fileLink }));
+            Assert.Throws<ArgumentException>(() =>
+                VisioShowcaseSummary.Create(root, new[] { Path.Combine(directoryLink, "outside.vsdx") }));
+        } finally {
+            Directory.Delete(parent, true);
+        }
+    }
+#endif
 }

--- a/OfficeIMO.Visio.Tests/Visio.Security.AllSeverityBatch14.cs
+++ b/OfficeIMO.Visio.Tests/Visio.Security.AllSeverityBatch14.cs
@@ -1,0 +1,23 @@
+using OfficeIMO.Visio;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class VisioAllSeverityBatch14SecurityTests {
+    [Fact]
+    public void ShowcaseSummaryRejectsArtifactsOutsideItsRootBeforeHashing() {
+        string parent = Path.Combine(Path.GetTempPath(), "officeimo-showcase-boundary-" + Guid.NewGuid().ToString("N"));
+        string root = Path.Combine(parent, "root");
+        string outside = Path.Combine(parent, "outside.vsdx");
+        Directory.CreateDirectory(root);
+        File.WriteAllText(outside, "outside");
+        try {
+            ArgumentException exception = Assert.Throws<ArgumentException>(() =>
+                VisioShowcaseSummary.Create(root, new[] { outside }));
+
+            Assert.Contains("inside the showcase root", exception.Message, StringComparison.Ordinal);
+        } finally {
+            Directory.Delete(parent, true);
+        }
+    }
+}

--- a/OfficeIMO.Visio.Tests/Visio.Security.AllSeverityBatch14.cs
+++ b/OfficeIMO.Visio.Tests/Visio.Security.AllSeverityBatch14.cs
@@ -45,5 +45,23 @@ public sealed class VisioAllSeverityBatch14SecurityTests {
             Directory.Delete(parent, true);
         }
     }
+
+    [Fact]
+    public void ShowcaseSummaryRejectsSymlinkedRootBeforeHashingArtifacts() {
+        string parent = Path.Combine(Path.GetTempPath(), "officeimo-showcase-root-symlink-" + Guid.NewGuid().ToString("N"));
+        string outsideDirectory = Path.Combine(parent, "outside");
+        string rootLink = Path.Combine(parent, "root-link");
+        Directory.CreateDirectory(outsideDirectory);
+        string outside = Path.Combine(outsideDirectory, "outside.vsdx");
+        File.WriteAllText(outside, "outside");
+        try {
+            Directory.CreateSymbolicLink(rootLink, outsideDirectory);
+
+            Assert.Throws<ArgumentException>(() =>
+                VisioShowcaseSummary.Create(rootLink, new[] { Path.Combine(rootLink, "outside.vsdx") }));
+        } finally {
+            Directory.Delete(parent, true);
+        }
+    }
 #endif
 }

--- a/OfficeIMO.Visio/Gallery/VisioShowcaseSummary.cs
+++ b/OfficeIMO.Visio/Gallery/VisioShowcaseSummary.cs
@@ -206,6 +206,11 @@ namespace OfficeIMO.Visio {
 
         private static bool ContainsReparsePoint(string root, string filePath) {
             string normalizedRoot = Path.GetFullPath(root);
+            if ((File.Exists(normalizedRoot) || Directory.Exists(normalizedRoot)) &&
+                (File.GetAttributes(normalizedRoot) & FileAttributes.ReparsePoint) != 0) {
+                return true;
+            }
+
             string rootPrefix = EnsureTrailingSeparator(normalizedRoot);
             string relative = Path.GetFullPath(filePath).Substring(rootPrefix.Length);
             string current = normalizedRoot;

--- a/OfficeIMO.Visio/Gallery/VisioShowcaseSummary.cs
+++ b/OfficeIMO.Visio/Gallery/VisioShowcaseSummary.cs
@@ -181,7 +181,7 @@ namespace OfficeIMO.Visio {
 
         private static VisioShowcaseArtifact CreateArtifact(string root, string filePath, VisioShowcaseArtifactKind kind) {
             string fullPath = Path.GetFullPath(filePath);
-            if (!IsPathInsideRoot(root, fullPath)) {
+            if (!IsPathInsideRoot(root, fullPath) || ContainsReparsePoint(root, fullPath)) {
                 throw new ArgumentException("Showcase artifact paths must resolve inside the showcase root.", nameof(filePath));
             }
 
@@ -202,6 +202,24 @@ namespace OfficeIMO.Visio {
                 ? StringComparison.OrdinalIgnoreCase
                 : StringComparison.Ordinal;
             return normalizedFile.StartsWith(normalizedRoot, comparison);
+        }
+
+        private static bool ContainsReparsePoint(string root, string filePath) {
+            string normalizedRoot = Path.GetFullPath(root);
+            string rootPrefix = EnsureTrailingSeparator(normalizedRoot);
+            string relative = Path.GetFullPath(filePath).Substring(rootPrefix.Length);
+            string current = normalizedRoot;
+            string[] segments = relative.Split(
+                new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar },
+                StringSplitOptions.RemoveEmptyEntries);
+            foreach (string segment in segments) {
+                current = Path.Combine(current, segment);
+                if (!File.Exists(current) && !Directory.Exists(current)) break;
+                if ((File.GetAttributes(current) & FileAttributes.ReparsePoint) != 0) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         private static VisioShowcaseArtifactKind ClassifyPreviewKind(string root, string filePath) {

--- a/OfficeIMO.Visio/Gallery/VisioShowcaseSummary.cs
+++ b/OfficeIMO.Visio/Gallery/VisioShowcaseSummary.cs
@@ -181,6 +181,10 @@ namespace OfficeIMO.Visio {
 
         private static VisioShowcaseArtifact CreateArtifact(string root, string filePath, VisioShowcaseArtifactKind kind) {
             string fullPath = Path.GetFullPath(filePath);
+            if (!IsPathInsideRoot(root, fullPath)) {
+                throw new ArgumentException("Showcase artifact paths must resolve inside the showcase root.", nameof(filePath));
+            }
+
             string relativePath = GetRelativePath(root, fullPath);
             string extension = Path.GetExtension(fullPath);
             string format = string.IsNullOrEmpty(extension)
@@ -189,6 +193,15 @@ namespace OfficeIMO.Visio {
             long sizeBytes = File.Exists(fullPath) ? new FileInfo(fullPath).Length : 0;
             string sha256 = File.Exists(fullPath) ? ComputeSha256(fullPath) : string.Empty;
             return new VisioShowcaseArtifact(kind, relativePath, format, sizeBytes, sha256);
+        }
+
+        private static bool IsPathInsideRoot(string root, string filePath) {
+            string normalizedRoot = EnsureTrailingSeparator(Path.GetFullPath(root));
+            string normalizedFile = Path.GetFullPath(filePath);
+            StringComparison comparison = Path.DirectorySeparatorChar == '\\'
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+            return normalizedFile.StartsWith(normalizedRoot, comparison);
         }
 
         private static VisioShowcaseArtifactKind ClassifyPreviewKind(string root, string filePath) {

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.ParagraphStyles.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.ParagraphStyles.cs
@@ -678,6 +678,17 @@ namespace OfficeIMO.Word.Pdf {
                 section.DifferentFirstPage ? section.Footer?.First : null,
                 section.DifferentOddAndEvenPages ? section.Footer?.Even : null);
 
+            double baseTop = (section.Margins.Top ?? 0) / 20D;
+            double baseBottom = (section.Margins.Bottom ?? 0) / 20D;
+            double availableBodyHeight = Math.Max(0D, GetNativePageSize(section, options).Height - baseTop - baseBottom);
+            double minimumBodyHeight = Math.Min(NativeMinimumBodyHeight, availableBodyHeight);
+            double maximumExpansion = Math.Max(0D, availableBodyHeight - minimumBodyHeight);
+            double totalExpansion = headerExpansion + footerExpansion;
+            if (totalExpansion > maximumExpansion && totalExpansion > 0D) {
+                headerExpansion = maximumExpansion * (headerExpansion / totalExpansion);
+                footerExpansion = maximumExpansion - headerExpansion;
+            }
+
             return (headerExpansion, footerExpansion);
         }
 

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.Tables.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.Tables.cs
@@ -824,7 +824,8 @@ namespace OfficeIMO.Word.Pdf {
                 return null;
             }
 
-            return ConvertNativeTwipsToPoints(width.Width?.Value);
+            double? points = ConvertNativeTwipsToPoints(width.Width?.Value);
+            return points > 0D ? points : null;
         }
 
         private static double? GetNativeTablePreferredWidthPercent(W.TableWidth width) {

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.cs
@@ -18,6 +18,7 @@ namespace OfficeIMO.Word.Pdf {
         private const double NativeHeaderFooterFontSize = 9D;
         private const double NativeHeaderFooterLineHeight = NativeHeaderFooterFontSize * 1.2D;
         private const double NativeHeaderFooterBodyGap = 2D;
+        private const double NativeMinimumBodyHeight = 72D;
         private const double NativeHeaderFooterDefaultOffset = 18D;
         private const double NativeFooterDefaultOffset = 20D;
 

--- a/OfficeIMO.Word.Tests/Word.Security.AllSeverityBatch14.cs
+++ b/OfficeIMO.Word.Tests/Word.Security.AllSeverityBatch14.cs
@@ -1,0 +1,61 @@
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Pdf;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class WordAllSeverityBatch14SecurityTests {
+    [Fact]
+    public void RemovingStoryImagesDeletesRelationshipsFromTheirOwningParts() {
+        string imagePath = Path.Combine(AppContext.BaseDirectory, "Images", "Kulek.jpg");
+        using WordDocument document = WordDocument.Create();
+        WordParagraph body = document.AddParagraph("stories");
+        WordParagraph footnote = body.AddFootNote("footnote").FootNote!.Paragraphs![1];
+        WordParagraph endnote = body.AddEndNote("endnote").EndNote!.Paragraphs![1];
+        body.AddComment("OfficeIMO", "OI", "comment");
+        WordParagraph comment = Assert.Single(document.Comments).Paragraphs[0];
+        footnote.AddImage(imagePath, 16, 16);
+        endnote.AddImage(imagePath, 16, 16);
+        comment.AddImage(imagePath, 16, 16);
+
+        footnote.Image!.Remove();
+        endnote.Image!.Remove();
+        comment.Image!.Remove();
+
+        MainDocumentPart main = document._wordprocessingDocument.MainDocumentPart!;
+        Assert.DoesNotContain(main.FootnotesPart!.Parts, pair => pair.OpenXmlPart is ImagePart);
+        Assert.DoesNotContain(main.EndnotesPart!.Parts, pair => pair.OpenXmlPart is ImagePart);
+        Assert.DoesNotContain(main.WordprocessingCommentsPart!.Parts, pair => pair.OpenXmlPart is ImagePart);
+    }
+
+    [Fact]
+    public void NativePdfClampsUntrustedHeaderExpansionToThePage() {
+        using WordDocument document = WordDocument.Create();
+        document.AddHeadersAndFooters();
+        for (int index = 0; index < 100; index++) {
+            document.Header.Default!.AddParagraph("large header " + index);
+        }
+        document.AddParagraph("body remains renderable");
+        using var output = new MemoryStream();
+
+        document.SaveAsPdf(output, new PdfSaveOptions { IncludePageNumbers = false });
+
+        Assert.True(output.Length > 0);
+    }
+
+    [Fact]
+    public void NativePdfTreatsZeroDxaTableWidthAsAutomatic() {
+        using WordDocument document = WordDocument.Create();
+        WordTable table = document.AddTable(1, 1);
+        table.WidthType = TableWidthUnitValues.Dxa;
+        table.Width = 0;
+        table.Rows[0].Cells[0].Paragraphs[0].Text = "cell";
+        using var output = new MemoryStream();
+
+        document.SaveAsPdf(output, new PdfSaveOptions { IncludePageNumbers = false });
+
+        Assert.True(output.Length > 0);
+    }
+}

--- a/OfficeIMO.Word/WordImage.Content.cs
+++ b/OfficeIMO.Word/WordImage.Content.cs
@@ -203,38 +203,14 @@ namespace OfficeIMO.Word {
         /// </summary>
         public void Remove() {
             if (_imagePart != null) {
-                OpenXmlElement? parent = _Image?.Parent;
-                while (parent != null && parent is not Body && parent is not Header && parent is not Footer) {
-                    parent = parent.Parent;
-                }
-
-                OpenXmlPart? part = _document._wordprocessingDocument.MainDocumentPart;
-                if (parent is Header header) {
-                    part = header.HeaderPart;
-                } else if (parent is Footer footer) {
-                    part = footer.FooterPart;
-                }
-
-                part?.DeletePart(_imagePart);
+                OpenXmlPart part = GetContainingPart();
+                part.DeletePart(_imagePart);
                 _imagePart = null;
             } else if (!string.IsNullOrEmpty(_externalRelationshipId)) {
-                OpenXmlElement? parent = _Image?.Parent;
-                while (parent != null && parent is not Body && parent is not Header && parent is not Footer) {
-                    parent = parent.Parent;
-                }
-
-                OpenXmlPart? part = _document._wordprocessingDocument.MainDocumentPart;
-                if (parent is Header header) {
-                    part = header.HeaderPart;
-                } else if (parent is Footer footer) {
-                    part = footer.FooterPart;
-                }
-
-                if (part != null) {
-                    var rel = part.ExternalRelationships.FirstOrDefault(r => r.Id == _externalRelationshipId);
-                    if (rel != null) {
-                        part.DeleteExternalRelationship(rel);
-                    }
+                OpenXmlPart part = GetContainingPart();
+                var rel = part.ExternalRelationships.FirstOrDefault(r => r.Id == _externalRelationshipId);
+                if (rel != null) {
+                    part.DeleteExternalRelationship(rel);
                 }
                 _externalRelationshipId = null;
             }


### PR DESCRIPTION
## Summary

This batch resolves 16 validated all-severity security findings across document metadata, conversion, export, and parser boundaries.

- stop ignored HTML containers, detached and nested RTF notes, malformed custom properties, and stale MIME headers from leaking or reappearing
- keep signed Excel packages immutable on fast-save paths, reject non-finite custom-formula inputs, and keep workbook directories private in image exports by default
- make legacy PowerPoint mutations fail closed when retained records cannot be rewritten safely
- bound lazy Reader input enumeration without false truncation diagnostics at exact limits
- normalize non-finite PDF coordinates and keep URL query secrets out of source identities
- delete Word story-image relationships from the owning part, reserve usable PDF body space around hostile headers, and treat zero-width tables as automatic
- reject Visio showcase artifacts outside the configured root, including symbolic-link roots, linked files, and linked parent directories, before reading size or hash data

Trusted Excel export callers that intentionally require workbook directory fields can enable `IncludeWorkbookPathInHeaderFooter` explicitly.