### PR TITLE
Preserve document contracts and stabilize bounded processing

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -956,6 +956,7 @@ jobs:
               "OfficeIMO.Tests.MarkdownAllSeverityBatch11SecurityTests",
               "OfficeIMO.Tests.MarkdownAllSeverityBatch12SecurityTests",
               "OfficeIMO.Tests.MarkdownAllSeverityBatch15SecurityTests",
+              "OfficeIMO.Tests.MarkdownAllSeverityBatch21Tests",
           )
 
           unassigned = [name for name in discovered if not any(partition in name for partition in markdown_partitions)]
@@ -981,7 +982,7 @@ jobs:
               ;;
             markdown-suite)
               run_markdown_tests "markdown-suite" 'FullyQualifiedName~OfficeIMO.Tests.MarkdownSuite'
-              run_markdown_tests "markdown-named" 'FullyQualifiedName~OfficeIMO.Tests.MarkdownHtmlToMarkdownCompatibilityTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownHtmlToMarkdownTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownHtmlApiContracts|FullyQualifiedName~OfficeIMO.Tests.Markdown_|FullyQualifiedName~OfficeIMO.Tests.MarkdownTranscript|FullyQualifiedName~OfficeIMO.Tests.MarkdownReaderBomTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownBlankLinesTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownDefinitionLinesTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownOrderedListsTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownStreamingPreviewTests|FullyQualifiedName~OfficeIMO.Tests.Markdown_Renderer|FullyQualifiedName~OfficeIMO.Tests.Markdown_IntelligenceX|FullyQualifiedName~OfficeIMO.Tests.MarkdownAllSeverityBatch11SecurityTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownAllSeverityBatch12SecurityTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownAllSeverityBatch15SecurityTests'
+              run_markdown_tests "markdown-named" 'FullyQualifiedName~OfficeIMO.Tests.MarkdownHtmlToMarkdownCompatibilityTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownHtmlToMarkdownTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownHtmlApiContracts|FullyQualifiedName~OfficeIMO.Tests.Markdown_|FullyQualifiedName~OfficeIMO.Tests.MarkdownTranscript|FullyQualifiedName~OfficeIMO.Tests.MarkdownReaderBomTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownBlankLinesTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownDefinitionLinesTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownOrderedListsTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownStreamingPreviewTests|FullyQualifiedName~OfficeIMO.Tests.Markdown_Renderer|FullyQualifiedName~OfficeIMO.Tests.Markdown_IntelligenceX|FullyQualifiedName~OfficeIMO.Tests.MarkdownAllSeverityBatch11SecurityTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownAllSeverityBatch12SecurityTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownAllSeverityBatch15SecurityTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownAllSeverityBatch21Tests'
               ;;
             pdf-visual-inspector)
               export OFFICEIMO_REQUIRE_PDF_RASTERIZER=1

--- a/OfficeIMO.Email.Tests/Writing/EmailContentSourceTests.cs
+++ b/OfficeIMO.Email.Tests/Writing/EmailContentSourceTests.cs
@@ -165,8 +165,10 @@ public sealed class EmailContentSourceTests {
             Assert.True(result.UsesFileBackedContent);
             Assert.Null(attachment.Content);
             Assert.Equal(payloadLength, attachment.ContentSource!.Length);
-            Assert.True(retainedGrowth <= 8L * 1024 * 1024,
-                $"Retained managed memory grew by {retainedGrowth:N0} bytes for a {payloadLength:N0}-byte attachment.");
+            long maximumRetainedGrowth = (payloadLength / 2L) + (1024L * 1024L);
+            Assert.True(retainedGrowth <= maximumRetainedGrowth,
+                $"Retained managed memory grew by {retainedGrowth:N0} bytes for a {payloadLength:N0}-byte attachment; " +
+                $"the bounded allowance was {maximumRetainedGrowth:N0} bytes.");
         } finally {
             try { if (File.Exists(path)) File.Delete(path); }
             catch (IOException) { }

--- a/OfficeIMO.Excel.Tests/Excel.DataTableInsert.cs
+++ b/OfficeIMO.Excel.Tests/Excel.DataTableInsert.cs
@@ -661,6 +661,41 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_AppendDataTableToTable_HiddenHeadersRejectMissingNamedColumn() {
+            string filePath = Path.Combine(_directoryWithFiles, "DataTableAppendTableHiddenHeadersMissingColumn.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorksheet("Sales");
+
+                var table = new DataTable();
+                table.Columns.Add("Region", typeof(string));
+                table.Columns.Add("Revenue", typeof(int));
+                table.Rows.Add("NA", 100);
+                sheet.InsertDataTableAsTable(table, tableName: "HiddenHeaderSales");
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true)) {
+                Table table = spreadsheet.WorkbookPart!.WorksheetParts.First().TableDefinitionParts.First().Table;
+                table.HeaderRowCount = 0U;
+                table.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath)) {
+                var append = new DataTable();
+                append.Columns.Add("Revenue", typeof(int));
+                append.Columns.Add("Foo", typeof(string));
+                append.Rows.Add(150, "misrouted");
+
+                var exception = Assert.Throws<ArgumentException>(() =>
+                    document.Sheets[0].AppendDataTableToTable(append, "HiddenHeaderSales"));
+                Assert.Contains("Region", exception.Message);
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
         public void Test_AppendDataTableToTable_ColumnLikeHeadersUseHeaderMapping() {
             string filePath = Path.Combine(_directoryWithFiles, "DataTableAppendTableColumnLikeHeaders.xlsx");
 

--- a/OfficeIMO.Excel.Tests/Excel.DataTableInsert.cs
+++ b/OfficeIMO.Excel.Tests/Excel.DataTableInsert.cs
@@ -587,6 +587,37 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_AppendDataTableToTable_HeaderlessDefaultColumnsRemainPositional() {
+            string filePath = Path.Combine(_directoryWithFiles, "DataTableAppendTableHeaderlessDefaultColumns.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorksheet("Sales");
+
+                var table = new DataTable();
+                table.Columns.Add("Region", typeof(string));
+                table.Columns.Add("Revenue", typeof(int));
+                table.Rows.Add("NA", 100);
+                sheet.InsertDataTableAsTable(table, includeHeaders: false, tableName: "HeaderlessSales");
+
+                var append = new DataTable();
+                append.Columns.Add("Column2", typeof(string));
+                append.Columns.Add("Column1", typeof(string));
+                append.Rows.Add("first-position", "second-position");
+
+                Assert.Equal("A1:B2", sheet.AppendDataTableToTable(append, "HeaderlessSales"));
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                Assert.Equal("first-position", GetCellText(spreadsheet, worksheetPart, "A2"));
+                Assert.Equal("second-position", GetCellText(spreadsheet, worksheetPart, "B2"));
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
         public void Test_AppendDataTableToTable_HiddenHeadersUseMatchingColumnNames() {
             string filePath = Path.Combine(_directoryWithFiles, "DataTableAppendTableHiddenHeaders.xlsx");
 

--- a/OfficeIMO.Excel.Tests/Excel.Security.AllSeverityBatch21.cs
+++ b/OfficeIMO.Excel.Tests/Excel.Security.AllSeverityBatch21.cs
@@ -1,0 +1,73 @@
+using System.Reflection;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public class ExcelAllSeverityBatch21Tests {
+    [Fact]
+    public void EscapedAmpersandBeforeDigitsRemainsLiteralHeaderText() {
+        using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+        ExcelSheet sheet = document.AddWorksheet("Report");
+        MethodInfo parser = typeof(ExcelSheet).GetMethod(
+            "TryResolveHeaderFooterText",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        object?[] arguments = {
+            "Budget &&14 Report",
+            1,
+            1,
+            DateTime.UnixEpoch,
+            false,
+            null
+        };
+
+        Assert.True((bool)parser.Invoke(sheet, arguments)!);
+        Assert.NotNull(arguments[5]);
+        object section = arguments[5]!;
+        Assert.Equal(parser.GetParameters()[5].ParameterType.GetElementType(), section.GetType());
+        string text = (string)section.GetType()
+            .GetProperty("Text", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)!
+            .GetValue(section)!;
+        Assert.Equal("Budget &14 Report", text);
+    }
+
+    [Fact]
+    public void DirectHeaderStylingHonorsCustomHeaderConversion() {
+        using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+        ExcelSheet sheet = document.AddWorksheet("Data");
+        sheet.InsertObjects(
+            new[] { new HeaderRow("Alpha") },
+            ("RawHeader", row => row.Value));
+        ExcelReadOptions options = new() {
+            CellValueConverter = _ => new ExcelCellValue("ConvertedHeader")
+        };
+
+        bool found = sheet.TryGetColumnStyleByHeader(
+            "ConvertedHeader",
+            includeHeader: false,
+            out _,
+            out int columnIndex,
+            options);
+
+        Assert.True(found);
+        Assert.Equal(1, columnIndex);
+    }
+
+    [Fact]
+    public void PendingPreflightSurvivesDirectCellValuePromotion() {
+        using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+        ExcelSheet sheet = document.AddWorksheet("Data");
+        sheet.CellValues(Enumerable.Range(1, 160)
+            .Select(row => (row, 1, (object)("value-" + row))));
+        typeof(ExcelDocument)
+            .GetField("_requiresSavePreflight", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(document, true);
+
+        using MemoryStream output = new();
+        document.Save(output);
+
+        Assert.NotEqual(ExcelSavePackageWriter.DirectDataSetPackage, document.LastSaveDiagnostics.Writer);
+    }
+
+    private sealed record HeaderRow(string Value);
+}

--- a/OfficeIMO.Excel.Tests/Excel.Security.AllSeverityBatch21.cs
+++ b/OfficeIMO.Excel.Tests/Excel.Security.AllSeverityBatch21.cs
@@ -69,5 +69,26 @@ public class ExcelAllSeverityBatch21Tests {
         Assert.NotEqual(ExcelSavePackageWriter.DirectDataSetPackage, document.LastSaveDiagnostics.Writer);
     }
 
+    [Fact]
+    public void MaterializingPendingCellsClearsThePromotionOnlyPreflightMarker() {
+        using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+        ExcelSheet sheet = document.AddWorksheet("Data");
+        sheet.CellValues(Enumerable.Range(1, 160)
+            .Select(row => (row, 1, (object)("value-" + row))));
+        typeof(ExcelDocument)
+            .GetMethod("MarkRequiresSavePreflight", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .Invoke(document, null);
+
+        Assert.True(sheet.TryGetCellText(1, 1, out string? value));
+
+        Assert.Equal("value-1", value);
+        Assert.False((bool)typeof(ExcelDocument)
+            .GetField("_pendingDirectCellValueRequiresSavePreflight", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(document)!);
+        Assert.True((bool)typeof(ExcelDocument)
+            .GetField("_requiresSavePreflight", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(document)!);
+    }
+
     private sealed record HeaderRow(string Value);
 }

--- a/OfficeIMO.Excel.Tests/Excel.Security.AllSeverityBatch21.cs
+++ b/OfficeIMO.Excel.Tests/Excel.Security.AllSeverityBatch21.cs
@@ -16,7 +16,7 @@ public class ExcelAllSeverityBatch21Tests {
             "Budget &&14 Report",
             1,
             1,
-            DateTime.UnixEpoch,
+            new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc),
             false,
             null
         };
@@ -60,8 +60,8 @@ public class ExcelAllSeverityBatch21Tests {
         sheet.CellValues(Enumerable.Range(1, 160)
             .Select(row => (row, 1, (object)("value-" + row))));
         typeof(ExcelDocument)
-            .GetField("_requiresSavePreflight", BindingFlags.Instance | BindingFlags.NonPublic)!
-            .SetValue(document, true);
+            .GetMethod("MarkRequiresSavePreflight", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .Invoke(document, null);
 
         using MemoryStream output = new();
         document.Save(output);

--- a/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Materialization.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Materialization.cs
@@ -87,6 +87,7 @@ namespace OfficeIMO.Excel {
 
             if (_pendingDirectCellValueSheet == null) {
                 _pendingDirectCellValueSheet = sheet;
+                _pendingDirectCellValueRequiresSavePreflight = false;
                 return true;
             }
 
@@ -96,6 +97,7 @@ namespace OfficeIMO.Excel {
         internal void ClearPendingDirectCellValueSheet(ExcelSheet sheet) {
             if (ReferenceEquals(_pendingDirectCellValueSheet, sheet)) {
                 _pendingDirectCellValueSheet = null;
+                _pendingDirectCellValueRequiresSavePreflight = false;
             }
         }
 

--- a/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Materialization.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Materialization.cs
@@ -108,6 +108,7 @@ namespace OfficeIMO.Excel {
             }
 
             _pendingDirectCellValueSheet = null;
+            _pendingDirectCellValueRequiresSavePreflight = false;
             sheet.MaterializePendingDirectCellValues();
             return sheet;
         }

--- a/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Package.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Package.cs
@@ -88,7 +88,9 @@ namespace OfficeIMO.Excel {
                 return false;
             }
 
+            bool requiredSavePreflightBeforePromotion = _requiresSavePreflight;
             PromotePendingDirectCellValueSheetIfPossible();
+            _requiresSavePreflight |= requiredSavePreflightBeforePromotion;
 
             if (_requiresSavePreflight) {
                 skipReason = "Save preflight is pending.";

--- a/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Package.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Package.cs
@@ -88,9 +88,9 @@ namespace OfficeIMO.Excel {
                 return false;
             }
 
-            bool requiredSavePreflightBeforePromotion = _requiresSavePreflight;
+            bool pendingWritesRequireSavePreflight = _pendingDirectCellValueRequiresSavePreflight;
             PromotePendingDirectCellValueSheetIfPossible();
-            _requiresSavePreflight |= requiredSavePreflightBeforePromotion;
+            _requiresSavePreflight |= pendingWritesRequireSavePreflight;
 
             if (_requiresSavePreflight) {
                 skipReason = "Save preflight is pending.";

--- a/OfficeIMO.Excel/ExcelDocument.cs
+++ b/OfficeIMO.Excel/ExcelDocument.cs
@@ -348,6 +348,7 @@ namespace OfficeIMO.Excel {
         private bool _materializedDirectDataSetFastSaveModelHasMaterializedWorksheet;
         private ExcelSheet? _directDataSetMetadataSourceSheet;
         private ExcelSheet? _pendingDirectCellValueSheet;
+        private bool _pendingDirectCellValueRequiresSavePreflight;
         private bool _materializingDeferredDataSetImport;
         private bool _preserveMaterializedDirectDataSetFastSaveModelForNextDirtyMark;
         private int _directDataSetExternalCellMutationPreservationDepth;
@@ -361,6 +362,9 @@ namespace OfficeIMO.Excel {
 
         internal void MarkRequiresSavePreflight() {
             _requiresSavePreflight = true;
+            if (_pendingDirectCellValueSheet != null) {
+                _pendingDirectCellValueRequiresSavePreflight = true;
+            }
             MarkPackageDirty();
         }
 

--- a/OfficeIMO.Excel/ExcelSheet.DataTable.Tables.cs
+++ b/OfficeIMO.Excel/ExcelSheet.DataTable.Tables.cs
@@ -330,11 +330,11 @@ namespace OfficeIMO.Excel {
                 return true;
             }
 
-            if (SourceContainsTableColumns(source, tableColumnNames)) {
-                return true;
+            if (HasDefaultHeaderlessColumnNames(tableColumnNames)) {
+                return false;
             }
 
-            return !HasDefaultHeaderlessColumnNames(tableColumnNames);
+            return SourceContainsTableColumns(source, tableColumnNames);
         }
 
         private static bool SourceContainsTableColumns(DataTable source, IReadOnlyList<string> tableColumnNames) {

--- a/OfficeIMO.Excel/ExcelSheet.DataTable.Tables.cs
+++ b/OfficeIMO.Excel/ExcelSheet.DataTable.Tables.cs
@@ -334,21 +334,6 @@ namespace OfficeIMO.Excel {
                 return false;
             }
 
-            return SourceContainsTableColumns(source, tableColumnNames);
-        }
-
-        private static bool SourceContainsTableColumns(DataTable source, IReadOnlyList<string> tableColumnNames) {
-            var sourceColumnNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            foreach (DataColumn column in source.Columns) {
-                sourceColumnNames.Add(column.ColumnName);
-            }
-
-            foreach (string tableColumnName in tableColumnNames) {
-                if (!sourceColumnNames.Contains(tableColumnName)) {
-                    return false;
-                }
-            }
-
             return true;
         }
 

--- a/OfficeIMO.Excel/ExcelSheet.Headers.Style.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Headers.Style.cs
@@ -33,7 +33,7 @@ namespace OfficeIMO.Excel {
             out int columnIndex,
             ExcelReadOptions? options = null,
             bool preferDirectTabularMetadata = true) {
-            if (preferDirectTabularMetadata &&
+            if (preferDirectTabularMetadata && options == null &&
                 _excelDocument.TryGetDirectTabularSaveCandidateColumnByHeader(this, header, includeHeader, options, out int directColumnIndex, out int directStartRow, out int directEndRow)) {
                 columnIndex = directColumnIndex;
                 builder = new ColumnStyleByHeaderBuilder(this, directColumnIndex, directStartRow, directEndRow);

--- a/OfficeIMO.Excel/Imaging/ExcelSheet.Imaging.HeaderFooter.Text.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelSheet.Imaging.HeaderFooter.Text.cs
@@ -41,18 +41,7 @@ namespace OfficeIMO.Excel {
 
                 char token = text[++i];
                 if (token == '&') {
-                    if (i + 1 < text.Length && char.IsDigit(text[i + 1])) {
-                        if (!TryReadHeaderFooterFontSizeToken(text, i + 1, out double parsedFontSize, out int tokenEnd)) {
-                            return false;
-                        }
-
-                        FlushHeaderFooterTextRun(runs, builder, bold, italic, underline, strikethrough, color, fontSize, fontFamily);
-                        fontSize = parsedFontSize;
-                        i = tokenEnd;
-                        hasFormatting = true;
-                    } else {
-                        builder.Append('&');
-                    }
+                    builder.Append('&');
                 } else if (token == 'B') {
                     FlushHeaderFooterTextRun(runs, builder, bold, italic, underline, strikethrough, color, fontSize, fontFamily);
                     bold = !bold;

--- a/OfficeIMO.Markdown.Tests/Markdown/Markdown_AllSeverityBatch21_Tests.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown/Markdown_AllSeverityBatch21_Tests.cs
@@ -1,0 +1,28 @@
+using OfficeIMO.Markdown;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public class MarkdownAllSeverityBatch21Tests {
+    [Theory]
+    [InlineData(@"\\")]
+    [InlineData(@"\#")]
+    [InlineData(@"\+")]
+    [InlineData(@"\-")]
+    [InlineData(@"\.")]
+    [InlineData(@"\!")]
+    [InlineData(@"\(")]
+    [InlineData(@"\}")]
+    [InlineData(@"\~")]
+    public void RawTableCellsPreserveLiteralBackslashes(string value) {
+        TableBlock table = new();
+        table.Headers.Add("Value");
+        table.Rows.Add(new[] { value });
+
+        string markdown = new MarkdownDoc().Add(table).ToMarkdown();
+        MarkdownDoc reparsed = MarkdownReader.Parse(markdown);
+        TableBlock reparsedTable = Assert.IsType<TableBlock>(Assert.Single(reparsed.Blocks));
+
+        Assert.Equal(value, reparsedTable.Rows[0][0]);
+    }
+}

--- a/OfficeIMO.Markdown.Tests/Markdown/Markdown_TableBlock_Render_Tests.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown/Markdown_TableBlock_Render_Tests.cs
@@ -63,7 +63,7 @@ namespace OfficeIMO.Tests.MarkdownSuite {
         }
 
         [Fact]
-        public void TableBlock_RenderMarkdown_PreservesExistingParenthesisEscapes() {
+        public void TableBlock_RenderMarkdown_PreservesLiteralBackslashesBeforeParentheses() {
             var table = new TableBlock();
             table.Headers.Add("Header");
 
@@ -75,10 +75,10 @@ namespace OfficeIMO.Tests.MarkdownSuite {
 
             const string expected = "| Header |\n" +
                                     "| --- |\n" +
-                                    @"| Test A \(stacked bar\) |";
+                                    @"| Test A \\\(stacked bar\\\) |";
 
             Assert.Equal(expected, markdown);
-            Assert.Equal("Test A (stacked bar)", ExtractPlainText(parsedTable.RowInlines[0][0]));
+            Assert.Equal(@"Test A \(stacked bar\)", ExtractPlainText(parsedTable.RowInlines[0][0]));
         }
 
         [Fact]

--- a/OfficeIMO.Markdown/Blocks/TableBlock.Cells.cs
+++ b/OfficeIMO.Markdown/Blocks/TableBlock.Cells.cs
@@ -179,7 +179,7 @@ public sealed partial class TableBlock {
                     builder ??= AllocateCellBuilder(value, i);
                     if (preserveMarkdownEscapes && i + 1 < value.Length && IsMarkdownBackslashEscapable(value[i + 1])) {
                         builder.Append('\\').Append(value[++i]);
-                    } else if (!preserveMarkdownEscapes && i + 1 < value.Length && RequiresLiteralBackslashProtectionInRawCell(value[i + 1])) {
+                    } else if (!preserveMarkdownEscapes && i + 1 < value.Length && IsMarkdownBackslashEscapable(value[i + 1])) {
                         builder.Append("\\\\").Append('\\').Append(value[++i]);
                     } else if (i + 1 < value.Length && IsMarkdownBackslashEscapable(value[i + 1])) {
                         builder.Append('\\').Append(value[++i]);
@@ -302,18 +302,6 @@ public sealed partial class TableBlock {
             '>' => true,
             '=' => true,
             '~' => true,
-            _ => false
-        };
-    }
-
-    private static bool RequiresLiteralBackslashProtectionInRawCell(char value) {
-        return value switch {
-            '`' => true,
-            '*' => true,
-            '_' => true,
-            '[' => true,
-            ']' => true,
-            '|' => true,
             _ => false
         };
     }

--- a/OfficeIMO.Pdf.Tests/Pdf/Pdf.Security.AllSeverityBatch21.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/Pdf.Security.AllSeverityBatch21.cs
@@ -1,0 +1,170 @@
+using System.Reflection;
+using OfficeIMO.Pdf;
+using Xunit;
+
+namespace OfficeIMO.Tests.Pdf;
+
+public class PdfAllSeverityBatch21Tests {
+    [Fact]
+    public void UnprofiledExternalValidationDoesNotSatisfyProfiledProof() {
+        PdfOptions options = new PdfOptions().ConfigurePdfAGroundwork(PdfComplianceProfile.PdfA3B);
+        byte[] artifact = PdfDocument.Create(options).ToBytes();
+        PdfExternalValidationResult validation = PdfExternalValidationResult.PassedForArtifact(
+            PdfExternalValidatorKind.VeraPdf,
+            "veraPDF",
+            "1.30.2",
+            "Generic validation passed.",
+            artifact);
+
+        PdfComplianceProofReport proof = PdfComplianceAnalyzer.AssessProof(
+            PdfComplianceProfile.PdfA3B,
+            options,
+            artifact,
+            new[] { validation },
+            generatedStandardFonts: Array.Empty<PdfStandardFont>());
+
+        Assert.False(proof.HasRequiredExternalValidation);
+        Assert.False(proof.CanClaimConformance);
+        Assert.Contains(PdfExternalValidatorKind.VeraPdf, proof.MissingExternalValidators);
+    }
+
+    [Fact]
+    public void LegacyPublicTextAndFormSignaturesRemainAvailable() {
+        Type stringValues = typeof(IReadOnlyDictionary<string, string>);
+
+        AssertMethod(typeof(PdfEmbeddedFontFallbackSet), nameof(PdfEmbeddedFontFallbackSet.PlanText), typeof(string), typeof(string));
+        AssertMethod(typeof(PdfEmbeddedFontFallbackSet), nameof(PdfEmbeddedFontFallbackSet.PlanTextRuns), typeof(string), typeof(string), typeof(TextRun));
+        AssertMethod(
+            typeof(PdfEmbeddedFontFallbackSet),
+            nameof(PdfEmbeddedFontFallbackSet.TryPlanTextRuns),
+            typeof(string),
+            typeof(IReadOnlyList<TextRun>).MakeByRefType(),
+            typeof(string),
+            typeof(TextRun),
+            typeof(PdfConversionReport),
+            typeof(string));
+
+        Type diagnostics = typeof(PdfEmbeddedFontFallbackSet).Assembly.GetType("OfficeIMO.Pdf.PdfTextDiagnostics", throwOnError: true)!;
+        AssertMethod(
+            diagnostics,
+            "PlanEmbeddedFontFallbackText",
+            typeof(string),
+            typeof(IEnumerable<PdfEmbeddedFontFallbackCandidate>),
+            typeof(string));
+
+        AssertMethod(
+            typeof(PdfPageCanvas),
+            nameof(PdfPageCanvas.Image),
+            typeof(byte[]),
+            typeof(double),
+            typeof(double),
+            typeof(double),
+            typeof(double),
+            typeof(PdfImageStyle),
+            typeof(string),
+            typeof(string),
+            typeof(string),
+            typeof(double));
+
+        AssertMethod(typeof(PdfParagraphBuilder), nameof(PdfParagraphBuilder.Tab), typeof(PdfTabLeaderStyle));
+        AssertMethod(typeof(TextRun), nameof(TextRun.Tab), typeof(PdfTabLeaderStyle));
+        Assert.NotNull(typeof(TextRun).GetConstructor(new[] {
+            typeof(string),
+            typeof(bool),
+            typeof(bool),
+            typeof(PdfColor?),
+            typeof(bool),
+            typeof(bool),
+            typeof(double?),
+            typeof(PdfStandardFont?),
+            typeof(string),
+            typeof(string),
+            typeof(PdfTextBaseline),
+            typeof(string),
+            typeof(PdfTabLeaderStyle),
+            typeof(PdfColor?),
+            typeof(string)
+        }));
+    }
+
+    [Fact]
+    public void LegacyTwoArgumentFormCallsRemainSourceCompatibleWithoutMakingNullAmbiguous() {
+        PdfDocumentForms forms = PdfDocument.Open(PdfDocument.Create().ToBytes()).Forms;
+        var strings = new Dictionary<string, string>();
+        var typed = new Dictionary<string, PdfFormFieldValue>();
+        var formOptions = new PdfFormFillerOptions();
+
+        _ = forms.TryFill(strings, formOptions);
+        _ = forms.TryFill(typed, formOptions);
+        _ = forms.TryFlatten(formOptions);
+        _ = forms.TryFillAndFlatten(strings, formOptions);
+        _ = forms.TryFillAndFlatten(typed, formOptions);
+
+        _ = forms.TryFill(strings, null);
+        _ = forms.TryFill(typed, null);
+        _ = forms.TryFlatten(null);
+        _ = forms.TryFillAndFlatten(strings, null);
+        _ = forms.TryFillAndFlatten(typed, null);
+    }
+
+    [Fact]
+    public void TabAlignmentPreservesPersistedRightValue() {
+        Assert.Equal(0, (int)PdfTabAlignment.Left);
+        Assert.Equal(1, (int)PdfTabAlignment.Right);
+        Assert.Equal(2, (int)PdfTabAlignment.Center);
+        Assert.Equal(3, (int)PdfTabAlignment.DecimalSeparator);
+    }
+
+    [Fact]
+    public void TopOfPageKeepTogetherIgnoresSuppressedSpacingBefore() {
+        PdfOptions options = new() {
+            PageWidth = 320,
+            PageHeight = 170,
+            MarginLeft = 30,
+            MarginRight = 30,
+            MarginTop = 30,
+            MarginBottom = 30,
+            DefaultFontSize = 10
+        };
+
+        byte[] bytes = PdfDocument.Create(options)
+            .Paragraph(
+                paragraph => paragraph.Text("This visible paragraph fits."),
+                style: new PdfParagraphStyle {
+                    KeepTogether = true,
+                    SpacingBefore = 500
+                })
+            .ToBytes();
+
+        Assert.NotEmpty(bytes);
+    }
+
+    [Fact]
+    public void KeepTogetherCollapsesSpacingBeforeAfterMovingToFreshPage() {
+        PdfOptions options = new() {
+            PageWidth = 320,
+            PageHeight = 170,
+            MarginLeft = 30,
+            MarginRight = 30,
+            MarginTop = 30,
+            MarginBottom = 30,
+            DefaultFontSize = 10
+        };
+
+        byte[] bytes = PdfDocument.Create(options)
+            .Paragraph(paragraph => paragraph.Text("Preceding content."))
+            .Paragraph(
+                paragraph => paragraph.Text("This paragraph fits after its spacing collapses."),
+                style: new PdfParagraphStyle {
+                    KeepTogether = true,
+                    SpacingBefore = 500
+                })
+            .ToBytes();
+
+        Assert.NotEmpty(bytes);
+    }
+
+    private static void AssertMethod(Type type, string name, params Type[] parameters) {
+        Assert.NotNull(type.GetMethod(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance, binder: null, parameters, modifiers: null));
+    }
+}

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfComplianceAnalyzerProofTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfComplianceAnalyzerProofTests.cs
@@ -58,7 +58,7 @@ public partial class PdfComplianceAnalyzerTests {
     }
 
     [Fact]
-    public void ProofReportCountsUnprofiledValidatorResultForRequestedProof() {
+    public void ProofReportRejectsUnprofiledValidatorResultForRequestedProof() {
         var options = new PdfOptions()
             .ConfigurePdfAGroundwork(PdfComplianceProfile.PdfA3B);
         byte[] artifact = PdfDocument.Create(options).ToBytes();
@@ -77,10 +77,10 @@ public partial class PdfComplianceAnalyzerTests {
             generatedStandardFonts: Array.Empty<PdfStandardFont>());
 
         Assert.True(proof.IsInternallyReady);
-        Assert.True(proof.HasRequiredExternalValidation);
-        Assert.True(proof.CanClaimConformance);
-        Assert.Equal(1, proof.PassedExternalValidationCount);
-        Assert.Empty(proof.MissingExternalValidators);
+        Assert.False(proof.HasRequiredExternalValidation);
+        Assert.False(proof.CanClaimConformance);
+        Assert.Equal(0, proof.PassedExternalValidationCount);
+        Assert.Contains(PdfExternalValidatorKind.VeraPdf, proof.MissingExternalValidators);
     }
 
     [Fact]

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfPublicApiContractTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfPublicApiContractTests.cs
@@ -129,7 +129,7 @@ public sealed class PdfPublicApiContractTests {
                 BindingFlags.DeclaredOnly).Length);
 
         Assert.InRange(exportedTypes.Length, 1, 500);
-        Assert.InRange(publicMemberCount, 1, 9900);
+        Assert.InRange(publicMemberCount, 1, 9950);
 
         string[] officeReferences = assembly.GetReferencedAssemblies()
             .Select(reference => reference.Name)

--- a/OfficeIMO.Pdf/Compliance/PdfComplianceProofReport.cs
+++ b/OfficeIMO.Pdf/Compliance/PdfComplianceProofReport.cs
@@ -377,7 +377,7 @@ public sealed class PdfComplianceProofReport {
 
         string? resultProfile = result.Profile;
         if (string.IsNullOrWhiteSpace(resultProfile)) {
-            return true;
+            return false;
         }
 
         string normalizedResult = NormalizeProfileName(resultProfile!);

--- a/OfficeIMO.Pdf/Core/PdfDocumentFormsCompatibilityExtensions.cs
+++ b/OfficeIMO.Pdf/Core/PdfDocumentFormsCompatibilityExtensions.cs
@@ -1,0 +1,51 @@
+namespace OfficeIMO.Pdf;
+
+/// <summary>
+/// Preserves the original source-compatible form-operation calls without making
+/// an untyped <see langword="null"/> ambiguous with <see cref="PdfReadOptions"/>.
+/// </summary>
+public static class PdfDocumentFormsCompatibilityExtensions {
+    /// <summary>Attempts to fill string form values with explicit form options.</summary>
+    public static PdfOperationResult<PdfDocument> TryFill(
+        this PdfDocumentForms forms,
+        IReadOnlyDictionary<string, string> fieldValues,
+        PdfFormFillerOptions formOptions) {
+        Guard.NotNull(forms, nameof(forms));
+        return forms.TryFill(fieldValues, formOptions, readOptions: null);
+    }
+
+    /// <summary>Attempts to fill typed form values with explicit form options.</summary>
+    public static PdfOperationResult<PdfDocument> TryFill(
+        this PdfDocumentForms forms,
+        IReadOnlyDictionary<string, PdfFormFieldValue> fieldValues,
+        PdfFormFillerOptions formOptions) {
+        Guard.NotNull(forms, nameof(forms));
+        return forms.TryFill(fieldValues, formOptions, readOptions: null);
+    }
+
+    /// <summary>Attempts to flatten form fields with explicit form options.</summary>
+    public static PdfOperationResult<PdfDocument> TryFlatten(
+        this PdfDocumentForms forms,
+        PdfFormFillerOptions formOptions) {
+        Guard.NotNull(forms, nameof(forms));
+        return forms.TryFlatten(formOptions, readOptions: null);
+    }
+
+    /// <summary>Attempts to fill and flatten string form values with explicit form options.</summary>
+    public static PdfOperationResult<PdfDocument> TryFillAndFlatten(
+        this PdfDocumentForms forms,
+        IReadOnlyDictionary<string, string> fieldValues,
+        PdfFormFillerOptions formOptions) {
+        Guard.NotNull(forms, nameof(forms));
+        return forms.TryFillAndFlatten(fieldValues, formOptions, readOptions: null);
+    }
+
+    /// <summary>Attempts to fill and flatten typed form values with explicit form options.</summary>
+    public static PdfOperationResult<PdfDocument> TryFillAndFlatten(
+        this PdfDocumentForms forms,
+        IReadOnlyDictionary<string, PdfFormFieldValue> fieldValues,
+        PdfFormFillerOptions formOptions) {
+        Guard.NotNull(forms, nameof(forms));
+        return forms.TryFillAndFlatten(fieldValues, formOptions, readOptions: null);
+    }
+}

--- a/OfficeIMO.Pdf/Model/PdfEmbeddedFontFallbackSet.cs
+++ b/OfficeIMO.Pdf/Model/PdfEmbeddedFontFallbackSet.cs
@@ -136,8 +136,11 @@ public sealed class PdfEmbeddedFontFallbackSet {
     /// </summary>
     /// <param name="text">Text to inspect.</param>
     /// <param name="source">Optional caller-provided source label such as a block, field, sheet, slide, or converter area.</param>
-    /// <param name="shapingMode">Text shaping mode to use when checking fallback font coverage.</param>
     /// <returns>A fallback plan with covered text segments and missing-glyph diagnostics.</returns>
+    public PdfTextFallbackPlan PlanText(string text, string source) =>
+        PlanText(text, source, PdfTextShapingMode.UnicodeScalar);
+
+    /// <summary>Plans fallback coverage with an explicit text shaping mode.</summary>
     public PdfTextFallbackPlan PlanText(string text, string source = "", PdfTextShapingMode shapingMode = PdfTextShapingMode.UnicodeScalar) =>
         PdfTextDiagnostics.PlanEmbeddedFontFallbackText(text, _candidates, source, shapingMode);
 
@@ -157,8 +160,11 @@ public sealed class PdfEmbeddedFontFallbackSet {
     /// <param name="text">Text to inspect and convert.</param>
     /// <param name="source">Optional caller-provided source label such as a block, field, sheet, slide, or converter area.</param>
     /// <param name="styleTemplate">Optional run whose styling is copied to each generated text run.</param>
-    /// <param name="shapingMode">Text shaping mode to use when checking fallback font coverage.</param>
     /// <returns>Text runs that can be used with rich paragraphs, lists, tables, panels, and canvas text boxes.</returns>
+    public IReadOnlyList<TextRun> PlanTextRuns(string text, string source, TextRun? styleTemplate) =>
+        PlanTextRuns(text, source, styleTemplate, PdfTextShapingMode.UnicodeScalar);
+
+    /// <summary>Plans text runs with an explicit text shaping mode.</summary>
     public IReadOnlyList<TextRun> PlanTextRuns(string text, string source = "", TextRun? styleTemplate = null, PdfTextShapingMode shapingMode = PdfTextShapingMode.UnicodeScalar) =>
         UsesNamedFontFamilies
             ? PlanText(text, source, shapingMode).ToNamedTextRuns(_fontFamilyNames, styleTemplate)
@@ -173,8 +179,17 @@ public sealed class PdfEmbeddedFontFallbackSet {
     /// <param name="styleTemplate">Optional run whose styling is copied to each generated text run.</param>
     /// <param name="report">Optional conversion report that receives missing-glyph diagnostics from incomplete plans.</param>
     /// <param name="converter">Converter or adapter name used when writing diagnostics to <paramref name="report"/>.</param>
-    /// <param name="shapingMode">Text shaping mode to use when checking fallback font coverage.</param>
     /// <returns><c>true</c> when <paramref name="runs"/> contains a fully covered renderable plan; otherwise <c>false</c>.</returns>
+    public bool TryPlanTextRuns(
+        string text,
+        out IReadOnlyList<TextRun> runs,
+        string source,
+        TextRun? styleTemplate,
+        PdfConversionReport? report,
+        string converter) =>
+        TryPlanTextRuns(text, out runs, source, styleTemplate, report, converter, PdfTextShapingMode.UnicodeScalar);
+
+    /// <summary>Tries to plan renderable text runs with an explicit text shaping mode.</summary>
     public bool TryPlanTextRuns(
         string text,
         out IReadOnlyList<TextRun> runs,

--- a/OfficeIMO.Pdf/Model/PdfPageCanvas.cs
+++ b/OfficeIMO.Pdf/Model/PdfPageCanvas.cs
@@ -219,6 +219,10 @@ public sealed class PdfPageCanvas {
     }
 
     /// <summary>Adds a supported image at fixed top-left page coordinates.</summary>
+    public PdfPageCanvas Image(byte[] imageBytes, double x, double y, double width, double height, PdfImageStyle? style, string? linkUri, string? linkContents, string? alternativeText, double rotationAngle) =>
+        Image(imageBytes, x, y, width, height, style, linkUri, linkContents, alternativeText, rotationAngle, horizontalFlip: false, verticalFlip: false);
+
+    /// <summary>Adds a supported image at fixed top-left page coordinates.</summary>
     public PdfPageCanvas Image(byte[] imageBytes, double x, double y, double width, double height, PdfImageStyle? style = null, string? linkUri = null, string? linkContents = null, string? alternativeText = null, double rotationAngle = 0D, bool horizontalFlip = false, bool verticalFlip = false) {
         Guard.NotNullOrEmpty(imageBytes, nameof(imageBytes));
         return ImageShared(

--- a/OfficeIMO.Pdf/Model/PdfParagraphBuilder.cs
+++ b/OfficeIMO.Pdf/Model/PdfParagraphBuilder.cs
@@ -80,6 +80,8 @@ public sealed class PdfParagraphBuilder {
     /// <summary>Adds an explicit line break inside the current paragraph.</summary>
     public PdfParagraphBuilder LineBreak() { _runs.Add(TextRun.LineBreak()); return this; }
     /// <summary>Adds an explicit paragraph tab using the current style flags.</summary>
+    public PdfParagraphBuilder Tab(PdfTabLeaderStyle leader) => Tab(leader, PdfTabAlignment.Left);
+    /// <summary>Adds an aligned paragraph tab using the current style flags.</summary>
     public PdfParagraphBuilder Tab(PdfTabLeaderStyle leader = PdfTabLeaderStyle.None, PdfTabAlignment alignment = PdfTabAlignment.Left) { _runs.Add(new TextRun("\t", _currentBold, _currentUnderline, _currentColor, _currentItalic, _currentStrike, fontSize: _currentFontSize, font: _currentFont, baseline: _currentBaseline, tabLeader: leader, tabAlignment: alignment, backgroundColor: _currentBackgroundColor, fontFamily: _currentFontFamily)); return this; }
     /// <summary>Adds a fixed-size visual that participates in paragraph wrapping.</summary>
     public PdfParagraphBuilder Inline(PdfInlineElement element) { Guard.NotNull(element, nameof(element)); _runs.Add(TextRun.Inline(element)); return this; }

--- a/OfficeIMO.Pdf/Model/PdfTabAlignment.cs
+++ b/OfficeIMO.Pdf/Model/PdfTabAlignment.cs
@@ -6,10 +6,10 @@ namespace OfficeIMO.Pdf;
 public enum PdfTabAlignment {
     /// <summary>The following text starts at the tab stop.</summary>
     Left = 0,
-    /// <summary>The following text is centered on the tab stop.</summary>
-    Center = 1,
     /// <summary>The following text ends at the tab stop.</summary>
-    Right = 2,
+    Right = 1,
+    /// <summary>The following text is centered on the tab stop.</summary>
+    Center = 2,
     /// <summary>The following text's decimal separator is aligned to the tab stop.</summary>
     DecimalSeparator = 3
 }

--- a/OfficeIMO.Pdf/Model/PdfTextDiagnostics.cs
+++ b/OfficeIMO.Pdf/Model/PdfTextDiagnostics.cs
@@ -460,8 +460,11 @@ internal static class PdfTextDiagnostics {
     /// <param name="text">Text to inspect.</param>
     /// <param name="candidates">Candidate fonts in priority order.</param>
     /// <param name="source">Optional caller-provided source label such as a block, field, sheet, slide, or converter area.</param>
-    /// <param name="shapingMode">Text shaping mode to use when checking fallback font coverage.</param>
     /// <returns>A fallback plan with covered text segments and missing-glyph diagnostics.</returns>
+    public static PdfTextFallbackPlan PlanEmbeddedFontFallbackText(string text, IEnumerable<PdfEmbeddedFontFallbackCandidate> candidates, string source) =>
+        PlanEmbeddedFontFallbackText(text, candidates, source, PdfTextShapingMode.UnicodeScalar);
+
+    /// <summary>Plans embedded-font fallback text with an explicit text shaping mode.</summary>
     public static PdfTextFallbackPlan PlanEmbeddedFontFallbackText(string text, IEnumerable<PdfEmbeddedFontFallbackCandidate> candidates, string source = "", PdfTextShapingMode shapingMode = PdfTextShapingMode.UnicodeScalar) {
         Guard.NotNull(text, nameof(text));
         Guard.NotNull(candidates, nameof(candidates));

--- a/OfficeIMO.Pdf/Model/TextRun.cs
+++ b/OfficeIMO.Pdf/Model/TextRun.cs
@@ -53,9 +53,13 @@ public sealed class TextRun {
     /// <param name="baseline">Baseline placement for this run.</param>
     /// <param name="linkDestinationName">Optional named destination for an internal document link annotation.</param>
     /// <param name="tabLeader">Leader fill to render when the run text is a tab character.</param>
-    /// <param name="tabAlignment">Alignment to use when the run text is a tab character.</param>
     /// <param name="backgroundColor">Optional run background color.</param>
     /// <param name="fontFamily">Optional registered embedded family name. <paramref name="font"/> is used as its fallback.</param>
+    public TextRun(string text, bool bold, bool underline, PdfColor? color, bool italic, bool strike, double? fontSize, PdfStandardFont? font, string? linkUri, string? linkContents, PdfTextBaseline baseline, string? linkDestinationName, PdfTabLeaderStyle tabLeader, PdfColor? backgroundColor, string? fontFamily)
+        : this(text, bold, underline, color, italic, strike, fontSize, font, linkUri, linkContents, baseline, linkDestinationName, tabLeader, PdfTabAlignment.Left, backgroundColor, fontFamily) {
+    }
+
+    /// <summary>Create a new run with the specified styles and tab alignment.</summary>
     public TextRun(string text, bool bold = false, bool underline = false, PdfColor? color = null, bool italic = false, bool strike = false, double? fontSize = null, PdfStandardFont? font = null, string? linkUri = null, string? linkContents = null, PdfTextBaseline baseline = PdfTextBaseline.Normal, string? linkDestinationName = null, PdfTabLeaderStyle tabLeader = PdfTabLeaderStyle.None, PdfTabAlignment tabAlignment = PdfTabAlignment.Left, PdfColor? backgroundColor = null, string? fontFamily = null) {
         Guard.NotNull(text, nameof(text));
         Guard.TextBaseline(baseline, nameof(baseline));
@@ -126,6 +130,8 @@ public sealed class TextRun {
     /// <summary>Create an explicit line-break run.</summary>
     public static TextRun LineBreak() => new TextRun("\n", bold: false, underline: false, color: null, italic: false, strike: false);
     /// <summary>Create an explicit paragraph tab run.</summary>
+    public static TextRun Tab(PdfTabLeaderStyle leader) => Tab(leader, PdfTabAlignment.Left);
+    /// <summary>Create an explicit paragraph tab run with alignment.</summary>
     public static TextRun Tab(PdfTabLeaderStyle leader = PdfTabLeaderStyle.None, PdfTabAlignment alignment = PdfTabAlignment.Left) => new TextRun("\t", tabLeader: leader, tabAlignment: alignment);
     /// <summary>Create a fixed-size inline visual run.</summary>
     public static TextRun Inline(PdfInlineElement element) => new TextRun(element);

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Text.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Text.cs
@@ -86,12 +86,15 @@ internal static partial class PdfWriter {
             }
 
             if (paragraphStyle?.KeepTogether == true) {
-                double paragraphHeight = spacingBefore + lineHeights.Sum();
+                double paragraphContentHeight = lineHeights.Sum();
                 double availableHeight = currentOpts.PageHeight - currentOpts.MarginTop - currentOpts.MarginBottom;
-                if (paragraphHeight > availableHeight + 0.001) {
+                if (paragraphContentHeight > availableHeight + 0.001) {
                     throw new ArgumentException("Paragraph height exceeds the available page content height.");
                 }
 
+                double paragraphHeight =
+                    (y < yStart - 0.001D ? spacingBefore : 0D) +
+                    paragraphContentHeight;
                 if (y < yStart - 0.001 && y - paragraphHeight < currentOpts.MarginBottom) {
                     NewPage();
                 }

--- a/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.cs
+++ b/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.cs
@@ -315,7 +315,11 @@ public static partial class HtmlPowerPointConverterExtensions {
             }
 
             series.Add(hasXValues
-                ? new PptCore.PowerPointChartSeries(name, values, xValues)
+                ? new PptCore.PowerPointChartSeries(
+                    name,
+                    values,
+                    xValues,
+                    PptCore.PowerPointChartSnapshotKind.Scatter)
                 : new PptCore.PowerPointChartSeries(name, values));
         }
 

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.Security.AllSeverityBatch21.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.Security.AllSeverityBatch21.cs
@@ -1,0 +1,21 @@
+using OfficeIMO.PowerPoint;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public class PowerPointAllSeverityBatch21Tests {
+    [Fact]
+    public void CategorySeriesXValuesCannotBypassValueCountValidation() {
+        PowerPointChartSeries malformed = new(
+            "Series",
+            new[] { 1D },
+            new[] { 1D });
+
+        ArgumentException exception = Assert.Throws<ArgumentException>(() =>
+            new PowerPointChartData(
+                new[] { "First", "Second" },
+                new[] { malformed }));
+
+        Assert.Equal("series", exception.ParamName);
+    }
+}

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.Security.AllSeverityBatch21.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.Security.AllSeverityBatch21.cs
@@ -18,4 +18,26 @@ public class PowerPointAllSeverityBatch21Tests {
 
         Assert.Equal("series", exception.ParamName);
     }
+
+    [Fact]
+    public void ScatterSnapshotAllowsSeriesWithDifferentPointCounts() {
+        using var stream = new MemoryStream();
+        using PowerPointPresentation presentation = PowerPointPresentation.Create(stream);
+        PowerPointSlide slide = presentation.AddSlide();
+        var data = new PowerPointScatterChartData(new[] {
+            new PowerPointScatterChartSeries(
+                "Long",
+                new[] { 1D, 2D, 3D },
+                new[] { 10D, 20D, 30D }),
+            new PowerPointScatterChartSeries(
+                "Short",
+                new[] { 4D, 5D },
+                new[] { 40D, 50D })
+        });
+        PowerPointChart chart = slide.AddScatterChart(data);
+
+        Assert.True(chart.TryGetSnapshot(out PowerPointChartSnapshot snapshot));
+        Assert.Equal(new[] { 3, 2 }, snapshot.Data.Series.Select(series => series.Values.Count).ToArray());
+        Assert.Equal(new[] { 3, 2 }, snapshot.Data.Series.Select(series => series.XValues!.Count).ToArray());
+    }
 }

--- a/OfficeIMO.PowerPoint/PowerPointChartData.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChartData.cs
@@ -46,7 +46,13 @@ namespace OfficeIMO.PowerPoint {
 
             int expected = Categories.Count;
             foreach (PowerPointChartSeries item in Series) {
-                if (item.Values.Count != expected) {
+                if (item.ChartKind == PowerPointChartSnapshotKind.Scatter) {
+                    if (item.XValues == null || item.XValues.Count != item.Values.Count) {
+                        throw new System.ArgumentException(
+                            "Each scatter series must have matching X and Y value counts.",
+                            nameof(series));
+                    }
+                } else if (item.Values.Count != expected) {
                     throw new System.ArgumentException(
                         "Each series must have the same number of values as there are categories.",
                         nameof(series));

--- a/OfficeIMO.PowerPoint/PowerPointChartData.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChartData.cs
@@ -46,7 +46,7 @@ namespace OfficeIMO.PowerPoint {
 
             int expected = Categories.Count;
             foreach (PowerPointChartSeries item in Series) {
-                if (item.XValues == null && item.Values.Count != expected) {
+                if (item.Values.Count != expected) {
                     throw new System.ArgumentException(
                         "Each series must have the same number of values as there are categories.",
                         nameof(series));

--- a/OfficeIMO.Reader.Core/Ocr/OfficeDocumentOcrExecution.Concurrency.cs
+++ b/OfficeIMO.Reader.Core/Ocr/OfficeDocumentOcrExecution.Concurrency.cs
@@ -14,12 +14,16 @@ public static partial class OfficeDocumentOcrExecutionExtensions {
             return;
         }
 
-        _ = ReleaseSharedEngineGateWhenSettledAsync(gate, pending);
+        _ = Task.Factory.StartNew(
+            () => ReleaseSharedEngineGateWhenSettled(gate, pending),
+            CancellationToken.None,
+            TaskCreationOptions.LongRunning | TaskCreationOptions.DenyChildAttach,
+            TaskScheduler.Default);
     }
 
-    private static async Task ReleaseSharedEngineGateWhenSettledAsync(SemaphoreSlim gate, IReadOnlyList<Task> pending) {
+    private static void ReleaseSharedEngineGateWhenSettled(SemaphoreSlim gate, IReadOnlyList<Task> pending) {
         try {
-            await Task.WhenAll(pending).ConfigureAwait(false);
+            Task.WhenAll(pending).GetAwaiter().GetResult();
         } catch {
             // ExecuteCandidateAsync observes provider failures. The shared gate still has to be released.
         } finally {

--- a/OfficeIMO.Reader.Core/Ocr/OfficeDocumentOcrExecution.cs
+++ b/OfficeIMO.Reader.Core/Ocr/OfficeDocumentOcrExecution.cs
@@ -198,19 +198,29 @@ public static partial class OfficeDocumentOcrExecutionExtensions {
             Task<OfficeOcrEngineResult>? recognitionTask = null;
             try {
                 // Isolate both the provider's synchronous prefix and timeout supervision from a small thread pool.
+                var providerStart = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
                 recognitionTask = Task.Factory.StartNew(
-                        async () => await engine
-                            .RecognizeAsync(request, providerCancellation.Token)
-                            .ConfigureAwait(false),
+                        async () => {
+                            providerStart.Task.GetAwaiter().GetResult();
+                            return await engine
+                                .RecognizeAsync(request, providerCancellation.Token)
+                                .ConfigureAwait(false);
+                        },
                         CancellationToken.None,
                         TaskCreationOptions.LongRunning | TaskCreationOptions.DenyChildAttach,
                         TaskScheduler.Default)
                     .Unwrap();
-                OfficeOcrEngineResult result = await WaitWithTimeoutAsync(
-                    recognitionTask,
-                    options.CandidateTimeout,
-                    cancellationToken,
-                    providerCancellation).ConfigureAwait(false);
+                Task<OfficeOcrEngineResult> supervision;
+                try {
+                    supervision = WaitWithTimeoutAsync(
+                        recognitionTask,
+                        options.CandidateTimeout,
+                        cancellationToken,
+                        providerCancellation);
+                } finally {
+                    providerStart.TrySetResult(null);
+                }
+                OfficeOcrEngineResult result = await supervision.ConfigureAwait(false);
                 return CandidateOutcome.Success(job, result);
             } catch (Exception exception) when (
                 exception is OcrCandidateTimeoutException
@@ -262,23 +272,31 @@ public static partial class OfficeDocumentOcrExecutionExtensions {
             return operation;
         }
 
-        return Task.Factory.StartNew(
-            () => WaitWithTimeoutOnDedicatedThread(
-                operation,
-                timeout,
-                cancellationToken,
-                operationCancellation),
+        var supervisorReady = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        Task<T> supervision = Task.Factory.StartNew(
+            () => {
+                Stopwatch elapsed = Stopwatch.StartNew();
+                supervisorReady.TrySetResult(null);
+                return WaitWithTimeoutOnDedicatedThread(
+                    operation,
+                    timeout,
+                    cancellationToken,
+                    operationCancellation,
+                    elapsed);
+            },
             CancellationToken.None,
             TaskCreationOptions.LongRunning | TaskCreationOptions.DenyChildAttach,
             TaskScheduler.Default);
+        supervisorReady.Task.GetAwaiter().GetResult();
+        return supervision;
     }
 
     private static T WaitWithTimeoutOnDedicatedThread<T>(
         Task<T> operation,
         TimeSpan timeout,
         CancellationToken cancellationToken,
-        CancellationTokenSource operationCancellation) {
-        Stopwatch elapsed = Stopwatch.StartNew();
+        CancellationTokenSource operationCancellation,
+        Stopwatch elapsed) {
         try {
             while (true) {
                 TimeSpan elapsedTime = elapsed.Elapsed;

--- a/OfficeIMO.Reader.Core/Ocr/OfficeDocumentOcrExecution.cs
+++ b/OfficeIMO.Reader.Core/Ocr/OfficeDocumentOcrExecution.cs
@@ -196,8 +196,7 @@ public static partial class OfficeDocumentOcrExecutionExtensions {
             using var providerCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             Task<OfficeOcrEngineResult>? recognitionTask = null;
             try {
-                providerCancellation.CancelAfter(options.CandidateTimeout);
-                // Isolate a provider's synchronous prefix so it cannot starve the timeout timer on a small thread pool.
+                // Isolate both the provider's synchronous prefix and timeout supervision from a small thread pool.
                 recognitionTask = Task.Factory.StartNew(
                         async () => await engine
                             .RecognizeAsync(request, providerCancellation.Token)
@@ -209,7 +208,8 @@ public static partial class OfficeDocumentOcrExecutionExtensions {
                 OfficeOcrEngineResult result = await WaitWithTimeoutAsync(
                     recognitionTask,
                     options.CandidateTimeout,
-                    cancellationToken).ConfigureAwait(false);
+                    cancellationToken,
+                    providerCancellation).ConfigureAwait(false);
                 return CandidateOutcome.Success(job, result);
             } catch (Exception exception) when (
                 exception is OcrCandidateTimeoutException
@@ -252,20 +252,42 @@ public static partial class OfficeDocumentOcrExecutionExtensions {
         }
     }
 
-    private static async Task<T> WaitWithTimeoutAsync<T>(
+    private static Task<T> WaitWithTimeoutAsync<T>(
         Task<T> operation,
         TimeSpan timeout,
-        CancellationToken cancellationToken) {
-        if (operation.IsCompleted) return await operation.ConfigureAwait(false);
-        using var deadlineCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        Task deadline = Task.Delay(timeout, deadlineCancellation.Token);
-        Task completed = await Task.WhenAny(operation, deadline).ConfigureAwait(false);
-        if (completed == operation) {
-            deadlineCancellation.Cancel();
-            return await operation.ConfigureAwait(false);
+        CancellationToken cancellationToken,
+        CancellationTokenSource operationCancellation) {
+        if (operation.IsCompleted) {
+            return operation;
+        }
+
+        return Task.Factory.StartNew(
+            () => WaitWithTimeoutOnDedicatedThread(
+                operation,
+                timeout,
+                cancellationToken,
+                operationCancellation),
+            CancellationToken.None,
+            TaskCreationOptions.LongRunning | TaskCreationOptions.DenyChildAttach,
+            TaskScheduler.Default);
+    }
+
+    private static T WaitWithTimeoutOnDedicatedThread<T>(
+        Task<T> operation,
+        TimeSpan timeout,
+        CancellationToken cancellationToken,
+        CancellationTokenSource operationCancellation) {
+        try {
+            int timeoutMilliseconds = checked((int)timeout.TotalMilliseconds);
+            if (operation.Wait(timeoutMilliseconds, cancellationToken)) {
+                return operation.GetAwaiter().GetResult();
+            }
+        } catch (AggregateException) {
+            return operation.GetAwaiter().GetResult();
         }
 
         cancellationToken.ThrowIfCancellationRequested();
+        CancelProviderAfterTimeout(operationCancellation);
         throw new OcrCandidateTimeoutException();
     }
 

--- a/OfficeIMO.Reader.Core/Ocr/OfficeDocumentOcrExecution.cs
+++ b/OfficeIMO.Reader.Core/Ocr/OfficeDocumentOcrExecution.cs
@@ -197,8 +197,15 @@ public static partial class OfficeDocumentOcrExecutionExtensions {
             Task<OfficeOcrEngineResult>? recognitionTask = null;
             try {
                 providerCancellation.CancelAfter(options.CandidateTimeout);
-                recognitionTask = Task.Run(async () =>
-                    await engine.RecognizeAsync(request, providerCancellation.Token).ConfigureAwait(false));
+                // Isolate a provider's synchronous prefix so it cannot starve the timeout timer on a small thread pool.
+                recognitionTask = Task.Factory.StartNew(
+                        async () => await engine
+                            .RecognizeAsync(request, providerCancellation.Token)
+                            .ConfigureAwait(false),
+                        CancellationToken.None,
+                        TaskCreationOptions.LongRunning | TaskCreationOptions.DenyChildAttach,
+                        TaskScheduler.Default)
+                    .Unwrap();
                 OfficeOcrEngineResult result = await WaitWithTimeoutAsync(
                     recognitionTask,
                     options.CandidateTimeout,

--- a/OfficeIMO.Reader.Core/Ocr/OfficeDocumentOcrExecution.cs
+++ b/OfficeIMO.Reader.Core/Ocr/OfficeDocumentOcrExecution.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -277,10 +278,18 @@ public static partial class OfficeDocumentOcrExecutionExtensions {
         TimeSpan timeout,
         CancellationToken cancellationToken,
         CancellationTokenSource operationCancellation) {
+        Stopwatch elapsed = Stopwatch.StartNew();
         try {
-            int timeoutMilliseconds = checked((int)timeout.TotalMilliseconds);
-            if (operation.Wait(timeoutMilliseconds, cancellationToken)) {
-                return operation.GetAwaiter().GetResult();
+            while (true) {
+                TimeSpan elapsedTime = elapsed.Elapsed;
+                if (elapsedTime >= timeout) break;
+                TimeSpan remaining = timeout - elapsedTime;
+                int waitMilliseconds = remaining.TotalMilliseconds >= int.MaxValue
+                    ? int.MaxValue
+                    : Math.Max(1, (int)Math.Ceiling(remaining.TotalMilliseconds));
+                if (operation.Wait(waitMilliseconds, cancellationToken)) {
+                    return operation.GetAwaiter().GetResult();
+                }
             }
         } catch (AggregateException) {
             return operation.GetAwaiter().GetResult();

--- a/OfficeIMO.Reader.Tests/Reader.Ocr.Core.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Ocr.Core.cs
@@ -171,6 +171,28 @@ public sealed class ReaderOcrCoreTests {
     }
 
     [Fact]
+    public async Task ApplyOcrAsync_PreservesTimeoutsBeyondTheSignedWaitBoundary() {
+        OfficeDocumentReadResult source = CreateDocument(1);
+        using var providerStarted = new ManualResetEventSlim(false);
+        using var cancellation = new CancellationTokenSource();
+        var engine = new DelegateOfficeOcrEngine("long-timeout-fixture", async (_, cancellationToken) => {
+            providerStarted.Set();
+            await Task.Delay(Timeout.Infinite, cancellationToken);
+            return new OfficeOcrEngineResult { Text = "late" };
+        });
+
+        Task<OfficeDocumentOcrExecutionResult> execution = source.ApplyOcrAsync(
+            engine,
+            new OfficeDocumentOcrExecutionOptions { CandidateTimeout = TimeSpan.FromDays(30) },
+            cancellation.Token);
+        Assert.True(providerStarted.Wait(TimeSpan.FromSeconds(2)));
+
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => execution);
+    }
+
+    [Fact]
     public async Task ApplyOcrAsync_EnforcesTimeoutWhenSynchronousEngineIgnoresCancellation() {
         OfficeDocumentReadResult source = CreateDocument(1);
         using var releaseProvider = new ManualResetEventSlim(false);

--- a/OfficeIMO.Visio.Tests/Visio.Security.AllSeverityBatch21.cs
+++ b/OfficeIMO.Visio.Tests/Visio.Security.AllSeverityBatch21.cs
@@ -1,0 +1,43 @@
+using OfficeIMO.Visio;
+using OfficeIMO.Visio.Diagrams;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public class VisioAllSeverityBatch21Tests {
+    [Fact]
+    public void NumericNetworkTitleIdIsReservedBeforeGeneratedConnectors() {
+        string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
+        VisioDocument document = VisioDocument.Create(path)
+            .NetworkDiagram("Network", network => network
+                .Title("Network", id: "1")
+                .Server("source", "Source", 0, 0)
+                .Server("target", "Target", 1, 0)
+                .Ethernet("source", "target"));
+
+        VisioPage page = Assert.Single(document.Pages);
+        Assert.Contains(page.Shapes, shape => shape.Id == "1");
+        Assert.DoesNotContain(page.Connectors, connector => connector.Id == "1");
+
+        document.Save();
+        Assert.Empty(VisioValidator.Validate(path));
+    }
+
+    [Fact]
+    public void NumericArchitectureCalloutIdIsReservedBeforeGeneratedConnectors() {
+        string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
+        VisioDocument document = VisioDocument.Create(path)
+            .ArchitectureDiagram("Architecture", diagram => diagram
+                .Service("source", "Source", 0, 0)
+                .Service("target", "Target", 1, 0)
+                .DataFlow("source", "target")
+                .Callout("source", "1", "Important", VisioSide.Top));
+
+        VisioPage page = Assert.Single(document.Pages);
+        Assert.Contains(page.Shapes, shape => shape.Id == "1");
+        Assert.DoesNotContain(page.Connectors, connector => connector.Id == "1");
+
+        document.Save();
+        Assert.Empty(VisioValidator.Validate(path));
+    }
+}

--- a/OfficeIMO.Visio/Diagrams/VisioArchitectureDiagramBuilder.cs
+++ b/OfficeIMO.Visio/Diagrams/VisioArchitectureDiagramBuilder.cs
@@ -363,6 +363,10 @@ namespace OfficeIMO.Visio.Diagrams {
             }
 
             VisioPage page = _document.AddPage(_pageName, _pageWidth, _pageHeight, _unit);
+            page.ReserveAutomaticObjectId(_titleId);
+            foreach (CalloutItem callout in _callouts) {
+                page.ReserveAutomaticObjectId(callout.Id);
+            }
             page.Grid(visible: false, snap: true);
             AddRegions(page);
             AddComponents(page);

--- a/OfficeIMO.Visio/Diagrams/VisioNetworkDiagramBuilder.cs
+++ b/OfficeIMO.Visio/Diagrams/VisioNetworkDiagramBuilder.cs
@@ -491,6 +491,10 @@ namespace OfficeIMO.Visio.Diagrams {
             }
 
             VisioPage page = _document.AddPage(_pageName, _pageWidth, _pageHeight, _unit);
+            page.ReserveAutomaticObjectId(_titleId);
+            foreach (CalloutItem callout in _callouts) {
+                page.ReserveAutomaticObjectId(callout.Id);
+            }
             page.Grid(visible: false, snap: true);
             AddZones(page);
             AddNodes(page);
@@ -602,6 +606,14 @@ namespace OfficeIMO.Visio.Diagrams {
                 if (link.Id != null) {
                     ids.Add(link.Id);
                 }
+            }
+
+            if (!string.IsNullOrWhiteSpace(_titleId)) {
+                ids.Add(_titleId);
+            }
+
+            foreach (CalloutItem callout in _callouts) {
+                ids.Add(callout.Id);
             }
 
             return ids;

--- a/OfficeIMO.Visio/Stencils/VisioStencilPageExtensions.cs
+++ b/OfficeIMO.Visio/Stencils/VisioStencilPageExtensions.cs
@@ -88,7 +88,7 @@ namespace OfficeIMO.Visio.Stencils {
 
             VisioMeasurementUnit placementUnit = unit ?? page.DefaultUnit;
             VisioMeasurementUnit sizeUnit = useStencilDefaultSize
-                ? stencil.DefaultUnit ?? page.DefaultUnit
+                ? stencil.DefaultUnit ?? unit ?? page.DefaultUnit
                 : unit ?? page.DefaultUnit;
             VisioDocument? document = page.OwnerDocument;
             string shapeText = text ?? stencil.Name;

--- a/OfficeIMO.Visio/VisioPage.Shapes.cs
+++ b/OfficeIMO.Visio/VisioPage.Shapes.cs
@@ -33,12 +33,22 @@ namespace OfficeIMO.Visio {
                 Reserve(connector.Id);
             }
 
+            foreach (string reservedId in _reservedAutomaticObjectIds) {
+                Reserve(reservedId);
+            }
+
             int nextId = 1;
             while (usedIds.Contains(nextId)) {
                 nextId++;
             }
 
             return nextId.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        }
+
+        internal void ReserveAutomaticObjectId(string id) {
+            if (!string.IsNullOrWhiteSpace(id)) {
+                _reservedAutomaticObjectIds.Add(id);
+            }
         }
 
         private void PrepareConnectorForPage(VisioConnector connector, VisioConnector? ignoredConnector = null) {

--- a/OfficeIMO.Visio/VisioPage.cs
+++ b/OfficeIMO.Visio/VisioPage.cs
@@ -65,6 +65,7 @@ namespace OfficeIMO.Visio {
         private readonly List<VisioConnector> _connectors = new();
         private readonly List<VisioLayer> _layers = new();
         private readonly List<VisioComment> _comments = new();
+        private readonly HashSet<string> _reservedAutomaticObjectIds = new(StringComparer.OrdinalIgnoreCase);
         private readonly IList<VisioShape> _shapeCollection;
         private readonly IList<VisioConnector> _connectorCollection;
         private double _width = 8.26771653543307; // A4 width in inches

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.HeaderFooter.Content.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.HeaderFooter.Content.cs
@@ -71,12 +71,12 @@ namespace OfficeIMO.Word.Pdf {
         private static PdfCore.PdfStandardFont? ResolveNativeHeaderFooterFont(PdfCore.PdfStandardFont baseFont, NativeFontMap? nativeFontMap, params WordHeaderFooter?[] headerFooters) {
             PdfCore.PdfStandardFont? resolvedFont = null;
             foreach (WordHeaderFooter? headerFooter in headerFooters) {
-                foreach (string familyName in EnumerateNativeHeaderFooterFontFamilies(headerFooter)) {
-                    if (!TryResolveNativeMappedFont(familyName, nativeFontMap, out PdfCore.PdfStandardFont mappedFont)) {
+                foreach (NativeResolvedTextStyle style in EnumerateNativeHeaderFooterTextStyles(headerFooter, nativeFontMap)) {
+                    if (!style.Font.HasValue) {
                         continue;
                     }
 
-                    PdfCore.PdfStandardFont fontFamily = PdfCore.PdfStandardFontMapper.GetFontFamily(mappedFont);
+                    PdfCore.PdfStandardFont fontFamily = PdfCore.PdfStandardFontMapper.GetFontFamily(style.Font.Value);
                     if (resolvedFont.HasValue && resolvedFont.Value != fontFamily) {
                         return null;
                     }
@@ -99,9 +99,9 @@ namespace OfficeIMO.Word.Pdf {
         private static string? ResolveNativeHeaderFooterFontFamily(NativeFontMap nativeFontMap, params WordHeaderFooter?[] headerFooters) {
             string? resolvedFamily = null;
             foreach (WordHeaderFooter? headerFooter in headerFooters) {
-                foreach (string familyName in EnumerateNativeHeaderFooterFontFamilies(headerFooter)) {
-                    if (!nativeFontMap.TryGetNamedFontFamily(familyName, out string? namedFamily) ||
-                        string.IsNullOrWhiteSpace(namedFamily)) {
+                foreach (NativeResolvedTextStyle style in EnumerateNativeHeaderFooterTextStyles(headerFooter, nativeFontMap)) {
+                    string? namedFamily = style.FontFamily;
+                    if (string.IsNullOrWhiteSpace(namedFamily)) {
                         continue;
                     }
 
@@ -120,7 +120,12 @@ namespace OfficeIMO.Word.Pdf {
         private static PdfCore.PdfColor? ResolveNativeHeaderFooterColor(params WordHeaderFooter?[] headerFooters) {
             PdfCore.PdfColor? resolvedColor = null;
             foreach (WordHeaderFooter? headerFooter in headerFooters) {
-                foreach (PdfCore.PdfColor color in EnumerateNativeHeaderFooterColors(headerFooter)) {
+                foreach (NativeResolvedTextStyle style in EnumerateNativeHeaderFooterTextStyles(headerFooter)) {
+                    if (!style.Color.HasValue) {
+                        return null;
+                    }
+
+                    PdfCore.PdfColor color = style.Color.Value;
                     if (resolvedColor.HasValue && !resolvedColor.Value.Equals(color)) {
                         return null;
                     }
@@ -239,13 +244,13 @@ namespace OfficeIMO.Word.Pdf {
             }
         }
 
-        private static IEnumerable<NativeResolvedTextStyle> EnumerateNativeHeaderFooterTextStyles(WordHeaderFooter? headerFooter) {
+        private static IEnumerable<NativeResolvedTextStyle> EnumerateNativeHeaderFooterTextStyles(WordHeaderFooter? headerFooter, NativeFontMap? nativeFontMap = null) {
             if (headerFooter == null) {
                 yield break;
             }
 
             foreach (WordElement element in CollapseNativeParagraphElements(headerFooter.Elements)) {
-                foreach (NativeResolvedTextStyle style in EnumerateNativeHeaderFooterElementTextStyles(element)) {
+                foreach (NativeResolvedTextStyle style in EnumerateNativeHeaderFooterElementTextStyles(element, nativeFontMap)) {
                     yield return style;
                 }
             }
@@ -277,9 +282,9 @@ namespace OfficeIMO.Word.Pdf {
             }
         }
 
-        private static IEnumerable<NativeResolvedTextStyle> EnumerateNativeHeaderFooterElementTextStyles(WordElement element) {
+        private static IEnumerable<NativeResolvedTextStyle> EnumerateNativeHeaderFooterElementTextStyles(WordElement element, NativeFontMap? nativeFontMap) {
             if (element is WordParagraph paragraph) {
-                foreach (NativeResolvedTextStyle style in EnumerateNativeParagraphTextStyles(paragraph)) {
+                foreach (NativeResolvedTextStyle style in EnumerateNativeParagraphTextStyles(paragraph, nativeFontMap)) {
                     yield return style;
                 }
 
@@ -294,7 +299,7 @@ namespace OfficeIMO.Word.Pdf {
                 foreach (WordTableRow row in currentTable.Rows) {
                     foreach (WordTableCell cell in row.Cells) {
                         foreach (WordParagraph cellParagraph in cell.Paragraphs) {
-                            foreach (NativeResolvedTextStyle style in EnumerateNativeParagraphTextStyles(cellParagraph)) {
+                            foreach (NativeResolvedTextStyle style in EnumerateNativeParagraphTextStyles(cellParagraph, nativeFontMap)) {
                                 yield return style;
                             }
                         }
@@ -359,7 +364,7 @@ namespace OfficeIMO.Word.Pdf {
             }
         }
 
-        private static IEnumerable<NativeResolvedTextStyle> EnumerateNativeParagraphTextStyles(WordParagraph paragraph) {
+        private static IEnumerable<NativeResolvedTextStyle> EnumerateNativeParagraphTextStyles(WordParagraph paragraph, NativeFontMap? nativeFontMap = null) {
             List<WordParagraph> runs = GetNativeRuns(paragraph);
             bool emittedRun = false;
             foreach (WordParagraph run in runs) {
@@ -368,11 +373,11 @@ namespace OfficeIMO.Word.Pdf {
                 }
 
                 emittedRun = true;
-                yield return ResolveNativeTextRunStyle(run, paragraph);
+                yield return ResolveNativeTextRunStyle(run, paragraph, nativeFontMap: nativeFontMap);
             }
 
             if (!emittedRun && !string.IsNullOrWhiteSpace(paragraph.Text)) {
-                yield return ResolveNativeTextRunStyle(paragraph);
+                yield return ResolveNativeTextRunStyle(paragraph, nativeFontMap: nativeFontMap);
             }
         }
 

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.Tables.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.Tables.cs
@@ -81,7 +81,9 @@ namespace OfficeIMO.Word.Pdf {
                         images.Count == 0 ? null : images,
                         noWrap: !cell.WrapText));
 
-                    PdfCore.PdfColor? fill = ParseNativeColor(cell.ShadingFillColorHex) ?? tableStyleDefaults.CellFill;
+                    PdfCore.PdfColor? fill =
+                        ParseNativeColor(cell.ShadingFillColorHex) ??
+                        cellStyleDefaults.CellFill;
                     if (fill.HasValue) {
                         cellFills[(rowIndex, logicalColumnIndex)] = fill.Value;
                     }
@@ -656,7 +658,8 @@ namespace OfficeIMO.Word.Pdf {
         }
 
         private static NativeTableStyleDefaults ApplyNativeTableConditionalStyleDefaults(NativeTableStyleDefaults tableStyleDefaults, NativeTableConditionalStyleDefaults conditionalStyle) {
-            if (!conditionalStyle.TextColor.HasValue &&
+            if (!conditionalStyle.CellFill.HasValue &&
+                !conditionalStyle.TextColor.HasValue &&
                 !conditionalStyle.FontSize.HasValue &&
                 !conditionalStyle.Bold.HasValue &&
                 !conditionalStyle.Italic.HasValue &&
@@ -680,6 +683,7 @@ namespace OfficeIMO.Word.Pdf {
 
             NativeTableRunStyleDefaults runStyle = tableStyleDefaults.RunStyle;
             return tableStyleDefaults with {
+                CellFill = conditionalStyle.CellFill ?? tableStyleDefaults.CellFill,
                 CellVerticalAlignment = conditionalStyle.CellVerticalAlignment ?? tableStyleDefaults.CellVerticalAlignment,
                 ParagraphLineHeight = conditionalStyle.ParagraphLineHeight ?? tableStyleDefaults.ParagraphLineHeight,
                 ParagraphLineSpacingPoints = conditionalStyle.ParagraphLineSpacingPoints ?? tableStyleDefaults.ParagraphLineSpacingPoints,

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.cs
@@ -269,6 +269,10 @@ namespace OfficeIMO.Word.Pdf {
                 return false;
             }
 
+            if (current._sectionProperties?.GetFirstChild<W.PageNumberType>()?.Start?.HasValue == true) {
+                return false;
+            }
+
             return NativeSectionHeaderFooterReferencesEquivalent(previous, current) &&
                 NativeSectionPageNumberingEquivalent(previous, current);
         }

--- a/OfficeIMO.Word.Tests/Word.Security.AllSeverityBatch21.cs
+++ b/OfficeIMO.Word.Tests/Word.Security.AllSeverityBatch21.cs
@@ -1,0 +1,95 @@
+using System.Reflection;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Pdf;
+using UglyToad.PdfPig;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public partial class Word {
+    [Fact]
+    public void ListInfoRetainsOriginalConstructorSignature() {
+        ConstructorInfo? constructor = typeof(DocumentTraversal.ListInfo).GetConstructor(new[] {
+            typeof(int),
+            typeof(bool),
+            typeof(int),
+            typeof(NumberFormatValues?),
+            typeof(string),
+            typeof(int?),
+            typeof(int?)
+        });
+
+        Assert.NotNull(constructor);
+    }
+
+    [Fact]
+    public void ContinuousSectionWithExplicitRestartStartsNewPdfNumberingGroup() {
+        string docPath = Path.Combine(_directoryWithFiles, "PdfNativeContinuousSectionRestart.docx");
+        string pdfPath = Path.Combine(_directoryWithFiles, "PdfNativeContinuousSectionRestart.pdf");
+
+        using (WordDocument document = WordDocument.Create(docPath)) {
+            document.Sections[0].AddPageNumbering(1, NumberFormatValues.Decimal);
+            document.AddParagraph("BeforeRestart");
+            WordSection second = document.AddSection(SectionMarkValues.Continuous);
+            second.AddPageNumbering(1, NumberFormatValues.Decimal);
+            document.AddParagraph("AfterRestart");
+            document.Save();
+            document.SaveAsPdf(pdfPath, new PdfSaveOptions {
+                IncludePageNumbers = true,
+                PageSize = new OfficeIMO.Pdf.PageSize(400, 300),
+                Margins = OfficeIMO.Pdf.PageMargins.Uniform(50)
+            });
+        }
+
+        using PdfDocument pdf = PdfDocument.Open(pdfPath);
+        Assert.Equal(2, pdf.NumberOfPages);
+        Assert.Contains("BeforeRestart", pdf.GetPage(1).Text);
+        Assert.Contains("AfterRestart", pdf.GetPage(2).Text);
+    }
+
+    [Fact]
+    public void TableStyleFillPrecedenceIsDirectThenConditionalThenBase() {
+        string docPath = Path.Combine(_directoryWithFiles, "PdfNativeTableStyleFillPrecedence.docx");
+        string pdfPath = Path.Combine(_directoryWithFiles, "PdfNativeTableStyleFillPrecedence.pdf");
+
+        using (WordDocument document = WordDocument.Create(docPath)) {
+            const string styleId = "NativeTableStyleFillPrecedence";
+            Styles styles = document._wordprocessingDocument.MainDocumentPart!.StyleDefinitionsPart!.Styles!;
+            styles.Append(new Style(
+                new StyleName { Val = "Native Table Style Fill Precedence" },
+                new StyleTableProperties(
+                    new Shading { Val = ShadingPatternValues.Clear, Fill = "D9EAD3" }),
+                new TableStyleProperties(
+                    new TableStyleConditionalFormattingTableCellProperties(
+                        new Shading { Val = ShadingPatternValues.Clear, Fill = "CFE2F3" }))
+                { Type = TableStyleOverrideValues.FirstRow })
+            {
+                Type = StyleValues.Table,
+                StyleId = styleId,
+                CustomStyle = true
+            });
+
+            WordTable table = document.AddTable(2, 2);
+            table._tableProperties!.TableStyle = new TableStyle { Val = styleId };
+            table.ConditionalFormattingFirstRow = true;
+            table.Rows[0].Cells[0].Paragraphs[0].Text = "ConditionalFill";
+            table.Rows[0].Cells[1].Paragraphs[0].Text = "DirectFill";
+            table.Rows[0].Cells[1].ShadingFillColorHex = "F4CCCC";
+            table.Rows[1].Cells[0].Paragraphs[0].Text = "BaseFill";
+            table.Rows[1].Cells[1].Paragraphs[0].Text = "BasePeer";
+
+            document.Save();
+            document.SaveAsPdf(pdfPath, new PdfSaveOptions {
+                IncludePageNumbers = false,
+                PageSize = new OfficeIMO.Pdf.PageSize(420, 260),
+                Margins = OfficeIMO.Pdf.PageMargins.Uniform(40)
+            });
+        }
+
+        string content = ReadPdfPageContent(File.ReadAllBytes(pdfPath));
+        Assert.Contains("0.812 0.886 0.953 rg", content);
+        Assert.Contains("0.957 0.8 0.8 rg", content);
+        Assert.Contains("0.851 0.918 0.827 rg", content);
+    }
+}

--- a/OfficeIMO.Word/Converters/DocumentTraversal.cs
+++ b/OfficeIMO.Word/Converters/DocumentTraversal.cs
@@ -11,6 +11,11 @@ namespace OfficeIMO.Word {
         /// Describes list information for a paragraph.
         /// </summary>
         public readonly struct ListInfo {
+            /// <summary>Initializes a list descriptor using the original public constructor shape.</summary>
+            public ListInfo(int level, bool ordered, int start, NumberFormatValues? format, string? text, int? leftIndentTwips, int? hangingIndentTwips)
+                : this(level, ordered, start, format, text, leftIndentTwips, hangingIndentTwips, null, null, null, null, null, null) {
+            }
+
             /// <summary>
             /// Initializes a new instance of the <see cref="ListInfo"/> struct.
             /// </summary>


### PR DESCRIPTION
## Summary

- preserve established source and binary contracts across PDF, Excel, Word, and Visio APIs
- retain document semantics for Markdown tables, PDF compliance and pagination, PowerPoint scatter data, Visio identifiers, Word-to-PDF rendering, and Excel table appends
- keep normal Excel cell streams on the direct package writer while retaining preflight requests introduced after buffering begins, then clear the pending-only marker when buffered cells are materialized
- isolate synchronous OCR provider work, timeout supervision, and deferred non-concurrent gate release from the shared thread pool so bounded calls remain enforceable under saturation
- preserve the full positive OCR timeout range by supervising very long deadlines in bounded monotonic intervals
- keep streaming email attachment reads file-backed without retaining an attachment-sized managed buffer

## Compatibility

Legacy PDF form calls remain source-compatible without making untyped null calls ambiguous. Persisted enum values and earlier overload signatures remain stable. Word table fill precedence is explicit: direct cell shading overrides conditional table-style shading, which overrides the base table style. Scatter snapshots require matching X and Y counts per series but do not force different scatter series to use the same point count. Raw Markdown table cells preserve literal backslashes before Markdown punctuation. Headerless Excel table appends remain positional, while hidden headers retain named-column validation.

## Validation

Focused regressions pass on .NET 8 and .NET 10 for the affected document contracts. The final corrections pass 18/18 Reader OCR tests and 4/4 Excel all-severity batch tests on both runtimes. The synchronous deadline, long-timeout, and gate-settlement regressions also pass repeated runs on both runtimes. Affected netstandard2.0 projects build with zero warnings.