### PR TITLE
Preserve document compatibility across parser boundaries

### DIFF
--- a/OfficeIMO.Drawing.Tests/Drawing.Ink.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.Ink.cs
@@ -228,6 +228,26 @@ public class DrawingInkTests {
     }
 
     [Fact]
+    public void InkRendererFallsBackToLineForSingularAffineTipTransform() {
+        var stroke = new OfficeInkStroke {
+            Width = 8D,
+            Height = 6D,
+            Transform = OfficeTransform.Scale(1D, 0D)
+        }
+            .AddPoint(10D, 10D)
+            .AddPoint(40D, 10D);
+
+        OfficeDrawing drawing = OfficeInkRenderer.Render(
+            new OfficeInkDocument().Add(stroke), 100D, 100D);
+
+        OfficeDrawingShape line = Assert.Single(
+            drawing.Shapes,
+            item => item.Shape.Kind == OfficeShapeKind.Line);
+        Assert.Equal(OfficeShapeKind.Line, line.Shape.Kind);
+        Assert.Equal(0.01D, line.Shape.StrokeWidth, 6);
+    }
+
+    [Fact]
     public void InkPointsValidatePressureAndCoordinates() {
         Assert.Throws<ArgumentOutOfRangeException>(() => new OfficeInkPoint(double.NaN, 0));
         Assert.Throws<ArgumentOutOfRangeException>(() => new OfficeInkPoint(0, 0, 1.01));

--- a/OfficeIMO.Drawing.Tests/Drawing.Math.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.Math.cs
@@ -172,6 +172,18 @@ public class DrawingMathTests {
     }
 
     [Fact]
+    public void LatexParserAcceptsLegacyOfficeImoKindCommands() {
+        OfficeMathExpression expression = OfficeMathMarkup.FromLatex(
+            @"\officeimoidentifier{x}+\officeimonumber{42}+\officeimooperator{≈}+\officeimofunction{sin}{y}");
+
+        Assert.Equal(OfficeMathKind.Identifier, expression.Children[0].Kind);
+        Assert.Equal(OfficeMathKind.Number, expression.Children[2].Kind);
+        Assert.Equal(OfficeMathKind.Operator, expression.Children[4].Kind);
+        Assert.Equal(OfficeMathKind.Function, expression.Children[6].Kind);
+        Assert.Equal("x+42+≈+sin(y)", expression.ToPlainText());
+    }
+
+    [Fact]
     public void LatexGreekCommandsRemainIdentifiersInScriptsAndMathMl() {
         OfficeMathExpression expression = OfficeMathMarkup.FromLatex(@"\alpha_i+\beta");
 

--- a/OfficeIMO.Drawing.Tests/Drawing.OfficeArtBinary.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.OfficeArtBinary.cs
@@ -156,7 +156,7 @@ public partial class DrawingTests {
     public void OfficeArtShapeTransform_HonorsExplicitFlipOverrides() {
         var properties = new[] {
             new OfficeArtProperty(0, 0x033F,
-                (1U << 8) | (1U << 9) | (1U << 25))
+                (1U << 24) | (1U << 25) | (1U << 9))
         };
 
         OfficeArtShapeTransform transform = OfficeArtShapeTransform.Decode(

--- a/OfficeIMO.Drawing.Tests/Drawing.Security.AllSeverityBatch19.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.Security.AllSeverityBatch19.cs
@@ -1,0 +1,25 @@
+using OfficeIMO.Drawing;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public partial class DrawingTests {
+    [Fact]
+    public void AddPositionedTextRetainsNineParameterBinarySignature() {
+        Type[] legacyParameters = {
+            typeof(string),
+            typeof(double),
+            typeof(double),
+            typeof(double),
+            typeof(double),
+            typeof(OfficeFontInfo),
+            typeof(OfficeColor?),
+            typeof(OfficeTextAlignment),
+            typeof(double?)
+        };
+
+        Assert.NotNull(typeof(OfficeDrawing).GetMethod(
+            nameof(OfficeDrawing.AddPositionedText),
+            legacyParameters));
+    }
+}

--- a/OfficeIMO.Drawing.Tests/Drawing.Security.AllSeverityBatch19.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.Security.AllSeverityBatch19.cs
@@ -22,4 +22,20 @@ public partial class DrawingTests {
             nameof(OfficeDrawing.AddPositionedText),
             legacyParameters));
     }
+
+    [Fact]
+    public void AddPositionedTextRetainsNamedAdvanceSourceContract() {
+        OfficeDrawing drawing = new OfficeDrawing(100D, 40D)
+            .AddPositionedText(
+                "positioned",
+                0D,
+                0D,
+                80D,
+                20D,
+                textAdvanceWidth: 60D);
+
+        Assert.Equal(
+            60D,
+            Assert.IsType<OfficeDrawingText>(Assert.Single(drawing.Elements)).TextAdvanceWidth);
+    }
 }

--- a/OfficeIMO.Drawing/Binary/OfficeArtShapeTransform.cs
+++ b/OfficeIMO.Drawing/Binary/OfficeArtShapeTransform.cs
@@ -10,10 +10,10 @@ namespace OfficeIMO.Drawing.Binary;
 public sealed class OfficeArtShapeTransform {
     private const uint FlipHorizontalFlag = 1U << 6;
     private const uint FlipVerticalFlag = 1U << 7;
-    private const uint UseFlipHorizontalOverride = 1U << 8;
-    private const uint UseFlipVerticalOverride = 1U << 9;
-    private const uint FlipHorizontalOverride = 1U << 24;
-    private const uint FlipVerticalOverride = 1U << 25;
+    private const uint FlipHorizontalOverride = 1U << 8;
+    private const uint FlipVerticalOverride = 1U << 9;
+    private const uint UseFlipHorizontalOverride = 1U << 24;
+    private const uint UseFlipVerticalOverride = 1U << 25;
 
     private OfficeArtShapeTransform(double? rotationDegrees, bool flipHorizontal, bool flipVertical) {
         RotationDegrees = rotationDegrees;

--- a/OfficeIMO.Drawing/Ink/OfficeInkRenderer.cs
+++ b/OfficeIMO.Drawing/Ink/OfficeInkRenderer.cs
@@ -185,6 +185,23 @@ public static class OfficeInkRenderer {
         OfficePoint support = stroke.GetTransformedTipSupport(-deltaY, deltaX);
         OfficePoint fromSupport = new OfficePoint(support.X * fromPressure, support.Y * fromPressure);
         OfficePoint toSupport = new OfficePoint(support.X * toPressure, support.Y * toPressure);
+        double maximumSupport = Math.Max(
+            Math.Sqrt(fromSupport.X * fromSupport.X + fromSupport.Y * fromSupport.Y),
+            Math.Sqrt(toSupport.X * toSupport.X + toSupport.Y * toSupport.Y));
+        if (double.IsNaN(maximumSupport)
+            || double.IsInfinity(maximumSupport)
+            || maximumSupport <= 0.000000000001D) {
+            OfficeShape fallback = OfficeShape.Line(x1, y1, x2, y2);
+            fallback.StrokeColor = renderColor;
+            fallback.StrokeOpacity = opacity;
+            fallback.StrokeWidth = 0.01D;
+            fallback.StrokeLineCap = stroke.TipShape == OfficeInkTipShape.Rectangle
+                ? OfficeStrokeLineCap.Square
+                : OfficeStrokeLineCap.Round;
+            fallback.StrokeLineJoin = OfficeStrokeLineJoin.Round;
+            drawing.AddShapeForClippedRendering(fallback, Math.Min(x1, x2), Math.Min(y1, y2));
+            return;
+        }
         var points = new[] {
             new OfficePoint(x1 + fromSupport.X, y1 + fromSupport.Y),
             new OfficePoint(x2 + toSupport.X, y2 + toSupport.Y),

--- a/OfficeIMO.Drawing/Math/OfficeMathMarkup.cs
+++ b/OfficeIMO.Drawing/Math/OfficeMathMarkup.cs
@@ -677,13 +677,19 @@ public static class OfficeMathMarkup {
                 case "boxed": return OfficeMath.Box(ParseRequiredGroup());
                 case "phantom": return OfficeMath.Phantom(ParseRequiredGroup());
                 case "text": return OfficeMath.Text(ParseTextGroupValue());
-                case "mathit": return OfficeMath.Identifier(ParseRequiredGroup().ToPlainText());
-                case "mathrm": return OfficeMath.Number(ParseRequiredGroup().ToPlainText());
+                case "mathit":
+                case "officeimoidentifier":
+                    return OfficeMath.Identifier(ParseRequiredGroup().ToPlainText());
+                case "mathrm":
+                case "officeimonumber":
+                    return OfficeMath.Number(ParseRequiredGroup().ToPlainText());
                 case "mathbin":
+                case "officeimooperator":
                     string operatorValue = ParseRequiredGroup().ToPlainText();
                     _preserveNextOperatorKind = true;
                     return OfficeMath.Operator(operatorValue);
                 case "operatorname":
+                case "officeimofunction":
                     string functionName = ParseRequiredGroup().ToPlainText();
                     return OfficeMath.Function(functionName, ParseFunctionArgument());
                 case "backslash": return OfficeMath.Text("\\");

--- a/OfficeIMO.Drawing/OfficeDrawing.cs
+++ b/OfficeIMO.Drawing/OfficeDrawing.cs
@@ -104,9 +104,25 @@ public sealed partial class OfficeDrawing {
     /// <param name="color">Optional text color.</param>
     /// <param name="alignment">Horizontal alignment inside the frame.</param>
     /// <param name="lineHeight">Optional resolved line height.</param>
+    /// <returns>The current drawing.</returns>
+    public OfficeDrawing AddPositionedText(string text, double x, double y, double width, double height, OfficeFontInfo? font = null, OfficeColor? color = null, OfficeTextAlignment alignment = OfficeTextAlignment.Left, double? lineHeight = null) =>
+        AddPositionedText(text, x, y, width, height, font, color, alignment, lineHeight, null);
+
+    /// <summary>
+    /// Adds an already-positioned single text run with an explicit resolved glyph advance.
+    /// </summary>
+    /// <param name="text">Text content to draw.</param>
+    /// <param name="x">Horizontal frame position in drawing units.</param>
+    /// <param name="y">Vertical frame position in drawing units.</param>
+    /// <param name="width">Clipping frame width in drawing units.</param>
+    /// <param name="height">Clipping frame height in drawing units.</param>
+    /// <param name="font">Optional font descriptor.</param>
+    /// <param name="color">Optional text color.</param>
+    /// <param name="alignment">Horizontal alignment inside the frame.</param>
+    /// <param name="lineHeight">Optional resolved line height.</param>
     /// <param name="textAdvanceWidth">Resolved horizontal glyph advance, or <see langword="null"/> to use <paramref name="width"/>.</param>
     /// <returns>The current drawing.</returns>
-    public OfficeDrawing AddPositionedText(string text, double x, double y, double width, double height, OfficeFontInfo? font = null, OfficeColor? color = null, OfficeTextAlignment alignment = OfficeTextAlignment.Left, double? lineHeight = null, double? textAdvanceWidth = null) =>
+    public OfficeDrawing AddPositionedText(string text, double x, double y, double width, double height, OfficeFontInfo? font, OfficeColor? color, OfficeTextAlignment alignment, double? lineHeight, double? textAdvanceWidth) =>
         AddTextCore(text, x, y, width, height, font, color, alignment, lineHeight, OfficeTextVerticalAlignment.Top, 0D, null, null, false, false, false, false, false, null, null, OfficeTextOverflowBehavior.Clip, textAdvanceWidth ?? width, allowOverflow: false);
 
     private OfficeDrawing AddTextCore(string text, double x, double y, double width, double height, OfficeFontInfo? font, OfficeColor? color, OfficeTextAlignment alignment, double? lineHeight, OfficeTextVerticalAlignment verticalAlignment, double rotationDegrees, double? rotationCenterX, double? rotationCenterY, bool wrapText, bool shrinkToFit, bool stackedText, bool flipHorizontal, bool flipVertical, OfficeTextPadding? padding, OfficeTextParagraphIndent? paragraphIndent, OfficeTextOverflowBehavior overflowBehavior, double? textAdvanceWidth, bool allowOverflow) {

--- a/OfficeIMO.Drawing/OfficeDrawing.cs
+++ b/OfficeIMO.Drawing/OfficeDrawing.cs
@@ -105,7 +105,7 @@ public sealed partial class OfficeDrawing {
     /// <param name="alignment">Horizontal alignment inside the frame.</param>
     /// <param name="lineHeight">Optional resolved line height.</param>
     /// <returns>The current drawing.</returns>
-    public OfficeDrawing AddPositionedText(string text, double x, double y, double width, double height, OfficeFontInfo? font = null, OfficeColor? color = null, OfficeTextAlignment alignment = OfficeTextAlignment.Left, double? lineHeight = null) =>
+    public OfficeDrawing AddPositionedText(string text, double x, double y, double width, double height, OfficeFontInfo? font, OfficeColor? color, OfficeTextAlignment alignment, double? lineHeight) =>
         AddPositionedText(text, x, y, width, height, font, color, alignment, lineHeight, null);
 
     /// <summary>
@@ -122,7 +122,7 @@ public sealed partial class OfficeDrawing {
     /// <param name="lineHeight">Optional resolved line height.</param>
     /// <param name="textAdvanceWidth">Resolved horizontal glyph advance, or <see langword="null"/> to use <paramref name="width"/>.</param>
     /// <returns>The current drawing.</returns>
-    public OfficeDrawing AddPositionedText(string text, double x, double y, double width, double height, OfficeFontInfo? font, OfficeColor? color, OfficeTextAlignment alignment, double? lineHeight, double? textAdvanceWidth) =>
+    public OfficeDrawing AddPositionedText(string text, double x, double y, double width, double height, OfficeFontInfo? font = null, OfficeColor? color = null, OfficeTextAlignment alignment = OfficeTextAlignment.Left, double? lineHeight = null, double? textAdvanceWidth = null) =>
         AddTextCore(text, x, y, width, height, font, color, alignment, lineHeight, OfficeTextVerticalAlignment.Top, 0D, null, null, false, false, false, false, false, null, null, OfficeTextOverflowBehavior.Clip, textAdvanceWidth ?? width, allowOverflow: false);
 
     private OfficeDrawing AddTextCore(string text, double x, double y, double width, double height, OfficeFontInfo? font, OfficeColor? color, OfficeTextAlignment alignment, double? lineHeight, OfficeTextVerticalAlignment verticalAlignment, double rotationDegrees, double? rotationCenterX, double? rotationCenterY, bool wrapText, bool shrinkToFit, bool stackedText, bool flipHorizontal, bool flipVertical, OfficeTextPadding? padding, OfficeTextParagraphIndent? paragraphIndent, OfficeTextOverflowBehavior overflowBehavior, double? textAdvanceWidth, bool allowOverflow) {

--- a/OfficeIMO.Email.Tests/Mime/EmailContactConversionTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailContactConversionTests.cs
@@ -460,7 +460,8 @@ public sealed class EmailContactConversionTests {
         byte[] eml = Encoding.ASCII.GetBytes(
             "Content-Type: text/vcard; charset=utf-8\r\n\r\nBEGIN:VCARD\r\nVERSION:3.0\r\n" +
             "FN:Ada Lovelace\r\nEMAIL;TYPE=WORK:first@example.com\r\n" +
-            "EMAIL;TYPE=WORK:second@example.com\r\nEND:VCARD\r\n");
+            "EMAIL;TYPE=WORK:second@example.com\r\n" +
+            "TEL;TYPE=HOME:+48-123-456-789\r\nEND:VCARD\r\n");
         EmailDocument document = new EmailDocumentReader().Read(eml).Document;
 
         EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
@@ -468,6 +469,7 @@ public sealed class EmailContactConversionTests {
 
         Assert.Equal("first@example.com", document.Contact!.Email1.Address);
         Assert.Equal("second@example.com", document.Contact.Email2.Address);
+        Assert.Equal("+48-123-456-789", document.Contact.Phones.Home);
         Assert.False(report.CanWrite);
         Assert.Contains(report.Diagnostics,
             diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");

--- a/OfficeIMO.Email.Tests/Store/Reading/EmailStoreSessionTests.cs
+++ b/OfficeIMO.Email.Tests/Store/Reading/EmailStoreSessionTests.cs
@@ -466,12 +466,12 @@ public sealed class EmailStoreSessionTests {
         }
 
         public override int Read(byte[] buffer, int offset, int count) {
+            MaxSingleRead = Math.Max(MaxSingleRead, count);
             if (_position >= _data.LongLength) return 0;
             int available = checked((int)Math.Min(count, _data.LongLength - _position));
             Buffer.BlockCopy(_data, checked((int)_position), buffer, offset, available);
             _position += available;
             TotalBytesRead += available;
-            MaxSingleRead = Math.Max(MaxSingleRead, available);
             return available;
         }
 

--- a/OfficeIMO.Email/Contact/VCardCodec.cs
+++ b/OfficeIMO.Email/Contact/VCardCodec.cs
@@ -82,8 +82,10 @@ internal static partial class VCardCodec {
         contact.IsPrivate = sensitivity.HasValue ? sensitivity.Value != 0 : (bool?)null;
         if (sensitivity.HasValue) document.MessageMetadata.Sensitivity = sensitivity;
 
-        document.MimeSemanticProjectionIsIncomplete |= ApplyEmails(properties, contact) ||
-            ApplyPhones(properties, contact.Phones) ||
+        bool emailProjectionIncomplete = ApplyEmails(properties, contact);
+        bool phoneProjectionIncomplete = ApplyPhones(properties, contact.Phones);
+        document.MimeSemanticProjectionIsIncomplete |= emailProjectionIncomplete ||
+            phoneProjectionIncomplete ||
             HasAddressSlotOverflow(properties) || HasUnprojectedAddressComponents(properties) ||
             HasUnsupportedAddressTypes(properties) || HasUrlSlotOverflow(properties) ||
             HasUnsupportedUrlTypes(properties);

--- a/OfficeIMO.Epub/EpubReference.cs
+++ b/OfficeIMO.Epub/EpubReference.cs
@@ -266,7 +266,7 @@ public sealed class EpubReference {
         SplitReference(original, out string referencePathPart, out string? query, out string? encodedFragment);
         if (referencePathPart.Length == 0) {
             string containerPath = basePathPart.EndsWith("/", StringComparison.Ordinal)
-                ? effectiveBase.Length == 0 ? string.Empty : effectiveBase.TrimEnd('/') + "/"
+                ? effectiveBase.TrimEnd('/') + "/"
                 : effectiveBase;
             return Valid(
                 original,

--- a/OfficeIMO.Epub/EpubReference.cs
+++ b/OfficeIMO.Epub/EpubReference.cs
@@ -266,7 +266,7 @@ public sealed class EpubReference {
         SplitReference(original, out string referencePathPart, out string? query, out string? encodedFragment);
         if (referencePathPart.Length == 0) {
             string containerPath = basePathPart.EndsWith("/", StringComparison.Ordinal)
-                ? effectiveBase.TrimEnd('/') + "/"
+                ? effectiveBase.Length == 0 ? string.Empty : effectiveBase.TrimEnd('/') + "/"
                 : effectiveBase;
             return Valid(
                 original,

--- a/OfficeIMO.Excel.GoogleSheets/GoogleSheetsBatchCompiler.cs
+++ b/OfficeIMO.Excel.GoogleSheets/GoogleSheetsBatchCompiler.cs
@@ -326,6 +326,10 @@ namespace OfficeIMO.Excel.GoogleSheets {
 
             rowCount = Math.Max(rowCount, worksheet.FrozenRowCount);
             columnCount = Math.Max(columnCount, worksheet.FrozenColumnCount);
+            if (columnCount > 18_278 || checked((long)rowCount * columnCount) > 10_000_000L) {
+                throw new NotSupportedException(
+                    $"Worksheet '{worksheet.Name}' requires a {rowCount} by {columnCount} grid, which exceeds Google Sheets limits.");
+            }
         }
 
         private static void ExpandGridToInclude(string a1Range, ref int rowCount, ref int columnCount) {

--- a/OfficeIMO.Excel.GoogleSheets/GoogleSheetsBatchCompiler.cs
+++ b/OfficeIMO.Excel.GoogleSheets/GoogleSheetsBatchCompiler.cs
@@ -242,7 +242,19 @@ namespace OfficeIMO.Excel.GoogleSheets {
                 });
             }
 
+            EnsureSpreadsheetGridWithinLimits(batch);
             return batch;
+        }
+
+        private static void EnsureSpreadsheetGridWithinLimits(GoogleSheetsBatch batch) {
+            long totalCells = 0L;
+            foreach (GoogleSheetsAddSheetRequest sheet in batch.Requests.OfType<GoogleSheetsAddSheetRequest>()) {
+                totalCells = checked(totalCells + ((long)sheet.RowCount * sheet.ColumnCount));
+                if (totalCells > 10_000_000L) {
+                    throw new NotSupportedException(
+                        $"The compiled spreadsheet requires {totalCells.ToString(CultureInfo.InvariantCulture)} grid cells across all sheets, which exceeds Google Sheets limits.");
+                }
+            }
         }
 
         private static void ResolveGridSize(

--- a/OfficeIMO.Excel.Tests/Excel.FormulaDepth.cs
+++ b/OfficeIMO.Excel.Tests/Excel.FormulaDepth.cs
@@ -1083,7 +1083,7 @@ namespace OfficeIMO.Tests {
         [Fact]
         public void Test_FormulaInspection_ExpandsSharedWholeRowColumnSpillAndThreeDimensionalReferences() {
             string filePath = Path.Combine(_directoryWithFiles, "ExcelFormulaDepth.SharedReferenceKinds.xlsx");
-            const string masterFormula = "SUM(A:A,$A:$A,1:1,$1:$1,A1#,$A1#,A$1#,$A$1#,A1%)+LOG10(A1)+LOG10 (A1)+FOO1 (A1)+SUM(A1 (A1))+SUM(A1 (A1:A2))+Q1:Q4!A1";
+            const string masterFormula = "SUM(A:A,$A:$A,1:1,$1:$1,A1#,$A1#,A$1#,$A$1#,A1%)+LOG10(A1)+LOG10 (A1)+FOO1 (A1)+SUM(A1 (A1))+SUM(A1 (A1:A2))+SUM(A1 (A1,B2))+SUM(A1 ((A1,B2),C3))+Q1:Q4!A1";
 
             using (ExcelDocument document = ExcelDocument.Create(filePath)) {
                 document.AddWorksheet("Q1");
@@ -1124,7 +1124,7 @@ namespace OfficeIMO.Tests {
             // Built-in functions remain stable while cell-like tokens followed by
             // parenthesized references participate in whitespace intersections.
             Assert.Equal(
-                "SUM(B:B,$A:$A,2:2,$1:$1,B2#,$A2#,B$1#,$A$1#,B2%)+LOG10(B2)+LOG10 (B2)+FOP2 (B2)+SUM(B2 (B2))+SUM(B2 (B2:B3))+Q1:Q4!B2",
+                "SUM(B:B,$A:$A,2:2,$1:$1,B2#,$A2#,B$1#,$A$1#,B2%)+LOG10(B2)+LOG10 (B2)+FOP2 (B2)+SUM(B2 (B2))+SUM(B2 (B2:B3))+SUM(B2 (B2,C3))+SUM(B2 ((B2,C3),D4))+Q1:Q4!B2",
                 shared.GetFormulaText(2, 6));
         }
 

--- a/OfficeIMO.Excel.Tests/Excel.FormulaDepth.cs
+++ b/OfficeIMO.Excel.Tests/Excel.FormulaDepth.cs
@@ -1083,7 +1083,7 @@ namespace OfficeIMO.Tests {
         [Fact]
         public void Test_FormulaInspection_ExpandsSharedWholeRowColumnSpillAndThreeDimensionalReferences() {
             string filePath = Path.Combine(_directoryWithFiles, "ExcelFormulaDepth.SharedReferenceKinds.xlsx");
-            const string masterFormula = "SUM(A:A,$A:$A,1:1,$1:$1,A1#,$A1#,A$1#,$A$1#,A1%)+LOG10(A1)+LOG10 (A1)+FOO1 (A1)+SUM(A1 (A1:A2))+Q1:Q4!A1";
+            const string masterFormula = "SUM(A:A,$A:$A,1:1,$1:$1,A1#,$A1#,A$1#,$A$1#,A1%)+LOG10(A1)+LOG10 (A1)+FOO1 (A1)+SUM(A1 (A1))+SUM(A1 (A1:A2))+Q1:Q4!A1";
 
             using (ExcelDocument document = ExcelDocument.Create(filePath)) {
                 document.AddWorksheet("Q1");
@@ -1121,10 +1121,10 @@ namespace OfficeIMO.Tests {
             using ExcelDocument loaded = ExcelDocument.Load(filePath);
             ExcelSheet shared = loaded["Shared"];
             Assert.Equal(masterFormula, shared.GetFormulaText(1, 5));
-            // Preserve the ambiguous unregistered UDF, but translate the cell
-            // reference that participates in a whitespace intersection.
+            // Built-in functions remain stable while cell-like tokens followed by
+            // parenthesized references participate in whitespace intersections.
             Assert.Equal(
-                "SUM(B:B,$A:$A,2:2,$1:$1,B2#,$A2#,B$1#,$A$1#,B2%)+LOG10(B2)+LOG10 (B2)+FOO1 (B2)+SUM(B2 (B2:B3))+Q1:Q4!B2",
+                "SUM(B:B,$A:$A,2:2,$1:$1,B2#,$A2#,B$1#,$A$1#,B2%)+LOG10(B2)+LOG10 (B2)+FOP2 (B2)+SUM(B2 (B2))+SUM(B2 (B2:B3))+Q1:Q4!B2",
                 shared.GetFormulaText(2, 6));
         }
 

--- a/OfficeIMO.Excel.Tests/Excel.FormulaDepth.cs
+++ b/OfficeIMO.Excel.Tests/Excel.FormulaDepth.cs
@@ -1121,11 +1121,10 @@ namespace OfficeIMO.Tests {
             using ExcelDocument loaded = ExcelDocument.Load(filePath);
             ExcelSheet shared = loaded["Shared"];
             Assert.Equal(masterFormula, shared.GetFormulaText(1, 5));
-            // A cell-like token separated from an opening parenthesis is
-            // ambiguous without Excel's external UDF registry. Preserve it
-            // instead of corrupting a potentially valid unregistered UDF.
+            // Preserve the ambiguous unregistered UDF, but translate the cell
+            // reference that participates in a whitespace intersection.
             Assert.Equal(
-                "SUM(B:B,$A:$A,2:2,$1:$1,B2#,$A2#,B$1#,$A$1#,B2%)+LOG10(B2)+LOG10 (B2)+FOO1 (B2)+SUM(A1 (B2:B3))+Q1:Q4!B2",
+                "SUM(B:B,$A:$A,2:2,$1:$1,B2#,$A2#,B$1#,$A$1#,B2%)+LOG10(B2)+LOG10 (B2)+FOO1 (B2)+SUM(B2 (B2:B3))+Q1:Q4!B2",
                 shared.GetFormulaText(2, 6));
         }
 

--- a/OfficeIMO.Excel.Tests/Excel.FormulaDepth.cs
+++ b/OfficeIMO.Excel.Tests/Excel.FormulaDepth.cs
@@ -1119,11 +1119,13 @@ namespace OfficeIMO.Tests {
             }
 
             using ExcelDocument loaded = ExcelDocument.Load(filePath);
-            loaded.Calculation.RegisterCustomFunction("FOO1", (_, _) => ExcelFormulaValue.Blank);
             ExcelSheet shared = loaded["Shared"];
             Assert.Equal(masterFormula, shared.GetFormulaText(1, 5));
+            // A cell-like token separated from an opening parenthesis is
+            // ambiguous without Excel's external UDF registry. Preserve it
+            // instead of corrupting a potentially valid unregistered UDF.
             Assert.Equal(
-                "SUM(B:B,$A:$A,2:2,$1:$1,B2#,$A2#,B$1#,$A$1#,B2%)+LOG10(B2)+LOG10 (B2)+FOO1 (B2)+SUM(B2 (B2:B3))+Q1:Q4!B2",
+                "SUM(B:B,$A:$A,2:2,$1:$1,B2#,$A2#,B$1#,$A$1#,B2%)+LOG10(B2)+LOG10 (B2)+FOO1 (B2)+SUM(A1 (B2:B3))+Q1:Q4!B2",
                 shared.GetFormulaText(2, 6));
         }
 

--- a/OfficeIMO.Excel.Tests/Excel.GoogleSheets.cs
+++ b/OfficeIMO.Excel.Tests/Excel.GoogleSheets.cs
@@ -1118,7 +1118,7 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
-        public void Test_GoogleSheetsBatchCompiler_FullColumnValidationRemainsOneRangeRequest() {
+        public void Test_GoogleSheetsBatchCompiler_RejectsGridExpansionBeyondServiceLimits() {
             string filePath = Path.Combine(_directoryWithFiles, "GoogleSheetsFullColumnValidation.xlsx");
 
             try {
@@ -1130,13 +1130,9 @@ namespace OfficeIMO.Tests {
                 }
 
                 using var reloadedDocument = ExcelDocument.Load(filePath);
-                GoogleSheetsBatch batch = reloadedDocument.BuildGoogleSheetsBatch();
-
-                GoogleSheetsSetDataValidationRequest validation = Assert.Single(batch.Requests.OfType<GoogleSheetsSetDataValidationRequest>());
-                Assert.Equal(0, validation.StartRowIndex);
-                Assert.Equal(1048576, validation.EndRowIndexExclusive);
-                Assert.True(batch.Requests.Count < 20);
-                Assert.Single(batch.Requests.OfType<GoogleSheetsUpdateCellsRequest>().Single().Cells);
+                NotSupportedException exception = Assert.Throws<NotSupportedException>(
+                    () => reloadedDocument.BuildGoogleSheetsBatch());
+                Assert.Contains("exceeds Google Sheets limits", exception.Message, StringComparison.Ordinal);
             } finally {
                 if (File.Exists(filePath)) {
                     File.Delete(filePath);

--- a/OfficeIMO.Excel.Tests/Excel.GoogleSheets.cs
+++ b/OfficeIMO.Excel.Tests/Excel.GoogleSheets.cs
@@ -1141,6 +1141,21 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_GoogleSheetsBatchCompiler_RejectsAggregateGridExpansionBeyondServiceLimits() {
+            using ExcelDocument document = ExcelDocument.Create();
+            ExcelSheet first = document.AddWorksheet("First");
+            ExcelSheet second = document.AddWorksheet("Second");
+            first.ValidationWholeNumber("A1:ALM5000", DocumentFormat.OpenXml.Spreadsheet.DataValidationOperatorValues.Between, 1, 10);
+            second.ValidationWholeNumber("A1:ALM5000", DocumentFormat.OpenXml.Spreadsheet.DataValidationOperatorValues.Between, 1, 10);
+
+            NotSupportedException exception = Assert.Throws<NotSupportedException>(
+                () => document.BuildGoogleSheetsBatch());
+
+            Assert.Contains("across all sheets", exception.Message, StringComparison.Ordinal);
+            Assert.Contains("exceeds Google Sheets limits", exception.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void Test_GoogleSheetsBatchCompiler_AndApiPayloadBuilder_EmitWorksheetListValidationsOutsideTables() {
             string filePath = Path.Combine(_directoryWithFiles, "GoogleSheetsWorksheetListValidationOutsideTables.xlsx");
 

--- a/OfficeIMO.Excel.Tests/Excel.Security.AllSeverityBatch19.cs
+++ b/OfficeIMO.Excel.Tests/Excel.Security.AllSeverityBatch19.cs
@@ -46,6 +46,24 @@ public partial class Excel {
     }
 
     [Fact]
+    public void Batch19_LegacyXlsSaveRemovesEarlierDuplicateWhenLastCellIsBlank() {
+        using ExcelDocument document = ExcelDocument.Create();
+        ExcelSheet sheet = document.AddWorksheet("Duplicates");
+        SheetData data = sheet.WorksheetPart.Worksheet.GetFirstChild<SheetData>()!;
+        data.RemoveAllChildren();
+        data.Append(new Row(
+            new Cell { CellReference = "A1", DataType = CellValues.String, CellValue = new CellValue("stale") },
+            new Cell { CellReference = "A1" }) {
+            RowIndex = 1U
+        });
+
+        byte[] payload = document.ToBytes(ExcelFileFormat.Xls);
+        using ExcelDocument loaded = ExcelDocument.Load(new MemoryStream(payload, writable: false));
+
+        Assert.False(loaded["Duplicates"].TryGetCellText(1, 1, out _));
+    }
+
+    [Fact]
     public void Batch19_XlsbRewriteEnforcesActualUnreferencedPartSize() {
         byte[] source = AddZipEntry(
             CreateMinimalXlsbPackage(),

--- a/OfficeIMO.Excel.Tests/Excel.Security.AllSeverityBatch19.cs
+++ b/OfficeIMO.Excel.Tests/Excel.Security.AllSeverityBatch19.cs
@@ -1,0 +1,63 @@
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Excel;
+using OfficeIMO.Excel.Xlsb;
+using OfficeIMO.Excel.Xlsb.Write;
+using Xunit;
+using ExcelTableStyle = OfficeIMO.Excel.TableStyle;
+
+namespace OfficeIMO.Tests;
+
+public partial class Excel {
+    [Fact]
+    public void Batch19_MalformedStructuredRangeDoesNotResolveMissingEndpoint() {
+        using ExcelDocument document = ExcelDocument.Create();
+        ExcelSheet sheet = document.AddWorksheet("Malformed");
+        sheet.CellValue(1, 1, "A");
+        sheet.CellValue(1, 2, "B");
+        sheet.CellValue(2, 1, 1D);
+        sheet.CellValue(2, 2, 2D);
+        sheet.AddTable("A1:B2", hasHeader: true, name: "Sales", style: ExcelTableStyle.TableStyleMedium2);
+        sheet.CellFormula(2, 4, "SUM(Sales[[B]:])");
+        sheet.CellFormula(2, 5, "SUM(Sales[@[B]:])");
+
+        ExcelFormulaDependencyGraph graph = document.InspectFormulas().DependencyGraph;
+
+        Assert.Empty(Assert.IsType<ExcelFormulaDependencyNode>(graph.FindNode("Malformed", "D2")).Dependencies);
+        Assert.Empty(Assert.IsType<ExcelFormulaDependencyNode>(graph.FindNode("Malformed", "E2")).Dependencies);
+    }
+
+    [Fact]
+    public void Batch19_LegacyXlsSaveCoalescesDuplicateCellCoordinatesLastWins() {
+        using ExcelDocument document = ExcelDocument.Create();
+        ExcelSheet sheet = document.AddWorksheet("Duplicates");
+        SheetData data = sheet.WorksheetPart.Worksheet.GetFirstChild<SheetData>()!;
+        data.RemoveAllChildren();
+        data.Append(new Row(
+            new Cell { CellReference = "A1", DataType = CellValues.String, CellValue = new CellValue("first") },
+            new Cell { CellReference = "A1", DataType = CellValues.String, CellValue = new CellValue("last") }) {
+            RowIndex = 1U
+        });
+
+        byte[] payload = document.ToBytes(ExcelFileFormat.Xls);
+        using ExcelDocument loaded = ExcelDocument.Load(new MemoryStream(payload, writable: false));
+
+        Assert.True(loaded["Duplicates"].TryGetCellText(1, 1, out string? value));
+        Assert.Equal("last", value);
+    }
+
+    [Fact]
+    public void Batch19_XlsbRewriteEnforcesActualUnreferencedPartSize() {
+        byte[] source = AddZipEntry(
+            CreateMinimalXlsbPackage(),
+            "xl/media/unreferenced.bin",
+            Enumerable.Repeat((byte)0x41, 2_048).ToArray());
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(
+            () => XlsbNativePackageWriter.RewritePackage(
+                source,
+                new Dictionary<string, byte[]>(),
+                maxPartBytes: 1_024,
+                maxPackageBytes: 128 * 1_024));
+        Assert.Contains("configured rewrite limit", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/OfficeIMO.Excel/ExcelSheet.Formulas.References.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Formulas.References.cs
@@ -710,7 +710,7 @@ namespace OfficeIMO.Excel {
                     index++;
                 }
                 if (index == value.Length) {
-                    return sections.Count > 0;
+                    return sections.Count > 0 && separators.Count == sections.Count - 1;
                 }
 
                 if (value[index] != '[') {
@@ -733,7 +733,7 @@ namespace OfficeIMO.Excel {
                     index++;
                 }
                 if (index == value.Length) {
-                    return true;
+                    return separators.Count == sections.Count - 1;
                 }
 
                 if (value[index] != ',' && value[index] != ':') {
@@ -744,7 +744,7 @@ namespace OfficeIMO.Excel {
                 index++;
             }
 
-            return sections.Count > 0;
+            return sections.Count > 0 && separators.Count == sections.Count - 1;
         }
 
         private static bool TryResolveTableReferenceRange(

--- a/OfficeIMO.Excel/ExcelSheet.Formulas.Shared.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Formulas.Shared.cs
@@ -160,31 +160,29 @@ namespace OfficeIMO.Excel {
                 return true;
             }
 
-            // A cell-like unregistered UDF is ambiguous with Excel's whitespace
-            // intersection operator. Preserve the UDF spelling unless the following
-            // parenthesized operand is visibly a range, in which case the leading
-            // cell is the left side of the intersection and must be translated too.
-            return !IsParenthesizedRangeOperand(formula, cursor);
+            // An unregistered cell-like token followed by a parenthesized reference
+            // is Excel's whitespace intersection form. Named functions remain
+            // protected above, while both single-cell and range operands translate.
+            return !IsParenthesizedReferenceOperand(formula, cursor);
         }
 
-        private static bool IsParenthesizedRangeOperand(string formula, int openingParenthesis) {
-            int depth = 0;
-            bool hasRangeSeparator = false;
-            for (int index = openingParenthesis; index < formula.Length; index++) {
-                char value = formula[index];
-                if (value == '(') {
-                    depth++;
-                } else if (value == ')') {
-                    depth--;
-                    if (depth == 0) {
-                        return hasRangeSeparator;
-                    }
-                } else if (value == ':' && depth == 1) {
-                    hasRangeSeparator = true;
-                }
+        private static bool IsParenthesizedReferenceOperand(string formula, int openingParenthesis) {
+            int operandStart = openingParenthesis + 1;
+            while (operandStart < formula.Length && char.IsWhiteSpace(formula[operandStart])) {
+                operandStart++;
             }
 
-            return false;
+            Match operand = SharedFormulaReferenceRegex.Match(formula, operandStart);
+            if (!operand.Success || operand.Index != operandStart) {
+                return false;
+            }
+
+            int closingParenthesis = operand.Index + operand.Length;
+            while (closingParenthesis < formula.Length && char.IsWhiteSpace(formula[closingParenthesis])) {
+                closingParenthesis++;
+            }
+
+            return closingParenthesis < formula.Length && formula[closingParenthesis] == ')';
         }
 
         private static string TranslateSharedFormulaReference(Match match, int rowOffset, int columnOffset) {

--- a/OfficeIMO.Excel/ExcelSheet.Formulas.Shared.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Formulas.Shared.cs
@@ -135,7 +135,7 @@ namespace OfficeIMO.Excel {
                         : TranslateSharedFormulaReference(match, rowOffset, columnOffset)));
         }
 
-        private static bool IsSharedFormulaFunctionToken(string formula, Match match) {
+        private bool IsSharedFormulaFunctionToken(string formula, Match match) {
             if (match.Groups["qualifier"].Success
                 || match.Groups["cellEndColumn"].Success
                 || match.Groups["cellSpill"].Success
@@ -154,10 +154,37 @@ namespace OfficeIMO.Excel {
                 return false;
             }
 
-            // Formula preservation must not depend on whether OfficeIMO knows how to
-            // evaluate a UDF. Excel permits unregistered function names that resemble
-            // cell references, and translating those names corrupts the stored formula.
-            return true;
+            string token = match.Groups["cellStartColumn"].Value + match.Groups["cellStartRow"].Value;
+            if (ExcelFormulaCapabilities.IsBuiltInFunction(token)
+                || _excelDocument.Calculation.TryGetCustomFunction(token, out _)) {
+                return true;
+            }
+
+            // A cell-like unregistered UDF is ambiguous with Excel's whitespace
+            // intersection operator. Preserve the UDF spelling unless the following
+            // parenthesized operand is visibly a range, in which case the leading
+            // cell is the left side of the intersection and must be translated too.
+            return !IsParenthesizedRangeOperand(formula, cursor);
+        }
+
+        private static bool IsParenthesizedRangeOperand(string formula, int openingParenthesis) {
+            int depth = 0;
+            bool hasRangeSeparator = false;
+            for (int index = openingParenthesis; index < formula.Length; index++) {
+                char value = formula[index];
+                if (value == '(') {
+                    depth++;
+                } else if (value == ')') {
+                    depth--;
+                    if (depth == 0) {
+                        return hasRangeSeparator;
+                    }
+                } else if (value == ':' && depth == 1) {
+                    hasRangeSeparator = true;
+                }
+            }
+
+            return false;
         }
 
         private static string TranslateSharedFormulaReference(Match match, int rowOffset, int columnOffset) {

--- a/OfficeIMO.Excel/ExcelSheet.Formulas.Shared.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Formulas.Shared.cs
@@ -167,22 +167,40 @@ namespace OfficeIMO.Excel {
         }
 
         private static bool IsParenthesizedReferenceOperand(string formula, int openingParenthesis) {
-            int operandStart = openingParenthesis + 1;
-            while (operandStart < formula.Length && char.IsWhiteSpace(formula[operandStart])) {
-                operandStart++;
+            int cursor = openingParenthesis + 1;
+            int depth = 1;
+            bool sawReference = false;
+            while (cursor < formula.Length) {
+                if (char.IsWhiteSpace(formula[cursor]) || formula[cursor] == ',') {
+                    cursor++;
+                    continue;
+                }
+
+                if (formula[cursor] == '(') {
+                    depth++;
+                    cursor++;
+                    continue;
+                }
+
+                if (formula[cursor] == ')') {
+                    depth--;
+                    cursor++;
+                    if (depth == 0) {
+                        return sawReference;
+                    }
+                    continue;
+                }
+
+                Match reference = SharedFormulaReferenceRegex.Match(formula, cursor);
+                if (!reference.Success || reference.Index != cursor) {
+                    return false;
+                }
+
+                sawReference = true;
+                cursor += reference.Length;
             }
 
-            Match operand = SharedFormulaReferenceRegex.Match(formula, operandStart);
-            if (!operand.Success || operand.Index != operandStart) {
-                return false;
-            }
-
-            int closingParenthesis = operand.Index + operand.Length;
-            while (closingParenthesis < formula.Length && char.IsWhiteSpace(formula[closingParenthesis])) {
-                closingParenthesis++;
-            }
-
-            return closingParenthesis < formula.Length && formula[closingParenthesis] == ')';
+            return false;
         }
 
         private static string TranslateSharedFormulaReference(Match match, int rowOffset, int columnOffset) {

--- a/OfficeIMO.Excel/ExcelSheet.Formulas.Shared.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Formulas.Shared.cs
@@ -135,7 +135,7 @@ namespace OfficeIMO.Excel {
                         : TranslateSharedFormulaReference(match, rowOffset, columnOffset)));
         }
 
-        private bool IsSharedFormulaFunctionToken(string formula, Match match) {
+        private static bool IsSharedFormulaFunctionToken(string formula, Match match) {
             if (match.Groups["qualifier"].Success
                 || match.Groups["cellEndColumn"].Success
                 || match.Groups["cellSpill"].Success
@@ -154,9 +154,10 @@ namespace OfficeIMO.Excel {
                 return false;
             }
 
-            string token = match.Groups["cellStartColumn"].Value + match.Groups["cellStartRow"].Value;
-            return ExcelFormulaCapabilities.IsBuiltInFunction(token)
-                || _excelDocument.Calculation.TryGetCustomFunction(token, out _);
+            // Formula preservation must not depend on whether OfficeIMO knows how to
+            // evaluate a UDF. Excel permits unregistered function names that resemble
+            // cell references, and translating those names corrupts the stored formula.
+            return true;
         }
 
         private static string TranslateSharedFormulaReference(Match match, int rowOffset, int columnOffset) {

--- a/OfficeIMO.Excel/LegacyXls/Write/LegacyXlsWriter.cs
+++ b/OfficeIMO.Excel/LegacyXls/Write/LegacyXlsWriter.cs
@@ -360,6 +360,7 @@ namespace OfficeIMO.Excel.LegacyXls.Write {
                 return cells;
             }
 
+            var cellIndexes = new Dictionary<(ushort Row, ushort Column), int>();
             LegacyXlsSharedFormulaTable sharedFormulaTable = LegacyXlsSharedFormulaTable.Create(sheet, sheetIndex, formulaNameIndex);
             LegacyXlsArrayFormulaTable arrayFormulaTable = LegacyXlsArrayFormulaTable.Create(sheet, sheetIndex, formulaNameIndex);
             foreach (Row row in sheetData.Elements<Row>()) {
@@ -383,7 +384,17 @@ namespace OfficeIMO.Excel.LegacyXls.Write {
 
                     LegacyXlsCell? legacyCell = ConvertCell(sheet, workbookPart, sheetIndex, cell, checked((ushort)(effectiveRow - 1U)), checked((ushort)(effectiveColumn - 1)), styleTable, dateSystem, formulaNameIndex, sharedFormulaTable, arrayFormulaTable, fontTable);
                     if (legacyCell.HasValue) {
-                        cells.Add(legacyCell.Value);
+                        LegacyXlsCell value = legacyCell.Value;
+                        var coordinate = (value.Row, value.Column);
+                        if (cellIndexes.TryGetValue(coordinate, out int existingIndex)) {
+                            // Malformed Open XML can contain duplicate cell coordinates. BIFF8
+                            // cannot represent those deterministically, so preserve the last
+                            // authored cell just as ordinary worksheet lookup does.
+                            cells[existingIndex] = value;
+                        } else {
+                            cellIndexes.Add(coordinate, cells.Count);
+                            cells.Add(value);
+                        }
                     }
 
                     sequentialColumn = effectiveColumn + 1;

--- a/OfficeIMO.Excel/LegacyXls/Write/LegacyXlsWriter.cs
+++ b/OfficeIMO.Excel/LegacyXls/Write/LegacyXlsWriter.cs
@@ -360,7 +360,7 @@ namespace OfficeIMO.Excel.LegacyXls.Write {
                 return cells;
             }
 
-            var cellIndexes = new Dictionary<(ushort Row, ushort Column), int>();
+            var cellsByCoordinate = new Dictionary<(ushort Row, ushort Column), LegacyXlsCell>();
             LegacyXlsSharedFormulaTable sharedFormulaTable = LegacyXlsSharedFormulaTable.Create(sheet, sheetIndex, formulaNameIndex);
             LegacyXlsArrayFormulaTable arrayFormulaTable = LegacyXlsArrayFormulaTable.Create(sheet, sheetIndex, formulaNameIndex);
             foreach (Row row in sheetData.Elements<Row>()) {
@@ -382,25 +382,23 @@ namespace OfficeIMO.Excel.LegacyXls.Write {
                         throw new NotSupportedException("Native XLS saving supports the BIFF8 worksheet limit of 65,536 rows and 256 columns.");
                     }
 
-                    LegacyXlsCell? legacyCell = ConvertCell(sheet, workbookPart, sheetIndex, cell, checked((ushort)(effectiveRow - 1U)), checked((ushort)(effectiveColumn - 1)), styleTable, dateSystem, formulaNameIndex, sharedFormulaTable, arrayFormulaTable, fontTable);
+                    ushort legacyRow = checked((ushort)(effectiveRow - 1U));
+                    ushort legacyColumn = checked((ushort)(effectiveColumn - 1));
+                    var coordinate = (legacyRow, legacyColumn);
+                    LegacyXlsCell? legacyCell = ConvertCell(sheet, workbookPart, sheetIndex, cell, legacyRow, legacyColumn, styleTable, dateSystem, formulaNameIndex, sharedFormulaTable, arrayFormulaTable, fontTable);
                     if (legacyCell.HasValue) {
-                        LegacyXlsCell value = legacyCell.Value;
-                        var coordinate = (value.Row, value.Column);
-                        if (cellIndexes.TryGetValue(coordinate, out int existingIndex)) {
-                            // Malformed Open XML can contain duplicate cell coordinates. BIFF8
-                            // cannot represent those deterministically, so preserve the last
-                            // authored cell just as ordinary worksheet lookup does.
-                            cells[existingIndex] = value;
-                        } else {
-                            cellIndexes.Add(coordinate, cells.Count);
-                            cells.Add(value);
-                        }
+                        cellsByCoordinate[coordinate] = legacyCell.Value;
+                    } else {
+                        // A later empty, unstyled duplicate is still the last authored value.
+                        // Remove any earlier cell instead of resurrecting stale content.
+                        cellsByCoordinate.Remove(coordinate);
                     }
 
                     sequentialColumn = effectiveColumn + 1;
                 }
             }
 
+            cells.AddRange(cellsByCoordinate.Values);
             cells.Sort(static (left, right) => {
                 int rowComparison = left.Row.CompareTo(right.Row);
                 return rowComparison != 0 ? rowComparison : left.Column.CompareTo(right.Column);

--- a/OfficeIMO.Excel/Xlsb/Model/XlsbWorkbook.cs
+++ b/OfficeIMO.Excel/Xlsb/Model/XlsbWorkbook.cs
@@ -7,11 +7,17 @@ namespace OfficeIMO.Excel.Xlsb.Model {
         private readonly List<XlsbImportDiagnostic> _diagnostics = new List<XlsbImportDiagnostic>();
         private readonly List<XlsbPreservedRecordInfo> _preservedRecords = new List<XlsbPreservedRecordInfo>();
 
-        internal XlsbWorkbook(byte[] originalPackageBytes) {
+        internal XlsbWorkbook(byte[] originalPackageBytes, int maxPartBytes, long maxPackageBytes) {
             OriginalPackageBytes = originalPackageBytes ?? throw new ArgumentNullException(nameof(originalPackageBytes));
+            MaxPartBytes = maxPartBytes;
+            MaxPackageBytes = maxPackageBytes;
         }
 
         internal byte[] OriginalPackageBytes { get; }
+
+        internal int MaxPartBytes { get; }
+
+        internal long MaxPackageBytes { get; }
 
         internal IReadOnlyList<XlsbWorksheet> Worksheets => _worksheets;
 

--- a/OfficeIMO.Excel/Xlsb/Write/XlsbNativePackageWriter.cs
+++ b/OfficeIMO.Excel/Xlsb/Write/XlsbNativePackageWriter.cs
@@ -41,7 +41,11 @@ namespace OfficeIMO.Excel.Xlsb.Write {
             }
 
             if (replacements.Count == 0) return sourcePackageBytes;
-            byte[] rewritten = RewritePackage(sourcePackageBytes, replacements);
+            byte[] rewritten = RewritePackage(
+                sourcePackageBytes,
+                replacements,
+                sourceWorkbook.MaxPartBytes,
+                sourceWorkbook.MaxPackageBytes);
             if (!XlsbPackageDetector.TryFindWorkbookPart(rewritten, out _)) {
                 throw new InvalidDataException("The rewritten package no longer satisfies the XLSB package contract.");
             }
@@ -147,10 +151,16 @@ namespace OfficeIMO.Excel.Xlsb.Write {
             }
         }
 
-        private static byte[] RewritePackage(byte[] sourcePackageBytes, IReadOnlyDictionary<string, byte[]> replacements) {
+        internal static byte[] RewritePackage(
+            byte[] sourcePackageBytes,
+            IReadOnlyDictionary<string, byte[]> replacements,
+            int maxPartBytes,
+            long maxPackageBytes) {
             using var sourceStream = new MemoryStream(sourcePackageBytes, writable: false);
             using var sourceArchive = new ZipArchive(sourceStream, ZipArchiveMode.Read, leaveOpen: false);
             using var destinationStream = new MemoryStream(sourcePackageBytes.Length + 4096);
+            long decompressedBytes = 0;
+            byte[] buffer = new byte[81920];
             using (var destinationArchive = new ZipArchive(destinationStream, ZipArchiveMode.Create, leaveOpen: true)) {
                 foreach (ZipArchiveEntry sourceEntry in sourceArchive.Entries) {
                     string normalizedName = sourceEntry.FullName.Replace('\\', '/');
@@ -158,15 +168,73 @@ namespace OfficeIMO.Excel.Xlsb.Write {
                     try { destinationEntry.LastWriteTime = sourceEntry.LastWriteTime; } catch (ArgumentOutOfRangeException) { }
                     using Stream output = destinationEntry.Open();
                     if (replacements.TryGetValue(normalizedName, out byte[]? replacement)) {
+                        ChargeRewriteBytes(
+                            normalizedName,
+                            replacement.Length,
+                            maxPartBytes,
+                            maxPackageBytes,
+                            ref decompressedBytes);
                         output.Write(replacement, 0, replacement.Length);
                     } else {
+                        if (sourceEntry.Length > maxPartBytes) {
+                            throw new InvalidDataException(
+                                $"The XLSB package part '{normalizedName}' declares {sourceEntry.Length} decompressed bytes, exceeding the configured rewrite limit of {maxPartBytes} bytes.");
+                        }
                         using Stream input = sourceEntry.Open();
-                        input.CopyTo(output);
+                        int partBytes = 0;
+                        while (true) {
+                            int read = input.Read(buffer, 0, buffer.Length);
+                            if (read == 0) break;
+                            ChargeRewriteBytes(
+                                normalizedName,
+                                read,
+                                maxPartBytes,
+                                maxPackageBytes,
+                                ref decompressedBytes,
+                                ref partBytes);
+                            output.Write(buffer, 0, read);
+                        }
                     }
                 }
             }
 
             return destinationStream.ToArray();
+        }
+
+        private static void ChargeRewriteBytes(
+            string partName,
+            int bytes,
+            int maxPartBytes,
+            long maxPackageBytes,
+            ref long decompressedBytes) {
+            int partBytes = 0;
+            ChargeRewriteBytes(
+                partName,
+                bytes,
+                maxPartBytes,
+                maxPackageBytes,
+                ref decompressedBytes,
+                ref partBytes);
+        }
+
+        private static void ChargeRewriteBytes(
+            string partName,
+            int bytes,
+            int maxPartBytes,
+            long maxPackageBytes,
+            ref long decompressedBytes,
+            ref int partBytes) {
+            if (bytes < 0 || partBytes > maxPartBytes - bytes) {
+                throw new InvalidDataException(
+                    $"The XLSB package part '{partName}' exceeds the configured rewrite limit of {maxPartBytes} bytes while decompressing.");
+            }
+            if (decompressedBytes > maxPackageBytes - bytes) {
+                throw new InvalidDataException(
+                    $"The XLSB package exceeds the configured aggregate rewrite limit of {maxPackageBytes} bytes while decompressing.");
+            }
+
+            partBytes += bytes;
+            decompressedBytes += bytes;
         }
 
         private static byte[] ReadEntry(ZipArchiveEntry entry, int maxBytes) {

--- a/OfficeIMO.Excel/Xlsb/XlsbWorkbookReader.cs
+++ b/OfficeIMO.Excel/Xlsb/XlsbWorkbookReader.cs
@@ -85,7 +85,10 @@ namespace OfficeIMO.Excel.Xlsb {
                 throw new InvalidDataException("The package does not contain a canonical XLSB workbook part.");
             }
 
-            var workbook = new XlsbWorkbook((byte[])packageBytes.Clone());
+            var workbook = new XlsbWorkbook(
+                (byte[])packageBytes.Clone(),
+                resolved.MaxPartBytes,
+                resolved.MaxPackageBytes);
             using var packageStream = new MemoryStream(packageBytes, writable: false);
             using var archive = new ZipArchive(packageStream, ZipArchiveMode.Read, leaveOpen: false);
             var parts = new XlsbPackagePartReader(archive, resolved);

--- a/OfficeIMO.Html.Tests/Html.Rendering.cs
+++ b/OfficeIMO.Html.Tests/Html.Rendering.cs
@@ -1573,6 +1573,24 @@ public sealed partial class HtmlRenderingTests {
     }
 
     [Fact]
+    public void HtmlRenderer_TableCellMatchParentUsesRowAlignment() {
+        const string html =
+            "<table style='width:200px;text-align:left'><tr style='text-align:center'><td style='text-align:match-parent'>MatchedCell</td></tr></table>";
+
+        HtmlRenderDocument rendered = HtmlRenderTestDriver.Render(
+            HtmlConversionDocument.Parse(html),
+            new HtmlRenderOptions {
+                ViewportWidth = 200D,
+                Margins = HtmlRenderMargins.All(0D)
+            });
+
+        HtmlRenderText text = Assert.Single(
+            rendered.Pages[0].Visuals.OfType<HtmlRenderText>(),
+            item => item.Text == "MatchedCell");
+        Assert.True(text.X > 40D);
+    }
+
+    [Fact]
     public void HtmlRenderer_RootDirectionMetadataHonorsCssInitialReset() {
         const string html =
             "<!doctype html><html dir='rtl' style='direction:initial'><body><p>LTR metadata</p></body></html>";

--- a/OfficeIMO.Html.Tests/Html.Rendering.cs
+++ b/OfficeIMO.Html.Tests/Html.Rendering.cs
@@ -1547,6 +1547,43 @@ public sealed partial class HtmlRenderingTests {
     }
 
     [Fact]
+    public void HtmlRenderer_MatchParentUsesPhysicalParentAlignment() {
+        const string html =
+            "<div style='width:200px;text-align:center'><p style='margin:0;text-align:match-parent'>Matched</p></div>";
+
+        var parsed = HtmlDocumentParser.ParseDocument(html);
+        IReadOnlyDictionary<AngleSharp.Dom.IElement, HtmlComputedStyle> styles = HtmlComputedStyleEngine.Compute(parsed);
+        Assert.Equal("center", styles[parsed.QuerySelector("div")!].GetValue("text-align"));
+        Assert.Equal("match-parent", styles[parsed.QuerySelector("p")!].GetValue("text-align"));
+
+        HtmlRenderDocument rendered = HtmlRenderTestDriver.Render(
+            HtmlConversionDocument.Parse(html),
+            new HtmlRenderOptions {
+                ViewportWidth = 200D,
+                Margins = HtmlRenderMargins.All(0D)
+            });
+
+        HtmlRenderText text = Assert.Single(
+            rendered.Pages[0].Visuals.OfType<HtmlRenderText>(),
+            item => item.Text == "Matched");
+        // Inline text fragments are already physically positioned, so their
+        // local drawing frame remains left-aligned. The inherited alignment is
+        // observable through the centered physical position.
+        Assert.True(text.X > 50D);
+    }
+
+    [Fact]
+    public void HtmlRenderer_RootDirectionMetadataHonorsCssInitialReset() {
+        const string html =
+            "<!doctype html><html dir='rtl' style='direction:initial'><body><p>LTR metadata</p></body></html>";
+
+        HtmlRenderDocument rendered = HtmlRenderTestDriver.Render(
+            HtmlConversionDocument.Parse(html));
+
+        Assert.Equal(HtmlRenderTextDirection.LeftToRight, rendered.Metadata.Direction);
+    }
+
+    [Fact]
     public void HtmlPdf_DirectRenderer_TagsRasterAndVectorImageAlternativeTextAsFigures() {
         string rasterData = Convert.ToBase64String(PdfPngTestImages.CreateRgbPng(2, 2));
         const string vectorData = "%3Csvg xmlns='http://www.w3.org/2000/svg' width='2' height='2'%3E%3Crect width='2' height='2' fill='red'/%3E%3C/svg%3E";

--- a/OfficeIMO.Html/Rendering/HtmlRenderLayoutEngine.Tables.cs
+++ b/OfficeIMO.Html/Rendering/HtmlRenderLayoutEngine.Tables.cs
@@ -105,7 +105,7 @@ internal sealed partial class HtmlRenderLayoutEngine {
                 int rowSpan = ReadRowSpan(cell.GetAttribute("rowspan"), rows, rowIndex, table);
 
                 double cellOuterWidth = SumColumnWidths(columnWidths, column, columnSpan) + horizontalSpacing * (columnSpan - 1);
-                HtmlRenderBoxStyle cellStyle = _styleResolver.Resolve(cell, cellOuterWidth, style);
+                HtmlRenderBoxStyle cellStyle = _styleResolver.Resolve(cell, cellOuterWidth, rowStyle);
                 if (cellStyle.PaddingTop == 0D && cellStyle.PaddingRight == 0D && cellStyle.PaddingBottom == 0D && cellStyle.PaddingLeft == 0D) {
                     cellStyle.PaddingTop = cellStyle.PaddingRight = cellStyle.PaddingBottom = cellStyle.PaddingLeft = 2D;
                 }

--- a/OfficeIMO.Html/Rendering/HtmlRenderLayoutEngine.cs
+++ b/OfficeIMO.Html/Rendering/HtmlRenderLayoutEngine.cs
@@ -83,6 +83,9 @@ internal sealed partial class HtmlRenderLayoutEngine {
             if (string.Equals(computedDirection, "ltr", StringComparison.OrdinalIgnoreCase)) {
                 return HtmlRenderTextDirection.LeftToRight;
             }
+            // A computed root style is authoritative even when CSS reset the
+            // presentational dir hint to its initial (LTR) value.
+            return HtmlRenderTextDirection.LeftToRight;
         }
 
         string? attributeDirection = root?.GetAttribute("dir");

--- a/OfficeIMO.Html/Rendering/HtmlRenderStyleResolver.cs
+++ b/OfficeIMO.Html/Rendering/HtmlRenderStyleResolver.cs
@@ -62,7 +62,7 @@ internal sealed partial class HtmlRenderStyleResolver {
             PaintVisible = ResolvePaintVisibility(computed.GetValue("visibility"), parent),
             Font = new OfficeFontInfo(family, fontSize, fontStyle),
             Color = ResolveColor(computed.GetValue("color"), parent?.Color ?? OfficeColor.Black),
-            Alignment = ResolveAlignment(computed.GetValue("text-align"), direction),
+            Alignment = ResolveAlignment(computed.GetValue("text-align"), direction, parent?.Alignment),
             LineHeight = ResolveLineHeight(computed.GetValue("line-height"), fontSize),
             SemanticRole = pseudoElement ? pseudoSemanticRole : ResolveSemanticRole(tag),
             PreserveWhitespace = IsPreformatted(pseudoElement ? string.Empty : tag, computed.GetValue("white-space")),
@@ -331,10 +331,16 @@ internal sealed partial class HtmlRenderStyleResolver {
 
     private static OfficeColor ResolveColor(string value, OfficeColor fallback) => HtmlRenderCssValues.TryColor(value, out OfficeColor color) ? color : fallback;
 
-    private static OfficeTextAlignment ResolveAlignment(string value, string direction) {
+    private static OfficeTextAlignment ResolveAlignment(
+        string value,
+        string direction,
+        OfficeTextAlignment? parentAlignment) {
         if (string.Equals(value, "center", StringComparison.OrdinalIgnoreCase)) return OfficeTextAlignment.Center;
         if (string.Equals(value, "right", StringComparison.OrdinalIgnoreCase)) return OfficeTextAlignment.Right;
         if (string.Equals(value, "left", StringComparison.OrdinalIgnoreCase)) return OfficeTextAlignment.Left;
+        if (string.Equals(value, "match-parent", StringComparison.OrdinalIgnoreCase) && parentAlignment.HasValue) {
+            return parentAlignment.Value;
+        }
         bool rightToLeft = string.Equals(direction, "rtl", StringComparison.Ordinal);
         if (string.Equals(value, "end", StringComparison.OrdinalIgnoreCase)) return rightToLeft ? OfficeTextAlignment.Left : OfficeTextAlignment.Right;
         return rightToLeft ? OfficeTextAlignment.Right : OfficeTextAlignment.Left;

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfSecurityAllSeverityBatch19Tests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfSecurityAllSeverityBatch19Tests.cs
@@ -1,0 +1,46 @@
+using OfficeIMO.Pdf;
+using Xunit;
+
+namespace OfficeIMO.Tests.Pdf;
+
+public sealed class PdfSecurityAllSeverityBatch19Tests {
+    [Fact]
+    public void AnnotationUpdateRejectsNullInkPathEntryAtPublicBoundary() {
+        byte[] pdf = PdfDocument.Create()
+            .TextAnnotation("note")
+            .Paragraph(paragraph => paragraph.Text("source"))
+            .ToBytes();
+        int objectNumber = Assert.Single(
+            PdfInspector.Inspect(pdf).GetAnnotationsBySubtype("Text")).ObjectNumber!.Value;
+        var paths = new IReadOnlyList<double>[] { null! };
+
+        ArgumentException exception = Assert.Throws<ArgumentException>(() =>
+            PdfAnnotationEditor.UpdateAnnotation(
+                pdf,
+                objectNumber,
+                new PdfAnnotationUpdateOptions { InkPaths = paths }));
+
+        Assert.Contains("cannot contain null", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BookmarkEditorRejectsNonFiniteDestinationCoordinates() {
+        byte[] source = PdfDocument.Create()
+            .Paragraph(paragraph => paragraph.Text("one page"))
+            .ToBytes();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            PdfBookmarkEditor.Edit(
+                source,
+                session => session.Add("invalid", 1, destinationTop: double.NaN)));
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            PdfBookmarkEditor.Edit(source, session => {
+                PdfBookmarkNode node = session.Add("valid", 1);
+                session.Retarget(
+                    node.Id,
+                    1,
+                    PdfOpenActionDestinationMode.Xyz,
+                    destinationZoom: double.PositiveInfinity);
+            }));
+    }
+}

--- a/OfficeIMO.Pdf/Manipulation/PdfAnnotationEditor.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfAnnotationEditor.cs
@@ -374,7 +374,13 @@ internal static partial class PdfAnnotationEditor {
         ValidateCoordinateArray(options.Vertices, 4, 0, nameof(options.Vertices));
         ValidateCoordinateArray(options.Line, 4, 4, nameof(options.Line));
         ValidateCoordinateArray(options.PopupRectangle, 4, 4, nameof(options.PopupRectangle));
-        if (options.InkPaths is not null) { if (options.InkPaths.Count == 0) throw new ArgumentException("Ink paths cannot be empty.", nameof(options)); foreach (IReadOnlyList<double> path in options.InkPaths) ValidateCoordinateArray(path, 4, 0, nameof(options.InkPaths)); }
+        if (options.InkPaths is not null) {
+            if (options.InkPaths.Count == 0) throw new ArgumentException("Ink paths cannot be empty.", nameof(options));
+            foreach (IReadOnlyList<double> path in options.InkPaths) {
+                if (path is null) throw new ArgumentException("Ink paths cannot contain null entries.", nameof(options));
+                ValidateCoordinateArray(path, 4, 0, nameof(options.InkPaths));
+            }
+        }
         if (options.InReplyToObjectNumber.HasValue && options.InReplyToObjectNumber.Value <= 0) throw new ArgumentOutOfRangeException(nameof(options), "Reply parent object number must be positive.");
         if (options.ReplyType is not null && options.ReplyType != "R" && options.ReplyType != "Group") throw new ArgumentException("Reply type must be R or Group.", nameof(options));
         ValidatePdfName(options.LineStartEnding, nameof(options.LineStartEnding)); ValidatePdfName(options.LineEndEnding, nameof(options.LineEndEnding));

--- a/OfficeIMO.Pdf/Manipulation/PdfBookmarkEditSession.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfBookmarkEditSession.cs
@@ -56,9 +56,9 @@ public sealed class PdfBookmarkEditSession {
         target.Insert(index, node); return this;
     }
     /// <summary>Retargets a bookmark to a page and optional top coordinate.</summary>
-    public PdfBookmarkEditSession Retarget(string id, int pageNumber, double? destinationTop = null) { ValidatePage(pageNumber); PdfBookmarkNode node = Require(id); node.PageNumber = pageNumber; node.DestinationTop = destinationTop; node.DestinationMode = PdfOpenActionDestinationMode.Xyz; node.DestinationLeft = null; node.DestinationBottom = null; node.DestinationRight = null; node.DestinationZoom = null; return this; }
+    public PdfBookmarkEditSession Retarget(string id, int pageNumber, double? destinationTop = null) { ValidatePage(pageNumber); ValidateCoordinate(destinationTop, nameof(destinationTop)); PdfBookmarkNode node = Require(id); node.PageNumber = pageNumber; node.DestinationTop = destinationTop; node.DestinationMode = PdfOpenActionDestinationMode.Xyz; node.DestinationLeft = null; node.DestinationBottom = null; node.DestinationRight = null; node.DestinationZoom = null; return this; }
     /// <summary>Retargets a bookmark using an explicit viewer destination mode and coordinates.</summary>
-    public PdfBookmarkEditSession Retarget(string id, int pageNumber, PdfOpenActionDestinationMode destinationMode, double? destinationTop = null, double? destinationLeft = null, double? destinationBottom = null, double? destinationRight = null, double? destinationZoom = null) { ValidatePage(pageNumber); PdfBookmarkNode node = Require(id); node.PageNumber = pageNumber; node.DestinationMode = destinationMode; node.DestinationTop = destinationTop; node.DestinationLeft = destinationLeft; node.DestinationBottom = destinationBottom; node.DestinationRight = destinationRight; node.DestinationZoom = destinationZoom; return this; }
+    public PdfBookmarkEditSession Retarget(string id, int pageNumber, PdfOpenActionDestinationMode destinationMode, double? destinationTop = null, double? destinationLeft = null, double? destinationBottom = null, double? destinationRight = null, double? destinationZoom = null) { ValidatePage(pageNumber); ValidateCoordinates(destinationTop, destinationLeft, destinationBottom, destinationRight, destinationZoom); PdfBookmarkNode node = Require(id); node.PageNumber = pageNumber; node.DestinationMode = destinationMode; node.DestinationTop = destinationTop; node.DestinationLeft = destinationLeft; node.DestinationBottom = destinationBottom; node.DestinationRight = destinationRight; node.DestinationZoom = destinationZoom; return this; }
     /// <summary>Replaces bookmarks with the source document's inferred heading hierarchy.</summary>
     public PdfBookmarkEditSession RebuildFromHeadings() {
         _roots.Clear(); var stack = new List<PdfBookmarkNode>();
@@ -71,7 +71,10 @@ public sealed class PdfBookmarkEditSession {
     }
     internal IReadOnlyList<PdfBookmarkNode> Snapshot() => _roots;
     private void Import(IReadOnlyList<PdfOutlineItem> source, List<PdfBookmarkNode> target) { foreach (PdfOutlineItem item in source) { if (!item.PageNumber.HasValue) continue; PdfBookmarkNode node = NewNode(item.Title, item.PageNumber.Value, item.DestinationTop, item.IsExpanded, item.DestinationMode, item.DestinationLeft, item.DestinationBottom, item.DestinationRight, item.DestinationZoom); target.Add(node); Import(item.Children, node.MutableChildren); } }
-    private PdfBookmarkNode NewNode(string title, int page, double? top, bool expanded, PdfOpenActionDestinationMode? mode = null, double? left = null, double? bottom = null, double? right = null, double? zoom = null) => new PdfBookmarkNode("bookmark-" + (++_nextId).ToString(System.Globalization.CultureInfo.InvariantCulture), title, page, top, expanded, mode, left, bottom, right, zoom);
+    private PdfBookmarkNode NewNode(string title, int page, double? top, bool expanded, PdfOpenActionDestinationMode? mode = null, double? left = null, double? bottom = null, double? right = null, double? zoom = null) {
+        ValidateCoordinates(top, left, bottom, right, zoom);
+        return new PdfBookmarkNode("bookmark-" + (++_nextId).ToString(System.Globalization.CultureInfo.InvariantCulture), title, page, top, expanded, mode, left, bottom, right, zoom);
+    }
     private List<PdfBookmarkNode> GetChildren(string? parentId) => parentId == null ? _roots : Require(parentId).MutableChildren;
     private PdfBookmarkNode Require(string id) { Guard.NotNullOrWhiteSpace(id, nameof(id)); return Find(_roots, id) ?? throw new KeyNotFoundException("PDF bookmark was not found: " + id); }
     private (List<PdfBookmarkNode> Siblings, int Index) RequireLocation(string id) { if (TryFindLocation(_roots, id, out List<PdfBookmarkNode>? siblings, out int index)) return (siblings!, index); throw new KeyNotFoundException("PDF bookmark was not found: " + id); }
@@ -79,5 +82,17 @@ public sealed class PdfBookmarkEditSession {
     private static bool TryFindLocation(List<PdfBookmarkNode> nodes, string id, out List<PdfBookmarkNode>? siblings, out int index) { for (int i = 0; i < nodes.Count; i++) { if (nodes[i].Id == id) { siblings = nodes; index = i; return true; } if (TryFindLocation(nodes[i].MutableChildren, id, out siblings, out index)) return true; } siblings = null; index = -1; return false; }
     private static bool Contains(PdfBookmarkNode node, string id) => node.Id == id || node.MutableChildren.Any(child => Contains(child, id));
     private void ValidatePage(int page) { if (page < 1 || page > _logical.Pages.Count) throw new ArgumentOutOfRangeException(nameof(page)); }
+    private static void ValidateCoordinates(double? top, double? left, double? bottom, double? right, double? zoom) {
+        ValidateCoordinate(top, nameof(top));
+        ValidateCoordinate(left, nameof(left));
+        ValidateCoordinate(bottom, nameof(bottom));
+        ValidateCoordinate(right, nameof(right));
+        ValidateCoordinate(zoom, nameof(zoom));
+    }
+    private static void ValidateCoordinate(double? value, string parameterName) {
+        if (value.HasValue && (double.IsNaN(value.Value) || double.IsInfinity(value.Value))) {
+            throw new ArgumentOutOfRangeException(parameterName, "PDF bookmark destination coordinates must be finite.");
+        }
+    }
     private static void ValidateTitle(string title) => Guard.NotNullOrWhiteSpace(title, nameof(title));
 }

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.Security.AllSeverityBatch19.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.Security.AllSeverityBatch19.cs
@@ -1,0 +1,37 @@
+using OfficeIMO.PowerPoint.LegacyPpt;
+using OfficeIMO.PowerPoint.LegacyPpt.Internal;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public partial class PowerPoint {
+    [Fact]
+    public void MasterTextStyle9_ThreeDuplicateInstancesRemainAmbiguous() {
+        LegacyPptRecord[] records = {
+            CreateStyle9Record(7, 0),
+            CreateStyle9Record(7, 8),
+            CreateStyle9Record(7, 16)
+        };
+        int duplicateCount = 0;
+
+        IReadOnlyDictionary<ushort, LegacyPptRecord> selected =
+            LegacyPptPresentation.CollectUniqueMasterTextStyle9Records(
+                records,
+                _ => duplicateCount++);
+
+        Assert.Empty(selected);
+        Assert.Equal(1, duplicateCount);
+    }
+
+    private static LegacyPptRecord CreateStyle9Record(ushort instance, int offset) {
+        byte[] source = new byte[24];
+        return new LegacyPptRecord(
+            source,
+            offset,
+            version: 0,
+            instance,
+            type: 0x0FAD,
+            payloadOffset: offset + 8,
+            payloadLength: 0);
+    }
+}

--- a/OfficeIMO.PowerPoint/LegacyPpt/LegacyPptPresentation.MasterTextStyle9.cs
+++ b/OfficeIMO.PowerPoint/LegacyPpt/LegacyPptPresentation.MasterTextStyle9.cs
@@ -33,21 +33,21 @@ namespace OfficeIMO.PowerPoint.LegacyPpt {
             }
             try {
                 LegacyPptRecord blob = blobs[0];
-                foreach (LegacyPptRecord record in LegacyPptRecordReader
-                             .ReadSequence(blob.CopyRecordBytes(), 8,
-                                 blob.PayloadLength, options, _recordBudget)
-                             .Where(record => record.Type
-                                 == RecordTextMasterStyle9Atom)) {
-                    if (result.ContainsKey(record.Instance)) {
+                foreach (KeyValuePair<ushort, LegacyPptRecord> item in
+                         CollectUniqueMasterTextStyle9Records(
+                             LegacyPptRecordReader
+                                 .ReadSequence(blob.CopyRecordBytes(), 8,
+                                     blob.PayloadLength, options, _recordBudget)
+                                 .Where(record => record.Type
+                                     == RecordTextMasterStyle9Atom),
+                             record => {
                         AddDiagnostic(
                             "PPT-TEXT-MASTER-STYLE9-TYPE-DUPLICATE",
                             LegacyPptDiagnosticSeverity.Warning,
                             $"A master has multiple TextMasterStyle9Atom records for instance {record.Instance}; that extended style remains preserve-only.",
                             record.Offset);
-                        result.Remove(record.Instance);
-                    } else {
-                        result.Add(record.Instance, record);
-                    }
+                             })) {
+                    result.Add(item.Key, item.Value);
                 }
             } catch (Exception exception) when (exception
                 is InvalidDataException or OverflowException
@@ -57,6 +57,27 @@ namespace OfficeIMO.PowerPoint.LegacyPpt {
                     "A master PPT9 tag is malformed or truncated; its extended text defaults remain preserve-only.",
                     blobs[0].Offset);
                 result.Clear();
+            }
+            return result;
+        }
+
+        internal static IReadOnlyDictionary<ushort, LegacyPptRecord>
+            CollectUniqueMasterTextStyle9Records(
+                IEnumerable<LegacyPptRecord> records,
+                Action<LegacyPptRecord>? duplicate = null) {
+            var result = new Dictionary<ushort, LegacyPptRecord>();
+            var ambiguousInstances = new HashSet<ushort>();
+            foreach (LegacyPptRecord record in records) {
+                if (ambiguousInstances.Contains(record.Instance)) {
+                    continue;
+                }
+                if (result.ContainsKey(record.Instance)) {
+                    duplicate?.Invoke(record);
+                    result.Remove(record.Instance);
+                    ambiguousInstances.Add(record.Instance);
+                } else {
+                    result.Add(record.Instance, record);
+                }
             }
             return result;
         }

--- a/OfficeIMO.Reader.Core/OfficeDocumentModelTraversal.cs
+++ b/OfficeIMO.Reader.Core/OfficeDocumentModelTraversal.cs
@@ -8,20 +8,24 @@ namespace OfficeIMO.Reader;
 
 internal static class OfficeDocumentModelTraversal {
     internal static IEnumerable<OfficeDocumentBlock> Blocks(OfficeDocumentReadResult document) {
+        IEnumerable<OfficeDocumentBlock> candidates =
+            (document.Blocks ?? System.Array.Empty<OfficeDocumentBlock>())
+            .Concat((document.Pages ?? System.Array.Empty<OfficeDocumentPage>())
+                .Where(page => page?.Blocks != null)
+                .SelectMany(page => page.Blocks));
+        foreach (OfficeDocumentBlock block in OrderBlocks(candidates)) yield return block;
+    }
+
+    internal static IReadOnlyList<OfficeDocumentBlock> OrderBlocks(
+        IEnumerable<OfficeDocumentBlock> candidates) {
         var seen = new HashSet<OfficeDocumentBlock>(ReferenceIdentityComparer<OfficeDocumentBlock>.Instance);
         var ordered = new List<OrderedBlock>();
         int insertionIndex = 0;
-        foreach (OfficeDocumentBlock block in document.Blocks ?? System.Array.Empty<OfficeDocumentBlock>()) {
+        foreach (OfficeDocumentBlock block in candidates) {
             if (block != null && seen.Add(block)) ordered.Add(new OrderedBlock(block, insertionIndex++));
         }
-        foreach (OfficeDocumentPage page in document.Pages ?? System.Array.Empty<OfficeDocumentPage>()) {
-            if (page?.Blocks == null) continue;
-            foreach (OfficeDocumentBlock block in page.Blocks) {
-                if (block != null && seen.Add(block)) ordered.Add(new OrderedBlock(block, insertionIndex++));
-            }
-        }
         ordered.Sort(CompareBlocks);
-        for (int index = 0; index < ordered.Count; index++) yield return ordered[index].Block;
+        return ordered.Select(item => item.Block).ToArray();
     }
 
     internal static IEnumerable<ReaderTable> Tables(OfficeDocumentReadResult document) {

--- a/OfficeIMO.Reader.Core/OfficeDocumentModelTraversal.cs
+++ b/OfficeIMO.Reader.Core/OfficeDocumentModelTraversal.cs
@@ -17,12 +17,20 @@ internal static class OfficeDocumentModelTraversal {
     }
 
     internal static IReadOnlyList<OfficeDocumentBlock> OrderBlocks(
-        IEnumerable<OfficeDocumentBlock> candidates) {
+        IEnumerable<OfficeDocumentBlock> candidates) =>
+        OrderBlocks(candidates, static block => block.Location);
+
+    internal static IReadOnlyList<OfficeDocumentBlock> OrderBlocks(
+        IEnumerable<OfficeDocumentBlock> candidates,
+        Func<OfficeDocumentBlock, ReaderLocation?> locationSelector) {
+        if (locationSelector == null) throw new ArgumentNullException(nameof(locationSelector));
         var seen = new HashSet<OfficeDocumentBlock>(ReferenceIdentityComparer<OfficeDocumentBlock>.Instance);
         var ordered = new List<OrderedBlock>();
         int insertionIndex = 0;
         foreach (OfficeDocumentBlock block in candidates) {
-            if (block != null && seen.Add(block)) ordered.Add(new OrderedBlock(block, insertionIndex++));
+            if (block != null && seen.Add(block)) {
+                ordered.Add(new OrderedBlock(block, locationSelector(block), insertionIndex++));
+            }
         }
         ordered.Sort(CompareBlocks);
         return ordered.Select(item => item.Block).ToArray();
@@ -245,9 +253,9 @@ internal static class OfficeDocumentModelTraversal {
     }
 
     private static int CompareBlocks(OrderedBlock left, OrderedBlock right) {
-        int comparison = string.CompareOrdinal(BuildContainerOrderKey(left.Block.Location), BuildContainerOrderKey(right.Block.Location));
+        int comparison = string.CompareOrdinal(BuildContainerOrderKey(left.Location), BuildContainerOrderKey(right.Location));
         if (comparison != 0) return comparison;
-        comparison = BuildBlockPosition(left.Block.Location).CompareTo(BuildBlockPosition(right.Block.Location));
+        comparison = BuildBlockPosition(left.Location).CompareTo(BuildBlockPosition(right.Location));
         return comparison != 0 ? comparison : left.InsertionIndex.CompareTo(right.InsertionIndex);
     }
 
@@ -458,12 +466,14 @@ internal static class OfficeDocumentModelTraversal {
     }
 
     private readonly struct OrderedBlock {
-        internal OrderedBlock(OfficeDocumentBlock block, int insertionIndex) {
+        internal OrderedBlock(OfficeDocumentBlock block, ReaderLocation? location, int insertionIndex) {
             Block = block;
+            Location = location;
             InsertionIndex = insertionIndex;
         }
 
         internal OfficeDocumentBlock Block { get; }
+        internal ReaderLocation? Location { get; }
         internal int InsertionIndex { get; }
     }
 }

--- a/OfficeIMO.Reader.Core/ReaderHierarchicalChunker.cs
+++ b/OfficeIMO.Reader.Core/ReaderHierarchicalChunker.cs
@@ -290,7 +290,8 @@ public static partial class ReaderHierarchicalChunker {
             OfficeDocumentPage page = pages[pageIndex];
             if (page?.Blocks == null) continue;
             IReadOnlyList<OfficeDocumentBlock> pageBlocks = page.Blocks;
-            for (int blockIndex = 0;
+            int blockIndex = 0;
+            for (;
                  blockIndex < pageBlocks.Count && inspections < maximumInspections;
                  blockIndex++) {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -310,7 +311,7 @@ public static partial class ReaderHierarchicalChunker {
             }
             if (inspections >= maximumInspections) {
                 limitReached = pageIndex + 1 < pages.Count
-                    || pageBlocks.Count > 0;
+                    || blockIndex < pageBlocks.Count;
                 return new PageBlockIndex(byReference, byId);
             }
         }

--- a/OfficeIMO.Reader.Core/ReaderHierarchicalChunker.cs
+++ b/OfficeIMO.Reader.Core/ReaderHierarchicalChunker.cs
@@ -205,63 +205,32 @@ public static partial class ReaderHierarchicalChunker {
         IReadOnlyList<OfficeDocumentBlock> documentBlocks = document.Blocks ?? Array.Empty<OfficeDocumentBlock>();
         int documentInspectionCount = Math.Min(documentBlocks.Count, maximumInspections);
         var candidates = new List<OfficeDocumentBlock>(
-            Math.Min(documentInspectionCount, maximumInputChunks));
+            Math.Min(documentInspectionCount, maximumInspections));
         bool limitReached = documentBlocks.Count > documentInspectionCount;
         for (int blockIndex = 0; blockIndex < documentInspectionCount; blockIndex++) {
             cancellationToken.ThrowIfCancellationRequested();
             OfficeDocumentBlock block = documentBlocks[blockIndex];
             if (!TryRegisterFallbackBlock(block, seen, seenIds)) continue;
-            if (candidates.Count >= maximumInputChunks) {
-                limitReached = true;
-                break;
-            }
             candidates.Add(block);
         }
 
         int maximumPageIndexInspections = (int)Math.Min(
             int.MaxValue,
             (long)maximumInputChunks * PageIndexInspectionMultiplier);
-        PageBlockIndex pageIndex = IndexPageBlocks(
+        PageBlockIndex pageIndex = CollectPageFallbackBlocks(
             pages,
             candidates,
+            seen,
+            seenIds,
             maximumPageIndexInspections,
-            cancellationToken);
-
-        if (!limitReached) {
-            int inspectedPageEntries = 0;
-            for (int pageIndexValue = 0; pageIndexValue < pages.Count; pageIndexValue++) {
-                if (inspectedPageEntries >= maximumInspections) {
-                    limitReached = true;
-                    break;
-                }
-                cancellationToken.ThrowIfCancellationRequested();
-                inspectedPageEntries++;
-                OfficeDocumentPage page = pages[pageIndexValue];
-                if (page?.Blocks == null) continue;
-                IReadOnlyList<OfficeDocumentBlock> pageBlocks = page.Blocks;
-                for (int blockIndex = 0; blockIndex < pageBlocks.Count; blockIndex++) {
-                    if (inspectedPageEntries >= maximumInspections) {
-                        limitReached = true;
-                        break;
-                    }
-                    cancellationToken.ThrowIfCancellationRequested();
-                    inspectedPageEntries++;
-                    OfficeDocumentBlock block = pageBlocks[blockIndex];
-                    if (!TryRegisterFallbackBlock(block, seen, seenIds)) continue;
-                    if (candidates.Count >= maximumInputChunks) {
-                        limitReached = true;
-                        break;
-                    }
-                    candidates.Add(block);
-                    pageIndex.ByReference[block] = page;
-                    if (!string.IsNullOrWhiteSpace(block.Id)) pageIndex.ById[block.Id!] = page;
-                }
-                if (limitReached) break;
-            }
-        }
+            cancellationToken,
+            out bool pageInspectionLimitReached);
+        limitReached |= pageInspectionLimitReached;
 
         IReadOnlyList<OfficeDocumentBlock> ordered = OfficeDocumentModelTraversal.OrderBlocks(candidates);
-        for (int blockIndex = 0; blockIndex < ordered.Count; blockIndex++) {
+        if (ordered.Count > maximumInputChunks) limitReached = true;
+        int selectedCount = Math.Min(ordered.Count, maximumInputChunks);
+        for (int blockIndex = 0; blockIndex < selectedCount; blockIndex++) {
             OfficeDocumentBlock block = ordered[blockIndex];
             if (!pageIndex.ByReference.TryGetValue(block, out OfficeDocumentPage? page)
                 && !string.IsNullOrWhiteSpace(block.Id)) {
@@ -280,26 +249,23 @@ public static partial class ReaderHierarchicalChunker {
         return string.IsNullOrWhiteSpace(block.Id) || seenIds.Add(block.Id!);
     }
 
-    private static PageBlockIndex IndexPageBlocks(
+    private static PageBlockIndex CollectPageFallbackBlocks(
         IReadOnlyList<OfficeDocumentPage> pages,
-        IReadOnlyList<OfficeDocumentBlock> targetBlocks,
+        IList<OfficeDocumentBlock> candidates,
+        ISet<OfficeDocumentBlock> seen,
+        ISet<string> seenIds,
         int maximumInspections,
-        CancellationToken cancellationToken) {
+        CancellationToken cancellationToken,
+        out bool limitReached) {
         var byReference = new Dictionary<OfficeDocumentBlock, OfficeDocumentPage>(
             ReferenceIdentityComparer<OfficeDocumentBlock>.Instance);
         var byId = new Dictionary<string, OfficeDocumentPage>(StringComparer.Ordinal);
-        var remaining = new HashSet<OfficeDocumentBlock>(
-            targetBlocks,
-            ReferenceIdentityComparer<OfficeDocumentBlock>.Instance);
-        var targetsById = new Dictionary<string, OfficeDocumentBlock>(StringComparer.Ordinal);
-        for (int targetIndex = 0; targetIndex < targetBlocks.Count; targetIndex++) {
-            OfficeDocumentBlock target = targetBlocks[targetIndex];
-            if (!string.IsNullOrWhiteSpace(target.Id)) targetsById[target.Id!] = target;
-        }
+        limitReached = false;
 
         int inspections = 0;
         for (int pageIndex = 0; pageIndex < pages.Count; pageIndex++) {
             if (inspections >= maximumInspections) {
+                limitReached = true;
                 return new PageBlockIndex(byReference, byId);
             }
             cancellationToken.ThrowIfCancellationRequested();
@@ -314,18 +280,20 @@ public static partial class ReaderHierarchicalChunker {
                 OfficeDocumentBlock block = pageBlocks[blockIndex];
                 inspections++;
                 if (block == null) continue;
-                if (remaining.Contains(block)) {
+                if (seen.Contains(block)) {
                     byReference[block] = page;
-                    remaining.Remove(block);
                 }
-                if (!string.IsNullOrWhiteSpace(block.Id)
-                    && targetsById.TryGetValue(block.Id!, out OfficeDocumentBlock? target)) {
+                if (!string.IsNullOrWhiteSpace(block.Id) && seenIds.Contains(block.Id!)) {
                     byId[block.Id!] = page;
-                    remaining.Remove(target);
                 }
-                if (remaining.Count == 0) return new PageBlockIndex(byReference, byId);
+                if (!TryRegisterFallbackBlock(block, seen, seenIds)) continue;
+                candidates.Add(block);
+                byReference[block] = page;
+                if (!string.IsNullOrWhiteSpace(block.Id)) byId[block.Id!] = page;
             }
             if (inspections >= maximumInspections) {
+                limitReached = pageIndex + 1 < pages.Count
+                    || pageBlocks.Count > 0;
                 return new PageBlockIndex(byReference, byId);
             }
         }

--- a/OfficeIMO.Reader.Core/ReaderHierarchicalChunker.cs
+++ b/OfficeIMO.Reader.Core/ReaderHierarchicalChunker.cs
@@ -202,21 +202,20 @@ public static partial class ReaderHierarchicalChunker {
         var seenIds = new HashSet<string>(StringComparer.Ordinal);
         IReadOnlyList<OfficeDocumentPage> pages = document.Pages ?? Array.Empty<OfficeDocumentPage>();
         int maximumInspections = (int)Math.Min(int.MaxValue, (long)maximumInputChunks * 4L);
-        int emittedBlocks = 0;
         IReadOnlyList<OfficeDocumentBlock> documentBlocks = document.Blocks ?? Array.Empty<OfficeDocumentBlock>();
         int documentInspectionCount = Math.Min(documentBlocks.Count, maximumInspections);
-        var retainedDocumentBlocks = new List<OfficeDocumentBlock>(Math.Min(documentInspectionCount, maximumInputChunks));
-        bool documentLimitReached = documentBlocks.Count > documentInspectionCount;
+        var candidates = new List<OfficeDocumentBlock>(
+            Math.Min(documentInspectionCount, maximumInputChunks));
+        bool limitReached = documentBlocks.Count > documentInspectionCount;
         for (int blockIndex = 0; blockIndex < documentInspectionCount; blockIndex++) {
             cancellationToken.ThrowIfCancellationRequested();
             OfficeDocumentBlock block = documentBlocks[blockIndex];
             if (!TryRegisterFallbackBlock(block, seen, seenIds)) continue;
-            if (emittedBlocks >= maximumInputChunks) {
-                documentLimitReached = true;
+            if (candidates.Count >= maximumInputChunks) {
+                limitReached = true;
                 break;
             }
-            retainedDocumentBlocks.Add(block);
-            emittedBlocks++;
+            candidates.Add(block);
         }
 
         int maximumPageIndexInspections = (int)Math.Min(
@@ -224,49 +223,53 @@ public static partial class ReaderHierarchicalChunker {
             (long)maximumInputChunks * PageIndexInspectionMultiplier);
         PageBlockIndex pageIndex = IndexPageBlocks(
             pages,
-            retainedDocumentBlocks,
+            candidates,
             maximumPageIndexInspections,
             cancellationToken);
-        for (int blockIndex = 0; blockIndex < retainedDocumentBlocks.Count; blockIndex++) {
-            OfficeDocumentBlock block = retainedDocumentBlocks[blockIndex];
-            if (!pageIndex.ByReference.TryGetValue(block, out OfficeDocumentPage? page) && !string.IsNullOrWhiteSpace(block.Id)) {
+
+        if (!limitReached) {
+            int inspectedPageEntries = 0;
+            for (int pageIndexValue = 0; pageIndexValue < pages.Count; pageIndexValue++) {
+                if (inspectedPageEntries >= maximumInspections) {
+                    limitReached = true;
+                    break;
+                }
+                cancellationToken.ThrowIfCancellationRequested();
+                inspectedPageEntries++;
+                OfficeDocumentPage page = pages[pageIndexValue];
+                if (page?.Blocks == null) continue;
+                IReadOnlyList<OfficeDocumentBlock> pageBlocks = page.Blocks;
+                for (int blockIndex = 0; blockIndex < pageBlocks.Count; blockIndex++) {
+                    if (inspectedPageEntries >= maximumInspections) {
+                        limitReached = true;
+                        break;
+                    }
+                    cancellationToken.ThrowIfCancellationRequested();
+                    inspectedPageEntries++;
+                    OfficeDocumentBlock block = pageBlocks[blockIndex];
+                    if (!TryRegisterFallbackBlock(block, seen, seenIds)) continue;
+                    if (candidates.Count >= maximumInputChunks) {
+                        limitReached = true;
+                        break;
+                    }
+                    candidates.Add(block);
+                    pageIndex.ByReference[block] = page;
+                    if (!string.IsNullOrWhiteSpace(block.Id)) pageIndex.ById[block.Id!] = page;
+                }
+                if (limitReached) break;
+            }
+        }
+
+        IReadOnlyList<OfficeDocumentBlock> ordered = OfficeDocumentModelTraversal.OrderBlocks(candidates);
+        for (int blockIndex = 0; blockIndex < ordered.Count; blockIndex++) {
+            OfficeDocumentBlock block = ordered[blockIndex];
+            if (!pageIndex.ByReference.TryGetValue(block, out OfficeDocumentPage? page)
+                && !string.IsNullOrWhiteSpace(block.Id)) {
                 pageIndex.ById.TryGetValue(block.Id!, out page);
             }
             yield return new FallbackBlock(block, page);
         }
-        if (documentLimitReached) {
-            yield return FallbackBlock.LimitMarker;
-            yield break;
-        }
-
-        int inspectedPageEntries = 0;
-        for (int pageIndexValue = 0; pageIndexValue < pages.Count; pageIndexValue++) {
-            if (inspectedPageEntries >= maximumInspections) {
-                yield return FallbackBlock.LimitMarker;
-                yield break;
-            }
-            cancellationToken.ThrowIfCancellationRequested();
-            inspectedPageEntries++;
-            OfficeDocumentPage page = pages[pageIndexValue];
-            if (page?.Blocks == null) continue;
-            IReadOnlyList<OfficeDocumentBlock> pageBlocks = page.Blocks;
-            for (int blockIndex = 0; blockIndex < pageBlocks.Count; blockIndex++) {
-                if (inspectedPageEntries >= maximumInspections) {
-                    yield return FallbackBlock.LimitMarker;
-                    yield break;
-                }
-                cancellationToken.ThrowIfCancellationRequested();
-                inspectedPageEntries++;
-                OfficeDocumentBlock block = pageBlocks[blockIndex];
-                if (!TryRegisterFallbackBlock(block, seen, seenIds)) continue;
-                if (emittedBlocks >= maximumInputChunks) {
-                    yield return FallbackBlock.LimitMarker;
-                    yield break;
-                }
-                emittedBlocks++;
-                yield return new FallbackBlock(block, page);
-            }
-        }
+        if (limitReached) yield return FallbackBlock.LimitMarker;
     }
 
     private static bool TryRegisterFallbackBlock(
@@ -291,9 +294,7 @@ public static partial class ReaderHierarchicalChunker {
         var targetsById = new Dictionary<string, OfficeDocumentBlock>(StringComparer.Ordinal);
         for (int targetIndex = 0; targetIndex < targetBlocks.Count; targetIndex++) {
             OfficeDocumentBlock target = targetBlocks[targetIndex];
-            if (!string.IsNullOrWhiteSpace(target.Id)) {
-                targetsById[target.Id!] = target;
-            }
+            if (!string.IsNullOrWhiteSpace(target.Id)) targetsById[target.Id!] = target;
         }
 
         int inspections = 0;
@@ -317,8 +318,8 @@ public static partial class ReaderHierarchicalChunker {
                     byReference[block] = page;
                     remaining.Remove(block);
                 }
-                if (!string.IsNullOrWhiteSpace(block.Id) &&
-                    targetsById.TryGetValue(block.Id!, out OfficeDocumentBlock? target)) {
+                if (!string.IsNullOrWhiteSpace(block.Id)
+                    && targetsById.TryGetValue(block.Id!, out OfficeDocumentBlock? target)) {
                     byId[block.Id!] = page;
                     remaining.Remove(target);
                 }
@@ -333,14 +334,14 @@ public static partial class ReaderHierarchicalChunker {
 
     private sealed class PageBlockIndex {
         internal PageBlockIndex(
-            IReadOnlyDictionary<OfficeDocumentBlock, OfficeDocumentPage> byReference,
-            IReadOnlyDictionary<string, OfficeDocumentPage> byId) {
+            Dictionary<OfficeDocumentBlock, OfficeDocumentPage> byReference,
+            Dictionary<string, OfficeDocumentPage> byId) {
             ByReference = byReference;
             ById = byId;
         }
 
-        internal IReadOnlyDictionary<OfficeDocumentBlock, OfficeDocumentPage> ByReference { get; }
-        internal IReadOnlyDictionary<string, OfficeDocumentPage> ById { get; }
+        internal Dictionary<OfficeDocumentBlock, OfficeDocumentPage> ByReference { get; }
+        internal Dictionary<string, OfficeDocumentPage> ById { get; }
     }
 
     private static ReaderChunk InheritDocumentSource(ReaderChunk chunk, OfficeDocumentSource? source) {

--- a/OfficeIMO.Reader.Core/ReaderHierarchicalChunker.cs
+++ b/OfficeIMO.Reader.Core/ReaderHierarchicalChunker.cs
@@ -227,18 +227,35 @@ public static partial class ReaderHierarchicalChunker {
             out bool pageInspectionLimitReached);
         limitReached |= pageInspectionLimitReached;
 
-        IReadOnlyList<OfficeDocumentBlock> ordered = OfficeDocumentModelTraversal.OrderBlocks(candidates);
+        IReadOnlyList<OfficeDocumentBlock> ordered = OfficeDocumentModelTraversal.OrderBlocks(
+            candidates,
+            block => {
+                OfficeDocumentPage? page = ResolveFallbackPage(block, pageIndex);
+                ReaderLocation location = CloneLocation(block.Location);
+                InheritPageLocation(location, page);
+                return location;
+            });
         if (ordered.Count > maximumInputChunks) limitReached = true;
         int selectedCount = Math.Min(ordered.Count, maximumInputChunks);
         for (int blockIndex = 0; blockIndex < selectedCount; blockIndex++) {
             OfficeDocumentBlock block = ordered[blockIndex];
-            if (!pageIndex.ByReference.TryGetValue(block, out OfficeDocumentPage? page)
-                && !string.IsNullOrWhiteSpace(block.Id)) {
-                pageIndex.ById.TryGetValue(block.Id!, out page);
-            }
+            OfficeDocumentPage? page = ResolveFallbackPage(block, pageIndex);
             yield return new FallbackBlock(block, page);
         }
         if (limitReached) yield return FallbackBlock.LimitMarker;
+    }
+
+    private static OfficeDocumentPage? ResolveFallbackPage(
+        OfficeDocumentBlock block,
+        PageBlockIndex pageIndex) {
+        if (pageIndex.ByReference.TryGetValue(block, out OfficeDocumentPage? page)) {
+            return page;
+        }
+        if (!string.IsNullOrWhiteSpace(block.Id) &&
+            pageIndex.ById.TryGetValue(block.Id!, out page)) {
+            return page;
+        }
+        return null;
     }
 
     private static bool TryRegisterFallbackBlock(

--- a/OfficeIMO.Reader.Epub/EpubReaderAdapter.References.cs
+++ b/OfficeIMO.Reader.Epub/EpubReaderAdapter.References.cs
@@ -64,7 +64,8 @@ internal static partial class EpubReaderAdapter {
                 resolvedVisuals.Add(visual);
                 continue;
             }
-            if (string.Equals(visual.SourceName, "data-uri", StringComparison.Ordinal)) {
+            if (string.Equals(visual.SourceName, "data-uri", StringComparison.Ordinal)
+                && !string.IsNullOrWhiteSpace(visual.PayloadHash)) {
                 resolvedVisuals.Add(visual);
                 continue;
             }

--- a/OfficeIMO.Reader.Tests/Reader.Epub.Resources.Fixtures.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Epub.Resources.Fixtures.cs
@@ -23,6 +23,7 @@ public sealed partial class ReaderEpubModularTests {
             "<item id=\"second\" href=\"text/second.xhtml\" media-type=\"application/xhtml+xml\"/>" +
             "<item id=\"cover\" href=\"shared/images/cover%20art.png\" media-type=\"image/png\"/>" +
             "<item id=\"reserved-image\" href=\"shared/images/cover%23v2.png\" media-type=\"image/png\"/>" +
+            "<item id=\"literal-data-uri\" href=\"shared/data-uri\" media-type=\"image/png\"/>" +
             "<item id=\"root-image\" href=\"shared/images/root.png\" media-type=\"image/png\"/>" +
             "<item id=\"audio\" href=\"shared/audio/chapter.mp3\" media-type=\"audio/mpeg\"/>" +
             "<item id=\"video\" href=\"shared/video/clip.mp4\" media-type=\"video/mp4\"/>" +
@@ -38,6 +39,7 @@ public sealed partial class ReaderEpubModularTests {
             "<a href=\"../text/chapter.xhtml?mode=print#local\">base link</a>" +
             "<img src=\"images/cover%20art.png?display=1#front\" alt=\"Cover\"/>" +
             "<img src=\"images/cover%23v2.png\" alt=\"Reserved name\"/>" +
+            "<img src=\"data-uri\" alt=\"Literal data-uri path\"/>" +
             "<img src=\"/EPUB/shared/images/root.png\" alt=\"Root image\"/>" +
             "<img src=\"https://cdn.example/remote.png#v2\" alt=\"Remote image\"/>" +
             "<img src=\"data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==\" alt=\"Inline\"/>" +
@@ -58,6 +60,7 @@ public sealed partial class ReaderEpubModularTests {
 
         WriteResolvedResourceBytes(archive, "EPUB/shared/images/cover art.png", new byte[] { 137, 80, 78, 71 });
         WriteResolvedResourceBytes(archive, "EPUB/shared/images/cover#v2.png", new byte[] { 137, 80, 78, 71, 2 });
+        WriteResolvedResourceBytes(archive, "EPUB/shared/data-uri", new byte[] { 137, 80, 78, 71, 3 });
         WriteResolvedResourceBytes(archive, "EPUB/shared/images/root.png", new byte[] { 137, 80, 78, 71, 1 });
         WriteResolvedResourceBytes(archive, "EPUB/shared/audio/chapter.mp3", new byte[] { 73, 68, 51, 4 });
         WriteResolvedResourceBytes(archive, "EPUB/shared/video/clip.mp4", new byte[] { 0, 0, 0, 20, 102, 116, 121, 112 });

--- a/OfficeIMO.Reader.Tests/Reader.Epub.Resources.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Epub.Resources.cs
@@ -48,6 +48,9 @@ public sealed partial class ReaderEpubModularTests {
             Assert.Contains(result.Visuals, visual =>
                 visual.Language == "img" &&
                 visual.SourceName == prefix + "EPUB/shared/images/cover%23v2.png");
+            Assert.Contains(result.Visuals, visual =>
+                visual.Language == "img" &&
+                visual.SourceName == prefix + "EPUB/shared/data-uri");
 
             OfficeDocumentAsset rootImage = Assert.Single(result.Assets, asset => asset.SourceObjectId == "root-image");
             Assert.Contains(result.Pages[0].Assets, asset => ReferenceEquals(asset, rootImage));

--- a/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
+++ b/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
@@ -466,21 +466,27 @@ public sealed class ReaderHierarchicalChunkingTests {
         var pageOneBody = new OfficeDocumentBlock {
             Id = "p1-body",
             Kind = "paragraph",
-            Text = "First body",
-            Location = new ReaderLocation { Page = 1, SourceBlockIndex = 1 }
+            Text = "First body"
         };
         var pageTwoBody = new OfficeDocumentBlock {
             Id = "p2-body",
             Kind = "paragraph",
-            Text = "Second body",
-            Location = new ReaderLocation { Page = 2, SourceBlockIndex = 1 }
+            Text = "Second body"
         };
         var document = new OfficeDocumentReadResult {
             Kind = ReaderInputKind.Text,
             Blocks = new[] { pageOneHeading, pageTwoHeading },
             Pages = new[] {
-                new OfficeDocumentPage { Number = 1, Blocks = new[] { pageOneBody } },
-                new OfficeDocumentPage { Number = 2, Blocks = new[] { pageTwoBody } }
+                new OfficeDocumentPage {
+                    Number = 1,
+                    Location = new ReaderLocation { Page = 1 },
+                    Blocks = new[] { pageOneBody }
+                },
+                new OfficeDocumentPage {
+                    Number = 2,
+                    Location = new ReaderLocation { Page = 2 },
+                    Blocks = new[] { pageTwoBody }
+                }
             }
         };
 
@@ -545,7 +551,7 @@ public sealed class ReaderHierarchicalChunkingTests {
     }
 
     [Fact]
-    public void Chunk_InheritsPageLocationPastUnrelatedPageBlocks() {
+    public void Chunk_OrdersEarlierPageBlocksAndInheritsLaterAggregatePageLocation() {
         var retained = new OfficeDocumentBlock { Id = "retained", Text = "body" };
         var unrelated = new OfficeDocumentBlock { Id = "unrelated", Text = "other" };
         var document = new OfficeDocumentReadResult {
@@ -561,13 +567,14 @@ public sealed class ReaderHierarchicalChunkingTests {
             new ReaderHierarchicalChunkingOptions {
                 MaxTokens = 10,
                 OverlapTokens = 0,
-                MaxInputChunks = 1,
+                MaxInputChunks = 2,
                 IncludeContextInText = false,
                 TokenCounter = WordCounter
             });
 
-        ReaderChunk chunk = Assert.Single(result.Chunks);
-        Assert.Equal(2, chunk.Location.Page);
+        Assert.Equal(new[] { "other", "body" }, result.Chunks.Select(chunk => chunk.Text));
+        Assert.Equal(1, result.Chunks[0].Location.Page);
+        Assert.Equal(2, result.Chunks[1].Location.Page);
     }
 
     [Fact]

--- a/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
+++ b/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
@@ -499,6 +499,23 @@ public sealed class ReaderHierarchicalChunkingTests {
             result.Chunks.Select(chunk => chunk.Text));
         Assert.Equal("Page one", result.Chunks[1].Location.HeadingPath);
         Assert.Equal("Page two", result.Chunks[3].Location.HeadingPath);
+
+        ReaderChunkHierarchyResult bounded = ReaderHierarchicalChunker.Chunk(
+            document,
+            new ReaderHierarchicalChunkingOptions {
+                MaxTokens = 20,
+                OverlapTokens = 0,
+                MaxInputChunks = 2,
+                IncludeContextInText = false,
+                TokenCounter = WordCounter
+            });
+
+        Assert.Equal(
+            new[] { "Page one", "First body" },
+            bounded.Chunks.Select(chunk => chunk.Text));
+        Assert.Contains(
+            bounded.Diagnostics,
+            diagnostic => diagnostic.Code == "hierarchical-input-chunk-limit");
     }
 
     [Fact]
@@ -658,7 +675,7 @@ public sealed class ReaderHierarchicalChunkingTests {
             });
 
         Assert.Single(result.Chunks);
-        Assert.Equal(20, pages.ReadCount);
+        Assert.Equal(16, pages.ReadCount);
         Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "hierarchical-input-chunk-limit");
     }
 

--- a/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
+++ b/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
@@ -448,6 +448,60 @@ public sealed class ReaderHierarchicalChunkingTests {
     }
 
     [Fact]
+    public void Chunk_OrdersFallbackPageBodiesBeforeLaterPageHeadings() {
+        var pageOneHeading = new OfficeDocumentBlock {
+            Id = "p1-heading",
+            Kind = "heading",
+            Level = 1,
+            Text = "Page one",
+            Location = new ReaderLocation { Page = 1, SourceBlockIndex = 0 }
+        };
+        var pageTwoHeading = new OfficeDocumentBlock {
+            Id = "p2-heading",
+            Kind = "heading",
+            Level = 1,
+            Text = "Page two",
+            Location = new ReaderLocation { Page = 2, SourceBlockIndex = 0 }
+        };
+        var pageOneBody = new OfficeDocumentBlock {
+            Id = "p1-body",
+            Kind = "paragraph",
+            Text = "First body",
+            Location = new ReaderLocation { Page = 1, SourceBlockIndex = 1 }
+        };
+        var pageTwoBody = new OfficeDocumentBlock {
+            Id = "p2-body",
+            Kind = "paragraph",
+            Text = "Second body",
+            Location = new ReaderLocation { Page = 2, SourceBlockIndex = 1 }
+        };
+        var document = new OfficeDocumentReadResult {
+            Kind = ReaderInputKind.Text,
+            Blocks = new[] { pageOneHeading, pageTwoHeading },
+            Pages = new[] {
+                new OfficeDocumentPage { Number = 1, Blocks = new[] { pageOneBody } },
+                new OfficeDocumentPage { Number = 2, Blocks = new[] { pageTwoBody } }
+            }
+        };
+
+        ReaderChunkHierarchyResult result = ReaderHierarchicalChunker.Chunk(
+            document,
+            new ReaderHierarchicalChunkingOptions {
+                MaxTokens = 20,
+                OverlapTokens = 0,
+                MaxInputChunks = 8,
+                IncludeContextInText = false,
+                TokenCounter = WordCounter
+            });
+
+        Assert.Equal(
+            new[] { "Page one", "First body", "Page two", "Second body" },
+            result.Chunks.Select(chunk => chunk.Text));
+        Assert.Equal("Page one", result.Chunks[1].Location.HeadingPath);
+        Assert.Equal("Page two", result.Chunks[3].Location.HeadingPath);
+    }
+
+    [Fact]
     public void Chunk_InheritsPageLocationBeyondInputChunkOrdinal() {
         var block = new OfficeDocumentBlock { Id = "retained", Text = "body" };
         var document = new OfficeDocumentReadResult {

--- a/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
+++ b/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
@@ -604,6 +604,32 @@ public sealed class ReaderHierarchicalChunkingTests {
     }
 
     [Fact]
+    public void Chunk_DoesNotReportPageInspectionLimitAtExactFinalBlock() {
+        var retained = new OfficeDocumentBlock { Id = "retained", Text = "body" };
+        OfficeDocumentBlock[] pageBlocks = Enumerable.Repeat(retained, 15).ToArray();
+        var document = new OfficeDocumentReadResult {
+            Kind = ReaderInputKind.Text,
+            Blocks = new[] { retained },
+            Pages = new[] { new OfficeDocumentPage { Number = 7, Blocks = pageBlocks } }
+        };
+
+        ReaderChunkHierarchyResult result = ReaderHierarchicalChunker.Chunk(document,
+            new ReaderHierarchicalChunkingOptions {
+                MaxTokens = 10,
+                OverlapTokens = 0,
+                MaxInputChunks = 1,
+                IncludeContextInText = false,
+                TokenCounter = WordCounter
+            });
+
+        ReaderChunk chunk = Assert.Single(result.Chunks);
+        Assert.Equal(7, chunk.Location.Page);
+        Assert.DoesNotContain(
+            result.Diagnostics,
+            diagnostic => diagnostic.Code == "hierarchical-input-chunk-limit");
+    }
+
+    [Fact]
     public void Chunk_BoundsPageIndexInspectionWhenRetainedBlocksAreMissing() {
         var retained = new OfficeDocumentBlock { Id = "retained", Text = "body" };
         var unrelated = new OfficeDocumentBlock { Id = "unrelated", Text = "other" };

--- a/OfficeIMO.Shared.Tests/EpubReferenceContracts.cs
+++ b/OfficeIMO.Shared.Tests/EpubReferenceContracts.cs
@@ -157,4 +157,15 @@ public sealed class EpubReferenceContractTests {
         Assert.Equal("EPUB/shared/?edition=2#notes", directory.ResolvedValue);
         Assert.Equal("EPUB/text/appendix.xhtml?edition=3#notes", document.ResolvedValue);
     }
+
+    [Fact]
+    public void Resolve_BindsFragmentOnlyReferenceToContainerRootWithoutSlashPath() {
+        EpubReference reference = EpubReference.Resolve(
+            "chapter.xhtml",
+            "/",
+            "#notes");
+
+        Assert.Equal(string.Empty, reference.ContainerPath);
+        Assert.Equal("#notes", reference.ResolvedValue);
+    }
 }

--- a/OfficeIMO.Shared.Tests/EpubReferenceContracts.cs
+++ b/OfficeIMO.Shared.Tests/EpubReferenceContracts.cs
@@ -159,13 +159,13 @@ public sealed class EpubReferenceContractTests {
     }
 
     [Fact]
-    public void Resolve_BindsFragmentOnlyReferenceToContainerRootWithoutSlashPath() {
+    public void Resolve_BindsFragmentOnlyReferenceToContainerRoot() {
         EpubReference reference = EpubReference.Resolve(
             "chapter.xhtml",
             "/",
             "#notes");
 
-        Assert.Equal(string.Empty, reference.ContainerPath);
-        Assert.Equal("#notes", reference.ResolvedValue);
+        Assert.Equal("/", reference.ContainerPath);
+        Assert.Equal("/#notes", reference.ResolvedValue);
     }
 }

--- a/OfficeIMO.Word.Tests/Word.Security.AllSeverityBatch19.cs
+++ b/OfficeIMO.Word.Tests/Word.Security.AllSeverityBatch19.cs
@@ -1,0 +1,25 @@
+using DocumentFormat.OpenXml.Validation;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class WordAllSeverityBatch19SecurityTests {
+    [Fact]
+    public void AutomaticColorSentinelRemainsLowercaseAcrossPublicColorSetters() {
+        using WordDocument document = WordDocument.Create();
+        WordParagraph paragraph = document.AddParagraph("automatic");
+        paragraph.ColorHex = "AUTO";
+        document.Borders.LeftStyle = BorderValues.Single;
+        document.Borders.LeftColorHex = "Auto";
+        WordTableCell cell = document.AddTable(1, 1).Rows[0].Cells[0];
+        cell.Borders.TopStyle = BorderValues.Single;
+        cell.Borders.TopColorHex = "aUtO";
+
+        Assert.Equal("auto", paragraph.ColorHex);
+        Assert.Equal("auto", document.Borders.LeftColorHex);
+        Assert.Equal("auto", cell.Borders.TopColorHex);
+        Assert.Empty(new OpenXmlValidator().Validate(document._wordprocessingDocument));
+    }
+}

--- a/OfficeIMO.Word/Helpers.cs
+++ b/OfficeIMO.Word/Helpers.cs
@@ -57,6 +57,17 @@ namespace OfficeIMO.Word {
             }
         }
 
+        internal static string? NormalizeOpenXmlColor(string? color) {
+            if (color == null) {
+                return null;
+            }
+
+            string normalized = color.Replace("#", string.Empty);
+            return string.Equals(normalized, "auto", StringComparison.OrdinalIgnoreCase)
+                ? "auto"
+                : normalized.ToUpperInvariant();
+        }
+
         internal static TResult UseSeekableImageStream<TResult>(Stream imageStream, Func<Stream, TResult> action) {
             if (imageStream == null) {
                 throw new ArgumentNullException(nameof(imageStream));

--- a/OfficeIMO.Word/WordBorders.cs
+++ b/OfficeIMO.Word/WordBorders.cs
@@ -60,7 +60,7 @@ namespace OfficeIMO.Word {
         public string? LeftColorHex {
             get {
                 var color = _section._sectionProperties.GetFirstChild<PageBorders>()?.LeftBorder?.Color?.Value;
-                return color != null ? color.Replace("#", "").ToUpperInvariant() : null;
+                return Helpers.NormalizeOpenXmlColor(color);
             }
             set {
                 var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
@@ -70,7 +70,7 @@ namespace OfficeIMO.Word {
                 }
 
                 var leftBorder = pageBorder.LeftBorder ?? (pageBorder.LeftBorder = new LeftBorder());
-                leftBorder.Color = value?.Replace("#", "").ToUpperInvariant();
+                leftBorder.Color = Helpers.NormalizeOpenXmlColor(value);
             }
         }
 
@@ -194,7 +194,7 @@ namespace OfficeIMO.Word {
         public string? RightColorHex {
             get {
                 var color = _section._sectionProperties.GetFirstChild<PageBorders>()?.RightBorder?.Color?.Value;
-                return color != null ? color.Replace("#", "").ToUpperInvariant() : null;
+                return Helpers.NormalizeOpenXmlColor(color);
             }
             set {
                 var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
@@ -204,7 +204,7 @@ namespace OfficeIMO.Word {
                 }
 
                 var rightBorder = pageBorder.RightBorder ?? (pageBorder.RightBorder = new RightBorder());
-                rightBorder.Color = value?.Replace("#", "").ToUpperInvariant();
+                rightBorder.Color = Helpers.NormalizeOpenXmlColor(value);
             }
         }
 
@@ -328,7 +328,7 @@ namespace OfficeIMO.Word {
         public string? TopColorHex {
             get {
                 var color = _section._sectionProperties.GetFirstChild<PageBorders>()?.TopBorder?.Color?.Value;
-                return color != null ? color.Replace("#", "").ToUpperInvariant() : null;
+                return Helpers.NormalizeOpenXmlColor(color);
             }
             set {
                 var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
@@ -338,7 +338,7 @@ namespace OfficeIMO.Word {
                 }
 
                 var topBorder = pageBorder.TopBorder ?? (pageBorder.TopBorder = new TopBorder());
-                topBorder.Color = value?.Replace("#", "").ToUpperInvariant();
+                topBorder.Color = Helpers.NormalizeOpenXmlColor(value);
             }
         }
 
@@ -465,7 +465,7 @@ namespace OfficeIMO.Word {
         public string? BottomColorHex {
             get {
                 var color = _section._sectionProperties.GetFirstChild<PageBorders>()?.BottomBorder?.Color?.Value;
-                return color != null ? color.Replace("#", "").ToUpperInvariant() : null;
+                return Helpers.NormalizeOpenXmlColor(color);
             }
             set {
                 var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
@@ -475,7 +475,7 @@ namespace OfficeIMO.Word {
                 }
 
                 var bottomBorder = pageBorder.BottomBorder ?? (pageBorder.BottomBorder = new BottomBorder());
-                bottomBorder.Color = value?.Replace("#", "").ToUpperInvariant();
+                bottomBorder.Color = Helpers.NormalizeOpenXmlColor(value);
             }
         }
 

--- a/OfficeIMO.Word/WordParagraph.RunProperties.cs
+++ b/OfficeIMO.Word/WordParagraph.RunProperties.cs
@@ -338,7 +338,7 @@ namespace OfficeIMO.Word {
                 }
                 if (value != "") {
                     var color = new DocumentFormat.OpenXml.Wordprocessing.Color();
-                    color.Val = value.Replace("#", "").ToUpperInvariant();
+                    color.Val = Helpers.NormalizeOpenXmlColor(value);
                     runProperties.Color = color;
                 } else {
                     if (runProperties.Color != null) runProperties.Color.Remove();

--- a/OfficeIMO.Word/WordTableCellBorder.cs
+++ b/OfficeIMO.Word/WordTableCellBorder.cs
@@ -68,11 +68,11 @@ namespace OfficeIMO.Word {
         /// </summary>
         public string? LeftColorHex {
             get {
-                return BordersOrNull?.LeftBorder?.Color?.Value?.Replace("#", "").ToUpperInvariant();
+                return BordersOrNull?.LeftBorder?.Color?.Value is string color ? Helpers.NormalizeOpenXmlColor(color) : null;
             }
             set {
                 var lb = EnsureLeft();
-                lb.Color = value?.Replace("#", "").ToUpperInvariant();
+                lb.Color = Helpers.NormalizeOpenXmlColor(value);
             }
         }
 
@@ -132,11 +132,11 @@ namespace OfficeIMO.Word {
         /// </summary>
         public string? RightColorHex {
             get {
-                return BordersOrNull?.RightBorder?.Color?.Value?.Replace("#", "").ToUpperInvariant();
+                return BordersOrNull?.RightBorder?.Color?.Value is string color ? Helpers.NormalizeOpenXmlColor(color) : null;
             }
             set {
                 var rb = EnsureRight();
-                rb.Color = value?.Replace("#", "").ToUpperInvariant();
+                rb.Color = Helpers.NormalizeOpenXmlColor(value);
             }
         }
 
@@ -198,11 +198,11 @@ namespace OfficeIMO.Word {
         /// </summary>
         public string? TopColorHex {
             get {
-                return BordersOrNull?.TopBorder?.Color?.Value?.Replace("#", "").ToUpperInvariant();
+                return BordersOrNull?.TopBorder?.Color?.Value is string color ? Helpers.NormalizeOpenXmlColor(color) : null;
             }
             set {
                 var tb = EnsureTop();
-                tb.Color = value?.Replace("#", "").ToUpperInvariant();
+                tb.Color = Helpers.NormalizeOpenXmlColor(value);
             }
         }
 
@@ -267,11 +267,11 @@ namespace OfficeIMO.Word {
         /// </summary>
         public string? BottomColorHex {
             get {
-                return BordersOrNull?.BottomBorder?.Color?.Value?.Replace("#", "").ToUpperInvariant();
+                return BordersOrNull?.BottomBorder?.Color?.Value is string color ? Helpers.NormalizeOpenXmlColor(color) : null;
             }
             set {
                 var bb = EnsureBottom();
-                bb.Color = value?.Replace("#", "").ToUpperInvariant();
+                bb.Color = Helpers.NormalizeOpenXmlColor(value);
             }
         }
 
@@ -338,11 +338,11 @@ namespace OfficeIMO.Word {
         /// </summary>
         public string? InsideHorizontalColorHex {
             get {
-                return BordersOrNull?.InsideHorizontalBorder?.Color?.Value?.Replace("#", "").ToUpperInvariant();
+                return BordersOrNull?.InsideHorizontalBorder?.Color?.Value is string color ? Helpers.NormalizeOpenXmlColor(color) : null;
             }
             set {
                 var hb = EnsureInsideHorizontal();
-                hb.Color = value?.Replace("#", "").ToUpperInvariant();
+                hb.Color = Helpers.NormalizeOpenXmlColor(value);
             }
         }
 
@@ -409,11 +409,11 @@ namespace OfficeIMO.Word {
         /// </summary>
         public string? InsideVerticalColorHex {
             get {
-                return BordersOrNull?.InsideVerticalBorder?.Color?.Value?.Replace("#", "").ToUpperInvariant();
+                return BordersOrNull?.InsideVerticalBorder?.Color?.Value is string color ? Helpers.NormalizeOpenXmlColor(color) : null;
             }
             set {
                 var vb = EnsureInsideVertical();
-                vb.Color = value?.Replace("#", "").ToUpperInvariant();
+                vb.Color = Helpers.NormalizeOpenXmlColor(value);
             }
         }
 
@@ -477,11 +477,11 @@ namespace OfficeIMO.Word {
         /// </summary>
         public string? StartColorHex {
             get {
-                return BordersOrNull?.StartBorder?.Color?.Value?.Replace("#", "").ToUpperInvariant();
+                return BordersOrNull?.StartBorder?.Color?.Value is string color ? Helpers.NormalizeOpenXmlColor(color) : null;
             }
             set {
                 var sb = EnsureStart();
-                sb.Color = value?.Replace("#", "").ToUpperInvariant();
+                sb.Color = Helpers.NormalizeOpenXmlColor(value);
             }
         }
 
@@ -545,11 +545,11 @@ namespace OfficeIMO.Word {
         /// </summary>
         public string? EndColorHex {
             get {
-                return BordersOrNull?.EndBorder?.Color?.Value?.Replace("#", "").ToUpperInvariant();
+                return BordersOrNull?.EndBorder?.Color?.Value is string color ? Helpers.NormalizeOpenXmlColor(color) : null;
             }
             set {
                 var eb = EnsureEnd();
-                eb.Color = value?.Replace("#", "").ToUpperInvariant();
+                eb.Color = Helpers.NormalizeOpenXmlColor(value);
             }
         }
 
@@ -620,11 +620,11 @@ namespace OfficeIMO.Word {
         /// </summary>
         public string? TopLeftToBottomRightColorHex {
             get {
-                return BordersOrNull?.TopLeftToBottomRightCellBorder?.Color?.Value?.Replace("#", "").ToUpperInvariant();
+                return BordersOrNull?.TopLeftToBottomRightCellBorder?.Color?.Value is string color ? Helpers.NormalizeOpenXmlColor(color) : null;
             }
             set {
                 var d = EnsureTLBR();
-                d.Color = value?.Replace("#", "").ToUpperInvariant();
+                d.Color = Helpers.NormalizeOpenXmlColor(value);
             }
         }
 
@@ -686,11 +686,11 @@ namespace OfficeIMO.Word {
         /// </summary>
         public string? TopRightToBottomLeftColorHex {
             get {
-                return BordersOrNull?.TopRightToBottomLeftCellBorder?.Color?.Value?.Replace("#", "").ToUpperInvariant();
+                return BordersOrNull?.TopRightToBottomLeftCellBorder?.Color?.Value is string color ? Helpers.NormalizeOpenXmlColor(color) : null;
             }
             set {
                 var d = EnsureTRBL();
-                d.Color = value?.Replace("#", "").ToUpperInvariant();
+                d.Color = Helpers.NormalizeOpenXmlColor(value);
             }
         }
 


### PR DESCRIPTION
## Summary

- preserve valid formulas, structured references, math markup, colors, hyperlinks, EPUB resources, and legacy drawing/PowerPoint semantics while rejecting malformed input safely
- bound XLSB rewriting and Google Sheets grid growth, including the spreadsheet-wide 10-million-cell limit and generated chart-data sheets
- retain public drawing source and binary compatibility, including named optional positioned-text arguments
- restore source-ordered Reader fallback chunking before the input cap, while keeping page inspection bounded
- harden PDF ink annotations and bookmark destinations against null or non-finite values

## Compatibility

Shared formulas distinguish registered functions from Excel whitespace intersections, including parenthesized single-cell and range operands. Legacy drawing signatures remain discoverable by existing binaries and the earlier optional source contract remains callable. Reader fallback blocks from document and page projections are combined in source order before truncation.

## Validation

- focused regressions pass on .NET 8 and .NET 10 for all affected components
- Reader hierarchical chunking: 52/52 on .NET 8 and .NET 10
- Google Sheets compiler regression set: 16/16 on .NET 8, plus the focused aggregate-limit checks on both runtimes
- HTML rendering: 419/419 on .NET 8 and .NET 10
- affected netstandard2.0 production builds complete with zero warnings
- independent read-only security/compatibility review and the allowed targeted confirmation completed cleanly