### PR TITLE
Harden document parsing and mutation boundaries

### DIFF
--- a/OfficeIMO.Excel.Tests/Excel.Security.AllSeverityBatch17.cs
+++ b/OfficeIMO.Excel.Tests/Excel.Security.AllSeverityBatch17.cs
@@ -1,0 +1,103 @@
+using System.Reflection;
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Excel;
+using OfficeIMO.Excel.LegacyXls;
+using OfficeIMO.Excel.LegacyXls.Model;
+using OfficeIMO.Excel.LegacyXls.Projection;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public partial class Excel {
+    [Fact]
+    public void ValuesModeWorkbookMergeDoesNotResolveOrCopySourceDefinedNames() {
+        using var sourceStream = new MemoryStream();
+        using (ExcelDocument source = ExcelDocument.Create(sourceStream)) {
+            ExcelSheet data = source.AddWorksheet("Data");
+            data.CellValue(1, 1, 21);
+            data.CellFormula(1, 2, "TaxRate*2");
+            source.SetNamedRange("TaxRate", "A1", data, save: false);
+            source.Save(sourceStream);
+        }
+
+        sourceStream.Position = 0;
+        using ExcelDocument sourceDocument = ExcelDocument.Load(sourceStream, new ExcelLoadOptions {
+            AccessMode = OfficeIMO.Drawing.DocumentAccessMode.ReadOnly
+        });
+        using ExcelDocument target = ExcelDocument.Create(new MemoryStream());
+        target.AddWorksheet("Existing");
+
+        target.MergeWorkbookFrom(sourceDocument, new ExcelWorkbookMergeOptions {
+            CopyMode = ExcelWorksheetCopyMode.Values
+        });
+
+        Assert.Null(target.WorkbookPartRoot.Workbook.DefinedNames);
+        Assert.Empty(target["Data"].WorksheetPart.Worksheet.Descendants<CellFormula>());
+    }
+
+    [Fact]
+    public void LegacyExternalReferenceFilterTracksQuotedQualifiersIndependentlyFromStringLiterals() {
+        byte[] workbookStream = LegacyXlsTestWorkbookBuilder.CreateFormulaExternalWorkbookReferenceWorkbookStream();
+        byte[] compound = LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFile(workbookStream);
+        LegacyXlsWorkbook workbook = LegacyXlsWorkbook.Load(compound, new LegacyXlsImportOptions());
+        MethodInfo method = typeof(LegacyXlsWorkbookProjector).GetMethod(
+            "ReferencesExternalWorkbook",
+            BindingFlags.Static | BindingFlags.NonPublic)!;
+
+        bool external = (bool)method.Invoke(null, new object[] {
+            workbook,
+            "'Decoy\"Sheet'!A1+'[Budget.xls]Jan'!A1"
+        })!;
+        bool literalOnly = (bool)method.Invoke(null, new object[] {
+            workbook,
+            "\"[Budget.xls]Jan\"&A1"
+        })!;
+
+        Assert.True(external);
+        Assert.False(literalOnly);
+    }
+
+    [Fact]
+    public void LegacyExternalReferenceFilterHandlesClosingBracketInWorkbookName() {
+        Type matcherType = typeof(LegacyXlsWorkbookProjector).GetNestedType(
+            "ExternalWorkbookReferenceMatcher",
+            BindingFlags.NonPublic)!;
+        var reference = new LegacyXlsExternalReference(
+            LegacyXlsExternalReferenceKind.ExternalWorkbook,
+            "Budget]2025.xls",
+            new[] { "Jan" },
+            1);
+        object matcher = Activator.CreateInstance(
+            matcherType,
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            binder: null,
+            args: new object[] { new[] { reference } },
+            culture: null)!;
+        MethodInfo matches = matcherType.GetMethod(
+            "ReferencesExternalWorkbook",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+        Assert.True((bool)matches.Invoke(matcher, new object[] { "'[Budget]2025.xls]Jan'!A1" })!);
+    }
+
+    [Fact]
+    public void TemporaryPackageStagingStopsBeforeExceedingItsConfiguredLimit() {
+        using var inner = new MemoryStream();
+        using var staging = new ExcelBoundedSeekableStream(inner, maximumBytes: 8, leaveOpen: true);
+        staging.Write(new byte[8], 0, 8);
+
+        IOException exception = Assert.Throws<IOException>(() => staging.WriteByte(1));
+
+        Assert.Equal(8, inner.Length);
+        Assert.Contains("8-byte temporary package limit", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ConversionSaveOptionsPreserveTheTemporaryPackageLimit() {
+        var options = new ExcelSaveOptions { MaxTemporaryPackageBytes = 1_024 };
+
+        ExcelSaveOptions copy = options.WithLossPolicy(ExcelConversionLossPolicy.Allow);
+
+        Assert.Equal(1_024, copy.MaxTemporaryPackageBytes);
+    }
+}

--- a/OfficeIMO.Excel/ExcelBoundedSeekableStream.cs
+++ b/OfficeIMO.Excel/ExcelBoundedSeekableStream.cs
@@ -1,0 +1,94 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OfficeIMO.Excel {
+    /// <summary>Bounds a seekable staging stream while retaining package-writer compatibility.</summary>
+    internal sealed class ExcelBoundedSeekableStream : Stream {
+        private readonly Stream _inner;
+        private readonly long _maximumBytes;
+        private readonly bool _leaveOpen;
+
+        internal ExcelBoundedSeekableStream(Stream inner, long maximumBytes, bool leaveOpen = false) {
+            _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+            if (!inner.CanSeek || !inner.CanWrite) {
+                throw new ArgumentException("The staging stream must be seekable and writable.", nameof(inner));
+            }
+            if (maximumBytes <= 0) throw new ArgumentOutOfRangeException(nameof(maximumBytes));
+            _maximumBytes = maximumBytes;
+            _leaveOpen = leaveOpen;
+        }
+
+        public override bool CanRead => _inner.CanRead;
+        public override bool CanSeek => true;
+        public override bool CanWrite => true;
+        public override long Length => _inner.Length;
+        public override long Position {
+            get => _inner.Position;
+            set {
+                EnsureWithinLimit(value);
+                _inner.Position = value;
+            }
+        }
+
+        public override void Flush() => _inner.Flush();
+        public override Task FlushAsync(CancellationToken cancellationToken) => _inner.FlushAsync(cancellationToken);
+        public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+
+        public override long Seek(long offset, SeekOrigin origin) {
+            long position;
+            switch (origin) {
+                case SeekOrigin.Begin:
+                    position = offset;
+                    break;
+                case SeekOrigin.Current:
+                    position = checked(_inner.Position + offset);
+                    break;
+                case SeekOrigin.End:
+                    position = checked(_inner.Length + offset);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(origin));
+            }
+            EnsureWithinLimit(position);
+            return _inner.Seek(offset, origin);
+        }
+
+        public override void SetLength(long value) {
+            EnsureWithinLimit(value);
+            _inner.SetLength(value);
+        }
+
+        public override void Write(byte[] buffer, int offset, int count) {
+            EnsureWriteWithinLimit(count);
+            _inner.Write(buffer, offset, count);
+        }
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) {
+            EnsureWriteWithinLimit(count);
+            return _inner.WriteAsync(buffer, offset, count, cancellationToken);
+        }
+
+        public override void WriteByte(byte value) {
+            EnsureWriteWithinLimit(1);
+            _inner.WriteByte(value);
+        }
+
+        protected override void Dispose(bool disposing) {
+            if (disposing && !_leaveOpen) _inner.Dispose();
+            base.Dispose(disposing);
+        }
+
+        private void EnsureWriteWithinLimit(int count) {
+            if (count < 0) throw new ArgumentOutOfRangeException(nameof(count));
+            EnsureWithinLimit(checked(_inner.Position + count));
+        }
+
+        private void EnsureWithinLimit(long value) {
+            if (value < 0 || value > _maximumBytes) {
+                throw new IOException($"The staged Excel package exceeds the {_maximumBytes}-byte temporary package limit.");
+            }
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelDocument.Save.Public.cs
+++ b/OfficeIMO.Excel/ExcelDocument.Save.Public.cs
@@ -580,11 +580,15 @@ namespace OfficeIMO.Excel {
             Stream destination,
             ExcelFileFormat format,
             ExcelSaveOptions? options) {
-            using FileStream staging = OfficeTemporaryFile.Create(
+            using FileStream stagingFile = OfficeTemporaryFile.Create(
                 "OfficeIMO.Excel-",
                 ".tmp",
                 FileOptions.SequentialScan,
                 out _);
+            using var staging = new ExcelBoundedSeekableStream(
+                stagingFile,
+                ResolveTemporaryPackageLimit(options),
+                leaveOpen: true);
             SaveToStreamCore(staging, format, options);
             staging.Position = 0L;
             staging.CopyTo(destination, 81920);
@@ -596,15 +600,29 @@ namespace OfficeIMO.Excel {
             ExcelFileFormat format,
             ExcelSaveOptions? options,
             CancellationToken cancellationToken) {
-            using FileStream staging = OfficeTemporaryFile.Create(
+            using FileStream stagingFile = OfficeTemporaryFile.Create(
                 "OfficeIMO.Excel-",
                 ".tmp",
                 FileOptions.Asynchronous | FileOptions.SequentialScan,
                 out _);
+            using var staging = new ExcelBoundedSeekableStream(
+                stagingFile,
+                ResolveTemporaryPackageLimit(options),
+                leaveOpen: true);
             await SaveToStreamAsyncCore(staging, format, options, cancellationToken).ConfigureAwait(false);
             staging.Position = 0L;
             await staging.CopyToAsync(destination, 81920, cancellationToken).ConfigureAwait(false);
             await destination.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        private static long ResolveTemporaryPackageLimit(ExcelSaveOptions? options) {
+            long? limit = options == null
+                ? ExcelSaveOptions.DefaultMaxTemporaryPackageBytes
+                : options.MaxTemporaryPackageBytes;
+            if (limit.HasValue && limit.Value <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(ExcelSaveOptions.MaxTemporaryPackageBytes));
+            }
+            return limit ?? long.MaxValue;
         }
 #endif
 

--- a/OfficeIMO.Excel/ExcelDocument.WorkbookMerge.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorkbookMerge.cs
@@ -74,15 +74,17 @@ namespace OfficeIMO.Excel {
             }
 
             RewriteMergedWorksheetReferences(createdTargetNames, sheetNameMap, tableNameMap);
-            for (int index = 0; index < importedSourceNames.Count; index++) {
-                ExcelSheet targetSheet = GetSheet(createdTargetNames[index]);
-                externalReferenceMaps.TryGetValue(targetSheet.Name, out IReadOnlyDictionary<int, int>? externalReferenceMap);
-                CopyReferencedDefinedNamesFromSource(
-                    sourceDocument,
-                    targetSheet,
-                    sheetNameMap,
-                    tableNameMap,
-                    externalReferenceMap);
+            if (options.CopyMode == ExcelWorksheetCopyMode.Package) {
+                for (int index = 0; index < importedSourceNames.Count; index++) {
+                    ExcelSheet targetSheet = GetSheet(createdTargetNames[index]);
+                    externalReferenceMaps.TryGetValue(targetSheet.Name, out IReadOnlyDictionary<int, int>? externalReferenceMap);
+                    CopyReferencedDefinedNamesFromSource(
+                        sourceDocument,
+                        targetSheet,
+                        sheetNameMap,
+                        tableNameMap,
+                        externalReferenceMap);
+                }
             }
 
             MarkPackageDirty();

--- a/OfficeIMO.Excel/ExcelSaveOptions.cs
+++ b/OfficeIMO.Excel/ExcelSaveOptions.cs
@@ -20,11 +20,21 @@ namespace OfficeIMO.Excel {
         /// <summary>Default maximum package size materialized by save operations: 256 MiB.</summary>
         public const long DefaultMaxInMemoryPackageBytes = 256L * 1024L * 1024L;
 
+        /// <summary>Default maximum temporary package size staged for a non-seekable destination: 256 MiB.</summary>
+        public const long DefaultMaxTemporaryPackageBytes = 256L * 1024L * 1024L;
+
         /// <summary>
         /// Maximum package size that may be materialized in memory while saving. The default is
         /// 256 MiB. Set to <c>null</c> only for explicitly trusted, intentionally larger workbooks.
         /// </summary>
         public long? MaxInMemoryPackageBytes { get; set; } = DefaultMaxInMemoryPackageBytes;
+
+        /// <summary>
+        /// Maximum package size that may be staged in a temporary file when a target framework
+        /// requires a seekable package destination. The default is 256 MiB. Set to <c>null</c>
+        /// only for explicitly trusted, intentionally larger workbooks.
+        /// </summary>
+        public long? MaxTemporaryPackageBytes { get; set; } = DefaultMaxTemporaryPackageBytes;
 
         /// <summary>
         /// When true, attempts to repair common defined-name issues (duplicates, out-of-range LocalSheetId, #REF!) before save.
@@ -90,8 +100,12 @@ namespace OfficeIMO.Excel {
             if (MaxInMemoryPackageBytes.HasValue && MaxInMemoryPackageBytes.Value <= 0) {
                 throw new ArgumentOutOfRangeException(nameof(MaxInMemoryPackageBytes));
             }
+            if (MaxTemporaryPackageBytes.HasValue && MaxTemporaryPackageBytes.Value <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(MaxTemporaryPackageBytes));
+            }
             return new ExcelSaveOptions {
                 MaxInMemoryPackageBytes = MaxInMemoryPackageBytes,
+                MaxTemporaryPackageBytes = MaxTemporaryPackageBytes,
                 SafeRepairDefinedNames = SafeRepairDefinedNames,
                 ValidateOpenXml = ValidateOpenXml,
                 SafePreflight = SafePreflight,

--- a/OfficeIMO.Excel/LegacyXls/Projection/LegacyXlsWorkbookProjector.ExternalReferences.cs
+++ b/OfficeIMO.Excel/LegacyXls/Projection/LegacyXlsWorkbookProjector.ExternalReferences.cs
@@ -1,0 +1,97 @@
+using OfficeIMO.Excel.LegacyXls.Biff;
+using OfficeIMO.Excel.LegacyXls.Model;
+using System.Runtime.CompilerServices;
+
+namespace OfficeIMO.Excel.LegacyXls.Projection {
+    internal static partial class LegacyXlsWorkbookProjector {
+        private static readonly ConditionalWeakTable<LegacyXlsWorkbook, ExternalWorkbookReferenceMatcher>
+            ExternalWorkbookReferenceMatchers = new();
+
+        private sealed class ExternalWorkbookReferenceMatcher {
+            private readonly HashSet<string> _fileNames = new(StringComparer.OrdinalIgnoreCase);
+
+            internal ExternalWorkbookReferenceMatcher(IReadOnlyList<LegacyXlsExternalReference> references) {
+                foreach (LegacyXlsExternalReference reference in references) {
+                    if (reference.Kind != LegacyXlsExternalReferenceKind.ExternalWorkbook ||
+                        string.IsNullOrWhiteSpace(reference.Target)) {
+                        continue;
+                    }
+
+                    string fileName = BiffFormulaReferenceFormatter.NormalizeExternalWorkbookTarget(reference.Target);
+                    if (fileName.Length > 0) _fileNames.Add(fileName);
+                }
+            }
+
+            internal bool ReferencesExternalWorkbook(string formulaText) {
+                if (_fileNames.Count == 0 || string.IsNullOrEmpty(formulaText)) return false;
+
+                bool inStringLiteral = false;
+                for (int index = 0; index < formulaText.Length; index++) {
+                    char current = formulaText[index];
+                    if (current == '"') {
+                        if (inStringLiteral && index + 1 < formulaText.Length && formulaText[index + 1] == '"') {
+                            index++;
+                        } else {
+                            inStringLiteral = !inStringLiteral;
+                        }
+                        continue;
+                    }
+                    if (inStringLiteral) continue;
+
+                    if (current == '\'') {
+                        int end = FindQuotedQualifierEnd(formulaText, index + 1);
+                        if (end < 0) return false;
+                        if (end + 1 < formulaText.Length && formulaText[end + 1] == '!' &&
+                            QualifierMatches(formulaText.Substring(index + 1, end - index - 1).Replace("''", "'"))) {
+                            return true;
+                        }
+                        index = end;
+                        continue;
+                    }
+
+                    if (current == '[') {
+                        int qualifierEnd = formulaText.IndexOf('!', index + 1);
+                        int end = qualifierEnd < 0
+                            ? -1
+                            : formulaText.LastIndexOf(']', qualifierEnd - 1, qualifierEnd - index - 1);
+                        if (end > index + 1 && _fileNames.Contains(formulaText.Substring(index + 1, end - index - 1))) {
+                            return true;
+                        }
+                    } else if (current == '!') {
+                        int start = index - 1;
+                        while (start >= 0 && !IsQualifierBoundary(formulaText[start])) start--;
+                        start++;
+                        if (start < index && _fileNames.Contains(formulaText.Substring(start, index - start))) {
+                            return true;
+                        }
+                    }
+                }
+
+                return false;
+            }
+
+            private bool QualifierMatches(string qualifier) {
+                int open = qualifier.IndexOf('[');
+                int close = open < 0 ? -1 : qualifier.LastIndexOf(']');
+                return open >= 0 && close > open + 1
+                    ? _fileNames.Contains(qualifier.Substring(open + 1, close - open - 1))
+                    : _fileNames.Contains(qualifier);
+            }
+
+            private static int FindQuotedQualifierEnd(string formulaText, int start) {
+                for (int index = start; index < formulaText.Length; index++) {
+                    if (formulaText[index] != '\'') continue;
+                    if (index + 1 < formulaText.Length && formulaText[index + 1] == '\'') {
+                        index++;
+                        continue;
+                    }
+                    return index;
+                }
+                return -1;
+            }
+
+            private static bool IsQualifierBoundary(char value) =>
+                char.IsWhiteSpace(value) || "+-*/^&=<>(),;:{}".IndexOf(value) >= 0;
+        }
+    }
+}

--- a/OfficeIMO.Excel/LegacyXls/Projection/LegacyXlsWorkbookProjector.cs
+++ b/OfficeIMO.Excel/LegacyXls/Projection/LegacyXlsWorkbookProjector.cs
@@ -933,50 +933,11 @@ namespace OfficeIMO.Excel.LegacyXls.Projection {
         private static bool ShouldProjectFormula(LegacyXlsWorkbook workbook, string formulaText) =>
             workbook.PreserveExternalWorkbookLinks || !ReferencesExternalWorkbook(workbook, formulaText);
 
-        private static bool ReferencesExternalWorkbook(LegacyXlsWorkbook workbook, string formulaText) {
-            foreach (LegacyXlsExternalReference reference in workbook.ExternalReferences) {
-                if (reference.Kind != LegacyXlsExternalReferenceKind.ExternalWorkbook ||
-                    string.IsNullOrWhiteSpace(reference.Target)) {
-                    continue;
-                }
-
-                string fileName = BiffFormulaReferenceFormatter.NormalizeExternalWorkbookTarget(reference.Target);
-                if (fileName.Length == 0) continue;
-                string escapedFileName = fileName.Replace("'", "''");
-                if (ContainsFormulaTokenOutsideStringLiteral(formulaText, "[" + escapedFileName + "]") ||
-                    ContainsFormulaTokenOutsideStringLiteral(formulaText, "'" + escapedFileName + "'!") ||
-                    ContainsFormulaTokenOutsideStringLiteral(formulaText, escapedFileName + "!")) {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        private static bool ContainsFormulaTokenOutsideStringLiteral(string formulaText, string token) {
-            bool inStringLiteral = false;
-            for (int index = 0; index < formulaText.Length;) {
-                if (formulaText[index] == '"') {
-                    if (inStringLiteral && index + 1 < formulaText.Length && formulaText[index + 1] == '"') {
-                        index += 2;
-                        continue;
-                    }
-
-                    inStringLiteral = !inStringLiteral;
-                    index++;
-                    continue;
-                }
-
-                if (!inStringLiteral && index <= formulaText.Length - token.Length &&
-                    string.Compare(formulaText, index, token, 0, token.Length, StringComparison.OrdinalIgnoreCase) == 0) {
-                    return true;
-                }
-
-                index++;
-            }
-
-            return false;
-        }
+        private static bool ReferencesExternalWorkbook(LegacyXlsWorkbook workbook, string formulaText) =>
+            ExternalWorkbookReferenceMatchers.GetValue(
+                workbook,
+                static source => new ExternalWorkbookReferenceMatcher(source.ExternalReferences))
+            .ReferencesExternalWorkbook(formulaText);
 
         private static void ProjectTableDefinitions(LegacyXlsWorkbook workbook, LegacyXlsWorksheet legacySheet, ExcelSheet sheet) {
             if (legacySheet.TableDefinitions.Count == 0) {

--- a/OfficeIMO.Html.Pdf/HtmlPdfSaveOptions.cs
+++ b/OfficeIMO.Html.Pdf/HtmlPdfSaveOptions.cs
@@ -33,10 +33,12 @@ public sealed class HtmlPdfSaveOptions : HtmlRenderOptions {
     /// PDF conversion enforces paged layout on its own conversion snapshot.
     /// </summary>
     /// <param name="renderOptions">Shared settings used by PNG, SVG, and PDF rendering.</param>
-    /// <remarks>The supplied URL policy is preserved. The parameterless constructor provides the PDF hyperlink default.</remarks>
+    /// <remarks>Generic rendering settings are intersected with the PDF hyperlink policy so caller restrictions are preserved. PDF-specific snapshots preserve their explicitly configured URL policy.</remarks>
     public HtmlPdfSaveOptions(HtmlRenderOptions renderOptions) : base(renderOptions) {
         if (renderOptions is HtmlPdfSaveOptions pdfOptions) {
             CopyPdfSettingsFrom(pdfOptions);
+        } else {
+            UrlPolicy = HtmlUrlPolicy.Intersect(UrlPolicy, HtmlUrlPolicy.CreateHyperlinkProfile());
         }
     }
 

--- a/OfficeIMO.Html.Tests/Html.ApiConsistency.cs
+++ b/OfficeIMO.Html.Tests/Html.ApiConsistency.cs
@@ -149,16 +149,19 @@ public sealed class HtmlApiConsistencyTests {
     }
 
     [Fact]
-    public void HtmlPdfOptions_FromRenderOptionsPreserveCallerUrlPolicy() {
+    public void HtmlPdfOptions_FromRenderOptionsPreserveCallerRestrictionsWithinPdfPolicy() {
         var source = new HtmlRenderOptions {
             UrlPolicy = HtmlUrlPolicy.CreateOfficeIMOProfile()
         };
 
         var copied = new HtmlPdfSaveOptions(source);
 
-        Assert.False(copied.UrlPolicy.RestrictUrlSchemes);
-        Assert.False(copied.UrlPolicy.DisallowFileUrls);
-        Assert.True(copied.UrlPolicy.AllowDataUrls);
+        Assert.True(copied.UrlPolicy.RestrictUrlSchemes);
+        Assert.True(copied.UrlPolicy.DisallowFileUrls);
+        Assert.False(copied.UrlPolicy.AllowDataUrls);
+        Assert.True(HtmlUrlPolicyEvaluator.IsAllowed("https://example.test/report", copied.UrlPolicy));
+        Assert.False(HtmlUrlPolicyEvaluator.IsAllowed("file:///private/report.html", copied.UrlPolicy));
+        Assert.False(HtmlUrlPolicyEvaluator.IsAllowed("data:text/html,report", copied.UrlPolicy));
     }
 
     [Fact]

--- a/OfficeIMO.Html.Tests/Html.Security.AllSeverityBatch17.cs
+++ b/OfficeIMO.Html.Tests/Html.Security.AllSeverityBatch17.cs
@@ -1,0 +1,48 @@
+using OfficeIMO.Html;
+using OfficeIMO.Html.Pdf;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class HtmlAllSeverityBatch17SecurityTests {
+    [Fact]
+    public void GenericRenderOptionsCannotWidenPdfHyperlinkSchemes() {
+        int transformCalls = 0;
+        HtmlUrlPolicy callerPolicy = HtmlUrlPolicy.CreateHyperlinkProfile();
+        callerPolicy.AllowMailtoUrls = false;
+        callerPolicy.AllowProtocolRelativeUrls = false;
+        callerPolicy.AllowedUrlSchemes.Remove(Uri.UriSchemeHttp);
+        callerPolicy.ResolvedUrlTransform = value => {
+            transformCalls++;
+            return value;
+        };
+        var generic = new HtmlRenderOptions {
+            UrlPolicy = callerPolicy
+        };
+
+        var pdf = new HtmlPdfSaveOptions(generic);
+
+        Assert.False(HtmlUrlPolicyEvaluator.IsAllowed("file:///private/secret.txt", pdf.UrlPolicy));
+        Assert.False(HtmlUrlPolicyEvaluator.IsAllowed("data:text/html,secret", pdf.UrlPolicy));
+        Assert.False(HtmlUrlPolicyEvaluator.IsAllowed("smb://server/share", pdf.UrlPolicy));
+        Assert.False(HtmlUrlPolicyEvaluator.IsAllowed("http://example.test/report", pdf.UrlPolicy));
+        Assert.False(HtmlUrlPolicyEvaluator.IsAllowed("mailto:security@example.test", pdf.UrlPolicy));
+        Assert.False(HtmlUrlPolicyEvaluator.IsAllowed("//example.test/report", pdf.UrlPolicy));
+        Assert.True(HtmlUrlPolicyEvaluator.IsAllowed("https://example.test/report", pdf.UrlPolicy));
+        Assert.Equal(
+            "https://example.test/report",
+            HtmlUrlPolicyEvaluator.ResolveUrl("https://example.test/report", null, pdf.UrlPolicy));
+        Assert.True(transformCalls > 0);
+    }
+
+    [Fact]
+    public void PdfSpecificOptionSnapshotsRetainExplicitPdfPolicy() {
+        var source = new HtmlPdfSaveOptions {
+            UrlPolicy = HtmlUrlPolicy.CreateOfficeIMOProfile()
+        };
+
+        var copy = new HtmlPdfSaveOptions(source);
+
+        Assert.False(copy.UrlPolicy.RestrictUrlSchemes);
+    }
+}

--- a/OfficeIMO.Markdown.Tests/Markdown/CommonMark/CommonMarkHtmlComparison.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown/CommonMark/CommonMarkHtmlComparison.cs
@@ -5,11 +5,18 @@ namespace OfficeIMO.Tests.MarkdownSuite;
 
 internal static class CommonMarkHtmlComparison {
     public static HtmlOptions CreatePlainHtmlOptions() {
-        return new HtmlOptions {
+        var options = new HtmlOptions {
             Style = HtmlStyle.Plain,
             CssDelivery = CssDelivery.None,
             BodyClass = null
         };
+        options.AdditionalAllowedLinkSchemes.AddRange(new[] {
+            "a+b+c",
+            "irc",
+            "localhost",
+            "made-up-scheme"
+        });
+        return options;
     }
 
     public static string Normalize(string html) {

--- a/OfficeIMO.Markdown.Tests/Markdown/GitHubFlavoredMarkdown/GfmHtmlComparison.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown/GitHubFlavoredMarkdown/GfmHtmlComparison.cs
@@ -5,7 +5,9 @@ namespace OfficeIMO.Tests.MarkdownSuite;
 
 internal static class GfmHtmlComparison {
     public static HtmlOptions CreatePlainHtmlOptions() {
-        return HtmlOptions.CreateGitHubFlavoredMarkdownProfile();
+        HtmlOptions options = HtmlOptions.CreateGitHubFlavoredMarkdownProfile();
+        options.AdditionalAllowedLinkSchemes.Add("xmpp");
+        return options;
     }
 
     public static string Normalize(string html) {

--- a/OfficeIMO.Markdown.Tests/Markdown/Markdown_AllSeverityBatch17_Security_Tests.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown/Markdown_AllSeverityBatch17_Security_Tests.cs
@@ -39,4 +39,40 @@ public sealed class MarkdownAllSeverityBatch17SecurityTests {
         Assert.Contains("<a ", html, StringComparison.OrdinalIgnoreCase);
         Assert.Contains(target, html, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void HtmlRendererAllowsAdditionalSchemesOnlyWhenExplicitlyConfigured() {
+        MarkdownDoc document = MarkdownReader.Parse("[open](acme-safe:resource)");
+        var defaultOptions = new HtmlOptions {
+            Style = HtmlStyle.Plain,
+            CssDelivery = CssDelivery.None,
+            BodyClass = null
+        };
+
+        string defaultHtml = document.ToHtmlFragment(defaultOptions);
+        Assert.DoesNotContain("href=", defaultHtml, StringComparison.OrdinalIgnoreCase);
+
+        var configuredOptions = new HtmlOptions {
+            Style = HtmlStyle.Plain,
+            CssDelivery = CssDelivery.None,
+            BodyClass = null
+        };
+        configuredOptions.AdditionalAllowedLinkSchemes.Add("acme-safe");
+
+        string configuredHtml = document.ToHtmlFragment(configuredOptions);
+        Assert.Contains("href=\"acme-safe:resource\"", configuredHtml, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HtmlRendererKeepsColonContainingRelativeTargetsThatCannotNameAProtocol() {
+        MarkdownDoc document = MarkdownReader.Parse("[link](foo\\)\\:)");
+
+        string html = document.ToHtmlFragment(new HtmlOptions {
+            Style = HtmlStyle.Plain,
+            CssDelivery = CssDelivery.None,
+            BodyClass = null
+        });
+
+        Assert.Contains("href=\"foo):\"", html, StringComparison.Ordinal);
+    }
 }

--- a/OfficeIMO.Markdown.Tests/Markdown/Markdown_AllSeverityBatch17_Security_Tests.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown/Markdown_AllSeverityBatch17_Security_Tests.cs
@@ -1,0 +1,42 @@
+using OfficeIMO.Markdown;
+using Xunit;
+
+namespace OfficeIMO.Tests.MarkdownSuite;
+
+public sealed class MarkdownAllSeverityBatch17SecurityTests {
+    [Theory]
+    [InlineData("ms-msdt:diagnostic")]
+    [InlineData("search-ms:query=secret")]
+    [InlineData("shell:Downloads")]
+    [InlineData("smb://server/share")]
+    public void HtmlRendererRejectsUnlistedLinkSchemes(string target) {
+        MarkdownDoc document = MarkdownReader.Parse($"[open]({target})");
+
+        string html = document.ToHtmlFragment(new HtmlOptions {
+            Style = HtmlStyle.Plain,
+            CssDelivery = CssDelivery.None,
+            BodyClass = null
+        });
+
+        Assert.DoesNotContain("<a ", html, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("href=", html, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(">open<", html, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("https://example.test/report")]
+    [InlineData("mailto:security@example.test")]
+    [InlineData("tel:+12025550123")]
+    public void HtmlRendererRetainsExplicitlyAllowedLinkSchemes(string target) {
+        MarkdownDoc document = MarkdownReader.Parse($"[open]({target})");
+
+        string html = document.ToHtmlFragment(new HtmlOptions {
+            Style = HtmlStyle.Plain,
+            CssDelivery = CssDelivery.None,
+            BodyClass = null
+        });
+
+        Assert.Contains("<a ", html, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(target, html, StringComparison.Ordinal);
+    }
+}

--- a/OfficeIMO.Markdown/Options/HtmlOptions.cs
+++ b/OfficeIMO.Markdown/Options/HtmlOptions.cs
@@ -258,6 +258,15 @@ public sealed class HtmlOptions {
     public List<string> AllowedHttpLinkHosts { get; } = new();
 
     /// <summary>
+    /// Additional URL schemes permitted for rendered hyperlinks beyond the built-in
+    /// <c>http</c>, <c>https</c>, <c>mailto</c>, <c>tel</c>, <c>ftp</c>,
+    /// and <c>urn</c> schemes.
+    /// Keep this list empty for untrusted Markdown. Add only application-specific
+    /// schemes whose protocol handlers are safe for the rendering host.
+    /// </summary>
+    public List<string> AdditionalAllowedLinkSchemes { get; } = new();
+
+    /// <summary>
     /// Optional allowlist of host patterns for absolute HTTP(S) images during HTML rendering.
     /// When non-empty, absolute HTTP(S) images are suppressed unless their host matches an entry.
     /// Pattern rules match <see cref="AllowedHttpLinkHosts"/>.
@@ -359,6 +368,7 @@ public sealed class HtmlOptions {
         clone.SyntaxBlockRenderExtensions.AddRange(SyntaxBlockRenderExtensions);
         clone.SyntaxInlineRenderExtensions.AddRange(SyntaxInlineRenderExtensions);
         clone.AllowedHttpLinkHosts.AddRange(AllowedHttpLinkHosts);
+        clone.AdditionalAllowedLinkSchemes.AddRange(AdditionalAllowedLinkSchemes);
         clone.AllowedHttpImageHosts.AddRange(AllowedHttpImageHosts);
         return clone;
     }

--- a/OfficeIMO.Markdown/Utilities/UrlOriginPolicy.cs
+++ b/OfficeIMO.Markdown/Utilities/UrlOriginPolicy.cs
@@ -86,10 +86,10 @@ internal static class UrlOriginPolicy {
         if (value.Length == 0 || value.StartsWith("#", StringComparison.Ordinal)) return true;
         if (!TryGetScheme(value, out string? scheme)) return true;
 
-        return scheme != "javascript"
-            && scheme != "vbscript"
-            && scheme != "data"
-            && scheme != "file";
+        return scheme == "http"
+            || scheme == "https"
+            || scheme == "mailto"
+            || scheme == "tel";
     }
 
     private static bool IsSafeImageUrl(string? url) {

--- a/OfficeIMO.Markdown/Utilities/UrlOriginPolicy.cs
+++ b/OfficeIMO.Markdown/Utilities/UrlOriginPolicy.cs
@@ -2,7 +2,7 @@ namespace OfficeIMO.Markdown;
 
 internal static class UrlOriginPolicy {
     internal static bool IsAllowedHttpLink(HtmlOptions? o, string? url) {
-        if (!IsSafeLinkUrl(url)) return false;
+        if (!IsSafeLinkUrl(o, url)) return false;
         return IsAllowedHttpUrl(o, url, forImages: false);
     }
 
@@ -81,15 +81,23 @@ internal static class UrlOriginPolicy {
         return IsSameOrigin(baseUri, abs);
     }
 
-    private static bool IsSafeLinkUrl(string? url) {
+    private static bool IsSafeLinkUrl(HtmlOptions? options, string? url) {
         string value = (url ?? string.Empty).Trim();
         if (value.Length == 0 || value.StartsWith("#", StringComparison.Ordinal)) return true;
         if (!TryGetScheme(value, out string? scheme)) return true;
+        if (string.IsNullOrEmpty(scheme)) return true;
 
-        return scheme == "http"
+        if (scheme == "http"
             || scheme == "https"
             || scheme == "mailto"
-            || scheme == "tel";
+            || scheme == "tel"
+            || scheme == "ftp"
+            || scheme == "urn") {
+            return true;
+        }
+
+        return options?.AdditionalAllowedLinkSchemes.Any(candidate =>
+            string.Equals(candidate?.Trim(), scheme, StringComparison.OrdinalIgnoreCase)) == true;
     }
 
     private static bool IsSafeImageUrl(string? url) {

--- a/OfficeIMO.Pdf.Tests/Pdf/Pdf.Security.AllSeverityBatch17.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/Pdf.Security.AllSeverityBatch17.cs
@@ -1,0 +1,77 @@
+using System.Reflection;
+using System.Text;
+using OfficeIMO.Pdf;
+using Xunit;
+
+namespace OfficeIMO.Tests.Pdf;
+
+public sealed class PdfAllSeverityBatch17SecurityTests {
+    [Fact]
+    public void SignaturePlaceholderScanIgnoresDecoysInsideStreamBodies() {
+        string streamPayload =
+            "BT\n" +
+            "endstream\n<< /Type /Sig /ByteRange [0 0 0 0] /Contents <0000> >>\nendobj\n" +
+            "ET\n";
+        byte[] source = Encoding.ASCII.GetBytes(
+            "%PDF-1.7\n" +
+            "1 0 obj\n<< /Length " + Encoding.ASCII.GetByteCount(streamPayload) + " >>\nstream\n" +
+            streamPayload +
+            "endstream\nendobj\n" +
+            "2 0 obj\n<< /Type /Sig /ByteRange [0 0 0 0] /Contents <0000> >>\nendobj\n");
+        MethodInfo method = typeof(PdfIncrementalUpdater).GetMethod(
+            "FindZeroFilledSignatureContents",
+            BindingFlags.Static | BindingFlags.NonPublic)!;
+        object[] arguments = { source, 0, 0, 0 };
+
+        int count = (int)method.Invoke(null, arguments)!;
+
+        Assert.Equal(1, count);
+        Assert.Equal(2, (int)arguments[3]);
+        Assert.True((int)arguments[1] > 0);
+        Assert.Equal(4, (int)arguments[2]);
+    }
+
+    [Fact]
+    public void RawSignatureCompletionIgnoresEndstreamDecoyInDeclaredStreamData() {
+        const string decoy =
+            "endstream\n<< /Type /Sig /ByteRange [0 0 0 0] /Contents <0000> >>\nendobj";
+        byte[] source = PdfDocument.Create(new PdfOptions { CompressContentStreams = false })
+            .Paragraph(paragraph => paragraph.Text(decoy))
+            .ToBytes();
+        PdfExternalSignaturePreparation preparation = PdfIncrementalUpdater.PrepareExternalSignature(
+            source,
+            new PdfExternalSignatureOptions { ReservedSignatureContentsBytes = 256 });
+
+        byte[] completed = PdfIncrementalUpdater.ApplyExternalSignature(
+            preparation.PreparedPdf,
+            new byte[] { 0x30, 0x01, 0x00 });
+
+        Assert.Equal(preparation.PreparedPdf.Length, completed.Length);
+        Assert.Contains("300100", Encoding.ASCII.GetString(completed), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SignaturePlaceholderScanResolvesIndirectStreamLengthBeforeStructuralFallback() {
+        string streamPayload =
+            "BT\n" +
+            "endstream\nendobj\n" +
+            "9 0 obj\n<< /Type /Sig /ByteRange [0 0 0 0] /Contents <0000> >>\nendobj\n" +
+            "ET\n";
+        byte[] source = Encoding.ASCII.GetBytes(
+            "%PDF-1.7\n" +
+            "1 0 obj\n<< /Length 5 0 R >>\nstream\n" +
+            streamPayload +
+            "endstream\nendobj\n" +
+            "5 0 obj\n" + Encoding.ASCII.GetByteCount(streamPayload) + "\nendobj\n" +
+            "2 0 obj\n<< /Type /Sig /ByteRange [0 0 0 0] /Contents <0000> >>\nendobj\n");
+        MethodInfo method = typeof(PdfIncrementalUpdater).GetMethod(
+            "FindZeroFilledSignatureContents",
+            BindingFlags.Static | BindingFlags.NonPublic)!;
+        object[] arguments = { source, 0, 0, 0 };
+
+        int count = (int)method.Invoke(null, arguments)!;
+
+        Assert.Equal(1, count);
+        Assert.Equal(2, (int)arguments[3]);
+    }
+}

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfRedactionApplierTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfRedactionApplierTests.cs
@@ -27,7 +27,7 @@ public class PdfRedactionApplierTests {
     }
 
     [Fact]
-    public void Apply_AreaRedactionPreservesTextObjectsWithoutKnownGeometry() {
+    public void Apply_AreaRedactionFailsClosedForTextObjectsWithoutKnownGeometry() {
         const string content =
             "BT\n/F1 12 Tf\n50 60 Td\n(   ) Tj\nET\n" +
             "BT\n% unlocatable-outside-target\nET";
@@ -45,7 +45,7 @@ public class PdfRedactionApplierTests {
         string rewritten = PdfEncoding.Latin1GetString(redacted);
 
         Assert.DoesNotContain("(   ) Tj", rewritten, StringComparison.Ordinal);
-        Assert.Contains("unlocatable-outside-target", rewritten, StringComparison.Ordinal);
+        Assert.DoesNotContain("unlocatable-outside-target", rewritten, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/OfficeIMO.Pdf/Manipulation/PdfIncrementalUpdater.Signatures.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfIncrementalUpdater.Signatures.cs
@@ -6,6 +6,16 @@ namespace OfficeIMO.Pdf;
 internal static partial class PdfIncrementalUpdater {
     private const string SignatureByteRangePlaceholder =
         "00000000000000000000 00000000000000000000 00000000000000000000 00000000000000000000";
+    private static readonly byte[] SignatureContentsMarker = PdfEncoding.Latin1GetBytes("/Contents <");
+    private static readonly byte[] SignatureContentsName = PdfEncoding.Latin1GetBytes("/Contents");
+    private static readonly byte[] SignatureTypeMarker = PdfEncoding.Latin1GetBytes("/Type /Sig");
+    private static readonly byte[] DocumentTimestampTypeMarker = PdfEncoding.Latin1GetBytes("/Type /DocTimeStamp");
+    private static readonly byte[] SignatureByteRangeMarker = PdfEncoding.Latin1GetBytes("/ByteRange [");
+    private static readonly byte[] PdfObjectKeyword = PdfEncoding.Latin1GetBytes("obj");
+    private static readonly byte[] PdfEndObjectKeyword = PdfEncoding.Latin1GetBytes("endobj");
+    private static readonly byte[] PdfStreamKeyword = PdfEncoding.Latin1GetBytes("stream");
+    private static readonly byte[] PdfEndStreamKeyword = PdfEncoding.Latin1GetBytes("endstream");
+    private static readonly byte[] PdfLengthName = PdfEncoding.Latin1GetBytes("/Length");
 
     /// <summary>
     /// Appends an AcroForm signature field and a detached-signature placeholder as a new incremental revision.
@@ -449,7 +459,13 @@ internal static partial class PdfIncrementalUpdater {
         contentsHexLength = 0;
         contentsObjectNumber = 0;
         int placeholderCount = 0;
-        byte[] marker = PdfEncoding.Latin1GetBytes("/Contents <");
+        byte[] marker = SignatureContentsMarker;
+        Dictionary<(int ObjectNumber, int Generation), int> indirectLengths =
+            ReadIndirectPdfLengthValues(pdf);
+        List<PdfIndirectObjectSpan> objectSpans = FindIndirectObjectSpans(pdf, indirectLengths);
+        List<PdfByteSpan> streamSpans = FindPdfStreamSpans(pdf, indirectLengths);
+        int objectSpanIndex = 0;
+        int streamSpanIndex = 0;
         int searchOffset = 0;
         while (true) {
             int markerOffset = IndexOf(pdf, marker, searchOffset);
@@ -472,7 +488,9 @@ internal static partial class PdfIncrementalUpdater {
                 pdf[end] == (byte)'>' &&
                 end > start &&
                 IsZeroFilled(pdf, start, end - start) &&
-                IsSignatureContentsPlaceholder(pdf, markerOffset, end + 1, out int objectNumber)) {
+                !IsOffsetInsideSpan(streamSpans, markerOffset, ref streamSpanIndex) &&
+                TryGetContainingObjectSpan(objectSpans, markerOffset, end + 1, ref objectSpanIndex, out PdfIndirectObjectSpan objectSpan) &&
+                IsSignatureContentsPlaceholder(pdf, markerOffset, objectSpan.Start, objectSpan.End, out int objectNumber)) {
                 if (placeholderCount == 0) {
                     contentsHexOffset = start;
                     contentsHexLength = end - start;
@@ -489,30 +507,21 @@ internal static partial class PdfIncrementalUpdater {
     private static bool IsSignatureContentsPlaceholder(
         byte[] pdf,
         int contentsMarkerOffset,
-        int contentsLiteralEndExclusive,
+        int objectStart,
+        int objectEnd,
         out int objectNumber) {
         objectNumber = 0;
-        int objectStart = FindContainingObjectStart(pdf, contentsMarkerOffset);
-        if (objectStart < 0) {
-            return false;
-        }
-
-        int objectEnd = FindContainingObjectEnd(pdf, objectStart, contentsMarkerOffset);
-        if (objectEnd < 0 || objectEnd < contentsLiteralEndExclusive) {
-            return false;
-        }
-
         if (!TryReadIndirectObjectNumber(pdf, objectStart, objectEnd, out objectNumber) ||
-            !TryFindSolePdfNameOffset(pdf, "/Contents", objectStart, objectEnd, out int contentsNameOffset) ||
+            !TryFindSolePdfNameOffset(pdf, SignatureContentsName, objectStart, objectEnd, out int contentsNameOffset) ||
             contentsNameOffset != contentsMarkerOffset) {
             return false;
         }
 
         bool hasSignatureType =
-            IndexOf(pdf, PdfEncoding.Latin1GetBytes("/Type /Sig"), objectStart, objectEnd) >= 0 ||
-            IndexOf(pdf, PdfEncoding.Latin1GetBytes("/Type /DocTimeStamp"), objectStart, objectEnd) >= 0;
+            IndexOf(pdf, SignatureTypeMarker, objectStart, objectEnd) >= 0 ||
+            IndexOf(pdf, DocumentTimestampTypeMarker, objectStart, objectEnd) >= 0;
         return hasSignatureType &&
-            IndexOf(pdf, PdfEncoding.Latin1GetBytes("/ByteRange ["), objectStart, objectEnd) >= 0;
+            IndexOf(pdf, SignatureByteRangeMarker, objectStart, objectEnd) >= 0;
     }
 
     private static bool TryReadIndirectObjectNumber(
@@ -535,31 +544,17 @@ internal static partial class PdfIncrementalUpdater {
 
     private static bool TryFindSolePdfNameOffset(
         byte[] pdf,
-        string name,
+        byte[] marker,
         int start,
         int endExclusive,
         out int nameOffset) {
-        byte[] marker = PdfEncoding.Latin1GetBytes(name);
         nameOffset = -1;
         int index = start;
         while (index < endExclusive) {
+            if (SkipPdfLexicalValue(pdf, ref index, endExclusive)) continue;
             byte value = pdf[index];
-            if (value == (byte)'%') {
-                while (index < endExclusive && pdf[index] != (byte)'\r' && pdf[index] != (byte)'\n') index++;
-                continue;
-            }
-            if (value == (byte)'(') {
-                SkipPdfLiteralString(pdf, ref index, endExclusive);
-                continue;
-            }
             if (value == (byte)'<' && index + 1 < endExclusive && pdf[index + 1] == (byte)'<') {
                 index += 2;
-                continue;
-            }
-            if (value == (byte)'<') {
-                index++;
-                while (index < endExclusive && pdf[index] != (byte)'>') index++;
-                if (index < endExclusive) index++;
                 continue;
             }
             if (value == (byte)'/' && MatchesAt(pdf, marker, index, endExclusive)) {
@@ -605,39 +600,245 @@ internal static partial class PdfIncrementalUpdater {
         value == (byte)'[' || value == (byte)']' || value == (byte)'{' || value == (byte)'}' ||
         value == (byte)'/' || value == (byte)'%';
 
-    private static int FindContainingObjectStart(byte[] pdf, int offset) {
+    private static List<PdfIndirectObjectSpan> FindIndirectObjectSpans(
+        byte[] pdf,
+        IReadOnlyDictionary<(int ObjectNumber, int Generation), int> indirectLengths) {
+        var spans = new List<PdfIndirectObjectSpan>();
         int index = 0;
         int objectStart = -1;
-        while (index < offset) {
-            if (SkipPdfLexicalValue(pdf, ref index, offset)) continue;
-            if (objectStart >= 0 && MatchesPdfKeyword(pdf, index, offset, "endobj")) {
+        while (index < pdf.Length) {
+            if (SkipPdfLexicalValue(pdf, ref index, pdf.Length, indirectLengths)) continue;
+            if (objectStart >= 0 && MatchesPdfKeyword(pdf, index, pdf.Length, PdfEndObjectKeyword)) {
+                spans.Add(new PdfIndirectObjectSpan(objectStart, index));
                 objectStart = -1;
-                index += 6;
+                index += PdfEndObjectKeyword.Length;
                 continue;
             }
-            if (objectStart < 0 && TryMatchIndirectObjectHeader(pdf, index, offset)) {
+            if (objectStart < 0 && TryMatchIndirectObjectHeader(pdf, index, pdf.Length)) {
                 objectStart = index;
             }
             index++;
         }
-
-        return objectStart;
+        return spans;
     }
 
-    private static int FindContainingObjectEnd(byte[] pdf, int objectStart, int minimumOffset) {
-        int index = objectStart;
+    private static bool TryGetContainingObjectSpan(
+        List<PdfIndirectObjectSpan> spans,
+        int markerOffset,
+        int literalEndExclusive,
+        ref int spanIndex,
+        out PdfIndirectObjectSpan span) {
+        while (spanIndex < spans.Count && spans[spanIndex].End < markerOffset) spanIndex++;
+        if (spanIndex < spans.Count && spans[spanIndex].Start <= markerOffset && spans[spanIndex].End >= literalEndExclusive) {
+            span = spans[spanIndex];
+            return true;
+        }
+        span = default;
+        return false;
+    }
+
+    private static List<PdfByteSpan> FindPdfStreamSpans(
+        byte[] pdf,
+        IReadOnlyDictionary<(int ObjectNumber, int Generation), int> indirectLengths) {
+        var spans = new List<PdfByteSpan>();
+        int index = 0;
         while (index < pdf.Length) {
-            if (SkipPdfLexicalValue(pdf, ref index, pdf.Length)) continue;
-            if (index >= minimumOffset && MatchesPdfKeyword(pdf, index, pdf.Length, "endobj")) {
-                return index;
+            if (MatchesPdfKeyword(pdf, index, pdf.Length, PdfStreamKeyword)) {
+                int start = index + PdfStreamKeyword.Length;
+                if (start < pdf.Length && pdf[start] == (byte)'\r') start++;
+                if (start < pdf.Length && pdf[start] == (byte)'\n') start++;
+                if (!TryFindPdfStreamBoundary(pdf, index, start, pdf.Length, indirectLengths, out int end, out int endStream)) break;
+                spans.Add(new PdfByteSpan(start, end));
+                index = endStream + PdfEndStreamKeyword.Length;
+                continue;
+            }
+            if (SkipPdfLexicalValue(pdf, ref index, pdf.Length, indirectLengths)) continue;
+            index++;
+        }
+        return spans;
+    }
+
+    private static bool IsOffsetInsideSpan(List<PdfByteSpan> spans, int offset, ref int spanIndex) {
+        while (spanIndex < spans.Count && spans[spanIndex].End <= offset) spanIndex++;
+        return spanIndex < spans.Count && spans[spanIndex].Start <= offset && offset < spans[spanIndex].End;
+    }
+
+    private static Dictionary<(int ObjectNumber, int Generation), int> ReadIndirectPdfLengthValues(byte[] pdf) {
+        var values = new Dictionary<(int ObjectNumber, int Generation), int>();
+        try {
+            var (objects, _) = PdfSyntax.ParseObjects(pdf);
+            foreach (PdfIndirectObject indirect in objects.Values) {
+                if (indirect.Value is not PdfNumber number ||
+                    number.Value < 0d ||
+                    number.Value > int.MaxValue ||
+                    number.Value != Math.Truncate(number.Value)) {
+                    continue;
+                }
+                values[(indirect.ObjectNumber, indirect.Generation)] = (int)number.Value;
+            }
+        } catch (Exception ex) when (ex is not OutOfMemoryException) {
+            // The raw placeholder scan still uses structurally paired boundaries when
+            // a malformed PDF cannot provide a trustworthy indirect length value.
+        }
+        return values;
+    }
+
+    private static bool TryFindPdfStreamBoundary(
+        byte[] pdf,
+        int streamKeywordOffset,
+        int streamDataStart,
+        int endExclusive,
+        IReadOnlyDictionary<(int ObjectNumber, int Generation), int>? indirectLengths,
+        out int streamDataEnd,
+        out int endStreamOffset) {
+        streamDataEnd = -1;
+        endStreamOffset = -1;
+        if (TryReadPdfStreamLength(pdf, streamKeywordOffset, indirectLengths, out int declaredLength) &&
+            declaredLength <= endExclusive - streamDataStart) {
+            int declaredEnd = streamDataStart + declaredLength;
+            int markerOffset = SkipPdfWhitespaceAndComments(pdf, declaredEnd, endExclusive);
+            if (MatchesPdfKeyword(pdf, markerOffset, endExclusive, PdfEndStreamKeyword)) {
+                streamDataEnd = declaredEnd;
+                endStreamOffset = markerOffset;
+                return true;
+            }
+        }
+
+        int searchOffset = streamDataStart;
+        while (searchOffset < endExclusive) {
+            int candidate = IndexOfPdfKeyword(pdf, PdfEndStreamKeyword, searchOffset, endExclusive);
+            if (candidate < 0) return false;
+            int nextToken = SkipPdfWhitespaceAndComments(
+                pdf,
+                candidate + PdfEndStreamKeyword.Length,
+                endExclusive);
+            if (MatchesPdfKeyword(pdf, nextToken, endExclusive, PdfEndObjectKeyword)) {
+                streamDataEnd = candidate;
+                endStreamOffset = candidate;
+                return true;
+            }
+            searchOffset = candidate + PdfEndStreamKeyword.Length;
+        }
+        return false;
+    }
+
+    private static bool TryReadPdfStreamLength(
+        byte[] pdf,
+        int streamKeywordOffset,
+        IReadOnlyDictionary<(int ObjectNumber, int Generation), int>? indirectLengths,
+        out int length) {
+        length = 0;
+        int cursor = streamKeywordOffset - 1;
+        while (cursor >= 0 && IsPdfWhitespace(pdf[cursor])) cursor--;
+        if (cursor < 1 || pdf[cursor - 1] != (byte)'>' || pdf[cursor] != (byte)'>') return false;
+
+        int dictionaryEnd = cursor + 1;
+        int dictionaryStart = -1;
+        int depth = 1;
+        cursor -= 2;
+        while (cursor >= 1) {
+            if (pdf[cursor - 1] == (byte)'>' && pdf[cursor] == (byte)'>') {
+                depth++;
+                cursor -= 2;
+                continue;
+            }
+            if (pdf[cursor - 1] == (byte)'<' && pdf[cursor] == (byte)'<') {
+                depth--;
+                if (depth == 0) {
+                    dictionaryStart = cursor - 1;
+                    break;
+                }
+                cursor -= 2;
+                continue;
+            }
+            cursor--;
+        }
+        if (dictionaryStart < 0) return false;
+
+        depth = 1;
+        int index = dictionaryStart + 2;
+        while (index < dictionaryEnd - 1) {
+            if (pdf[index] == (byte)'%') {
+                while (index < dictionaryEnd && pdf[index] != (byte)'\r' && pdf[index] != (byte)'\n') index++;
+                continue;
+            }
+            if (pdf[index] == (byte)'(') {
+                SkipPdfLiteralString(pdf, ref index, dictionaryEnd);
+                continue;
+            }
+            if (pdf[index] == (byte)'<' && index + 1 < dictionaryEnd && pdf[index + 1] != (byte)'<') {
+                index++;
+                while (index < dictionaryEnd && pdf[index] != (byte)'>') index++;
+                if (index < dictionaryEnd) index++;
+                continue;
+            }
+            if (index + 1 < dictionaryEnd && pdf[index] == (byte)'<' && pdf[index + 1] == (byte)'<') {
+                depth++;
+                index += 2;
+                continue;
+            }
+            if (index + 1 < dictionaryEnd && pdf[index] == (byte)'>' && pdf[index + 1] == (byte)'>') {
+                depth--;
+                index += 2;
+                continue;
+            }
+            if (depth == 1 && MatchesAt(pdf, PdfLengthName, index, dictionaryEnd)) {
+                int afterName = index + PdfLengthName.Length;
+                if (afterName < dictionaryEnd && !IsPdfWhitespace(pdf[afterName])) {
+                    index++;
+                    continue;
+                }
+                int valueOffset = SkipPdfWhitespaceAndComments(pdf, afterName, dictionaryEnd);
+                if (!TryReadNonNegativePdfInteger(pdf, ref valueOffset, dictionaryEnd, out length)) return false;
+                int nextToken = SkipPdfWhitespaceAndComments(pdf, valueOffset, dictionaryEnd);
+                if (nextToken >= dictionaryEnd || pdf[nextToken] < (byte)'0' || pdf[nextToken] > (byte)'9') {
+                    return true;
+                }
+
+                int objectNumber = length;
+                if (!TryReadNonNegativePdfInteger(pdf, ref nextToken, dictionaryEnd, out int generation)) return false;
+                nextToken = SkipPdfWhitespaceAndComments(pdf, nextToken, dictionaryEnd);
+                if (nextToken >= dictionaryEnd || pdf[nextToken] != (byte)'R') return false;
+                int afterReference = nextToken + 1;
+                if (afterReference < dictionaryEnd &&
+                    !IsPdfWhitespace(pdf[afterReference]) &&
+                    !IsPdfDelimiter(pdf[afterReference])) {
+                    return false;
+                }
+                return indirectLengths != null &&
+                    indirectLengths.TryGetValue((objectNumber, generation), out length);
             }
             index++;
         }
-
-        return -1;
+        return false;
     }
 
-    private static bool SkipPdfLexicalValue(byte[] pdf, ref int index, int endExclusive) {
+    private static bool TryReadNonNegativePdfInteger(byte[] pdf, ref int index, int endExclusive, out int value) {
+        value = 0;
+        int start = index;
+        while (index < endExclusive && pdf[index] >= (byte)'0' && pdf[index] <= (byte)'9') {
+            int digit = pdf[index] - (byte)'0';
+            if (value > (int.MaxValue - digit) / 10) return false;
+            value = (value * 10) + digit;
+            index++;
+        }
+        return index > start;
+    }
+
+    private static int SkipPdfWhitespaceAndComments(byte[] pdf, int index, int endExclusive) {
+        while (index < endExclusive) {
+            while (index < endExclusive && IsPdfWhitespace(pdf[index])) index++;
+            if (index >= endExclusive || pdf[index] != (byte)'%') return index;
+            while (index < endExclusive && pdf[index] != (byte)'\r' && pdf[index] != (byte)'\n') index++;
+        }
+        return index;
+    }
+
+    private static bool SkipPdfLexicalValue(
+        byte[] pdf,
+        ref int index,
+        int endExclusive,
+        IReadOnlyDictionary<(int ObjectNumber, int Generation), int>? indirectLengths = null) {
         byte value = pdf[index];
         if (value == (byte)'%') {
             while (index < endExclusive && pdf[index] != (byte)'\r' && pdf[index] != (byte)'\n') index++;
@@ -653,6 +854,22 @@ internal static partial class PdfIncrementalUpdater {
             if (index < endExclusive) index++;
             return true;
         }
+        if (MatchesPdfKeyword(pdf, index, endExclusive, PdfStreamKeyword)) {
+            int streamDataStart = index + PdfStreamKeyword.Length;
+            if (streamDataStart < endExclusive && pdf[streamDataStart] == (byte)'\r') streamDataStart++;
+            if (streamDataStart < endExclusive && pdf[streamDataStart] == (byte)'\n') streamDataStart++;
+            index = TryFindPdfStreamBoundary(
+                pdf,
+                index,
+                streamDataStart,
+                endExclusive,
+                indirectLengths,
+                out _,
+                out int endStream)
+                ? endStream + PdfEndStreamKeyword.Length
+                : endExclusive;
+            return true;
+        }
         return false;
     }
 
@@ -665,7 +882,7 @@ internal static partial class PdfIncrementalUpdater {
             !SkipRequiredPdfWhitespace(pdf, ref index, endExclusive)) {
             return false;
         }
-        return MatchesPdfKeyword(pdf, index, endExclusive, "obj");
+        return MatchesPdfKeyword(pdf, index, endExclusive, PdfObjectKeyword);
     }
 
     private static bool TrySkipUnsignedInteger(byte[] pdf, ref int index, int endExclusive, bool requirePositive) {
@@ -684,13 +901,40 @@ internal static partial class PdfIncrementalUpdater {
         return index > start;
     }
 
-    private static bool MatchesPdfKeyword(byte[] pdf, int offset, int endExclusive, string keyword) {
+    private static bool MatchesPdfKeyword(byte[] pdf, int offset, int endExclusive, byte[] keyword) {
         if (offset > 0 && pdf[offset - 1] == (byte)'/') return false;
         if (offset > 0 && !IsPdfWhitespace(pdf[offset - 1]) && !IsPdfDelimiter(pdf[offset - 1])) return false;
-        byte[] expected = PdfEncoding.Latin1GetBytes(keyword);
-        if (!MatchesAt(pdf, expected, offset, endExclusive)) return false;
-        int after = offset + expected.Length;
+        if (!MatchesAt(pdf, keyword, offset, endExclusive)) return false;
+        int after = offset + keyword.Length;
         return after >= endExclusive || IsPdfWhitespace(pdf[after]) || IsPdfDelimiter(pdf[after]);
+    }
+
+    private static int IndexOfPdfKeyword(byte[] pdf, byte[] keyword, int startOffset, int endExclusive) {
+        int lastStart = Math.Min(endExclusive, pdf.Length) - keyword.Length;
+        for (int index = Math.Max(0, startOffset); index <= lastStart; index++) {
+            if (MatchesPdfKeyword(pdf, index, endExclusive, keyword)) return index;
+        }
+        return -1;
+    }
+
+    private readonly struct PdfIndirectObjectSpan {
+        internal PdfIndirectObjectSpan(int start, int end) {
+            Start = start;
+            End = end;
+        }
+
+        internal int Start { get; }
+        internal int End { get; }
+    }
+
+    private readonly struct PdfByteSpan {
+        internal PdfByteSpan(int start, int end) {
+            Start = start;
+            End = end;
+        }
+
+        internal int Start { get; }
+        internal int End { get; }
     }
 
     private static bool IsZeroFilled(byte[] bytes, int offset, int length) {

--- a/OfficeIMO.Pdf/Manipulation/PdfRedactionApplier.TextScrubbing.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfRedactionApplier.TextScrubbing.cs
@@ -594,10 +594,10 @@ internal static partial class PdfRedactionApplier {
 
     private static bool IntersectsTarget(RedactionTextBounds? bounds, RedactionTextTarget target) {
         if (bounds is null) {
-            // An area target may only remove text whose geometry proves an intersection.
-            // Treating an unknown location as a match lets one unlocatable object remove
-            // every other unlocatable BT/ET block on the page.
-            return false;
+            // An area redaction is a confidentiality boundary. If a text object cannot be
+            // located, retaining it could leave extractable text inside the painted area.
+            // Text-targeted redactions still require their textual match before reaching here.
+            return target.Text.Length == 0;
         }
 
         return Intersects(

--- a/OfficeIMO.Reader.OneNote/OneNoteReaderAdapter.Chunking.cs
+++ b/OfficeIMO.Reader.OneNote/OneNoteReaderAdapter.Chunking.cs
@@ -202,11 +202,13 @@ internal static partial class OneNoteReaderAdapter {
         var result = new List<ProjectionPart>();
         var text = new StringBuilder();
         var markdown = new StringBuilder();
+        bool continuesPreviousChunk = false;
 
         foreach (ProjectionPart source in units) {
             if (!source.Fits(maxChars)) {
-                FlushProjectionPart(result, text, markdown);
+                FlushProjectionPart(result, text, markdown, continuesPreviousChunk);
                 SplitOversizedProjectionPart(source, maxChars, result);
+                continuesPreviousChunk = false;
                 continue;
             }
             string textSeparator = text.Length == 0 || source.Text.Length == 0 ? string.Empty : Environment.NewLine;
@@ -216,16 +218,22 @@ internal static partial class OneNoteReaderAdapter {
             bool fits = text.Length + textSeparator.Length + source.Text.Length <= maxChars &&
                         markdown.Length + markdownSeparator.Length + source.Markdown.Length <= maxChars;
             if (!fits && (text.Length > 0 || markdown.Length > 0)) {
-                FlushProjectionPart(result, text, markdown);
+                FlushProjectionPart(result, text, markdown, continuesPreviousChunk);
                 textSeparator = string.Empty;
                 markdownSeparator = string.Empty;
+            }
+            if (text.Length == 0 && markdown.Length == 0) {
+                continuesPreviousChunk = source.ContinuesPreviousChunk;
             }
             text.Append(textSeparator).Append(source.Text);
             markdown.Append(markdownSeparator).Append(source.Markdown);
         }
 
         if (text.Length > 0 || markdown.Length > 0 || result.Count == 0) {
-            result.Add(new ProjectionPart(text.ToString(), markdown.ToString()));
+            result.Add(new ProjectionPart(
+                text.ToString(),
+                markdown.ToString(),
+                continuesPreviousChunk));
         }
         return result;
     }
@@ -240,28 +248,38 @@ internal static partial class OneNoteReaderAdapter {
         for (int index = 0; index < partCount; index++) {
             result.Add(new ProjectionPart(
                 index < textParts.Count ? textParts[index] : string.Empty,
-                index < markdownParts.Count ? markdownParts[index] : string.Empty));
+                index < markdownParts.Count ? markdownParts[index] : string.Empty,
+                source.ContinuesPreviousChunk || index > 0));
         }
     }
 
     private static void FlushProjectionPart(
         ICollection<ProjectionPart> result,
         StringBuilder text,
-        StringBuilder markdown) {
+        StringBuilder markdown,
+        bool continuesPreviousChunk) {
         if (text.Length == 0 && markdown.Length == 0) return;
-        result.Add(new ProjectionPart(text.ToString(), markdown.ToString()));
+        result.Add(new ProjectionPart(
+            text.ToString(),
+            markdown.ToString(),
+            continuesPreviousChunk));
         text.Clear();
         markdown.Clear();
     }
 
     private readonly struct ProjectionPart {
-        internal ProjectionPart(string text, string markdown) {
+        internal ProjectionPart(
+            string text,
+            string markdown,
+            bool continuesPreviousChunk = false) {
             Text = text;
             Markdown = markdown;
+            ContinuesPreviousChunk = continuesPreviousChunk;
         }
 
         internal string Text { get; }
         internal string Markdown { get; }
+        internal bool ContinuesPreviousChunk { get; }
         internal bool Fits(int maxChars) => Text.Length <= maxChars && Markdown.Length <= maxChars;
     }
 }

--- a/OfficeIMO.Reader.OneNote/OneNoteReaderAdapter.Chunking.cs
+++ b/OfficeIMO.Reader.OneNote/OneNoteReaderAdapter.Chunking.cs
@@ -206,7 +206,7 @@ internal static partial class OneNoteReaderAdapter {
         foreach (ProjectionPart source in units) {
             if (!source.Fits(maxChars)) {
                 FlushProjectionPart(result, text, markdown);
-                result.Add(source);
+                SplitOversizedProjectionPart(source, maxChars, result);
                 continue;
             }
             string textSeparator = text.Length == 0 || source.Text.Length == 0 ? string.Empty : Environment.NewLine;
@@ -228,6 +228,20 @@ internal static partial class OneNoteReaderAdapter {
             result.Add(new ProjectionPart(text.ToString(), markdown.ToString()));
         }
         return result;
+    }
+
+    private static void SplitOversizedProjectionPart(
+        ProjectionPart source,
+        int maxChars,
+        ICollection<ProjectionPart> result) {
+        IReadOnlyList<string> textParts = DocumentReaderEngine.SplitAdapterProjection(source.Text, maxChars);
+        IReadOnlyList<string> markdownParts = DocumentReaderEngine.SplitAdapterProjection(source.Markdown, maxChars);
+        int partCount = Math.Max(textParts.Count, markdownParts.Count);
+        for (int index = 0; index < partCount; index++) {
+            result.Add(new ProjectionPart(
+                index < textParts.Count ? textParts[index] : string.Empty,
+                index < markdownParts.Count ? markdownParts[index] : string.Empty));
+        }
     }
 
     private static void FlushProjectionPart(

--- a/OfficeIMO.Reader.OneNote/OneNoteReaderAdapter.Projection.cs
+++ b/OfficeIMO.Reader.OneNote/OneNoteReaderAdapter.Projection.cs
@@ -43,6 +43,7 @@ internal static partial class OneNoteReaderAdapter {
                     SourceLengthBytes = source.LengthBytes,
                     Text = part.Text,
                     Markdown = part.Markdown,
+                    ContinuesPreviousChunk = part.ContinuesPreviousChunk,
                     Tables = partIndex == 0 && tables.Length > 0 ? tables : null,
                     Warnings = chunkWarnings.Count > 0 ? chunkWarnings.ToArray() : null
                 };

--- a/OfficeIMO.Reader.OneNote/OneNoteReaderAdapter.Projection.cs
+++ b/OfficeIMO.Reader.OneNote/OneNoteReaderAdapter.Projection.cs
@@ -30,9 +30,6 @@ internal static partial class OneNoteReaderAdapter {
                 ProjectionPart part = parts[partIndex];
                 var chunkWarnings = new List<string>();
                 if (partIndex == 0) chunkWarnings.AddRange(warnings);
-                if (!part.Fits(options.MaxChars)) {
-                    chunkWarnings.Add("A single OneNote Markdown unit exceeded MaxChars and was preserved as one chunk.");
-                }
                 string anchor = "page-" + (pageIndex + 1).ToString(CultureInfo.InvariantCulture) +
                     (partCount == 1 ? string.Empty : "-part-" + (partIndex + 1).ToString(CultureInfo.InvariantCulture));
                 var chunk = new ReaderChunk {

--- a/OfficeIMO.Reader.Tests/Reader.OneNote.Modular.cs
+++ b/OfficeIMO.Reader.Tests/Reader.OneNote.Modular.cs
@@ -232,7 +232,7 @@ public sealed class ReaderOneNoteModularTests {
     }
 
     [Fact]
-    public void OneNoteAdapter_PreservesOversizedNonTextUnitsAtSharedSourceBoundaries() {
+    public void OneNoteAdapter_SplitsOversizedNonTextUnitsAtTheConfiguredBoundary() {
         string title = "Heading " + new string('h', 40);
         string altText = "Preview " + new string('i', 40);
         var section = new OneNoteSection { Name = "Oversized" };
@@ -249,15 +249,17 @@ public sealed class ReaderOneNoteModularTests {
             section,
             readerOptions: new ReaderOptions { MaxChars = 16 });
 
-        Assert.Equal(2, result.Chunks.Count);
-        Assert.Equal(title, result.Chunks[0].Text);
-        Assert.Equal("# " + title, result.Chunks[0].Markdown);
-        Assert.Equal("[Image: " + altText + "]", result.Chunks[1].Text);
-        Assert.Equal("![" + altText + "](onenote-page-0001-asset-0001)",
-            result.Chunks[1].Markdown);
-        Assert.All(result.Chunks, chunk =>
-            Assert.Contains(chunk.Warnings!, warning =>
-                warning.Contains("preserved as one chunk", StringComparison.OrdinalIgnoreCase)));
+        Assert.True(result.Chunks.Count > 2);
+        Assert.All(result.Chunks, chunk => {
+            Assert.True(chunk.Text.Length <= 16);
+            Assert.True(chunk.Markdown!.Length <= 16);
+            Assert.DoesNotContain(chunk.Warnings ?? Array.Empty<string>(), warning =>
+                warning.Contains("preserved as one chunk", StringComparison.OrdinalIgnoreCase));
+        });
+        Assert.Equal(title + "[Image: " + altText + "]",
+            string.Concat(result.Chunks.Select(chunk => chunk.Text)));
+        Assert.Equal("# " + title + "![" + altText + "](onenote-page-0001-asset-0001)",
+            string.Concat(result.Chunks.Select(chunk => chunk.Markdown)));
     }
 
     [Theory]
@@ -297,13 +299,21 @@ public sealed class ReaderOneNoteModularTests {
         OfficeDocumentReadResult result = OneNoteReaderAdapter.ReadDocument(
             section,
             readerOptions: new ReaderOptions { MaxChars = 1 });
-        ReaderChunk[] contentChunks = result.Chunks.Skip(1).ToArray();
+        int contentStart = result.Chunks.ToList().FindIndex(
+            chunk => chunk.Text.Contains("\U0001F642", StringComparison.Ordinal));
+        Assert.True(contentStart >= 0);
+        ReaderChunk[] contentChunks = result.Chunks.Skip(contentStart).ToArray();
 
         Assert.Equal(sourceText, string.Concat(contentChunks.Select(chunk => chunk.Text)));
         Assert.Equal(sourceText, string.Concat(contentChunks.Select(chunk => chunk.Markdown)));
         Assert.DoesNotContain('?', string.Concat(contentChunks.Select(chunk => chunk.Text)));
         Assert.Equal("\U0001F642", contentChunks[0].Text);
-        Assert.Contains(contentChunks[0].Warnings!, warning => warning.Contains("preserved as one chunk", StringComparison.OrdinalIgnoreCase));
+        Assert.All(result.Chunks, chunk => {
+            Assert.True(chunk.Text.Length <= 1 || chunk.Text == "\U0001F642");
+            Assert.True(chunk.Markdown!.Length <= 1 || chunk.Markdown == "\U0001F642");
+            Assert.DoesNotContain(chunk.Warnings ?? Array.Empty<string>(), warning =>
+                warning.Contains("preserved as one chunk", StringComparison.OrdinalIgnoreCase));
+        });
     }
 
     [Fact]

--- a/OfficeIMO.Reader.Tests/Reader.OneNote.Modular.cs
+++ b/OfficeIMO.Reader.Tests/Reader.OneNote.Modular.cs
@@ -260,6 +260,10 @@ public sealed class ReaderOneNoteModularTests {
             string.Concat(result.Chunks.Select(chunk => chunk.Text)));
         Assert.Equal("# " + title + "![" + altText + "](onenote-page-0001-asset-0001)",
             string.Concat(result.Chunks.Select(chunk => chunk.Markdown)));
+        Assert.Equal(
+            "# " + title + Environment.NewLine + Environment.NewLine +
+            "![" + altText + "](onenote-page-0001-asset-0001)",
+            result.Markdown);
     }
 
     [Theory]

--- a/OfficeIMO.Visio.Tests/Visio.Security.AllSeverityBatch17.cs
+++ b/OfficeIMO.Visio.Tests/Visio.Security.AllSeverityBatch17.cs
@@ -1,0 +1,30 @@
+using System.IO.Compression;
+using OfficeIMO.Visio;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class VisioAllSeverityBatch17SecurityTests {
+    [Fact]
+    public void ValidatorRejectsUnixLinkMetadataAcrossTargetFrameworks() {
+        string path = Path.Combine(Path.GetTempPath(), "officeimo-vsdx-link-" + Guid.NewGuid().ToString("N") + ".vsdx");
+        try {
+            using (var file = new FileStream(path, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None))
+            using (var archive = new ZipArchive(file, ZipArchiveMode.Create)) {
+                ZipArchiveEntry entry = archive.CreateEntry("visio/document.xml");
+                typeof(ZipArchiveEntry).GetProperty("ExternalAttributes")!
+                    .SetValue(entry, unchecked((int)0xA0000000), null);
+                using StreamWriter writer = new StreamWriter(entry.Open());
+                writer.Write("<document />");
+            }
+
+            var validator = new VsdxPackageValidator();
+
+            Assert.False(validator.ValidateFile(path));
+            Assert.Contains(validator.Errors, error =>
+                error.Contains("link entry", StringComparison.OrdinalIgnoreCase));
+        } finally {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+}

--- a/OfficeIMO.Visio/VsdxPackageValidator.cs
+++ b/OfficeIMO.Visio/VsdxPackageValidator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Xml;
 using System.Xml.Linq;
@@ -12,6 +13,10 @@ namespace OfficeIMO.Visio {
     /// Validates and optionally fixes Visio VSDX packages for common structural issues.
     /// </summary>
     public partial class VsdxPackageValidator {
+#if !NET8_0_OR_GREATER
+        private static readonly PropertyInfo? ExternalAttributesProperty =
+            typeof(ZipArchiveEntry).GetProperty("ExternalAttributes", BindingFlags.Instance | BindingFlags.Public);
+#endif
         private static readonly XNamespace nsCore = "http://schemas.microsoft.com/office/visio/2012/main";
         private static readonly XNamespace nsPkgRel = "http://schemas.openxmlformats.org/package/2006/relationships";
         private static readonly XNamespace nsDocRel = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
@@ -219,15 +224,18 @@ namespace OfficeIMO.Visio {
 
         private static bool IsLinkEntry(ZipArchiveEntry entry) {
             // ExternalAttributes is unavailable in the netstandard2.0 reference surface.
-            // Older targets still copy bytes into newly created regular files; modern targets
-            // can reject link metadata before extraction without reflection or trim warnings.
+            // Modern targets use it directly; older runtimes are inspected through the cached
+            // runtime property and fail closed if that metadata cannot be read.
 #if NET8_0_OR_GREATER
             int attributes = entry.ExternalAttributes;
+#else
+            object? rawAttributes = ExternalAttributesProperty?.GetValue(entry, null);
+            // If this runtime cannot expose the metadata, extraction cannot prove the entry
+            // is a regular file. Reject it instead of silently disabling link protection.
+            if (!(rawAttributes is int attributes)) return true;
+#endif
             int unixType = (attributes >> 16) & 0xF000;
             return unixType == 0xA000 || (attributes & (int)FileAttributes.ReparsePoint) != 0;
-#else
-            return false;
-#endif
         }
 
         private void ValidateArchiveLimits(ZipArchive archive) {

--- a/OfficeIMO.Word.Markdown/Converters/WordToMarkdownConverter.Ast.cs
+++ b/OfficeIMO.Word.Markdown/Converters/WordToMarkdownConverter.Ast.cs
@@ -1145,7 +1145,14 @@ namespace OfficeIMO.Word.Markdown {
                 return true;
             }
 
-            if (paragraph.IsShape || paragraph._paragraph.Descendants<Wps.WordprocessingShape>().Any() || paragraph._paragraph.Descendants<V.Shape>().Any()) {
+            if (paragraph.IsShape ||
+                paragraph._paragraph.Descendants<Wps.WordprocessingShape>().Any() ||
+                paragraph._paragraph.Descendants<V.Shape>().Any() ||
+                paragraph._paragraph.Descendants<V.Rectangle>().Any() ||
+                paragraph._paragraph.Descendants<V.RoundRectangle>().Any() ||
+                paragraph._paragraph.Descendants<V.Oval>().Any() ||
+                paragraph._paragraph.Descendants<V.Line>().Any() ||
+                paragraph._paragraph.Descendants<V.PolyLine>().Any()) {
                 kind = "shape";
                 return true;
             }

--- a/OfficeIMO.Word.Tests/Word.Security.AllSeverityBatch17.cs
+++ b/OfficeIMO.Word.Tests/Word.Security.AllSeverityBatch17.cs
@@ -1,0 +1,146 @@
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using Color = OfficeIMO.Drawing.OfficeColor;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public partial class Word {
+    [Fact]
+    public void LineColorFallsBackForMissingAutomaticAndMalformedValues() {
+        using WordDocument document = WordDocument.Create();
+        WordLine line = document.AddParagraph("line").AddLine(0, 0, 20, 0);
+
+        line._line.StrokeColor = "auto";
+        Assert.Equal(Color.Black, line.Color);
+        line._line.StrokeColor = "not-a-color";
+        Assert.Equal(Color.Black, line.Color);
+        line._line.StrokeColor = null;
+        Assert.Equal(Color.Black, line.Color);
+    }
+
+    [Fact]
+    public void CloneListBeforeParagraphPreservesSourceOrderInDocumentXml() {
+        using WordDocument document = WordDocument.Create();
+        WordParagraph marker = document.AddParagraph("marker");
+        WordList list = document.AddList(WordListStyle.Bulleted);
+        list.AddItem("first");
+        list.AddItem("second");
+
+        _ = list.Clone(marker, after: false);
+
+        string[] paragraphs = document.Paragraphs.Select(paragraph => paragraph.Text).ToArray();
+        int markerIndex = Array.IndexOf(paragraphs, "marker");
+        Assert.True(markerIndex >= 2);
+        Assert.Equal("first", paragraphs[markerIndex - 2]);
+        Assert.Equal("second", paragraphs[markerIndex - 1]);
+    }
+
+    [Fact]
+    public void RemovingSectionDoesNotDeleteSameNumberingItemsOutsideTheSection() {
+        using WordDocument document = WordDocument.Create();
+        WordList list = document.AddList(WordListStyle.Bulleted);
+        WordParagraph outside = list.AddItem("outside-list-item");
+        WordSection targetSection = document.AddSection();
+        WordParagraph target = targetSection.AddParagraph("target-list-item");
+        target._paragraph.ParagraphProperties ??= new ParagraphProperties();
+        target._paragraph.ParagraphProperties.NumberingProperties =
+            (NumberingProperties)outside._paragraph.ParagraphProperties!.NumberingProperties!.CloneNode(true);
+
+        Assert.NotEmpty(targetSection.Lists);
+        targetSection.RemoveSection();
+
+        Assert.Contains(document.Paragraphs, paragraph => paragraph.Text == "outside-list-item");
+        Assert.DoesNotContain(document.Paragraphs, paragraph => paragraph.Text == "target-list-item");
+    }
+
+    [Fact]
+    public void RemoveSectionToleratesMissingAndDuplicateHeaderRelationships() {
+        using WordDocument document = WordDocument.Create();
+        document.AddParagraph("first section");
+        WordSection section = document.AddSection();
+        section.AddHeadersAndFooters();
+        HeaderReference valid = section._sectionProperties.Elements<HeaderReference>().First();
+        section._sectionProperties.Append((HeaderReference)valid.CloneNode(true));
+        section._sectionProperties.Append(new HeaderReference {
+            Type = HeaderFooterValues.Even,
+            Id = "rIdMissingHeader"
+        });
+
+        Exception? exception = Record.Exception(section.RemoveSection);
+
+        Assert.Null(exception);
+        Assert.Single(document.Sections);
+    }
+
+    [Fact]
+    public void SelectiveHeaderFooterRemovalToleratesMissingAndDuplicateRelationships() {
+        using WordDocument document = WordDocument.Create();
+        document.AddHeadersAndFooters();
+        SectionProperties section = document.Sections[0]._sectionProperties;
+        HeaderReference header = section.Elements<HeaderReference>().First(reference => reference.Type?.Value == HeaderFooterValues.Default);
+        FooterReference footer = section.Elements<FooterReference>().First(reference => reference.Type?.Value == HeaderFooterValues.Default);
+        section.Append((HeaderReference)header.CloneNode(true));
+        section.Append((FooterReference)footer.CloneNode(true));
+        section.Append(new HeaderReference { Type = HeaderFooterValues.Default, Id = "rIdMissingHeader" });
+        section.Append(new FooterReference { Type = HeaderFooterValues.Default, Id = "rIdMissingFooter" });
+
+        Exception? exception = Record.Exception(() => {
+            WordHeader.RemoveHeaders(document._wordprocessingDocument, HeaderFooterValues.Default);
+            WordFooter.RemoveFooters(document._wordprocessingDocument, HeaderFooterValues.Default);
+        });
+
+        Assert.Null(exception);
+        Assert.Empty(section.Elements<HeaderReference>().Where(reference => reference.Type?.Value == HeaderFooterValues.Default));
+        Assert.Empty(section.Elements<FooterReference>().Where(reference => reference.Type?.Value == HeaderFooterValues.Default));
+    }
+
+    [Fact]
+    public void RemovingShapePreservesTextInItsParagraph() {
+        using WordDocument document = WordDocument.Create();
+        WordParagraph paragraph = document.AddParagraph("keep this text");
+        WordShape shape = paragraph.AddShape(20, 10);
+
+        shape.Remove();
+
+        Assert.Equal("keep this text", paragraph.Text);
+        Assert.False(paragraph.IsShape);
+    }
+
+    [Fact]
+    public void SetFixedWidthAcceptsRowsWhoseCellsWereRemoved() {
+        using WordDocument document = WordDocument.Create();
+        WordTable table = document.AddTable(1, 1);
+        table.Rows[0].Cells[0].Remove();
+
+        Exception? exception = Record.Exception(() => table.SetFixedWidth(50));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void ListFormattingReturnsNullForAutomaticAndMalformedColors() {
+        using WordDocument document = WordDocument.Create();
+        WordList list = document.AddList(WordListStyle.Bulleted);
+
+        list.ColorHex = "auto";
+        Assert.Null(list.Color);
+        list.ColorHex = "not-a-color";
+        Assert.Null(list.Color);
+    }
+
+    [Fact]
+    public void DotxConversionRemovesAttachedTemplateRelationships() {
+        string templatePath = Path.Combine(_directoryDocuments, "ExampleTemplate.dotx");
+        string outputPath = Path.Combine(_directoryWithFiles, "ExampleTemplate_NoAttachedTemplate.docx");
+
+        WordHelpers.ConvertDotxToDocx(templatePath, outputPath);
+
+        using WordprocessingDocument converted = WordprocessingDocument.Open(outputPath, false);
+        DocumentSettingsPart? settingsPart = converted.MainDocumentPart?.DocumentSettingsPart;
+        Assert.DoesNotContain(settingsPart?.ExternalRelationships ?? Enumerable.Empty<ExternalRelationship>(),
+            relationship => relationship.RelationshipType.EndsWith("/attachedTemplate", StringComparison.Ordinal));
+        Assert.Empty(settingsPart?.Settings?.Elements<AttachedTemplate>() ?? Enumerable.Empty<AttachedTemplate>());
+    }
+}

--- a/OfficeIMO.Word.Tests/Word.Security.AllSeverityBatch17.cs
+++ b/OfficeIMO.Word.Tests/Word.Security.AllSeverityBatch17.cs
@@ -56,6 +56,58 @@ public partial class Word {
     }
 
     [Fact]
+    public void RemovingSectionCleansNumberingUsedOnlyInTablesAndHeaders() {
+        using WordDocument document = WordDocument.Create();
+        document.AddParagraph("retained");
+        WordSection targetSection = document.AddSection();
+
+        WordList tableList = targetSection.AddTable(1, 1).Rows[0].Cells[0].AddList(WordListStyle.Bulleted);
+        tableList.AddItem("table-list-item");
+        targetSection.AddHeadersAndFooters();
+        WordHeaderFooter header = Assert.IsAssignableFrom<WordHeaderFooter>(targetSection.Header.Default);
+        WordList headerList = header.AddList(WordListStyle.Numbered);
+        headerList.AddItem("header-list-item");
+        int[] removedNumberingIds = { tableList._numberId, headerList._numberId };
+
+        targetSection.RemoveSection();
+
+        Numbering? numbering = document._wordprocessingDocument.MainDocumentPart?
+            .NumberingDefinitionsPart?
+            .Numbering;
+        Assert.DoesNotContain(
+            numbering?.Elements<NumberingInstance>() ?? Enumerable.Empty<NumberingInstance>(),
+            instance => removedNumberingIds.Contains(instance.NumberID?.Value ?? -1));
+    }
+
+    [Fact]
+    public void RemovingSectionPreservesNumberingReferencedByFootnotes() {
+        using WordDocument document = WordDocument.Create();
+        document.AddParagraph("retained");
+        WordSection targetSection = document.AddSection();
+        WordList removedList = targetSection.AddParagraph("section-list").AddList(WordListStyle.Bulleted);
+        int sharedNumberingId = removedList._numberId;
+
+        MainDocumentPart mainPart = document._wordprocessingDocument.MainDocumentPart!;
+        FootnotesPart footnotesPart = mainPart.FootnotesPart ?? mainPart.AddNewPart<FootnotesPart>();
+        footnotesPart.Footnotes = new Footnotes(
+            new Footnote(
+                new Paragraph(
+                    new ParagraphProperties(
+                        new NumberingProperties(new NumberingId { Val = sharedNumberingId })),
+                    new Run(new Text("footnote-list-item")))) {
+                Id = 1
+            });
+
+        targetSection.RemoveSection();
+
+        Numbering numbering = Assert.IsType<Numbering>(
+            mainPart.NumberingDefinitionsPart?.Numbering);
+        Assert.Contains(
+            numbering.Elements<NumberingInstance>(),
+            instance => instance.NumberID?.Value == sharedNumberingId);
+    }
+
+    [Fact]
     public void RemoveSectionToleratesMissingAndDuplicateHeaderRelationships() {
         using WordDocument document = WordDocument.Create();
         document.AddParagraph("first section");

--- a/OfficeIMO.Word/WordFooter.cs
+++ b/OfficeIMO.Word/WordFooter.cs
@@ -110,14 +110,20 @@ namespace OfficeIMO.Word {
                 .Where(f => f.Type != null && types.Contains(WordSection.GetType(f.Type))).ToList();
             foreach (var footer in footersToRemove) {
                 if (footer.Id == null) continue;
-                var part = mainDocumentPart.GetPartById(footer.Id.Value!) as FooterPart;
+                string relationshipId = footer.Id.Value!;
+                var part = mainDocumentPart.Parts
+                    .FirstOrDefault(candidate => candidate.RelationshipId == relationshipId)
+                    .OpenXmlPart as FooterPart;
                 if (part != null) {
                     partsToDelete.Add(part);
                 }
                 footer.Remove();
             }
             foreach (var part in partsToDelete) {
-                mainDocumentPart.DeletePart(part);
+                string relationshipId = mainDocumentPart.GetIdOfPart(part);
+                if (!documentRoot.Descendants<FooterReference>().Any(footer => footer.Id?.Value == relationshipId)) {
+                    mainDocumentPart.DeletePart(part);
+                }
             }
         }
         /// <summary>

--- a/OfficeIMO.Word/WordHeader.cs
+++ b/OfficeIMO.Word/WordHeader.cs
@@ -98,14 +98,20 @@ namespace OfficeIMO.Word {
                 .Where(h => h.Type != null && types.Contains(WordSection.GetType(h.Type))).ToList();
             foreach (var header in headersToRemove) {
                 if (header.Id == null) continue;
-                var part = mainDocumentPart.GetPartById(header.Id.Value!) as HeaderPart;
+                string relationshipId = header.Id.Value!;
+                var part = mainDocumentPart.Parts
+                    .FirstOrDefault(candidate => candidate.RelationshipId == relationshipId)
+                    .OpenXmlPart as HeaderPart;
                 if (part != null) {
                     partsToDelete.Add(part);
                 }
                 header.Remove();
             }
             foreach (var part in partsToDelete) {
-                mainDocumentPart.DeletePart(part);
+                string relationshipId = mainDocumentPart.GetIdOfPart(part);
+                if (!documentRoot.Descendants<HeaderReference>().Any(header => header.Id?.Value == relationshipId)) {
+                    mainDocumentPart.DeletePart(part);
+                }
             }
         }
         /// <summary>

--- a/OfficeIMO.Word/WordHelpers.Converters.cs
+++ b/OfficeIMO.Word/WordHelpers.Converters.cs
@@ -24,13 +24,18 @@ namespace OfficeIMO.Word {
                     template.ChangeDocumentType(DocumentFormat.OpenXml.WordprocessingDocumentType.Document);
 
                     MainDocumentPart mainPart = template.MainDocumentPart ?? throw new InvalidOperationException("MainDocumentPart is missing in template.");
-                    if (mainPart.DocumentSettingsPart == null) {
-                        mainPart.AddNewPart<DocumentSettingsPart>();
+                    DocumentSettingsPart? settingsPart = mainPart.DocumentSettingsPart;
+                    if (settingsPart != null) {
+                        const string attachedTemplateRelationship =
+                            "http://schemas.openxmlformats.org/officeDocument/2006/relationships/attachedTemplate";
+                        foreach (ExternalRelationship relationship in settingsPart.ExternalRelationships
+                            .Where(relationship => relationship.RelationshipType == attachedTemplateRelationship)
+                            .ToList()) {
+                            settingsPart.DeleteExternalRelationship(relationship.Id);
+                        }
+                        settingsPart.Settings?.RemoveAllChildren<DocumentFormat.OpenXml.Wordprocessing.AttachedTemplate>();
+                        settingsPart.Settings?.Save();
                     }
-
-                    mainPart.DocumentSettingsPart!.AddExternalRelationship(
-                        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/attachedTemplate",
-                        new Uri(fullTemplatePath, UriKind.Absolute));
                     mainPart.Document?.Save();
                 }
 

--- a/OfficeIMO.Word/WordLine.cs
+++ b/OfficeIMO.Word/WordLine.cs
@@ -62,9 +62,8 @@ namespace OfficeIMO.Word {
         /// </summary>
         public Color Color {
             get {
-                var color = _line.StrokeColor?.Value ?? "";
-                if (!color.StartsWith("#", StringComparison.Ordinal)) color = "#" + color;
-                return Color.Parse(color);
+                var color = _line.StrokeColor?.Value;
+                return Color.TryParse(color, out Color parsed) ? parsed : Color.Black;
             }
             set {
                 var hex = value.ToRgbHex();

--- a/OfficeIMO.Word/WordList.Private.cs
+++ b/OfficeIMO.Word/WordList.Private.cs
@@ -285,8 +285,13 @@ public partial class WordList : WordElement {
             if (numberingProps?.NumberingId != null) {
                 numberingProps.NumberingId.Val = newNumberId;
             }
-            currentRef = after ? currentRef.InsertAfterSelf(clonedParagraph) : currentRef.InsertBeforeSelf(clonedParagraph);
-            var paragraphElement = currentRef as Paragraph;
+            OpenXmlElement inserted = after
+                ? currentRef.InsertAfterSelf(clonedParagraph)
+                : currentRef.InsertBeforeSelf(clonedParagraph);
+            if (after) {
+                currentRef = inserted;
+            }
+            var paragraphElement = inserted as Paragraph;
             if (paragraphElement == null) {
                 continue;
             }

--- a/OfficeIMO.Word/WordList.cs
+++ b/OfficeIMO.Word/WordList.cs
@@ -157,10 +157,7 @@ public partial class WordList : WordElement {
     /// </summary>
     public OfficeIMO.Drawing.OfficeColor? Color {
         get {
-            if (ColorHex == "") {
-                return null;
-            }
-            return Helpers.ParseColor(ColorHex);
+            return OfficeIMO.Drawing.OfficeColor.TryParse(ColorHex, out var color) ? color : null;
         }
         set {
             if (value != null) {

--- a/OfficeIMO.Word/WordSection.PublicMethods.cs
+++ b/OfficeIMO.Word/WordSection.PublicMethods.cs
@@ -519,6 +519,8 @@ namespace OfficeIMO.Word {
         /// cleaning up numbering and any unreferenced header and footer parts.
         /// </summary>
         public void RemoveSection() {
+            HashSet<int> numberingIds = CollectReferencedNumberingIds();
+
             foreach (var element in this.ElementsByType.ToList()) {
                 switch (element) {
                     case WordParagraph paragraph:
@@ -584,6 +586,71 @@ namespace OfficeIMO.Word {
             }
 
             _document.Sections.Remove(this);
+            RemoveOrphanedNumbering(numberingIds);
+        }
+
+        private void RemoveOrphanedNumbering(IEnumerable<int> numberingIds) {
+            NumberingDefinitionsPart? numberingPart =
+                _document._wordprocessingDocument?.MainDocumentPart?.NumberingDefinitionsPart;
+            Numbering? numbering = numberingPart?.Numbering;
+            if (numbering == null) {
+                return;
+            }
+
+            HashSet<int> referencedIds = CollectReferencedNumberingIds();
+
+            foreach (int numberingId in numberingIds.Where(id => !referencedIds.Contains(id))) {
+                NumberingInstance? instance = numbering.Elements<NumberingInstance>()
+                    .FirstOrDefault(candidate => candidate.NumberID?.Value == numberingId);
+                int? abstractId = instance?.AbstractNumId?.Val?.Value;
+                instance?.Remove();
+
+                if (abstractId.HasValue &&
+                    !numbering.Elements<NumberingInstance>()
+                        .Any(candidate => candidate.AbstractNumId?.Val?.Value == abstractId.Value)) {
+                    numbering.Elements<AbstractNum>()
+                        .FirstOrDefault(candidate => candidate.AbstractNumberId?.Value == abstractId.Value)
+                        ?.Remove();
+                }
+            }
+
+            if (!numbering.Elements<AbstractNum>().Any() &&
+                !numbering.Elements<NumberingInstance>().Any() &&
+                !numbering.Elements<NumberingPictureBullet>().Any() &&
+                numberingPart != null) {
+                _document._wordprocessingDocument!.MainDocumentPart!.DeletePart(numberingPart);
+            }
+        }
+
+        private HashSet<int> CollectReferencedNumberingIds() {
+            var numberingIds = new HashSet<int>();
+            MainDocumentPart? mainPart = _document._wordprocessingDocument?.MainDocumentPart;
+            if (mainPart == null) {
+                return numberingIds;
+            }
+
+            var visited = new HashSet<OpenXmlPart>();
+            void Visit(OpenXmlPart part) {
+                if (!visited.Add(part)) {
+                    return;
+                }
+
+                OpenXmlPartRootElement? root = part.RootElement;
+                if (root != null) {
+                    foreach (NumberingId numberingId in root.Descendants<NumberingId>()) {
+                        if (numberingId.Val?.Value is int value) {
+                            numberingIds.Add(value);
+                        }
+                    }
+                }
+
+                foreach (IdPartPair child in part.Parts) {
+                    Visit(child.OpenXmlPart);
+                }
+            }
+
+            Visit(mainPart);
+            return numberingIds;
         }
     }
 }

--- a/OfficeIMO.Word/WordSection.PublicMethods.cs
+++ b/OfficeIMO.Word/WordSection.PublicMethods.cs
@@ -519,10 +519,6 @@ namespace OfficeIMO.Word {
         /// cleaning up numbering and any unreferenced header and footer parts.
         /// </summary>
         public void RemoveSection() {
-            foreach (var list in this.Lists.ToList()) {
-                list.Remove();
-            }
-
             foreach (var element in this.ElementsByType.ToList()) {
                 switch (element) {
                     case WordParagraph paragraph:
@@ -551,7 +547,9 @@ namespace OfficeIMO.Word {
                         .Any(s => s._sectionProperties.Elements<HeaderReference>().Any(hr => hr.Id == id));
                     if (!usedElsewhere) {
                         var mainDocumentPart = _document._wordprocessingDocument?.MainDocumentPart;
-                        var part = mainDocumentPart?.GetPartById(id) as HeaderPart;
+                        var part = mainDocumentPart?.Parts
+                            .FirstOrDefault(candidate => candidate.RelationshipId == id)
+                            .OpenXmlPart as HeaderPart;
                         if (part != null) {
                             mainDocumentPart!.DeletePart(part);
                         }
@@ -568,7 +566,9 @@ namespace OfficeIMO.Word {
                         .Any(s => s._sectionProperties.Elements<FooterReference>().Any(fr => fr.Id == id));
                     if (!usedElsewhere) {
                         var mainDocumentPart = _document._wordprocessingDocument?.MainDocumentPart;
-                        var part = mainDocumentPart?.GetPartById(id) as FooterPart;
+                        var part = mainDocumentPart?.Parts
+                            .FirstOrDefault(candidate => candidate.RelationshipId == id)
+                            .OpenXmlPart as FooterPart;
                         if (part != null) {
                             mainDocumentPart!.DeletePart(part);
                         }

--- a/OfficeIMO.Word/WordShape.cs
+++ b/OfficeIMO.Word/WordShape.cs
@@ -105,12 +105,6 @@ namespace OfficeIMO.Word {
             return color!.StartsWith("#", StringComparison.Ordinal) ? color : "#" + color;
         }
 
-        private static Run AppendDedicatedShapeRun(WordParagraph paragraph, OpenXmlElement content) {
-            var run = new Run(content);
-            paragraph._paragraph!.Append(run);
-            return run;
-        }
-
         private static Wps.WordprocessingShape BuildWpsShape(long cx, long cy, ShapeType shapeType) {
             var wsp = new Wps.WordprocessingShape();
             wsp.Append(new Wps.NonVisualDrawingShapeProperties(new A.ShapeLocks() { NoChangeArrowheads = true }));
@@ -195,7 +189,8 @@ namespace OfficeIMO.Word {
             Picture pict = new Picture();
             pict.Append(_rectangle);
 
-            _run = AppendDedicatedShapeRun(paragraph, pict);
+            _run = paragraph.VerifyRun();
+            _run.Append(pict);
         }
 
         /// <summary>
@@ -233,7 +228,8 @@ namespace OfficeIMO.Word {
             Picture pict = new Picture();
             pict.Append(ellipse);
 
-            Run run = AppendDedicatedShapeRun(paragraph, pict);
+            Run run = paragraph.VerifyRun();
+            run.Append(pict);
 
             return new WordShape(paragraph._document!, paragraph._paragraph!, run);
         }
@@ -264,7 +260,8 @@ namespace OfficeIMO.Word {
             Picture pict = new Picture();
             pict.Append(roundRect);
 
-            Run run = AppendDedicatedShapeRun(paragraph, pict);
+            Run run = paragraph.VerifyRun();
+            run.Append(pict);
 
             return new WordShape(paragraph._document!, paragraph._paragraph!, run);
         }
@@ -286,7 +283,8 @@ namespace OfficeIMO.Word {
             Picture pict = new Picture();
             pict.Append(line);
 
-            Run run = AppendDedicatedShapeRun(paragraph, pict);
+            Run run = paragraph.VerifyRun();
+            run.Append(pict);
 
             return new WordShape(paragraph._document!, paragraph._paragraph!, run);
         }
@@ -315,7 +313,8 @@ namespace OfficeIMO.Word {
             Picture pict = new Picture();
             pict.Append(poly);
 
-            Run run = AppendDedicatedShapeRun(paragraph, pict);
+            Run run = paragraph.VerifyRun();
+            run.Append(pict);
 
             return new WordShape(paragraph._document!, paragraph._paragraph!, run);
         }
@@ -395,7 +394,8 @@ namespace OfficeIMO.Word {
             inline.Append(graphic);
 
             var WordDrawing = new WordDrawing(inline);
-            Run run = AppendDedicatedShapeRun(paragraph, WordDrawing);
+            Run run = paragraph.VerifyRun();
+            run.Append(WordDrawing);
 
             return new WordShape(paragraph._document!, paragraph._paragraph!, run, WordDrawing);
         }
@@ -421,7 +421,8 @@ namespace OfficeIMO.Word {
             var graphic = new A.Graphic(new A.GraphicData(wsp) { Uri = "http://schemas.microsoft.com/office/word/2010/wordprocessingShape" });
             var anchor = BuildAnchor(cx, cy, offX, offY, graphic);
             var WordDrawing = new WordDrawing(anchor);
-            Run run = AppendDedicatedShapeRun(paragraph, WordDrawing);
+            Run run = paragraph.VerifyRun();
+            run.Append(WordDrawing);
             return new WordShape(paragraph._document!, paragraph._paragraph!, run, WordDrawing);
         }
 

--- a/OfficeIMO.Word/WordShape.cs
+++ b/OfficeIMO.Word/WordShape.cs
@@ -105,6 +105,12 @@ namespace OfficeIMO.Word {
             return color!.StartsWith("#", StringComparison.Ordinal) ? color : "#" + color;
         }
 
+        private static Run AppendDedicatedShapeRun(WordParagraph paragraph, OpenXmlElement content) {
+            var run = new Run(content);
+            paragraph._paragraph!.Append(run);
+            return run;
+        }
+
         private static Wps.WordprocessingShape BuildWpsShape(long cx, long cy, ShapeType shapeType) {
             var wsp = new Wps.WordprocessingShape();
             wsp.Append(new Wps.NonVisualDrawingShapeProperties(new A.ShapeLocks() { NoChangeArrowheads = true }));
@@ -189,8 +195,7 @@ namespace OfficeIMO.Word {
             Picture pict = new Picture();
             pict.Append(_rectangle);
 
-            _run = paragraph.VerifyRun();
-            _run.Append(pict);
+            _run = AppendDedicatedShapeRun(paragraph, pict);
         }
 
         /// <summary>
@@ -228,8 +233,7 @@ namespace OfficeIMO.Word {
             Picture pict = new Picture();
             pict.Append(ellipse);
 
-            var run = paragraph.VerifyRun();
-            run.Append(pict);
+            Run run = AppendDedicatedShapeRun(paragraph, pict);
 
             return new WordShape(paragraph._document!, paragraph._paragraph!, run);
         }
@@ -260,8 +264,7 @@ namespace OfficeIMO.Word {
             Picture pict = new Picture();
             pict.Append(roundRect);
 
-            var run = paragraph.VerifyRun();
-            run.Append(pict);
+            Run run = AppendDedicatedShapeRun(paragraph, pict);
 
             return new WordShape(paragraph._document!, paragraph._paragraph!, run);
         }
@@ -283,8 +286,7 @@ namespace OfficeIMO.Word {
             Picture pict = new Picture();
             pict.Append(line);
 
-            var run = paragraph.VerifyRun();
-            run.Append(pict);
+            Run run = AppendDedicatedShapeRun(paragraph, pict);
 
             return new WordShape(paragraph._document!, paragraph._paragraph!, run);
         }
@@ -313,8 +315,7 @@ namespace OfficeIMO.Word {
             Picture pict = new Picture();
             pict.Append(poly);
 
-            var run = paragraph.VerifyRun();
-            run.Append(pict);
+            Run run = AppendDedicatedShapeRun(paragraph, pict);
 
             return new WordShape(paragraph._document!, paragraph._paragraph!, run);
         }
@@ -337,8 +338,6 @@ namespace OfficeIMO.Word {
             ValidateDimensions(widthPt, heightPt);
             long cx = ToEmuChecked(widthPt, nameof(widthPt));
             long cy = ToEmuChecked(heightPt, nameof(heightPt));
-
-            var run = paragraph.VerifyRun();
 
             var inline = new DW.Inline() {
                 DistanceFromTop = 0U,
@@ -396,7 +395,7 @@ namespace OfficeIMO.Word {
             inline.Append(graphic);
 
             var WordDrawing = new WordDrawing(inline);
-            run.Append(WordDrawing);
+            Run run = AppendDedicatedShapeRun(paragraph, WordDrawing);
 
             return new WordShape(paragraph._document!, paragraph._paragraph!, run, WordDrawing);
         }
@@ -418,12 +417,11 @@ namespace OfficeIMO.Word {
             long offX = ToEmuChecked(leftPt, nameof(leftPt));
             long offY = ToEmuChecked(topPt, nameof(topPt));
 
-            var run = paragraph.VerifyRun();
             var wsp = BuildWpsShape(cx, cy, shapeType);
             var graphic = new A.Graphic(new A.GraphicData(wsp) { Uri = "http://schemas.microsoft.com/office/word/2010/wordprocessingShape" });
             var anchor = BuildAnchor(cx, cy, offX, offY, graphic);
             var WordDrawing = new WordDrawing(anchor);
-            run.Append(WordDrawing);
+            Run run = AppendDedicatedShapeRun(paragraph, WordDrawing);
             return new WordShape(paragraph._document!, paragraph._paragraph!, run, WordDrawing);
         }
 
@@ -901,7 +899,22 @@ namespace OfficeIMO.Word {
         /// Removes the shape from the paragraph.
         /// </summary>
         public void Remove() {
-            _run?.Remove();
+            OpenXmlElement? shape = _drawing;
+            shape ??= _rectangle;
+            shape ??= _roundRectangle;
+            shape ??= _ellipse;
+            shape ??= _line;
+            shape ??= _polygon;
+            shape ??= _shape;
+            if (shape?.Parent is Picture picture && picture.ChildElements.Count == 1) {
+                picture.Remove();
+            } else {
+                shape?.Remove();
+            }
+
+            if (_run != null && !_run.ChildElements.Any(child => !(child is RunProperties))) {
+                _run.Remove();
+            }
         }
     }
 }

--- a/OfficeIMO.Word/WordTable.Methods.cs
+++ b/OfficeIMO.Word/WordTable.Methods.cs
@@ -591,7 +591,7 @@ namespace OfficeIMO.Word {
             _tableProperties.TableWidth.Width = (percentage * 50).ToString(); // Convert percentage to Word units (50 = 1%)
 
             // Set fixed column widths proportionally
-            if (Rows.Count > 0) {
+            if (Rows.Count > 0 && Rows[0].Cells.Count > 0) {
                 int columnCount = Rows[0].Cells.Count;
                 int columnWidth = percentage * 50 / columnCount;
 


### PR DESCRIPTION
## Summary

- bound Excel workbook merge, legacy-link parsing, formula filtering, and save staging work before expensive materialization
- harden PDF redaction/signature scanning, OneNote chunking, HTML/PDF and Markdown URL handling, and VSDX package validation against malformed or hostile inputs
- make Word mutation APIs resilient to malformed headers, footers, lists, shapes, sections, lines, and tables while preserving valid document behavior
- preserve OneNote Markdown structure when one heading, image, or other semantic unit spans multiple bounded chunks

## Security impact

This addresses the 19 valid findings assigned to this all-severity batch. The twentieth record in the batch was already fixed on master and is tracked separately for closure evidence.

## Compatibility

Markdown HTML rendering keeps a positive built-in scheme allowlist and exposes an explicit per-scheme opt-in for trusted application protocols. CommonMark/GFM comparison profiles opt into only their fixture schemes. Valid external workbook names containing `]` remain supported, PDF streams using either direct or indirect `/Length` values retain correct signature-placeholder behavior, shape removal preserves surrounding paragraph text and existing Word-to-Markdown shape discovery, numbering definitions shared with retained document parts survive section removal, and split OneNote units reconstruct without added paragraph breaks.

## Validation

Focused security regressions pass on .NET 8 and .NET 10 across Excel, HTML, Markdown, PDF, Reader, Visio, and Word. The complete HTML suite passes 1,215/1,215 on both runtimes, the complete Word suite passes 2,514 tests with 9 expected skips on each runtime, the complete Markdown suite passes 2,958/2,958 on both runtimes, all 29 OneNote adapter tests pass on both runtimes, affected netstandard2.0 builds are warning-free, and an independent read-only security review plus targeted confirmation completed cleanly.