### PR TITLE
Harden final security boundaries and OCR timeout scheduling

### DIFF
--- a/.github/workflows/visio-showcase-artifacts.yml
+++ b/.github/workflows/visio-showcase-artifacts.yml
@@ -92,12 +92,14 @@ jobs:
 
   visio-desktop-showcase:
     name: Generate desktop Visio preview bundle
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_desktop_preview }}
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_desktop_preview && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
     runs-on: [self-hosted, Windows, Visio]
     timeout-minutes: 45
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5

--- a/OfficeIMO.Html.Tests/Html.Security.AllSeverityFinalHighs.cs
+++ b/OfficeIMO.Html.Tests/Html.Security.AllSeverityFinalHighs.cs
@@ -1,0 +1,33 @@
+using System.Text;
+using OfficeIMO.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class HtmlAllSeverityFinalHighSecurityTests {
+    [Fact]
+    public void TableImageAncestorStyleWalksConsumeTheLayoutOperationBudget() {
+        var html = new StringBuilder("<table><tr><td>");
+        for (int depth = 0; depth < 8; depth++) {
+            html.Append("<div>");
+        }
+        for (int image = 0; image < 12; image++) {
+            html.Append("<img width='1' height='1'>");
+        }
+        for (int depth = 0; depth < 8; depth++) {
+            html.Append("</div>");
+        }
+        html.Append("</td></tr></table>");
+
+        HtmlDomLimitException exception = Assert.Throws<HtmlDomLimitException>(() =>
+            HtmlRenderTestDriver.Render(
+                html.ToString(),
+                new HtmlRenderOptions {
+                    MaxLayoutDepth = 32,
+                    MaxLayoutOperations = 80
+                }));
+
+        Assert.Equal(HtmlRenderDiagnosticCodes.LayoutOperationLimitExceeded, exception.Code);
+        Assert.Equal(nameof(HtmlRenderOptions.MaxLayoutOperations), exception.LimitSource);
+    }
+}

--- a/OfficeIMO.Html/Rendering/HtmlRenderLayoutEngine.Tables.Columns.cs
+++ b/OfficeIMO.Html/Rendering/HtmlRenderLayoutEngine.Tables.Columns.cs
@@ -3,7 +3,7 @@ using AngleSharp.Dom;
 namespace OfficeIMO.Html;
 
 internal sealed partial class HtmlRenderLayoutEngine {
-    private IReadOnlyList<double> ResolveTableColumnWidths(IReadOnlyList<IElement> rows, IElement table, int columnCount, double contentWidth, HtmlRenderBoxStyle tableStyle) {
+    private IReadOnlyList<double> ResolveTableColumnWidths(IReadOnlyList<IElement> rows, IElement table, int columnCount, double contentWidth, HtmlRenderBoxStyle tableStyle, int depth) {
         if (tableStyle.TableLayout == "fixed") {
             var fixedWidths = new double[columnCount];
             ApplyDeclaredColumnWidths(table, contentWidth, tableStyle, fixedWidths, fixedWidths);
@@ -23,7 +23,7 @@ internal sealed partial class HtmlRenderLayoutEngine {
                 if (column >= columnCount) break;
                 int span = Math.Max(1, Math.Min(requestedSpan, columnCount - column));
                 HtmlRenderBoxStyle cellStyle = _styleResolver.Resolve(cell, contentWidth, tableStyle);
-                ResolveTableCellIntrinsicWidths(cell, cellStyle, contentWidth, out double minimum, out double maximum);
+                ResolveTableCellIntrinsicWidths(cell, cellStyle, contentWidth, depth, out double minimum, out double maximum);
                 ApplySpanningWidth(minimums, column, span, minimum);
                 ApplySpanningWidth(preferred, column, span, maximum);
                 int rowSpan = ReadRowSpan(cell.GetAttribute("rowspan"), rows, rowIndex, table);
@@ -70,7 +70,7 @@ internal sealed partial class HtmlRenderLayoutEngine {
         }
     }
 
-    private void ResolveTableCellIntrinsicWidths(IElement cell, HtmlRenderBoxStyle style, double containingWidth, out double minimum, out double preferred) {
+    private void ResolveTableCellIntrinsicWidths(IElement cell, HtmlRenderBoxStyle style, double containingWidth, int depth, out double minimum, out double preferred) {
         string text = ApplyTextTransform(cell.TextContent ?? string.Empty, style.TextTransform);
         IReadOnlyList<string> tokens = HtmlRenderCssValues.SplitWhitespace(text);
         string normalized = string.Join(" ", tokens);
@@ -88,6 +88,7 @@ internal sealed partial class HtmlRenderLayoutEngine {
                     cell,
                     style,
                     containingWidth,
+                    depth,
                     out HtmlRenderBoxStyle imageStyle)) {
                 continue;
             }
@@ -103,23 +104,32 @@ internal sealed partial class HtmlRenderLayoutEngine {
         IElement cell,
         HtmlRenderBoxStyle cellStyle,
         double containingWidth,
+        int depth,
         out HtmlRenderBoxStyle elementStyle) {
         var ancestors = new Stack<IElement>();
         for (IElement? current = element.ParentElement;
              current != null && !ReferenceEquals(current, cell);
              current = current.ParentElement) {
+            CheckCancellation();
+            EnsureDepth(depth + ancestors.Count + 2, element);
+            ChargeLayoutOperation(HtmlRenderStyleResolver.DescribeSource(current));
             ancestors.Push(current);
         }
 
         HtmlRenderBoxStyle parentStyle = cellStyle;
         while (ancestors.Count > 0) {
-            parentStyle = _styleResolver.Resolve(ancestors.Pop(), containingWidth, parentStyle);
+            CheckCancellation();
+            IElement ancestor = ancestors.Pop();
+            parentStyle = _styleResolver.Resolve(ancestor, containingWidth, parentStyle);
             if (string.Equals(parentStyle.Display, "none", StringComparison.OrdinalIgnoreCase)) {
                 elementStyle = parentStyle;
                 return false;
             }
         }
 
+        CheckCancellation();
+        EnsureDepth(depth + 1, element);
+        ChargeLayoutOperation(HtmlRenderStyleResolver.DescribeSource(element));
         elementStyle = _styleResolver.Resolve(element, containingWidth, parentStyle);
         return !string.Equals(elementStyle.Display, "none", StringComparison.OrdinalIgnoreCase);
     }

--- a/OfficeIMO.Html/Rendering/HtmlRenderLayoutEngine.Tables.cs
+++ b/OfficeIMO.Html/Rendering/HtmlRenderLayoutEngine.Tables.cs
@@ -78,7 +78,7 @@ internal sealed partial class HtmlRenderLayoutEngine {
         double horizontalSpacing = style.BorderCollapse == "collapse" ? 0D : style.BorderSpacingX;
         double verticalSpacing = style.BorderCollapse == "collapse" ? 0D : style.BorderSpacingY;
         double trackWidth = Math.Max(0.01D, contentWidth - horizontalSpacing * (columnCount + 1));
-        IReadOnlyList<double> columnWidths = ResolveTableColumnWidths(rows, table, columnCount, trackWidth, style);
+        IReadOnlyList<double> columnWidths = ResolveTableColumnWidths(rows, table, columnCount, trackWidth, style, depth);
         double[] columnOffsets = CreateColumnOffsets(columnWidths);
         var rowLayouts = new List<TableRowLayout>();
         var occupiedColumns = new int[columnCount];

--- a/OfficeIMO.Reader.Core/Ocr/OfficeDocumentOcrExecution.cs
+++ b/OfficeIMO.Reader.Core/Ocr/OfficeDocumentOcrExecution.cs
@@ -198,9 +198,12 @@ public static partial class OfficeDocumentOcrExecutionExtensions {
             Task<OfficeOcrEngineResult>? recognitionTask = null;
             try {
                 // Isolate both the provider's synchronous prefix and timeout supervision from a small thread pool.
+                // Confirm the provider worker is parked before arming the deadline so scheduling delay cannot consume it.
+                var providerReady = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
                 var providerStart = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
                 recognitionTask = Task.Factory.StartNew(
                         async () => {
+                            providerReady.TrySetResult(null);
                             providerStart.Task.GetAwaiter().GetResult();
                             return await engine
                                 .RecognizeAsync(request, providerCancellation.Token)
@@ -210,6 +213,7 @@ public static partial class OfficeDocumentOcrExecutionExtensions {
                         TaskCreationOptions.LongRunning | TaskCreationOptions.DenyChildAttach,
                         TaskScheduler.Default)
                     .Unwrap();
+                providerReady.Task.GetAwaiter().GetResult();
                 Task<OfficeOcrEngineResult> supervision;
                 try {
                     supervision = WaitWithTimeoutAsync(


### PR DESCRIPTION
## Summary

- bound HTML table-image ancestor discovery by the existing cancellation, depth, and operation budgets
- restrict the optional self-hosted Visio desktop lane to the repository's full default-branch ref and avoid persisted checkout credentials
- prevent OCR candidate deadlines from expiring before their dedicated provider workers are ready to run under constrained .NET Framework scheduling
- add a regression proving repeated table-image ancestor walks cannot bypass the layout budget

## Validation

- focused HTML security and table tests pass on .NET 8 and .NET 10
- Reader OCR core tests pass 18/18 on .NET 8 and .NET 10
- both previously failing OCR scheduling paths pass 20 consecutive runs on each target
- OfficeIMO.Html and OfficeIMO.Reader.Core netstandard2.0 builds succeed with zero warnings
- workflow YAML parses successfully
- one independent local security review completed for the original security diff; both findings were corrected and targeted confirmation passed
