### PR TITLE
Keep headerless Excel table appends positional

### DIFF
--- a/OfficeIMO.Excel.Tests/Excel.DataTableInsert.cs
+++ b/OfficeIMO.Excel.Tests/Excel.DataTableInsert.cs
@@ -661,6 +661,41 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_AppendDataTableToTable_HiddenHeadersRejectMissingNamedColumn() {
+            string filePath = Path.Combine(_directoryWithFiles, "DataTableAppendTableHiddenHeadersMissingColumn.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorksheet("Sales");
+
+                var table = new DataTable();
+                table.Columns.Add("Region", typeof(string));
+                table.Columns.Add("Revenue", typeof(int));
+                table.Rows.Add("NA", 100);
+                sheet.InsertDataTableAsTable(table, tableName: "HiddenHeaderSales");
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true)) {
+                Table table = spreadsheet.WorkbookPart!.WorksheetParts.First().TableDefinitionParts.First().Table;
+                table.HeaderRowCount = 0U;
+                table.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath)) {
+                var append = new DataTable();
+                append.Columns.Add("Revenue", typeof(int));
+                append.Columns.Add("Foo", typeof(string));
+                append.Rows.Add(150, "misrouted");
+
+                var exception = Assert.Throws<ArgumentException>(() =>
+                    document.Sheets[0].AppendDataTableToTable(append, "HiddenHeaderSales"));
+                Assert.Contains("Region", exception.Message);
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
         public void Test_AppendDataTableToTable_ColumnLikeHeadersUseHeaderMapping() {
             string filePath = Path.Combine(_directoryWithFiles, "DataTableAppendTableColumnLikeHeaders.xlsx");
 

--- a/OfficeIMO.Excel.Tests/Excel.DataTableInsert.cs
+++ b/OfficeIMO.Excel.Tests/Excel.DataTableInsert.cs
@@ -587,6 +587,37 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_AppendDataTableToTable_HeaderlessDefaultColumnsRemainPositional() {
+            string filePath = Path.Combine(_directoryWithFiles, "DataTableAppendTableHeaderlessDefaultColumns.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorksheet("Sales");
+
+                var table = new DataTable();
+                table.Columns.Add("Region", typeof(string));
+                table.Columns.Add("Revenue", typeof(int));
+                table.Rows.Add("NA", 100);
+                sheet.InsertDataTableAsTable(table, includeHeaders: false, tableName: "HeaderlessSales");
+
+                var append = new DataTable();
+                append.Columns.Add("Column2", typeof(string));
+                append.Columns.Add("Column1", typeof(string));
+                append.Rows.Add("first-position", "second-position");
+
+                Assert.Equal("A1:B2", sheet.AppendDataTableToTable(append, "HeaderlessSales"));
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                Assert.Equal("first-position", GetCellText(spreadsheet, worksheetPart, "A2"));
+                Assert.Equal("second-position", GetCellText(spreadsheet, worksheetPart, "B2"));
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
         public void Test_AppendDataTableToTable_HiddenHeadersUseMatchingColumnNames() {
             string filePath = Path.Combine(_directoryWithFiles, "DataTableAppendTableHiddenHeaders.xlsx");
 

--- a/OfficeIMO.Excel/ExcelSheet.DataTable.Tables.cs
+++ b/OfficeIMO.Excel/ExcelSheet.DataTable.Tables.cs
@@ -330,11 +330,11 @@ namespace OfficeIMO.Excel {
                 return true;
             }
 
-            if (SourceContainsTableColumns(source, tableColumnNames)) {
-                return true;
+            if (HasDefaultHeaderlessColumnNames(tableColumnNames)) {
+                return false;
             }
 
-            return !HasDefaultHeaderlessColumnNames(tableColumnNames);
+            return SourceContainsTableColumns(source, tableColumnNames);
         }
 
         private static bool SourceContainsTableColumns(DataTable source, IReadOnlyList<string> tableColumnNames) {

--- a/OfficeIMO.Excel/ExcelSheet.DataTable.Tables.cs
+++ b/OfficeIMO.Excel/ExcelSheet.DataTable.Tables.cs
@@ -334,21 +334,6 @@ namespace OfficeIMO.Excel {
                 return false;
             }
 
-            return SourceContainsTableColumns(source, tableColumnNames);
-        }
-
-        private static bool SourceContainsTableColumns(DataTable source, IReadOnlyList<string> tableColumnNames) {
-            var sourceColumnNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            foreach (DataColumn column in source.Columns) {
-                sourceColumnNames.Add(column.ColumnName);
-            }
-
-            foreach (string tableColumnName in tableColumnNames) {
-                if (!sourceColumnNames.Contains(tableColumnName)) {
-                    return false;
-                }
-            }
-
             return true;
         }
 


### PR DESCRIPTION
## Summary

- keep append mapping positional for headerless tables that use generated Column1, Column2 metadata
- retain header-name mapping and missing-column validation for real hidden headers and ordinary tables
- add regressions for reversed generated names and a missing named hidden header

## Security impact

This resolves the remaining informational finding where attacker-controlled or externally supplied DataTable column names could reorder values during append to a headerless Excel table.

## Validation

All 14 AppendDataTableToTable regressions pass on .NET 8 and .NET 10. The OfficeIMO.Excel netstandard2.0 build completes with zero warnings and zero errors.