### PR TITLE
Harden Word layout and attachment edge cases

### DIFF
--- a/OfficeIMO.Drawing.Tests/Drawing.TextTypography.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.TextTypography.cs
@@ -139,6 +139,9 @@ public class DrawingTextTypographyTests {
 
         Assert.True(horizontal.Clipped);
         Assert.True(stacked.Clipped);
+        Assert.Single(horizontal.Lines);
+        Assert.NotEmpty(horizontal.Lines[0].Segments);
+        Assert.StartsWith("A", horizontal.Lines[0].Segments[0].Text, StringComparison.Ordinal);
         Assert.Equal(4_096, stacked.Lines.Count);
     }
 

--- a/OfficeIMO.Drawing/OfficeTextLayoutEngine.RichText.cs
+++ b/OfficeIMO.Drawing/OfficeTextLayoutEngine.RichText.cs
@@ -243,16 +243,19 @@ public static partial class OfficeTextLayoutEngine {
         var builder = new RichTextLineBuilder(measure);
         builder.SetOffset(ResolveLineOffset(paragraphIndent, firstVisualLine: true));
         bool clipped = inputTruncated;
+        bool processingStopped = false;
 
         foreach (RichTextToken token in CreateRichTextTokens(runs, cancellationToken)) {
             cancellationToken.ThrowIfCancellationRequested();
             if (lines.Count >= MaximumLayoutLines) {
                 clipped = true;
+                processingStopped = true;
                 break;
             }
             if (token.HardBreak) {
                 if (!AddRichTextLine(lines, builder)) {
                     clipped = true;
+                    processingStopped = true;
                     break;
                 }
                 builder.SetOffset(ResolveLineOffset(paragraphIndent, firstVisualLine: true));
@@ -268,6 +271,7 @@ public static partial class OfficeTextLayoutEngine {
             if (wrap && builder.Width + tokenWidth > availableWidth && !builder.IsEmpty) {
                 if (!AddRichTextLine(lines, builder)) {
                     clipped = true;
+                    processingStopped = true;
                     break;
                 }
                 builder.SetOffset(ResolveLineOffset(paragraphIndent, firstVisualLine: false));
@@ -288,6 +292,7 @@ public static partial class OfficeTextLayoutEngine {
                     paragraphIndent,
                     cancellationToken)) {
                     clipped = true;
+                    processingStopped = true;
                     break;
                 }
             } else {
@@ -295,7 +300,7 @@ public static partial class OfficeTextLayoutEngine {
             }
         }
 
-        if (!clipped && !AddRichTextLine(lines, builder)) {
+        if (!processingStopped && !AddRichTextLine(lines, builder)) {
             clipped = true;
         }
         if (lines.Count == 0) {

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfAssociatedFileTestSupport.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfAssociatedFileTestSupport.cs
@@ -47,6 +47,24 @@ internal static class PdfAssociatedFileTestSupport {
         return Encoding.ASCII.GetBytes(pdf);
     }
 
+    internal static byte[] BuildAliasedFileAttachmentAnnotationPdf() {
+        const string payload = "ALIASED-ATTACHMENT-PAYLOAD";
+        string pdf = string.Join("\n", new[] {
+            "%PDF-1.7",
+            "1 0 obj", "<< /Type /Catalog /Pages 2 0 R /Names << /EmbeddedFiles 8 0 R >> >>", "endobj",
+            "2 0 obj", "<< /Type /Pages /Count 1 /Kids [3 0 R] >>", "endobj",
+            "3 0 obj", "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R /Annots [7 0 R] >>", "endobj",
+            "4 0 obj", "<< /Length 0 >>", "stream", string.Empty, "endstream", "endobj",
+            "5 0 obj", "<< /Type /Filespec /F (canonical.txt) /UF (canonical.txt) /EF << /F 6 0 R /UF 6 0 R >> >>", "endobj",
+            "6 0 obj", "<< /Type /EmbeddedFile /Subtype /text#2Fplain /Length " + payload.Length.ToString(System.Globalization.CultureInfo.InvariantCulture) + " >>", "stream", payload, "endstream", "endobj",
+            "7 0 obj", "<< /Type /Annot /Subtype /FileAttachment /Rect [10 10 30 30] /FS 9 0 R >>", "endobj",
+            "8 0 obj", "<< /Names [(canonical.txt) 5 0 R] >>", "endobj",
+            "9 0 obj", "<< /Type /Filespec /F (alias.txt) /UF (alias.txt) /EF << /F 6 0 R /UF 6 0 R >> >>", "endobj",
+            "trailer", "<< /Root 1 0 R /Size 10 >>", "%%EOF"
+        }) + "\n";
+        return Encoding.ASCII.GetBytes(pdf);
+    }
+
     private static byte[] BuildFileAttachmentAnnotationPdf(bool includePageAssociatedFile) {
         string associatedFiles = includePageAssociatedFile ? " /AF [5 0 R]" : string.Empty;
         string pdf = string.Join("\n", new[] {

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfAttachmentEditorTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfAttachmentEditorTests.cs
@@ -150,6 +150,24 @@ public class PdfAttachmentEditorTests {
     }
 
     [Fact]
+    public void Edit_ReconnectsAnnotationThroughSharedEmbeddedFileIdentity() {
+        byte[] source = PdfAssociatedFileTestSupport.BuildAliasedFileAttachmentAnnotationPdf();
+
+        byte[] output = PdfAttachmentEditor.Remove(source, "alias.txt").ToBytes();
+        var (objects, _) = PdfSyntax.ParseObjects(output);
+        PdfDictionary annotation = Assert.Single(
+            objects.Values.Select(static item => item.Value as PdfDictionary),
+            static dictionary => string.Equals(
+                dictionary?.Get<PdfName>("Subtype")?.Name,
+                "FileAttachment",
+                StringComparison.Ordinal))!;
+
+        Assert.Equal("ALIASED-ATTACHMENT-PAYLOAD", ReadAnnotationPayload(objects, annotation));
+        Assert.Empty(PdfAttachmentExtractor.ExtractAttachmentsByFileName(output, "alias.txt"));
+        Assert.Single(PdfAttachmentExtractor.ExtractAttachmentsByFileName(output, "canonical.txt"));
+    }
+
+    [Fact]
     public void Edit_RemovesFileAttachmentAnnotationWhenItsPayloadIsRemoved() {
         byte[] source = PdfAssociatedFileTestSupport.BuildFileAttachmentAnnotationPdf();
 

--- a/OfficeIMO.Pdf/Manipulation/PdfAttachmentEditor.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfAttachmentEditor.cs
@@ -212,10 +212,12 @@ internal static class PdfAttachmentEditor {
             if (annotation.FileSpecObjectNumber > 0) {
                 fileSpecificationsByOriginalObject.TryGetValue(
                     annotation.FileSpecObjectNumber, out replacement);
-            } else if (annotation.EmbeddedFileObjectNumber > 0) {
+            }
+            if (replacement == null && annotation.EmbeddedFileObjectNumber > 0) {
                 fileSpecificationsByOriginalEmbeddedFile.TryGetValue(
                     annotation.EmbeddedFileObjectNumber, out replacement);
-            } else if (annotation.FileName != null &&
+            }
+            if (replacement == null && annotation.FileName != null &&
                 retainedOriginalNames.TryGetValue(annotation.FileName, out string? retainedName) &&
                 fileSpecificationsByName.TryGetValue(retainedName, out PdfReference? nameReplacement)) {
                 replacement = nameReplacement;

--- a/OfficeIMO.Word.Tests/Word.Security.AllSeverityBatch18.cs
+++ b/OfficeIMO.Word.Tests/Word.Security.AllSeverityBatch18.cs
@@ -1,0 +1,119 @@
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public class WordAllSeverityBatch18SecurityTests {
+    [Fact]
+    public void TextBoxAlignmentAcceptsInsideAndDefaultsMalformedValues() {
+        Assert.Equal(WordHorizontalAlignmentValues.Inside, HorizontalAlignmentHelper.FromString(" inside "));
+        Assert.Equal("inside", HorizontalAlignmentHelper.ToString(WordHorizontalAlignmentValues.Inside));
+        Assert.Equal(WordHorizontalAlignmentValues.Center, HorizontalAlignmentHelper.FromString(null));
+        Assert.Equal(WordHorizontalAlignmentValues.Center, HorizontalAlignmentHelper.FromString(string.Empty));
+        Assert.Equal(WordHorizontalAlignmentValues.Center, HorizontalAlignmentHelper.FromString("future-value"));
+        Assert.Equal(3, (int)WordHorizontalAlignmentValues.Outside);
+        Assert.Equal(4, (int)WordHorizontalAlignmentValues.Inside);
+    }
+
+    [Fact]
+    public void ParagraphFormattingCreatesMissingRunAndParagraphProperties() {
+        using WordDocument document = WordDocument.Create();
+        var paragraph = new WordParagraph(document, newParagraph: true, newRun: false);
+
+        paragraph.VerticalTextAlignment = VerticalPositionValues.Superscript;
+        paragraph.Borders.LeftStyle = BorderValues.Single;
+        WordParagraph emptyText = paragraph.AddText(null);
+
+        Assert.NotNull(paragraph._run);
+        Assert.Equal(VerticalPositionValues.Superscript,
+            paragraph._run!.RunProperties?.VerticalTextAlignment?.Val?.Value);
+        Assert.Equal(BorderValues.Single,
+            paragraph._paragraph.ParagraphProperties?.ParagraphBorders?.LeftBorder?.Val?.Value);
+        Assert.Equal(string.Empty, emptyText.Text);
+    }
+
+    [Fact]
+    public void EmptyTableHeaderAndRowApisRemainUsable() {
+        using WordDocument document = WordDocument.Create();
+        WordTable table = document.AddTable(0, 3);
+
+        Assert.False(table.RepeatAsHeaderRowAtTheTopOfEachPage);
+        Assert.False(table.RepeatHeaderRowAtTheTopOfEachPage);
+        table.RepeatAsHeaderRowAtTheTopOfEachPage = true;
+        table.RepeatHeaderRowAtTheTopOfEachPage = true;
+        Exception? commentException = Record.Exception(
+            () => table.AddComment("Reviewer", "R", "No range exists"));
+        WordTableRow row = table.AddRow();
+
+        Assert.Null(commentException);
+        Assert.Equal(3, row.CellsCount);
+    }
+
+    [Fact]
+    public void TableCommentRepairsCellsWithoutParagraphs() {
+        using WordDocument document = WordDocument.Create();
+        WordTable table = document.AddTable(1, 1);
+        table.Rows[0].Cells[0]._tableCell.RemoveAllChildren<Paragraph>();
+
+        Exception? exception = Record.Exception(
+            () => table.AddComment("Reviewer", "R", "Comment"));
+
+        Assert.Null(exception);
+        Paragraph paragraph = Assert.Single(
+            table.Rows[0].Cells[0]._tableCell.Elements<Paragraph>());
+        Assert.NotNull(paragraph.GetFirstChild<CommentRangeStart>());
+        Assert.NotNull(paragraph.GetFirstChild<CommentRangeEnd>());
+        Assert.NotNull(paragraph.Descendants<CommentReference>().SingleOrDefault());
+    }
+
+    [Fact]
+    public void TableCommentKeepsRangeOutsideNestedTables() {
+        using WordDocument document = WordDocument.Create();
+        WordTable table = document.AddTable(1, 2);
+        WordTable nested = table.Rows[0].Cells[1].AddTable(1, 1);
+
+        table.AddComment("Reviewer", "R", "Comment");
+
+        TableCell outerLastCell = table.Rows[0].Cells[1]._tableCell;
+        Paragraph outerLastParagraph = outerLastCell.Elements<Paragraph>().Last();
+        Assert.NotNull(outerLastParagraph.GetFirstChild<CommentRangeEnd>());
+        Assert.NotNull(outerLastParagraph.Descendants<CommentReference>().SingleOrDefault());
+        Assert.Empty(nested._table.Descendants<CommentRangeEnd>());
+        Assert.Empty(nested._table.Descendants<CommentReference>());
+    }
+
+    [Fact]
+    public void CleanupDoesNotMergeRunsContainingNonTextContent() {
+        using WordDocument document = WordDocument.Create();
+        WordParagraph paragraph = document.AddParagraph();
+        paragraph._paragraph.RemoveAllChildren<Run>();
+        paragraph._paragraph.Append(
+            new Run(new Text("first")),
+            new Run(new Text("second"), new Break(), new Text("third")));
+
+        document.CleanupDocument(DocumentCleanupOptions.MergeIdenticalRuns);
+
+        Run[] runs = paragraph._paragraph.Elements<Run>().ToArray();
+        Assert.Equal(2, runs.Length);
+        Assert.NotNull(runs[1].GetFirstChild<Break>());
+        Assert.Equal(new[] { "second", "third" },
+            runs[1].Elements<Text>().Select(static text => text.Text).ToArray());
+    }
+
+    [Fact]
+    public void VerticalMergeUsesCellIndexWhenRowsHaveProperties() {
+        using WordDocument document = WordDocument.Create();
+        WordTable table = document.AddTable(2, 2);
+        table.Rows[0]._tableRow.TableRowProperties = new TableRowProperties();
+        table.Rows[1]._tableRow.TableRowProperties = new TableRowProperties();
+
+        table.Rows[0].Cells[0].MergeVertically(1);
+
+        Assert.Equal(MergedCellValues.Restart,
+            table.Rows[0].Cells[0]._tableCell.TableCellProperties?.VerticalMerge?.Val?.Value);
+        Assert.Equal(MergedCellValues.Continue,
+            table.Rows[1].Cells[0]._tableCell.TableCellProperties?.VerticalMerge?.Val?.Value);
+        Assert.Null(table.Rows[1].Cells[1]._tableCell.TableCellProperties?.VerticalMerge);
+    }
+}

--- a/OfficeIMO.Word.Tests/Word.Security.AllSeverityBatch18.cs
+++ b/OfficeIMO.Word.Tests/Word.Security.AllSeverityBatch18.cs
@@ -34,6 +34,30 @@ public class WordAllSeverityBatch18SecurityTests {
     }
 
     [Fact]
+    public void VerticalTextAlignmentFormatsTheHyperlinkRunInPlace() {
+        using WordDocument document = WordDocument.Create();
+        WordParagraph paragraph = document.AddParagraph("Before ");
+        paragraph.AddHyperLink("linked", new Uri("https://example.test"));
+        WordParagraph hyperlinkParagraph = Assert.Single(
+            document.Paragraphs,
+            candidate => candidate.IsHyperLink);
+        int directRunCount = paragraph._paragraph.Elements<Run>().Count();
+
+        hyperlinkParagraph.VerticalTextAlignment = VerticalPositionValues.Superscript;
+
+        Assert.Equal(VerticalPositionValues.Superscript, hyperlinkParagraph.VerticalTextAlignment);
+        Assert.Equal(
+            VerticalPositionValues.Superscript,
+            hyperlinkParagraph.Hyperlink!._runProperties.VerticalTextAlignment?.Val?.Value);
+        Assert.Equal(directRunCount, paragraph._paragraph.Elements<Run>().Count());
+
+        hyperlinkParagraph.VerticalTextAlignment = null;
+
+        Assert.Null(hyperlinkParagraph.VerticalTextAlignment);
+        Assert.Null(hyperlinkParagraph.Hyperlink!._runProperties.VerticalTextAlignment);
+    }
+
+    [Fact]
     public void EmptyTableHeaderAndRowApisRemainUsable() {
         using WordDocument document = WordDocument.Create();
         WordTable table = document.AddTable(0, 3);

--- a/OfficeIMO.Word/WordDocument.PrivateMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PrivateMethods.cs
@@ -48,11 +48,10 @@ public partial class WordDocument {
         List<Run> runsToRemove = new List<Run>();
         List<Run> runs = paragraph.Elements<Run>().ToList();
         for (int i = runs.Count - 2; i >= 0; i--) {
-            Text? text1 = runs[i].GetFirstChild<Text>();
-            Text? text2 = runs[i + 1].GetFirstChild<Text>();
-            if (text1 != null && text2 != null) {
+            if (TryGetMergeableRunText(runs[i], out Text? text1) &&
+                TryGetMergeableRunText(runs[i + 1], out Text? text2)) {
                 if (AreRunPropertiesEqual(runs[i].RunProperties, runs[i + 1].RunProperties)) {
-                    text1.Text += text2.Text;
+                    text1!.Text += text2!.Text;
 
                     // if the text doesn't have space preservation, during merge potential double spaces
                     // or start/ending spaces could be removed which will mean the view won't be so pretty
@@ -70,6 +69,14 @@ public partial class WordDocument {
             count++;
         }
         return count;
+    }
+
+    private static bool TryGetMergeableRunText(Run run, out Text? text) {
+        var content = run.ChildElements
+            .Where(static element => element is not RunProperties)
+            .ToArray();
+        text = content.Length == 1 ? content[0] as Text : null;
+        return text != null;
     }
 
     private static int CleanupParagraph(Paragraph paragraph, DocumentCleanupOptions options) {

--- a/OfficeIMO.Word/WordHorizontalAlignmentValues.cs
+++ b/OfficeIMO.Word/WordHorizontalAlignmentValues.cs
@@ -7,19 +7,23 @@ public enum WordHorizontalAlignmentValues {
     /// <summary>
     /// Content is aligned to the left.
     /// </summary>
-    Left,
+    Left = 0,
     /// <summary>
     /// Content is centered.
     /// </summary>
-    Center,
+    Center = 1,
     /// <summary>
     /// Content is aligned to the right.
     /// </summary>
-    Right,
+    Right = 2,
     /// <summary>
     /// Content is aligned to the outside of odd or even pages.
     /// </summary>
-    Outside
+    Outside = 3,
+    /// <summary>
+    /// Content is aligned to the inside of odd or even pages.
+    /// </summary>
+    Inside = 4
 }
 
 /// <summary>
@@ -37,6 +41,7 @@ internal static class HorizontalAlignmentHelper {
             WordHorizontalAlignmentValues.Left => "left",
             WordHorizontalAlignmentValues.Center => "center",
             WordHorizontalAlignmentValues.Right => "right",
+            WordHorizontalAlignmentValues.Inside => "inside",
             WordHorizontalAlignmentValues.Outside => "outside",
             _ => throw new ArgumentException($"Invalid alignment value: {alignment}")
         };
@@ -47,14 +52,14 @@ internal static class HorizontalAlignmentHelper {
     /// </summary>
     /// <param name="value"></param>
     /// <returns></returns>
-    /// <exception cref="ArgumentException"></exception>
-    public static WordHorizontalAlignmentValues FromString(string value) {
-        return value.ToLowerInvariant() switch {
+    public static WordHorizontalAlignmentValues FromString(string? value) {
+        return value?.Trim().ToLowerInvariant() switch {
             "left" => WordHorizontalAlignmentValues.Left,
             "center" => WordHorizontalAlignmentValues.Center,
             "right" => WordHorizontalAlignmentValues.Right,
+            "inside" => WordHorizontalAlignmentValues.Inside,
             "outside" => WordHorizontalAlignmentValues.Outside,
-            _ => throw new ArgumentException($"Invalid alignment value: {value}")
+            _ => WordHorizontalAlignmentValues.Center
         };
     }
 }

--- a/OfficeIMO.Word/WordParagraph.ParagraphProperties.cs
+++ b/OfficeIMO.Word/WordParagraph.ParagraphProperties.cs
@@ -477,14 +477,13 @@ namespace OfficeIMO.Word {
                 return null;
             }
             set {
-                _runProperties ??= new RunProperties();
                 if (value == null) {
-                    if (_runProperties.VerticalTextAlignment == null) {
+                    if (_runProperties?.VerticalTextAlignment == null) {
                         return;
                     }
-                    _runProperties.VerticalTextAlignment = null;
+                    _runProperties!.VerticalTextAlignment = null;
                 } else {
-                    _runProperties.VerticalTextAlignment = new VerticalTextAlignment { Val = value };
+                    VerifyRunProperties().VerticalTextAlignment = new VerticalTextAlignment { Val = value };
                 }
             }
         }

--- a/OfficeIMO.Word/WordParagraph.ParagraphProperties.cs
+++ b/OfficeIMO.Word/WordParagraph.ParagraphProperties.cs
@@ -471,19 +471,30 @@ namespace OfficeIMO.Word {
         /// </summary>
         public VerticalPositionValues? VerticalTextAlignment {
             get {
-                if (_runProperties != null && _runProperties.VerticalTextAlignment != null) {
-                    return _runProperties.VerticalTextAlignment.Val?.Value;
+                RunProperties? runProperties = IsHyperLink ? Hyperlink?._runProperties : _runProperties;
+                if (runProperties?.VerticalTextAlignment != null) {
+                    return runProperties.VerticalTextAlignment.Val?.Value;
                 }
                 return null;
             }
             set {
+                RunProperties? runProperties = IsHyperLink ? Hyperlink?._runProperties : _runProperties;
                 if (value == null) {
-                    if (_runProperties?.VerticalTextAlignment == null) {
+                    if (runProperties?.VerticalTextAlignment == null) {
                         return;
                     }
-                    _runProperties!.VerticalTextAlignment = null;
+                    runProperties.VerticalTextAlignment = null;
                 } else {
-                    VerifyRunProperties().VerticalTextAlignment = new VerticalTextAlignment { Val = value };
+                    if (IsHyperLink) {
+                        WordHyperLink hyperlink = Hyperlink!;
+                        runProperties = VerifyRunProperties(
+                            hyperlink._hyperlink!,
+                            hyperlink._run!,
+                            hyperlink._runProperties);
+                    } else {
+                        runProperties = VerifyRunProperties();
+                    }
+                    runProperties.VerticalTextAlignment = new VerticalTextAlignment { Val = value };
                 }
             }
         }

--- a/OfficeIMO.Word/WordParagraph.PublicMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PublicMethods.cs
@@ -21,8 +21,8 @@ namespace OfficeIMO.Word {
         /// </summary>
         /// <param name="text">The text to be added to the paragraph.</param>
         /// <returns>The paragraph containing the new text.</returns>
-        public WordParagraph AddText(string text) {
-            WordParagraph wordParagraph = ConvertToTextWithBreaks(text);
+        public WordParagraph AddText(string? text) {
+            WordParagraph wordParagraph = ConvertToTextWithBreaks(text ?? string.Empty);
             //WordParagraph wordParagraph = new WordParagraph(this._document, this._paragraph, new Run());
             //wordParagraph.Text = text;
             //this._paragraph.Append(wordParagraph._run);

--- a/OfficeIMO.Word/WordParagraphBorders.cs
+++ b/OfficeIMO.Word/WordParagraphBorders.cs
@@ -48,7 +48,8 @@ namespace OfficeIMO.Word {
             var pageBorder = GetParagraphBorders();
             if (pageBorder == null) {
                 pageBorder = Custom;
-                _wordParagraph._paragraphProperties!.Append(pageBorder);
+                var paragraphProperties = _wordParagraph._paragraph.ParagraphProperties ??= new ParagraphProperties();
+                paragraphProperties.Append(pageBorder);
             }
 
             return pageBorder;

--- a/OfficeIMO.Word/WordTable.Methods.cs
+++ b/OfficeIMO.Word/WordTable.Methods.cs
@@ -15,20 +15,45 @@ namespace OfficeIMO.Word {
         /// <param name="initials">Provide initials of an author</param>
         /// <param name="comment">Provide comment to insert</param>
         public void AddComment(string author, string initials, string comment) {
+            TableCell[] cells = _table.Elements<TableRow>()
+                .SelectMany(static row => row.Elements<TableCell>())
+                .ToArray();
+            TableCell? firstCell = cells.FirstOrDefault();
+            TableCell? lastCell = cells.LastOrDefault();
+            if (firstCell == null || lastCell == null) {
+                return;
+            }
+
+            Paragraph firstParagraph = firstCell.Elements<Paragraph>().FirstOrDefault()
+                ?? firstCell.AppendChild(new Paragraph());
+            Paragraph lastParagraph = lastCell.Elements<Paragraph>().LastOrDefault()
+                ?? lastCell.AppendChild(new Paragraph());
             WordComment wordComment = WordComment.Create(_document, author, initials, comment);
             InsertComment(wordComment,
-                this.FirstRow.FirstCell.Paragraphs[0]._paragraph,
-                this.LastRow.LastCell.Paragraphs[0]._paragraph,
-                this.LastRow.LastCell.Paragraphs[0]._paragraph);
+                firstParagraph,
+                lastParagraph,
+                lastParagraph);
         }
 
         internal void InsertComment(WordComment wordComment, OpenXmlElement rangeStart, OpenXmlElement rangeEnd, OpenXmlElement reference) {
             // Specify the text range for the Comment.
             // Insert the new CommentRangeStart before the first run of paragraph.
-            rangeStart.InsertBefore(new CommentRangeStart() { Id = wordComment.Id }, rangeStart.GetFirstChild<OpenXmlElement>());
+            var commentStart = new CommentRangeStart { Id = wordComment.Id };
+            OpenXmlElement? firstChild = rangeStart.GetFirstChild<OpenXmlElement>();
+            if (firstChild == null) {
+                rangeStart.Append(commentStart);
+            } else {
+                rangeStart.InsertBefore(commentStart, firstChild);
+            }
 
             // Insert the new CommentRangeEnd after last run of paragraph.
-            var cmtEnd = rangeEnd.InsertAfter(new CommentRangeEnd() { Id = wordComment.Id }, rangeEnd.Elements().Last());
+            var cmtEnd = new CommentRangeEnd { Id = wordComment.Id };
+            OpenXmlElement? lastChild = rangeEnd.Elements().LastOrDefault();
+            if (lastChild == null) {
+                rangeEnd.Append(cmtEnd);
+            } else {
+                rangeEnd.InsertAfter(cmtEnd, lastChild);
+            }
 
             // Compose a run with CommentReference and insert it.
             reference.InsertAfter(new Run(new CommentReference() { Id = wordComment.Id }), cmtEnd);

--- a/OfficeIMO.Word/WordTable.cs
+++ b/OfficeIMO.Word/WordTable.cs
@@ -51,20 +51,30 @@ namespace OfficeIMO.Word {
         /// </summary>
         public bool RepeatAsHeaderRowAtTheTopOfEachPage {
             get {
-                var tableRowProperties = this.Rows[0]._tableRow.TableRowProperties;
+                WordTableRow? firstRow = Rows.FirstOrDefault();
+                if (firstRow == null) {
+                    return false;
+                }
+
+                var tableRowProperties = firstRow._tableRow.TableRowProperties;
                 var tableHeader = tableRowProperties?.OfType<TableHeader>().FirstOrDefault();
                 return tableHeader != null;
             }
             set {
+                WordTableRow? firstRow = Rows.FirstOrDefault();
+                if (firstRow == null) {
+                    return;
+                }
+
                 if (value) {
-                    this.Rows[0].AddTableRowProperties();
-                    var tableProperties = this.Rows[0]._tableRow.TableRowProperties;
+                    firstRow.AddTableRowProperties();
+                    var tableProperties = firstRow._tableRow.TableRowProperties;
                     var tableHeader = tableProperties?.OfType<TableHeader>().FirstOrDefault();
                     if (tableHeader == null) {
                         tableProperties?.InsertAt(new TableHeader(), 0);
                     }
                 } else {
-                    var tableRowTableRowProperties = this.Rows[0]._tableRow.TableRowProperties;
+                    var tableRowTableRowProperties = firstRow._tableRow.TableRowProperties;
                     var tableHeader = tableRowTableRowProperties?.OfType<TableHeader>().FirstOrDefault();
                     if (tableHeader != null) {
                         tableRowTableRowProperties!.RemoveChild(tableHeader);
@@ -252,8 +262,13 @@ namespace OfficeIMO.Word {
         /// Specifies that the first row shall be repeated at the top of each page on which the table is displayed.
         /// </summary>
         public bool RepeatHeaderRowAtTheTopOfEachPage {
-            get => Rows[0].RepeatHeaderRowAtTheTopOfEachPage;
-            set => Rows[0].RepeatHeaderRowAtTheTopOfEachPage = value;
+            get => Rows.FirstOrDefault()?.RepeatHeaderRowAtTheTopOfEachPage ?? false;
+            set {
+                WordTableRow? firstRow = Rows.FirstOrDefault();
+                if (firstRow != null) {
+                    firstRow.RepeatHeaderRowAtTheTopOfEachPage = value;
+                }
+            }
         }
 
         /// <summary>
@@ -516,8 +531,12 @@ namespace OfficeIMO.Word {
         /// <param name="cellsCount"></param>
         private void AddCells(WordTableRow row, int cellsCount = 0) {
             if (cellsCount == 0) {
-                // we try to get the last row and fill it with same number of cells
-                cellsCount = this.Rows[this.RowsCount - 2].CellsCount;
+                // Match the previous row when available; otherwise use the
+                // declared grid width retained by an initially empty table.
+                List<WordTableRow> rows = Rows;
+                cellsCount = rows.Count > 1
+                    ? rows[rows.Count - 2].CellsCount
+                    : _table.GetFirstChild<TableGrid>()?.Elements<GridColumn>().Count() ?? 0;
             }
             for (int j = 0; j < cellsCount; j++) {
                 WordTableCell cell = new WordTableCell(_document, this, row);

--- a/OfficeIMO.Word/WordTableCell.cs
+++ b/OfficeIMO.Word/WordTableCell.cs
@@ -803,7 +803,7 @@ namespace OfficeIMO.Word {
             };
             NormalizeTableCellPropertiesOrder();
             var tableRow = _tableCell.Parent as TableRow;
-            var indexOfCell = tableRow?.ChildElements.ToList().IndexOf(_tableCell) ?? -1;
+            var indexOfCell = tableRow?.Elements<TableCell>().ToList().IndexOf(_tableCell) ?? -1;
 
             for (int i = 0; i < cellsCount; i++) {
                 if (tableRow != null) {
@@ -849,7 +849,7 @@ namespace OfficeIMO.Word {
             _tableCellProperties!.VerticalMerge?.Remove();
 
             var tableRow = _tableCell.Parent as TableRow;
-            var indexOfCell = tableRow?.ChildElements.ToList().IndexOf(_tableCell) ?? -1;
+            var indexOfCell = tableRow?.Elements<TableCell>().ToList().IndexOf(_tableCell) ?? -1;
 
             for (int i = 0; i < cellsCount; i++) {
                 if (tableRow != null) {


### PR DESCRIPTION
## Summary

- make Word alignment, paragraph formatting, cleanup, table comments, empty-table headers and rows, and vertical merges resilient to valid edge cases and malformed document state
- keep vertical text alignment on the actual hyperlink run instead of creating a detached paragraph run
- preserve bounded rich-text output when input normalization truncates an oversized run
- reconnect PDF file-attachment annotations through their shared embedded-file identity when their original file specification is removed

## Security impact

This fixes the 11 valid findings assigned to this 20-record all-severity batch. Seven records in the batch were already fixed, duplicate, or not applicable and have separate disposition evidence; two more are fixed by batch 16 and will close with that merge.

## Compatibility

The existing public Outside enum ordinal remains 3, with Inside added as 4. Comment ranges stay in direct cells of the target table rather than crossing into nested tables. Hyperlink-backed paragraph entries retain their hyperlink containment. Existing bounded layout and attachment-removal semantics remain intact.

## Validation

The eight Word regressions pass on .NET 8 and .NET 10. Drawing typography passes 13/13 and PDF attachment editing passes 11/11 on each runtime. Word, Drawing, and PDF netstandard2.0 builds succeed with zero warnings. One independent read-only review and one targeted confirmation completed; all accepted local and repository feedback is fixed and validated.

Stacked on #2170; merge after the parent batches land.