### PR TITLE
Repin PowerForge housekeeping audit fix

### DIFF
--- a/.github/workflows/github-housekeeping.yml
+++ b/.github/workflows/github-housekeeping.yml
@@ -20,11 +20,11 @@ concurrency:
 
 jobs:
   housekeeping:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-github-housekeeping.yml@23bb7cb83ca9fda14c5972f58ec1667fa87511cc
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-github-housekeeping.yml@c6451c9d264a81c7f179b38f6e4d2b62f0784037
     with:
       config_path: ./.powerforge/github-housekeeping.json
       apply: ${{ (github.event_name == 'workflow_dispatch' && inputs.apply == 'true') || (github.event_name != 'workflow_dispatch' && vars.POWERFORGE_GITHUB_HOUSEKEEPING_APPLY == 'true') }}
-      powerforge_ref: 23bb7cb83ca9fda14c5972f58ec1667fa87511cc
+      powerforge_ref: c6451c9d264a81c7f179b38f6e4d2b62f0784037
       report_artifact_name: github-housekeeping-reports
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Repins the affected PowerForge workflow/action to PSPublishModule `c6451c9`, whose owner build is green and resolves the Magick.NET 14.14.0 audit failure. The paired validation path uses the same verified immutable revision.