### PR TITLE
Harden document parsing and rendering boundaries

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -955,6 +955,7 @@ jobs:
               "OfficeIMO.Tests.Markdown_IntelligenceX",
               "OfficeIMO.Tests.MarkdownAllSeverityBatch11SecurityTests",
               "OfficeIMO.Tests.MarkdownAllSeverityBatch12SecurityTests",
+              "OfficeIMO.Tests.MarkdownAllSeverityBatch15SecurityTests",
           )
 
           unassigned = [name for name in discovered if not any(partition in name for partition in markdown_partitions)]
@@ -980,7 +981,7 @@ jobs:
               ;;
             markdown-suite)
               run_markdown_tests "markdown-suite" 'FullyQualifiedName~OfficeIMO.Tests.MarkdownSuite'
-              run_markdown_tests "markdown-named" 'FullyQualifiedName~OfficeIMO.Tests.MarkdownHtmlToMarkdownCompatibilityTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownHtmlToMarkdownTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownHtmlApiContracts|FullyQualifiedName~OfficeIMO.Tests.Markdown_|FullyQualifiedName~OfficeIMO.Tests.MarkdownTranscript|FullyQualifiedName~OfficeIMO.Tests.MarkdownReaderBomTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownBlankLinesTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownDefinitionLinesTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownOrderedListsTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownStreamingPreviewTests|FullyQualifiedName~OfficeIMO.Tests.Markdown_Renderer|FullyQualifiedName~OfficeIMO.Tests.Markdown_IntelligenceX|FullyQualifiedName~OfficeIMO.Tests.MarkdownAllSeverityBatch11SecurityTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownAllSeverityBatch12SecurityTests'
+              run_markdown_tests "markdown-named" 'FullyQualifiedName~OfficeIMO.Tests.MarkdownHtmlToMarkdownCompatibilityTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownHtmlToMarkdownTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownHtmlApiContracts|FullyQualifiedName~OfficeIMO.Tests.Markdown_|FullyQualifiedName~OfficeIMO.Tests.MarkdownTranscript|FullyQualifiedName~OfficeIMO.Tests.MarkdownReaderBomTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownBlankLinesTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownDefinitionLinesTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownOrderedListsTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownStreamingPreviewTests|FullyQualifiedName~OfficeIMO.Tests.Markdown_Renderer|FullyQualifiedName~OfficeIMO.Tests.Markdown_IntelligenceX|FullyQualifiedName~OfficeIMO.Tests.MarkdownAllSeverityBatch11SecurityTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownAllSeverityBatch12SecurityTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownAllSeverityBatch15SecurityTests'
               ;;
             pdf-visual-inspector)
               export OFFICEIMO_REQUIRE_PDF_RASTERIZER=1

--- a/Build/Generate-ExcelBenchmarkWebsiteData.ps1
+++ b/Build/Generate-ExcelBenchmarkWebsiteData.ps1
@@ -128,6 +128,50 @@ function Get-PublicRuntimeLabel([object] $Value) {
     return $null
 }
 
+function Get-PublicPath([object] $Value) {
+    if ($null -eq $Value) { return $null }
+    $text = ([string] $Value).Trim()
+    if ([string]::IsNullOrWhiteSpace($text)) { return $null }
+
+    $normalized = $text.Replace('\', '/')
+    if ($normalized -match '(?i)(?:^|/)(?<root>Docs|Website)/(?<relative>.+)$') {
+        return ".\$($Matches['root'])\$($Matches['relative'].Replace('/', '\'))"
+    }
+
+    $isAbsolute = [System.IO.Path]::IsPathRooted($text) `
+        -or $normalized -match '^[A-Za-z]:/' `
+        -or $normalized.StartsWith('//', [System.StringComparison]::Ordinal) `
+        -or $normalized.StartsWith('~', [System.StringComparison]::Ordinal)
+    $hasParentTraversal = $normalized -match '(^|/)\.\.(/|$)'
+    if ($isAbsolute -or $hasParentTraversal) {
+        return [System.IO.Path]::GetFileName($normalized)
+    }
+
+    return $text
+}
+
+function Get-PublicArtifacts([object] $Artifacts) {
+    return @(
+        foreach ($artifact in @($Artifacts)) {
+            if ($null -eq $artifact) { continue }
+            if ($artifact -is [string]) {
+                Get-PublicPath $artifact
+                continue
+            }
+
+            $publicArtifact = [ordered]@{}
+            foreach ($property in $artifact.PSObject.Properties) {
+                $publicArtifact[$property.Name] = if ($property.Name -in @('Path', 'ArtifactPath', 'SourcePath')) {
+                    Get-PublicPath $property.Value
+                } else {
+                    $property.Value
+                }
+            }
+            $publicArtifact
+        }
+    )
+}
+
 function Get-PublicManifest([object] $Manifest) {
     if (-not $Manifest) { return $null }
 
@@ -137,7 +181,13 @@ function Get-PublicManifest([object] $Manifest) {
         'IncludeLegacyEpPlus', 'IncludePackageProfile', 'IncludeDenseHelloWorld',
         'ScenarioFilters', 'PackageScenarioFilters', 'DenseHelloWorldScenarios', 'Artifacts')) {
         $property = $Manifest.PSObject.Properties[$name]
-        if ($property) { $public[$name] = $property.Value }
+        if ($property) {
+            if ($name -eq 'Artifacts') {
+                $public[$name] = @(Get-PublicArtifacts $property.Value)
+            } else {
+                $public[$name] = $property.Value
+            }
+        }
     }
     $public['Framework'] = Get-PublicRuntimeLabel $Manifest.Framework
     return $public
@@ -212,7 +262,7 @@ function Convert-SummaryRow([object] $Row) {
         packageRatioToOfficeImo = $Row.PackageRatioToOfficeImo
         packageRatioToOfficeImoText = Format-Ratio $Row.PackageRatioToOfficeImo
         outcome = $Row.Outcome
-        artifactPath = $Row.ArtifactPath
+        artifactPath = Get-PublicPath $Row.ArtifactPath
     }
 }
 
@@ -244,7 +294,7 @@ function Convert-PackageProfileScenario([object] $Scenario, [int] $RowCount, [st
         worksheetCellCount = if ($Scenario.Package) { $Scenario.Package.WorksheetCellCount } else { $null }
         sharedStringCount = if ($Scenario.Package) { $Scenario.Package.SharedStringCount } else { $null }
         uniqueSharedStringCount = if ($Scenario.Package) { $Scenario.Package.UniqueSharedStringCount } else { $null }
-        sourcePath = $SourcePath
+        sourcePath = Get-PublicPath $SourcePath
     }
 }
 
@@ -616,9 +666,9 @@ $document = [ordered]@{
     framework = Get-PublicRuntimeLabel $(if ($manifest) { $manifest.Framework } else { $summaryInput.Framework })
     configuration = if ($manifest) { "Release" } else { $null }
     source = [ordered]@{
-        summaryPath = $SummaryPath
-        manifestPath = if (Test-Path $ManifestPath) { $ManifestPath } else { $null }
-        packageProfilePaths = $packageProfilePaths
+        summaryPath = Get-PublicPath $SummaryPath
+        manifestPath = if (Test-Path $ManifestPath) { Get-PublicPath $ManifestPath } else { $null }
+        packageProfilePaths = @($packageProfilePaths | ForEach-Object { Get-PublicPath $_ })
     }
     meta = Get-EvidenceMeta -Manifest $manifest -Summary $summaryInput -Profiles $allPackageProfiles
     howToRead = @(
@@ -665,9 +715,9 @@ $indexDocument = [ordered]@{
             runMode = $document.runMode
             publish = $document.publish
             framework = $document.framework
-            summaryPath = $WebsiteSummaryPath
-            dataPath = $WebsiteDataPath
-            markdownPath = $MarkdownPath
+            summaryPath = Get-PublicPath $WebsiteSummaryPath
+            dataPath = Get-PublicPath $WebsiteDataPath
+            markdownPath = Get-PublicPath $MarkdownPath
             meta = $document.meta
         }
     )

--- a/Build/Generate-ExcelBenchmarkWebsiteData.ps1
+++ b/Build/Generate-ExcelBenchmarkWebsiteData.ps1
@@ -119,21 +119,36 @@ function Get-ScenarioCategory([string] $Scenario, [string] $ArtifactKind) {
     return "Other"
 }
 
+function Get-PublicRuntimeLabel([object] $Value) {
+    $text = [string] $Value
+    if ($text -match '(?i)(?:\.NET|net)\s*(?<major>\d+)') {
+        return ".NET $($Matches['major'])"
+    }
+
+    return $null
+}
+
+function Get-PublicManifest([object] $Manifest) {
+    if (-not $Manifest) { return $null }
+
+    $public = [ordered]@{}
+    foreach ($name in @(
+        'GeneratedAtUtc', 'RowCounts', 'WarmupIterations', 'MeasuredIterations',
+        'IncludeLegacyEpPlus', 'IncludePackageProfile', 'IncludeDenseHelloWorld',
+        'ScenarioFilters', 'PackageScenarioFilters', 'DenseHelloWorldScenarios', 'Artifacts')) {
+        $property = $Manifest.PSObject.Properties[$name]
+        if ($property) { $public[$name] = $property.Value }
+    }
+    $public['Framework'] = Get-PublicRuntimeLabel $Manifest.Framework
+    return $public
+}
+
 function Get-EvidenceMeta([object] $Manifest, [object] $Summary, [object[]] $Profiles) {
     $profile = @($Profiles) | Select-Object -First 1
-    $machineName = if ($Manifest -and $Manifest.MachineName) { $Manifest.MachineName } elseif ($profile -and $profile.MachineName) { $profile.MachineName } else { $null }
     $runtime = if ($Manifest -and $Manifest.Framework) { $Manifest.Framework } elseif ($Summary -and $Summary.Framework) { $Summary.Framework } elseif ($profile -and $profile.Framework) { $profile.Framework } else { $null }
 
     return [ordered]@{
-        commit = $null
-        branch = $null
-        dotnetSdk = $null
-        runtime = $runtime
-        osDescription = $null
-        osArchitecture = $null
-        processArchitecture = $null
-        machineName = $machineName
-        processorCount = $null
+        runtime = Get-PublicRuntimeLabel $runtime
     }
 }
 
@@ -384,7 +399,7 @@ function Write-MarkdownReport([object] $Document, [string] $Path) {
     $lines.Add("Generated: $($Document.generatedUtc)")
     $lines.Add("Run mode: $($Document.runMode)")
     $lines.Add("Publish: $($Document.publish)")
-    $lines.Add("Machine: $($Document.meta.machineName) ($($Document.meta.processorCount) processors)")
+    $lines.Add("Runtime family: $($Document.meta.runtime)")
     $lines.Add("")
     $lines.Add("## How to Read")
     foreach ($note in $Document.howToRead) {
@@ -598,7 +613,7 @@ $document = [ordered]@{
     generatedUtc = Get-LatestEvidenceTimestamp -Manifest $manifest -Summary $summaryInput -Profiles $allPackageProfiles
     runMode = $RunMode
     publish = $publishValue
-    framework = if ($manifest) { $manifest.Framework } else { $summaryInput.Framework }
+    framework = Get-PublicRuntimeLabel $(if ($manifest) { $manifest.Framework } else { $summaryInput.Framework })
     configuration = if ($manifest) { "Release" } else { $null }
     source = [ordered]@{
         summaryPath = $SummaryPath
@@ -620,7 +635,7 @@ $document = [ordered]@{
         "Generated provenance comes from the committed benchmark evidence, not the website build environment.",
         "Website consumers should read this generated JSON instead of hand-maintained benchmark rows."
     )
-    manifest = $manifest
+    manifest = Get-PublicManifest $manifest
     metrics = $metrics
     matrix = $matrix
     summary = Build-Summary -Rows $allRows

--- a/Docs/benchmarks/officeimo.excel.comparison-report.md
+++ b/Docs/benchmarks/officeimo.excel.comparison-report.md
@@ -3,7 +3,7 @@
 Generated: 2026-05-31T18:44:43.8878299+00:00
 Run mode: quick
 Publish: False
-Machine: EVOMAGIC ( processors)
+Runtime family: .NET 8
 
 ## How to Read
 - Mean: average elapsed time for the measured operation. Lower is better.

--- a/OfficeIMO.Drawing/Internal/OfficeFileCommit.cs
+++ b/OfficeIMO.Drawing/Internal/OfficeFileCommit.cs
@@ -265,6 +265,15 @@ namespace OfficeIMO.Drawing.Internal {
                 // The destination appeared after the existence check. Replace it below.
             }
 
+#if NET6_0_OR_GREATER
+            if (!OperatingSystem.IsWindows()) {
+                // A rename/replace installs the staging inode on Unix. Apply the existing
+                // destination's mode first so a restrictive workbook or document cannot be
+                // widened to the staging file's default umask-derived permissions.
+                File.SetUnixFileMode(temporaryPath, File.GetUnixFileMode(fullTargetPath));
+            }
+#endif
+
             try {
                 ExecuteWithRetry(() => File.Replace(temporaryPath, fullTargetPath, destinationBackupFileName: null));
                 return;

--- a/OfficeIMO.Excel.Tests/Excel.Security.AllSeverityBatch15.cs
+++ b/OfficeIMO.Excel.Tests/Excel.Security.AllSeverityBatch15.cs
@@ -33,6 +33,11 @@ public sealed class ExcelAllSeverityBatch15SecurityTests {
                     new XElement(extension + "sheet",
                         new XAttribute("name", "ExtensionBogus"),
                         new XAttribute(relationships + "id", realRelationshipId))));
+                workbook.Root.AddFirst(new XElement(extension + "wrapper",
+                    new XElement(spreadsheet + "sheets",
+                        new XElement(spreadsheet + "sheet",
+                            new XAttribute("name", "SameNamespaceBogus"),
+                            new XAttribute(relationships + "id", realRelationshipId)))));
                 sheets.AddFirst(new XElement(spreadsheet + "sheet",
                     new XAttribute("name", "WrongNamespaceBogus"),
                     new XAttribute(XNamespace.Xmlns + "r", "urn:attacker-relationships"),
@@ -47,6 +52,8 @@ public sealed class ExcelAllSeverityBatch15SecurityTests {
             using ExcelDocumentReader reader = ExcelDocumentReader.Open(path);
             Assert.Equal(new[] { "Data" }, reader.GetSheetNames());
             Assert.Equal(1, reader.SheetCount);
+            Assert.NotNull(reader.GetSheet("Data"));
+            Assert.Throws<KeyNotFoundException>(() => reader.GetSheet("SameNamespaceBogus"));
         } finally {
             if (File.Exists(path)) File.Delete(path);
         }
@@ -105,17 +112,24 @@ public sealed class ExcelAllSeverityBatch15SecurityTests {
     }
 
     [Fact]
-    public void ParallelRowAutoFitRequestsSerializeOpenXmlTraversal() {
+    public void ParallelRowAutoFitAndRowMutationsSerializeOpenXmlTraversal() {
         using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
         ExcelSheet sheet = document.AddWorksheet("Data");
         for (int row = 1; row <= 100; row++) sheet.CellValue(row, 1, "row " + row);
 
         Parallel.Invoke(
-            () => sheet.AutoFitRows(ExecutionMode.Parallel),
-            () => sheet.AutoFitRows(ExecutionMode.Parallel),
-            () => sheet.AutoFitRows(ExecutionMode.Parallel));
+            () => {
+                for (int row = 101; row <= 600; row++) sheet.CellValue(row, 1, "row " + row);
+            },
+            () => {
+                for (int pass = 0; pass < 8; pass++) sheet.AutoFitRows(ExecutionMode.Parallel);
+            },
+            () => {
+                for (int pass = 0; pass < 8; pass++) sheet.AutoFitRows(ExecutionMode.Parallel);
+            });
 
         Assert.NotNull(sheet.WorksheetPart.Worksheet.GetFirstChild<SheetData>()!.Elements<Row>().First().Height);
+        Assert.Equal(600, sheet.WorksheetPart.Worksheet.GetFirstChild<SheetData>()!.Elements<Row>().Count());
     }
 
     private sealed record WideRow(string Name, int Score, int Total);

--- a/OfficeIMO.Excel.Tests/Excel.Security.AllSeverityBatch15.cs
+++ b/OfficeIMO.Excel.Tests/Excel.Security.AllSeverityBatch15.cs
@@ -1,0 +1,122 @@
+using System.IO.Compression;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Excel;
+using OfficeIMO.Excel.Fluent;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class ExcelAllSeverityBatch15SecurityTests {
+    [Fact]
+    public void FastSheetReaderIgnoresLookalikeElementsAndWrongRelationshipNamespaces() {
+        string path = Path.Combine(Path.GetTempPath(), "officeimo-sheet-fast-" + Guid.NewGuid().ToString("N") + ".xlsx");
+        try {
+            using (ExcelDocument document = ExcelDocument.Create(path)) {
+                document.AddWorksheet("Data").CellValue(1, 1, "safe");
+                document.Save();
+            }
+
+            using (ZipArchive archive = ZipFile.Open(path, ZipArchiveMode.Update)) {
+                ZipArchiveEntry entry = archive.GetEntry("xl/workbook.xml")!;
+                XDocument workbook;
+                using (Stream input = entry.Open()) workbook = XDocument.Load(input);
+                XNamespace spreadsheet = workbook.Root!.Name.Namespace;
+                XNamespace relationships = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+                XNamespace extension = "urn:attacker-extension";
+                XElement sheets = workbook.Root.Element(spreadsheet + "sheets")!;
+                string realRelationshipId = sheets.Elements(spreadsheet + "sheet").First().Attribute(relationships + "id")!.Value;
+
+                workbook.Root.AddFirst(new XElement(extension + "sheets",
+                    new XElement(extension + "sheet",
+                        new XAttribute("name", "ExtensionBogus"),
+                        new XAttribute(relationships + "id", realRelationshipId))));
+                sheets.AddFirst(new XElement(spreadsheet + "sheet",
+                    new XAttribute("name", "WrongNamespaceBogus"),
+                    new XAttribute(XNamespace.Xmlns + "r", "urn:attacker-relationships"),
+                    new XAttribute(XName.Get("id", "urn:attacker-relationships"), realRelationshipId)));
+
+                entry.Delete();
+                ZipArchiveEntry replacement = archive.CreateEntry("xl/workbook.xml", CompressionLevel.Optimal);
+                using Stream output = replacement.Open();
+                workbook.Save(output);
+            }
+
+            using ExcelDocumentReader reader = ExcelDocumentReader.Open(path);
+            Assert.Equal(new[] { "Data" }, reader.GetSheetNames());
+            Assert.Equal(1, reader.SheetCount);
+        } finally {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void UncachedSheetReadsDoNotMutateSharedSheetIdState() {
+        using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+        document.AddWorksheet("Data");
+        document.SheetCachingEnabled = false;
+
+        Parallel.For(0, 200, _ => Assert.Single(document.Sheets));
+    }
+
+    [Fact]
+    public void TableTotalsRetainLastCaseInsensitiveDuplicate() {
+        using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+        ExcelSheet sheet = document.AddWorksheet("Data");
+        sheet.CellValue(1, 1, "Name");
+        sheet.CellValue(1, 2, "Value");
+        sheet.CellValue(2, 1, "A");
+        sheet.CellValue(2, 2, 1);
+        sheet.AddTable("A1:B2", true, "DataTable", OfficeIMO.Excel.TableStyle.TableStyleMedium2);
+        var totals = new Dictionary<string, TotalsRowFunctionValues>(StringComparer.Ordinal) {
+            ["Name"] = TotalsRowFunctionValues.Count,
+            ["NAME"] = TotalsRowFunctionValues.None
+        };
+
+        Exception? exception = Record.Exception(() => sheet.SetTableTotals("A1:B2", totals));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void SummarizeOverflowFitsMoreIntoSingleAvailableColumn() {
+        string path = Path.Combine(Path.GetTempPath(), "officeimo-summary-one-column-" + Guid.NewGuid().ToString("N") + ".xlsx");
+        try {
+            using (ExcelDocument document = ExcelDocument.Create(path)) {
+                document.Compose("Report", composer => {
+                    composer.Columns(2, columns => columns[0].TableFrom(
+                        new[] { new WideRow("Alpha", 1, 2) }, title: "Wide"),
+                        columnWidth: 1,
+                        overflow: OverflowMode.Summarize);
+                    composer.Finish(autoFitColumns: false);
+                });
+                document.Save();
+            }
+
+            using SpreadsheetDocument package = SpreadsheetDocument.Open(path, false);
+            Table table = Assert.Single(package.WorkbookPart!.WorksheetParts.First().TableDefinitionParts).Table!;
+            Assert.Equal("A2:A3", table.Reference!.Value);
+            Assert.Equal("More", Assert.Single(table.TableColumns!.Elements<TableColumn>()).Name!.Value);
+        } finally {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void ParallelRowAutoFitRequestsSerializeOpenXmlTraversal() {
+        using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+        ExcelSheet sheet = document.AddWorksheet("Data");
+        for (int row = 1; row <= 100; row++) sheet.CellValue(row, 1, "row " + row);
+
+        Parallel.Invoke(
+            () => sheet.AutoFitRows(ExecutionMode.Parallel),
+            () => sheet.AutoFitRows(ExecutionMode.Parallel),
+            () => sheet.AutoFitRows(ExecutionMode.Parallel));
+
+        Assert.NotNull(sheet.WorksheetPart.Worksheet.GetFirstChild<SheetData>()!.Elements<Row>().First().Height);
+    }
+
+    private sealed record WideRow(string Name, int Score, int Total);
+}

--- a/OfficeIMO.Excel/ExcelDocument.cs
+++ b/OfficeIMO.Excel/ExcelDocument.cs
@@ -263,7 +263,6 @@ namespace OfficeIMO.Excel {
         private List<ExcelSheet> BuildSheetsWithoutCaching()
         {
             var elements = ReadSheetElements();
-            UpdateSheetIdCache(elements);
             return MaterializeSheets(elements);
         }
 

--- a/OfficeIMO.Excel/ExcelSheet.RowAutoFit.cs
+++ b/OfficeIMO.Excel/ExcelSheet.RowAutoFit.cs
@@ -309,11 +309,11 @@ namespace OfficeIMO.Excel {
         /// <param name="mode">Overrides how the auto-fit work is scheduled across rows.</param>
         /// <param name="ct">Cancels the row auto-fit pass while heights are being calculated or applied.</param>
         public void AutoFitRows(ExecutionMode? mode = null, CancellationToken ct = default) {
-            _excelDocument.MaterializeDeferredDataSetImport();
             // CalculateRowHeight reads shared Open XML nodes. Keep the read-and-apply pass
             // serialized even when callers request parallel execution; parallelizing the DOM
             // traversal is not safe and the public mode remains a scheduling hint.
             WriteLock(() => {
+                _excelDocument.MaterializeDeferredDataSetImport();
                 var worksheet = WorksheetRoot;
                 SheetData? sheetData = worksheet.GetFirstChild<SheetData>();
                 if (sheetData == null) return;

--- a/OfficeIMO.Excel/ExcelSheet.RowAutoFit.cs
+++ b/OfficeIMO.Excel/ExcelSheet.RowAutoFit.cs
@@ -310,20 +310,18 @@ namespace OfficeIMO.Excel {
         /// <param name="ct">Cancels the row auto-fit pass while heights are being calculated or applied.</param>
         public void AutoFitRows(ExecutionMode? mode = null, CancellationToken ct = default) {
             _excelDocument.MaterializeDeferredDataSetImport();
-            var worksheet = WorksheetRoot;
-            SheetData? sheetData = worksheet.GetFirstChild<SheetData>();
-            if (sheetData == null) return;
-
-            var rowIndexes = sheetData.Elements<Row>()
-                .Select(r => (int)r.RowIndex!.Value)
-                .ToList();
-
-            if (rowIndexes.Count == 0) return;
-
             // CalculateRowHeight reads shared Open XML nodes. Keep the read-and-apply pass
             // serialized even when callers request parallel execution; parallelizing the DOM
             // traversal is not safe and the public mode remains a scheduling hint.
             WriteLock(() => {
+                var worksheet = WorksheetRoot;
+                SheetData? sheetData = worksheet.GetFirstChild<SheetData>();
+                if (sheetData == null) return;
+                var rowIndexes = sheetData.Elements<Row>()
+                    .Select(r => (int)r.RowIndex!.Value)
+                    .ToList();
+                if (rowIndexes.Count == 0) return;
+
                 for (int i = 0; i < rowIndexes.Count; i++) {
                     ct.ThrowIfCancellationRequested();
                     double height = CalculateRowHeight(rowIndexes[i]);

--- a/OfficeIMO.Excel/ExcelSheet.RowAutoFit.cs
+++ b/OfficeIMO.Excel/ExcelSheet.RowAutoFit.cs
@@ -320,62 +320,21 @@ namespace OfficeIMO.Excel {
 
             if (rowIndexes.Count == 0) return;
 
-            double[] computed = new double[rowIndexes.Count];
+            // CalculateRowHeight reads shared Open XML nodes. Keep the read-and-apply pass
+            // serialized even when callers request parallel execution; parallelizing the DOM
+            // traversal is not safe and the public mode remains a scheduling hint.
+            WriteLock(() => {
+                for (int i = 0; i < rowIndexes.Count; i++) {
+                    ct.ThrowIfCancellationRequested();
+                    double height = CalculateRowHeight(rowIndexes[i]);
+                    SetRowHeightCore(rowIndexes[i], height, normalizeForExcelVisibleHeight: true);
+                }
 
-            ExecuteWithPolicy(
-                opName: "AutoFitRows",
-                itemCount: rowIndexes.Count,
-                overrideMode: mode,
-                sequentialCore: () => {
-                    // Sequential path with NoLock
-                    for (int i = 0; i < rowIndexes.Count; i++) {
-                        computed[i] = CalculateRowHeight(rowIndexes[i]);
-                    }
-
-                    for (int i = 0; i < rowIndexes.Count; i++) {
-                        // Excel normalizes OfficeIMO-authored auto-fit row heights down on open/save; serialize a
-                        // pixel-equivalent height so the visible Excel row height matches the measured value.
-                        SetRowHeightCore(rowIndexes[i], computed[i], normalizeForExcelVisibleHeight: true);
-                    }
-
-                    UpdateSheetFormat();
-                    if (EffectiveExecution.SaveWorksheetAfterAutoFit) {
-                        worksheet.Save();
-                    }
-                },
-                computeParallel: () => {
-                    // Parallel compute phase - calculate heights without DOM mutation
-                    var failures = new System.Collections.Concurrent.ConcurrentBag<int>();
-                    Parallel.For(0, rowIndexes.Count, new ParallelOptions {
-                        CancellationToken = ct,
-                        MaxDegreeOfParallelism = EffectiveExecution.MaxDegreeOfParallelism ?? -1
-                    }, i => {
-                        try {
-                            computed[i] = CalculateRowHeight(rowIndexes[i]);
-                        } catch {
-                            failures.Add(i);
-                        }
-                    });
-                    if (!failures.IsEmpty) {
-                        foreach (var idx in failures) {
-                            try { computed[idx] = CalculateRowHeight(rowIndexes[idx]); } catch { computed[idx] = 0; }
-                        }
-                    }
-                },
-                applySequential: () => {
-                    // Apply phase - write all row heights to DOM
-                    for (int i = 0; i < rowIndexes.Count; i++) {
-                        // Excel normalizes OfficeIMO-authored auto-fit row heights down on open/save; serialize a
-                        // pixel-equivalent height so the visible Excel row height matches the measured value.
-                        SetRowHeightCore(rowIndexes[i], computed[i], normalizeForExcelVisibleHeight: true);
-                    }
-                    UpdateSheetFormat();
-                    if (EffectiveExecution.SaveWorksheetAfterAutoFit) {
-                        worksheet.Save();
-                    }
-                },
-                ct: ct
-            );
+                UpdateSheetFormat();
+                if (EffectiveExecution.SaveWorksheetAfterAutoFit) {
+                    worksheet.Save();
+                }
+            });
         }
 
 

--- a/OfficeIMO.Excel/ExcelSheet.Tables.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Tables.cs
@@ -117,7 +117,10 @@ namespace OfficeIMO.Excel {
         }
 
         private void SetTableTotalsCore(string tableOrRange, System.Collections.Generic.IDictionary<string, DocumentFormat.OpenXml.Spreadsheet.TotalsRowFunctionValues> byHeader, bool throwIfMissing) {
-            var totalsByHeader = new System.Collections.Generic.Dictionary<string, DocumentFormat.OpenXml.Spreadsheet.TotalsRowFunctionValues>(byHeader, System.StringComparer.OrdinalIgnoreCase);
+            var totalsByHeader = new System.Collections.Generic.Dictionary<string, DocumentFormat.OpenXml.Spreadsheet.TotalsRowFunctionValues>(System.StringComparer.OrdinalIgnoreCase);
+            foreach (var entry in byHeader) {
+                totalsByHeader[entry.Key] = entry.Value;
+            }
             WriteLock(() => {
                 var table = FindTableByRangeNameOrDisplayName(tableOrRange);
                 if (table == null) {

--- a/OfficeIMO.Excel/Fluent/SheetComposer.ColumnsLayout.cs
+++ b/OfficeIMO.Excel/Fluent/SheetComposer.ColumnsLayout.cs
@@ -128,7 +128,7 @@ namespace OfficeIMO.Excel.Fluent {
                         effPaths = paths.Take(_maxTableColumns.Value).ToList();
                         _sheet.EffectiveExecution.ReportInfo($"[Columns Shrink] Sheet='{_sheet.Name}', baseCol={_baseCol}, kept={effPaths.Count}, dropped={paths.Count - effPaths.Count}");
                     } else if (_overflowMode == OverflowMode.Summarize) {
-                        int keep = Math.Max(1, _maxTableColumns.Value - 1);
+                        int keep = Math.Max(0, _maxTableColumns.Value - 1);
                         if (keep <= 0) {
                             effPaths = new List<string> { "__More__" };
                         } else {

--- a/OfficeIMO.Excel/Read/ExcelDocumentReader.cs
+++ b/OfficeIMO.Excel/Read/ExcelDocumentReader.cs
@@ -14,6 +14,8 @@ namespace OfficeIMO.Excel {
     public sealed partial class ExcelDocumentReader : IDisposable {
         private const string OfficeDocumentRelationshipNamespace = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
         private const string StrictOfficeDocumentRelationshipNamespace = "http://purl.oclc.org/ooxml/officeDocument/relationships";
+        private const string SpreadsheetNamespace = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+        private const string StrictSpreadsheetNamespace = "http://purl.oclc.org/ooxml/spreadsheetml/main";
         private static readonly XmlReaderSettings WorkbookXmlReaderSettings = CreateWorkbookXmlReaderSettings();
 
         private readonly SpreadsheetDocument _doc;
@@ -181,8 +183,9 @@ namespace OfficeIMO.Excel {
             try {
                 using var stream = WorkbookPartRoot.GetStream(FileMode.Open, FileAccess.Read);
                 using var reader = XmlReader.Create(stream, WorkbookXmlReaderSettings);
+                int sheetsDepth = -1;
                 while (reader.Read()) {
-                    if (reader.NodeType != XmlNodeType.Element || reader.LocalName != "sheet") {
+                    if (!IsWorkbookSheetElement(reader, ref sheetsDepth)) {
                         continue;
                     }
 
@@ -223,8 +226,7 @@ namespace OfficeIMO.Excel {
 
         private static string? GetRelationshipIdAttribute(XmlReader reader) {
             string? relationshipId = reader.GetAttribute("id", OfficeDocumentRelationshipNamespace)
-                ?? reader.GetAttribute("id", StrictOfficeDocumentRelationshipNamespace)
-                ?? reader.GetAttribute("r:id");
+                ?? reader.GetAttribute("id", StrictOfficeDocumentRelationshipNamespace);
             if (!string.IsNullOrEmpty(relationshipId)) {
                 return relationshipId;
             }
@@ -237,8 +239,7 @@ namespace OfficeIMO.Excel {
                 do {
                     if (reader.LocalName == "id"
                         && (reader.NamespaceURI == OfficeDocumentRelationshipNamespace
-                            || reader.NamespaceURI == StrictOfficeDocumentRelationshipNamespace
-                            || reader.Prefix == "r")) {
+                            || reader.NamespaceURI == StrictOfficeDocumentRelationshipNamespace)) {
                         return reader.Value;
                     }
                 } while (reader.MoveToNextAttribute());
@@ -261,8 +262,9 @@ namespace OfficeIMO.Excel {
                 using var stream = WorkbookPartRoot.GetStream(FileMode.Open, FileAccess.Read);
                 using var reader = XmlReader.Create(stream, WorkbookXmlReaderSettings);
                 int currentIndex = 0;
+                int sheetsDepth = -1;
                 while (reader.Read()) {
-                    if (reader.NodeType != XmlNodeType.Element || reader.LocalName != "sheet") {
+                    if (!IsWorkbookSheetElement(reader, ref sheetsDepth)) {
                         continue;
                     }
 
@@ -312,8 +314,9 @@ namespace OfficeIMO.Excel {
             try {
                 using var stream = WorkbookPartRoot.GetStream(FileMode.Open, FileAccess.Read);
                 using var reader = XmlReader.Create(stream, WorkbookXmlReaderSettings);
+                int sheetsDepth = -1;
                 while (reader.Read()) {
-                    if (reader.NodeType != XmlNodeType.Element || reader.LocalName != "sheet") {
+                    if (!IsWorkbookSheetElement(reader, ref sheetsDepth)) {
                         continue;
                     }
 
@@ -363,8 +366,9 @@ namespace OfficeIMO.Excel {
             try {
                 using var stream = WorkbookPartRoot.GetStream(FileMode.Open, FileAccess.Read);
                 using var reader = XmlReader.Create(stream, WorkbookXmlReaderSettings);
+                int sheetsDepth = -1;
                 while (reader.Read()) {
-                    if (reader.NodeType != XmlNodeType.Element || reader.LocalName != "sheet") {
+                    if (!IsWorkbookSheetElement(reader, ref sheetsDepth)) {
                         continue;
                     }
 
@@ -395,6 +399,32 @@ namespace OfficeIMO.Excel {
                 count = 0;
                 return false;
             }
+        }
+
+        private static bool IsWorkbookSheetElement(XmlReader reader, ref int sheetsDepth) {
+            bool isSpreadsheetNamespace = reader.NamespaceURI == SpreadsheetNamespace
+                || reader.NamespaceURI == StrictSpreadsheetNamespace;
+
+            if (reader.NodeType == XmlNodeType.EndElement
+                && sheetsDepth == reader.Depth
+                && reader.LocalName == "sheets"
+                && isSpreadsheetNamespace) {
+                sheetsDepth = -1;
+                return false;
+            }
+
+            if (reader.NodeType != XmlNodeType.Element || !isSpreadsheetNamespace) {
+                return false;
+            }
+
+            if (reader.LocalName == "sheets") {
+                sheetsDepth = reader.IsEmptyElement ? -1 : reader.Depth;
+                return false;
+            }
+
+            return sheetsDepth >= 0
+                && reader.Depth == sheetsDepth + 1
+                && reader.LocalName == "sheet";
         }
 
         private static XmlReaderSettings CreateWorkbookXmlReaderSettings() {

--- a/OfficeIMO.Excel/Read/ExcelDocumentReader.cs
+++ b/OfficeIMO.Excel/Read/ExcelDocumentReader.cs
@@ -183,9 +183,11 @@ namespace OfficeIMO.Excel {
             try {
                 using var stream = WorkbookPartRoot.GetStream(FileMode.Open, FileAccess.Read);
                 using var reader = XmlReader.Create(stream, WorkbookXmlReaderSettings);
-                int sheetsDepth = -1;
+                var state = new WorkbookSheetXmlState();
+                string? resolvedName = null;
+                WorksheetPart? resolvedWorksheetPart = null;
                 while (reader.Read()) {
-                    if (!IsWorkbookSheetElement(reader, ref sheetsDepth)) {
+                    if (!IsWorkbookSheetElement(reader, state)) {
                         continue;
                     }
 
@@ -203,12 +205,16 @@ namespace OfficeIMO.Excel {
                         return false;
                     }
 
-                    sheetName = candidateName!;
-                    worksheetPart = resolvedPart;
-                    return true;
+                    resolvedName ??= candidateName;
+                    resolvedWorksheetPart ??= resolvedPart;
                 }
 
-                return false;
+                if (state.IsInvalid || resolvedName == null || resolvedWorksheetPart == null) {
+                    return false;
+                }
+                sheetName = resolvedName;
+                worksheetPart = resolvedWorksheetPart;
+                return true;
             } catch (XmlException) {
                 return false;
             } catch (IOException) {
@@ -262,9 +268,11 @@ namespace OfficeIMO.Excel {
                 using var stream = WorkbookPartRoot.GetStream(FileMode.Open, FileAccess.Read);
                 using var reader = XmlReader.Create(stream, WorkbookXmlReaderSettings);
                 int currentIndex = 0;
-                int sheetsDepth = -1;
+                var state = new WorkbookSheetXmlState();
+                string? resolvedName = null;
+                WorksheetPart? resolvedWorksheetPart = null;
                 while (reader.Read()) {
-                    if (!IsWorkbookSheetElement(reader, ref sheetsDepth)) {
+                    if (!IsWorkbookSheetElement(reader, state)) {
                         continue;
                     }
 
@@ -283,12 +291,16 @@ namespace OfficeIMO.Excel {
                         continue;
                     }
 
-                    sheetName = candidateName!;
-                    worksheetPart = resolvedPart;
-                    return true;
+                    resolvedName ??= candidateName;
+                    resolvedWorksheetPart ??= resolvedPart;
                 }
 
-                return false;
+                if (state.IsInvalid || resolvedName == null || resolvedWorksheetPart == null) {
+                    return false;
+                }
+                sheetName = resolvedName;
+                worksheetPart = resolvedWorksheetPart;
+                return true;
             } catch (XmlException) {
                 return false;
             } catch (IOException) {
@@ -314,9 +326,9 @@ namespace OfficeIMO.Excel {
             try {
                 using var stream = WorkbookPartRoot.GetStream(FileMode.Open, FileAccess.Read);
                 using var reader = XmlReader.Create(stream, WorkbookXmlReaderSettings);
-                int sheetsDepth = -1;
+                var state = new WorkbookSheetXmlState();
                 while (reader.Read()) {
-                    if (!IsWorkbookSheetElement(reader, ref sheetsDepth)) {
+                    if (!IsWorkbookSheetElement(reader, state)) {
                         continue;
                     }
 
@@ -334,7 +346,7 @@ namespace OfficeIMO.Excel {
                     names.Add(sheetName!);
                 }
 
-                return names.Count > 0;
+                return !state.IsInvalid && names.Count > 0;
             } catch (XmlException) {
                 names = [];
                 return false;
@@ -366,9 +378,9 @@ namespace OfficeIMO.Excel {
             try {
                 using var stream = WorkbookPartRoot.GetStream(FileMode.Open, FileAccess.Read);
                 using var reader = XmlReader.Create(stream, WorkbookXmlReaderSettings);
-                int sheetsDepth = -1;
+                var state = new WorkbookSheetXmlState();
                 while (reader.Read()) {
-                    if (!IsWorkbookSheetElement(reader, ref sheetsDepth)) {
+                    if (!IsWorkbookSheetElement(reader, state)) {
                         continue;
                     }
 
@@ -379,7 +391,7 @@ namespace OfficeIMO.Excel {
                     }
                 }
 
-                return count > 0;
+                return !state.IsInvalid && count > 0;
             } catch (XmlException) {
                 count = 0;
                 return false;
@@ -401,30 +413,57 @@ namespace OfficeIMO.Excel {
             }
         }
 
-        private static bool IsWorkbookSheetElement(XmlReader reader, ref int sheetsDepth) {
+        private static bool IsWorkbookSheetElement(XmlReader reader, WorkbookSheetXmlState state) {
             bool isSpreadsheetNamespace = reader.NamespaceURI == SpreadsheetNamespace
                 || reader.NamespaceURI == StrictSpreadsheetNamespace;
 
+            if (reader.NodeType == XmlNodeType.Element && reader.Depth == 0) {
+                if (!isSpreadsheetNamespace || reader.LocalName != "workbook") {
+                    state.IsInvalid = true;
+                } else {
+                    state.WorkbookDepth = reader.Depth;
+                    state.WorkbookNamespace = reader.NamespaceURI;
+                }
+                return false;
+            }
+
             if (reader.NodeType == XmlNodeType.EndElement
-                && sheetsDepth == reader.Depth
+                && state.SheetsDepth == reader.Depth
                 && reader.LocalName == "sheets"
-                && isSpreadsheetNamespace) {
-                sheetsDepth = -1;
+                && reader.NamespaceURI == state.WorkbookNamespace) {
+                state.SheetsDepth = -1;
                 return false;
             }
 
-            if (reader.NodeType != XmlNodeType.Element || !isSpreadsheetNamespace) {
+            if (reader.NodeType != XmlNodeType.Element) {
                 return false;
             }
 
-            if (reader.LocalName == "sheets") {
-                sheetsDepth = reader.IsEmptyElement ? -1 : reader.Depth;
+            if (isSpreadsheetNamespace && reader.LocalName == "sheets") {
+                if (state.WorkbookDepth < 0
+                    || state.SheetsContainerSeen
+                    || reader.Depth != state.WorkbookDepth + 1
+                    || reader.NamespaceURI != state.WorkbookNamespace) {
+                    state.IsInvalid = true;
+                    return false;
+                }
+                state.SheetsContainerSeen = true;
+                state.SheetsDepth = reader.IsEmptyElement ? -1 : reader.Depth;
                 return false;
             }
 
-            return sheetsDepth >= 0
-                && reader.Depth == sheetsDepth + 1
-                && reader.LocalName == "sheet";
+            return state.SheetsDepth >= 0
+                && reader.Depth == state.SheetsDepth + 1
+                && reader.LocalName == "sheet"
+                && reader.NamespaceURI == state.WorkbookNamespace;
+        }
+
+        private sealed class WorkbookSheetXmlState {
+            internal int WorkbookDepth { get; set; } = -1;
+            internal int SheetsDepth { get; set; } = -1;
+            internal string? WorkbookNamespace { get; set; }
+            internal bool SheetsContainerSeen { get; set; }
+            internal bool IsInvalid { get; set; }
         }
 
         private static XmlReaderSettings CreateWorkbookXmlReaderSettings() {

--- a/OfficeIMO.Markdown.Tests/Markdown/Markdown_AllSeverityBatch15_Security_Tests.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown/Markdown_AllSeverityBatch15_Security_Tests.cs
@@ -74,6 +74,21 @@ public sealed class MarkdownAllSeverityBatch15SecurityTests {
     }
 
     [Fact]
+    public void LinkPolicyKeepsNonExecutableProtocolsButRejectsMalformedPolicyTargets() {
+        var document = MarkdownDoc.Create()
+            .Add(new ParagraphBlock(new InlineSequence()
+                .Link("archive", "ftp://files.example/archive")
+                .Link("blocked", "https:/tracker.example/pixel")));
+        var options = new HtmlOptions();
+        options.AllowedHttpLinkHosts.Add("safe.example");
+
+        string html = document.ToHtmlFragment(options);
+
+        Assert.Contains("href=\"ftp://files.example/archive\"", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("tracker.example", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void InvalidThemeColorsCannotEscapeTheStyleElement() {
         string payload = "red;}</style><script>alert(1)</script>";
         string html = MarkdownDoc.Create().H1("safe").ToHtmlDocument(new HtmlOptions {

--- a/OfficeIMO.Markdown.Tests/Markdown/Markdown_AllSeverityBatch15_Security_Tests.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown/Markdown_AllSeverityBatch15_Security_Tests.cs
@@ -69,6 +69,10 @@ public sealed class MarkdownAllSeverityBatch15SecurityTests {
             MarkdownDoc.Create().H1("safe").ToHtmlDocument(new HtmlOptions {
                 CssScopeSelector = ".tenant-" + index
             });
+            MarkdownDoc.Create().H1("safe").ToHtmlDocument(new HtmlOptions {
+                Style = (HtmlStyle)(10_000 + index),
+                Theme = new MarkdownVisualTheme { HtmlStyle = (HtmlStyle)(20_000 + index) }
+            });
         }
 
         FieldInfo field = typeof(HtmlRenderer).GetField("_unscopedBaseCssCache", BindingFlags.NonPublic | BindingFlags.Static)!;

--- a/OfficeIMO.Markdown.Tests/Markdown/Markdown_AllSeverityBatch15_Security_Tests.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown/Markdown_AllSeverityBatch15_Security_Tests.cs
@@ -41,6 +41,21 @@ public sealed class MarkdownAllSeverityBatch15SecurityTests {
     }
 
     [Fact]
+    public void PictureSrcSetFiltersCommaSeparatedCandidatesWithoutWhitespace() {
+        var image = new ImageBlock("https://images.example/photo.png", "photo");
+        image.PictureSources.Add(new ImagePictureSource(
+            "https://tracker.example/fallback.webp",
+            srcSet: "https://images.example/photo.webp,https://tracker.example/pixel.webp 2x"));
+
+        var options = new HtmlOptions();
+        options.AllowedHttpImageHosts.Add("images.example");
+        string html = MarkdownDoc.Create().Add(image).ToHtmlFragment(options);
+
+        Assert.Contains("https://images.example/photo.webp", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("tracker.example", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void InvalidThemeColorsCannotEscapeTheStyleElement() {
         string payload = "red;}</style><script>alert(1)</script>";
         string html = MarkdownDoc.Create().H1("safe").ToHtmlDocument(new HtmlOptions {

--- a/OfficeIMO.Markdown.Tests/Markdown/Markdown_AllSeverityBatch15_Security_Tests.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown/Markdown_AllSeverityBatch15_Security_Tests.cs
@@ -56,6 +56,24 @@ public sealed class MarkdownAllSeverityBatch15SecurityTests {
     }
 
     [Fact]
+    public void PictureSrcSetRejectsSlashMalformedAbsoluteHttpCandidates() {
+        var image = new ImageBlock("https://images.example/photo.png", "photo");
+        image.PictureSources.Add(new ImagePictureSource(
+            "https://images.example/photo.webp",
+            srcSet: "https://images.example/photo.webp 1x, https:/tracker.example/pixel.webp 2x"));
+
+        var options = new HtmlOptions {
+            BlockExternalHttpImages = true,
+            BaseUri = new Uri("https://images.example/")
+        };
+        options.AllowedHttpImageHosts.Add("images.example");
+        string html = MarkdownDoc.Create().Add(image).ToHtmlFragment(options);
+
+        Assert.Contains("https://images.example/photo.webp 1x", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("tracker.example", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void InvalidThemeColorsCannotEscapeTheStyleElement() {
         string payload = "red;}</style><script>alert(1)</script>";
         string html = MarkdownDoc.Create().H1("safe").ToHtmlDocument(new HtmlOptions {

--- a/OfficeIMO.Markdown.Tests/Markdown/Markdown_AllSeverityBatch15_Security_Tests.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown/Markdown_AllSeverityBatch15_Security_Tests.cs
@@ -1,0 +1,91 @@
+using System.Reflection;
+using OfficeIMO.Markdown;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class MarkdownAllSeverityBatch15SecurityTests {
+    [Fact]
+    public void TypedHtmlRenderingRejectsUnsafeSchemesButKeepsRasterDataImages() {
+        var document = MarkdownDoc.Create()
+            .Add(new ParagraphBlock(new InlineSequence()
+                .Link("script", "java\tscript:alert(1)")
+                .Image("svg", "data:image/svg+xml,<svg onload=alert(1)></svg>")
+                .Image("png", "data:image/png;base64,AQID")));
+
+        string html = document.ToHtmlFragment(new HtmlOptions {
+            Style = HtmlStyle.Plain,
+            CssDelivery = CssDelivery.None,
+            BodyClass = null
+        });
+
+        Assert.DoesNotContain("javascript", html, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("image/svg", html, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("data:image/png;base64,AQID", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PictureSrcSetFiltersEveryCandidateAgainstImageOriginPolicy() {
+        var image = new ImageBlock("https://images.example/photo.png", "photo");
+        image.PictureSources.Add(new ImagePictureSource(
+            "https://images.example/photo.webp",
+            srcSet: "https://images.example/photo.webp 1x, https://tracker.example/pixel.webp 2x, javascript:alert(1) 3x"));
+
+        var options = new HtmlOptions();
+        options.AllowedHttpImageHosts.Add("images.example");
+        string html = MarkdownDoc.Create().Add(image).ToHtmlFragment(options);
+
+        Assert.Contains("https://images.example/photo.webp 1x", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("tracker.example", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("javascript", html, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void InvalidThemeColorsCannotEscapeTheStyleElement() {
+        string payload = "red;}</style><script>alert(1)</script>";
+        string html = MarkdownDoc.Create().H1("safe").ToHtmlDocument(new HtmlOptions {
+            ColorOverrides = new MarkdownHtmlColorOverrides { AccentLight = payload }
+        });
+
+        Assert.DoesNotContain(payload, html, StringComparison.Ordinal);
+        Assert.DoesNotContain("<script>alert(1)</script>", html, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void CustomAcronymsAreHandledWithoutDynamicRegularExpressions() {
+        string transformed = HeaderTransforms.Pretty("DnsReport", new[] {
+            string.Empty,
+            "(",
+            new string('A', 64),
+            "DNS"
+        });
+
+        Assert.Equal("DNS Report", transformed);
+    }
+
+    [Fact]
+    public void CallerControlledCssScopesDoNotGrowStaticCache() {
+        for (int index = 0; index < 128; index++) {
+            MarkdownDoc.Create().H1("safe").ToHtmlDocument(new HtmlOptions {
+                CssScopeSelector = ".tenant-" + index
+            });
+        }
+
+        FieldInfo field = typeof(HtmlRenderer).GetField("_unscopedBaseCssCache", BindingFlags.NonPublic | BindingFlags.Static)!;
+        object cache = Assert.IsType<System.Collections.Concurrent.ConcurrentDictionary<HtmlStyle, string>>(field.GetValue(null));
+        int count = (int)cache.GetType().GetProperty("Count")!.GetValue(cache)!;
+        Assert.InRange(count, 1, Enum.GetValues(typeof(HtmlStyle)).Length);
+    }
+
+    [Fact]
+    public void NestedStrongNormalizationHasABoundedNumberOfPasses() {
+        string adversarial = "**outer " + string.Concat(Enumerable.Repeat("**inner value** ", 2_000)) + "tail**";
+
+        string normalized = MarkdownInputNormalizer.Normalize(adversarial, new MarkdownInputNormalizationOptions {
+            NormalizeNestedStrongDelimiters = true
+        });
+
+        Assert.NotEmpty(normalized);
+        Assert.InRange(normalized.Length, 1, adversarial.Length * 2);
+    }
+}

--- a/OfficeIMO.Markdown/Blocks/ImageBlock.cs
+++ b/OfficeIMO.Markdown/Blocks/ImageBlock.cs
@@ -133,13 +133,18 @@ public sealed class ImageBlock : MarkdownBlock, IMarkdownBlock, ICaptionable, IS
         sb.Append("<picture>");
         for (int i = 0; i < PictureSources.Count; i++) {
             var source = PictureSources[i];
-            if (source == null || string.IsNullOrWhiteSpace(source.Path) || !UrlOriginPolicy.IsAllowedHttpImage(options, source.Path)) {
+            if (source == null || string.IsNullOrWhiteSpace(source.Path)) {
                 continue;
             }
 
             string srcSet = NormalizeAttributeValue(source.SrcSet) ?? source.Path;
+            string allowedSrcSet = UrlOriginPolicy.FilterAllowedImageSrcSet(options, srcSet);
+            if (allowedSrcSet.Length == 0) {
+                continue;
+            }
+
             sb.Append("<source srcset=\"")
-                .Append(HtmlAttributeUrlEncoder.EncodeSrcSet(srcSet, options))
+                .Append(HtmlAttributeUrlEncoder.EncodeSrcSet(allowedSrcSet, options))
                 .Append('"');
             AppendAttribute(sb, "media", NormalizeAttributeValue(source.Media), options);
             AppendAttribute(sb, "type", NormalizeAttributeValue(source.Type), options);

--- a/OfficeIMO.Markdown/Utilities/HeaderTransforms.cs
+++ b/OfficeIMO.Markdown/Utilities/HeaderTransforms.cs
@@ -25,16 +25,22 @@ public static class HeaderTransforms {
         if (!name.Contains(' ')) name = SplitPascal.Replace(name, " ");
         // Trim
         name = name.Trim();
-        // Uppercase provided acronyms
-        foreach (var ac in acronyms) {
-            name = Regex.Replace(name, $"\\b{ac.Substring(0, 1)}{ac.Substring(1).ToLower()}\\b|\\b{ac.ToLower()}\\b|\\b{ac}\\b", ac, RegexOptions.IgnoreCase);
+        var safeAcronyms = new System.Collections.Generic.Dictionary<string, string>(System.StringComparer.OrdinalIgnoreCase);
+        if (acronyms != null) {
+            foreach (var candidate in acronyms.Take(128)) {
+                string acronym = (candidate ?? string.Empty).Trim();
+                if (acronym.Length == 0 || acronym.Length > 32 || acronym.Any(c => !char.IsLetterOrDigit(c))) continue;
+                if (!safeAcronyms.ContainsKey(acronym)) safeAcronyms.Add(acronym, acronym);
+            }
         }
         // Title case words that are not fully uppercase
         var parts = name.Split(' ');
         var sb = new StringBuilder();
         for (int i = 0; i < parts.Length; i++) {
             var w = parts[i];
-            if (IsAllUpper(w)) { sb.Append(w); } else { sb.Append(char.ToUpperInvariant(w[0])); if (w.Length > 1) sb.Append(w.Substring(1).ToLowerInvariant()); }
+            if (safeAcronyms.TryGetValue(w, out string? acronym)) { sb.Append(acronym); }
+            else if (IsAllUpper(w)) { sb.Append(w); }
+            else { sb.Append(char.ToUpperInvariant(w[0])); if (w.Length > 1) sb.Append(w.Substring(1).ToLowerInvariant()); }
             if (i < parts.Length - 1) sb.Append(' ');
         }
         return sb.ToString();

--- a/OfficeIMO.Markdown/Utilities/HtmlRenderer.cs
+++ b/OfficeIMO.Markdown/Utilities/HtmlRenderer.cs
@@ -310,7 +310,7 @@ internal static class HtmlRenderer {
         // Only cache the finite built-in style set. Caller-controlled scope selectors are
         // deliberately rendered on demand so unique request values cannot grow static state.
         MarkdownVisualTheme? effectiveVisualTheme = ResolveVisualTheme(options);
-        HtmlStyle effectiveStyle = GetEffectiveStyle(options, effectiveVisualTheme);
+        HtmlStyle effectiveStyle = NormalizeHtmlStyle(GetEffectiveStyle(options, effectiveVisualTheme));
         string rawBaseCss = _unscopedBaseCssCache.GetOrAdd(effectiveStyle,
             static style => HtmlResources.GetStyleCss(style) + HtmlResources.CommonExtraCss);
         string baseCss = string.IsNullOrWhiteSpace(options.CssScopeSelector)
@@ -394,6 +394,19 @@ internal static class HtmlRenderer {
 
         return options.Style;
     }
+
+    private static HtmlStyle NormalizeHtmlStyle(HtmlStyle style) => style switch {
+        HtmlStyle.Plain => style,
+        HtmlStyle.Clean => style,
+        HtmlStyle.GithubLight => style,
+        HtmlStyle.GithubDark => style,
+        HtmlStyle.GithubAuto => style,
+        HtmlStyle.ChatLight => style,
+        HtmlStyle.ChatDark => style,
+        HtmlStyle.ChatAuto => style,
+        HtmlStyle.Word => style,
+        _ => HtmlStyle.Clean
+    };
 
     private static string BuildThemeOverrides(HtmlOptions options, MarkdownVisualTheme? theme) {
         MarkdownHtmlColorOverrides t = BuildEffectiveThemeColors(options, theme);

--- a/OfficeIMO.Markdown/Utilities/HtmlRenderer.cs
+++ b/OfficeIMO.Markdown/Utilities/HtmlRenderer.cs
@@ -303,18 +303,19 @@ internal static class HtmlRenderer {
         return sb.ToString();
     }
 
-    private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, string> _scopedBaseCssCache = new System.Collections.Concurrent.ConcurrentDictionary<string, string>(System.StringComparer.Ordinal);
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<HtmlStyle, string> _unscopedBaseCssCache = new System.Collections.Concurrent.ConcurrentDictionary<HtmlStyle, string>();
 
     private static string? BuildCss(HtmlOptions options, out string? cssLinkTag, out string? cssToWrite, out string? extraHeadLinks) {
         cssLinkTag = null; cssToWrite = null; extraHeadLinks = null;
-        // Cache scoped base CSS (style preset + common extras) by (style|scopeSelector)
+        // Only cache the finite built-in style set. Caller-controlled scope selectors are
+        // deliberately rendered on demand so unique request values cannot grow static state.
         MarkdownVisualTheme? effectiveVisualTheme = ResolveVisualTheme(options);
         HtmlStyle effectiveStyle = GetEffectiveStyle(options, effectiveVisualTheme);
-        string cacheKey = ((int)effectiveStyle).ToString() + "|" + (options.CssScopeSelector ?? string.Empty);
-        if (!_scopedBaseCssCache.TryGetValue(cacheKey, out var baseCss)) {
-            baseCss = ScopeCss(HtmlResources.GetStyleCss(effectiveStyle) + HtmlResources.CommonExtraCss, options.CssScopeSelector);
-            _scopedBaseCssCache[cacheKey] = baseCss;
-        }
+        string rawBaseCss = _unscopedBaseCssCache.GetOrAdd(effectiveStyle,
+            static style => HtmlResources.GetStyleCss(style) + HtmlResources.CommonExtraCss);
+        string baseCss = string.IsNullOrWhiteSpace(options.CssScopeSelector)
+            ? rawBaseCss
+            : ScopeCss(rawBaseCss, options.CssScopeSelector);
 
         // Additional CSS/JS URLs may be included in head as link/script or inlined depending on AssetMode
         StringBuilder headLinks = new StringBuilder();
@@ -495,20 +496,23 @@ internal static class HtmlRenderer {
             return;
         }
 
-        if (!string.IsNullOrWhiteSpace(overrides.AccentLight)) target.AccentLight = NormalizeCssColor(overrides.AccentLight!);
-        if (!string.IsNullOrWhiteSpace(overrides.AccentDark)) target.AccentDark = NormalizeCssColor(overrides.AccentDark!);
-        if (!string.IsNullOrWhiteSpace(overrides.HeadingLight)) target.HeadingLight = NormalizeCssColor(overrides.HeadingLight!);
-        if (!string.IsNullOrWhiteSpace(overrides.HeadingDark)) target.HeadingDark = NormalizeCssColor(overrides.HeadingDark!);
-        if (!string.IsNullOrWhiteSpace(overrides.TocBgLight)) target.TocBgLight = NormalizeCssColor(overrides.TocBgLight!);
-        if (!string.IsNullOrWhiteSpace(overrides.TocBgDark)) target.TocBgDark = NormalizeCssColor(overrides.TocBgDark!);
-        if (!string.IsNullOrWhiteSpace(overrides.TocBorderLight)) target.TocBorderLight = NormalizeCssColor(overrides.TocBorderLight!);
-        if (!string.IsNullOrWhiteSpace(overrides.TocBorderDark)) target.TocBorderDark = NormalizeCssColor(overrides.TocBorderDark!);
-        if (!string.IsNullOrWhiteSpace(overrides.ActiveLinkLight)) target.ActiveLinkLight = NormalizeCssColor(overrides.ActiveLinkLight!);
-        if (!string.IsNullOrWhiteSpace(overrides.ActiveLinkDark)) target.ActiveLinkDark = NormalizeCssColor(overrides.ActiveLinkDark!);
+        TryApplyCssColor(overrides.AccentLight, value => target.AccentLight = value);
+        TryApplyCssColor(overrides.AccentDark, value => target.AccentDark = value);
+        TryApplyCssColor(overrides.HeadingLight, value => target.HeadingLight = value);
+        TryApplyCssColor(overrides.HeadingDark, value => target.HeadingDark = value);
+        TryApplyCssColor(overrides.TocBgLight, value => target.TocBgLight = value);
+        TryApplyCssColor(overrides.TocBgDark, value => target.TocBgDark = value);
+        TryApplyCssColor(overrides.TocBorderLight, value => target.TocBorderLight = value);
+        TryApplyCssColor(overrides.TocBorderDark, value => target.TocBorderDark = value);
+        TryApplyCssColor(overrides.ActiveLinkLight, value => target.ActiveLinkLight = value);
+        TryApplyCssColor(overrides.ActiveLinkDark, value => target.ActiveLinkDark = value);
     }
 
-    private static string NormalizeCssColor(string value) =>
-        OfficeColor.TryParse(value, out OfficeColor color) ? color.ToCssColor() : value;
+    private static void TryApplyCssColor(string? value, Action<string> apply) {
+        if (!string.IsNullOrWhiteSpace(value) && OfficeColor.TryParse(value, out OfficeColor color)) {
+            apply(color.ToCssColor());
+        }
+    }
 
     internal static string ResolveExternalText(string? url, MarkdownExternalTextResolver? resolver) {
         if (string.IsNullOrWhiteSpace(url)

--- a/OfficeIMO.Markdown/Utilities/HtmlRenderer.cs
+++ b/OfficeIMO.Markdown/Utilities/HtmlRenderer.cs
@@ -313,9 +313,7 @@ internal static class HtmlRenderer {
         HtmlStyle effectiveStyle = NormalizeHtmlStyle(GetEffectiveStyle(options, effectiveVisualTheme));
         string rawBaseCss = _unscopedBaseCssCache.GetOrAdd(effectiveStyle,
             static style => HtmlResources.GetStyleCss(style) + HtmlResources.CommonExtraCss);
-        string baseCss = string.IsNullOrWhiteSpace(options.CssScopeSelector)
-            ? rawBaseCss
-            : ScopeCss(rawBaseCss, options.CssScopeSelector);
+        string baseCss = ScopeCss(rawBaseCss, options.CssScopeSelector);
 
         // Additional CSS/JS URLs may be included in head as link/script or inlined depending on AssetMode
         StringBuilder headLinks = new StringBuilder();

--- a/OfficeIMO.Markdown/Utilities/MarkdownInputNormalizer.StrongSpans.cs
+++ b/OfficeIMO.Markdown/Utilities/MarkdownInputNormalizer.StrongSpans.cs
@@ -13,7 +13,7 @@ public static partial class MarkdownInputNormalizer {
 
     private static string FlattenNestedStrongSpansPreservingInlineCode(string input) {
         var current = input ?? string.Empty;
-        while (true) {
+        for (var iteration = 0; iteration < StrongFlattenMaxIterations; iteration++) {
             var flattened = NestedStrongSpanRegex.Replace(
                 current,
                 static match =>

--- a/OfficeIMO.Markdown/Utilities/SrcSetParser.cs
+++ b/OfficeIMO.Markdown/Utilities/SrcSetParser.cs
@@ -26,7 +26,9 @@ internal static class SrcSetParser {
             }
 
             int urlStart = index;
-            while (index < value.Length && !char.IsWhiteSpace(value[index])) {
+            while (index < value.Length &&
+                   !char.IsWhiteSpace(value[index]) &&
+                   (value[index] != ',' || !StartsNewCandidate(value, index + 1))) {
                 index++;
             }
 
@@ -47,6 +49,12 @@ internal static class SrcSetParser {
                 continue;
             }
 
+            if (index < value.Length && value[index] == ',') {
+                index++;
+                candidates.Add(new SrcSetCandidate(url, string.Empty));
+                continue;
+            }
+
             SkipWhitespace(value, ref index);
 
             int descriptorStart = index;
@@ -63,6 +71,24 @@ internal static class SrcSetParser {
         }
 
         return candidates;
+    }
+
+    private static bool StartsNewCandidate(string value, int index) {
+        if (index >= value.Length || char.IsWhiteSpace(value[index])) return true;
+        if (value[index] == '/' || value[index] == '#' || value[index] == '.') return true;
+        if (!char.IsLetter(value[index])) return false;
+
+        index++;
+        while (index < value.Length) {
+            char current = value[index];
+            if (current == ':') return true;
+            if (!char.IsLetterOrDigit(current) && current != '+' && current != '-' && current != '.') {
+                return false;
+            }
+            index++;
+        }
+
+        return false;
     }
 
     private static void SkipWhitespaceAndCommas(string value, ref int index) {

--- a/OfficeIMO.Markdown/Utilities/UrlOriginPolicy.cs
+++ b/OfficeIMO.Markdown/Utilities/UrlOriginPolicy.cs
@@ -79,9 +79,11 @@ internal static class UrlOriginPolicy {
         if (value.Length == 0 || value.StartsWith("#", StringComparison.Ordinal)) return true;
         if (!TryGetScheme(value, out string? scheme)) return true;
 
-        return scheme == "http"
-            || scheme == "https"
-            || scheme == "mailto"
+        if (scheme == "http" || scheme == "https") {
+            return IsWellFormedAbsoluteHttpUrl(value, scheme);
+        }
+
+        return scheme == "mailto"
             || scheme == "tel";
     }
 
@@ -90,8 +92,19 @@ internal static class UrlOriginPolicy {
         if (value.Length == 0 || value.StartsWith("#", StringComparison.Ordinal)) return true;
         if (!TryGetScheme(value, out string? scheme)) return true;
 
-        if (scheme == "http" || scheme == "https" || scheme == "cid") return true;
+        if (scheme == "http" || scheme == "https") {
+            return IsWellFormedAbsoluteHttpUrl(value, scheme);
+        }
+
+        if (scheme == "cid") return true;
         return scheme == "data" && IsSafeRasterDataImage(value);
+    }
+
+    private static bool IsWellFormedAbsoluteHttpUrl(string value, string expectedScheme) {
+        return Uri.TryCreate(value, UriKind.Absolute, out Uri? uri)
+            && uri != null
+            && string.Equals(uri.Scheme, expectedScheme, StringComparison.OrdinalIgnoreCase)
+            && !string.IsNullOrWhiteSpace(uri.Host);
     }
 
     private static bool TryGetScheme(string value, out string? scheme) {

--- a/OfficeIMO.Markdown/Utilities/UrlOriginPolicy.cs
+++ b/OfficeIMO.Markdown/Utilities/UrlOriginPolicy.cs
@@ -1,10 +1,13 @@
 namespace OfficeIMO.Markdown;
 
 internal static class UrlOriginPolicy {
-    internal static bool IsAllowedHttpLink(HtmlOptions? o, string? url)
-        => IsAllowedHttpUrl(o, url, forImages: false);
+    internal static bool IsAllowedHttpLink(HtmlOptions? o, string? url) {
+        if (!IsSafeLinkUrl(url)) return false;
+        return IsAllowedHttpUrl(o, url, forImages: false);
+    }
 
     internal static bool IsAllowedHttpImage(HtmlOptions? o, string? url) {
+        if (!IsSafeImageUrl(url)) return false;
         if (o == null) return true;
         var u = (url ?? string.Empty).Trim();
         if (u.Length == 0) return true;
@@ -23,6 +26,23 @@ internal static class UrlOriginPolicy {
         }
 
         return IsAllowedHttpUrl(o, u, forImages: true);
+    }
+
+    internal static string FilterAllowedImageSrcSet(HtmlOptions? options, string? srcSet) {
+        if (string.IsNullOrWhiteSpace(srcSet)) return string.Empty;
+
+        var allowed = new System.Collections.Generic.List<string>();
+        foreach (SrcSetCandidate candidate in SrcSetParser.Parse(srcSet)) {
+            if (!IsAllowedHttpImage(options, candidate.Url) || !IsValidSrcSetDescriptor(candidate.Descriptor)) {
+                continue;
+            }
+
+            allowed.Add(candidate.Descriptor.Length == 0
+                ? candidate.Url
+                : candidate.Url + " " + candidate.Descriptor);
+        }
+
+        return string.Join(", ", allowed);
     }
 
     private static bool IsAllowedHttpUrl(HtmlOptions? o, string? url, bool forImages) {
@@ -52,6 +72,95 @@ internal static class UrlOriginPolicy {
         if (!IsHttpScheme(abs.Scheme)) return true; // mailto, etc.
 
         return IsSameOrigin(baseUri, abs);
+    }
+
+    private static bool IsSafeLinkUrl(string? url) {
+        string value = (url ?? string.Empty).Trim();
+        if (value.Length == 0 || value.StartsWith("#", StringComparison.Ordinal)) return true;
+        if (!TryGetScheme(value, out string? scheme)) return true;
+
+        return scheme == "http"
+            || scheme == "https"
+            || scheme == "mailto"
+            || scheme == "tel";
+    }
+
+    private static bool IsSafeImageUrl(string? url) {
+        string value = (url ?? string.Empty).Trim();
+        if (value.Length == 0 || value.StartsWith("#", StringComparison.Ordinal)) return true;
+        if (!TryGetScheme(value, out string? scheme)) return true;
+
+        if (scheme == "http" || scheme == "https" || scheme == "cid") return true;
+        return scheme == "data" && IsSafeRasterDataImage(value);
+    }
+
+    private static bool TryGetScheme(string value, out string? scheme) {
+        scheme = null;
+        int colon = value.IndexOf(':');
+        if (colon <= 0) return false;
+
+        int slash = value.IndexOfAny(new[] { '/', '?', '#' });
+        if (slash >= 0 && slash < colon) return false;
+
+        var builder = new System.Text.StringBuilder(colon);
+        for (int i = 0; i < colon; i++) {
+            char current = value[i];
+            if (char.IsWhiteSpace(current) || char.IsControl(current)) continue;
+            builder.Append(char.ToLowerInvariant(current));
+        }
+
+        if (builder.Length == 0 || !char.IsLetter(builder[0])) {
+            scheme = string.Empty;
+            return true;
+        }
+
+        for (int i = 1; i < builder.Length; i++) {
+            char current = builder[i];
+            if (!char.IsLetterOrDigit(current) && current != '+' && current != '-' && current != '.') {
+                scheme = string.Empty;
+                return true;
+            }
+        }
+
+        scheme = builder.ToString();
+        return true;
+    }
+
+    private static bool IsSafeRasterDataImage(string value) {
+        int comma = value.IndexOf(',');
+        if (comma <= 5) return false;
+
+        string metadata = value.Substring(5, comma - 5).Trim();
+        int separator = metadata.IndexOf(';');
+        string mediaType = (separator >= 0 ? metadata.Substring(0, separator) : metadata).Trim();
+        string parameters = separator >= 0 ? metadata.Substring(separator + 1) : string.Empty;
+        bool base64 = parameters.Split(';').Any(parameter => string.Equals(parameter.Trim(), "base64", StringComparison.OrdinalIgnoreCase));
+        if (!base64) return false;
+
+        return mediaType.Equals("image/png", StringComparison.OrdinalIgnoreCase)
+            || mediaType.Equals("image/jpeg", StringComparison.OrdinalIgnoreCase)
+            || mediaType.Equals("image/gif", StringComparison.OrdinalIgnoreCase)
+            || mediaType.Equals("image/webp", StringComparison.OrdinalIgnoreCase)
+            || mediaType.Equals("image/bmp", StringComparison.OrdinalIgnoreCase)
+            || mediaType.Equals("image/tiff", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsValidSrcSetDescriptor(string descriptor) {
+        if (string.IsNullOrEmpty(descriptor)) return true;
+        if (descriptor.IndexOfAny(new[] { ' ', '\t', '\r', '\n' }) >= 0 || descriptor.Length < 2) return false;
+
+        char suffix = descriptor[descriptor.Length - 1];
+        string number = descriptor.Substring(0, descriptor.Length - 1);
+        if (suffix == 'w') {
+            return int.TryParse(number, System.Globalization.NumberStyles.None, System.Globalization.CultureInfo.InvariantCulture, out int width)
+                && width > 0;
+        }
+
+        return suffix == 'x'
+            && double.TryParse(number, System.Globalization.NumberStyles.AllowDecimalPoint, System.Globalization.CultureInfo.InvariantCulture, out double density)
+            && density > 0
+            && !double.IsInfinity(density)
+            && !double.IsNaN(density);
     }
 
     private static bool TryGetAbsoluteHttpUri(string u, Uri? baseUri, out Uri? abs) {

--- a/OfficeIMO.Markdown/Utilities/UrlOriginPolicy.cs
+++ b/OfficeIMO.Markdown/Utilities/UrlOriginPolicy.cs
@@ -53,13 +53,20 @@ internal static class UrlOriginPolicy {
 
         // Host allowlist (absolute HTTP(S) only).
         var allowHosts = forImages ? o.AllowedHttpImageHosts : o.AllowedHttpLinkHosts;
+        bool restrict = forImages ? o.RestrictHttpImagesToBaseOrigin : o.RestrictHttpLinksToBaseOrigin;
+        if ((restrict || allowHosts != null && allowHosts.Count > 0)
+            && TryGetScheme(u, out string? explicitScheme)
+            && (explicitScheme == "http" || explicitScheme == "https")
+            && !IsWellFormedAbsoluteHttpUrl(u, explicitScheme)) {
+            return false;
+        }
+
         if (allowHosts != null && allowHosts.Count > 0) {
             if (TryGetAbsoluteHttpUri(u, o.BaseUri, out var absForHost) && absForHost != null && IsHttpScheme(absForHost.Scheme)) {
                 if (!HostAllowList.IsAllowed(absForHost.Host, allowHosts)) return false;
             }
         }
 
-        bool restrict = forImages ? o.RestrictHttpImagesToBaseOrigin : o.RestrictHttpLinksToBaseOrigin;
         if (!restrict) return true;
 
         var baseUri = o.BaseUri;
@@ -79,12 +86,10 @@ internal static class UrlOriginPolicy {
         if (value.Length == 0 || value.StartsWith("#", StringComparison.Ordinal)) return true;
         if (!TryGetScheme(value, out string? scheme)) return true;
 
-        if (scheme == "http" || scheme == "https") {
-            return IsWellFormedAbsoluteHttpUrl(value, scheme);
-        }
-
-        return scheme == "mailto"
-            || scheme == "tel";
+        return scheme != "javascript"
+            && scheme != "vbscript"
+            && scheme != "data"
+            && scheme != "file";
     }
 
     private static bool IsSafeImageUrl(string? url) {

--- a/OfficeIMO.Shared.Tests/OfficeFileCommit.cs
+++ b/OfficeIMO.Shared.Tests/OfficeFileCommit.cs
@@ -126,5 +126,28 @@ namespace OfficeIMO.Shared.Tests {
                 if (Directory.Exists(root)) Directory.Delete(root, recursive: true);
             }
         }
+
+#if NET6_0_OR_GREATER
+        [Fact]
+        public void CommitTemporaryFile_PreservesRestrictiveUnixMode() {
+            if (OperatingSystem.IsWindows()) return;
+
+            string root = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            string destination = Path.Combine(root, "private.xlsx");
+            string temporary = Path.Combine(root, "private.staged.xlsx");
+            Directory.CreateDirectory(root);
+            File.WriteAllBytes(destination, new byte[] { 1 });
+            File.SetUnixFileMode(destination, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+            File.WriteAllBytes(temporary, new byte[] { 2 });
+
+            try {
+                OfficeFileCommit.CommitTemporaryFile(temporary, destination);
+
+                Assert.Equal(UnixFileMode.UserRead | UnixFileMode.UserWrite, File.GetUnixFileMode(destination));
+            } finally {
+                if (Directory.Exists(root)) Directory.Delete(root, true);
+            }
+        }
+#endif
     }
 }

--- a/OfficeIMO.Visio.Tests/Visio.Security.AllSeverityBatch15.cs
+++ b/OfficeIMO.Visio.Tests/Visio.Security.AllSeverityBatch15.cs
@@ -1,0 +1,70 @@
+using System.IO.Compression;
+using System.Xml.Linq;
+using OfficeIMO.Visio;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class VisioAllSeverityBatch15SecurityTests {
+    [Theory]
+    [InlineData("1E309")]
+    [InlineData("NaN")]
+    [InlineData("2147483648")]
+    public void LoadIgnoresOutOfRangePatternValues(string value) {
+        string path = CreateSample();
+        try {
+            UpdateXml(path, "visio/pages/page1.xml", document => {
+                XElement shape = document.Descendants().First(element => element.Name.LocalName == "Shape");
+                shape.Add(new XElement(shape.Name.Namespace + "Cell",
+                    new XAttribute("N", "LinePattern"),
+                    new XAttribute("V", value)));
+            });
+
+            Exception? exception = Record.Exception(() => VisioDocument.Load(path));
+
+            Assert.Null(exception);
+        } finally {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void StreamingValidatorReportsDuplicateRelationshipIdsWithoutThrowing() {
+        string path = CreateSample();
+        try {
+            UpdateXml(path, "visio/pages/_rels/pages.xml.rels", document => {
+                XElement relationship = document.Root!.Elements().First();
+                document.Root.Add(new XElement(relationship));
+            });
+            var validator = new VsdxPackageValidator();
+
+            bool valid = validator.ValidateFileStreaming(path);
+
+            Assert.False(valid);
+            Assert.Contains(validator.Errors, error => error.Contains("Duplicate relationship Id", StringComparison.Ordinal));
+        } finally {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    private static string CreateSample() {
+        string path = Path.Combine(Path.GetTempPath(), "officeimo-visio-b15-" + Guid.NewGuid().ToString("N") + ".vsdx");
+        VisioDocument document = VisioDocument.Create(path);
+        VisioPage page = document.AddPage("Page-1", 8.5, 11);
+        page.Shapes.Add(new VisioShape("1", 1, 1, 2, 1, "Sample"));
+        document.Save();
+        return path;
+    }
+
+    private static void UpdateXml(string path, string entryName, Action<XDocument> update) {
+        using ZipArchive archive = ZipFile.Open(path, ZipArchiveMode.Update);
+        ZipArchiveEntry entry = archive.GetEntry(entryName)!;
+        XDocument document;
+        using (Stream input = entry.Open()) document = XDocument.Load(input);
+        update(document);
+        entry.Delete();
+        ZipArchiveEntry replacement = archive.CreateEntry(entryName, CompressionLevel.Optimal);
+        using Stream output = replacement.Open();
+        document.Save(output);
+    }
+}

--- a/OfficeIMO.Visio.Tests/Visio.Security.AllSeverityBatch15.cs
+++ b/OfficeIMO.Visio.Tests/Visio.Security.AllSeverityBatch15.cs
@@ -47,6 +47,27 @@ public sealed class VisioAllSeverityBatch15SecurityTests {
         }
     }
 
+    [Fact]
+    public void StreamingValidatorRejectsAdditionalRelationshipWithoutId() {
+        string path = CreateSample();
+        try {
+            UpdateXml(path, "visio/pages/_rels/pages.xml.rels", document => {
+                XElement relationship = document.Root!.Elements().First();
+                document.Root.Add(new XElement(relationship.Name,
+                    relationship.Attributes().Where(attribute => attribute.Name.LocalName != "Id")));
+            });
+            var validator = new VsdxPackageValidator();
+
+            bool valid = validator.ValidateFileStreaming(path);
+
+            Assert.False(valid);
+            Assert.Contains(validator.Errors, error =>
+                error.Contains("missing or empty Id", StringComparison.Ordinal));
+        } finally {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
     private static string CreateSample() {
         string path = Path.Combine(Path.GetTempPath(), "officeimo-visio-b15-" + Guid.NewGuid().ToString("N") + ".vsdx");
         VisioDocument document = VisioDocument.Create(path);

--- a/OfficeIMO.Visio/VisioDocument.LoadCore.Connectors.cs
+++ b/OfficeIMO.Visio/VisioDocument.LoadCore.Connectors.cs
@@ -211,7 +211,11 @@ namespace OfficeIMO.Visio {
                 return true;
             }
 
-            if (double.TryParse(normalized, NumberStyles.Float, CultureInfo.InvariantCulture, out double numericValue)) {
+            if (double.TryParse(normalized, NumberStyles.Float, CultureInfo.InvariantCulture, out double numericValue)
+                && !double.IsNaN(numericValue)
+                && !double.IsInfinity(numericValue)
+                && numericValue >= int.MinValue
+                && numericValue <= int.MaxValue) {
                 int integerValue = Convert.ToInt32(numericValue);
                 if (Math.Abs(numericValue - integerValue) <= 1e-9) {
                     result = integerValue;

--- a/OfficeIMO.Visio/VsdxPackageValidator.cs
+++ b/OfficeIMO.Visio/VsdxPackageValidator.cs
@@ -377,6 +377,9 @@ namespace OfficeIMO.Visio {
             var pagesRels = LoadZipXml(zip, "visio/pages/_rels/pages.xml.rels");
             if (pagesRels?.Root == null) { _errors.Add("Missing /visio/pages/_rels/pages.xml.rels"); return; }
             var relElems = pagesRels.Root.Elements(nsPkgRel + "Relationship").ToList();
+            if (relElems.Any(element => string.IsNullOrWhiteSpace((string?)element.Attribute("Id")))) {
+                _errors.Add("pages.xml.rels contains a relationship with missing or empty Id");
+            }
             // r:id uniqueness in pages.xml.rels
             var idGroups = relElems.Select(e => (string?)e.Attribute("Id") ?? string.Empty)
                 .GroupBy(id => id, StringComparer.Ordinal)

--- a/OfficeIMO.Visio/VsdxPackageValidator.cs
+++ b/OfficeIMO.Visio/VsdxPackageValidator.cs
@@ -384,7 +384,11 @@ namespace OfficeIMO.Visio {
                 .ToList();
             foreach (var g in idGroups) _errors.Add($"Duplicate relationship Id in pages.xml.rels: '{g.Key}'");
 
-            var relsById = relElems.ToDictionary(e => (string?)e.Attribute("Id") ?? string.Empty, e => e);
+            var relsById = relElems
+                .Select(e => new { Id = (string?)e.Attribute("Id"), Element = e })
+                .Where(item => !string.IsNullOrEmpty(item.Id))
+                .GroupBy(item => item.Id!, StringComparer.Ordinal)
+                .ToDictionary(group => group.Key, group => group.First().Element, StringComparer.Ordinal);
 
             // Page ID uniqueness in pages.xml
             var idAttrGroups = pages.Select(p => (string?)p.Attribute("ID") ?? string.Empty)

--- a/OfficeIMO.Word.Tests/Word.Security.AllSeverityBatch15.cs
+++ b/OfficeIMO.Word.Tests/Word.Security.AllSeverityBatch15.cs
@@ -1,0 +1,71 @@
+using System.Xml.Linq;
+using DocumentFormat.OpenXml.CustomXmlDataProperties;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class WordAllSeverityBatch15SecurityTests {
+    [Fact]
+    public void NestedTablePreservesNonTextParagraphContentByDefault() {
+        using WordDocument document = WordDocument.Create();
+        WordTable outer = document.AddTable(1, 1);
+        WordTableCell cell = outer.Rows[0].Cells[0];
+        Paragraph paragraph = cell.Paragraphs[0]._paragraph;
+        paragraph.Append(new BookmarkStart { Name = "marker", Id = "1" });
+        paragraph.Append(new BookmarkEnd { Id = "1" });
+
+        cell.AddTable(1, 1);
+
+        Assert.Single(cell._tableCell.Descendants<BookmarkStart>());
+        Assert.Single(cell._tableCell.Descendants<BookmarkEnd>());
+    }
+
+    [Fact]
+    public void CoverPagePropertiesRejectExternalEntities() {
+        string root = Path.Combine(Path.GetTempPath(), "officeimo-cover-page-" + Guid.NewGuid().ToString("N"));
+        string documentPath = Path.Combine(root, "cover.docx");
+        string secretPath = Path.Combine(root, "secret.txt");
+        Directory.CreateDirectory(root);
+        File.WriteAllText(secretPath, "should-not-be-expanded");
+        try {
+            using (WordDocument document = WordDocument.Create(documentPath)) {
+                document.CoverPageProperties.Abstract = "safe";
+                document.Save();
+            }
+
+            using (WordprocessingDocument package = WordprocessingDocument.Open(documentPath, true)) {
+                CustomXmlPart part = package.MainDocumentPart!.CustomXmlParts.Single(customPart =>
+                    string.Equals(customPart.CustomXmlPropertiesPart?.DataStoreItem?.ItemId?.Value,
+                        WordCoverPageProperties.CoverPagePropsStoreItemId,
+                        StringComparison.OrdinalIgnoreCase));
+                using Stream output = part.GetStream(FileMode.Create, FileAccess.Write);
+                using var writer = new StreamWriter(output);
+                writer.Write("<!DOCTYPE CoverPageProperties [<!ENTITY xxe SYSTEM \"");
+                writer.Write(new Uri(secretPath).AbsoluteUri);
+                writer.Write("\">]><CoverPageProperties xmlns=\"http://schemas.microsoft.com/office/2006/coverPageProps\"><Abstract>&xxe;</Abstract></CoverPageProperties>");
+            }
+
+            using WordDocument loaded = WordDocument.Load(documentPath);
+            Assert.DoesNotContain("should-not-be-expanded", loaded.CoverPageProperties.Abstract, StringComparison.Ordinal);
+        } finally {
+            if (Directory.Exists(root)) Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void WideTableOnlineNormalizationCompletesWithoutRepeatedCellMaterialization() {
+        using WordDocument document = WordDocument.Create();
+        WordTable table = document.AddTable(2, 256);
+        for (int column = 0; column < 256; column++) {
+            table.Rows[0].Cells[column].Width = 100;
+        }
+
+        Exception? exception = Record.Exception(table.NormalizeForOnline);
+
+        Assert.Null(exception);
+        Assert.Equal(256, table.Rows[0].Cells.Count);
+    }
+}

--- a/OfficeIMO.Word/WordCoverPageProperties.cs
+++ b/OfficeIMO.Word/WordCoverPageProperties.cs
@@ -1,5 +1,6 @@
 using DocumentFormat.OpenXml.CustomXmlDataProperties;
 using DocumentFormat.OpenXml.Packaging;
+using System.Xml;
 using System.Xml.Linq;
 
 namespace OfficeIMO.Word {
@@ -184,7 +185,12 @@ namespace OfficeIMO.Word {
             }
 
             try {
-                return XDocument.Load(stream, LoadOptions.PreserveWhitespace);
+                var settings = new XmlReaderSettings {
+                    DtdProcessing = DtdProcessing.Prohibit,
+                    XmlResolver = null
+                };
+                using var reader = XmlReader.Create(stream, settings);
+                return XDocument.Load(reader, LoadOptions.PreserveWhitespace);
             } catch {
                 // If the part is malformed, fall back to a minimal valid structure.
                 return new XDocument(new XElement(CoverPagePropsNs + "CoverPageProperties"));

--- a/OfficeIMO.Word/WordTable.Properties.cs
+++ b/OfficeIMO.Word/WordTable.Properties.cs
@@ -133,11 +133,12 @@ namespace OfficeIMO.Word {
             TableWidthUnitValues? candidateType = null;
 
             foreach (var row in Rows) {
+                var rowCells = row.Cells;
                 var w = new List<int>();
                 TableWidthUnitValues? typeForRow = null;
                 bool allPresent = true;
-                for (int i = 0; i < System.Math.Min(cols, row.Cells.Count); i++) {
-                    var cell = row.Cells[i];
+                for (int i = 0; i < System.Math.Min(cols, rowCells.Count); i++) {
+                    var cell = rowCells[i];
                     var wv = cell.Width;
                     if (wv == null) { allPresent = false; w.Add(0); continue; }
                     w.Add(wv.Value);

--- a/OfficeIMO.Word/WordTableCell.cs
+++ b/OfficeIMO.Word/WordTableCell.cs
@@ -885,8 +885,7 @@ namespace OfficeIMO.Word {
             // Remove preceding empty paragraph by default (safe), or when explicitly requested.
             var paragraph = _tableCell.ChildElements.OfType<Paragraph>().LastOrDefault();
             if (paragraph != null) {
-                bool hasText = paragraph.Descendants<Text>().Any(t => !string.IsNullOrWhiteSpace(t.Text));
-                if (removePrecedingParagraph || !hasText) {
+                if (removePrecedingParagraph || !HasMeaningfulParagraphContent(paragraph)) {
                     paragraph.Remove();
                 }
             }
@@ -902,6 +901,25 @@ namespace OfficeIMO.Word {
             };
             _tableCell.Append(trailing);
             return wordTable;
+        }
+
+        private static bool HasMeaningfulParagraphContent(Paragraph paragraph) {
+            foreach (var element in paragraph.Descendants()) {
+                if (element is Text text) {
+                    if (!string.IsNullOrWhiteSpace(text.Text)) return true;
+                    continue;
+                }
+
+                if (element is ParagraphProperties || element is Run || element is RunProperties) {
+                    continue;
+                }
+
+                // Drawings, fields, bookmarks, hyperlinks, and other non-text content are data,
+                // even when the paragraph has no w:t descendants.
+                return true;
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/Website/content/docs/capabilities/benchmarks/index.md
+++ b/Website/content/docs/capabilities/benchmarks/index.md
@@ -21,7 +21,7 @@ The Excel suite covers 25,000-row creation, `IDataReader` writes, typed reads, s
 dotnet run -c Release --project OfficeIMO.Excel.Benchmarks -- --help
 ```
 
-Use the scenario links on the [benchmark page](/benchmarks/#excel-evidence) to inspect the recorded runtime, machine, workload, and result matrix.
+Use the scenario links on the [benchmark page](/benchmarks/#excel-evidence) to inspect the runtime family, workload, and result matrix. Public website artifacts intentionally omit runner host identifiers and detailed operating-system inventory.
 
 ### CSV reads and writes
 

--- a/Website/content/pages/benchmarks.md
+++ b/Website/content/pages/benchmarks.md
@@ -14,7 +14,7 @@ meta.raw_html: true
       <span>Equivalent work</span>
       <span>Validated output</span>
       <span>Committed artifacts</span>
-      <span>Machine context retained</span>
+      <span>Runtime class retained</span>
     </div>
   </section>
 

--- a/Website/data/benchmarks-excel-index.json
+++ b/Website/data/benchmarks-excel-index.json
@@ -5,20 +5,12 @@
       "generatedUtc": "2026-05-31T18:44:43.8878299+00:00",
       "runMode": "quick",
       "publish": false,
-      "framework": ".NET 8.0.27",
+      "framework": ".NET 8",
       "summaryPath": ".\\Website\\data\\benchmarks-excel-summary.json",
       "dataPath": ".\\Website\\data\\benchmarks-excel.json",
       "markdownPath": ".\\Docs\\benchmarks\\officeimo.excel.comparison-report.md",
       "meta": {
-        "commit": null,
-        "branch": null,
-        "dotnetSdk": null,
-        "runtime": ".NET 8.0.27",
-        "osDescription": null,
-        "osArchitecture": null,
-        "processArchitecture": null,
-        "machineName": "EVOMAGIC",
-        "processorCount": null
+        "runtime": ".NET 8"
       }
     }
   ]

--- a/Website/data/benchmarks-excel-summary.json
+++ b/Website/data/benchmarks-excel-summary.json
@@ -3,17 +3,9 @@
   "generatedUtc": "2026-05-31T18:44:43.8878299+00:00",
   "runMode": "quick",
   "publish": false,
-  "framework": ".NET 8.0.27",
+  "framework": ".NET 8",
   "meta": {
-    "commit": null,
-    "branch": null,
-    "dotnetSdk": null,
-    "runtime": ".NET 8.0.27",
-    "osDescription": null,
-    "osArchitecture": null,
-    "processArchitecture": null,
-    "machineName": "EVOMAGIC",
-    "processorCount": null
+    "runtime": ".NET 8"
   },
   "source": {
     "summaryPath": ".\\Docs\\benchmarks\\comparison-current\\officeimo.excel.comparison-summary.json",

--- a/Website/data/benchmarks-excel.json
+++ b/Website/data/benchmarks-excel.json
@@ -3,7 +3,7 @@
   "generatedUtc": "2026-05-31T18:44:43.8878299+00:00",
   "runMode": "quick",
   "publish": false,
-  "framework": ".NET 8.0.27",
+  "framework": ".NET 8",
   "configuration": "Release",
   "source": {
     "summaryPath": ".\\Docs\\benchmarks\\comparison-current\\officeimo.excel.comparison-summary.json",
@@ -14,15 +14,7 @@
     ]
   },
   "meta": {
-    "commit": null,
-    "branch": null,
-    "dotnetSdk": null,
-    "runtime": ".NET 8.0.27",
-    "osDescription": null,
-    "osArchitecture": null,
-    "processArchitecture": null,
-    "machineName": "EVOMAGIC",
-    "processorCount": null
+    "runtime": ".NET 8"
   },
   "howToRead": [
     "Mean: average elapsed time for the measured operation. Lower is better.",
@@ -40,8 +32,6 @@
   ],
   "manifest": {
     "GeneratedAtUtc": "2026-05-31T18:44:43.8878299Z",
-    "Framework": ".NET 8.0.27",
-    "MachineName": "EVOMAGIC",
     "RowCounts": [
       2500,
       25000
@@ -103,7 +93,8 @@
         "RowCount": 0,
         "Path": ".\\Docs\\benchmarks\\comparison-current\\officeimo.excel.comparison-summary.json"
       }
-    ]
+    ],
+    "Framework": ".NET 8"
   },
   "metrics": {
     "scenarioGroups": 274,

--- a/Website/themes/officeimo/partials/generated/benchmarks-excel.html
+++ b/Website/themes/officeimo/partials/generated/benchmarks-excel.html
@@ -10,7 +10,7 @@
 <span>Generated 2026-05-31T18:44:43.8878299+00:00</span>
 <span>quick</span>
 <span>local quick</span>
-<span>.NET 8.0.27</span>
+<span>.NET 8</span>
 <span>Evidence: committed Excel comparison artifacts</span>
 </div>
 <div class="imo-benchmark-kpis" data-benchmark-kpis>


### PR DESCRIPTION
## Summary

- harden Excel workbook discovery, collection bounds, concurrent row auto-fit, and deterministic totals
- constrain Markdown URL, srcset, CSS/color, and acronym handling while preserving explicit raw-HTML behavior and valid non-executable link protocols
- validate Visio numeric inputs and relationship identities, harden Word XML/nested-table handling, preserve Unix modes during atomic commits, and remove host/path details from benchmark publication

This batch resolves 18 valid all-severity security findings. Two adjacent scanner entries describe explicit opt-in behavior and were closed separately as not applicable.

The final review fixes reject malformed absolute HTTP(S) image and policy candidates before browser interpretation, preserve documented body scoping when the CSS scope selector is empty, and keep compatibility with valid FTP, IRC, and custom-scheme links while continuing to reject executable and local-resource schemes.