### PR TITLE
Add first-class PowerPoint bubble charts

### DIFF
--- a/OfficeIMO.Drawing.Tests/Drawing.ChartBubbles.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.ChartBubbles.cs
@@ -96,6 +96,63 @@ public class DrawingChartBubbleTests {
     }
 
     [Fact]
+    public void OfficeChartDrawingRenderer_InsetsBubblesInMixedScatterCharts() {
+        OfficeColor bubbleColor = OfficeColor.Parse("#2A9D8F");
+        var data = new OfficeChartData(new[] { "1", "2" }, new OfficeChartSeries[] {
+            new OfficeChartSeries(
+                "Scatter",
+                new[] { 1D, 2D },
+                new[] { 1D, 2D },
+                OfficeColor.Parse("#264653"),
+                pointColors: null,
+                showMarkers: true,
+                renderKind: OfficeChartKind.Scatter),
+            OfficeChartSeries.CreateBubble(
+                "Bubbles",
+                new[] { 1D, 2D },
+                new[] { 1D, 2D },
+                new[] { 25D, 100D },
+                bubbleColor)
+        });
+        OfficeDrawing drawing = OfficeChartDrawingRenderer.Render(
+            new OfficeChartSnapshot(
+                "Mixed scatter",
+                null,
+                OfficeChartKind.Scatter,
+                data,
+                widthPoints: 420D,
+                heightPoints: 260D,
+                style: null,
+                layout: new OfficeChartLayout(showLegend: false),
+                bubbleScalePercent: 200D,
+                bubbleSizeMode: OfficeChartBubbleSizeMode.Area));
+        OfficeDrawingShape horizontalAxis = drawing.Shapes
+            .Where(shape => shape.Shape.Kind == OfficeShapeKind.Line &&
+                            shape.Shape.Width > 100D && shape.Shape.Height == 0D)
+            .OrderByDescending(shape => shape.Shape.Width)
+            .First();
+        OfficeDrawingShape verticalAxis = drawing.Shapes
+            .Where(shape => shape.Shape.Kind == OfficeShapeKind.Line &&
+                            shape.Shape.Width == 0D && shape.Shape.Height > 50D)
+            .OrderByDescending(shape => shape.Shape.Height)
+            .First();
+
+        OfficeDrawingShape[] bubbles = drawing.Shapes.Where(shape =>
+                shape.Shape.Kind == OfficeShapeKind.Ellipse &&
+                shape.Shape.FillColor == bubbleColor)
+            .ToArray();
+        Assert.Equal(2, bubbles.Length);
+        Assert.All(bubbles, bubble => {
+            Assert.True(bubble.X >= horizontalAxis.X - 0.001D);
+            Assert.True(bubble.X + bubble.Shape.Width <=
+                        horizontalAxis.X + horizontalAxis.Shape.Width + 0.001D);
+            Assert.True(bubble.Y >= verticalAxis.Y - 0.001D);
+            Assert.True(bubble.Y + bubble.Shape.Height <=
+                        verticalAxis.Y + verticalAxis.Shape.Height + 0.001D);
+        });
+    }
+
+    [Fact]
     public void OfficeChartDrawingRenderer_RendersBubblesWhenScatterMarkersAreHidden() {
         OfficeColor color = OfficeColor.Parse("#2A9D8F");
         var data = new OfficeChartData(new[] { "1", "2" }, new[] {

--- a/OfficeIMO.Drawing.Tests/Drawing.ChartBubbles.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.ChartBubbles.cs
@@ -1,0 +1,81 @@
+using System.Linq;
+using OfficeIMO.Drawing;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public class DrawingChartBubbleTests {
+    [Fact]
+    public void OfficeChartDrawingRenderer_HonorsBubbleScaleAndSizeMode() {
+        OfficeDrawing area = RenderBubbles(100D, OfficeChartBubbleSizeMode.Area);
+        OfficeDrawing width = RenderBubbles(100D, OfficeChartBubbleSizeMode.Width);
+        OfficeDrawing scaled = RenderBubbles(200D, OfficeChartBubbleSizeMode.Area);
+
+        double[] areaDiameters = GetBubbleDiameters(area);
+        double[] widthDiameters = GetBubbleDiameters(width);
+        double[] scaledDiameters = GetBubbleDiameters(scaled);
+
+        Assert.Equal(2, areaDiameters.Length);
+        Assert.Equal(2, widthDiameters.Length);
+        Assert.Equal(2, scaledDiameters.Length);
+        Assert.True(widthDiameters[0] < areaDiameters[0]);
+        Assert.Equal(areaDiameters[1], widthDiameters[1], precision: 6);
+        Assert.True(scaledDiameters[1] > areaDiameters[1] * 1.9D);
+    }
+
+    [Fact]
+    public void OfficeChartDrawingRenderer_InsetsBubbleExtremaInsidePlotAxes() {
+        OfficeDrawing drawing = RenderBubbles(200D, OfficeChartBubbleSizeMode.Area);
+        OfficeDrawingShape horizontalAxis = drawing.Shapes
+            .Where(shape => shape.Shape.Kind == OfficeShapeKind.Line &&
+                            shape.Shape.Width > 100D && shape.Shape.Height == 0D)
+            .OrderByDescending(shape => shape.Shape.Width)
+            .First();
+        OfficeDrawingShape verticalAxis = drawing.Shapes
+            .Where(shape => shape.Shape.Kind == OfficeShapeKind.Line &&
+                            shape.Shape.Width == 0D && shape.Shape.Height > 50D)
+            .OrderByDescending(shape => shape.Shape.Height)
+            .First();
+
+        foreach (OfficeDrawingShape bubble in GetBubbles(drawing)) {
+            Assert.True(bubble.X >= horizontalAxis.X - 0.001D);
+            Assert.True(bubble.X + bubble.Shape.Width <=
+                        horizontalAxis.X + horizontalAxis.Shape.Width + 0.001D);
+            Assert.True(bubble.Y >= verticalAxis.Y - 0.001D);
+            Assert.True(bubble.Y + bubble.Shape.Height <=
+                        verticalAxis.Y + verticalAxis.Shape.Height + 0.001D);
+        }
+    }
+
+    private static OfficeDrawing RenderBubbles(double scale,
+        OfficeChartBubbleSizeMode sizeMode) {
+        OfficeColor color = OfficeColor.Parse("#2A9D8F");
+        var data = new OfficeChartData(new[] { "1", "2" }, new[] {
+            OfficeChartSeries.CreateBubble("Portfolio",
+                new[] { 1D, 2D },
+                new[] { 1D, 2D },
+                new[] { 25D, 100D },
+                color)
+        });
+        return OfficeChartDrawingRenderer.Render(new OfficeChartSnapshot(
+            "Bubbles",
+            null,
+            OfficeChartKind.Bubble,
+            data,
+            widthPoints: 420D,
+            heightPoints: 260D,
+            layout: new OfficeChartLayout(showLegend: false),
+            bubbleScalePercent: scale,
+            bubbleSizeMode: sizeMode));
+    }
+
+    private static OfficeDrawingShape[] GetBubbles(OfficeDrawing drawing) =>
+        drawing.Shapes.Where(shape =>
+                shape.Shape.Kind == OfficeShapeKind.Ellipse &&
+                shape.Shape.FillColor == OfficeColor.Parse("#2A9D8F"))
+            .OrderBy(shape => shape.Shape.Width)
+            .ToArray();
+
+    private static double[] GetBubbleDiameters(OfficeDrawing drawing) =>
+        GetBubbles(drawing).Select(shape => shape.Shape.Width).ToArray();
+}

--- a/OfficeIMO.Drawing.Tests/Drawing.ChartBubbles.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.ChartBubbles.cs
@@ -221,6 +221,43 @@ public class DrawingChartBubbleTests {
             heightPoints: 260D));
     }
 
+    [Fact]
+    public void OfficeChartSnapshot_RejectsMixedBubbleSeriesWithoutSizes() {
+        var data = new OfficeChartData(new[] { "1", "2" }, new[] {
+            new OfficeChartSeries(
+                "Incomplete bubble",
+                new[] { 2D, 4D },
+                new[] { 1D, 2D },
+                color: null,
+                pointColors: null,
+                showMarkers: true,
+                renderKind: OfficeChartKind.Bubble)
+        });
+
+        Assert.Throws<System.ArgumentException>(() => new OfficeChartSnapshot(
+            "Malformed mixed scatter",
+            null,
+            OfficeChartKind.Scatter,
+            data,
+            widthPoints: 420D,
+            heightPoints: 260D));
+    }
+
+    [Theory]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity)]
+    public void OfficeChartSeries_RejectsNonFiniteBubbleOutlineWidths(
+        double outlineWidth) {
+        Assert.Throws<System.ArgumentOutOfRangeException>(() =>
+            OfficeChartSeries.CreateBubble(
+                "Invalid outline",
+                new[] { 1D },
+                new[] { 2D },
+                new[] { 4D },
+                markerOutlineWidth: outlineWidth));
+    }
+
     private static OfficeDrawing RenderBubbles(double scale,
         OfficeChartBubbleSizeMode sizeMode) {
         OfficeColor color = OfficeColor.Parse("#2A9D8F");

--- a/OfficeIMO.Drawing.Tests/Drawing.ChartBubbles.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.ChartBubbles.cs
@@ -243,6 +243,25 @@ public class DrawingChartBubbleTests {
             heightPoints: 260D));
     }
 
+    [Fact]
+    public void OfficeChartSnapshot_RejectsBubbleSeriesOnCategoricalAxes() {
+        var data = new OfficeChartData(new[] { "1", "2" }, new[] {
+            OfficeChartSeries.CreateBubble(
+                "Misplaced bubble",
+                new[] { 1D, 2D },
+                new[] { 3D, 4D },
+                new[] { 5D, 6D })
+        });
+
+        Assert.Throws<System.ArgumentException>(() => new OfficeChartSnapshot(
+            "Categorical",
+            null,
+            OfficeChartKind.ColumnClustered,
+            data,
+            widthPoints: 420D,
+            heightPoints: 260D));
+    }
+
     [Theory]
     [InlineData(double.NaN)]
     [InlineData(double.PositiveInfinity)]

--- a/OfficeIMO.Drawing.Tests/Drawing.ChartBubbles.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.ChartBubbles.cs
@@ -18,9 +18,10 @@ public class DrawingChartBubbleTests {
         Assert.Equal(2, areaDiameters.Length);
         Assert.Equal(2, widthDiameters.Length);
         Assert.Equal(2, scaledDiameters.Length);
-        Assert.True(widthDiameters[0] < areaDiameters[0]);
+        Assert.Equal(areaDiameters[1] * 0.5D, areaDiameters[0], precision: 6);
+        Assert.Equal(widthDiameters[1] * 0.25D, widthDiameters[0], precision: 6);
         Assert.Equal(areaDiameters[1], widthDiameters[1], precision: 6);
-        Assert.True(scaledDiameters[1] > areaDiameters[1] * 1.9D);
+        Assert.Equal(areaDiameters[1] * 2D, scaledDiameters[1], precision: 6);
     }
 
     [Fact]
@@ -45,6 +46,39 @@ public class DrawingChartBubbleTests {
             Assert.True(bubble.Y + bubble.Shape.Height <=
                         verticalAxis.Y + verticalAxis.Shape.Height + 0.001D);
         }
+
+        OfficeDrawingShape[] bubbles = GetBubbles(drawing)
+            .OrderBy(shape => shape.X + shape.Shape.Width / 2D)
+            .ToArray();
+        double[] horizontalTickPositions = drawing.Shapes
+            .Where(shape => shape.Shape.Kind == OfficeShapeKind.Line &&
+                            shape.Shape.Width == 0D &&
+                            shape.Shape.Height > 0D &&
+                            shape.Shape.Height <= 4.001D)
+            .Select(shape => shape.X)
+            .Distinct()
+            .OrderBy(value => value)
+            .ToArray();
+        double[] verticalTickPositions = drawing.Shapes
+            .Where(shape => shape.Shape.Kind == OfficeShapeKind.Line &&
+                            shape.Shape.Height == 0D &&
+                            shape.Shape.Width > 0D &&
+                            shape.Shape.Width <= 4.001D)
+            .Select(shape => shape.Y)
+            .Distinct()
+            .OrderBy(value => value)
+            .ToArray();
+
+        Assert.Equal(5, horizontalTickPositions.Length);
+        Assert.Equal(5, verticalTickPositions.Length);
+        Assert.Equal(horizontalTickPositions[0],
+            bubbles[0].X + bubbles[0].Shape.Width / 2D, precision: 6);
+        Assert.Equal(horizontalTickPositions[4],
+            bubbles[1].X + bubbles[1].Shape.Width / 2D, precision: 6);
+        Assert.Equal(verticalTickPositions[0],
+            bubbles[1].Y + bubbles[1].Shape.Height / 2D, precision: 6);
+        Assert.Equal(verticalTickPositions[4],
+            bubbles[0].Y + bubbles[0].Shape.Height / 2D, precision: 6);
     }
 
     private static OfficeDrawing RenderBubbles(double scale,
@@ -64,7 +98,10 @@ public class DrawingChartBubbleTests {
             data,
             widthPoints: 420D,
             heightPoints: 260D,
-            layout: new OfficeChartLayout(showLegend: false),
+            layout: new OfficeChartLayout(
+                showLegend: false,
+                horizontalAxisMajorTickMark: OfficeChartAxisTickMark.Cross,
+                verticalAxisMajorTickMark: OfficeChartAxisTickMark.Cross),
             bubbleScalePercent: scale,
             bubbleSizeMode: sizeMode));
     }

--- a/OfficeIMO.Drawing.Tests/Drawing.ChartBubbles.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.ChartBubbles.cs
@@ -151,6 +151,49 @@ public class DrawingChartBubbleTests {
     }
 
     [Fact]
+    public void OfficeChartDrawingRenderer_CapsExtremeBubbleOutlineInsets() {
+        OfficeColor color = OfficeColor.Parse("#2A9D8F");
+        var data = new OfficeChartData(new[] { "1" }, new[] {
+            OfficeChartSeries.CreateBubble(
+                "Outlined", new[] { 1D }, new[] { 1D },
+                new[] { 100D }, color,
+                markerOutlineWidth: 1000D)
+        });
+        OfficeDrawing drawing = OfficeChartDrawingRenderer.Render(
+            new OfficeChartSnapshot(
+                "Compact",
+                null,
+                OfficeChartKind.Bubble,
+                data,
+                widthPoints: 80D,
+                heightPoints: 60D,
+                layout: new OfficeChartLayout(showLegend: false)),
+            useMinimumCanvas: false);
+        OfficeDrawingShape horizontalAxis = drawing.Shapes
+            .Where(shape => shape.Shape.Kind == OfficeShapeKind.Line &&
+                            shape.Shape.Width > 10D &&
+                            shape.Shape.Height == 0D)
+            .OrderByDescending(shape => shape.Shape.Width)
+            .First();
+        OfficeDrawingShape verticalAxis = drawing.Shapes
+            .Where(shape => shape.Shape.Kind == OfficeShapeKind.Line &&
+                            shape.Shape.Width == 0D &&
+                            shape.Shape.Height > 10D)
+            .OrderByDescending(shape => shape.Shape.Height)
+            .First();
+        OfficeDrawingShape bubble = Assert.Single(GetBubbles(drawing));
+        double centerX = bubble.X + bubble.Shape.Width / 2D;
+        double centerY = bubble.Y + bubble.Shape.Height / 2D;
+
+        Assert.InRange(centerX, horizontalAxis.X,
+            horizontalAxis.X + horizontalAxis.Shape.Width);
+        Assert.InRange(centerY, verticalAxis.Y,
+            verticalAxis.Y + verticalAxis.Shape.Height);
+        Assert.InRange(centerX, 0D, drawing.Width);
+        Assert.InRange(centerY, 0D, drawing.Height);
+    }
+
+    [Fact]
     public void OfficeChartDrawingRenderer_InsetsBubblesInMixedScatterCharts() {
         OfficeColor bubbleColor = OfficeColor.Parse("#2A9D8F");
         var data = new OfficeChartData(new[] { "1", "2" }, new OfficeChartSeries[] {

--- a/OfficeIMO.Drawing.Tests/Drawing.ChartBubbles.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.ChartBubbles.cs
@@ -6,6 +6,20 @@ namespace OfficeIMO.Tests;
 
 public class DrawingChartBubbleTests {
     [Fact]
+    public void OfficeChartSnapshot_RetainsBinaryCompatibleConstructor() {
+        Assert.NotNull(typeof(OfficeChartSnapshot).GetConstructor(new[] {
+            typeof(string),
+            typeof(string),
+            typeof(OfficeChartKind),
+            typeof(OfficeChartData),
+            typeof(double),
+            typeof(double),
+            typeof(OfficeChartStyle),
+            typeof(OfficeChartLayout)
+        }));
+    }
+
+    [Fact]
     public void OfficeChartDrawingRenderer_HonorsBubbleScaleAndSizeMode() {
         OfficeDrawing area = RenderBubbles(100D, OfficeChartBubbleSizeMode.Area);
         OfficeDrawing width = RenderBubbles(100D, OfficeChartBubbleSizeMode.Width);
@@ -167,6 +181,7 @@ public class DrawingChartBubbleTests {
             data,
             widthPoints: 420D,
             heightPoints: 260D,
+            style: null,
             layout: new OfficeChartLayout(
                 showLegend: false,
                 horizontalAxisMajorTickMark: OfficeChartAxisTickMark.Cross,

--- a/OfficeIMO.Drawing.Tests/Drawing.ChartBubbles.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.ChartBubbles.cs
@@ -96,6 +96,61 @@ public class DrawingChartBubbleTests {
     }
 
     [Fact]
+    public void OfficeChartDrawingRenderer_InsetsBubbleOutlinesInsidePlotAxes() {
+        OfficeColor color = OfficeColor.Parse("#2A9D8F");
+        var data = new OfficeChartData(new[] { "1", "2" }, new[] {
+            OfficeChartSeries.CreateBubble(
+                "Outlined",
+                new[] { 1D, 2D },
+                new[] { 1D, 2D },
+                new[] { 25D, 100D },
+                color,
+                markerOutlineColor: OfficeColor.Parse("#112233"),
+                markerOutlineWidth: 12D)
+        });
+        OfficeDrawing drawing = OfficeChartDrawingRenderer.Render(
+            new OfficeChartSnapshot(
+                "Outlined bubbles",
+                null,
+                OfficeChartKind.Bubble,
+                data,
+                widthPoints: 420D,
+                heightPoints: 260D,
+                style: null,
+                layout: new OfficeChartLayout(showLegend: false),
+                bubbleScalePercent: 200D,
+                bubbleSizeMode: OfficeChartBubbleSizeMode.Area));
+        OfficeDrawingShape horizontalAxis = drawing.Shapes
+            .Where(shape => shape.Shape.Kind == OfficeShapeKind.Line &&
+                            shape.Shape.Width > 100D &&
+                            shape.Shape.Height == 0D)
+            .OrderByDescending(shape => shape.Shape.Width)
+            .First();
+        OfficeDrawingShape verticalAxis = drawing.Shapes
+            .Where(shape => shape.Shape.Kind == OfficeShapeKind.Line &&
+                            shape.Shape.Width == 0D &&
+                            shape.Shape.Height > 50D)
+            .OrderByDescending(shape => shape.Shape.Height)
+            .First();
+
+        Assert.All(GetBubbles(drawing), bubble => {
+            double halfStroke = bubble.Shape.StrokeWidth / 2D;
+            Assert.True(bubble.X - halfStroke >=
+                        horizontalAxis.X - 0.001D,
+                $"Left edge {bubble.X - halfStroke} is before axis {horizontalAxis.X}.");
+            Assert.True(bubble.X + bubble.Shape.Width + halfStroke <=
+                        horizontalAxis.X + horizontalAxis.Shape.Width + 0.001D,
+                $"Right edge {bubble.X + bubble.Shape.Width + halfStroke} exceeds axis {horizontalAxis.X + horizontalAxis.Shape.Width}.");
+            Assert.True(bubble.Y - halfStroke >=
+                        verticalAxis.Y - 0.001D,
+                $"Top edge {bubble.Y - halfStroke} is above axis {verticalAxis.Y}.");
+            Assert.True(bubble.Y + bubble.Shape.Height + halfStroke <=
+                        verticalAxis.Y + verticalAxis.Shape.Height + 0.001D,
+                $"Bottom edge {bubble.Y + bubble.Shape.Height + halfStroke} exceeds axis {verticalAxis.Y + verticalAxis.Shape.Height}.");
+        });
+    }
+
+    [Fact]
     public void OfficeChartDrawingRenderer_InsetsBubblesInMixedScatterCharts() {
         OfficeColor bubbleColor = OfficeColor.Parse("#2A9D8F");
         var data = new OfficeChartData(new[] { "1", "2" }, new OfficeChartSeries[] {

--- a/OfficeIMO.Drawing.Tests/Drawing.ChartBubbles.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.ChartBubbles.cs
@@ -81,6 +81,75 @@ public class DrawingChartBubbleTests {
             bubbles[0].Y + bubbles[0].Shape.Height / 2D, precision: 6);
     }
 
+    [Fact]
+    public void OfficeChartDrawingRenderer_RendersBubblesWhenScatterMarkersAreHidden() {
+        OfficeColor color = OfficeColor.Parse("#2A9D8F");
+        var data = new OfficeChartData(new[] { "1", "2" }, new[] {
+            OfficeChartSeries.CreateBubble("Portfolio",
+                new[] { 1D, 2D },
+                new[] { 1D, 2D },
+                new[] { 25D, 100D },
+                color)
+        });
+
+        OfficeDrawing drawing = OfficeChartDrawingRenderer.Render(
+            new OfficeChartSnapshot(
+                "Bubbles",
+                null,
+                OfficeChartKind.Bubble,
+                data,
+                widthPoints: 420D,
+                heightPoints: 260D,
+                layout: new OfficeChartLayout(showLegend: false, showMarkers: false)));
+
+        Assert.Equal(2, GetBubbles(drawing).Length);
+    }
+
+    [Fact]
+    public void OfficeChartDrawingRenderer_PreservesDisabledBubbleOutline() {
+        OfficeColor color = OfficeColor.Parse("#2A9D8F");
+        var data = new OfficeChartData(new[] { "1" }, new[] {
+            OfficeChartSeries.CreateBubble("Portfolio",
+                new[] { 1D },
+                new[] { 2D },
+                new[] { 25D },
+                color,
+                showMarkerOutline: false)
+        });
+
+        OfficeDrawing drawing = OfficeChartDrawingRenderer.Render(
+            new OfficeChartSnapshot(
+                "Bubbles",
+                null,
+                OfficeChartKind.Bubble,
+                data,
+                widthPoints: 420D,
+                heightPoints: 260D));
+        OfficeDrawingShape bubble = Assert.Single(GetBubbles(drawing));
+
+        Assert.False(Assert.Single(data.Series).ShowMarkerOutline);
+        Assert.Null(bubble.Shape.StrokeColor);
+        Assert.Equal(0D, bubble.Shape.StrokeWidth);
+    }
+
+    [Fact]
+    public void OfficeChartSnapshot_RejectsBubbleSeriesWithoutSizes() {
+        var data = new OfficeChartData(new[] { "1", "2" }, new[] {
+            new OfficeChartSeries(
+                "Incomplete",
+                new[] { 2D, 4D },
+                new[] { 1D, 2D })
+        });
+
+        Assert.Throws<System.ArgumentException>(() => new OfficeChartSnapshot(
+            "Malformed",
+            null,
+            OfficeChartKind.Bubble,
+            data,
+            widthPoints: 420D,
+            heightPoints: 260D));
+    }
+
     private static OfficeDrawing RenderBubbles(double scale,
         OfficeChartBubbleSizeMode sizeMode) {
         OfficeColor color = OfficeColor.Parse("#2A9D8F");

--- a/OfficeIMO.Drawing/OfficeChartBubbleSizeMode.cs
+++ b/OfficeIMO.Drawing/OfficeChartBubbleSizeMode.cs
@@ -1,0 +1,16 @@
+namespace OfficeIMO.Drawing;
+
+/// <summary>
+/// Defines how bubble values are translated into rendered bubble dimensions.
+/// </summary>
+public enum OfficeChartBubbleSizeMode {
+    /// <summary>
+    /// Bubble values are proportional to the rendered bubble area.
+    /// </summary>
+    Area,
+
+    /// <summary>
+    /// Bubble values are proportional to the rendered bubble width.
+    /// </summary>
+    Width
+}

--- a/OfficeIMO.Drawing/OfficeChartDrawingRenderer.Bubbles.cs
+++ b/OfficeIMO.Drawing/OfficeChartDrawingRenderer.Bubbles.cs
@@ -28,8 +28,12 @@ public static partial class OfficeChartDrawingRenderer {
         if (diameter <= 0D) {
             return;
         }
-        double outlineWidth = series.MarkerOutlineWidth ?? 1D;
-        OfficeColor outlineColor = series.MarkerOutlineColor ?? color;
+        double outlineWidth = series.ShowMarkerOutline
+            ? series.MarkerOutlineWidth ?? 1D
+            : 0D;
+        OfficeColor? outlineColor = series.ShowMarkerOutline
+            ? series.MarkerOutlineColor ?? color
+            : null;
         AddShape(drawing, OfficeShape.Ellipse(diameter, diameter),
             center.X - diameter / 2D, center.Y - diameter / 2D,
             color, outlineColor, outlineWidth);

--- a/OfficeIMO.Drawing/OfficeChartDrawingRenderer.Bubbles.cs
+++ b/OfficeIMO.Drawing/OfficeChartDrawingRenderer.Bubbles.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+
+namespace OfficeIMO.Drawing;
+
+public static partial class OfficeChartDrawingRenderer {
+    private static void AddBubbleMarker(OfficeDrawing drawing, OfficeChartSeries series,
+        int pointIndex, OfficePoint center, double plotWidth, double plotHeight,
+        double maximumBubbleSize, OfficeColor color) {
+        if (series.BubbleSizes == null || pointIndex < 0 ||
+            pointIndex >= series.BubbleSizes.Count) {
+            return;
+        }
+
+        double size = series.BubbleSizes[pointIndex];
+        double maximumDiameter = Math.Max(12D, Math.Min(42D, Math.Min(plotWidth, plotHeight) * 0.16D));
+        double diameter = maximumBubbleSize <= 0D
+            ? 3D
+            : 3D + (maximumDiameter - 3D) * Math.Sqrt(size / maximumBubbleSize);
+        double outlineWidth = series.MarkerOutlineWidth ?? 1D;
+        OfficeColor outlineColor = series.MarkerOutlineColor ?? color;
+        AddShape(drawing, OfficeShape.Ellipse(diameter, diameter),
+            center.X - diameter / 2D, center.Y - diameter / 2D,
+            color, outlineColor, outlineWidth);
+    }
+
+    private static double GetMaximumBubbleSize(
+        System.Collections.Generic.IReadOnlyList<OfficeChartSeries> series) {
+        double maximum = 0D;
+        for (int seriesIndex = 0; seriesIndex < series.Count; seriesIndex++) {
+            IReadOnlyList<double>? sizes = series[seriesIndex].BubbleSizes;
+            if (sizes == null) continue;
+            for (int pointIndex = 0; pointIndex < sizes.Count; pointIndex++) {
+                maximum = Math.Max(maximum, sizes[pointIndex]);
+            }
+        }
+        return maximum;
+    }
+}

--- a/OfficeIMO.Drawing/OfficeChartDrawingRenderer.Bubbles.cs
+++ b/OfficeIMO.Drawing/OfficeChartDrawingRenderer.Bubbles.cs
@@ -60,12 +60,19 @@ public static partial class OfficeChartDrawingRenderer {
                 snapshot.BubbleScalePercent)
             : 0D;
 
-    private static double GetBubblePlotPadding(OfficeChartSnapshot snapshot,
-        double maximumBubbleDiameter) =>
-        maximumBubbleDiameter > 0D
+    private static void GetBubblePlotPadding(
+        OfficeChartSnapshot snapshot, double maximumBubbleDiameter,
+        double plotWidth, double plotHeight,
+        out double horizontalPadding, out double verticalPadding) {
+        double requestedPadding = maximumBubbleDiameter > 0D
             ? maximumBubbleDiameter / 2D +
               GetMaximumBubbleOutlineWidth(snapshot.Data.Series) / 2D
             : 0D;
+        horizontalPadding = Math.Min(
+            requestedPadding, Math.Max(0D, (plotWidth - 1D) / 2D));
+        verticalPadding = Math.Min(
+            requestedPadding, Math.Max(0D, (plotHeight - 1D) / 2D));
+    }
 
     private static double GetMaximumBubbleOutlineWidth(
         IReadOnlyList<OfficeChartSeries> series) {

--- a/OfficeIMO.Drawing/OfficeChartDrawingRenderer.Bubbles.cs
+++ b/OfficeIMO.Drawing/OfficeChartDrawingRenderer.Bubbles.cs
@@ -22,10 +22,9 @@ public static partial class OfficeChartDrawingRenderer {
         double sizeFactor = sizeMode == OfficeChartBubbleSizeMode.Width
             ? ratio
             : Math.Sqrt(ratio);
-        double minimumDiameter = Math.Min(3D, maximumDiameter);
         double diameter = maximumBubbleSize <= 0D
             ? 0D
-            : minimumDiameter + (maximumDiameter - minimumDiameter) * sizeFactor;
+            : maximumDiameter * sizeFactor;
         if (diameter <= 0D) {
             return;
         }
@@ -48,6 +47,13 @@ public static partial class OfficeChartDrawingRenderer {
         return Math.Min(shortestSide * 0.8D,
             defaultDiameter * bubbleScalePercent / 100D);
     }
+
+    private static double GetBubblePlotPadding(OfficeChartSnapshot snapshot,
+        double plotWidth, double plotHeight) =>
+        GetMaximumBubbleSize(snapshot.Data.Series) > 0D
+            ? GetMaximumBubbleDiameter(plotWidth, plotHeight,
+                snapshot.BubbleScalePercent) / 2D
+            : 0D;
 
     private static double GetMaximumBubbleSize(
         System.Collections.Generic.IReadOnlyList<OfficeChartSeries> series) {

--- a/OfficeIMO.Drawing/OfficeChartDrawingRenderer.Bubbles.cs
+++ b/OfficeIMO.Drawing/OfficeChartDrawingRenderer.Bubbles.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace OfficeIMO.Drawing;
 
@@ -52,12 +53,33 @@ public static partial class OfficeChartDrawingRenderer {
             defaultDiameter * bubbleScalePercent / 100D);
     }
 
-    private static double GetBubblePlotPadding(OfficeChartSnapshot snapshot,
+    private static double GetBubbleMaximumDiameter(OfficeChartSnapshot snapshot,
         double plotWidth, double plotHeight) =>
         GetMaximumBubbleSize(snapshot.Data.Series) > 0D
             ? GetMaximumBubbleDiameter(plotWidth, plotHeight,
-                snapshot.BubbleScalePercent) / 2D
+                snapshot.BubbleScalePercent)
             : 0D;
+
+    private static double GetBubblePlotPadding(OfficeChartSnapshot snapshot,
+        double maximumBubbleDiameter) =>
+        maximumBubbleDiameter > 0D
+            ? maximumBubbleDiameter / 2D +
+              GetMaximumBubbleOutlineWidth(snapshot.Data.Series) / 2D
+            : 0D;
+
+    private static double GetMaximumBubbleOutlineWidth(
+        IReadOnlyList<OfficeChartSeries> series) {
+        double maximum = 0D;
+        for (int seriesIndex = 0; seriesIndex < series.Count; seriesIndex++) {
+            OfficeChartSeries item = series[seriesIndex];
+            if (!item.ShowMarkerOutline || item.BubbleSizes == null ||
+                !item.BubbleSizes.Any(size => size > 0D)) {
+                continue;
+            }
+            maximum = Math.Max(maximum, item.MarkerOutlineWidth ?? 1D);
+        }
+        return maximum;
+    }
 
     private static double GetMaximumBubbleSize(
         System.Collections.Generic.IReadOnlyList<OfficeChartSeries> series) {

--- a/OfficeIMO.Drawing/OfficeChartDrawingRenderer.Bubbles.cs
+++ b/OfficeIMO.Drawing/OfficeChartDrawingRenderer.Bubbles.cs
@@ -13,9 +13,13 @@ public static partial class OfficeChartDrawingRenderer {
         }
 
         double size = series.BubbleSizes[pointIndex];
+        if (size <= 0D) {
+            return;
+        }
+
         double maximumDiameter = Math.Max(12D, Math.Min(42D, Math.Min(plotWidth, plotHeight) * 0.16D));
         double diameter = maximumBubbleSize <= 0D
-            ? 3D
+            ? 0D
             : 3D + (maximumDiameter - 3D) * Math.Sqrt(size / maximumBubbleSize);
         double outlineWidth = series.MarkerOutlineWidth ?? 1D;
         OfficeColor outlineColor = series.MarkerOutlineColor ?? color;

--- a/OfficeIMO.Drawing/OfficeChartDrawingRenderer.Bubbles.cs
+++ b/OfficeIMO.Drawing/OfficeChartDrawingRenderer.Bubbles.cs
@@ -5,8 +5,9 @@ namespace OfficeIMO.Drawing;
 
 public static partial class OfficeChartDrawingRenderer {
     private static void AddBubbleMarker(OfficeDrawing drawing, OfficeChartSeries series,
-        int pointIndex, OfficePoint center, double plotWidth, double plotHeight,
-        double maximumBubbleSize, OfficeColor color) {
+        int pointIndex, OfficePoint center, double maximumBubbleSize,
+        double maximumDiameter, OfficeChartBubbleSizeMode sizeMode,
+        OfficeColor color) {
         if (series.BubbleSizes == null || pointIndex < 0 ||
             pointIndex >= series.BubbleSizes.Count) {
             return;
@@ -17,15 +18,35 @@ public static partial class OfficeChartDrawingRenderer {
             return;
         }
 
-        double maximumDiameter = Math.Max(12D, Math.Min(42D, Math.Min(plotWidth, plotHeight) * 0.16D));
+        double ratio = Math.Min(1D, size / maximumBubbleSize);
+        double sizeFactor = sizeMode == OfficeChartBubbleSizeMode.Width
+            ? ratio
+            : Math.Sqrt(ratio);
+        double minimumDiameter = Math.Min(3D, maximumDiameter);
         double diameter = maximumBubbleSize <= 0D
             ? 0D
-            : 3D + (maximumDiameter - 3D) * Math.Sqrt(size / maximumBubbleSize);
+            : minimumDiameter + (maximumDiameter - minimumDiameter) * sizeFactor;
+        if (diameter <= 0D) {
+            return;
+        }
         double outlineWidth = series.MarkerOutlineWidth ?? 1D;
         OfficeColor outlineColor = series.MarkerOutlineColor ?? color;
         AddShape(drawing, OfficeShape.Ellipse(diameter, diameter),
             center.X - diameter / 2D, center.Y - diameter / 2D,
             color, outlineColor, outlineWidth);
+    }
+
+    private static double GetMaximumBubbleDiameter(double plotWidth,
+        double plotHeight, double bubbleScalePercent) {
+        if (bubbleScalePercent <= 0D) {
+            return 0D;
+        }
+
+        double shortestSide = Math.Min(plotWidth, plotHeight);
+        double defaultDiameter = Math.Max(12D,
+            Math.Min(42D, shortestSide * 0.16D));
+        return Math.Min(shortestSide * 0.8D,
+            defaultDiameter * bubbleScalePercent / 100D);
     }
 
     private static double GetMaximumBubbleSize(

--- a/OfficeIMO.Drawing/OfficeChartDrawingRenderer.Helpers.cs
+++ b/OfficeIMO.Drawing/OfficeChartDrawingRenderer.Helpers.cs
@@ -32,7 +32,8 @@ public static partial class OfficeChartDrawingRenderer {
         || kind == OfficeChartKind.AreaStacked
         || kind == OfficeChartKind.AreaStacked100;
 
-    private static bool IsScatterChart(OfficeChartKind kind) => kind == OfficeChartKind.Scatter;
+    private static bool IsScatterChart(OfficeChartKind kind) =>
+        kind == OfficeChartKind.Scatter || kind == OfficeChartKind.Bubble;
 
     private static bool IsRadarChart(OfficeChartKind kind) => kind == OfficeChartKind.Radar;
 

--- a/OfficeIMO.Drawing/OfficeChartDrawingRenderer.SecondaryAxes.cs
+++ b/OfficeIMO.Drawing/OfficeChartDrawingRenderer.SecondaryAxes.cs
@@ -91,8 +91,10 @@ public static partial class OfficeChartDrawingRenderer {
 
     private static void AddMixedCartesianSeries(OfficeDrawing drawing, OfficeChartSnapshot snapshot,
         ValueRange primaryValueAxisRange, ValueRange secondaryValueAxisRange, bool hasSecondaryAxis,
-        double plotLeft, double plotTop, double plotWidth, double plotHeight, OfficeChartStyle style,
-        OfficeChartLayout layout) {
+        double plotLeft, double plotTop, double plotWidth, double plotHeight,
+        double numericPlotLeft, double numericPlotTop, double numericPlotWidth,
+        double numericPlotHeight, OfficeChartStyle style, OfficeChartLayout layout,
+        double maximumBubbleDiameter) {
         AddAxisGroupSeries(drawing, snapshot, primaryValueAxisRange, OfficeChartAxisGroup.Primary,
             plotLeft, plotTop, plotWidth, plotHeight, style, layout);
         if (hasSecondaryAxis) {
@@ -100,11 +102,15 @@ public static partial class OfficeChartDrawingRenderer {
                 plotLeft, plotTop, plotWidth, plotHeight, style, layout);
         }
         if (!HasMixedScatterSeriesOnCategoryAxes(snapshot)) {
-            AddScatterSeries(drawing, snapshot, plotLeft, plotTop, plotWidth, plotHeight, style, layout,
-                primaryValueAxisRange, OfficeChartAxisGroup.Primary);
+            AddScatterSeries(drawing, snapshot, numericPlotLeft, numericPlotTop,
+                numericPlotWidth, numericPlotHeight, style, layout,
+                primaryValueAxisRange, OfficeChartAxisGroup.Primary,
+                maximumBubbleDiameter);
             if (hasSecondaryAxis) {
-                AddScatterSeries(drawing, snapshot, plotLeft, plotTop, plotWidth, plotHeight, style, layout,
-                    secondaryValueAxisRange, OfficeChartAxisGroup.Secondary);
+                AddScatterSeries(drawing, snapshot, numericPlotLeft, numericPlotTop,
+                    numericPlotWidth, numericPlotHeight, style, layout,
+                    secondaryValueAxisRange, OfficeChartAxisGroup.Secondary,
+                    maximumBubbleDiameter);
             }
         }
     }

--- a/OfficeIMO.Drawing/OfficeChartDrawingRenderer.cs
+++ b/OfficeIMO.Drawing/OfficeChartDrawingRenderer.cs
@@ -124,8 +124,11 @@ public static partial class OfficeChartDrawingRenderer {
         double plotBottom = 40D + horizontalAxisTitleHeight + bottomLegendHeight;
         double plotWidth = Math.Max(20D, width - plotLeft - plotRight);
         double plotHeight = Math.Max(20D, height - plotTop - plotBottom);
-        double bubblePlotPadding = IsScatterChart(snapshot.ChartKind)
-            ? GetBubblePlotPadding(snapshot, plotWidth, plotHeight)
+        double maximumBubbleDiameter = IsScatterChart(snapshot.ChartKind)
+            ? GetBubbleMaximumDiameter(snapshot, plotWidth, plotHeight)
+            : 0D;
+        double bubblePlotPadding = maximumBubbleDiameter > 0D
+            ? GetBubblePlotPadding(snapshot, maximumBubbleDiameter)
             : 0D;
         double numericPlotLeft = plotLeft + bubblePlotPadding;
         double numericPlotTop = plotTop + bubblePlotPadding;
@@ -416,13 +419,13 @@ public static partial class OfficeChartDrawingRenderer {
             AddMixedCartesianSeries(drawing, snapshot, axisRange, secondaryAxisRange, hasSecondaryAxis,
                 plotLeft, plotTop, plotWidth, plotHeight,
                 numericPlotLeft, numericPlotTop, numericPlotWidth, numericPlotHeight,
-                style, layout, bubblePlotPadding * 2D);
+                style, layout, maximumBubbleDiameter);
         } else if (IsAreaChart(snapshot.ChartKind)) {
             AddAreaSeries(drawing, snapshot, plotLeft, plotTop, plotWidth, plotHeight, style, layout);
         } else if (IsScatterChart(snapshot.ChartKind)) {
             AddScatterSeries(drawing, snapshot, numericPlotLeft, numericPlotTop,
                 numericPlotWidth, numericPlotHeight, style, layout,
-                maximumBubbleDiameterOverride: bubblePlotPadding * 2D);
+                maximumBubbleDiameterOverride: maximumBubbleDiameter);
         } else if (IsLineChart(snapshot.ChartKind)) {
             AddLineSeries(drawing, snapshot, plotLeft, plotTop, plotWidth, plotHeight, style, layout);
         } else {

--- a/OfficeIMO.Drawing/OfficeChartDrawingRenderer.cs
+++ b/OfficeIMO.Drawing/OfficeChartDrawingRenderer.cs
@@ -1641,15 +1641,14 @@ public static partial class OfficeChartDrawingRenderer {
             }
             for (int i = 0; i < points.Count; i++) {
                 OfficePoint point = points[i].Point;
-                if (layout.ShowMarkers && currentSeries.ShowMarkers) {
-                    OfficeColor pointColor = GetPointColor(currentSeries.PointColors, points[i].SourceIndex, color);
-                    if (currentSeries.BubbleSizes != null) {
-                        AddBubbleMarker(drawing, currentSeries, points[i].SourceIndex, point,
-                            maximumBubbleSize, maximumBubbleDiameter,
-                            snapshot.BubbleSizeMode, pointColor);
-                    } else {
+                OfficeColor pointColor = GetPointColor(
+                    currentSeries.PointColors, points[i].SourceIndex, color);
+                if (currentSeries.BubbleSizes != null) {
+                    AddBubbleMarker(drawing, currentSeries, points[i].SourceIndex, point,
+                        maximumBubbleSize, maximumBubbleDiameter,
+                        snapshot.BubbleSizeMode, pointColor);
+                } else if (layout.ShowMarkers && currentSeries.ShowMarkers) {
                         AddMarker(drawing, currentSeries, point, 5D, pointColor, 1.25D);
-                    }
                 }
 
                 int pointIndex = points[i].SourceIndex;

--- a/OfficeIMO.Drawing/OfficeChartDrawingRenderer.cs
+++ b/OfficeIMO.Drawing/OfficeChartDrawingRenderer.cs
@@ -127,13 +127,15 @@ public static partial class OfficeChartDrawingRenderer {
         double maximumBubbleDiameter = IsScatterChart(snapshot.ChartKind)
             ? GetBubbleMaximumDiameter(snapshot, plotWidth, plotHeight)
             : 0D;
-        double bubblePlotPadding = maximumBubbleDiameter > 0D
-            ? GetBubblePlotPadding(snapshot, maximumBubbleDiameter)
-            : 0D;
-        double numericPlotLeft = plotLeft + bubblePlotPadding;
-        double numericPlotTop = plotTop + bubblePlotPadding;
-        double numericPlotWidth = Math.Max(1D, plotWidth - bubblePlotPadding * 2D);
-        double numericPlotHeight = Math.Max(1D, plotHeight - bubblePlotPadding * 2D);
+        GetBubblePlotPadding(snapshot, maximumBubbleDiameter,
+            plotWidth, plotHeight, out double horizontalBubblePadding,
+            out double verticalBubblePadding);
+        double numericPlotLeft = plotLeft + horizontalBubblePadding;
+        double numericPlotTop = plotTop + verticalBubblePadding;
+        double numericPlotWidth = Math.Max(
+            1D, plotWidth - horizontalBubblePadding * 2D);
+        double numericPlotHeight = Math.Max(
+            1D, plotHeight - verticalBubblePadding * 2D);
         double plotBottomY = plotTop + plotHeight;
         double horizontalAxisY = horizontalAxisCrossesAtMaximum ? plotTop : plotBottomY;
         double axisLabelLeft = leftLegend ? legendWidth + 2D : 2D;

--- a/OfficeIMO.Drawing/OfficeChartDrawingRenderer.cs
+++ b/OfficeIMO.Drawing/OfficeChartDrawingRenderer.cs
@@ -1579,6 +1579,7 @@ public static partial class OfficeChartDrawingRenderer {
         ValueRange pairedYRange = GetScatterPointRanges(rangeSeries, sharedXValues).YRange;
         ValueRange xRange = ApplyValueAxisScale(pairedXRange, layout, horizontal: true);
         ValueRange yRange = valueAxisRange ?? ApplyValueAxisScale(pairedYRange, layout, horizontal: false);
+        double maximumBubbleSize = GetMaximumBubbleSize(allRangeSeries);
         for (int s = 0; s < scatterSeries.Count; s++) {
             OfficeChartSeries currentSeries = scatterSeries[s].Series;
             int sourceSeriesIndex = scatterSeries[s].SourceIndex;
@@ -1625,7 +1626,12 @@ public static partial class OfficeChartDrawingRenderer {
                 OfficePoint point = points[i].Point;
                 if (layout.ShowMarkers && currentSeries.ShowMarkers) {
                     OfficeColor pointColor = GetPointColor(currentSeries.PointColors, points[i].SourceIndex, color);
-                    AddMarker(drawing, currentSeries, point, 5D, pointColor, 1.25D);
+                    if (currentSeries.BubbleSizes != null) {
+                        AddBubbleMarker(drawing, currentSeries, points[i].SourceIndex, point,
+                            plotWidth, plotHeight, maximumBubbleSize, pointColor);
+                    } else {
+                        AddMarker(drawing, currentSeries, point, 5D, pointColor, 1.25D);
+                    }
                 }
 
                 int pointIndex = points[i].SourceIndex;

--- a/OfficeIMO.Drawing/OfficeChartDrawingRenderer.cs
+++ b/OfficeIMO.Drawing/OfficeChartDrawingRenderer.cs
@@ -414,7 +414,9 @@ public static partial class OfficeChartDrawingRenderer {
 
         if (HasMixedCartesianSeriesKinds(snapshot) || hasSecondaryAxis) {
             AddMixedCartesianSeries(drawing, snapshot, axisRange, secondaryAxisRange, hasSecondaryAxis,
-                plotLeft, plotTop, plotWidth, plotHeight, style, layout);
+                plotLeft, plotTop, plotWidth, plotHeight,
+                numericPlotLeft, numericPlotTop, numericPlotWidth, numericPlotHeight,
+                style, layout, bubblePlotPadding * 2D);
         } else if (IsAreaChart(snapshot.ChartKind)) {
             AddAreaSeries(drawing, snapshot, plotLeft, plotTop, plotWidth, plotHeight, style, layout);
         } else if (IsScatterChart(snapshot.ChartKind)) {

--- a/OfficeIMO.Drawing/OfficeChartDrawingRenderer.cs
+++ b/OfficeIMO.Drawing/OfficeChartDrawingRenderer.cs
@@ -124,6 +124,13 @@ public static partial class OfficeChartDrawingRenderer {
         double plotBottom = 40D + horizontalAxisTitleHeight + bottomLegendHeight;
         double plotWidth = Math.Max(20D, width - plotLeft - plotRight);
         double plotHeight = Math.Max(20D, height - plotTop - plotBottom);
+        double bubblePlotPadding = IsScatterChart(snapshot.ChartKind)
+            ? GetBubblePlotPadding(snapshot, plotWidth, plotHeight)
+            : 0D;
+        double numericPlotLeft = plotLeft + bubblePlotPadding;
+        double numericPlotTop = plotTop + bubblePlotPadding;
+        double numericPlotWidth = Math.Max(1D, plotWidth - bubblePlotPadding * 2D);
+        double numericPlotHeight = Math.Max(1D, plotHeight - bubblePlotPadding * 2D);
         double plotBottomY = plotTop + plotHeight;
         double horizontalAxisY = horizontalAxisCrossesAtMaximum ? plotTop : plotBottomY;
         double axisLabelLeft = leftLegend ? legendWidth + 2D : 2D;
@@ -168,9 +175,9 @@ public static partial class OfficeChartDrawingRenderer {
             } else {
                 AddHorizontalAxisMajorTickMarks(
                     drawing,
-                    plotLeft,
+                    numericPlotLeft,
                     horizontalAxisY,
-                    plotWidth,
+                    numericPlotWidth,
                     layout.HorizontalAxisMajorTickMark,
                     horizontalAxisColor,
                     horizontalAxisLineWidth,
@@ -192,9 +199,9 @@ public static partial class OfficeChartDrawingRenderer {
             } else {
                 AddHorizontalAxisMinorTickMarks(
                     drawing,
-                    plotLeft,
+                    numericPlotLeft,
                     horizontalAxisY,
-                    plotWidth,
+                    numericPlotWidth,
                     layout.HorizontalAxisMinorTickMark,
                     horizontalAxisColor,
                     horizontalAxisLineWidth,
@@ -217,8 +224,8 @@ public static partial class OfficeChartDrawingRenderer {
                 AddVerticalValueAxisMajorTickMarks(
                     drawing,
                     verticalAxisX,
-                    plotTop,
-                    plotHeight,
+                    numericPlotTop,
+                    numericPlotHeight,
                     axisRange,
                     valueAxisMajorTicks,
                     layout.VerticalAxisMajorTickMark,
@@ -230,8 +237,8 @@ public static partial class OfficeChartDrawingRenderer {
                 AddVerticalValueAxisMinorTickMarks(
                     drawing,
                     verticalAxisX,
-                    plotTop,
-                    plotHeight,
+                    numericPlotTop,
+                    numericPlotHeight,
                     axisRange,
                     valueAxisMinorTicks,
                     layout.VerticalAxisMinorTickMark,
@@ -276,9 +283,9 @@ public static partial class OfficeChartDrawingRenderer {
             } else {
                 AddVerticalGridLines(
                     drawing,
-                    plotLeft,
+                    numericPlotLeft,
                     plotTop,
-                    plotWidth,
+                    numericPlotWidth,
                     plotHeight,
                     divisions: 8,
                     startIndex: 1,
@@ -322,9 +329,9 @@ public static partial class OfficeChartDrawingRenderer {
                     AddHorizontalValueGridLines(
                         drawing,
                         plotLeft,
-                        plotTop,
+                        numericPlotTop,
                         plotWidth,
-                        plotHeight,
+                        numericPlotHeight,
                         axisRange,
                         valueAxisMinorTicks,
                         GetValueMinorGridLineColor(style),
@@ -334,9 +341,9 @@ public static partial class OfficeChartDrawingRenderer {
                     AddHorizontalGridLines(
                         drawing,
                         plotLeft,
-                        plotTop,
+                        numericPlotTop,
                         plotWidth,
-                        plotHeight,
+                        numericPlotHeight,
                         divisions: 8,
                         startIndex: 1,
                         step: 2,
@@ -364,9 +371,9 @@ public static partial class OfficeChartDrawingRenderer {
             } else {
                 AddVerticalGridLines(
                     drawing,
-                    plotLeft,
+                    numericPlotLeft,
                     plotTop,
-                    plotWidth,
+                    numericPlotWidth,
                     plotHeight,
                     divisions: 4,
                     startIndex: 1,
@@ -394,9 +401,9 @@ public static partial class OfficeChartDrawingRenderer {
                 AddHorizontalValueGridLines(
                     drawing,
                     plotLeft,
-                    plotTop,
+                    numericPlotTop,
                     plotWidth,
-                    plotHeight,
+                    numericPlotHeight,
                     axisRange,
                     valueAxisMajorTicks,
                     GetValueGridLineColor(style),
@@ -411,7 +418,9 @@ public static partial class OfficeChartDrawingRenderer {
         } else if (IsAreaChart(snapshot.ChartKind)) {
             AddAreaSeries(drawing, snapshot, plotLeft, plotTop, plotWidth, plotHeight, style, layout);
         } else if (IsScatterChart(snapshot.ChartKind)) {
-            AddScatterSeries(drawing, snapshot, plotLeft, plotTop, plotWidth, plotHeight, style, layout);
+            AddScatterSeries(drawing, snapshot, numericPlotLeft, numericPlotTop,
+                numericPlotWidth, numericPlotHeight, style, layout,
+                maximumBubbleDiameterOverride: bubblePlotPadding * 2D);
         } else if (IsLineChart(snapshot.ChartKind)) {
             AddLineSeries(drawing, snapshot, plotLeft, plotTop, plotWidth, plotHeight, style, layout);
         } else {
@@ -455,8 +464,8 @@ public static partial class OfficeChartDrawingRenderer {
                 AddValueAxisLabels(
                     drawing,
                     axisRange,
-                    plotTop,
-                    plotHeight,
+                    numericPlotTop,
+                    numericPlotHeight,
                     verticalAxisLabelsHigh ? axisLabelRight : axisLabelLeft,
                     verticalAxisLabelsHigh ? axisLabelRightWidth : axisLabelWidth,
                     verticalAxisLabelsHigh ? OfficeTextAlignment.Left : OfficeTextAlignment.Right,
@@ -478,9 +487,9 @@ public static partial class OfficeChartDrawingRenderer {
                     AddHorizontalValueAxisLabels(
                         drawing,
                         scatterXRange,
-                        plotLeft,
+                        numericPlotLeft,
                         horizontalAxisLabelsHigh ? plotTop - 13D : plotBottomY + 4D,
-                        plotWidth,
+                        numericPlotWidth,
                         horizontalValueAxisLabelWidth,
                         horizontalAxisLabelsHigh,
                         style,
@@ -1556,7 +1565,8 @@ public static partial class OfficeChartDrawingRenderer {
 
     private static void AddScatterSeries(OfficeDrawing drawing, OfficeChartSnapshot snapshot, double plotLeft,
         double plotTop, double plotWidth, double plotHeight, OfficeChartStyle style, OfficeChartLayout layout,
-        ValueRange? valueAxisRange = null, OfficeChartAxisGroup? axisGroup = null) {
+        ValueRange? valueAxisRange = null, OfficeChartAxisGroup? axisGroup = null,
+        double? maximumBubbleDiameterOverride = null) {
         IReadOnlyList<string> categories = snapshot.Data.Categories;
         IReadOnlyList<OfficeChartSeries> series = snapshot.Data.Series;
         if (categories.Count == 0 || series.Count == 0) {
@@ -1580,15 +1590,11 @@ public static partial class OfficeChartDrawingRenderer {
         ValueRange xRange = ApplyValueAxisScale(pairedXRange, layout, horizontal: true);
         ValueRange yRange = valueAxisRange ?? ApplyValueAxisScale(pairedYRange, layout, horizontal: false);
         double maximumBubbleSize = GetMaximumBubbleSize(allRangeSeries);
-        double maximumBubbleDiameter = maximumBubbleSize > 0D
+        double maximumBubbleDiameter = maximumBubbleDiameterOverride ??
+            (maximumBubbleSize > 0D
             ? GetMaximumBubbleDiameter(plotWidth, plotHeight,
                 snapshot.BubbleScalePercent)
-            : 0D;
-        double bubbleRadius = maximumBubbleDiameter / 2D;
-        double pointPlotLeft = plotLeft + bubbleRadius;
-        double pointPlotTop = plotTop + bubbleRadius;
-        double pointPlotWidth = Math.Max(1D, plotWidth - maximumBubbleDiameter);
-        double pointPlotHeight = Math.Max(1D, plotHeight - maximumBubbleDiameter);
+            : 0D);
         for (int s = 0; s < scatterSeries.Count; s++) {
             OfficeChartSeries currentSeries = scatterSeries[s].Series;
             int sourceSeriesIndex = scatterSeries[s].SourceIndex;
@@ -1620,9 +1626,9 @@ public static partial class OfficeChartDrawingRenderer {
                 }
 
                 double x = ToPlotX(xValue, xRange.Min, xRange.Max,
-                    pointPlotLeft, pointPlotWidth);
+                    plotLeft, plotWidth);
                 double y = ToPlotY(yValue, yRange.Min, yRange.Max,
-                    pointPlotTop, pointPlotHeight);
+                    plotTop, plotHeight);
                 var point = new OfficePoint(x, y);
                 points.Add((point, i));
                 if (layout.ConnectScatterPoints && currentSeries.ConnectLine) {

--- a/OfficeIMO.Drawing/OfficeChartDrawingRenderer.cs
+++ b/OfficeIMO.Drawing/OfficeChartDrawingRenderer.cs
@@ -1580,6 +1580,15 @@ public static partial class OfficeChartDrawingRenderer {
         ValueRange xRange = ApplyValueAxisScale(pairedXRange, layout, horizontal: true);
         ValueRange yRange = valueAxisRange ?? ApplyValueAxisScale(pairedYRange, layout, horizontal: false);
         double maximumBubbleSize = GetMaximumBubbleSize(allRangeSeries);
+        double maximumBubbleDiameter = maximumBubbleSize > 0D
+            ? GetMaximumBubbleDiameter(plotWidth, plotHeight,
+                snapshot.BubbleScalePercent)
+            : 0D;
+        double bubbleRadius = maximumBubbleDiameter / 2D;
+        double pointPlotLeft = plotLeft + bubbleRadius;
+        double pointPlotTop = plotTop + bubbleRadius;
+        double pointPlotWidth = Math.Max(1D, plotWidth - maximumBubbleDiameter);
+        double pointPlotHeight = Math.Max(1D, plotHeight - maximumBubbleDiameter);
         for (int s = 0; s < scatterSeries.Count; s++) {
             OfficeChartSeries currentSeries = scatterSeries[s].Series;
             int sourceSeriesIndex = scatterSeries[s].SourceIndex;
@@ -1610,8 +1619,10 @@ public static partial class OfficeChartDrawingRenderer {
                     continue;
                 }
 
-                double x = ToPlotX(xValue, xRange.Min, xRange.Max, plotLeft, plotWidth);
-                double y = ToPlotY(yValue, yRange.Min, yRange.Max, plotTop, plotHeight);
+                double x = ToPlotX(xValue, xRange.Min, xRange.Max,
+                    pointPlotLeft, pointPlotWidth);
+                double y = ToPlotY(yValue, yRange.Min, yRange.Max,
+                    pointPlotTop, pointPlotHeight);
                 var point = new OfficePoint(x, y);
                 points.Add((point, i));
                 if (layout.ConnectScatterPoints && currentSeries.ConnectLine) {
@@ -1628,7 +1639,8 @@ public static partial class OfficeChartDrawingRenderer {
                     OfficeColor pointColor = GetPointColor(currentSeries.PointColors, points[i].SourceIndex, color);
                     if (currentSeries.BubbleSizes != null) {
                         AddBubbleMarker(drawing, currentSeries, points[i].SourceIndex, point,
-                            plotWidth, plotHeight, maximumBubbleSize, pointColor);
+                            maximumBubbleSize, maximumBubbleDiameter,
+                            snapshot.BubbleSizeMode, pointColor);
                     } else {
                         AddMarker(drawing, currentSeries, point, 5D, pointColor, 1.25D);
                     }

--- a/OfficeIMO.Drawing/OfficeChartKind.cs
+++ b/OfficeIMO.Drawing/OfficeChartKind.cs
@@ -50,5 +50,8 @@ public enum OfficeChartKind {
     Pie,
 
     /// <summary>Doughnut chart.</summary>
-    Doughnut
+    Doughnut,
+
+    /// <summary>Bubble chart with numeric X/Y coordinates and per-point sizes.</summary>
+    Bubble
 }

--- a/OfficeIMO.Drawing/OfficeChartSeries.cs
+++ b/OfficeIMO.Drawing/OfficeChartSeries.cs
@@ -65,7 +65,37 @@ public sealed class OfficeChartSeries {
     /// <param name="strokeDashStyle">Optional source-defined series stroke dash style.</param>
     /// <param name="renderKind">Optional per-series chart kind used by mixed/combo chart renderers.</param>
     /// <param name="axisGroup">Primary or secondary value axis used by combo chart renderers.</param>
-    public OfficeChartSeries(string name, IEnumerable<double> values, IEnumerable<double>? xValues, OfficeColor? color, IEnumerable<OfficeColor?>? pointColors, bool showMarkers, bool showInLegend = true, bool connectLine = true, int? markerSize = null, OfficeChartMarkerShape? markerShape = null, OfficeColor? markerOutlineColor = null, double? markerOutlineWidth = null, double? strokeWidth = null, OfficeStrokeDashStyle? strokeDashStyle = null, OfficeChartKind? renderKind = null, OfficeChartAxisGroup axisGroup = OfficeChartAxisGroup.Primary) {
+    public OfficeChartSeries(string name, IEnumerable<double> values, IEnumerable<double>? xValues, OfficeColor? color, IEnumerable<OfficeColor?>? pointColors, bool showMarkers, bool showInLegend = true, bool connectLine = true, int? markerSize = null, OfficeChartMarkerShape? markerShape = null, OfficeColor? markerOutlineColor = null, double? markerOutlineWidth = null, double? strokeWidth = null, OfficeStrokeDashStyle? strokeDashStyle = null, OfficeChartKind? renderKind = null, OfficeChartAxisGroup axisGroup = OfficeChartAxisGroup.Primary)
+        : this(name, values, xValues, bubbleSizes: null, color, pointColors, showMarkers, showInLegend,
+            connectLine, markerSize, markerShape, markerOutlineColor, markerOutlineWidth, strokeWidth,
+            strokeDashStyle, renderKind, axisGroup) {
+    }
+
+    /// <summary>
+    /// Creates a bubble-chart series with numeric X/Y coordinates and per-point bubble sizes.
+    /// </summary>
+    /// <param name="name">Display name for the series.</param>
+    /// <param name="xValues">Numeric X-axis values.</param>
+    /// <param name="yValues">Numeric Y-axis values.</param>
+    /// <param name="bubbleSizes">Non-negative bubble sizes aligned with the X/Y values.</param>
+    /// <param name="color">Optional source-defined series color.</param>
+    /// <param name="pointColors">Optional source-defined colors aligned with individual bubbles.</param>
+    /// <param name="showInLegend">Whether this series should appear in rendered legends.</param>
+    public static OfficeChartSeries CreateBubble(string name, IEnumerable<double> xValues,
+        IEnumerable<double> yValues, IEnumerable<double> bubbleSizes, OfficeColor? color = null,
+        IEnumerable<OfficeColor?>? pointColors = null, bool showInLegend = true) =>
+        new(name, yValues, xValues, bubbleSizes, color, pointColors, showMarkers: true,
+            showInLegend, connectLine: false, markerSize: null, markerShape: OfficeChartMarkerShape.Circle,
+            markerOutlineColor: color, markerOutlineWidth: null, strokeWidth: null,
+            strokeDashStyle: null, renderKind: OfficeChartKind.Bubble,
+            axisGroup: OfficeChartAxisGroup.Primary);
+
+    private OfficeChartSeries(string name, IEnumerable<double> values, IEnumerable<double>? xValues,
+        IEnumerable<double>? bubbleSizes, OfficeColor? color, IEnumerable<OfficeColor?>? pointColors,
+        bool showMarkers, bool showInLegend, bool connectLine, int? markerSize,
+        OfficeChartMarkerShape? markerShape, OfficeColor? markerOutlineColor,
+        double? markerOutlineWidth, double? strokeWidth, OfficeStrokeDashStyle? strokeDashStyle,
+        OfficeChartKind? renderKind, OfficeChartAxisGroup axisGroup) {
         if (values == null) {
             throw new ArgumentNullException(nameof(values));
         }
@@ -85,6 +115,19 @@ public sealed class OfficeChartSeries {
             XValues = new ReadOnlyCollection<double>(new List<double>(xValues));
             if (XValues.Count != Values.Count) {
                 throw new ArgumentException("Series X-axis values must match the number of series values.", nameof(xValues));
+            }
+        }
+        if (bubbleSizes != null) {
+            BubbleSizes = new ReadOnlyCollection<double>(new List<double>(bubbleSizes));
+            if (BubbleSizes.Count != Values.Count) {
+                throw new ArgumentException("Series bubble sizes must match the number of series values.", nameof(bubbleSizes));
+            }
+            for (int index = 0; index < BubbleSizes.Count; index++) {
+                double size = BubbleSizes[index];
+                if (double.IsNaN(size) || double.IsInfinity(size) || size < 0D) {
+                    throw new ArgumentOutOfRangeException(nameof(bubbleSizes),
+                        "Bubble sizes must contain only finite, non-negative values.");
+                }
             }
         }
 
@@ -116,6 +159,9 @@ public sealed class OfficeChartSeries {
 
     /// <summary>Optional per-series numeric X-axis values for scatter charts.</summary>
     public IReadOnlyList<double>? XValues { get; }
+
+    /// <summary>Optional per-point sizes for bubble charts.</summary>
+    public IReadOnlyList<double>? BubbleSizes { get; }
 
     /// <summary>Optional source-defined series color.</summary>
     public OfficeColor? Color { get; }

--- a/OfficeIMO.Drawing/OfficeChartSeries.cs
+++ b/OfficeIMO.Drawing/OfficeChartSeries.cs
@@ -83,22 +83,26 @@ public sealed class OfficeChartSeries {
     /// <param name="showInLegend">Whether this series should appear in rendered legends.</param>
     /// <param name="markerOutlineColor">Optional source-defined bubble outline color.</param>
     /// <param name="markerOutlineWidth">Optional source-defined bubble outline width in drawing units.</param>
+    /// <param name="showMarkerOutline">Whether the bubble outline should be rendered.</param>
     public static OfficeChartSeries CreateBubble(string name, IEnumerable<double> xValues,
         IEnumerable<double> yValues, IEnumerable<double> bubbleSizes, OfficeColor? color = null,
         IEnumerable<OfficeColor?>? pointColors = null, bool showInLegend = true,
-        OfficeColor? markerOutlineColor = null, double? markerOutlineWidth = null) =>
+        OfficeColor? markerOutlineColor = null, double? markerOutlineWidth = null,
+        bool showMarkerOutline = true) =>
         new(name, yValues, xValues, bubbleSizes, color, pointColors, showMarkers: true,
             showInLegend, connectLine: false, markerSize: null, markerShape: OfficeChartMarkerShape.Circle,
             markerOutlineColor: markerOutlineColor ?? color, markerOutlineWidth, strokeWidth: null,
             strokeDashStyle: null, renderKind: OfficeChartKind.Bubble,
-            axisGroup: OfficeChartAxisGroup.Primary);
+            axisGroup: OfficeChartAxisGroup.Primary,
+            showMarkerOutline: showMarkerOutline);
 
     private OfficeChartSeries(string name, IEnumerable<double> values, IEnumerable<double>? xValues,
         IEnumerable<double>? bubbleSizes, OfficeColor? color, IEnumerable<OfficeColor?>? pointColors,
         bool showMarkers, bool showInLegend, bool connectLine, int? markerSize,
         OfficeChartMarkerShape? markerShape, OfficeColor? markerOutlineColor,
         double? markerOutlineWidth, double? strokeWidth, OfficeStrokeDashStyle? strokeDashStyle,
-        OfficeChartKind? renderKind, OfficeChartAxisGroup axisGroup) {
+        OfficeChartKind? renderKind, OfficeChartAxisGroup axisGroup,
+        bool showMarkerOutline = true) {
         if (values == null) {
             throw new ArgumentNullException(nameof(values));
         }
@@ -142,6 +146,7 @@ public sealed class OfficeChartSeries {
         MarkerShape = markerShape;
         MarkerOutlineColor = markerOutlineColor;
         MarkerOutlineWidth = markerOutlineWidth;
+        ShowMarkerOutline = showMarkerOutline;
         StrokeWidth = strokeWidth;
         StrokeDashStyle = strokeDashStyle;
         RenderKind = renderKind;
@@ -186,6 +191,9 @@ public sealed class OfficeChartSeries {
 
     /// <summary>Optional source-defined marker outline width in drawing units.</summary>
     public double? MarkerOutlineWidth { get; }
+
+    /// <summary>Whether the marker or bubble outline should be rendered.</summary>
+    public bool ShowMarkerOutline { get; }
 
     /// <summary>Optional source-defined series stroke width in drawing units.</summary>
     public double? StrokeWidth { get; }

--- a/OfficeIMO.Drawing/OfficeChartSeries.cs
+++ b/OfficeIMO.Drawing/OfficeChartSeries.cs
@@ -81,12 +81,15 @@ public sealed class OfficeChartSeries {
     /// <param name="color">Optional source-defined series color.</param>
     /// <param name="pointColors">Optional source-defined colors aligned with individual bubbles.</param>
     /// <param name="showInLegend">Whether this series should appear in rendered legends.</param>
+    /// <param name="markerOutlineColor">Optional source-defined bubble outline color.</param>
+    /// <param name="markerOutlineWidth">Optional source-defined bubble outline width in drawing units.</param>
     public static OfficeChartSeries CreateBubble(string name, IEnumerable<double> xValues,
         IEnumerable<double> yValues, IEnumerable<double> bubbleSizes, OfficeColor? color = null,
-        IEnumerable<OfficeColor?>? pointColors = null, bool showInLegend = true) =>
+        IEnumerable<OfficeColor?>? pointColors = null, bool showInLegend = true,
+        OfficeColor? markerOutlineColor = null, double? markerOutlineWidth = null) =>
         new(name, yValues, xValues, bubbleSizes, color, pointColors, showMarkers: true,
             showInLegend, connectLine: false, markerSize: null, markerShape: OfficeChartMarkerShape.Circle,
-            markerOutlineColor: color, markerOutlineWidth: null, strokeWidth: null,
+            markerOutlineColor: markerOutlineColor ?? color, markerOutlineWidth, strokeWidth: null,
             strokeDashStyle: null, renderKind: OfficeChartKind.Bubble,
             axisGroup: OfficeChartAxisGroup.Primary);
 

--- a/OfficeIMO.Drawing/OfficeChartSeries.cs
+++ b/OfficeIMO.Drawing/OfficeChartSeries.cs
@@ -109,8 +109,12 @@ public sealed class OfficeChartSeries {
         if (markerSize is <= 0) {
             throw new ArgumentOutOfRangeException(nameof(markerSize), "Marker size must be greater than zero.");
         }
-        if (markerOutlineWidth is <= 0D) {
-            throw new ArgumentOutOfRangeException(nameof(markerOutlineWidth), "Marker outline width must be greater than zero.");
+        if (markerOutlineWidth.HasValue &&
+            (double.IsNaN(markerOutlineWidth.Value) ||
+             double.IsInfinity(markerOutlineWidth.Value) ||
+             markerOutlineWidth.Value <= 0D)) {
+            throw new ArgumentOutOfRangeException(nameof(markerOutlineWidth),
+                "Marker outline width must be finite and greater than zero.");
         }
         if (strokeWidth is <= 0D) {
             throw new ArgumentOutOfRangeException(nameof(strokeWidth), "Series stroke width must be greater than zero.");

--- a/OfficeIMO.Drawing/OfficeChartSeries.cs
+++ b/OfficeIMO.Drawing/OfficeChartSeries.cs
@@ -125,6 +125,20 @@ public sealed class OfficeChartSeries {
             }
         }
         if (bubbleSizes != null) {
+            for (int index = 0; index < Values.Count; index++) {
+                double value = Values[index];
+                if (double.IsNaN(value) || double.IsInfinity(value)) {
+                    throw new ArgumentOutOfRangeException(nameof(values),
+                        "Bubble Y-axis values must contain only finite values.");
+                }
+            }
+            for (int index = 0; index < XValues!.Count; index++) {
+                double value = XValues[index];
+                if (double.IsNaN(value) || double.IsInfinity(value)) {
+                    throw new ArgumentOutOfRangeException(nameof(xValues),
+                        "Bubble X-axis values must contain only finite values.");
+                }
+            }
             BubbleSizes = new ReadOnlyCollection<double>(new List<double>(bubbleSizes));
             if (BubbleSizes.Count != Values.Count) {
                 throw new ArgumentException("Series bubble sizes must match the number of series values.", nameof(bubbleSizes));

--- a/OfficeIMO.Drawing/OfficeChartSeries.cs
+++ b/OfficeIMO.Drawing/OfficeChartSeries.cs
@@ -88,13 +88,18 @@ public sealed class OfficeChartSeries {
         IEnumerable<double> yValues, IEnumerable<double> bubbleSizes, OfficeColor? color = null,
         IEnumerable<OfficeColor?>? pointColors = null, bool showInLegend = true,
         OfficeColor? markerOutlineColor = null, double? markerOutlineWidth = null,
-        bool showMarkerOutline = true) =>
-        new(name, yValues, xValues, bubbleSizes, color, pointColors, showMarkers: true,
+        bool showMarkerOutline = true) {
+        if (xValues == null) throw new ArgumentNullException(nameof(xValues));
+        if (yValues == null) throw new ArgumentNullException(nameof(yValues));
+        if (bubbleSizes == null) throw new ArgumentNullException(nameof(bubbleSizes));
+
+        return new(name, yValues, xValues, bubbleSizes, color, pointColors, showMarkers: true,
             showInLegend, connectLine: false, markerSize: null, markerShape: OfficeChartMarkerShape.Circle,
             markerOutlineColor: markerOutlineColor ?? color, markerOutlineWidth, strokeWidth: null,
             strokeDashStyle: null, renderKind: OfficeChartKind.Bubble,
             axisGroup: OfficeChartAxisGroup.Primary,
             showMarkerOutline: showMarkerOutline);
+    }
 
     private OfficeChartSeries(string name, IEnumerable<double> values, IEnumerable<double>? xValues,
         IEnumerable<double>? bubbleSizes, OfficeColor? color, IEnumerable<OfficeColor?>? pointColors,

--- a/OfficeIMO.Drawing/OfficeChartSnapshot.cs
+++ b/OfficeIMO.Drawing/OfficeChartSnapshot.cs
@@ -38,6 +38,18 @@ public sealed class OfficeChartSnapshot {
         if (!Enum.IsDefined(typeof(OfficeChartBubbleSizeMode), bubbleSizeMode)) {
             throw new ArgumentOutOfRangeException(nameof(bubbleSizeMode));
         }
+        if (chartKind == OfficeChartKind.Bubble) {
+            for (int seriesIndex = 0; seriesIndex < data.Series.Count; seriesIndex++) {
+                OfficeChartSeries series = data.Series[seriesIndex];
+                if (series.XValues == null || series.BubbleSizes == null ||
+                    series.XValues.Count != series.Values.Count ||
+                    series.BubbleSizes.Count != series.Values.Count) {
+                    throw new ArgumentException(
+                        "Bubble chart snapshots require matching X, Y, and size values for every series.",
+                        nameof(data));
+                }
+            }
+        }
 
         Name = name ?? string.Empty;
         Title = title;

--- a/OfficeIMO.Drawing/OfficeChartSnapshot.cs
+++ b/OfficeIMO.Drawing/OfficeChartSnapshot.cs
@@ -17,13 +17,27 @@ public sealed class OfficeChartSnapshot {
     /// <param name="heightPoints">Requested render height in points.</param>
     /// <param name="style">Optional shared chart style metadata.</param>
     /// <param name="layout">Optional shared chart layout metadata.</param>
-    public OfficeChartSnapshot(string name, string? title, OfficeChartKind chartKind, OfficeChartData data, double widthPoints, double heightPoints, OfficeChartStyle? style = null, OfficeChartLayout? layout = null) {
+    /// <param name="bubbleScalePercent">Bubble diameter scale as a percentage from zero through 300.</param>
+    /// <param name="bubbleSizeMode">Whether bubble values represent area or width.</param>
+    public OfficeChartSnapshot(string name, string? title, OfficeChartKind chartKind,
+        OfficeChartData data, double widthPoints, double heightPoints,
+        OfficeChartStyle? style = null, OfficeChartLayout? layout = null,
+        double bubbleScalePercent = 100D,
+        OfficeChartBubbleSizeMode bubbleSizeMode = OfficeChartBubbleSizeMode.Area) {
         if (data == null) {
             throw new ArgumentNullException(nameof(data));
         }
 
         ValidatePositiveFinite(widthPoints, nameof(widthPoints));
         ValidatePositiveFinite(heightPoints, nameof(heightPoints));
+        if (double.IsNaN(bubbleScalePercent) || double.IsInfinity(bubbleScalePercent) ||
+            bubbleScalePercent < 0D || bubbleScalePercent > 300D) {
+            throw new ArgumentOutOfRangeException(nameof(bubbleScalePercent),
+                "Bubble scale must be a finite percentage from zero through 300.");
+        }
+        if (!Enum.IsDefined(typeof(OfficeChartBubbleSizeMode), bubbleSizeMode)) {
+            throw new ArgumentOutOfRangeException(nameof(bubbleSizeMode));
+        }
 
         Name = name ?? string.Empty;
         Title = title;
@@ -33,6 +47,8 @@ public sealed class OfficeChartSnapshot {
         HeightPoints = heightPoints;
         Style = style ?? OfficeChartStyle.Default;
         Layout = layout ?? OfficeChartLayout.Default;
+        BubbleScalePercent = bubbleScalePercent;
+        BubbleSizeMode = bubbleSizeMode;
     }
 
     /// <summary>Source shape or drawing name.</summary>
@@ -58,6 +74,12 @@ public sealed class OfficeChartSnapshot {
 
     /// <summary>Shared chart layout metadata.</summary>
     public OfficeChartLayout Layout { get; }
+
+    /// <summary>Bubble diameter scale as a percentage from zero through 300.</summary>
+    public double BubbleScalePercent { get; }
+
+    /// <summary>Whether bubble values represent area or width.</summary>
+    public OfficeChartBubbleSizeMode BubbleSizeMode { get; }
 
     private static void ValidatePositiveFinite(double value, string paramName) {
         if (double.IsNaN(value) || double.IsInfinity(value) || value <= 0D) {

--- a/OfficeIMO.Drawing/OfficeChartSnapshot.cs
+++ b/OfficeIMO.Drawing/OfficeChartSnapshot.cs
@@ -17,13 +17,49 @@ public sealed class OfficeChartSnapshot {
     /// <param name="heightPoints">Requested render height in points.</param>
     /// <param name="style">Optional shared chart style metadata.</param>
     /// <param name="layout">Optional shared chart layout metadata.</param>
+    public OfficeChartSnapshot(string name, string? title, OfficeChartKind chartKind,
+        OfficeChartData data, double widthPoints, double heightPoints,
+        OfficeChartStyle? style = null, OfficeChartLayout? layout = null)
+        : this(name, title, chartKind, data, widthPoints, heightPoints,
+            style, layout, 100D, OfficeChartBubbleSizeMode.Area) {
+    }
+
+    /// <summary>
+    /// Initializes a bubble-aware chart snapshot for rendering with default style and layout.
+    /// </summary>
+    /// <param name="name">Source shape or drawing name.</param>
+    /// <param name="title">Optional display title.</param>
+    /// <param name="chartKind">Supported chart family.</param>
+    /// <param name="data">Chart category and series data.</param>
+    /// <param name="widthPoints">Requested render width in points.</param>
+    /// <param name="heightPoints">Requested render height in points.</param>
     /// <param name="bubbleScalePercent">Bubble diameter scale as a percentage from zero through 300.</param>
     /// <param name="bubbleSizeMode">Whether bubble values represent area or width.</param>
     public OfficeChartSnapshot(string name, string? title, OfficeChartKind chartKind,
         OfficeChartData data, double widthPoints, double heightPoints,
-        OfficeChartStyle? style = null, OfficeChartLayout? layout = null,
-        double bubbleScalePercent = 100D,
-        OfficeChartBubbleSizeMode bubbleSizeMode = OfficeChartBubbleSizeMode.Area) {
+        double bubbleScalePercent,
+        OfficeChartBubbleSizeMode bubbleSizeMode = OfficeChartBubbleSizeMode.Area)
+        : this(name, title, chartKind, data, widthPoints, heightPoints,
+            null, null, bubbleScalePercent, bubbleSizeMode) {
+    }
+
+    /// <summary>
+    /// Initializes a bubble-aware chart snapshot for rendering.
+    /// </summary>
+    /// <param name="name">Source shape or drawing name.</param>
+    /// <param name="title">Optional display title.</param>
+    /// <param name="chartKind">Supported chart family.</param>
+    /// <param name="data">Chart category and series data.</param>
+    /// <param name="widthPoints">Requested render width in points.</param>
+    /// <param name="heightPoints">Requested render height in points.</param>
+    /// <param name="style">Optional shared chart style metadata.</param>
+    /// <param name="layout">Optional shared chart layout metadata.</param>
+    /// <param name="bubbleScalePercent">Bubble diameter scale as a percentage from zero through 300.</param>
+    /// <param name="bubbleSizeMode">Whether bubble values represent area or width.</param>
+    public OfficeChartSnapshot(string name, string? title, OfficeChartKind chartKind,
+        OfficeChartData data, double widthPoints, double heightPoints,
+        OfficeChartStyle? style, OfficeChartLayout? layout,
+        double bubbleScalePercent, OfficeChartBubbleSizeMode bubbleSizeMode) {
         if (data == null) {
             throw new ArgumentNullException(nameof(data));
         }

--- a/OfficeIMO.Drawing/OfficeChartSnapshot.cs
+++ b/OfficeIMO.Drawing/OfficeChartSnapshot.cs
@@ -78,6 +78,13 @@ public sealed class OfficeChartSnapshot {
             OfficeChartSeries series = data.Series[seriesIndex];
             OfficeChartKind effectiveKind = series.RenderKind ?? chartKind;
             if (effectiveKind == OfficeChartKind.Bubble &&
+                chartKind != OfficeChartKind.Bubble &&
+                chartKind != OfficeChartKind.Scatter) {
+                throw new ArgumentException(
+                    "Bubble series require a bubble or scatter snapshot with numeric axes.",
+                    nameof(data));
+            }
+            if (effectiveKind == OfficeChartKind.Bubble &&
                 (series.XValues == null || series.BubbleSizes == null ||
                  series.XValues.Count != series.Values.Count ||
                  series.BubbleSizes.Count != series.Values.Count)) {

--- a/OfficeIMO.Drawing/OfficeChartSnapshot.cs
+++ b/OfficeIMO.Drawing/OfficeChartSnapshot.cs
@@ -74,16 +74,16 @@ public sealed class OfficeChartSnapshot {
         if (!Enum.IsDefined(typeof(OfficeChartBubbleSizeMode), bubbleSizeMode)) {
             throw new ArgumentOutOfRangeException(nameof(bubbleSizeMode));
         }
-        if (chartKind == OfficeChartKind.Bubble) {
-            for (int seriesIndex = 0; seriesIndex < data.Series.Count; seriesIndex++) {
-                OfficeChartSeries series = data.Series[seriesIndex];
-                if (series.XValues == null || series.BubbleSizes == null ||
-                    series.XValues.Count != series.Values.Count ||
-                    series.BubbleSizes.Count != series.Values.Count) {
-                    throw new ArgumentException(
-                        "Bubble chart snapshots require matching X, Y, and size values for every series.",
-                        nameof(data));
-                }
+        for (int seriesIndex = 0; seriesIndex < data.Series.Count; seriesIndex++) {
+            OfficeChartSeries series = data.Series[seriesIndex];
+            OfficeChartKind effectiveKind = series.RenderKind ?? chartKind;
+            if (effectiveKind == OfficeChartKind.Bubble &&
+                (series.XValues == null || series.BubbleSizes == null ||
+                 series.XValues.Count != series.Values.Count ||
+                 series.BubbleSizes.Count != series.Values.Count)) {
+                throw new ArgumentException(
+                    "Bubble chart snapshots require matching X, Y, and size values for every bubble series.",
+                    nameof(data));
             }
         }
 

--- a/OfficeIMO.Excel.Tests/Excel.SharedChartAuthoring.cs
+++ b/OfficeIMO.Excel.Tests/Excel.SharedChartAuthoring.cs
@@ -134,6 +134,23 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_ExcelCharts_SharedBubbleKindIsRejectedInsteadOfFallingBack() {
+            using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet sheet = document.AddWorksheet("Shared");
+            var data = new OfficeChartData(new[] { "1", "2" }, new[] {
+                OfficeChartSeries.CreateBubble("Bubbles",
+                    new[] { 1D, 2D }, new[] { 10D, 20D }, new[] { 4D, 9D })
+            });
+
+            NotSupportedException exception = Assert.Throws<NotSupportedException>(() =>
+                sheet.AddChart(OfficeChartKind.Bubble, data, row: 1, column: 5));
+
+            Assert.Contains("native Excel bubble-chart API", exception.Message,
+                StringComparison.Ordinal);
+            Assert.Empty(sheet.Charts);
+        }
+
+        [Fact]
         public void Test_ExcelCharts_SharedContractPersistsAuthoredSeriesStyles() {
             string filePath = Path.Combine(_directoryWithFiles, "ExcelCharts.SharedContract.Styles.xlsx");
             var sharedData = new OfficeChartData(new[] { "Q1", "Q2" }, new[] {

--- a/OfficeIMO.Excel/ExcelSheet.SharedCharts.cs
+++ b/OfficeIMO.Excel/ExcelSheet.SharedCharts.cs
@@ -60,7 +60,12 @@ namespace OfficeIMO.Excel {
                 case OfficeChartKind.Radar: return ExcelChartType.Radar;
                 case OfficeChartKind.Pie: return ExcelChartType.Pie;
                 case OfficeChartKind.Doughnut: return ExcelChartType.Doughnut;
-                default: return ExcelChartType.ColumnClustered;
+                case OfficeChartKind.Bubble:
+                    throw new NotSupportedException(
+                        "Bubble charts are not supported by the shared Excel chart API. Use the native Excel bubble-chart API.");
+                default:
+                    throw new NotSupportedException(
+                        $"Shared chart kind '{kind}' is not supported by Excel.");
             }
         }
     }

--- a/OfficeIMO.Html.Tests/Html.OfficeAdapterLimits.cs
+++ b/OfficeIMO.Html.Tests/Html.OfficeAdapterLimits.cs
@@ -1,6 +1,8 @@
 using OfficeIMO.Excel;
 using OfficeIMO.Excel.Html;
+using OfficeIMO.Drawing;
 using OfficeIMO.Html;
+using OfficeIMO.PowerPoint;
 using OfficeIMO.PowerPoint.Html;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Html;
@@ -389,6 +391,49 @@ public sealed class HtmlOfficeAdapterLimitTests {
         Assert.Contains(result.Report.Diagnostics,
             diagnostic => diagnostic.Code ==
                           HtmlConversionDiagnosticCodes.TargetLimitExceeded);
+    }
+
+    [Fact]
+    public void PowerPointHtml_BudgetsUnevenBubbleRowsByActualPoints() {
+        const string html = """
+            <main class="officeimo-document" data-officeimo-source="powerpoint" data-officeimo-profile="PowerPointSemanticSlides" data-officeimo-schema-version="1">
+              <section class="officeimo-slide" data-officeimo-slide="1">
+                <section class="officeimo-charts"><ul><li>
+                  <span class="officeimo-feature-label">Uneven bubble</span>
+                  <span class="officeimo-feature-meta">Type: Bubble; Series: 2; Categories: 3</span>
+                  <table class="officeimo-chart-data">
+                    <thead><tr><th>Series</th><th>One</th><th>Two</th><th>Three</th></tr></thead>
+                    <tbody>
+                      <tr><th>Wide</th>
+                        <td data-officeimo-x="1" data-officeimo-bubble-size="4">10</td>
+                        <td data-officeimo-x="2" data-officeimo-bubble-size="9">20</td>
+                        <td data-officeimo-x="3" data-officeimo-bubble-size="16">30</td>
+                      </tr>
+                      <tr><th>Narrow</th>
+                        <td data-officeimo-x="4" data-officeimo-bubble-size="25">40</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </li></ul></section>
+              </section>
+            </main>
+            """;
+        HtmlImportLimits limits = HtmlImportLimits.CreateDefault();
+        limits.MaxChartPoints = 4;
+
+        HtmlToPowerPointResult result = HtmlConversionDocument.Parse(html)
+            .ToPowerPointPresentationResult(
+                new HtmlToPowerPointOptions { Limits = limits });
+        using var presentation = result.Value;
+
+        Assert.Equal(1, result.Charts);
+        PowerPointChart chart =
+            Assert.Single(Assert.Single(presentation.Slides).Charts);
+        Assert.True(chart.TryGetOfficeSnapshot(
+            out OfficeChartSnapshot snapshot));
+        Assert.Equal(
+            new[] { 3, 1 },
+            snapshot.Data.Series.Select(series => series.Values.Count));
     }
 
     [Fact]

--- a/OfficeIMO.Html.Tests/Html.OfficeAdapterLimits.cs
+++ b/OfficeIMO.Html.Tests/Html.OfficeAdapterLimits.cs
@@ -357,6 +357,41 @@ public sealed class HtmlOfficeAdapterLimitTests {
     }
 
     [Fact]
+    public void PowerPointHtml_BoundsBubbleRowsWiderThanSemanticHeaders() {
+        const string html = """
+            <main class="officeimo-document" data-officeimo-source="powerpoint" data-officeimo-profile="PowerPointSemanticSlides" data-officeimo-schema-version="1">
+              <section class="officeimo-slide" data-officeimo-slide="1">
+                <section class="officeimo-charts"><ul><li>
+                  <span class="officeimo-feature-label">Bubble</span>
+                  <span class="officeimo-feature-meta">Type: Bubble; Series: 1; Categories: 1</span>
+                  <table class="officeimo-chart-data">
+                    <thead><tr><th>Series</th><th>One</th></tr></thead>
+                    <tbody><tr><th>Portfolio</th>
+                      <td data-officeimo-x="1" data-officeimo-bubble-size="4">10</td>
+                      <td data-officeimo-x="2" data-officeimo-bubble-size="9">20</td>
+                      <td data-officeimo-x="3" data-officeimo-bubble-size="16">30</td>
+                    </tr></tbody>
+                  </table>
+                </li></ul></section>
+              </section>
+            </main>
+            """;
+        HtmlImportLimits limits = HtmlImportLimits.CreateDefault();
+        limits.MaxChartCategories = 2;
+
+        HtmlToPowerPointResult result = HtmlConversionDocument.Parse(html)
+            .ToPowerPointPresentationResult(
+                new HtmlToPowerPointOptions { Limits = limits });
+        using var presentation = result.Value;
+
+        Assert.Equal(0, result.Charts);
+        Assert.Empty(Assert.Single(presentation.Slides).Charts);
+        Assert.Contains(result.Report.Diagnostics,
+            diagnostic => diagnostic.Code ==
+                          HtmlConversionDiagnosticCodes.TargetLimitExceeded);
+    }
+
+    [Fact]
     public void PowerPointHtml_RejectedChartDoesNotConsumeTheSharedShapeBudget() {
         const string html = """
             <main class="officeimo-document" data-officeimo-source="powerpoint" data-officeimo-profile="PowerPointSemanticSlides" data-officeimo-schema-version="1">

--- a/OfficeIMO.Html.Tests/Html.OfficeAdapterLimits.cs
+++ b/OfficeIMO.Html.Tests/Html.OfficeAdapterLimits.cs
@@ -392,6 +392,40 @@ public sealed class HtmlOfficeAdapterLimitTests {
     }
 
     [Fact]
+    public void PowerPointHtml_OmitsBubbleInventoryAboveSharedPointLimit() {
+        const string html = """
+            <main class="officeimo-document" data-officeimo-source="powerpoint" data-officeimo-profile="PowerPointSemanticSlides" data-officeimo-schema-version="1">
+              <section class="officeimo-slide" data-officeimo-slide="1">
+                <section class="officeimo-charts"><ul><li>
+                  <span class="officeimo-feature-label">Oversized bubble inventory</span>
+                  <span class="officeimo-feature-meta">Type: Bubble; Series: 101; Categories: 1000</span>
+                </li></ul></section>
+              </section>
+            </main>
+            """;
+        HtmlImportLimits limits = HtmlImportLimits.CreateDefault();
+        limits.MaxChartSeries = 101;
+        limits.MaxChartCategories = 1000;
+        limits.MaxChartPoints = 101_000;
+
+        HtmlToPowerPointResult result = HtmlConversionDocument.Parse(html)
+            .ToPowerPointPresentationResult(
+                new HtmlToPowerPointOptions { Limits = limits });
+        using var presentation = result.Value;
+
+        Assert.Equal(0, result.Charts);
+        Assert.Empty(Assert.Single(presentation.Slides).Charts);
+        Assert.Contains(result.Report.Diagnostics,
+            diagnostic =>
+                diagnostic.Code ==
+                    HtmlConversionDiagnosticCodes.TargetLimitExceeded &&
+                diagnostic.LossKind == HtmlConversionLossKind.Omission &&
+                diagnostic.Detail != null &&
+                diagnostic.Detail.Contains("Actual=101000",
+                    StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void PowerPointHtml_RejectedChartDoesNotConsumeTheSharedShapeBudget() {
         const string html = """
             <main class="officeimo-document" data-officeimo-source="powerpoint" data-officeimo-profile="PowerPointSemanticSlides" data-officeimo-schema-version="1">

--- a/OfficeIMO.Html.Tests/Html.OfficeAdapters.cs
+++ b/OfficeIMO.Html.Tests/Html.OfficeAdapters.cs
@@ -863,7 +863,8 @@ public class HtmlOfficeAdapters {
             OfficeChartSeries.CreateBubble("Portfolio",
                 new[] { 1.5D, 2.5D },
                 new[] { 10D, 20D },
-                new[] { 4D, 9D })
+                new[] { 4D, 9D },
+                showInLegend: false)
         });
         slide.AddChartPoints(OfficeChartKind.Bubble, data, 72, 96, 240, 140)
             .SetTitle("Bubble")
@@ -881,6 +882,8 @@ public class HtmlOfficeAdapters {
             StringComparison.Ordinal);
         Assert.Contains("data-officeimo-bubble-size-mode=\"Width\"", html,
             StringComparison.Ordinal);
+        Assert.Contains("data-officeimo-show-in-legend=\"false\"", html,
+            StringComparison.Ordinal);
 
         HtmlToPowerPointResult result =
             HtmlConversionDocument.Parse(html).ToPowerPointPresentationResult();
@@ -892,6 +895,7 @@ public class HtmlOfficeAdapters {
         Assert.Equal(new[] { 1.5D, 2.5D }, series.XValues);
         Assert.Equal(new[] { 10D, 20D }, series.Values);
         Assert.Equal(new[] { 4D, 9D }, series.BubbleSizes);
+        Assert.False(series.ShowInLegend);
         Assert.Equal(145D, snapshot.BubbleScalePercent);
         Assert.Equal(OfficeChartBubbleSizeMode.Width, snapshot.BubbleSizeMode);
         Assert.DoesNotContain(result.Report.Diagnostics,

--- a/OfficeIMO.Html.Tests/Html.OfficeAdapters.cs
+++ b/OfficeIMO.Html.Tests/Html.OfficeAdapters.cs
@@ -866,7 +866,8 @@ public class HtmlOfficeAdapters {
                 new[] { 4D, 9D })
         });
         slide.AddChartPoints(OfficeChartKind.Bubble, data, 72, 96, 240, 140)
-            .SetTitle("Bubble");
+            .SetTitle("Bubble")
+            .SetBubbleSizing(145U, OfficeChartBubbleSizeMode.Width);
 
         string html = presentation.ToHtml(new PowerPointHtmlSaveOptions {
             Profile = OfficeHtmlConversionProfile.PowerPointSemanticSlides
@@ -875,6 +876,10 @@ public class HtmlOfficeAdapters {
         Assert.Contains("data-officeimo-bubble-size=\"4\"", html,
             StringComparison.Ordinal);
         Assert.Contains("data-officeimo-bubble-size=\"9\"", html,
+            StringComparison.Ordinal);
+        Assert.Contains("data-officeimo-bubble-scale=\"145\"", html,
+            StringComparison.Ordinal);
+        Assert.Contains("data-officeimo-bubble-size-mode=\"Width\"", html,
             StringComparison.Ordinal);
 
         HtmlToPowerPointResult result =
@@ -887,6 +892,8 @@ public class HtmlOfficeAdapters {
         Assert.Equal(new[] { 1.5D, 2.5D }, series.XValues);
         Assert.Equal(new[] { 10D, 20D }, series.Values);
         Assert.Equal(new[] { 4D, 9D }, series.BubbleSizes);
+        Assert.Equal(145D, snapshot.BubbleScalePercent);
+        Assert.Equal(OfficeChartBubbleSizeMode.Width, snapshot.BubbleSizeMode);
         Assert.DoesNotContain(result.Report.Diagnostics,
             diagnostic => diagnostic.Code == HtmlConversionDiagnosticCodes.ContentOmitted ||
                           diagnostic.Code == HtmlConversionDiagnosticCodes.ContentApproximated);

--- a/OfficeIMO.Html.Tests/Html.OfficeAdapters.cs
+++ b/OfficeIMO.Html.Tests/Html.OfficeAdapters.cs
@@ -893,6 +893,33 @@ public class HtmlOfficeAdapters {
     }
 
     [Fact]
+    public void PowerPointHtml_RejectsBubbleSizesWithoutXValues() {
+        using PowerPointPresentation presentation =
+            PowerPointPresentation.Create(new MemoryStream());
+        PowerPointSlide slide = presentation.AddSlide();
+        var data = new OfficeChartData(new[] { "1.5", "2.5" }, new[] {
+            OfficeChartSeries.CreateBubble("Portfolio",
+                new[] { 1.5D, 2.5D },
+                new[] { 10D, 20D },
+                new[] { 4D, 9D })
+        });
+        slide.AddChartPoints(OfficeChartKind.Bubble, data, 72, 96, 240, 140);
+        string html = presentation.ToHtml(new PowerPointHtmlSaveOptions {
+            Profile = OfficeHtmlConversionProfile.PowerPointSemanticSlides
+        }).Replace(" data-officeimo-x=\"1.5\"", string.Empty)
+          .Replace(" data-officeimo-x=\"2.5\"", string.Empty);
+
+        HtmlToPowerPointResult result =
+            HtmlConversionDocument.Parse(html).ToPowerPointPresentationResult();
+        using PowerPointPresentation imported = result.Value;
+
+        Assert.Empty(imported.Slides[0].Charts);
+        Assert.Contains(result.Report.Diagnostics,
+            diagnostic => diagnostic.Code ==
+                          HtmlConversionDiagnosticCodes.ContentOmitted);
+    }
+
+    [Fact]
     public void PowerPointHtml_RejectsXValuesOnMismatchedNonScatterSeries() {
         using PowerPointPresentation presentation = PowerPointPresentation.Create(new MemoryStream());
         PowerPointSlide slide = presentation.AddSlide();

--- a/OfficeIMO.Html.Tests/Html.OfficeAdapters.cs
+++ b/OfficeIMO.Html.Tests/Html.OfficeAdapters.cs
@@ -855,6 +855,44 @@ public class HtmlOfficeAdapters {
     }
 
     [Fact]
+    public void PowerPointHtml_RoundTripsBubbleChartSizesInSemanticChartData() {
+        using PowerPointPresentation presentation =
+            PowerPointPresentation.Create(new MemoryStream());
+        PowerPointSlide slide = presentation.AddSlide();
+        var data = new OfficeChartData(new[] { "1.5", "2.5" }, new[] {
+            OfficeChartSeries.CreateBubble("Portfolio",
+                new[] { 1.5D, 2.5D },
+                new[] { 10D, 20D },
+                new[] { 4D, 9D })
+        });
+        slide.AddChartPoints(OfficeChartKind.Bubble, data, 72, 96, 240, 140)
+            .SetTitle("Bubble");
+
+        string html = presentation.ToHtml(new PowerPointHtmlSaveOptions {
+            Profile = OfficeHtmlConversionProfile.PowerPointSemanticSlides
+        });
+
+        Assert.Contains("data-officeimo-bubble-size=\"4\"", html,
+            StringComparison.Ordinal);
+        Assert.Contains("data-officeimo-bubble-size=\"9\"", html,
+            StringComparison.Ordinal);
+
+        HtmlToPowerPointResult result =
+            HtmlConversionDocument.Parse(html).ToPowerPointPresentationResult();
+        using PowerPointPresentation imported = result.Value;
+        PowerPointChart importedChart = Assert.Single(imported.Slides[0].Charts);
+        Assert.True(importedChart.TryGetOfficeSnapshot(out OfficeChartSnapshot snapshot));
+        Assert.Equal(OfficeChartKind.Bubble, snapshot.ChartKind);
+        OfficeChartSeries series = Assert.Single(snapshot.Data.Series);
+        Assert.Equal(new[] { 1.5D, 2.5D }, series.XValues);
+        Assert.Equal(new[] { 10D, 20D }, series.Values);
+        Assert.Equal(new[] { 4D, 9D }, series.BubbleSizes);
+        Assert.DoesNotContain(result.Report.Diagnostics,
+            diagnostic => diagnostic.Code == HtmlConversionDiagnosticCodes.ContentOmitted ||
+                          diagnostic.Code == HtmlConversionDiagnosticCodes.ContentApproximated);
+    }
+
+    [Fact]
     public void PowerPointHtml_RejectsXValuesOnMismatchedNonScatterSeries() {
         using PowerPointPresentation presentation = PowerPointPresentation.Create(new MemoryStream());
         PowerPointSlide slide = presentation.AddSlide();

--- a/OfficeIMO.Html.Tests/Html.OfficeAdapters.cs
+++ b/OfficeIMO.Html.Tests/Html.OfficeAdapters.cs
@@ -859,12 +859,25 @@ public class HtmlOfficeAdapters {
         using PowerPointPresentation presentation =
             PowerPointPresentation.Create(new MemoryStream());
         PowerPointSlide slide = presentation.AddSlide();
+        OfficeColor seriesColor = OfficeColor.FromRgba(17, 34, 51, 128);
+        OfficeColor pointColor = OfficeColor.FromRgba(68, 85, 102, 96);
+        OfficeColor outlineColor = OfficeColor.FromRgba(119, 136, 153, 64);
         var data = new OfficeChartData(new[] { "1.5", "2.5" }, new[] {
             OfficeChartSeries.CreateBubble("Portfolio",
                 new[] { 1.5D, 2.5D },
                 new[] { 10D, 20D },
                 new[] { 4D, 9D },
-                showInLegend: false)
+                seriesColor,
+                new OfficeColor?[] { pointColor, null },
+                showInLegend: false,
+                markerOutlineColor: outlineColor,
+                markerOutlineWidth: 1.5D),
+            OfficeChartSeries.CreateBubble("No outline",
+                new[] { 1.5D, 2.5D },
+                new[] { 8D, 16D },
+                new[] { 3D, 7D },
+                color: OfficeColor.Parse("#AABBCC"),
+                showMarkerOutline: false)
         });
         slide.AddChartPoints(OfficeChartKind.Bubble, data, 72, 96, 240, 140)
             .SetTitle("Bubble")
@@ -884,6 +897,16 @@ public class HtmlOfficeAdapters {
             StringComparison.Ordinal);
         Assert.Contains("data-officeimo-show-in-legend=\"false\"", html,
             StringComparison.Ordinal);
+        Assert.Contains("data-officeimo-series-color=\"#11223380\"", html,
+            StringComparison.Ordinal);
+        Assert.Contains("data-officeimo-point-color=\"#44556660\"", html,
+            StringComparison.Ordinal);
+        Assert.Contains("data-officeimo-outline-color=\"#77889940\"", html,
+            StringComparison.Ordinal);
+        Assert.Contains("data-officeimo-outline-width=\"1.5\"", html,
+            StringComparison.Ordinal);
+        Assert.Contains("data-officeimo-show-outline=\"false\"", html,
+            StringComparison.Ordinal);
 
         HtmlToPowerPointResult result =
             HtmlConversionDocument.Parse(html).ToPowerPointPresentationResult();
@@ -891,11 +914,19 @@ public class HtmlOfficeAdapters {
         PowerPointChart importedChart = Assert.Single(imported.Slides[0].Charts);
         Assert.True(importedChart.TryGetOfficeSnapshot(out OfficeChartSnapshot snapshot));
         Assert.Equal(OfficeChartKind.Bubble, snapshot.ChartKind);
-        OfficeChartSeries series = Assert.Single(snapshot.Data.Series);
+        Assert.Equal(2, snapshot.Data.Series.Count);
+        OfficeChartSeries series = snapshot.Data.Series[0];
         Assert.Equal(new[] { 1.5D, 2.5D }, series.XValues);
         Assert.Equal(new[] { 10D, 20D }, series.Values);
         Assert.Equal(new[] { 4D, 9D }, series.BubbleSizes);
         Assert.False(series.ShowInLegend);
+        Assert.Equal(seriesColor, series.Color);
+        Assert.Equal(pointColor, series.PointColors![0]);
+        Assert.Null(series.PointColors[1]);
+        Assert.Equal(outlineColor, series.MarkerOutlineColor);
+        Assert.Equal(1.5D, series.MarkerOutlineWidth);
+        Assert.True(series.ShowMarkerOutline);
+        Assert.False(snapshot.Data.Series[1].ShowMarkerOutline);
         Assert.Equal(145D, snapshot.BubbleScalePercent);
         Assert.Equal(OfficeChartBubbleSizeMode.Width, snapshot.BubbleSizeMode);
         Assert.DoesNotContain(result.Report.Diagnostics,

--- a/OfficeIMO.Html.Tests/Html.OfficeAdapters.cs
+++ b/OfficeIMO.Html.Tests/Html.OfficeAdapters.cs
@@ -935,6 +935,40 @@ public class HtmlOfficeAdapters {
     }
 
     [Fact]
+    public void PowerPointHtml_CreatesBubblePlaceholderDataWithoutSemanticTable() {
+        string html = """
+            <main>
+              <section class="officeimo-slide">
+                <section class="officeimo-feature officeimo-charts">
+                  <ul class="officeimo-feature-list">
+                    <li class="officeimo-feature-item">
+                      <span class="officeimo-feature-label">Bubble inventory</span>
+                      <div class="officeimo-feature-meta">Type: Bubble; Series: 2; Categories: 3</div>
+                    </li>
+                  </ul>
+                </section>
+              </section>
+            </main>
+            """;
+
+        HtmlToPowerPointResult result =
+            HtmlConversionDocument.Parse(html).ToPowerPointPresentationResult();
+        using PowerPointPresentation imported = result.Value;
+        PowerPointChart chart = Assert.Single(imported.Slides[0].Charts);
+
+        Assert.True(chart.TryGetOfficeSnapshot(out OfficeChartSnapshot snapshot));
+        Assert.Equal(OfficeChartKind.Bubble, snapshot.ChartKind);
+        Assert.Equal(2, snapshot.Data.Series.Count);
+        Assert.All(snapshot.Data.Series, series => {
+            Assert.Equal(3, series.XValues!.Count);
+            Assert.Equal(3, series.BubbleSizes!.Count);
+        });
+        Assert.Contains(result.Report.Diagnostics,
+            diagnostic => diagnostic.Code ==
+                          HtmlConversionDiagnosticCodes.ContentApproximated);
+    }
+
+    [Fact]
     public void PowerPointHtml_RejectsBubbleSizesWithoutXValues() {
         using PowerPointPresentation presentation =
             PowerPointPresentation.Create(new MemoryStream());

--- a/OfficeIMO.Html.Tests/Html.PowerPointBubbleCharts.cs
+++ b/OfficeIMO.Html.Tests/Html.PowerPointBubbleCharts.cs
@@ -1,0 +1,67 @@
+using System.IO;
+using System.Linq;
+using OfficeIMO.Drawing;
+using OfficeIMO.Html;
+using OfficeIMO.PowerPoint;
+using OfficeIMO.PowerPoint.Html;
+using Xunit;
+using C = DocumentFormat.OpenXml.Drawing.Charts;
+
+namespace OfficeIMO.Tests;
+
+public class HtmlPowerPointBubbleChartTests {
+    [Fact]
+    public void PowerPointHtml_RoundTripsBubbleChartLegendLayout() {
+        using PowerPointPresentation presentation =
+            PowerPointPresentation.Create(new MemoryStream());
+        presentation.AddSlide().AddChart(
+                OfficeChartKind.Bubble, CreateBubbleData())
+            .SetTitle("Positioned")
+            .SetLegend(C.LegendPositionValues.Top, overlay: true);
+        presentation.AddSlide().AddChart(
+                OfficeChartKind.Bubble, CreateBubbleData())
+            .SetTitle("Hidden")
+            .HideLegend();
+
+        string html = presentation.ToHtml(
+            new PowerPointHtmlSaveOptions {
+                Profile = OfficeHtmlConversionProfile.PowerPointSemanticSlides
+            });
+
+        Assert.Contains("data-officeimo-show-legend=\"true\"", html,
+            System.StringComparison.Ordinal);
+        Assert.Contains("data-officeimo-legend-position=\"Top\"", html,
+            System.StringComparison.Ordinal);
+        Assert.Contains("data-officeimo-overlay-legend=\"true\"", html,
+            System.StringComparison.Ordinal);
+        Assert.Contains("data-officeimo-show-legend=\"false\"", html,
+            System.StringComparison.Ordinal);
+
+        HtmlToPowerPointResult result = HtmlConversionDocument.Parse(html)
+            .ToPowerPointPresentationResult();
+        using PowerPointPresentation imported = result.Value;
+        Assert.True(imported.Slides[0].Charts.Single().TryGetOfficeSnapshot(
+            out OfficeChartSnapshot positionedSnapshot));
+        Assert.True(positionedSnapshot.Layout.ShowLegend);
+        Assert.Equal(OfficeChartLegendPosition.Top,
+            positionedSnapshot.Layout.LegendPosition);
+        Assert.True(positionedSnapshot.Layout.OverlayLegend);
+
+        Assert.True(imported.Slides[1].Charts.Single().TryGetOfficeSnapshot(
+            out OfficeChartSnapshot hiddenSnapshot));
+        Assert.False(hiddenSnapshot.Layout.ShowLegend);
+        Assert.DoesNotContain(result.Report.Diagnostics,
+            diagnostic =>
+                diagnostic.Code ==
+                    HtmlConversionDiagnosticCodes.ContentOmitted ||
+                diagnostic.Code ==
+                    HtmlConversionDiagnosticCodes.ContentApproximated);
+    }
+
+    private static OfficeChartData CreateBubbleData() =>
+        new(new[] { "1", "2" }, new[] {
+            OfficeChartSeries.CreateBubble(
+                "Portfolio", new[] { 1D, 2D }, new[] { 3D, 4D },
+                new[] { 5D, 6D })
+        });
+}

--- a/OfficeIMO.Html/Engine/HtmlImportBudget.cs
+++ b/OfficeIMO.Html/Engine/HtmlImportBudget.cs
@@ -75,17 +75,40 @@ internal sealed class HtmlImportBudget {
         int series,
         int categories,
         out HtmlImportBudgetReservation reservation,
+        out string detail) =>
+        TryReserveChartWithShape(
+            series, categories, explicitPoints: null,
+            out reservation, out detail);
+
+    internal bool TryReserveChartWithShape(
+        int series,
+        int categories,
+        long points,
+        out HtmlImportBudgetReservation reservation,
+        out string detail) =>
+        TryReserveChartWithShape(
+            series, categories, explicitPoints: points,
+            out reservation, out detail);
+
+    private bool TryReserveChartWithShape(
+        int series,
+        int categories,
+        long? explicitPoints,
+        out HtmlImportBudgetReservation reservation,
         out string detail) {
         reservation = null!;
-        if (!CanReserveChart(series, categories, out long points, out detail)
+        if (!CanReserveChart(
+                series, categories, explicitPoints,
+                out long reservedPoints, out detail)
             || !CanIncrement(_shapes, _limits.MaxShapes, nameof(HtmlImportLimits.MaxShapes), out detail)) {
             return false;
         }
 
         _charts++;
-        _chartPoints += points;
+        _chartPoints += reservedPoints;
         _shapes++;
-        reservation = new HtmlImportBudgetReservation(() => ReleaseChartWithShape(points));
+        reservation = new HtmlImportBudgetReservation(
+            () => ReleaseChartWithShape(reservedPoints));
         detail = string.Empty;
         return true;
     }
@@ -96,7 +119,12 @@ internal sealed class HtmlImportBudget {
         _shapes--;
     }
 
-    private bool CanReserveChart(int series, int categories, out long points, out string detail) {
+    private bool CanReserveChart(
+        int series,
+        int categories,
+        long? explicitPoints,
+        out long points,
+        out string detail) {
         if (_charts >= _limits.MaxCharts) {
             points = 0L;
             detail = Detail(nameof(HtmlImportLimits.MaxCharts), _charts + 1L, _limits.MaxCharts);
@@ -115,7 +143,13 @@ internal sealed class HtmlImportBudget {
             return false;
         }
 
-        points = (long)series * categories;
+        points = explicitPoints ?? (long)series * categories;
+        if (points < 0L) {
+            detail = Detail(
+                nameof(HtmlImportLimits.MaxChartPoints),
+                points, _limits.MaxChartPoints);
+            return false;
+        }
         if (points > _limits.MaxChartPoints - _chartPoints) {
             detail = Detail(nameof(HtmlImportLimits.MaxChartPoints), _chartPoints + points, _limits.MaxChartPoints);
             return false;

--- a/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.Bubbles.cs
+++ b/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.Bubbles.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using AngleSharp.Dom;
+using OfficeIMO.Drawing;
+using C = DocumentFormat.OpenXml.Drawing.Charts;
+using PptCore = OfficeIMO.PowerPoint;
+
+namespace OfficeIMO.PowerPoint.Html;
+
+public static partial class HtmlPowerPointConverterExtensions {
+    private static bool TryCreateBubbleChartData(
+        PptCore.PowerPointChartData data,
+        out OfficeChartData? bubbleData) {
+        bubbleData = null;
+        var series = new List<OfficeChartSeries>();
+        foreach (PptCore.PowerPointChartSeries item in data.Series) {
+            if (item.XValues == null || item.BubbleSizes == null ||
+                item.XValues.Count != item.Values.Count ||
+                item.BubbleSizes.Count != item.Values.Count) {
+                return false;
+            }
+
+            series.Add(OfficeChartSeries.CreateBubble(
+                item.Name, item.XValues, item.Values, item.BubbleSizes,
+                item.Color, item.PointColors,
+                showInLegend: item.ShowInLegend,
+                markerOutlineColor: item.StrokeColor ?? item.Color,
+                markerOutlineWidth: item.StrokeWidth,
+                showMarkerOutline: item.ShowStroke));
+        }
+
+        if (series.Count == 0) {
+            return false;
+        }
+
+        bubbleData = new OfficeChartData(data.Categories, series);
+        return true;
+    }
+
+    private static bool TryReadBubbleSizing(
+        IElement item, out uint scalePercent,
+        out OfficeChartBubbleSizeMode sizeMode) {
+        scalePercent = 100U;
+        sizeMode = OfficeChartBubbleSizeMode.Area;
+        IElement? table =
+            item.QuerySelector("table.officeimo-chart-data");
+        if (table == null) {
+            return true;
+        }
+
+        string? rawScale =
+            table.GetAttribute("data-officeimo-bubble-scale");
+        if (rawScale != null &&
+            (!uint.TryParse(
+                 rawScale, NumberStyles.None,
+                 CultureInfo.InvariantCulture, out scalePercent) ||
+             scalePercent > 300U)) {
+            return false;
+        }
+
+        string? rawMode =
+            table.GetAttribute("data-officeimo-bubble-size-mode");
+        return rawMode == null ||
+               Enum.TryParse(
+                   rawMode, ignoreCase: true, out sizeMode) &&
+               Enum.IsDefined(
+                   typeof(OfficeChartBubbleSizeMode), sizeMode);
+    }
+
+    private static bool TryReadBubbleLegend(
+        IElement item, out bool showLegend,
+        out OfficeChartLegendPosition position,
+        out bool overlayLegend) {
+        showLegend = true;
+        position = OfficeChartLegendPosition.Bottom;
+        overlayLegend = false;
+        IElement? table =
+            item.QuerySelector("table.officeimo-chart-data");
+        if (table == null) {
+            return true;
+        }
+
+        string? rawShow =
+            table.GetAttribute("data-officeimo-show-legend");
+        if (rawShow != null &&
+            !bool.TryParse(rawShow, out showLegend)) {
+            return false;
+        }
+
+        string? rawPosition =
+            table.GetAttribute("data-officeimo-legend-position");
+        if (rawPosition != null &&
+            (!Enum.TryParse(
+                 rawPosition, ignoreCase: true, out position) ||
+             !Enum.IsDefined(
+                 typeof(OfficeChartLegendPosition), position))) {
+            return false;
+        }
+
+        string? rawOverlay =
+            table.GetAttribute("data-officeimo-overlay-legend");
+        return rawOverlay == null ||
+               bool.TryParse(rawOverlay, out overlayLegend);
+    }
+
+    private static C.LegendPositionValues ToPowerPointLegendPosition(
+        OfficeChartLegendPosition position) =>
+        position switch {
+            OfficeChartLegendPosition.Left =>
+                C.LegendPositionValues.Left,
+            OfficeChartLegendPosition.Right =>
+                C.LegendPositionValues.Right,
+            OfficeChartLegendPosition.Top =>
+                C.LegendPositionValues.Top,
+            OfficeChartLegendPosition.Bottom =>
+                C.LegendPositionValues.Bottom,
+            _ => throw new ArgumentOutOfRangeException(nameof(position))
+        };
+}

--- a/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.cs
+++ b/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.cs
@@ -262,7 +262,13 @@ public static partial class HtmlPowerPointConverterExtensions {
         }
 
         series = Math.Max(1, table.QuerySelectorAll("tbody tr").Length);
-        categories = Math.Max(1, table.QuerySelectorAll("thead tr th").Length - 1);
+        int headerCategories =
+            Math.Max(0, table.QuerySelectorAll("thead tr th").Length - 1);
+        int widestSeries = table.QuerySelectorAll("tbody tr")
+            .Select(row => row.QuerySelectorAll("td").Length)
+            .DefaultIfEmpty(0)
+            .Max();
+        categories = Math.Max(1, Math.Max(headerCategories, widestSeries));
     }
 
     private static PptCore.PowerPointChartData CreatePlaceholderChartData(int seriesCount, int categoryCount) {

--- a/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.cs
+++ b/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.cs
@@ -184,13 +184,32 @@ public static partial class HtmlPowerPointConverterExtensions {
         using (reservation) {
             string chartKind = ReadChartKind(item);
             bool isBubble = chartKind.Equals("Bubble", StringComparison.OrdinalIgnoreCase);
+            bool hasSemanticTable =
+                item.QuerySelector("table.officeimo-chart-data") != null;
+            if (isBubble && !hasSemanticTable &&
+                (long)seriesCount * categoryCount >
+                    PptCore.PowerPointUtils.MaximumSharedChartPoints) {
+                AddImportDiagnostic(result,
+                    HtmlConversionDiagnosticCodes.TargetLimitExceeded,
+                    "Chart inventory item '" +
+                    (title.Length == 0 ? "Imported chart" : title) +
+                    "' was omitted because its bubble point count exceeded the shared chart limit.",
+                    lossKind: HtmlConversionLossKind.Omission,
+                    detail: "BubblePoints: Actual=" +
+                        ((long)seriesCount * categoryCount)
+                            .ToString(CultureInfo.InvariantCulture) +
+                        "; Limit=" +
+                        PptCore.PowerPointUtils.MaximumSharedChartPoints
+                            .ToString(CultureInfo.InvariantCulture));
+                return;
+            }
             bool restoredFromSemanticData = TryReadChartData(
                 item,
                 chartKind.Equals("Scatter", StringComparison.OrdinalIgnoreCase) || isBubble,
                 isBubble,
                 out PptCore.PowerPointChartData? semanticData);
             if (isBubble && !restoredFromSemanticData &&
-                item.QuerySelector("table.officeimo-chart-data") != null) {
+                hasSemanticTable) {
                 AddImportDiagnostic(result,
                     HtmlConversionDiagnosticCodes.ContentOmitted,
                     "Chart inventory item '" +
@@ -214,6 +233,25 @@ public static partial class HtmlPowerPointConverterExtensions {
                 (isBubble
                     ? CreatePlaceholderBubbleChartDataFromInventory(item)
                     : CreatePlaceholderChartDataFromInventory(item));
+            if (isBubble) {
+                long bubblePointCount = data.Series.Sum(series =>
+                    (long)series.Values.Count);
+                if (bubblePointCount >
+                    PptCore.PowerPointUtils.MaximumSharedChartPoints) {
+                    AddImportDiagnostic(result,
+                        HtmlConversionDiagnosticCodes.TargetLimitExceeded,
+                        "Chart inventory item '" +
+                        (title.Length == 0 ? "Imported chart" : title) +
+                        "' was omitted because its bubble point count exceeded the shared chart limit.",
+                        lossKind: HtmlConversionLossKind.Omission,
+                        detail: "BubblePoints: Actual=" +
+                            bubblePointCount.ToString(CultureInfo.InvariantCulture) +
+                            "; Limit=" +
+                            PptCore.PowerPointUtils.MaximumSharedChartPoints
+                                .ToString(CultureInfo.InvariantCulture));
+                    return;
+                }
+            }
             ReadChartGeometry(item, 500D, fallbackTop, 320D, 180D, budget, result, out double left, out double chartTop, out double width, out double height);
             if (!TryAddChartByKind(slide, chartKind, data, left, chartTop, width, height, out PptCore.PowerPointChart? chart, out string? fallbackMessage) || chart == null) {
                 AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.ContentOmitted,

--- a/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.cs
+++ b/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.cs
@@ -301,6 +301,9 @@ public static partial class HtmlPowerPointConverterExtensions {
             if (hasBubbleSizes != allowBubbleSizes) {
                 return false;
             }
+            if (hasBubbleSizes && !hasXValues) {
+                return false;
+            }
 
             for (int i = 0; i < valueCells.Count; i++) {
                 IElement cell = valueCells[i];

--- a/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.cs
+++ b/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.cs
@@ -301,6 +301,9 @@ public static partial class HtmlPowerPointConverterExtensions {
             if (name.Length == 0) {
                 name = "Series " + (series.Count + 1).ToString(CultureInfo.InvariantCulture);
             }
+            bool showInLegend = !string.Equals(
+                row.GetAttribute("data-officeimo-show-in-legend"), "false",
+                StringComparison.OrdinalIgnoreCase);
 
             List<IElement> valueCells = row.QuerySelectorAll("td").ToList();
             var values = new double[valueCells.Count];
@@ -357,15 +360,20 @@ public static partial class HtmlPowerPointConverterExtensions {
                     values,
                     xValues,
                     PptCore.PowerPointChartSnapshotKind.Bubble) {
-                    BubbleSizes = bubbleSizes
+                    BubbleSizes = bubbleSizes,
+                    ShowInLegend = showInLegend
                 }
                 : hasXValues
                 ? new PptCore.PowerPointChartSeries(
                     name,
                     values,
                     xValues,
-                    PptCore.PowerPointChartSnapshotKind.Scatter)
-                : new PptCore.PowerPointChartSeries(name, values));
+                    PptCore.PowerPointChartSnapshotKind.Scatter) {
+                    ShowInLegend = showInLegend
+                }
+                : new PptCore.PowerPointChartSeries(name, values) {
+                    ShowInLegend = showInLegend
+                });
         }
 
         if (series.Count == 0) {
@@ -705,7 +713,8 @@ public static partial class HtmlPowerPointConverterExtensions {
             }
 
             series.Add(OfficeChartSeries.CreateBubble(
-                item.Name, item.XValues, item.Values, item.BubbleSizes));
+                item.Name, item.XValues, item.Values, item.BubbleSizes,
+                showInLegend: item.ShowInLegend));
         }
 
         if (series.Count == 0) {

--- a/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.cs
+++ b/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.cs
@@ -189,6 +189,17 @@ public static partial class HtmlPowerPointConverterExtensions {
                 chartKind.Equals("Scatter", StringComparison.OrdinalIgnoreCase) || isBubble,
                 isBubble,
                 out PptCore.PowerPointChartData? semanticData);
+            uint bubbleScale = 100U;
+            OfficeChartBubbleSizeMode bubbleSizeMode = OfficeChartBubbleSizeMode.Area;
+            if (isBubble && !TryReadBubbleSizing(item, out bubbleScale,
+                    out bubbleSizeMode)) {
+                AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.ContentOmitted,
+                    "Chart inventory item '" +
+                    (title.Length == 0 ? "Imported chart" : title) +
+                    "' contained invalid bubble sizing metadata and was not imported.",
+                    lossKind: HtmlConversionLossKind.Omission);
+                return;
+            }
             PptCore.PowerPointChartData data = semanticData ?? CreatePlaceholderChartDataFromInventory(item);
             ReadChartGeometry(item, 500D, fallbackTop, 320D, 180D, budget, result, out double left, out double chartTop, out double width, out double height);
             if (!TryAddChartByKind(slide, chartKind, data, left, chartTop, width, height, out PptCore.PowerPointChart? chart, out string? fallbackMessage) || chart == null) {
@@ -198,6 +209,9 @@ public static partial class HtmlPowerPointConverterExtensions {
             }
 
             reservation.Commit();
+            if (isBubble) {
+                chart.SetBubbleSizing(bubbleScale, bubbleSizeMode);
+            }
             chart.SetTitle(title.Length == 0 ? "Imported chart" : title);
             ApplyShapeTransforms(item, chart, budget, result);
             result.Charts++;
@@ -700,6 +714,28 @@ public static partial class HtmlPowerPointConverterExtensions {
 
         bubbleData = new OfficeChartData(data.Categories, series);
         return true;
+    }
+
+    private static bool TryReadBubbleSizing(IElement item, out uint scalePercent,
+        out OfficeChartBubbleSizeMode sizeMode) {
+        scalePercent = 100U;
+        sizeMode = OfficeChartBubbleSizeMode.Area;
+        IElement? table = item.QuerySelector("table.officeimo-chart-data");
+        if (table == null) {
+            return true;
+        }
+
+        string? rawScale = table.GetAttribute("data-officeimo-bubble-scale");
+        if (rawScale != null &&
+            (!uint.TryParse(rawScale, NumberStyles.None, CultureInfo.InvariantCulture,
+                out scalePercent) || scalePercent > 300U)) {
+            return false;
+        }
+
+        string? rawMode = table.GetAttribute("data-officeimo-bubble-size-mode");
+        return rawMode == null ||
+               Enum.TryParse(rawMode, ignoreCase: true, out sizeMode) &&
+               Enum.IsDefined(typeof(OfficeChartBubbleSizeMode), sizeMode);
     }
 
     private static string ReadChartKind(IElement item) {

--- a/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.cs
+++ b/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.cs
@@ -174,7 +174,26 @@ public static partial class HtmlPowerPointConverterExtensions {
     private static void ImportChart(IElement item, PptCore.PowerPointSlide slide, HtmlToPowerPointResult result, HtmlImportBudget budget, ref double fallbackTop) {
         string title = NormalizeText(item.QuerySelector(".officeimo-feature-label")?.TextContent);
         ReadChartDataDimensions(item, out int seriesCount, out int categoryCount);
-        if (!budget.TryReserveChartWithShape(seriesCount, categoryCount, out HtmlImportBudgetReservation reservation, out string chartLimit)) {
+        string chartKind = ReadChartKind(item);
+        bool isBubble =
+            chartKind.Equals("Bubble", StringComparison.OrdinalIgnoreCase);
+        IElement? semanticTable =
+            item.QuerySelector("table.officeimo-chart-data");
+        bool hasSemanticTable = semanticTable != null;
+        long? semanticPointCount = isBubble && semanticTable != null
+            ? semanticTable.QuerySelectorAll("tbody tr")
+                .Sum(row => (long)row.QuerySelectorAll("td").Length)
+            : null;
+        HtmlImportBudgetReservation reservation;
+        string chartLimit;
+        bool reserved = semanticPointCount.HasValue
+            ? budget.TryReserveChartWithShape(
+                seriesCount, categoryCount, semanticPointCount.Value,
+                out reservation, out chartLimit)
+            : budget.TryReserveChartWithShape(
+                seriesCount, categoryCount,
+                out reservation, out chartLimit);
+        if (!reserved) {
             AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.TargetLimitExceeded,
                 "Chart inventory item '" + title + "' was omitted because the shared chart limit was reached.",
                 lossKind: HtmlConversionLossKind.Omission, detail: chartLimit);
@@ -182,10 +201,6 @@ public static partial class HtmlPowerPointConverterExtensions {
         }
 
         using (reservation) {
-            string chartKind = ReadChartKind(item);
-            bool isBubble = chartKind.Equals("Bubble", StringComparison.OrdinalIgnoreCase);
-            bool hasSemanticTable =
-                item.QuerySelector("table.officeimo-chart-data") != null;
             if (isBubble && !hasSemanticTable &&
                 (long)seriesCount * categoryCount >
                     PptCore.PowerPointUtils.MaximumSharedChartPoints) {

--- a/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.cs
+++ b/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.cs
@@ -244,6 +244,21 @@ public static partial class HtmlPowerPointConverterExtensions {
                     lossKind: HtmlConversionLossKind.Omission);
                 return;
             }
+            bool showLegend = true;
+            OfficeChartLegendPosition legendPosition =
+                OfficeChartLegendPosition.Bottom;
+            bool overlayLegend = false;
+            if (isBubble && !TryReadBubbleLegend(
+                    item, out showLegend, out legendPosition,
+                    out overlayLegend)) {
+                AddImportDiagnostic(result,
+                    HtmlConversionDiagnosticCodes.ContentOmitted,
+                    "Chart inventory item '" +
+                    (title.Length == 0 ? "Imported chart" : title) +
+                    "' contained invalid bubble legend metadata and was not imported.",
+                    lossKind: HtmlConversionLossKind.Omission);
+                return;
+            }
             PptCore.PowerPointChartData data = semanticData ??
                 (isBubble
                     ? CreatePlaceholderBubbleChartDataFromInventory(item)
@@ -277,6 +292,13 @@ public static partial class HtmlPowerPointConverterExtensions {
             reservation.Commit();
             if (isBubble) {
                 chart.SetBubbleSizing(bubbleScale, bubbleSizeMode);
+                if (showLegend) {
+                    chart.SetLegend(
+                        ToPowerPointLegendPosition(legendPosition),
+                        overlayLegend);
+                } else {
+                    chart.HideLegend();
+                }
             }
             chart.SetTitle(title.Length == 0 ? "Imported chart" : title);
             ApplyShapeTransforms(item, chart, budget, result);
@@ -852,56 +874,6 @@ public static partial class HtmlPowerPointConverterExtensions {
 
         scatterData = new PptCore.PowerPointScatterChartData(series);
         return true;
-    }
-
-    private static bool TryCreateBubbleChartData(PptCore.PowerPointChartData data,
-        out OfficeChartData? bubbleData) {
-        bubbleData = null;
-        var series = new List<OfficeChartSeries>();
-        foreach (PptCore.PowerPointChartSeries item in data.Series) {
-            if (item.XValues == null || item.BubbleSizes == null ||
-                item.XValues.Count != item.Values.Count ||
-                item.BubbleSizes.Count != item.Values.Count) {
-                return false;
-            }
-
-            series.Add(OfficeChartSeries.CreateBubble(
-                item.Name, item.XValues, item.Values, item.BubbleSizes,
-                item.Color, item.PointColors,
-                showInLegend: item.ShowInLegend,
-                markerOutlineColor: item.StrokeColor ?? item.Color,
-                markerOutlineWidth: item.StrokeWidth,
-                showMarkerOutline: item.ShowStroke));
-        }
-
-        if (series.Count == 0) {
-            return false;
-        }
-
-        bubbleData = new OfficeChartData(data.Categories, series);
-        return true;
-    }
-
-    private static bool TryReadBubbleSizing(IElement item, out uint scalePercent,
-        out OfficeChartBubbleSizeMode sizeMode) {
-        scalePercent = 100U;
-        sizeMode = OfficeChartBubbleSizeMode.Area;
-        IElement? table = item.QuerySelector("table.officeimo-chart-data");
-        if (table == null) {
-            return true;
-        }
-
-        string? rawScale = table.GetAttribute("data-officeimo-bubble-scale");
-        if (rawScale != null &&
-            (!uint.TryParse(rawScale, NumberStyles.None, CultureInfo.InvariantCulture,
-                out scalePercent) || scalePercent > 300U)) {
-            return false;
-        }
-
-        string? rawMode = table.GetAttribute("data-officeimo-bubble-size-mode");
-        return rawMode == null ||
-               Enum.TryParse(rawMode, ignoreCase: true, out sizeMode) &&
-               Enum.IsDefined(typeof(OfficeChartBubbleSizeMode), sizeMode);
     }
 
     private static string ReadChartKind(IElement item) {

--- a/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.cs
+++ b/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.cs
@@ -189,6 +189,16 @@ public static partial class HtmlPowerPointConverterExtensions {
                 chartKind.Equals("Scatter", StringComparison.OrdinalIgnoreCase) || isBubble,
                 isBubble,
                 out PptCore.PowerPointChartData? semanticData);
+            if (isBubble && !restoredFromSemanticData &&
+                item.QuerySelector("table.officeimo-chart-data") != null) {
+                AddImportDiagnostic(result,
+                    HtmlConversionDiagnosticCodes.ContentOmitted,
+                    "Chart inventory item '" +
+                    (title.Length == 0 ? "Imported chart" : title) +
+                    "' contained invalid semantic bubble data and was not imported.",
+                    lossKind: HtmlConversionLossKind.Omission);
+                return;
+            }
             uint bubbleScale = 100U;
             OfficeChartBubbleSizeMode bubbleSizeMode = OfficeChartBubbleSizeMode.Area;
             if (isBubble && !TryReadBubbleSizing(item, out bubbleScale,
@@ -200,7 +210,10 @@ public static partial class HtmlPowerPointConverterExtensions {
                     lossKind: HtmlConversionLossKind.Omission);
                 return;
             }
-            PptCore.PowerPointChartData data = semanticData ?? CreatePlaceholderChartDataFromInventory(item);
+            PptCore.PowerPointChartData data = semanticData ??
+                (isBubble
+                    ? CreatePlaceholderBubbleChartDataFromInventory(item)
+                    : CreatePlaceholderChartDataFromInventory(item));
             ReadChartGeometry(item, 500D, fallbackTop, 320D, 180D, budget, result, out double left, out double chartTop, out double width, out double height);
             if (!TryAddChartByKind(slide, chartKind, data, left, chartTop, width, height, out PptCore.PowerPointChart? chart, out string? fallbackMessage) || chart == null) {
                 AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.ContentOmitted,
@@ -252,6 +265,34 @@ public static partial class HtmlPowerPointConverterExtensions {
     private static PptCore.PowerPointChartData CreatePlaceholderChartDataFromInventory(IElement item) {
         ReadChartShape(item, out int seriesCount, out int categoryCount);
         return CreatePlaceholderChartData(seriesCount, categoryCount);
+    }
+
+    private static PptCore.PowerPointChartData CreatePlaceholderBubbleChartDataFromInventory(
+        IElement item) {
+        ReadChartShape(item, out int seriesCount, out int categoryCount);
+        seriesCount = Math.Max(1, seriesCount);
+        categoryCount = Math.Max(1, categoryCount);
+        string[] categories = Enumerable.Range(1, categoryCount)
+            .Select(index => index.ToString(CultureInfo.InvariantCulture))
+            .ToArray();
+        PptCore.PowerPointChartSeries[] series =
+            Enumerable.Range(1, seriesCount)
+                .Select(seriesIndex => {
+                    double[] xValues = Enumerable.Range(1, categoryCount)
+                        .Select(index => (double)index)
+                        .ToArray();
+                    double[] values = xValues
+                        .Select(value => value * seriesIndex)
+                        .ToArray();
+                    return new PptCore.PowerPointChartSeries(
+                        "Series " +
+                        seriesIndex.ToString(CultureInfo.InvariantCulture),
+                        values, xValues) {
+                        BubbleSizes = xValues
+                    };
+                })
+                .ToArray();
+        return new PptCore.PowerPointChartData(categories, series);
     }
 
     private static void ReadChartDataDimensions(IElement item, out int series, out int categories) {

--- a/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.cs
+++ b/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.cs
@@ -1,5 +1,6 @@
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
+using OfficeIMO.Drawing;
 using OfficeIMO.Html;
 using C = DocumentFormat.OpenXml.Drawing.Charts;
 using PptCore = OfficeIMO.PowerPoint;
@@ -182,9 +183,11 @@ public static partial class HtmlPowerPointConverterExtensions {
 
         using (reservation) {
             string chartKind = ReadChartKind(item);
+            bool isBubble = chartKind.Equals("Bubble", StringComparison.OrdinalIgnoreCase);
             bool restoredFromSemanticData = TryReadChartData(
                 item,
-                chartKind.Equals("Scatter", StringComparison.OrdinalIgnoreCase),
+                chartKind.Equals("Scatter", StringComparison.OrdinalIgnoreCase) || isBubble,
+                isBubble,
                 out PptCore.PowerPointChartData? semanticData);
             PptCore.PowerPointChartData data = semanticData ?? CreatePlaceholderChartDataFromInventory(item);
             ReadChartGeometry(item, 500D, fallbackTop, 320D, 180D, budget, result, out double left, out double chartTop, out double width, out double height);
@@ -262,7 +265,8 @@ public static partial class HtmlPowerPointConverterExtensions {
         return new PptCore.PowerPointChartData(categories, series);
     }
 
-    private static bool TryReadChartData(IElement item, bool allowXValues, out PptCore.PowerPointChartData? data) {
+    private static bool TryReadChartData(IElement item, bool allowXValues, bool allowBubbleSizes,
+        out PptCore.PowerPointChartData? data) {
         data = null;
         IElement? table = item.QuerySelector("table.officeimo-chart-data");
         if (table == null) {
@@ -287,8 +291,14 @@ public static partial class HtmlPowerPointConverterExtensions {
             List<IElement> valueCells = row.QuerySelectorAll("td").ToList();
             var values = new double[valueCells.Count];
             var xValues = new double[valueCells.Count];
+            var bubbleSizes = new double[valueCells.Count];
             bool hasXValues = valueCells.Any(cell => cell.GetAttribute("data-officeimo-x") != null);
+            bool hasBubbleSizes = valueCells.Any(
+                cell => cell.GetAttribute("data-officeimo-bubble-size") != null);
             if (hasXValues && !allowXValues) {
+                return false;
+            }
+            if (hasBubbleSizes != allowBubbleSizes) {
                 return false;
             }
 
@@ -308,13 +318,31 @@ public static partial class HtmlPowerPointConverterExtensions {
                         return false;
                     }
                 }
+                if (hasBubbleSizes) {
+                    string? rawBubbleSize = cell.GetAttribute("data-officeimo-bubble-size");
+                    if (rawBubbleSize == null
+                        || !double.TryParse(rawBubbleSize, NumberStyles.Float,
+                            CultureInfo.InvariantCulture, out bubbleSizes[i])
+                        || double.IsNaN(bubbleSizes[i]) || double.IsInfinity(bubbleSizes[i])
+                        || bubbleSizes[i] < 0D) {
+                        return false;
+                    }
+                }
             }
 
             if (!hasXValues && values.Length != categories.Count) {
                 return false;
             }
 
-            series.Add(hasXValues
+            series.Add(hasBubbleSizes
+                ? new PptCore.PowerPointChartSeries(
+                    name,
+                    values,
+                    xValues,
+                    PptCore.PowerPointChartSnapshotKind.Bubble) {
+                    BubbleSizes = bubbleSizes
+                }
+                : hasXValues
                 ? new PptCore.PowerPointChartSeries(
                     name,
                     values,
@@ -598,6 +626,17 @@ public static partial class HtmlPowerPointConverterExtensions {
             return true;
         }
 
+        if (chartKind.Equals("Bubble", StringComparison.OrdinalIgnoreCase)) {
+            if (!TryCreateBubbleChartData(data, out OfficeChartData? bubbleData) ||
+                bubbleData == null) {
+                return false;
+            }
+
+            chart = slide.AddChartPoints(OfficeChartKind.Bubble, bubbleData,
+                left, top, width, height);
+            return true;
+        }
+
         if (CanImportAsClusteredColumnFallback(chartKind)) {
             chart = slide.AddChartPoints(data, left, top, width, height);
             fallbackMessage = "used chart kind '" + chartKind + "' and was imported as a clustered column fallback.";
@@ -634,6 +673,29 @@ public static partial class HtmlPowerPointConverterExtensions {
         }
 
         scatterData = new PptCore.PowerPointScatterChartData(series);
+        return true;
+    }
+
+    private static bool TryCreateBubbleChartData(PptCore.PowerPointChartData data,
+        out OfficeChartData? bubbleData) {
+        bubbleData = null;
+        var series = new List<OfficeChartSeries>();
+        foreach (PptCore.PowerPointChartSeries item in data.Series) {
+            if (item.XValues == null || item.BubbleSizes == null ||
+                item.XValues.Count != item.Values.Count ||
+                item.BubbleSizes.Count != item.Values.Count) {
+                return false;
+            }
+
+            series.Add(OfficeChartSeries.CreateBubble(
+                item.Name, item.XValues, item.Values, item.BubbleSizes));
+        }
+
+        if (series.Count == 0) {
+            return false;
+        }
+
+        bubbleData = new OfficeChartData(data.Categories, series);
         return true;
     }
 

--- a/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.cs
+++ b/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.cs
@@ -304,11 +304,49 @@ public static partial class HtmlPowerPointConverterExtensions {
             bool showInLegend = !string.Equals(
                 row.GetAttribute("data-officeimo-show-in-legend"), "false",
                 StringComparison.OrdinalIgnoreCase);
+            OfficeColor? seriesColor = null;
+            string? rawSeriesColor =
+                row.GetAttribute("data-officeimo-series-color");
+            if (rawSeriesColor != null) {
+                if (!OfficeColor.TryParse(rawSeriesColor,
+                        out OfficeColor parsedSeriesColor)) {
+                    return false;
+                }
+                seriesColor = parsedSeriesColor;
+            }
+            OfficeColor? outlineColor = null;
+            string? rawOutlineColor =
+                row.GetAttribute("data-officeimo-outline-color");
+            if (rawOutlineColor != null) {
+                if (!OfficeColor.TryParse(rawOutlineColor,
+                        out OfficeColor parsedOutlineColor)) {
+                    return false;
+                }
+                outlineColor = parsedOutlineColor;
+            }
+            double? outlineWidth = null;
+            string? rawOutlineWidth =
+                row.GetAttribute("data-officeimo-outline-width");
+            if (rawOutlineWidth != null) {
+                if (!double.TryParse(rawOutlineWidth, NumberStyles.Float,
+                        CultureInfo.InvariantCulture, out double parsedOutlineWidth) ||
+                    double.IsNaN(parsedOutlineWidth) ||
+                    double.IsInfinity(parsedOutlineWidth) ||
+                    parsedOutlineWidth <= 0D) {
+                    return false;
+                }
+                outlineWidth = parsedOutlineWidth;
+            }
+            bool showOutline = !string.Equals(
+                row.GetAttribute("data-officeimo-show-outline"), "false",
+                StringComparison.OrdinalIgnoreCase);
 
             List<IElement> valueCells = row.QuerySelectorAll("td").ToList();
             var values = new double[valueCells.Count];
             var xValues = new double[valueCells.Count];
             var bubbleSizes = new double[valueCells.Count];
+            var pointColors = new OfficeColor?[valueCells.Count];
+            bool hasPointColors = false;
             bool hasXValues = valueCells.Any(cell => cell.GetAttribute("data-officeimo-x") != null);
             bool hasBubbleSizes = valueCells.Any(
                 cell => cell.GetAttribute("data-officeimo-bubble-size") != null);
@@ -347,6 +385,16 @@ public static partial class HtmlPowerPointConverterExtensions {
                         || bubbleSizes[i] < 0D) {
                         return false;
                     }
+                    string? rawPointColor =
+                        cell.GetAttribute("data-officeimo-point-color");
+                    if (rawPointColor != null) {
+                        if (!OfficeColor.TryParse(rawPointColor,
+                                out OfficeColor parsedPointColor)) {
+                            return false;
+                        }
+                        pointColors[i] = parsedPointColor;
+                        hasPointColors = true;
+                    }
                 }
             }
 
@@ -359,8 +407,13 @@ public static partial class HtmlPowerPointConverterExtensions {
                     name,
                     values,
                     xValues,
-                    PptCore.PowerPointChartSnapshotKind.Bubble) {
+                    PptCore.PowerPointChartSnapshotKind.Bubble,
+                    seriesColor,
+                    outlineWidth) {
                     BubbleSizes = bubbleSizes,
+                    PointColors = hasPointColors ? pointColors : null,
+                    StrokeColor = outlineColor,
+                    ShowStroke = showOutline,
                     ShowInLegend = showInLegend
                 }
                 : hasXValues
@@ -714,7 +767,11 @@ public static partial class HtmlPowerPointConverterExtensions {
 
             series.Add(OfficeChartSeries.CreateBubble(
                 item.Name, item.XValues, item.Values, item.BubbleSizes,
-                showInLegend: item.ShowInLegend));
+                item.Color, item.PointColors,
+                showInLegend: item.ShowInLegend,
+                markerOutlineColor: item.StrokeColor ?? item.Color,
+                markerOutlineWidth: item.StrokeWidth,
+                showMarkerOutline: item.ShowStroke));
         }
 
         if (series.Count == 0) {

--- a/OfficeIMO.PowerPoint.Html/PowerPointHtmlConverterExtensions.cs
+++ b/OfficeIMO.PowerPoint.Html/PowerPointHtmlConverterExtensions.cs
@@ -542,6 +542,13 @@ public static partial class PowerPointHtmlConverterExtensions {
                 .Append(snapshot.BubbleScalePercent.ToString("G17", CultureInfo.InvariantCulture))
                 .Append("\" data-officeimo-bubble-size-mode=\"")
                 .Append(OfficeHtmlText.EscapeAttribute(snapshot.BubbleSizeMode.ToString()))
+                .Append("\" data-officeimo-show-legend=\"")
+                .Append(snapshot.Layout.ShowLegend ? "true" : "false")
+                .Append("\" data-officeimo-legend-position=\"")
+                .Append(OfficeHtmlText.EscapeAttribute(
+                    snapshot.Layout.LegendPosition.ToString()))
+                .Append("\" data-officeimo-overlay-legend=\"")
+                .Append(snapshot.Layout.OverlayLegend ? "true" : "false")
                 .Append('"');
         }
         body.Append("><thead><tr><th>Series</th>");

--- a/OfficeIMO.PowerPoint.Html/PowerPointHtmlConverterExtensions.cs
+++ b/OfficeIMO.PowerPoint.Html/PowerPointHtmlConverterExtensions.cs
@@ -433,10 +433,13 @@ public static partial class PowerPointHtmlConverterExtensions {
 
         try {
             var series = snapshot.Data.Series
-                .Select(item => new OfficeChartSeries(item.Name, item.Values, item.XValues, item.Color,
-                    pointColors: null, showMarkers: true, strokeWidth: item.StrokeWidth,
-                    renderKind: item.ChartKind.HasValue ? MapChartKind(item.ChartKind.Value) : null,
-                    axisGroup: item.AxisGroup))
+                .Select(item => item.BubbleSizes != null
+                    ? OfficeChartSeries.CreateBubble(item.Name, item.XValues!, item.Values,
+                        item.BubbleSizes, item.Color, item.PointColors)
+                    : new OfficeChartSeries(item.Name, item.Values, item.XValues, item.Color,
+                        pointColors: null, showMarkers: true, strokeWidth: item.StrokeWidth,
+                        renderKind: item.ChartKind.HasValue ? MapChartKind(item.ChartKind.Value) : null,
+                        axisGroup: item.AxisGroup))
                 .ToList();
             var data = new OfficeChartData(snapshot.Data.Categories, series);
             officeSnapshot = new OfficeChartSnapshot(
@@ -483,6 +486,8 @@ public static partial class PowerPointHtmlConverterExtensions {
                 return OfficeChartKind.Radar;
             case PptCore.PowerPointChartSnapshotKind.Scatter:
                 return OfficeChartKind.Scatter;
+            case PptCore.PowerPointChartSnapshotKind.Bubble:
+                return OfficeChartKind.Bubble;
             case PptCore.PowerPointChartSnapshotKind.Pie:
                 return OfficeChartKind.Pie;
             case PptCore.PowerPointChartSnapshotKind.Doughnut:

--- a/OfficeIMO.PowerPoint.Html/PowerPointHtmlConverterExtensions.cs
+++ b/OfficeIMO.PowerPoint.Html/PowerPointHtmlConverterExtensions.cs
@@ -437,7 +437,8 @@ public static partial class PowerPointHtmlConverterExtensions {
                     ? OfficeChartSeries.CreateBubble(item.Name, item.XValues!, item.Values,
                         item.BubbleSizes, item.Color, item.PointColors,
                         markerOutlineColor: item.StrokeColor ?? item.Color,
-                        markerOutlineWidth: item.StrokeWidth)
+                        markerOutlineWidth: item.StrokeWidth,
+                        showMarkerOutline: item.ShowStroke)
                     : new OfficeChartSeries(item.Name, item.Values, item.XValues, item.Color,
                         pointColors: null, showMarkers: true, strokeWidth: item.StrokeWidth,
                         renderKind: item.ChartKind.HasValue ? MapChartKind(item.ChartKind.Value) : null,
@@ -519,7 +520,7 @@ public static partial class PowerPointHtmlConverterExtensions {
                 .Append("; Categories: ")
                 .Append(snapshot.Data.Categories.Count.ToString(CultureInfo.InvariantCulture))
                 .Append("</div>");
-            AppendChartDataTable(body, snapshot.Data);
+            AppendChartDataTable(body, snapshot);
             return;
         }
 
@@ -528,8 +529,18 @@ public static partial class PowerPointHtmlConverterExtensions {
             .Append("</span><div class=\"officeimo-diagnostic\">Chart snapshot unavailable.</div>");
     }
 
-    private static void AppendChartDataTable(StringBuilder body, PptCore.PowerPointChartData data) {
-        body.Append("<table class=\"officeimo-chart-data\"><thead><tr><th>Series</th>");
+    private static void AppendChartDataTable(
+        StringBuilder body, PptCore.PowerPointChartSnapshot snapshot) {
+        PptCore.PowerPointChartData data = snapshot.Data;
+        body.Append("<table class=\"officeimo-chart-data\"");
+        if (snapshot.ChartKind == PptCore.PowerPointChartSnapshotKind.Bubble) {
+            body.Append(" data-officeimo-bubble-scale=\"")
+                .Append(snapshot.BubbleScalePercent.ToString("G17", CultureInfo.InvariantCulture))
+                .Append("\" data-officeimo-bubble-size-mode=\"")
+                .Append(OfficeHtmlText.EscapeAttribute(snapshot.BubbleSizeMode.ToString()))
+                .Append('"');
+        }
+        body.Append("><thead><tr><th>Series</th>");
         foreach (string category in data.Categories) {
             body.Append("<th>")
                 .Append(OfficeHtmlText.Escape(category))

--- a/OfficeIMO.PowerPoint.Html/PowerPointHtmlConverterExtensions.cs
+++ b/OfficeIMO.PowerPoint.Html/PowerPointHtmlConverterExtensions.cs
@@ -555,6 +555,29 @@ public static partial class PowerPointHtmlConverterExtensions {
             if (!series.ShowInLegend) {
                 body.Append(" data-officeimo-show-in-legend=\"false\"");
             }
+            if (series.BubbleSizes != null) {
+                if (series.Color.HasValue) {
+                    body.Append(" data-officeimo-series-color=\"")
+                        .Append(OfficeHtmlText.EscapeAttribute(
+                            series.Color.Value.ToString()))
+                        .Append('"');
+                }
+                if (series.StrokeColor.HasValue) {
+                    body.Append(" data-officeimo-outline-color=\"")
+                        .Append(OfficeHtmlText.EscapeAttribute(
+                            series.StrokeColor.Value.ToString()))
+                        .Append('"');
+                }
+                if (series.StrokeWidth.HasValue) {
+                    body.Append(" data-officeimo-outline-width=\"")
+                        .Append(series.StrokeWidth.Value.ToString(
+                            "G17", CultureInfo.InvariantCulture))
+                        .Append('"');
+                }
+                if (!series.ShowStroke) {
+                    body.Append(" data-officeimo-show-outline=\"false\"");
+                }
+            }
             body.Append("><th>")
                 .Append(OfficeHtmlText.Escape(series.Name))
                 .Append("</th>");
@@ -569,6 +592,13 @@ public static partial class PowerPointHtmlConverterExtensions {
                     body.Append(" data-officeimo-bubble-size=\"")
                         .Append(OfficeHtmlText.EscapeAttribute(series.BubbleSizes[i].ToString("G17", CultureInfo.InvariantCulture)))
                         .Append('"');
+                    if (series.PointColors != null && i < series.PointColors.Count &&
+                        series.PointColors[i].HasValue) {
+                        body.Append(" data-officeimo-point-color=\"")
+                            .Append(OfficeHtmlText.EscapeAttribute(
+                                series.PointColors[i]!.Value.ToString()))
+                            .Append('"');
+                    }
                 }
 
                 body.Append('>')

--- a/OfficeIMO.PowerPoint.Html/PowerPointHtmlConverterExtensions.cs
+++ b/OfficeIMO.PowerPoint.Html/PowerPointHtmlConverterExtensions.cs
@@ -436,7 +436,8 @@ public static partial class PowerPointHtmlConverterExtensions {
                 .Select(item => item.BubbleSizes != null
                     ? OfficeChartSeries.CreateBubble(item.Name, item.XValues!, item.Values,
                         item.BubbleSizes, item.Color, item.PointColors,
-                        markerOutlineColor: item.Color, markerOutlineWidth: item.StrokeWidth)
+                        markerOutlineColor: item.StrokeColor ?? item.Color,
+                        markerOutlineWidth: item.StrokeWidth)
                     : new OfficeChartSeries(item.Name, item.Values, item.XValues, item.Color,
                         pointColors: null, showMarkers: true, strokeWidth: item.StrokeWidth,
                         renderKind: item.ChartKind.HasValue ? MapChartKind(item.ChartKind.Value) : null,
@@ -449,7 +450,9 @@ public static partial class PowerPointHtmlConverterExtensions {
                 MapChartKind(snapshot.ChartKind),
                 data,
                 Math.Max(1D, width),
-                Math.Max(1D, height));
+                Math.Max(1D, height),
+                bubbleScalePercent: snapshot.BubbleScalePercent,
+                bubbleSizeMode: snapshot.BubbleSizeMode);
             return true;
         } catch (Exception ex) {
             warning = "Chart snapshot could not be mapped to the shared Drawing chart model: " + ex.Message;

--- a/OfficeIMO.PowerPoint.Html/PowerPointHtmlConverterExtensions.cs
+++ b/OfficeIMO.PowerPoint.Html/PowerPointHtmlConverterExtensions.cs
@@ -436,11 +436,13 @@ public static partial class PowerPointHtmlConverterExtensions {
                 .Select(item => item.BubbleSizes != null
                     ? OfficeChartSeries.CreateBubble(item.Name, item.XValues!, item.Values,
                         item.BubbleSizes, item.Color, item.PointColors,
+                        showInLegend: item.ShowInLegend,
                         markerOutlineColor: item.StrokeColor ?? item.Color,
                         markerOutlineWidth: item.StrokeWidth,
                         showMarkerOutline: item.ShowStroke)
                     : new OfficeChartSeries(item.Name, item.Values, item.XValues, item.Color,
-                        pointColors: null, showMarkers: true, strokeWidth: item.StrokeWidth,
+                        pointColors: null, showMarkers: true,
+                        showInLegend: item.ShowInLegend, strokeWidth: item.StrokeWidth,
                         renderKind: item.ChartKind.HasValue ? MapChartKind(item.ChartKind.Value) : null,
                         axisGroup: item.AxisGroup))
                 .ToList();
@@ -549,7 +551,11 @@ public static partial class PowerPointHtmlConverterExtensions {
 
         body.Append("</tr></thead><tbody>");
         foreach (PptCore.PowerPointChartSeries series in data.Series) {
-            body.Append("<tr><th>")
+            body.Append("<tr");
+            if (!series.ShowInLegend) {
+                body.Append(" data-officeimo-show-in-legend=\"false\"");
+            }
+            body.Append("><th>")
                 .Append(OfficeHtmlText.Escape(series.Name))
                 .Append("</th>");
             for (int i = 0; i < series.Values.Count; i++) {

--- a/OfficeIMO.PowerPoint.Html/PowerPointHtmlConverterExtensions.cs
+++ b/OfficeIMO.PowerPoint.Html/PowerPointHtmlConverterExtensions.cs
@@ -435,7 +435,8 @@ public static partial class PowerPointHtmlConverterExtensions {
             var series = snapshot.Data.Series
                 .Select(item => item.BubbleSizes != null
                     ? OfficeChartSeries.CreateBubble(item.Name, item.XValues!, item.Values,
-                        item.BubbleSizes, item.Color, item.PointColors)
+                        item.BubbleSizes, item.Color, item.PointColors,
+                        markerOutlineColor: item.Color, markerOutlineWidth: item.StrokeWidth)
                     : new OfficeChartSeries(item.Name, item.Values, item.XValues, item.Color,
                         pointColors: null, showMarkers: true, strokeWidth: item.StrokeWidth,
                         renderKind: item.ChartKind.HasValue ? MapChartKind(item.ChartKind.Value) : null,
@@ -542,6 +543,11 @@ public static partial class PowerPointHtmlConverterExtensions {
                 if (series.XValues != null && i < series.XValues.Count) {
                     body.Append(" data-officeimo-x=\"")
                         .Append(OfficeHtmlText.EscapeAttribute(series.XValues[i].ToString("G17", CultureInfo.InvariantCulture)))
+                        .Append('"');
+                }
+                if (series.BubbleSizes != null && i < series.BubbleSizes.Count) {
+                    body.Append(" data-officeimo-bubble-size=\"")
+                        .Append(OfficeHtmlText.EscapeAttribute(series.BubbleSizes[i].ToString("G17", CultureInfo.InvariantCulture)))
                         .Append('"');
                 }
 

--- a/OfficeIMO.PowerPoint.Html/PowerPointHtmlConverterExtensions.cs
+++ b/OfficeIMO.PowerPoint.Html/PowerPointHtmlConverterExtensions.cs
@@ -454,6 +454,8 @@ public static partial class PowerPointHtmlConverterExtensions {
                 data,
                 Math.Max(1D, width),
                 Math.Max(1D, height),
+                style: null,
+                layout: snapshot.Layout,
                 bubbleScalePercent: snapshot.BubbleScalePercent,
                 bubbleSizeMode: snapshot.BubbleSizeMode);
             return true;

--- a/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.Charts.cs
+++ b/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.Charts.cs
@@ -86,7 +86,8 @@ public static partial class PowerPointPdfConverterExtensions {
                 ? OfficeChartSeries.CreateBubble(item.Name, item.XValues!, item.Values,
                     item.BubbleSizes, item.Color, item.PointColors,
                     markerOutlineColor: item.StrokeColor ?? item.Color,
-                    markerOutlineWidth: item.StrokeWidth)
+                    markerOutlineWidth: item.StrokeWidth,
+                    showMarkerOutline: item.ShowStroke)
                 : new OfficeChartSeries(item.Name, item.Values, item.XValues, item.Color,
                     pointColors: null, showMarkers: true, strokeWidth: item.StrokeWidth,
                     renderKind: item.ChartKind.HasValue ? MapChartKind(item.ChartKind.Value) : null,

--- a/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.Charts.cs
+++ b/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.Charts.cs
@@ -85,11 +85,13 @@ public static partial class PowerPointPdfConverterExtensions {
             .Select(item => item.BubbleSizes != null
                 ? OfficeChartSeries.CreateBubble(item.Name, item.XValues!, item.Values,
                     item.BubbleSizes, item.Color, item.PointColors,
+                    showInLegend: item.ShowInLegend,
                     markerOutlineColor: item.StrokeColor ?? item.Color,
                     markerOutlineWidth: item.StrokeWidth,
                     showMarkerOutline: item.ShowStroke)
                 : new OfficeChartSeries(item.Name, item.Values, item.XValues, item.Color,
-                    pointColors: null, showMarkers: true, strokeWidth: item.StrokeWidth,
+                    pointColors: null, showMarkers: true,
+                    showInLegend: item.ShowInLegend, strokeWidth: item.StrokeWidth,
                     renderKind: item.ChartKind.HasValue ? MapChartKind(item.ChartKind.Value) : null,
                     axisGroup: item.AxisGroup))
             .ToList();

--- a/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.Charts.cs
+++ b/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.Charts.cs
@@ -79,10 +79,13 @@ public static partial class PowerPointPdfConverterExtensions {
 
     private static OfficeChartSnapshot CreateOfficeChartSnapshot(PptCore.PowerPointChartSnapshot snapshot, double width, double height, PowerPointPdfSaveOptions options) {
         var series = snapshot.Data.Series
-            .Select(item => new OfficeChartSeries(item.Name, item.Values, item.XValues, item.Color,
-                pointColors: null, showMarkers: true, strokeWidth: item.StrokeWidth,
-                renderKind: item.ChartKind.HasValue ? MapChartKind(item.ChartKind.Value) : null,
-                axisGroup: item.AxisGroup))
+            .Select(item => item.BubbleSizes != null
+                ? OfficeChartSeries.CreateBubble(item.Name, item.XValues!, item.Values,
+                    item.BubbleSizes, item.Color, item.PointColors)
+                : new OfficeChartSeries(item.Name, item.Values, item.XValues, item.Color,
+                    pointColors: null, showMarkers: true, strokeWidth: item.StrokeWidth,
+                    renderKind: item.ChartKind.HasValue ? MapChartKind(item.ChartKind.Value) : null,
+                    axisGroup: item.AxisGroup))
             .ToList();
         var data = new OfficeChartData(snapshot.Data.Categories, series);
         return new OfficeChartSnapshot(
@@ -126,6 +129,8 @@ public static partial class PowerPointPdfConverterExtensions {
                 return OfficeChartKind.Radar;
             case PptCore.PowerPointChartSnapshotKind.Scatter:
                 return OfficeChartKind.Scatter;
+            case PptCore.PowerPointChartSnapshotKind.Bubble:
+                return OfficeChartKind.Bubble;
             case PptCore.PowerPointChartSnapshotKind.Pie:
                 return OfficeChartKind.Pie;
             case PptCore.PowerPointChartSnapshotKind.Doughnut:

--- a/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.Charts.cs
+++ b/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.Charts.cs
@@ -77,11 +77,16 @@ public static partial class PowerPointPdfConverterExtensions {
         return string.Join("; ", qualityReport.Issues.Select(issue => issue.ToString()));
     }
 
-    private static OfficeChartSnapshot CreateOfficeChartSnapshot(PptCore.PowerPointChartSnapshot snapshot, double width, double height, PowerPointPdfSaveOptions options) {
+    /// <summary>
+    /// Maps the native PowerPoint snapshot into the shared chart contract used by PDF rendering.
+    /// </summary>
+    internal static OfficeChartSnapshot CreateOfficeChartSnapshot(PptCore.PowerPointChartSnapshot snapshot, double width, double height, PowerPointPdfSaveOptions options) {
         var series = snapshot.Data.Series
             .Select(item => item.BubbleSizes != null
                 ? OfficeChartSeries.CreateBubble(item.Name, item.XValues!, item.Values,
-                    item.BubbleSizes, item.Color, item.PointColors)
+                    item.BubbleSizes, item.Color, item.PointColors,
+                    markerOutlineColor: item.StrokeColor ?? item.Color,
+                    markerOutlineWidth: item.StrokeWidth)
                 : new OfficeChartSeries(item.Name, item.Values, item.XValues, item.Color,
                     pointColors: null, showMarkers: true, strokeWidth: item.StrokeWidth,
                     renderKind: item.ChartKind.HasValue ? MapChartKind(item.ChartKind.Value) : null,
@@ -96,7 +101,9 @@ public static partial class PowerPointPdfConverterExtensions {
             width,
             height,
             options.ChartStyle,
-            options.ChartLayout);
+            options.ChartLayout,
+            bubbleScalePercent: snapshot.BubbleScalePercent,
+            bubbleSizeMode: snapshot.BubbleSizeMode);
     }
 
     private static OfficeChartKind MapChartKind(PptCore.PowerPointChartSnapshotKind kind) {

--- a/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.Charts.cs
+++ b/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.Charts.cs
@@ -104,7 +104,7 @@ public static partial class PowerPointPdfConverterExtensions {
             width,
             height,
             options.ChartStyle,
-            options.ChartLayout,
+            options.ChartLayout ?? snapshot.Layout,
             bubbleScalePercent: snapshot.BubbleScalePercent,
             bubbleSizeMode: snapshot.BubbleSizeMode);
     }

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleChartImportContracts.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleChartImportContracts.cs
@@ -1,0 +1,101 @@
+using System;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using OfficeIMO.Drawing;
+using OfficeIMO.PowerPoint;
+using Xunit;
+using A = DocumentFormat.OpenXml.Drawing;
+using C = DocumentFormat.OpenXml.Drawing.Charts;
+
+namespace OfficeIMO.Tests;
+
+public class PowerPointSharedBubbleChartImportContractTests {
+    [Fact]
+    public void BubbleChart_RejectsInheritedSeriesOutline() {
+        using PowerPointPresentation presentation = CreatePresentation(out PowerPointChart chart);
+        C.BubbleChartSeries series = presentation.Slides[0].SlidePart
+            .ChartParts.Single().ChartSpace!
+            .Descendants<C.BubbleChartSeries>().Single();
+
+        series.GetFirstChild<C.ChartShapeProperties>()!
+            .RemoveAllChildren<A.Outline>();
+
+        Assert.False(chart.TryGetOfficeSnapshot(out _));
+    }
+
+    [Fact]
+    public void BubbleChart_PreservesMultilineChartAndAxisTitles() {
+        using PowerPointPresentation presentation = CreatePresentation(out PowerPointChart chart);
+        chart.SetTitle("Chart title").SetScatterXAxisTitle("Axis title");
+        C.Chart nativeChart = presentation.Slides[0].SlidePart.ChartParts
+            .Single().ChartSpace!.GetFirstChild<C.Chart>()!;
+        SetMultilineText(nativeChart.GetFirstChild<C.Title>()!
+            .GetFirstChild<C.ChartText>()!, "Risk", "Return", "Portfolio");
+        C.ValueAxis horizontalAxis = nativeChart.GetFirstChild<C.PlotArea>()!
+            .Elements<C.ValueAxis>().Single(axis =>
+                axis.AxisPosition?.Val?.Value == C.AxisPositionValues.Bottom);
+        SetMultilineText(horizontalAxis.GetFirstChild<C.Title>()!
+            .GetFirstChild<C.ChartText>()!, "Expected", "return", "percent");
+
+        Assert.True(chart.TryGetOfficeSnapshot(out OfficeChartSnapshot snapshot));
+        Assert.Equal("Risk" + Environment.NewLine + "Return" +
+            Environment.NewLine + "Portfolio", snapshot.Title);
+        Assert.Equal("Expected" + Environment.NewLine + "return" +
+            Environment.NewLine + "percent", snapshot.Layout.CategoryAxisTitle);
+    }
+
+    [Fact]
+    public void BubbleChart_RejectsFormulaBackedSeriesNameWithoutCache() {
+        using PowerPointPresentation presentation = CreatePresentation(out PowerPointChart chart);
+        C.SeriesText seriesText = presentation.Slides[0].SlidePart.ChartParts
+            .Single().ChartSpace!.Descendants<C.BubbleChartSeries>().Single()
+            .GetFirstChild<C.SeriesText>()!;
+        Assert.NotNull(seriesText.GetFirstChild<C.StringReference>());
+        seriesText.GetFirstChild<C.StringReference>()!
+            .RemoveAllChildren<C.StringCache>();
+
+        Assert.False(chart.TryGetOfficeSnapshot(out _));
+    }
+
+    [Fact]
+    public void BubbleChart_UpdateRejectsMissingEmbeddedWorkbookBeforeMutation() {
+        using PowerPointPresentation presentation = CreatePresentation(out PowerPointChart chart);
+        ChartPart chartPart = presentation.Slides[0].SlidePart.ChartParts.Single();
+        EmbeddedPackagePart embedded = Assert.Single(
+            chartPart.GetPartsOfType<EmbeddedPackagePart>());
+        chartPart.DeletePart(embedded);
+        string originalChartXml = chartPart.ChartSpace!.OuterXml;
+
+        Assert.Throws<NotSupportedException>(() => chart.UpdateData(CreateData(3D, 5D, 16D)));
+        Assert.Equal(originalChartXml, chartPart.ChartSpace!.OuterXml);
+    }
+
+    private static PowerPointPresentation CreatePresentation(out PowerPointChart chart) {
+        PowerPointPresentation presentation =
+            PowerPointPresentation.Create(new MemoryStream());
+        chart = presentation.AddSlide().AddChart(
+            OfficeChartKind.Bubble, CreateData(1D, 2D, 4D));
+        return presentation;
+    }
+
+    private static OfficeChartData CreateData(double x, double y, double size) =>
+        new(new[] { x.ToString(System.Globalization.CultureInfo.InvariantCulture) },
+            new[] {
+                OfficeChartSeries.CreateBubble(
+                    "Portfolio", new[] { x }, new[] { y }, new[] { size })
+            });
+
+    private static void SetMultilineText(C.ChartText chartText,
+        string firstLine, string secondLine, string secondParagraph) {
+        C.RichText richText = chartText.GetFirstChild<C.RichText>()!;
+        richText.RemoveAllChildren<A.Paragraph>();
+        richText.Append(
+            new A.Paragraph(
+                new A.Run(new A.Text { Text = firstLine }),
+                new A.Break(),
+                new A.Run(new A.Text { Text = secondLine })),
+            new A.Paragraph(
+                new A.Run(new A.Text { Text = secondParagraph })));
+    }
+}

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleChartImportContracts.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleChartImportContracts.cs
@@ -2,11 +2,13 @@ using System;
 using System.IO;
 using System.Linq;
 using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Validation;
 using OfficeIMO.Drawing;
 using OfficeIMO.PowerPoint;
 using Xunit;
 using A = DocumentFormat.OpenXml.Drawing;
 using C = DocumentFormat.OpenXml.Drawing.Charts;
+using S = DocumentFormat.OpenXml.Spreadsheet;
 
 namespace OfficeIMO.Tests;
 
@@ -71,6 +73,104 @@ public class PowerPointSharedBubbleChartImportContractTests {
         Assert.Equal(originalChartXml, chartPart.ChartSpace!.OuterXml);
     }
 
+    [Fact]
+    public void BubbleChart_HidesLegendEntriesByPlottedOrder() {
+        using PowerPointPresentation presentation =
+            PowerPointPresentation.Create(new MemoryStream());
+        var data = new OfficeChartData(new[] { "1" }, new[] {
+            OfficeChartSeries.CreateBubble(
+                "First", new[] { 1D }, new[] { 2D }, new[] { 4D }),
+            OfficeChartSeries.CreateBubble(
+                "Second", new[] { 3D }, new[] { 4D }, new[] { 9D })
+        });
+        PowerPointChart chart = presentation.AddSlide().AddChart(
+            OfficeChartKind.Bubble, data);
+        C.Chart nativeChart = presentation.Slides[0].SlidePart.ChartParts
+            .Single().ChartSpace!.GetFirstChild<C.Chart>()!;
+        C.BubbleChartSeries[] series = nativeChart
+            .Descendants<C.BubbleChartSeries>().ToArray();
+        series[0].Index!.Val = 5U;
+        series[0].Order!.Val = 1U;
+        series[1].Index!.Val = 9U;
+        series[1].Order!.Val = 0U;
+        C.Legend legend = nativeChart.GetFirstChild<C.Legend>()!;
+        legend.InsertAfter(new C.LegendEntry(
+            new C.Index { Val = 0U }, new C.Delete { Val = true }),
+            legend.GetFirstChild<C.LegendPosition>());
+
+        Assert.True(chart.TryGetOfficeSnapshot(out OfficeChartSnapshot snapshot));
+        Assert.Equal("Second", snapshot.Data.Series[0].Name);
+        Assert.False(snapshot.Data.Series[0].ShowInLegend);
+        Assert.True(snapshot.Data.Series[1].ShowInLegend);
+    }
+
+    [Fact]
+    public void BubbleChart_RejectsInsetSeriesOutlineAlignment() {
+        using PowerPointPresentation presentation = CreatePresentation(out PowerPointChart chart);
+        A.Outline outline = presentation.Slides[0].SlidePart.ChartParts
+            .Single().ChartSpace!.Descendants<C.BubbleChartSeries>().Single()
+            .GetFirstChild<C.ChartShapeProperties>()!
+            .GetFirstChild<A.Outline>()!;
+
+        outline.Alignment = A.PenAlignmentValues.Insert;
+        Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+        outline.Alignment = A.PenAlignmentValues.Center;
+        Assert.True(chart.TryGetOfficeSnapshot(out _));
+    }
+
+    [Fact]
+    public void BubbleChart_RejectsVisibleOnlySnapshotWithHiddenWorkbookRows() {
+        using PowerPointPresentation presentation = CreatePresentation(out PowerPointChart chart);
+        ChartPart chartPart = presentation.Slides[0].SlidePart.ChartParts.Single();
+        EmbeddedPackagePart embedded = Assert.Single(
+            chartPart.GetPartsOfType<EmbeddedPackagePart>());
+        using (Stream stream = embedded.GetStream(FileMode.Open, FileAccess.ReadWrite))
+        using (SpreadsheetDocument workbook = SpreadsheetDocument.Open(stream, true)) {
+            S.Row row = workbook.WorkbookPart!.WorksheetParts.Single()
+                .Worksheet!.Descendants<S.Row>().Single(item =>
+                    item.RowIndex?.Value == 2U);
+            row.Hidden = true;
+            row.Ancestors<S.Worksheet>().Single().Save();
+        }
+
+        Assert.False(chart.TryGetOfficeSnapshot(out _));
+    }
+
+    [Fact]
+    public void BubbleChart_RecreatedDataLabelsPrecedeBubble3D() {
+        using PowerPointPresentation presentation = CreatePresentation(out PowerPointChart chart);
+
+        chart.ClearDataLabels().SetDataLabels();
+
+        ChartPart chartPart = presentation.Slides[0].SlidePart.ChartParts.Single();
+        C.BubbleChart nativeChart = chartPart.ChartSpace!
+            .Descendants<C.BubbleChart>().Single();
+        Assert.True(nativeChart.ChildElements.ToList().IndexOf(
+            nativeChart.GetFirstChild<C.DataLabels>()!) <
+            nativeChart.ChildElements.ToList().IndexOf(
+                nativeChart.GetFirstChild<C.Bubble3D>()!));
+        Assert.Empty(new OpenXmlValidator().Validate(chartPart));
+    }
+
+    [Fact]
+    public void BubbleChart_UpdatedPointColorsPrecedePreservedTrendline() {
+        using PowerPointPresentation presentation = CreatePresentation(out PowerPointChart chart);
+        chart.SetSeriesTrendline(0, C.TrendlineValues.Linear);
+
+        chart.UpdateData(CreateData(3D, 5D, 16D,
+            new OfficeColor?[] { OfficeColor.Parse("#445566") }));
+
+        ChartPart chartPart = presentation.Slides[0].SlidePart.ChartParts.Single();
+        C.BubbleChartSeries series = chartPart.ChartSpace!
+            .Descendants<C.BubbleChartSeries>().Single();
+        Assert.True(series.ChildElements.ToList().IndexOf(
+            series.GetFirstChild<C.DataPoint>()!) <
+            series.ChildElements.ToList().IndexOf(
+                series.GetFirstChild<C.Trendline>()!));
+        Assert.Empty(new OpenXmlValidator().Validate(chartPart));
+    }
+
     private static PowerPointPresentation CreatePresentation(out PowerPointChart chart) {
         PowerPointPresentation presentation =
             PowerPointPresentation.Create(new MemoryStream());
@@ -79,11 +179,13 @@ public class PowerPointSharedBubbleChartImportContractTests {
         return presentation;
     }
 
-    private static OfficeChartData CreateData(double x, double y, double size) =>
+    private static OfficeChartData CreateData(double x, double y, double size,
+        OfficeColor?[]? pointColors = null) =>
         new(new[] { x.ToString(System.Globalization.CultureInfo.InvariantCulture) },
             new[] {
                 OfficeChartSeries.CreateBubble(
-                    "Portfolio", new[] { x }, new[] { y }, new[] { size })
+                    "Portfolio", new[] { x }, new[] { y }, new[] { size },
+                    pointColors: pointColors)
             });
 
     private static void SetMultilineText(C.ChartText chartText,

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleChartOrdering.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleChartOrdering.cs
@@ -1,0 +1,43 @@
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using OfficeIMO.Drawing;
+using OfficeIMO.PowerPoint;
+using Xunit;
+using C = DocumentFormat.OpenXml.Drawing.Charts;
+
+namespace OfficeIMO.Tests;
+
+public class PowerPointSharedBubbleChartOrderingTests {
+    [Fact]
+    public void BubbleChart_SnapshotUsesNativeSeriesOrder() {
+        using PowerPointPresentation presentation =
+            PowerPointPresentation.Create(new MemoryStream());
+        var data = new OfficeChartData(new[] { "1" }, new[] {
+            OfficeChartSeries.CreateBubble(
+                "First", new[] { 1D }, new[] { 10D }, new[] { 4D }),
+            OfficeChartSeries.CreateBubble(
+                "Second", new[] { 2D }, new[] { 20D }, new[] { 9D })
+        });
+        PowerPointChart chart = presentation.AddSlide().AddChart(
+            OfficeChartKind.Bubble, data);
+        ChartPart chartPart = presentation.Slides[0].SlidePart
+            .ChartParts.Single();
+        C.BubbleChartSeries[] nativeSeries = chartPart.ChartSpace!
+            .Descendants<C.BubbleChartSeries>().ToArray();
+        nativeSeries[0].Order!.Val = 1U;
+        nativeSeries[1].Order!.Val = 0U;
+
+        Assert.True(chart.TryGetOfficeSnapshot(
+            out OfficeChartSnapshot snapshot));
+        Assert.Equal(new[] { "Second", "First" },
+            snapshot.Data.Series.Select(series => series.Name));
+        Assert.Equal(new[] { 20D, 10D },
+            snapshot.Data.Series.Select(series => series.Values[0]));
+
+        nativeSeries[0].Order.Val = 0U;
+        Assert.False(chart.TryGetOfficeSnapshot(out _));
+        nativeSeries[0].Order.Remove();
+        Assert.False(chart.TryGetOfficeSnapshot(out _));
+    }
+}

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
@@ -593,6 +593,30 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void BubbleChart_RejectsLogarithmicValueAxes() {
+            using PowerPointPresentation presentation =
+                PowerPointPresentation.Create(new MemoryStream());
+            PowerPointChart chart = presentation.AddSlide().AddChart(
+                OfficeChartKind.Bubble,
+                CreateBubbleData(
+                    new[] { 1D },
+                    new[] { 2D },
+                    new[] { 4D }));
+            C.PlotArea plotArea = presentation.Slides[0].SlidePart.ChartParts
+                .Single().ChartSpace!.GetFirstChild<C.Chart>()!
+                .GetFirstChild<C.PlotArea>()!;
+
+            foreach (C.ValueAxis axis in plotArea.Elements<C.ValueAxis>()) {
+                var logBase = new C.LogBase { Val = 10D };
+                axis.GetFirstChild<C.Scaling>()!.AddChild(logBase, true);
+                Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+                logBase.Remove();
+                Assert.True(chart.TryGetOfficeSnapshot(out _));
+            }
+        }
+
+        [Fact]
         public void BubbleChart_RejectsUnsupportedFillStyles() {
             using PowerPointPresentation presentation =
                 PowerPointPresentation.Create(new MemoryStream());

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Drawing.Charts;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Validation;
@@ -340,6 +341,25 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void BubbleChart_PreservesMissingChartLegendAcrossSharedSnapshots() {
+            using PowerPointPresentation presentation =
+                PowerPointPresentation.Create(new MemoryStream());
+            PowerPointChart chart = presentation.AddSlide().AddChart(
+                OfficeChartKind.Bubble,
+                CreateBubbleData(
+                    new[] { 1D },
+                    new[] { 2D },
+                    new[] { 4D }));
+            C.Chart nativeChart = presentation.Slides[0].SlidePart.ChartParts
+                .Single().ChartSpace!.GetFirstChild<C.Chart>()!;
+            nativeChart.GetFirstChild<C.Legend>()!.Remove();
+
+            Assert.True(chart.TryGetOfficeSnapshot(
+                out OfficeChartSnapshot snapshot));
+            Assert.False(Assert.Single(snapshot.Data.Series).ShowInLegend);
+        }
+
+        [Fact]
         public void BubbleChart_RejectsMixedSnapshotsThatWouldDropBubbleSeries() {
             using PowerPointPresentation presentation =
                 PowerPointPresentation.Create(new MemoryStream());
@@ -659,6 +679,27 @@ namespace OfficeIMO.Tests {
 
                 orientation.Val = C.OrientationValues.MinMax;
                 Assert.True(chart.TryGetOfficeSnapshot(out _));
+
+                C.Delete delete = axis.GetFirstChild<C.Delete>()!;
+                delete.Val = true;
+                Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+                delete.Val = false;
+                Assert.True(chart.TryGetOfficeSnapshot(out _));
+
+                var majorUnit = new C.MajorUnit { Val = 2D };
+                axis.AddChild(majorUnit, true);
+                Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+                majorUnit.Remove();
+                Assert.True(chart.TryGetOfficeSnapshot(out _));
+
+                var minorUnit = new C.MinorUnit { Val = 1D };
+                axis.AddChild(minorUnit, true);
+                Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+                minorUnit.Remove();
+                Assert.True(chart.TryGetOfficeSnapshot(out _));
             }
         }
 
@@ -882,6 +923,34 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void BubbleChart_UpdateDataPreservesExportOnlyNativeStyles() {
+            using PowerPointPresentation presentation =
+                PowerPointPresentation.Create(new MemoryStream());
+            PowerPointChart chart = presentation.AddSlide().AddChart(
+                OfficeChartKind.Bubble,
+                CreateBubbleData(
+                    new[] { 1D, 2D },
+                    new[] { 2D, 4D },
+                    new[] { 4D, 9D }));
+            chart.SetSeriesTrendline(0, C.TrendlineValues.Linear);
+
+            chart.UpdateData(CreateBubbleData(
+                new[] { 3D, 6D },
+                new[] { 5D, 10D },
+                new[] { 16D, 25D }));
+
+            Assert.Single(presentation.Slides[0].SlidePart.ChartParts.Single()
+                .ChartSpace!.Descendants<C.Trendline>());
+            chart.ClearSeriesTrendline(0);
+            Assert.True(chart.TryGetOfficeSnapshot(
+                out OfficeChartSnapshot snapshot));
+            OfficeChartSeries series = Assert.Single(snapshot.Data.Series);
+            Assert.Equal(new[] { 3D, 6D }, series.XValues);
+            Assert.Equal(new[] { 5D, 10D }, series.Values);
+            Assert.Equal(new[] { 16D, 25D }, series.BubbleSizes);
+        }
+
+        [Fact]
         public void BubbleChart_ResolvesThemeColorsInParameterlessSnapshots() {
             using PowerPointPresentation presentation =
                 PowerPointPresentation.Create(new MemoryStream());
@@ -978,6 +1047,22 @@ namespace OfficeIMO.Tests {
                 new A.Glow(new A.RgbColorModelHex { Val = "445566" }) {
                     Radius = 12700L
                 }));
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+            properties.RemoveAllChildren<A.EffectList>();
+            var scene3D = new OpenXmlUnknownElement(
+                "a", "scene3d",
+                "http://schemas.openxmlformats.org/drawingml/2006/main");
+            properties.Append(scene3D);
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+            scene3D.Remove();
+            var shape3D = new OpenXmlUnknownElement(
+                "a", "sp3d",
+                "http://schemas.openxmlformats.org/drawingml/2006/main");
+            series.PrependChild(new C.DataPoint(
+                new C.Index { Val = 0U },
+                new C.ChartShapeProperties(shape3D)));
             Assert.False(chart.TryGetOfficeSnapshot(out _));
         }
 

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
@@ -285,6 +285,18 @@ namespace OfficeIMO.Tests {
                 .RgbColorModelHex!.Val!.Value);
             Assert.Empty(new OpenXmlValidator().Validate(
                 presentation.Slides[0].SlidePart.ChartParts.Single()));
+
+            outline.RemoveAllChildren<A.SolidFill>();
+            outline.Append(new A.NoFill());
+            chart.UpdateData(CreateBubbleData(
+                new[] { 2D }, new[] { 3D }, new[] { 5D }));
+            outline = presentation.Slides[0].SlidePart.ChartParts.Single()
+                .ChartSpace!.Descendants<C.BubbleChartSeries>().Single()
+                .GetFirstChild<C.ChartShapeProperties>()!
+                .GetFirstChild<A.Outline>()!;
+            Assert.Null(outline.GetFirstChild<A.NoFill>());
+            Assert.Empty(new OpenXmlValidator().Validate(
+                presentation.Slides[0].SlidePart.ChartParts.Single()));
         }
 
         [Fact]
@@ -738,6 +750,23 @@ namespace OfficeIMO.Tests {
             Assert.False(chart.TryGetOfficeSnapshot(out _));
 
             labels.GetFirstChild<C.ShowBubbleSize>()!.Val = false;
+            Assert.True(chart.TryGetOfficeSnapshot(out _));
+
+            var customLabel = new C.DataLabel(
+                new C.Index { Val = 0U },
+                new C.ChartText(
+                    new C.RichText(
+                        new A.BodyProperties(),
+                        new A.ListStyle(),
+                        new A.Paragraph(
+                            new A.Run(
+                                new A.RunProperties { Language = "en-US" },
+                                new A.Text { Text = "Custom" })))));
+            labels.PrependChild(customLabel);
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+            customLabel.InsertAfter(new C.Delete(),
+                customLabel.GetFirstChild<C.Index>());
             Assert.True(chart.TryGetOfficeSnapshot(out _));
 
             C.BubbleChartSeries series =

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
@@ -406,19 +406,50 @@ namespace OfficeIMO.Tests {
                         new[] { 1D, 2D },
                         new[] { 2D, 4D },
                         new[] { 4D, 9D }))
+                .SetTitle("Risk and return")
                 .SetScatterXAxisTitle("Risk")
                 .SetScatterYAxisTitle("Return")
                 .SetScatterXAxisNumberFormat("0.0x")
                 .SetScatterYAxisNumberFormat("0.0y");
+            C.Chart nativeChart = slide.SlidePart.ChartParts.Single()
+                .ChartSpace!.GetFirstChild<C.Chart>()!;
+            nativeChart.GetFirstChild<C.Title>()!
+                .GetFirstChild<C.Overlay>()!.Val = true;
+            C.PlotArea plotArea = nativeChart.GetFirstChild<C.PlotArea>()!;
+            C.BubbleChart bubble =
+                plotArea.GetFirstChild<C.BubbleChart>()!;
+            uint[] axisIds = bubble.Elements<C.AxisId>()
+                .Select(axis => axis.Val!.Value).ToArray();
+            C.ValueAxis horizontalAxis = plotArea.Elements<C.ValueAxis>()
+                .Single(axis => axis.AxisId!.Val!.Value == axisIds[0]);
+            C.ValueAxis verticalAxis = plotArea.Elements<C.ValueAxis>()
+                .Single(axis => axis.AxisId!.Val!.Value == axisIds[1]);
+            horizontalAxis.GetFirstChild<C.MajorTickMark>()!.Val =
+                C.TickMarkValues.Outside;
+            horizontalAxis.GetFirstChild<C.MinorTickMark>()!.Val =
+                C.TickMarkValues.Inside;
+            verticalAxis.GetFirstChild<C.MajorTickMark>()!.Val =
+                C.TickMarkValues.Cross;
+            verticalAxis.GetFirstChild<C.MinorTickMark>()!.Val =
+                C.TickMarkValues.Outside;
 
             Assert.True(chart.TryGetOfficeSnapshot(
                 out OfficeChartSnapshot snapshot));
+            Assert.True(snapshot.Layout.OverlayTitle);
             Assert.Equal("Risk", snapshot.Layout.CategoryAxisTitle);
             Assert.Equal("Return", snapshot.Layout.ValueAxisTitle);
             Assert.Equal("0.0x",
                 snapshot.Layout.HorizontalAxisNumberFormat);
             Assert.Equal("0.0y",
                 snapshot.Layout.VerticalAxisNumberFormat);
+            Assert.Equal(OfficeChartAxisTickMark.Outside,
+                snapshot.Layout.HorizontalAxisMajorTickMark);
+            Assert.Equal(OfficeChartAxisTickMark.Inside,
+                snapshot.Layout.HorizontalAxisMinorTickMark);
+            Assert.Equal(OfficeChartAxisTickMark.Cross,
+                snapshot.Layout.VerticalAxisMajorTickMark);
+            Assert.Equal(OfficeChartAxisTickMark.Outside,
+                snapshot.Layout.VerticalAxisMinorTickMark);
 
             string svg = System.Text.Encoding.UTF8.GetString(
                 slide.ExportImage(OfficeImageExportFormat.Svg).Bytes);
@@ -604,6 +635,15 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void BubbleChart_RejectsMissingOrInvalidSizesBeforeMutatingSlide() {
+            Assert.Throws<ArgumentNullException>(() =>
+                OfficeChartSeries.CreateBubble("Invalid",
+                    null!, new[] { 2D }, new[] { 5D }));
+            Assert.Throws<ArgumentNullException>(() =>
+                OfficeChartSeries.CreateBubble("Invalid",
+                    new[] { 1D }, null!, new[] { 5D }));
+            Assert.Throws<ArgumentNullException>(() =>
+                OfficeChartSeries.CreateBubble("Invalid",
+                    new[] { 1D }, new[] { 2D }, null!));
             Assert.Throws<ArgumentException>(() => OfficeChartSeries.CreateBubble("Invalid",
                 new[] { 1D, 2D }, new[] { 2D, 3D }, new[] { 5D }));
             Assert.Throws<ArgumentOutOfRangeException>(() => OfficeChartSeries.CreateBubble("Invalid",

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
@@ -467,6 +467,25 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void BubbleChart_RejectsWorkbookColumnOverflowBeforeMutatingSlide() {
+            OfficeChartSeries[] series = Enumerable.Range(1, 5_462)
+                .Select(index => OfficeChartSeries.CreateBubble(
+                    "Series " + index,
+                    new[] { 1D },
+                    new[] { 2D },
+                    new[] { 4D }))
+                .ToArray();
+            var data = new OfficeChartData(new[] { "1" }, series);
+            using PowerPointPresentation presentation =
+                PowerPointPresentation.Create(new MemoryStream());
+            PowerPointSlide slide = presentation.AddSlide();
+
+            Assert.Throws<ArgumentException>(() =>
+                slide.AddChart(OfficeChartKind.Bubble, data));
+            Assert.Empty(slide.Charts);
+        }
+
+        [Fact]
         public void BubbleChart_RejectsMismatchedImportedCaches() {
             using PowerPointPresentation presentation =
                 PowerPointPresentation.Create(new MemoryStream());

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
@@ -396,6 +396,110 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void BubbleChart_PreservesAxisTitlesAndNumberFormats() {
+            using PowerPointPresentation presentation =
+                PowerPointPresentation.Create(new MemoryStream());
+            PowerPointSlide slide = presentation.AddSlide();
+            PowerPointChart chart = slide.AddChart(
+                    OfficeChartKind.Bubble,
+                    CreateBubbleData(
+                        new[] { 1D, 2D },
+                        new[] { 2D, 4D },
+                        new[] { 4D, 9D }))
+                .SetScatterXAxisTitle("Risk")
+                .SetScatterYAxisTitle("Return")
+                .SetScatterXAxisNumberFormat("0.0x")
+                .SetScatterYAxisNumberFormat("0.0y");
+
+            Assert.True(chart.TryGetOfficeSnapshot(
+                out OfficeChartSnapshot snapshot));
+            Assert.Equal("Risk", snapshot.Layout.CategoryAxisTitle);
+            Assert.Equal("Return", snapshot.Layout.ValueAxisTitle);
+            Assert.Equal("0.0x",
+                snapshot.Layout.HorizontalAxisNumberFormat);
+            Assert.Equal("0.0y",
+                snapshot.Layout.VerticalAxisNumberFormat);
+
+            string svg = System.Text.Encoding.UTF8.GetString(
+                slide.ExportImage(OfficeImageExportFormat.Svg).Bytes);
+            Assert.Contains("Risk", svg, StringComparison.Ordinal);
+            Assert.Contains("Return", svg, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void BubbleChart_RejectsNonDefaultAxisPositions() {
+            using PowerPointPresentation presentation =
+                PowerPointPresentation.Create(new MemoryStream());
+            PowerPointChart chart = presentation.AddSlide().AddChart(
+                OfficeChartKind.Bubble,
+                CreateBubbleData(
+                    new[] { 1D },
+                    new[] { 2D },
+                    new[] { 4D }));
+            C.PlotArea plotArea = presentation.Slides[0].SlidePart.ChartParts
+                .Single().ChartSpace!.GetFirstChild<C.Chart>()!
+                .GetFirstChild<C.PlotArea>()!;
+            C.BubbleChart nativeChart =
+                plotArea.GetFirstChild<C.BubbleChart>()!;
+            uint[] axisIds = nativeChart.Elements<C.AxisId>()
+                .Select(axis => axis.Val!.Value).ToArray();
+            C.ValueAxis horizontal = plotArea.Elements<C.ValueAxis>()
+                .Single(axis => axis.AxisId!.Val!.Value == axisIds[0]);
+            C.ValueAxis vertical = plotArea.Elements<C.ValueAxis>()
+                .Single(axis => axis.AxisId!.Val!.Value == axisIds[1]);
+
+            horizontal.AxisPosition!.Val = C.AxisPositionValues.Top;
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+            horizontal.AxisPosition.Val = C.AxisPositionValues.Bottom;
+            Assert.True(chart.TryGetOfficeSnapshot(out _));
+
+            vertical.AxisPosition!.Val = C.AxisPositionValues.Right;
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
+        }
+
+        [Fact]
+        public void BubbleChart_RejectsManualPlotLayoutAndAreaStyles() {
+            using PowerPointPresentation presentation =
+                PowerPointPresentation.Create(new MemoryStream());
+            PowerPointChart chart = presentation.AddSlide().AddChart(
+                OfficeChartKind.Bubble,
+                CreateBubbleData(
+                    new[] { 1D },
+                    new[] { 2D },
+                    new[] { 4D }));
+            ChartPart chartPart = presentation.Slides[0].SlidePart
+                .ChartParts.Single();
+            C.PlotArea plotArea = chartPart.ChartSpace!
+                .GetFirstChild<C.Chart>()!.GetFirstChild<C.PlotArea>()!;
+            C.Layout layout = plotArea.GetFirstChild<C.Layout>()!;
+            C.ManualLayout manualLayout = layout.AppendChild(
+                new C.ManualLayout(
+                    new C.LayoutTarget {
+                        Val = C.LayoutTargetValues.Inner
+                    },
+                    new C.LeftMode { Val = C.LayoutModeValues.Factor },
+                    new C.TopMode { Val = C.LayoutModeValues.Factor },
+                    new C.Left { Val = 0.1D },
+                    new C.Top { Val = 0.1D }));
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+            manualLayout.Remove();
+            Assert.True(chart.TryGetOfficeSnapshot(out _));
+
+            chart.SetChartAreaStyle(fillColor: "112233");
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+            chartPart.ChartSpace!.GetFirstChild<C.ShapeProperties>()!.Remove();
+            Assert.True(chart.TryGetOfficeSnapshot(out _));
+
+            chart.SetPlotAreaStyle(
+                fillColor: "445566", lineColor: "778899",
+                lineWidthPoints: 1.5D);
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
+        }
+
+        [Fact]
         public void BubbleChart_RejectsMixedSnapshotsThatWouldDropBubbleSeries() {
             using PowerPointPresentation presentation =
                 PowerPointPresentation.Create(new MemoryStream());
@@ -551,12 +655,37 @@ namespace OfficeIMO.Tests {
         public void BubbleChart_RejectsSharedSnapshotPointOverflow() {
             PowerPointUtils.ValidateBubbleWorkbookDimensions(
                 seriesCount: 1,
-                maximumPoints: 100_000);
+                maximumPoints: 100_000,
+                totalPoints: 100_000);
 
             Assert.Throws<ArgumentException>(() =>
                 PowerPointUtils.ValidateBubbleWorkbookDimensions(
                     seriesCount: 1,
-                    maximumPoints: 100_001));
+                    maximumPoints: 100_001,
+                    totalPoints: 100_001));
+        }
+
+        [Fact]
+        public void BubbleChart_RejectsAggregatePointOverflowBeforeMutatingSlide() {
+            double[] values = Enumerable.Repeat(1D, 50_001).ToArray();
+            var data = new OfficeChartData(
+                new[] { "1" },
+                new[] {
+                    OfficeChartSeries.CreateBubble(
+                        "First", values, values, values),
+                    OfficeChartSeries.CreateBubble(
+                        "Second", values, values, values)
+                });
+            using PowerPointPresentation presentation =
+                PowerPointPresentation.Create(new MemoryStream());
+            PowerPointSlide slide = presentation.AddSlide();
+
+            ArgumentException exception = Assert.Throws<ArgumentException>(() =>
+                slide.AddChart(OfficeChartKind.Bubble, data));
+
+            Assert.Contains("total point limit", exception.Message,
+                StringComparison.Ordinal);
+            Assert.Empty(slide.Charts);
         }
 
         [Fact]
@@ -594,7 +723,8 @@ namespace OfficeIMO.Tests {
             ArgumentException exception = Assert.Throws<ArgumentException>(() =>
                 PowerPointUtils.ValidateBubbleWorkbookDimensions(
                     seriesCount: 1,
-                    maximumPoints: 1_048_576));
+                    maximumPoints: 1_048_576,
+                    totalPoints: 1_048_576));
 
             Assert.Contains("worksheet row limit", exception.Message,
                 StringComparison.Ordinal);

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
@@ -79,6 +79,19 @@ namespace OfficeIMO.Tests {
                     Assert.Equal(145D, refreshed.BubbleScalePercent);
                     Assert.Equal(OfficeChartBubbleSizeMode.Width,
                         refreshed.BubbleSizeMode);
+                    Assert.True(chart.TryGetSnapshot(
+                        out PowerPointChartSnapshot nativeSnapshot));
+                    OfficeChartSnapshot pdfSnapshot =
+                        PowerPointPdfConverterExtensions.CreateOfficeChartSnapshot(
+                            nativeSnapshot, 420D, 250D,
+                            new PowerPointPdfSaveOptions());
+                    Assert.Equal(145D, pdfSnapshot.BubbleScalePercent);
+                    Assert.Equal(OfficeChartBubbleSizeMode.Width,
+                        pdfSnapshot.BubbleSizeMode);
+                    Assert.Equal(OfficeColor.Parse("#654321"),
+                        Assert.Single(pdfSnapshot.Data.Series).MarkerOutlineColor);
+                    Assert.Equal(2.5D,
+                        Assert.Single(pdfSnapshot.Data.Series).MarkerOutlineWidth);
                     C.BubbleChart preservedBubble = authoredChartPart.ChartSpace!
                         .GetFirstChild<C.Chart>()!.GetFirstChild<C.PlotArea>()!
                         .GetFirstChild<C.BubbleChart>()!;
@@ -310,6 +323,32 @@ namespace OfficeIMO.Tests {
 
                 Assert.False(chart.TryGetOfficeSnapshot(out _));
             }
+        }
+
+        [Fact]
+        public void BubbleChart_RejectsEnabledThreeDimensionalRendering() {
+            using PowerPointPresentation presentation =
+                PowerPointPresentation.Create(new MemoryStream());
+            PowerPointChart chart = presentation.AddSlide().AddChart(
+                OfficeChartKind.Bubble,
+                CreateBubbleData(
+                    new[] { 1D },
+                    new[] { 2D },
+                    new[] { 4D }));
+            C.BubbleChart nativeChart = presentation.Slides[0].SlidePart.ChartParts
+                .Single().ChartSpace!.Descendants<C.BubbleChart>().Single();
+            C.BubbleChartSeries nativeSeries =
+                nativeChart.Elements<C.BubbleChartSeries>().Single();
+
+            nativeChart.GetFirstChild<C.Bubble3D>()!.Val = true;
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+            nativeChart.GetFirstChild<C.Bubble3D>()!.Val = false;
+            nativeSeries.GetFirstChild<C.Bubble3D>()!.Val = true;
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+            nativeSeries.GetFirstChild<C.Bubble3D>()!.Val = false;
+            Assert.True(chart.TryGetOfficeSnapshot(out _));
         }
 
         private static int CountOccurrences(string value, string marker) {

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
@@ -506,6 +506,36 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void BubbleChart_RejectsEnabledInvertIfNegativeForNegativeValues() {
+            using PowerPointPresentation presentation =
+                PowerPointPresentation.Create(new MemoryStream());
+            PowerPointChart chart = presentation.AddSlide().AddChart(
+                OfficeChartKind.Bubble,
+                CreateBubbleData(
+                    new[] { 1D },
+                    new[] { 2D },
+                    new[] { 4D }));
+            C.BubbleChartSeries nativeSeries = presentation.Slides[0].SlidePart
+                .ChartParts.Single().ChartSpace!
+                .Descendants<C.BubbleChartSeries>().Single();
+            nativeSeries.GetFirstChild<C.YValues>()!.NumberReference!
+                .NumberingCache!.Elements<C.NumericPoint>().Single()
+                .NumericValue!.Text = "-2";
+            C.InvertIfNegative invertIfNegative = nativeSeries.InsertBefore(
+                new C.InvertIfNegative(),
+                nativeSeries.GetFirstChild<C.XValues>())!;
+
+            invertIfNegative.Val = true;
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+            invertIfNegative.Val = null;
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+            invertIfNegative.Val = false;
+            Assert.True(chart.TryGetOfficeSnapshot(out _));
+        }
+
+        [Fact]
         public void BubbleChart_RejectsEnabledThreeDimensionalRendering() {
             using PowerPointPresentation presentation =
                 PowerPointPresentation.Create(new MemoryStream());
@@ -629,6 +659,15 @@ namespace OfficeIMO.Tests {
             outline.RemoveAllChildren<DocumentFormat.OpenXml.Drawing.PresetDash>();
             outline.Append(new DocumentFormat.OpenXml.Drawing.CustomDash());
             Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+            outline.RemoveAllChildren<DocumentFormat.OpenXml.Drawing.CustomDash>();
+            outline.CompoundLineType =
+                DocumentFormat.OpenXml.Drawing.CompoundLineValues.Double;
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+            outline.CompoundLineType =
+                DocumentFormat.OpenXml.Drawing.CompoundLineValues.Single;
+            Assert.True(chart.TryGetOfficeSnapshot(out _));
         }
 
         [Fact]

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
@@ -394,6 +394,17 @@ namespace OfficeIMO.Tests {
                 new C.Left { Val = 0.2D },
                 new C.Top { Val = 0.1D }));
             Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+            layout.GetFirstChild<C.ManualLayout>()!.Remove();
+            Assert.True(chart.TryGetOfficeSnapshot(out _));
+
+            chart.SetLegendTextStyle(
+                fontSizePoints: 10D, bold: true,
+                color: "445566", fontName: "Arial");
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+            chart.ClearLegendTextStyle();
+            Assert.True(chart.TryGetOfficeSnapshot(out _));
         }
 
         [Fact]
@@ -456,6 +467,62 @@ namespace OfficeIMO.Tests {
                 slide.ExportImage(OfficeImageExportFormat.Svg).Bytes);
             Assert.Contains("Risk", svg, StringComparison.Ordinal);
             Assert.Contains("Return", svg, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void BubbleChart_RejectsUnprojectedAxisPresentation() {
+            using PowerPointPresentation presentation =
+                PowerPointPresentation.Create(new MemoryStream());
+            PowerPointChart chart = presentation.AddSlide().AddChart(
+                    OfficeChartKind.Bubble,
+                    CreateBubbleData(
+                        new[] { 1D },
+                        new[] { 2D },
+                        new[] { 4D }))
+                .SetScatterXAxisTitle("Risk")
+                .SetScatterYAxisTitle("Return");
+            C.PlotArea plotArea = presentation.Slides[0].SlidePart.ChartParts
+                .Single().ChartSpace!.GetFirstChild<C.Chart>()!
+                .GetFirstChild<C.PlotArea>()!;
+            C.BubbleChart bubble =
+                plotArea.GetFirstChild<C.BubbleChart>()!;
+            uint[] axisIds = bubble.Elements<C.AxisId>()
+                .Select(axis => axis.Val!.Value).ToArray();
+            C.ValueAxis horizontal = plotArea.Elements<C.ValueAxis>()
+                .Single(axis => axis.AxisId!.Val!.Value == axisIds[0]);
+
+            chart.SetScatterXAxisTitleTextStyle(
+                fontSizePoints: 11D, bold: true,
+                color: "445566", fontName: "Arial");
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
+            chart.ClearScatterXAxisTitleTextStyle();
+            Assert.True(chart.TryGetOfficeSnapshot(out _));
+
+            chart.SetScatterXAxisLabelTextStyle(
+                fontSizePoints: 9D, italic: true,
+                color: "778899", fontName: "Calibri");
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
+            chart.ClearScatterXAxisLabelTextStyle();
+            Assert.True(chart.TryGetOfficeSnapshot(out _));
+
+            C.Title axisTitle = horizontal.GetFirstChild<C.Title>()!;
+            C.Layout titleLayout =
+                axisTitle.GetFirstChild<C.Layout>()!;
+            titleLayout.Append(new C.ManualLayout(
+                new C.LeftMode { Val = C.LayoutModeValues.Factor },
+                new C.Left { Val = 0.15D }));
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
+            titleLayout.GetFirstChild<C.ManualLayout>()!.Remove();
+            Assert.True(chart.TryGetOfficeSnapshot(out _));
+
+            horizontal.AddChild(
+                new C.ChartShapeProperties(
+                    new A.Outline(
+                        new A.SolidFill(
+                            new A.RgbColorModelHex {
+                                Val = "AABBCC"
+                            }))), true);
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
         }
 
         [Fact]
@@ -581,6 +648,14 @@ namespace OfficeIMO.Tests {
             Assert.False(chart.TryGetOfficeSnapshot(out _));
 
             titleManualLayout.Remove();
+            Assert.True(chart.TryGetOfficeSnapshot(out _));
+
+            chart.SetTitle("Styled title")
+                .SetTitleTextStyle(
+                    fontSizePoints: 14D, bold: true,
+                    color: "445566", fontName: "Arial");
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
+            chart.ClearTitleTextStyle();
             Assert.True(chart.TryGetOfficeSnapshot(out _));
 
             C.Layout layout = plotArea.GetFirstChild<C.Layout>()!;

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
@@ -360,6 +360,28 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void BubbleChart_PreservesLegendPlacementAndOverlay() {
+            using PowerPointPresentation presentation =
+                PowerPointPresentation.Create(new MemoryStream());
+            PowerPointChart chart = presentation.AddSlide().AddChart(
+                OfficeChartKind.Bubble,
+                CreateBubbleData(
+                    new[] { 1D },
+                    new[] { 2D },
+                    new[] { 4D }))
+                .SetLegend(C.LegendPositionValues.Top, overlay: true);
+
+            Assert.True(chart.TryGetOfficeSnapshot(
+                out OfficeChartSnapshot snapshot));
+            Assert.Equal(OfficeChartLegendPosition.Top,
+                snapshot.Layout.LegendPosition);
+            Assert.True(snapshot.Layout.OverlayLegend);
+
+            chart.SetLegend(C.LegendPositionValues.TopRight);
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
+        }
+
+        [Fact]
         public void BubbleChart_RejectsMixedSnapshotsThatWouldDropBubbleSeries() {
             using PowerPointPresentation presentation =
                 PowerPointPresentation.Create(new MemoryStream());
@@ -700,6 +722,20 @@ namespace OfficeIMO.Tests {
 
                 minorUnit.Remove();
                 Assert.True(chart.TryGetOfficeSnapshot(out _));
+
+                C.Crosses crosses = axis.GetFirstChild<C.Crosses>()!;
+                crosses.Val = C.CrossesValues.Maximum;
+                Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+                crosses.Val = C.CrossesValues.AutoZero;
+                Assert.True(chart.TryGetOfficeSnapshot(out _));
+
+                var crossesAt = new C.CrossesAt { Val = 1D };
+                axis.AddChild(crossesAt, true);
+                Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+                crossesAt.Remove();
+                Assert.True(chart.TryGetOfficeSnapshot(out _));
             }
         }
 
@@ -948,6 +984,40 @@ namespace OfficeIMO.Tests {
             Assert.Equal(new[] { 3D, 6D }, series.XValues);
             Assert.Equal(new[] { 5D, 10D }, series.Values);
             Assert.Equal(new[] { 16D, 25D }, series.BubbleSizes);
+        }
+
+        [Fact]
+        public void BubbleChart_UpdateDataReplacesNonSolidSeriesFill() {
+            using PowerPointPresentation presentation =
+                PowerPointPresentation.Create(new MemoryStream());
+            PowerPointChart chart = presentation.AddSlide().AddChart(
+                OfficeChartKind.Bubble,
+                CreateBubbleData(
+                    new[] { 1D },
+                    new[] { 2D },
+                    new[] { 4D },
+                    seriesColor: OfficeColor.Parse("#112233")));
+            C.ChartShapeProperties properties = presentation.Slides[0].SlidePart
+                .ChartParts.Single().ChartSpace!
+                .Descendants<C.BubbleChartSeries>().Single()
+                .GetFirstChild<C.ChartShapeProperties>()!;
+            properties.RemoveAllChildren<A.SolidFill>();
+            properties.PrependChild(new A.GradientFill());
+
+            chart.UpdateData(CreateBubbleData(
+                new[] { 3D },
+                new[] { 5D },
+                new[] { 16D },
+                seriesColor: OfficeColor.Parse("#445566")));
+
+            properties = presentation.Slides[0].SlidePart.ChartParts.Single()
+                .ChartSpace!.Descendants<C.BubbleChartSeries>().Single()
+                .GetFirstChild<C.ChartShapeProperties>()!;
+            Assert.Null(properties.GetFirstChild<A.GradientFill>());
+            Assert.Equal("445566", properties.GetFirstChild<A.SolidFill>()!
+                .RgbColorModelHex!.Val!.Value);
+            Assert.Empty(new OpenXmlValidator().Validate(
+                presentation.Slides[0].SlidePart.ChartParts.Single()));
         }
 
         [Fact]

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
@@ -888,6 +888,41 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void BubbleChart_SetSeriesFillColorReplacesImageAndGroupFills() {
+            using PowerPointPresentation presentation =
+                PowerPointPresentation.Create(new MemoryStream());
+            PowerPointChart chart = presentation.AddSlide().AddChart(
+                OfficeChartKind.Bubble,
+                CreateBubbleData(
+                    new[] { 1D },
+                    new[] { 2D },
+                    new[] { 4D },
+                    seriesColor: OfficeColor.Parse("#112233")));
+            C.ChartShapeProperties properties = presentation.Slides[0].SlidePart
+                .ChartParts.Single().ChartSpace!
+                .Descendants<C.BubbleChartSeries>().Single()
+                .GetFirstChild<C.ChartShapeProperties>()!;
+            properties.RemoveAllChildren<A.SolidFill>();
+            properties.PrependChild(new A.BlipFill());
+
+            chart.SetSeriesFillColor(0, "445566");
+
+            Assert.Null(properties.GetFirstChild<A.BlipFill>());
+            Assert.Equal("445566", properties.GetFirstChild<A.SolidFill>()!
+                .RgbColorModelHex!.Val!.Value);
+
+            properties.RemoveAllChildren<A.SolidFill>();
+            properties.PrependChild(new A.GroupFill());
+            chart.SetSeriesFillColor(0, "778899");
+
+            Assert.Null(properties.GetFirstChild<A.GroupFill>());
+            Assert.Equal("778899", properties.GetFirstChild<A.SolidFill>()!
+                .RgbColorModelHex!.Val!.Value);
+            Assert.Empty(new OpenXmlValidator().Validate(
+                presentation.Slides[0].SlidePart.ChartParts.Single()));
+        }
+
+        [Fact]
         public void BubbleChart_RejectsUnsupportedSeriesOutlineFills() {
             using PowerPointPresentation presentation =
                 PowerPointPresentation.Create(new MemoryStream());
@@ -1051,6 +1086,96 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void BubbleChart_UpdateDataPreservesNoncontiguousSeriesStyles() {
+            using PowerPointPresentation presentation =
+                PowerPointPresentation.Create(new MemoryStream());
+            var initial = new OfficeChartData(new[] { "1" }, new[] {
+                OfficeChartSeries.CreateBubble(
+                    "First", new[] { 1D }, new[] { 2D }, new[] { 4D }),
+                OfficeChartSeries.CreateBubble(
+                    "Second", new[] { 3D }, new[] { 4D }, new[] { 9D })
+            });
+            PowerPointChart chart = presentation.AddSlide().AddChart(
+                OfficeChartKind.Bubble, initial);
+            chart.SetSeriesTrendline(0, C.TrendlineValues.Linear);
+            C.BubbleChartSeries[] nativeSeries = presentation.Slides[0]
+                .SlidePart.ChartParts.Single().ChartSpace!
+                .Descendants<C.BubbleChartSeries>().ToArray();
+            nativeSeries[0].Index!.Val = 5U;
+            nativeSeries[0].Order!.Val = 5U;
+            nativeSeries[1].Index!.Val = 9U;
+            nativeSeries[1].Order!.Val = 9U;
+            var updated = new OfficeChartData(new[] { "5" }, new[] {
+                OfficeChartSeries.CreateBubble(
+                    "First", new[] { 5D }, new[] { 6D }, new[] { 16D }),
+                OfficeChartSeries.CreateBubble(
+                    "Second", new[] { 7D }, new[] { 8D }, new[] { 25D })
+            });
+
+            chart.UpdateData(updated);
+
+            nativeSeries = presentation.Slides[0].SlidePart.ChartParts.Single()
+                .ChartSpace!.Descendants<C.BubbleChartSeries>().ToArray();
+            Assert.NotNull(nativeSeries[0].GetFirstChild<C.Trendline>());
+            Assert.Null(nativeSeries[1].GetFirstChild<C.Trendline>());
+            Assert.Equal(0U, nativeSeries[0].Index!.Val!.Value);
+            Assert.Equal(1U, nativeSeries[1].Index!.Val!.Value);
+            Assert.Equal("6", nativeSeries[0].GetFirstChild<C.YValues>()!
+                .NumberReference!
+                .NumberingCache!.Elements<C.NumericPoint>().Single()
+                .NumericValue!.Text);
+        }
+
+        [Fact]
+        public void BubbleChart_UpdateDataPreservesAxesByReferencedIdentity() {
+            using PowerPointPresentation presentation =
+                PowerPointPresentation.Create(new MemoryStream());
+            PowerPointChart chart = presentation.AddSlide().AddChart(
+                OfficeChartKind.Bubble,
+                CreateBubbleData(
+                    new[] { 1D },
+                    new[] { 2D },
+                    new[] { 4D }));
+            C.PlotArea plotArea = presentation.Slides[0].SlidePart.ChartParts
+                .Single().ChartSpace!.GetFirstChild<C.Chart>()!
+                .GetFirstChild<C.PlotArea>()!;
+            C.BubbleChart nativeChart =
+                plotArea.GetFirstChild<C.BubbleChart>()!;
+            uint[] referencedIds = nativeChart.Elements<C.AxisId>()
+                .Select(axis => axis.Val!.Value).ToArray();
+            C.ValueAxis xAxis = plotArea.Elements<C.ValueAxis>().Single(axis =>
+                axis.AxisId!.Val!.Value == referencedIds[0]);
+            C.ValueAxis yAxis = plotArea.Elements<C.ValueAxis>().Single(axis =>
+                axis.AxisId!.Val!.Value == referencedIds[1]);
+            xAxis.NumberingFormat!.FormatCode = "0.00x";
+            yAxis.NumberingFormat!.FormatCode = "0.00y";
+            yAxis.Remove();
+            plotArea.InsertBefore(yAxis, xAxis);
+
+            chart.UpdateData(CreateBubbleData(
+                new[] { 3D },
+                new[] { 5D },
+                new[] { 16D }));
+
+            plotArea = presentation.Slides[0].SlidePart.ChartParts.Single()
+                .ChartSpace!.GetFirstChild<C.Chart>()!
+                .GetFirstChild<C.PlotArea>()!;
+            nativeChart = plotArea.GetFirstChild<C.BubbleChart>()!;
+            referencedIds = nativeChart.Elements<C.AxisId>()
+                .Select(axis => axis.Val!.Value).ToArray();
+            xAxis = plotArea.Elements<C.ValueAxis>().Single(axis =>
+                axis.AxisId!.Val!.Value == referencedIds[0]);
+            yAxis = plotArea.Elements<C.ValueAxis>().Single(axis =>
+                axis.AxisId!.Val!.Value == referencedIds[1]);
+            Assert.Equal("0.00x", xAxis.NumberingFormat!.FormatCode!.Value);
+            Assert.Equal(C.AxisPositionValues.Bottom,
+                xAxis.AxisPosition!.Val!.Value);
+            Assert.Equal("0.00y", yAxis.NumberingFormat!.FormatCode!.Value);
+            Assert.Equal(C.AxisPositionValues.Left,
+                yAxis.AxisPosition!.Val!.Value);
+        }
+
+        [Fact]
         public void BubbleChart_UpdateDataReplacesNonSolidSeriesFill() {
             using PowerPointPresentation presentation =
                 PowerPointPresentation.Create(new MemoryStream());
@@ -1135,6 +1260,90 @@ namespace OfficeIMO.Tests {
             Assert.NotNull(outline.GetFirstChild<A.NoFill>());
             Assert.Empty(new OpenXmlValidator().Validate(
                 presentation.Slides[0].SlidePart.ChartParts.Single()));
+        }
+
+        [Fact]
+        public void BubbleChart_UpdateDataPreservesOutlineColorForWidthOnlyChange() {
+            using PowerPointPresentation presentation =
+                PowerPointPresentation.Create(new MemoryStream());
+            PowerPointChart chart = presentation.AddSlide().AddChart(
+                OfficeChartKind.Bubble,
+                CreateBubbleData(
+                    new[] { 1D },
+                    new[] { 2D },
+                    new[] { 4D },
+                    seriesColor: OfficeColor.Parse("#112233")));
+
+            chart.UpdateData(CreateBubbleData(
+                new[] { 3D },
+                new[] { 5D },
+                new[] { 16D },
+                markerOutlineWidth: 2.5D));
+
+            A.Outline outline = presentation.Slides[0].SlidePart.ChartParts
+                .Single().ChartSpace!.Descendants<C.BubbleChartSeries>().Single()
+                .GetFirstChild<C.ChartShapeProperties>()!
+                .GetFirstChild<A.Outline>()!;
+            Assert.Equal("112233", outline.GetFirstChild<A.SolidFill>()!
+                .RgbColorModelHex!.Val!.Value);
+            Assert.Equal(PowerPointUnits.FromPoints(2.5D),
+                outline.Width!.Value);
+            Assert.Empty(new OpenXmlValidator().Validate(
+                presentation.Slides[0].SlidePart.ChartParts.Single()));
+        }
+
+        [Fact]
+        public void BubbleChart_UpdateDataPreservesNonFillPointFormatting() {
+            using PowerPointPresentation presentation =
+                PowerPointPresentation.Create(new MemoryStream());
+            PowerPointChart chart = presentation.AddSlide().AddChart(
+                OfficeChartKind.Bubble,
+                CreateBubbleData(
+                    new[] { 1D },
+                    new[] { 2D },
+                    new[] { 4D }));
+            C.BubbleChartSeries nativeSeries = presentation.Slides[0].SlidePart
+                .ChartParts.Single().ChartSpace!
+                .Descendants<C.BubbleChartSeries>().Single();
+            var nativePoint = new C.DataPoint(
+                new C.Index { Val = 0U },
+                new C.ChartShapeProperties(
+                    new A.SolidFill(
+                        new A.RgbColorModelHex { Val = "112233" }),
+                    new A.Outline(
+                        new A.SolidFill(
+                            new A.RgbColorModelHex { Val = "AABBCC" })) {
+                        Width = (int)PowerPointUnits.FromPoints(1.25D)
+                    }));
+            nativeSeries.AddChild(nativePoint, true);
+
+            chart.UpdateData(CreateBubbleData(
+                new[] { 3D },
+                new[] { 5D },
+                new[] { 16D },
+                pointColors: new OfficeColor?[] {
+                    OfficeColor.Parse("#445566")
+                }));
+
+            C.DataPoint point = presentation.Slides[0].SlidePart.ChartParts
+                .Single().ChartSpace!.Descendants<C.BubbleChartSeries>().Single()
+                .Elements<C.DataPoint>().Single();
+            C.ChartShapeProperties properties =
+                point.GetFirstChild<C.ChartShapeProperties>()!;
+            Assert.Equal("445566", properties.GetFirstChild<A.SolidFill>()!
+                .RgbColorModelHex!.Val!.Value);
+            A.Outline outline = properties.GetFirstChild<A.Outline>()!;
+            Assert.Equal("AABBCC", outline.GetFirstChild<A.SolidFill>()!
+                .RgbColorModelHex!.Val!.Value);
+            Assert.Equal(PowerPointUnits.FromPoints(1.25D),
+                outline.Width!.Value);
+            List<ValidationErrorInfo> validation = new OpenXmlValidator()
+                .Validate(presentation.Slides[0].SlidePart.ChartParts.Single())
+                .ToList();
+            Assert.True(validation.Count == 0, string.Join(
+                Environment.NewLine, validation.Select(error =>
+                    (error.Path?.XPath ?? string.Empty) + ": " +
+                    error.Description)));
         }
 
         [Fact]

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
@@ -568,6 +568,21 @@ namespace OfficeIMO.Tests {
                 .ChartParts.Single();
             C.PlotArea plotArea = chartPart.ChartSpace!
                 .GetFirstChild<C.Chart>()!.GetFirstChild<C.PlotArea>()!;
+            C.Chart nativeChart = chartPart.ChartSpace!
+                .GetFirstChild<C.Chart>()!;
+            C.Title title = nativeChart.GetFirstChild<C.Title>() ??
+                nativeChart.PrependChild(new C.Title());
+            C.Layout titleLayout = title.GetFirstChild<C.Layout>() ??
+                title.AppendChild(new C.Layout());
+            C.ManualLayout titleManualLayout = titleLayout.AppendChild(
+                new C.ManualLayout(
+                    new C.LeftMode { Val = C.LayoutModeValues.Factor },
+                    new C.Left { Val = 0.2D }));
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+            titleManualLayout.Remove();
+            Assert.True(chart.TryGetOfficeSnapshot(out _));
+
             C.Layout layout = plotArea.GetFirstChild<C.Layout>()!;
             C.ManualLayout manualLayout = layout.AppendChild(
                 new C.ManualLayout(
@@ -1266,6 +1281,56 @@ namespace OfficeIMO.Tests {
             Assert.Equal("778899",
                 outline.GetFirstChild<A.SolidFill>()!
                     .GetFirstChild<A.RgbColorModelHex>()!.Val!.Value);
+
+            outline.Append(new A.PresetDash {
+                Val = A.PresetLineDashValues.Dash
+            });
+            chart.SetSeriesLineColor(
+                0, "AABBCC", widthPoints: 2D);
+
+            List<OpenXmlElement> outlineChildren =
+                outline.ChildElements.ToList();
+            Assert.True(
+                outlineChildren.FindIndex(child => child is A.SolidFill) <
+                outlineChildren.FindIndex(child => child is A.PresetDash));
+            Assert.Empty(new OpenXmlValidator().Validate(
+                presentation.Slides[0].SlidePart.ChartParts.Single()));
+        }
+
+        [Fact]
+        public void BubbleChart_UpdateDataMaterializesColorOnlyForNewSeries() {
+            using PowerPointPresentation presentation =
+                PowerPointPresentation.Create(new MemoryStream());
+            var initial = new OfficeChartData(
+                new[] { "1" },
+                new[] {
+                    OfficeChartSeries.CreateBubble(
+                        "Existing", new[] { 1D }, new[] { 2D },
+                        new[] { 4D }, OfficeColor.Parse("#112233"))
+                });
+            PowerPointChart chart = presentation.AddSlide().AddChart(
+                OfficeChartKind.Bubble, initial);
+            var updated = new OfficeChartData(
+                new[] { "1" },
+                new[] {
+                    OfficeChartSeries.CreateBubble(
+                        "Existing", new[] { 3D }, new[] { 5D },
+                        new[] { 9D }),
+                    OfficeChartSeries.CreateBubble(
+                        "Added", new[] { 7D }, new[] { 11D },
+                        new[] { 16D })
+                });
+
+            chart.UpdateData(updated);
+
+            Assert.True(chart.TryGetOfficeSnapshot(
+                out OfficeChartSnapshot snapshot));
+            Assert.Equal(
+                OfficeColor.Parse("#112233"),
+                snapshot.Data.Series[0].Color);
+            Assert.Equal(
+                OfficeChartStyle.Default.GetSeriesColor(1),
+                snapshot.Data.Series[1].Color);
             Assert.Empty(new OpenXmlValidator().Validate(
                 presentation.Slides[0].SlidePart.ChartParts.Single()));
         }

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
@@ -12,6 +12,7 @@ using OfficeIMO.PowerPoint;
 using OfficeIMO.PowerPoint.Html;
 using OfficeIMO.PowerPoint.Pdf;
 using Xunit;
+using A = DocumentFormat.OpenXml.Drawing;
 using C = DocumentFormat.OpenXml.Drawing.Charts;
 using S = DocumentFormat.OpenXml.Spreadsheet;
 
@@ -613,6 +614,85 @@ namespace OfficeIMO.Tests {
                 .Descendants<C.BubbleChartSeries>().Single();
             series.RemoveAllChildren<C.Trendline>();
             series.Append(new C.ErrorBars());
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
+        }
+
+        [Fact]
+        public void BubbleChart_ResolvesThemeColorsInParameterlessSnapshots() {
+            using PowerPointPresentation presentation =
+                PowerPointPresentation.Create(new MemoryStream());
+            presentation.SetThemeColor(PowerPointThemeColor.Accent3, "2468AC");
+            presentation.SetThemeColor(PowerPointThemeColor.Accent4, "97531B");
+            PowerPointChart chart = presentation.AddSlide().AddChart(
+                OfficeChartKind.Bubble,
+                CreateBubbleData(
+                    new[] { 1D },
+                    new[] { 2D },
+                    new[] { 4D },
+                    seriesColor: OfficeColor.Parse("#112233")));
+            C.BubbleChartSeries series = presentation.Slides[0].SlidePart
+                .ChartParts.Single().ChartSpace!
+                .Descendants<C.BubbleChartSeries>().Single();
+            C.ChartShapeProperties seriesProperties =
+                series.GetFirstChild<C.ChartShapeProperties>()!;
+            seriesProperties.RemoveAllChildren<A.SolidFill>();
+            seriesProperties.PrependChild(new A.SolidFill(
+                new A.SchemeColor { Val = A.SchemeColorValues.Accent3 }));
+            A.Outline outline = seriesProperties.GetFirstChild<A.Outline>() ??
+                seriesProperties.AppendChild(new A.Outline());
+            outline.RemoveAllChildren<A.SolidFill>();
+            outline.PrependChild(new A.SolidFill(
+                new A.SchemeColor { Val = A.SchemeColorValues.Accent4 }));
+            series.PrependChild(new C.DataPoint(
+                new C.Index { Val = 0U },
+                new C.ChartShapeProperties(
+                    new A.SolidFill(
+                        new A.SchemeColor { Val = A.SchemeColorValues.Accent4 }))));
+
+            Assert.True(chart.TryGetOfficeSnapshot(out OfficeChartSnapshot snapshot));
+            OfficeChartSeries bubble = Assert.Single(snapshot.Data.Series);
+            Assert.Equal(OfficeColor.Parse("#2468AC"), bubble.Color);
+            Assert.Equal(OfficeColor.Parse("#97531B"), bubble.MarkerOutlineColor);
+            Assert.Equal(OfficeColor.Parse("#97531B"),
+                Assert.Single(bubble.PointColors!));
+            Assert.True(chart.TryGetSnapshot(out PowerPointChartSnapshot nativeSnapshot));
+            Assert.Equal(OfficeColor.Parse("#2468AC"),
+                Assert.Single(nativeSnapshot.Data.Series).Color);
+
+            seriesProperties.GetFirstChild<A.SolidFill>()!.SchemeColor!.Val =
+                A.SchemeColorValues.PhColor;
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
+        }
+
+        [Fact]
+        public void BubbleChart_RejectsBubbleSizeLabelsAndShapeEffects() {
+            using PowerPointPresentation presentation =
+                PowerPointPresentation.Create(new MemoryStream());
+            PowerPointChart chart = presentation.AddSlide().AddChart(
+                OfficeChartKind.Bubble,
+                CreateBubbleData(
+                    new[] { 1D },
+                    new[] { 2D },
+                    new[] { 4D },
+                    seriesColor: OfficeColor.Parse("#112233")));
+            chart.SetDataLabels(showValue: false);
+            C.BubbleChart nativeChart = presentation.Slides[0].SlidePart
+                .ChartParts.Single().ChartSpace!.Descendants<C.BubbleChart>().Single();
+            C.DataLabels labels = nativeChart.GetFirstChild<C.DataLabels>()!;
+            labels.GetFirstChild<C.ShowBubbleSize>()!.Val = true;
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+            labels.GetFirstChild<C.ShowBubbleSize>()!.Val = false;
+            Assert.True(chart.TryGetOfficeSnapshot(out _));
+
+            C.BubbleChartSeries series =
+                nativeChart.Elements<C.BubbleChartSeries>().Single();
+            C.ChartShapeProperties properties =
+                series.GetFirstChild<C.ChartShapeProperties>()!;
+            properties.Append(new A.EffectList(
+                new A.Glow(new A.RgbColorModelHex { Val = "445566" }) {
+                    Radius = 12700L
+                }));
             Assert.False(chart.TryGetOfficeSnapshot(out _));
         }
 

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
@@ -1316,6 +1316,12 @@ namespace OfficeIMO.Tests {
 
             outline.CompoundLineType =
                 DocumentFormat.OpenXml.Drawing.CompoundLineValues.Single;
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+            outline.PrependChild(new DocumentFormat.OpenXml.Drawing.SolidFill(
+                new DocumentFormat.OpenXml.Drawing.RgbColorModelHex {
+                    Val = "445566"
+                }));
             Assert.True(chart.TryGetOfficeSnapshot(out _));
         }
 

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
@@ -414,6 +414,66 @@ namespace OfficeIMO.Tests {
 
             nativeSeries.GetFirstChild<C.Bubble3D>()!.Val = false;
             Assert.True(chart.TryGetOfficeSnapshot(out _));
+
+            nativeSeries.GetFirstChild<C.Bubble3D>()!.Val = null;
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
+        }
+
+        [Fact]
+        public void BubbleChart_RejectsExplicitNoFillStyles() {
+            using PowerPointPresentation presentation =
+                PowerPointPresentation.Create(new MemoryStream());
+            PowerPointChart chart = presentation.AddSlide().AddChart(
+                OfficeChartKind.Bubble,
+                CreateBubbleData(
+                    new[] { 1D },
+                    new[] { 2D },
+                    new[] { 4D },
+                    seriesColor: OfficeColor.Parse("#112233")));
+            C.BubbleChartSeries nativeSeries = presentation.Slides[0].SlidePart
+                .ChartParts.Single().ChartSpace!
+                .Descendants<C.BubbleChartSeries>().Single();
+            C.ChartShapeProperties seriesProperties =
+                nativeSeries.GetFirstChild<C.ChartShapeProperties>() ??
+                nativeSeries.AppendChild(new C.ChartShapeProperties());
+            seriesProperties.RemoveAllChildren<DocumentFormat.OpenXml.Drawing.SolidFill>();
+            seriesProperties.PrependChild(new DocumentFormat.OpenXml.Drawing.NoFill());
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+            seriesProperties.RemoveAllChildren<DocumentFormat.OpenXml.Drawing.NoFill>();
+            seriesProperties.PrependChild(new DocumentFormat.OpenXml.Drawing.SolidFill(
+                new DocumentFormat.OpenXml.Drawing.RgbColorModelHex {
+                    Val = "112233"
+                }));
+            nativeSeries.PrependChild(new C.DataPoint(
+                new C.Index { Val = 0U },
+                new C.ChartShapeProperties(
+                    new DocumentFormat.OpenXml.Drawing.NoFill())));
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
+        }
+
+        [Fact]
+        public void BubbleChart_RejectsNativeVaryColors() {
+            using PowerPointPresentation presentation =
+                PowerPointPresentation.Create(new MemoryStream());
+            PowerPointChart chart = presentation.AddSlide().AddChart(
+                OfficeChartKind.Bubble,
+                CreateBubbleData(
+                    new[] { 1D },
+                    new[] { 2D },
+                    new[] { 4D }));
+            C.VaryColors varyColors = presentation.Slides[0].SlidePart.ChartParts
+                .Single().ChartSpace!.Descendants<C.BubbleChart>().Single()
+                .GetFirstChild<C.VaryColors>()!;
+
+            varyColors.Val = true;
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+            varyColors.Val = null;
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+            varyColors.Val = false;
+            Assert.True(chart.TryGetOfficeSnapshot(out _));
         }
 
         private static int CountOccurrences(string value, string marker) {

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
@@ -605,7 +605,7 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
-        public void BubbleChart_RejectsLogarithmicValueAxes() {
+        public void BubbleChart_RejectsUnsupportedValueAxisScaling() {
             using PowerPointPresentation presentation =
                 PowerPointPresentation.Create(new MemoryStream());
             PowerPointChart chart = presentation.AddSlide().AddChart(
@@ -625,7 +625,53 @@ namespace OfficeIMO.Tests {
 
                 logBase.Remove();
                 Assert.True(chart.TryGetOfficeSnapshot(out _));
+
+                var minimum = new C.MinAxisValue { Val = 0D };
+                axis.GetFirstChild<C.Scaling>()!.AddChild(minimum, true);
+                Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+                minimum.Remove();
+                Assert.True(chart.TryGetOfficeSnapshot(out _));
+
+                var maximum = new C.MaxAxisValue { Val = 10D };
+                axis.GetFirstChild<C.Scaling>()!.AddChild(maximum, true);
+                Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+                maximum.Remove();
+                Assert.True(chart.TryGetOfficeSnapshot(out _));
             }
+        }
+
+        [Fact]
+        public void BubbleChart_SetBubbleSizingUpdatesEveryNativeBubbleGroup() {
+            using PowerPointPresentation presentation =
+                PowerPointPresentation.Create(new MemoryStream());
+            PowerPointChart chart = presentation.AddSlide().AddChart(
+                OfficeChartKind.Bubble,
+                CreateBubbleData(
+                    new[] { 1D },
+                    new[] { 2D },
+                    new[] { 4D }));
+            C.PlotArea plotArea = presentation.Slides[0].SlidePart.ChartParts
+                .Single().ChartSpace!.GetFirstChild<C.Chart>()!
+                .GetFirstChild<C.PlotArea>()!;
+            C.BubbleChart original = plotArea.GetFirstChild<C.BubbleChart>()!;
+            C.BubbleChart secondary =
+                (C.BubbleChart)original.CloneNode(true);
+            secondary.GetFirstChild<C.BubbleScale>()!.Val = 75U;
+            secondary.GetFirstChild<C.SizeRepresents>()!.Val =
+                C.SizeRepresentsValues.Area;
+            plotArea.InsertAfter(secondary, original);
+
+            chart.SetBubbleSizing(180U, OfficeChartBubbleSizeMode.Width);
+
+            Assert.Equal(2, plotArea.Elements<C.BubbleChart>().Count());
+            Assert.All(plotArea.Elements<C.BubbleChart>(), bubble => {
+                Assert.Equal(180U,
+                    bubble.GetFirstChild<C.BubbleScale>()!.Val!.Value);
+                Assert.Equal(C.SizeRepresentsValues.Width,
+                    bubble.GetFirstChild<C.SizeRepresents>()!.Val!.Value);
+            });
         }
 
         [Fact]

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
@@ -74,6 +74,11 @@ namespace OfficeIMO.Tests {
                         Assert.Single(refreshed.Data.Series).PointColors![0]);
                     Assert.Equal(2.5D,
                         Assert.Single(refreshed.Data.Series).MarkerOutlineWidth);
+                    Assert.Equal(OfficeColor.Parse("#654321"),
+                        Assert.Single(refreshed.Data.Series).MarkerOutlineColor);
+                    Assert.Equal(145D, refreshed.BubbleScalePercent);
+                    Assert.Equal(OfficeChartBubbleSizeMode.Width,
+                        refreshed.BubbleSizeMode);
                     C.BubbleChart preservedBubble = authoredChartPart.ChartSpace!
                         .GetFirstChild<C.Chart>()!.GetFirstChild<C.PlotArea>()!
                         .GetFirstChild<C.BubbleChart>()!;
@@ -111,6 +116,10 @@ namespace OfficeIMO.Tests {
                     Assert.Equal(new[] { 16D, 36D, 64D }, series.BubbleSizes);
                     Assert.Equal(OfficeColor.Parse("#F4A261"), series.PointColors![2]);
                     Assert.Equal(2.5D, series.MarkerOutlineWidth);
+                    Assert.Equal(OfficeColor.Parse("#654321"), series.MarkerOutlineColor);
+                    Assert.Equal(145D, snapshot.BubbleScalePercent);
+                    Assert.Equal(OfficeChartBubbleSizeMode.Width,
+                        snapshot.BubbleSizeMode);
                 }
 
                 using PresentationDocument document = PresentationDocument.Open(output, false);
@@ -140,6 +149,39 @@ namespace OfficeIMO.Tests {
             } finally {
                 if (File.Exists(output)) File.Delete(output);
             }
+        }
+
+        [Fact]
+        public void BubbleChart_AuthorsSeriesOutlineFromBubbleOptions() {
+            using PowerPointPresentation presentation =
+                PowerPointPresentation.Create(new MemoryStream());
+            OfficeColor outlineColor = OfficeColor.Parse("#AABBCC");
+            var data = new OfficeChartData(new[] { "1" }, new[] {
+                OfficeChartSeries.CreateBubble("Portfolio",
+                    new[] { 1D },
+                    new[] { 2D },
+                    new[] { 4D },
+                    color: OfficeColor.Parse("#112233"),
+                    markerOutlineColor: outlineColor,
+                    markerOutlineWidth: 1.5D)
+            });
+
+            PowerPointChart chart = presentation.AddSlide().AddChart(
+                OfficeChartKind.Bubble, data);
+            C.BubbleChartSeries nativeSeries = presentation.Slides[0].SlidePart
+                .ChartParts.Single().ChartSpace!
+                .Descendants<C.BubbleChartSeries>().Single();
+            DocumentFormat.OpenXml.Drawing.Outline outline = nativeSeries
+                .GetFirstChild<C.ChartShapeProperties>()!
+                .GetFirstChild<DocumentFormat.OpenXml.Drawing.Outline>()!;
+
+            Assert.Equal(19050, outline.Width!.Value);
+            Assert.Equal("AABBCC", outline
+                .GetFirstChild<DocumentFormat.OpenXml.Drawing.SolidFill>()!
+                .RgbColorModelHex!.Val!.Value);
+            Assert.True(chart.TryGetOfficeSnapshot(out OfficeChartSnapshot snapshot));
+            Assert.Equal(outlineColor,
+                Assert.Single(snapshot.Data.Series).MarkerOutlineColor);
         }
 
         [Fact]
@@ -248,6 +290,26 @@ namespace OfficeIMO.Tests {
             sizeCache.PointCount!.Val = 2U;
 
             Assert.False(chart.TryGetOfficeSnapshot(out _));
+        }
+
+        [Fact]
+        public void BubbleChart_RejectsMalformedImportedSizeCaches() {
+            foreach (string malformed in new[] { "NaN", "Infinity", "not-a-number" }) {
+                using PowerPointPresentation presentation =
+                    PowerPointPresentation.Create(new MemoryStream());
+                PowerPointChart chart = presentation.AddSlide().AddChart(
+                    OfficeChartKind.Bubble,
+                    CreateBubbleData(
+                        new[] { 1D },
+                        new[] { 2D },
+                        new[] { 4D }));
+                C.NumericPoint point = presentation.Slides[0].SlidePart.ChartParts
+                    .Single().ChartSpace!.Descendants<C.BubbleSize>().Single()
+                    .NumberReference!.NumberingCache!.Elements<C.NumericPoint>().Single();
+                point.NumericValue!.Text = malformed;
+
+                Assert.False(chart.TryGetOfficeSnapshot(out _));
+            }
         }
 
         private static int CountOccurrences(string value, string marker) {

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
@@ -555,6 +555,16 @@ namespace OfficeIMO.Tests {
             outline.Append(new DocumentFormat.OpenXml.Drawing.GradientFill());
 
             Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+            outline.RemoveAllChildren<DocumentFormat.OpenXml.Drawing.GradientFill>();
+            outline.Append(new DocumentFormat.OpenXml.Drawing.PresetDash {
+                Val = DocumentFormat.OpenXml.Drawing.PresetLineDashValues.Dash
+            });
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+            outline.RemoveAllChildren<DocumentFormat.OpenXml.Drawing.PresetDash>();
+            outline.Append(new DocumentFormat.OpenXml.Drawing.CustomDash());
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
         }
 
         [Fact]
@@ -582,7 +592,7 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
-        public void BubbleChart_RejectsTrendlinesFromSharedSnapshots() {
+        public void BubbleChart_RejectsTrendlinesAndErrorBarsFromSharedSnapshots() {
             using PowerPointPresentation presentation =
                 PowerPointPresentation.Create(new MemoryStream());
             PowerPointChart chart = presentation.AddSlide().AddChart(
@@ -596,6 +606,13 @@ namespace OfficeIMO.Tests {
 
             Assert.NotNull(presentation.Slides[0].SlidePart.ChartParts.Single()
                 .ChartSpace!.Descendants<C.Trendline>().Single());
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+            C.BubbleChartSeries series = presentation.Slides[0].SlidePart
+                .ChartParts.Single().ChartSpace!
+                .Descendants<C.BubbleChartSeries>().Single();
+            series.RemoveAllChildren<C.Trendline>();
+            series.Append(new C.ErrorBars());
             Assert.False(chart.TryGetOfficeSnapshot(out _));
         }
 

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
@@ -486,6 +486,18 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void BubbleChart_RejectsWorkbookRowOverflow() {
+            PowerPointUtils.ValidateBubbleWorkbookDimensions(
+                seriesCount: 1,
+                maximumPoints: 1_048_575);
+
+            Assert.Throws<ArgumentException>(() =>
+                PowerPointUtils.ValidateBubbleWorkbookDimensions(
+                    seriesCount: 1,
+                    maximumPoints: 1_048_576));
+        }
+
+        [Fact]
         public void BubbleChart_RejectsMismatchedImportedCaches() {
             using PowerPointPresentation presentation =
                 PowerPointPresentation.Create(new MemoryStream());
@@ -711,6 +723,47 @@ namespace OfficeIMO.Tests {
             outline.CompoundLineType =
                 DocumentFormat.OpenXml.Drawing.CompoundLineValues.Single;
             Assert.True(chart.TryGetOfficeSnapshot(out _));
+        }
+
+        [Fact]
+        public void BubbleChart_LineColorReplacesUnsupportedOutlineFills() {
+            using PowerPointPresentation presentation =
+                PowerPointPresentation.Create(new MemoryStream());
+            PowerPointChart chart = presentation.AddSlide().AddChart(
+                OfficeChartKind.Bubble,
+                CreateBubbleData(
+                    new[] { 1D },
+                    new[] { 2D },
+                    new[] { 4D }));
+            C.BubbleChartSeries nativeSeries = presentation.Slides[0].SlidePart.ChartParts
+                .Single().ChartSpace!.Descendants<C.BubbleChartSeries>().Single();
+            C.ChartShapeProperties properties =
+                nativeSeries.GetFirstChild<C.ChartShapeProperties>() ??
+                nativeSeries.InsertAfter(
+                    new C.ChartShapeProperties(),
+                    nativeSeries.GetFirstChild<C.SeriesText>())!;
+            A.Outline outline = properties.GetFirstChild<A.Outline>() ??
+                properties.AppendChild(new A.Outline());
+            outline.RemoveAllChildren<A.SolidFill>();
+            outline.Append(new A.GradientFill());
+
+            chart.SetSeriesLineColor(0, "445566", widthPoints: 1.25D);
+
+            Assert.Null(outline.GetFirstChild<A.GradientFill>());
+            Assert.Equal("445566",
+                outline.GetFirstChild<A.SolidFill>()!
+                    .GetFirstChild<A.RgbColorModelHex>()!.Val!.Value);
+
+            outline.RemoveAllChildren<A.SolidFill>();
+            outline.Append(new A.PatternFill());
+            chart.SetSeriesLineColor(0, "778899", widthPoints: 1.5D);
+
+            Assert.Null(outline.GetFirstChild<A.PatternFill>());
+            Assert.Equal("778899",
+                outline.GetFirstChild<A.SolidFill>()!
+                    .GetFirstChild<A.RgbColorModelHex>()!.Val!.Value);
+            Assert.Empty(new OpenXmlValidator().Validate(
+                presentation.Slides[0].SlidePart.ChartParts.Single()));
         }
 
         [Fact]

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
@@ -417,6 +417,15 @@ namespace OfficeIMO.Tests {
 
             nativeSeries.GetFirstChild<C.Bubble3D>()!.Val = null;
             Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+            nativeSeries.GetFirstChild<C.Bubble3D>()!.Val = false;
+            C.DataPoint point = nativeSeries.PrependChild(new C.DataPoint(
+                new C.Index { Val = 0U },
+                new C.Bubble3D()));
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+            point.GetFirstChild<C.Bubble3D>()!.Val = false;
+            Assert.True(chart.TryGetOfficeSnapshot(out _));
         }
 
         [Fact]
@@ -460,6 +469,40 @@ namespace OfficeIMO.Tests {
                 point.GetFirstChild<C.ChartShapeProperties>()!;
             pointProperties.RemoveAllChildren<DocumentFormat.OpenXml.Drawing.NoFill>();
             pointProperties.Append(new DocumentFormat.OpenXml.Drawing.PatternFill());
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+            pointProperties.RemoveAllChildren<DocumentFormat.OpenXml.Drawing.PatternFill>();
+            pointProperties.Append(new DocumentFormat.OpenXml.Drawing.Outline(
+                new DocumentFormat.OpenXml.Drawing.SolidFill(
+                    new DocumentFormat.OpenXml.Drawing.RgbColorModelHex {
+                        Val = "445566"
+                    })));
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
+        }
+
+        [Fact]
+        public void BubbleChart_RejectsUnsupportedSeriesOutlineFills() {
+            using PowerPointPresentation presentation =
+                PowerPointPresentation.Create(new MemoryStream());
+            PowerPointChart chart = presentation.AddSlide().AddChart(
+                OfficeChartKind.Bubble,
+                CreateBubbleData(
+                    new[] { 1D },
+                    new[] { 2D },
+                    new[] { 4D },
+                    seriesColor: OfficeColor.Parse("#112233")));
+            C.BubbleChartSeries nativeSeries = presentation.Slides[0].SlidePart
+                .ChartParts.Single().ChartSpace!
+                .Descendants<C.BubbleChartSeries>().Single();
+            C.ChartShapeProperties properties =
+                nativeSeries.GetFirstChild<C.ChartShapeProperties>() ??
+                nativeSeries.AppendChild(new C.ChartShapeProperties());
+            DocumentFormat.OpenXml.Drawing.Outline outline =
+                properties.GetFirstChild<DocumentFormat.OpenXml.Drawing.Outline>() ??
+                properties.AppendChild(new DocumentFormat.OpenXml.Drawing.Outline());
+            outline.RemoveAllChildren<DocumentFormat.OpenXml.Drawing.SolidFill>();
+            outline.Append(new DocumentFormat.OpenXml.Drawing.GradientFill());
+
             Assert.False(chart.TryGetOfficeSnapshot(out _));
         }
 

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
@@ -198,6 +198,71 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void BubbleChart_PreservesExplicitlyDisabledSeriesOutline() {
+            using PowerPointPresentation presentation =
+                PowerPointPresentation.Create(new MemoryStream());
+            PowerPointChart chart = presentation.AddSlide().AddChart(
+                OfficeChartKind.Bubble,
+                CreateBubbleData(
+                    new[] { 1D },
+                    new[] { 2D },
+                    new[] { 4D },
+                    seriesColor: OfficeColor.Parse("#112233")));
+            C.BubbleChartSeries nativeSeries = presentation.Slides[0].SlidePart
+                .ChartParts.Single().ChartSpace!
+                .Descendants<C.BubbleChartSeries>().Single();
+            DocumentFormat.OpenXml.Drawing.Outline outline = nativeSeries
+                .GetFirstChild<C.ChartShapeProperties>()!
+                .GetFirstChild<DocumentFormat.OpenXml.Drawing.Outline>()!;
+            outline.RemoveAllChildren<DocumentFormat.OpenXml.Drawing.SolidFill>();
+            outline.Append(new DocumentFormat.OpenXml.Drawing.NoFill());
+
+            Assert.True(chart.TryGetOfficeSnapshot(out OfficeChartSnapshot snapshot));
+            OfficeChartSeries series = Assert.Single(snapshot.Data.Series);
+            Assert.False(series.ShowMarkerOutline);
+            OfficeDrawing drawing = OfficeChartDrawingRenderer.Render(snapshot);
+            OfficeDrawingShape bubble = Assert.Single(drawing.Shapes, shape =>
+                shape.Shape.Kind == OfficeShapeKind.Ellipse &&
+                shape.Shape.FillColor == OfficeColor.Parse("#112233"));
+            Assert.Null(bubble.Shape.StrokeColor);
+            Assert.Equal(0D, bubble.Shape.StrokeWidth);
+        }
+
+        [Fact]
+        public void BubbleChart_RejectsMixedSnapshotsThatWouldDropBubbleSeries() {
+            using PowerPointPresentation presentation =
+                PowerPointPresentation.Create(new MemoryStream());
+            PowerPointSlide slide = presentation.AddSlide();
+            PowerPointChart bubble = slide.AddChart(
+                OfficeChartKind.Bubble,
+                CreateBubbleData(
+                    new[] { 1D, 2D },
+                    new[] { 2D, 4D },
+                    new[] { 4D, 9D }));
+            OfficeChartData categoryData = new(
+                new[] { "A", "B" },
+                new[] { new OfficeChartSeries("Values", new[] { 1D, 2D }) });
+            slide.AddChart(OfficeChartKind.ColumnClustered, categoryData);
+            slide.AddChart(OfficeChartKind.Line, categoryData);
+
+            ChartPart[] chartParts = slide.SlidePart.ChartParts.ToArray();
+            C.PlotArea bubblePlot = chartParts[0].ChartSpace!
+                .GetFirstChild<C.Chart>()!.GetFirstChild<C.PlotArea>()!;
+            C.PlotArea columnPlot = chartParts[1].ChartSpace!
+                .GetFirstChild<C.Chart>()!.GetFirstChild<C.PlotArea>()!;
+            C.PlotArea linePlot = chartParts[2].ChartSpace!
+                .GetFirstChild<C.Chart>()!.GetFirstChild<C.PlotArea>()!;
+            bubblePlot.InsertBefore(
+                columnPlot.GetFirstChild<C.BarChart>()!.CloneNode(true),
+                bubblePlot.GetFirstChild<C.ValueAxis>());
+            bubblePlot.InsertBefore(
+                linePlot.GetFirstChild<C.LineChart>()!.CloneNode(true),
+                bubblePlot.GetFirstChild<C.ValueAxis>());
+
+            Assert.False(bubble.TryGetOfficeSnapshot(out _));
+        }
+
+        [Fact]
         public void BubbleChart_DrivesPngSvgHtmlAndPdfWithoutFallbackDiagnostics() {
             using var stream = new MemoryStream();
             using PowerPointPresentation presentation = PowerPointPresentation.Create(stream);

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
@@ -420,7 +420,7 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
-        public void BubbleChart_RejectsExplicitNoFillStyles() {
+        public void BubbleChart_RejectsUnsupportedFillStyles() {
             using PowerPointPresentation presentation =
                 PowerPointPresentation.Create(new MemoryStream());
             PowerPointChart chart = presentation.AddSlide().AddChart(
@@ -441,14 +441,25 @@ namespace OfficeIMO.Tests {
             Assert.False(chart.TryGetOfficeSnapshot(out _));
 
             seriesProperties.RemoveAllChildren<DocumentFormat.OpenXml.Drawing.NoFill>();
+            seriesProperties.PrependChild(
+                new DocumentFormat.OpenXml.Drawing.GradientFill());
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+            seriesProperties.RemoveAllChildren<DocumentFormat.OpenXml.Drawing.GradientFill>();
             seriesProperties.PrependChild(new DocumentFormat.OpenXml.Drawing.SolidFill(
                 new DocumentFormat.OpenXml.Drawing.RgbColorModelHex {
                     Val = "112233"
                 }));
-            nativeSeries.PrependChild(new C.DataPoint(
+            C.DataPoint point = nativeSeries.PrependChild(new C.DataPoint(
                 new C.Index { Val = 0U },
                 new C.ChartShapeProperties(
                     new DocumentFormat.OpenXml.Drawing.NoFill())));
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+            C.ChartShapeProperties pointProperties =
+                point.GetFirstChild<C.ChartShapeProperties>()!;
+            pointProperties.RemoveAllChildren<DocumentFormat.OpenXml.Drawing.NoFill>();
+            pointProperties.Append(new DocumentFormat.OpenXml.Drawing.PatternFill());
             Assert.False(chart.TryGetOfficeSnapshot(out _));
         }
 

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
@@ -930,6 +930,33 @@ namespace OfficeIMO.Tests {
 
                 tickLabels.Val = C.TickLabelPositionValues.NextTo;
                 Assert.True(chart.TryGetOfficeSnapshot(out _));
+
+                axis.AddChild(new C.DisplayUnits(
+                    new C.BuiltInUnit {
+                        Val = C.BuiltInUnitValues.Millions
+                    }), true);
+                Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+                axis.GetFirstChild<C.DisplayUnits>()!.Remove();
+                Assert.True(chart.TryGetOfficeSnapshot(out _));
+
+                C.NumberingFormat numberingFormat =
+                    axis.GetFirstChild<C.NumberingFormat>()!;
+                string? originalFormat = numberingFormat.FormatCode?.Value;
+                numberingFormat.FormatCode = "0.00E+00";
+                Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+                numberingFormat.FormatCode = "m/d/yyyy";
+                Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+                numberingFormat.FormatCode = "# ?/?";
+                Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+                numberingFormat.FormatCode = "\"E+00\"0.0x";
+                Assert.True(chart.TryGetOfficeSnapshot(out _));
+
+                numberingFormat.FormatCode = originalFormat;
+                Assert.True(chart.TryGetOfficeSnapshot(out _));
             }
         }
 

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
@@ -1,0 +1,221 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Drawing.Charts;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Validation;
+using OfficeIMO.Drawing;
+using OfficeIMO.Html;
+using OfficeIMO.Pdf;
+using OfficeIMO.PowerPoint;
+using OfficeIMO.PowerPoint.Html;
+using OfficeIMO.PowerPoint.Pdf;
+using Xunit;
+using C = DocumentFormat.OpenXml.Drawing.Charts;
+using S = DocumentFormat.OpenXml.Spreadsheet;
+
+namespace OfficeIMO.Tests {
+    public class PowerPointSharedBubbleCharts {
+        [Fact]
+        public void BubbleChart_CreateUpdateReopen_PreservesNativeDataAndWorkbook() {
+            string output = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".pptx");
+            OfficeChartData initial = CreateBubbleData(
+                new[] { 2D, 4D, 6D }, new[] { 10D, 20D, 30D }, new[] { 9D, 25D, 49D },
+                new OfficeColor?[] {
+                    OfficeColor.Parse("#D62828"),
+                    OfficeColor.Parse("#2A9D8F"),
+                    OfficeColor.Parse("#F4A261")
+                });
+            OfficeChartData updated = CreateBubbleData(
+                new[] { 3D, 6D, 9D }, new[] { 12D, 24D, 36D }, new[] { 16D, 36D, 64D });
+            try {
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(output)) {
+                    PowerPointChart chart = presentation.AddSlide().AddChartPoints(
+                        OfficeChartKind.Bubble, initial, 36, 30, 420, 250,
+                        new PowerPointChartAccessibilityOptions {
+                            AlternativeText = "Portfolio position by return, risk, and investment"
+                        });
+
+                    Assert.True(chart.TryGetOfficeSnapshot(out OfficeChartSnapshot authored));
+                    Assert.Equal(OfficeChartKind.Bubble, authored.ChartKind);
+                    Assert.Equal(new[] { 9D, 25D, 49D },
+                        Assert.Single(authored.Data.Series).BubbleSizes);
+                    Assert.Equal(OfficeColor.Parse("#2A9D8F"),
+                        Assert.Single(authored.Data.Series).PointColors![1]);
+                    Assert.Contains("Series\tX\tY\tSize", chart.CreateDataSummary(),
+                        StringComparison.Ordinal);
+                    Assert.Contains("Portfolio\t6\t30\t49", chart.CreateDataSummary(),
+                        StringComparison.Ordinal);
+
+                    chart.SetSeriesFillColor(0, "123456")
+                        .SetDataLabels(showValue: true)
+                        .SetSeriesDataLabels(0, showValue: true, numberFormat: "0.0");
+                    ChartPart authoredChartPart = presentation.Slides[0].SlidePart.ChartParts.Single();
+                    C.BubbleChart authoredBubble = authoredChartPart.ChartSpace!
+                        .GetFirstChild<C.Chart>()!.GetFirstChild<C.PlotArea>()!
+                        .GetFirstChild<C.BubbleChart>()!;
+                    authoredBubble.GetFirstChild<C.BubbleScale>()!.Val = 145U;
+                    authoredBubble.GetFirstChild<C.ShowNegativeBubbles>()!.Val = true;
+                    authoredBubble.GetFirstChild<C.SizeRepresents>()!.Val =
+                        C.SizeRepresentsValues.Width;
+                    authoredChartPart.ChartSpace.Save();
+
+                    chart.UpdateData(updated);
+                    Assert.True(chart.TryGetOfficeSnapshot(out OfficeChartSnapshot refreshed));
+                    Assert.Equal(new[] { 3D, 6D, 9D },
+                        Assert.Single(refreshed.Data.Series).XValues);
+                    Assert.Equal(new[] { 12D, 24D, 36D },
+                        Assert.Single(refreshed.Data.Series).Values);
+                    Assert.Equal(new[] { 16D, 36D, 64D },
+                        Assert.Single(refreshed.Data.Series).BubbleSizes);
+                    Assert.Equal(OfficeColor.Parse("#D62828"),
+                        Assert.Single(refreshed.Data.Series).PointColors![0]);
+                    C.BubbleChart preservedBubble = authoredChartPart.ChartSpace!
+                        .GetFirstChild<C.Chart>()!.GetFirstChild<C.PlotArea>()!
+                        .GetFirstChild<C.BubbleChart>()!;
+                    Assert.Equal(145U,
+                        preservedBubble.GetFirstChild<C.BubbleScale>()!.Val!.Value);
+                    Assert.True(preservedBubble.GetFirstChild<C.ShowNegativeBubbles>()!
+                        .Val!.Value);
+                    Assert.Equal(C.SizeRepresentsValues.Width,
+                        preservedBubble.GetFirstChild<C.SizeRepresents>()!.Val!.Value);
+                    Assert.NotNull(preservedBubble.GetFirstChild<C.DataLabels>());
+                    C.BubbleChartSeries preservedSeries =
+                        Assert.Single(preservedBubble.Elements<C.BubbleChartSeries>());
+                    Assert.NotNull(preservedSeries.GetFirstChild<C.DataLabels>());
+                    Assert.Equal("123456", preservedSeries.GetFirstChild<C.ChartShapeProperties>()!
+                        .GetFirstChild<DocumentFormat.OpenXml.Drawing.SolidFill>()!
+                        .RgbColorModelHex!.Val!.Value);
+
+                    List<ValidationErrorInfo> validation = presentation.ValidateDocument();
+                    Assert.True(validation.Count == 0, string.Join(Environment.NewLine,
+                        validation.Select(error =>
+                            (error.Path?.XPath ?? string.Empty) + ": " + error.Description)));
+                    presentation.Save();
+                }
+
+                using (PowerPointPresentation reopened = PowerPointPresentation.Load(output,
+                           new PowerPointLoadOptions {
+                               AccessMode = DocumentAccessMode.ReadOnly
+                           })) {
+                    PowerPointChart chart = Assert.Single(reopened.Slides[0].Charts);
+                    Assert.True(chart.TryGetOfficeSnapshot(out OfficeChartSnapshot snapshot));
+                    Assert.Equal(OfficeChartKind.Bubble, snapshot.ChartKind);
+                    OfficeChartSeries series = Assert.Single(snapshot.Data.Series);
+                    Assert.Equal(new[] { 3D, 6D, 9D }, series.XValues);
+                    Assert.Equal(new[] { 12D, 24D, 36D }, series.Values);
+                    Assert.Equal(new[] { 16D, 36D, 64D }, series.BubbleSizes);
+                    Assert.Equal(OfficeColor.Parse("#F4A261"), series.PointColors![2]);
+                }
+
+                using PresentationDocument document = PresentationDocument.Open(output, false);
+                ChartPart chartPart = Assert.Single(document.PresentationPart!.SlideParts
+                    .SelectMany(slidePart => slidePart.ChartParts));
+                C.PlotArea plotArea = chartPart.ChartSpace!.GetFirstChild<C.Chart>()!
+                    .GetFirstChild<C.PlotArea>()!;
+                C.BubbleChart bubbleChart = Assert.Single(plotArea.Elements<C.BubbleChart>());
+                C.BubbleChartSeries nativeSeries =
+                    Assert.Single(bubbleChart.Elements<C.BubbleChartSeries>());
+                C.BubbleSize bubbleSize = nativeSeries.GetFirstChild<C.BubbleSize>()!;
+                Assert.Contains("$C$2:$C$4",
+                    bubbleSize.NumberReference!.Formula!.Text,
+                    StringComparison.Ordinal);
+                Assert.Equal("64", bubbleSize.NumberReference.NumberingCache!
+                    .Elements<C.NumericPoint>().Last().NumericValue!.Text);
+                Assert.Equal(2, plotArea.Elements<C.ValueAxis>().Count());
+
+                EmbeddedPackagePart package =
+                    Assert.Single(chartPart.GetPartsOfType<EmbeddedPackagePart>());
+                using SpreadsheetDocument workbook =
+                    SpreadsheetDocument.Open(package.GetStream(), false);
+                S.Cell sizeCell = workbook.WorkbookPart!.WorksheetParts.Single().Worksheet
+                    .Descendants<S.Cell>().Single(cell => cell.CellReference?.Value == "C4");
+                Assert.Equal("64", sizeCell.CellValue?.Text);
+                Assert.Empty(new OpenXmlValidator().Validate(chartPart));
+            } finally {
+                if (File.Exists(output)) File.Delete(output);
+            }
+        }
+
+        [Fact]
+        public void BubbleChart_DrivesPngSvgHtmlAndPdfWithoutFallbackDiagnostics() {
+            using var stream = new MemoryStream();
+            using PowerPointPresentation presentation = PowerPointPresentation.Create(stream);
+            presentation.SlideSize.SetSizePoints(480, 300);
+            PowerPointSlide slide = presentation.AddSlide();
+            slide.AddChartPoints(OfficeChartKind.Bubble,
+                CreateBubbleData(
+                    new[] { 1D, 2D, 3D },
+                    new[] { 2D, 5D, 4D },
+                    new[] { 4D, 25D, 9D },
+                    new OfficeColor?[] {
+                        OfficeColor.Parse("#D62828"),
+                        OfficeColor.Parse("#2A9D8F"),
+                        OfficeColor.Parse("#F4A261")
+                    }),
+                30, 20, 420, 250);
+
+            OfficeImageExportResult png = slide.ExportImage(OfficeImageExportFormat.Png);
+            OfficeImageExportResult svg = slide.ExportImage(OfficeImageExportFormat.Svg);
+            string svgText = System.Text.Encoding.UTF8.GetString(svg.Bytes);
+            Assert.True(png.Bytes.Length > 100);
+            Assert.Contains("<ellipse", svgText, StringComparison.Ordinal);
+            Assert.Contains("#D62828", svgText, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain(png.Diagnostics,
+                diagnostic => diagnostic.Severity == OfficeImageExportDiagnosticSeverity.Error);
+            Assert.DoesNotContain(svg.Diagnostics,
+                diagnostic => diagnostic.Severity == OfficeImageExportDiagnosticSeverity.Error);
+
+            PowerPointToHtmlResult htmlResult = presentation.ToHtmlResult(new PowerPointHtmlSaveOptions {
+                Profile = OfficeHtmlConversionProfile.PowerPointVisualReview
+            });
+            string html = htmlResult.Value;
+            PdfDocumentConversionResult pdfResult = presentation.ToPdfDocumentResult();
+            byte[] pdf = pdfResult.ToBytes();
+            Assert.Contains("<ellipse", html, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain(htmlResult.ImageDiagnostics,
+                diagnostic => diagnostic.Severity == OfficeImageExportDiagnosticSeverity.Error);
+            Assert.DoesNotContain(pdfResult.Warnings,
+                warning => warning.Code == "snapshot-selective-fallback");
+            Assert.DoesNotContain(pdfResult.Warnings,
+                warning => warning.Code == "unsupported-chart");
+            Assert.True(pdf.Length > 500);
+        }
+
+        [Fact]
+        public void BubbleChart_RejectsMissingOrInvalidSizesBeforeMutatingSlide() {
+            Assert.Throws<ArgumentException>(() => OfficeChartSeries.CreateBubble("Invalid",
+                new[] { 1D, 2D }, new[] { 2D, 3D }, new[] { 5D }));
+            Assert.Throws<ArgumentOutOfRangeException>(() => OfficeChartSeries.CreateBubble("Invalid",
+                new[] { 1D }, new[] { 2D }, new[] { -1D }));
+
+            using PowerPointPresentation presentation =
+                PowerPointPresentation.Create(new MemoryStream());
+            PowerPointSlide slide = presentation.AddSlide();
+            var missingSizes = new OfficeChartData(new[] { "1", "2" }, new[] {
+                new OfficeChartSeries("Incomplete", new[] { 3D, 4D }, new[] { 1D, 2D })
+            });
+            Assert.Throws<ArgumentException>(() =>
+                slide.AddChart(OfficeChartKind.Bubble, missingSizes));
+            Assert.Empty(slide.Charts);
+
+            PowerPointChart imported = slide.AddChart(OfficeChartKind.Bubble,
+                CreateBubbleData(new[] { 1D }, new[] { 2D }, new[] { 4D }));
+            C.BubbleSize bubbleSize = slide.SlidePart.ChartParts.Single().ChartSpace!
+                .Descendants<C.BubbleSize>().Single();
+            bubbleSize.NumberReference!.NumberingCache!.Elements<C.NumericPoint>()
+                .Single().NumericValue!.Text = "-4";
+            Assert.False(imported.TryGetOfficeSnapshot(out _));
+        }
+
+        private static OfficeChartData CreateBubbleData(IReadOnlyList<double> xValues,
+            IReadOnlyList<double> yValues, IReadOnlyList<double> sizes,
+            IReadOnlyList<OfficeColor?>? pointColors = null, OfficeColor? seriesColor = null) =>
+            new(xValues.Select(value => value.ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                new[] {
+                    OfficeChartSeries.CreateBubble("Portfolio", xValues, yValues, sizes,
+                        seriesColor, pointColors)
+                });
+    }
+}

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
@@ -8,6 +8,7 @@ using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Validation;
 using OfficeIMO.Drawing;
 using OfficeIMO.Html;
+using OfficeIMO.OpenXml.Internal;
 using OfficeIMO.Pdf;
 using OfficeIMO.PowerPoint;
 using OfficeIMO.PowerPoint.Html;
@@ -455,6 +456,70 @@ namespace OfficeIMO.Tests {
                 slide.ExportImage(OfficeImageExportFormat.Svg).Bytes);
             Assert.Contains("Risk", svg, StringComparison.Ordinal);
             Assert.Contains("Return", svg, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void BubbleChart_MaterializesDefaultColorsAndGridlineFidelity() {
+            using PowerPointPresentation presentation =
+                PowerPointPresentation.Create(new MemoryStream());
+            PowerPointChart chart = presentation.AddSlide().AddChart(
+                OfficeChartKind.Bubble,
+                CreateBubbleData(
+                    new[] { 1D },
+                    new[] { 2D },
+                    new[] { 4D }));
+            C.PlotArea plotArea = presentation.Slides[0].SlidePart.ChartParts
+                .Single().ChartSpace!.GetFirstChild<C.Chart>()!
+                .GetFirstChild<C.PlotArea>()!;
+            C.BubbleChart nativeChart =
+                plotArea.GetFirstChild<C.BubbleChart>()!;
+            C.BubbleChartSeries nativeSeries =
+                nativeChart.Elements<C.BubbleChartSeries>().Single();
+            OfficeColor defaultColor =
+                OfficeChartStyle.Default.GetSeriesColor(0);
+
+            Assert.Equal(defaultColor,
+                OfficeOpenXmlThemeColorResolver.ResolveColor(
+                    nativeSeries.GetFirstChild<C.ChartShapeProperties>()!
+                        .GetFirstChild<A.SolidFill>(), colorScheme: null));
+
+            uint[] axisIds = nativeChart.Elements<C.AxisId>()
+                .Select(axis => axis.Val!.Value).ToArray();
+            C.ValueAxis horizontalAxis = plotArea.Elements<C.ValueAxis>()
+                .Single(axis => axis.AxisId!.Val!.Value == axisIds[0]);
+            C.ValueAxis verticalAxis = plotArea.Elements<C.ValueAxis>()
+                .Single(axis => axis.AxisId!.Val!.Value == axisIds[1]);
+            Assert.Null(horizontalAxis.GetFirstChild<C.MajorGridlines>());
+            C.MajorGridlines majorGridlines =
+                verticalAxis.GetFirstChild<C.MajorGridlines>()!;
+            A.Outline gridlineOutline = majorGridlines
+                .GetFirstChild<C.ChartShapeProperties>()!
+                .GetFirstChild<A.Outline>()!;
+            Assert.Equal(PowerPointUnits.FromPoints(0.5D),
+                gridlineOutline.Width!.Value);
+            Assert.Equal(OfficeChartStyle.Default.GridLineColor,
+                OfficeOpenXmlThemeColorResolver.ResolveColor(
+                    gridlineOutline.GetFirstChild<A.SolidFill>(),
+                    colorScheme: null));
+
+            Assert.True(chart.TryGetOfficeSnapshot(
+                out OfficeChartSnapshot snapshot));
+            Assert.Equal(defaultColor,
+                Assert.Single(snapshot.Data.Series).Color);
+
+            horizontalAxis.AddChild(new C.MajorGridlines(), true);
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
+            horizontalAxis.GetFirstChild<C.MajorGridlines>()!.Remove();
+
+            gridlineOutline.Width = checked((int)PowerPointUnits.FromPoints(1D));
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
+            gridlineOutline.Width =
+                checked((int)PowerPointUnits.FromPoints(0.5D));
+            Assert.True(chart.TryGetOfficeSnapshot(out _));
+
+            nativeSeries.GetFirstChild<C.ChartShapeProperties>()!
+                .RemoveAllChildren<A.SolidFill>();
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
         }
 
         [Fact]

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
@@ -64,6 +64,10 @@ namespace OfficeIMO.Tests {
                     authoredChartPart.ChartSpace.Save();
 
                     chart.UpdateData(updated);
+                    Assert.False(chart.TryGetOfficeSnapshot(out _));
+                    chart.SetDataLabels(showValue: false)
+                        .SetSeriesDataLabels(0, showValue: false,
+                            numberFormat: "0.0");
                     Assert.True(chart.TryGetOfficeSnapshot(out OfficeChartSnapshot refreshed));
                     Assert.Equal(new[] { 3D, 6D, 9D },
                         Assert.Single(refreshed.Data.Series).XValues);
@@ -298,6 +302,10 @@ namespace OfficeIMO.Tests {
             });
             PowerPointChart chart = slide.AddChartPoints(
                 OfficeChartKind.Bubble, data, 30, 20, 420, 250);
+            C.Delete nativeDelete = presentation.Slides[0].SlidePart.ChartParts
+                .Single().ChartSpace!.Descendants<C.LegendEntry>().Single()
+                .GetFirstChild<C.Delete>()!;
+            nativeDelete.Val = null;
 
             Assert.True(chart.TryGetSnapshot(out PowerPointChartSnapshot native));
             Assert.False(Assert.Single(native.Data.Series).ShowInLegend);
@@ -722,6 +730,10 @@ namespace OfficeIMO.Tests {
             C.BubbleChart nativeChart = presentation.Slides[0].SlidePart
                 .ChartParts.Single().ChartSpace!.Descendants<C.BubbleChart>().Single();
             C.DataLabels labels = nativeChart.GetFirstChild<C.DataLabels>()!;
+            labels.GetFirstChild<C.ShowValue>()!.Val = true;
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+            labels.GetFirstChild<C.ShowValue>()!.Val = false;
             labels.GetFirstChild<C.ShowBubbleSize>()!.Val = true;
             Assert.False(chart.TryGetOfficeSnapshot(out _));
 

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
@@ -49,6 +49,7 @@ namespace OfficeIMO.Tests {
                         StringComparison.Ordinal);
 
                     chart.SetSeriesFillColor(0, "123456")
+                        .SetSeriesLineColor(0, "654321", widthPoints: 2.5D)
                         .SetDataLabels(showValue: true)
                         .SetSeriesDataLabels(0, showValue: true, numberFormat: "0.0");
                     ChartPart authoredChartPart = presentation.Slides[0].SlidePart.ChartParts.Single();
@@ -71,6 +72,8 @@ namespace OfficeIMO.Tests {
                         Assert.Single(refreshed.Data.Series).BubbleSizes);
                     Assert.Equal(OfficeColor.Parse("#D62828"),
                         Assert.Single(refreshed.Data.Series).PointColors![0]);
+                    Assert.Equal(2.5D,
+                        Assert.Single(refreshed.Data.Series).MarkerOutlineWidth);
                     C.BubbleChart preservedBubble = authoredChartPart.ChartSpace!
                         .GetFirstChild<C.Chart>()!.GetFirstChild<C.PlotArea>()!
                         .GetFirstChild<C.BubbleChart>()!;
@@ -107,6 +110,7 @@ namespace OfficeIMO.Tests {
                     Assert.Equal(new[] { 12D, 24D, 36D }, series.Values);
                     Assert.Equal(new[] { 16D, 36D, 64D }, series.BubbleSizes);
                     Assert.Equal(OfficeColor.Parse("#F4A261"), series.PointColors![2]);
+                    Assert.Equal(2.5D, series.MarkerOutlineWidth);
                 }
 
                 using PresentationDocument document = PresentationDocument.Open(output, false);
@@ -184,6 +188,24 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void BubbleChart_ZeroSizesRemainInvisibleInSharedRendering() {
+            using PowerPointPresentation presentation =
+                PowerPointPresentation.Create(new MemoryStream());
+            PowerPointSlide slide = presentation.AddSlide();
+            slide.AddChartPoints(OfficeChartKind.Bubble,
+                CreateBubbleData(
+                    new[] { 1D, 2D },
+                    new[] { 2D, 4D },
+                    new[] { 0D, 9D }),
+                30, 20, 420, 250);
+
+            string svg = System.Text.Encoding.UTF8.GetString(
+                slide.ExportImage(OfficeImageExportFormat.Svg).Bytes);
+
+            Assert.Equal(1, CountOccurrences(svg, "<ellipse"));
+        }
+
+        [Fact]
         public void BubbleChart_RejectsMissingOrInvalidSizesBeforeMutatingSlide() {
             Assert.Throws<ArgumentException>(() => OfficeChartSeries.CreateBubble("Invalid",
                 new[] { 1D, 2D }, new[] { 2D, 3D }, new[] { 5D }));
@@ -207,6 +229,35 @@ namespace OfficeIMO.Tests {
             bubbleSize.NumberReference!.NumberingCache!.Elements<C.NumericPoint>()
                 .Single().NumericValue!.Text = "-4";
             Assert.False(imported.TryGetOfficeSnapshot(out _));
+        }
+
+        [Fact]
+        public void BubbleChart_RejectsMismatchedImportedCaches() {
+            using PowerPointPresentation presentation =
+                PowerPointPresentation.Create(new MemoryStream());
+            PowerPointChart chart = presentation.AddSlide().AddChart(
+                OfficeChartKind.Bubble,
+                CreateBubbleData(
+                    new[] { 1D, 2D, 3D },
+                    new[] { 2D, 4D, 6D },
+                    new[] { 4D, 9D, 16D }));
+            C.NumberingCache sizeCache = presentation.Slides[0].SlidePart.ChartParts.Single()
+                .ChartSpace!.Descendants<C.BubbleSize>().Single()
+                .NumberReference!.NumberingCache!;
+            sizeCache.Elements<C.NumericPoint>().Last().Remove();
+            sizeCache.PointCount!.Val = 2U;
+
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
+        }
+
+        private static int CountOccurrences(string value, string marker) {
+            int count = 0;
+            int offset = 0;
+            while ((offset = value.IndexOf(marker, offset, StringComparison.Ordinal)) >= 0) {
+                count++;
+                offset += marker.Length;
+            }
+            return count;
         }
 
         private static OfficeChartData CreateBubbleData(IReadOnlyList<double> xValues,

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
@@ -198,6 +198,53 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void BubbleChart_PreservesAlphaForSeriesPointAndOutlineColors() {
+            using PowerPointPresentation presentation =
+                PowerPointPresentation.Create(new MemoryStream());
+            OfficeColor seriesColor = OfficeColor.FromRgba(17, 34, 51, 128);
+            OfficeColor pointColor = OfficeColor.FromRgba(68, 85, 102, 96);
+            OfficeColor outlineColor = OfficeColor.FromRgba(119, 136, 153, 64);
+            var data = new OfficeChartData(new[] { "1" }, new[] {
+                OfficeChartSeries.CreateBubble(
+                    "Portfolio",
+                    new[] { 1D },
+                    new[] { 2D },
+                    new[] { 4D },
+                    seriesColor,
+                    new OfficeColor?[] { pointColor },
+                    markerOutlineColor: outlineColor)
+            });
+
+            PowerPointChart chart = presentation.AddSlide().AddChart(
+                OfficeChartKind.Bubble, data);
+            C.BubbleChartSeries nativeSeries = presentation.Slides[0].SlidePart
+                .ChartParts.Single().ChartSpace!
+                .Descendants<C.BubbleChartSeries>().Single();
+            C.ChartShapeProperties seriesProperties =
+                nativeSeries.GetFirstChild<C.ChartShapeProperties>()!;
+            Assert.Equal(50196, seriesProperties
+                .GetFirstChild<DocumentFormat.OpenXml.Drawing.SolidFill>()!
+                .RgbColorModelHex!.GetFirstChild<DocumentFormat.OpenXml.Drawing.Alpha>()!
+                .Val!.Value);
+            Assert.Equal(25098, seriesProperties
+                .GetFirstChild<DocumentFormat.OpenXml.Drawing.Outline>()!
+                .GetFirstChild<DocumentFormat.OpenXml.Drawing.SolidFill>()!
+                .RgbColorModelHex!.GetFirstChild<DocumentFormat.OpenXml.Drawing.Alpha>()!
+                .Val!.Value);
+            Assert.Equal(37647, nativeSeries.GetFirstChild<C.DataPoint>()!
+                .GetFirstChild<C.ChartShapeProperties>()!
+                .GetFirstChild<DocumentFormat.OpenXml.Drawing.SolidFill>()!
+                .RgbColorModelHex!.GetFirstChild<DocumentFormat.OpenXml.Drawing.Alpha>()!
+                .Val!.Value);
+
+            Assert.True(chart.TryGetOfficeSnapshot(out OfficeChartSnapshot snapshot));
+            OfficeChartSeries snapshotSeries = Assert.Single(snapshot.Data.Series);
+            Assert.Equal(seriesColor, snapshotSeries.Color);
+            Assert.Equal(pointColor, Assert.Single(snapshotSeries.PointColors!));
+            Assert.Equal(outlineColor, snapshotSeries.MarkerOutlineColor);
+        }
+
+        [Fact]
         public void BubbleChart_PreservesExplicitlyDisabledSeriesOutline() {
             using PowerPointPresentation presentation =
                 PowerPointPresentation.Create(new MemoryStream());
@@ -331,6 +378,10 @@ namespace OfficeIMO.Tests {
                 new[] { 1D, 2D }, new[] { 2D, 3D }, new[] { 5D }));
             Assert.Throws<ArgumentOutOfRangeException>(() => OfficeChartSeries.CreateBubble("Invalid",
                 new[] { 1D }, new[] { 2D }, new[] { -1D }));
+            Assert.Throws<ArgumentOutOfRangeException>(() => OfficeChartSeries.CreateBubble("Invalid",
+                new[] { double.NaN }, new[] { 2D }, new[] { 1D }));
+            Assert.Throws<ArgumentOutOfRangeException>(() => OfficeChartSeries.CreateBubble("Invalid",
+                new[] { 1D }, new[] { double.PositiveInfinity }, new[] { 1D }));
 
             using PowerPointPresentation presentation =
                 PowerPointPresentation.Create(new MemoryStream());
@@ -528,6 +579,24 @@ namespace OfficeIMO.Tests {
 
             varyColors.Val = false;
             Assert.True(chart.TryGetOfficeSnapshot(out _));
+        }
+
+        [Fact]
+        public void BubbleChart_RejectsTrendlinesFromSharedSnapshots() {
+            using PowerPointPresentation presentation =
+                PowerPointPresentation.Create(new MemoryStream());
+            PowerPointChart chart = presentation.AddSlide().AddChart(
+                OfficeChartKind.Bubble,
+                CreateBubbleData(
+                    new[] { 1D, 2D },
+                    new[] { 2D, 4D },
+                    new[] { 4D, 9D }));
+
+            chart.SetSeriesTrendline(0, C.TrendlineValues.Linear);
+
+            Assert.NotNull(presentation.Slides[0].SlidePart.ChartParts.Single()
+                .ChartSpace!.Descendants<C.Trendline>().Single());
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
         }
 
         private static int CountOccurrences(string value, string marker) {

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
@@ -379,6 +379,20 @@ namespace OfficeIMO.Tests {
 
             chart.SetLegend(C.LegendPositionValues.TopRight);
             Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+            chart.SetLegend(C.LegendPositionValues.Top, overlay: true);
+            C.Legend legend = presentation.Slides[0].SlidePart.ChartParts
+                .Single().ChartSpace!.GetFirstChild<C.Chart>()!
+                .GetFirstChild<C.Legend>()!;
+            C.Layout layout = legend.GetFirstChild<C.Layout>() ??
+                legend.PrependChild(new C.Layout());
+            layout.Append(new C.ManualLayout(
+                new C.LayoutTarget { Val = C.LayoutTargetValues.Inner },
+                new C.LeftMode { Val = C.LayoutModeValues.Factor },
+                new C.TopMode { Val = C.LayoutModeValues.Factor },
+                new C.Left { Val = 0.2D },
+                new C.Top { Val = 0.1D }));
+            Assert.False(chart.TryGetOfficeSnapshot(out _));
         }
 
         [Fact]
@@ -405,6 +419,12 @@ namespace OfficeIMO.Tests {
                 .GetFirstChild<C.Chart>()!.GetFirstChild<C.PlotArea>()!;
             C.PlotArea linePlot = chartParts[2].ChartSpace!
                 .GetFirstChild<C.Chart>()!.GetFirstChild<C.PlotArea>()!;
+            C.StockChart stockChart = bubblePlot.InsertBefore(
+                new C.StockChart(),
+                bubblePlot.GetFirstChild<C.ValueAxis>())!;
+            Assert.False(bubble.TryGetOfficeSnapshot(out _));
+            stockChart.Remove();
+
             bubblePlot.InsertBefore(
                 columnPlot.GetFirstChild<C.BarChart>()!.CloneNode(true),
                 bubblePlot.GetFirstChild<C.ValueAxis>());
@@ -537,6 +557,36 @@ namespace OfficeIMO.Tests {
                 PowerPointUtils.ValidateBubbleWorkbookDimensions(
                     seriesCount: 1,
                     maximumPoints: 100_001));
+        }
+
+        [Fact]
+        public void BubbleChart_WorkbookWritesOnlyExistingUnevenSeriesPoints() {
+            double[] longValues = Enumerable.Range(1, 500)
+                .Select(value => (double)value).ToArray();
+            OfficeChartSeries[] series = new[] {
+                OfficeChartSeries.CreateBubble(
+                    "Long", longValues, longValues, longValues)
+            }.Concat(Enumerable.Range(1, 100).Select(index =>
+                OfficeChartSeries.CreateBubble(
+                    "Short " + index,
+                    new[] { 1D },
+                    new[] { 2D },
+                    new[] { 3D }))).ToArray();
+            var data = new OfficeChartData(
+                longValues.Select(value => value.ToString(
+                    System.Globalization.CultureInfo.InvariantCulture)),
+                series);
+
+            using var stream = new MemoryStream(
+                PowerPointUtils.BuildBubbleChartWorkbook(data));
+            using SpreadsheetDocument workbook =
+                SpreadsheetDocument.Open(stream, false);
+            S.SheetData sheetData = workbook.WorkbookPart!.WorksheetParts
+                .Single().Worksheet.GetFirstChild<S.SheetData>()!;
+
+            Assert.Equal(501, sheetData.Elements<S.Row>().Count());
+            Assert.Equal(303 + 3 * (500 + 100),
+                sheetData.Descendants<S.Cell>().Count());
         }
 
         [Fact]
@@ -735,6 +785,20 @@ namespace OfficeIMO.Tests {
                 Assert.False(chart.TryGetOfficeSnapshot(out _));
 
                 crossesAt.Remove();
+                Assert.True(chart.TryGetOfficeSnapshot(out _));
+
+                C.TickLabelPosition tickLabels =
+                    axis.GetFirstChild<C.TickLabelPosition>()!;
+                tickLabels.Val = C.TickLabelPositionValues.None;
+                Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+                tickLabels.Val = C.TickLabelPositionValues.High;
+                Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+                tickLabels.Val = null;
+                Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+                tickLabels.Val = C.TickLabelPositionValues.NextTo;
                 Assert.True(chart.TryGetOfficeSnapshot(out _));
             }
         }
@@ -1021,6 +1085,59 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void BubbleChart_UpdateDataReplacesNonSolidSeriesOutlineFill() {
+            using PowerPointPresentation presentation =
+                PowerPointPresentation.Create(new MemoryStream());
+            PowerPointChart chart = presentation.AddSlide().AddChart(
+                OfficeChartKind.Bubble,
+                CreateBubbleData(
+                    new[] { 1D },
+                    new[] { 2D },
+                    new[] { 4D },
+                    seriesColor: OfficeColor.Parse("#112233")));
+            A.Outline outline = presentation.Slides[0].SlidePart.ChartParts
+                .Single().ChartSpace!.Descendants<C.BubbleChartSeries>().Single()
+                .GetFirstChild<C.ChartShapeProperties>()!
+                .GetFirstChild<A.Outline>()!;
+            outline.RemoveAllChildren<A.SolidFill>();
+            outline.Append(new A.GradientFill());
+
+            chart.UpdateData(CreateBubbleData(
+                new[] { 3D },
+                new[] { 5D },
+                new[] { 16D },
+                seriesColor: OfficeColor.Parse("#445566"),
+                markerOutlineColor: OfficeColor.Parse("#778899"),
+                markerOutlineWidth: 1.5D));
+
+            outline = presentation.Slides[0].SlidePart.ChartParts.Single()
+                .ChartSpace!.Descendants<C.BubbleChartSeries>().Single()
+                .GetFirstChild<C.ChartShapeProperties>()!
+                .GetFirstChild<A.Outline>()!;
+            Assert.Null(outline.GetFirstChild<A.GradientFill>());
+            Assert.Equal("778899", outline.GetFirstChild<A.SolidFill>()!
+                .RgbColorModelHex!.Val!.Value);
+
+            outline.RemoveAllChildren<A.SolidFill>();
+            outline.Append(new A.GroupFill());
+            chart.UpdateData(CreateBubbleData(
+                new[] { 7D },
+                new[] { 11D },
+                new[] { 25D },
+                seriesColor: OfficeColor.Parse("#445566"),
+                showMarkerOutline: false));
+
+            outline = presentation.Slides[0].SlidePart.ChartParts.Single()
+                .ChartSpace!.Descendants<C.BubbleChartSeries>().Single()
+                .GetFirstChild<C.ChartShapeProperties>()!
+                .GetFirstChild<A.Outline>()!;
+            Assert.Null(outline.GetFirstChild<A.GroupFill>());
+            Assert.NotNull(outline.GetFirstChild<A.NoFill>());
+            Assert.Empty(new OpenXmlValidator().Validate(
+                presentation.Slides[0].SlidePart.ChartParts.Single()));
+        }
+
+        [Fact]
         public void BubbleChart_ResolvesThemeColorsInParameterlessSnapshots() {
             using PowerPointPresentation presentation =
                 PowerPointPresentation.Create(new MemoryStream());
@@ -1148,11 +1265,18 @@ namespace OfficeIMO.Tests {
 
         private static OfficeChartData CreateBubbleData(IReadOnlyList<double> xValues,
             IReadOnlyList<double> yValues, IReadOnlyList<double> sizes,
-            IReadOnlyList<OfficeColor?>? pointColors = null, OfficeColor? seriesColor = null) =>
+            IReadOnlyList<OfficeColor?>? pointColors = null,
+            OfficeColor? seriesColor = null,
+            OfficeColor? markerOutlineColor = null,
+            double? markerOutlineWidth = null,
+            bool showMarkerOutline = true) =>
             new(xValues.Select(value => value.ToString(System.Globalization.CultureInfo.InvariantCulture)),
                 new[] {
                     OfficeChartSeries.CreateBubble("Portfolio", xValues, yValues, sizes,
-                        seriesColor, pointColors)
+                        seriesColor, pointColors,
+                        markerOutlineColor: markerOutlineColor,
+                        markerOutlineWidth: markerOutlineWidth,
+                        showMarkerOutline: showMarkerOutline)
                 });
     }
 }

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
@@ -274,6 +274,49 @@ namespace OfficeIMO.Tests {
                 shape.Shape.FillColor == OfficeColor.Parse("#112233"));
             Assert.Null(bubble.Shape.StrokeColor);
             Assert.Equal(0D, bubble.Shape.StrokeWidth);
+
+            chart.SetSeriesLineColor(0, "445566", widthPoints: 1.25D);
+            Assert.Null(outline.GetFirstChild<A.NoFill>());
+            Assert.Equal("445566", outline.GetFirstChild<A.SolidFill>()!
+                .RgbColorModelHex!.Val!.Value);
+            Assert.Empty(new OpenXmlValidator().Validate(
+                presentation.Slides[0].SlidePart.ChartParts.Single()));
+        }
+
+        [Fact]
+        public void BubbleChart_PreservesHiddenLegendEntriesAcrossSharedSnapshots() {
+            using PowerPointPresentation presentation =
+                PowerPointPresentation.Create(new MemoryStream());
+            PowerPointSlide slide = presentation.AddSlide();
+            var data = new OfficeChartData(new[] { "1", "2" }, new[] {
+                OfficeChartSeries.CreateBubble(
+                    "Hidden Portfolio",
+                    new[] { 1D, 2D },
+                    new[] { 2D, 4D },
+                    new[] { 4D, 9D },
+                    showInLegend: false)
+            });
+            PowerPointChart chart = slide.AddChartPoints(
+                OfficeChartKind.Bubble, data, 30, 20, 420, 250);
+
+            Assert.True(chart.TryGetSnapshot(out PowerPointChartSnapshot native));
+            Assert.False(Assert.Single(native.Data.Series).ShowInLegend);
+            Assert.True(chart.TryGetOfficeSnapshot(out OfficeChartSnapshot shared));
+            Assert.False(Assert.Single(shared.Data.Series).ShowInLegend);
+            OfficeChartSnapshot pdf =
+                PowerPointPdfConverterExtensions.CreateOfficeChartSnapshot(
+                    native, 420D, 250D, new PowerPointPdfSaveOptions());
+            Assert.False(Assert.Single(pdf.Data.Series).ShowInLegend);
+
+            string svg = System.Text.Encoding.UTF8.GetString(
+                slide.ExportImage(OfficeImageExportFormat.Svg).Bytes);
+            Assert.DoesNotContain("Hidden Portfolio", svg, StringComparison.Ordinal);
+
+            string html = presentation.ToHtml(new PowerPointHtmlSaveOptions {
+                Profile = OfficeHtmlConversionProfile.PowerPointSemanticSlides
+            });
+            Assert.Contains("data-officeimo-show-in-legend=\"false\"", html,
+                StringComparison.Ordinal);
         }
 
         [Fact]

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
@@ -486,15 +486,26 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
-        public void BubbleChart_RejectsWorkbookRowOverflow() {
+        public void BubbleChart_RejectsSharedSnapshotPointOverflow() {
             PowerPointUtils.ValidateBubbleWorkbookDimensions(
                 seriesCount: 1,
-                maximumPoints: 1_048_575);
+                maximumPoints: 100_000);
 
             Assert.Throws<ArgumentException>(() =>
                 PowerPointUtils.ValidateBubbleWorkbookDimensions(
                     seriesCount: 1,
+                    maximumPoints: 100_001));
+        }
+
+        [Fact]
+        public void BubbleChart_RejectsWorkbookRowOverflow() {
+            ArgumentException exception = Assert.Throws<ArgumentException>(() =>
+                PowerPointUtils.ValidateBubbleWorkbookDimensions(
+                    seriesCount: 1,
                     maximumPoints: 1_048_576));
+
+            Assert.Contains("worksheet row limit", exception.Message,
+                StringComparison.Ordinal);
         }
 
         [Fact]
@@ -638,6 +649,15 @@ namespace OfficeIMO.Tests {
                 Assert.False(chart.TryGetOfficeSnapshot(out _));
 
                 maximum.Remove();
+                Assert.True(chart.TryGetOfficeSnapshot(out _));
+
+                C.Orientation orientation =
+                    axis.GetFirstChild<C.Scaling>()!
+                        .GetFirstChild<C.Orientation>()!;
+                orientation.Val = C.OrientationValues.MaxMin;
+                Assert.False(chart.TryGetOfficeSnapshot(out _));
+
+                orientation.Val = C.OrientationValues.MinMax;
                 Assert.True(chart.TryGetOfficeSnapshot(out _));
             }
         }

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedChartAuthoring.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedChartAuthoring.cs
@@ -566,6 +566,15 @@ namespace OfficeIMO.Tests {
         }
 
         private static OfficeChartData CreateData(OfficeChartKind kind) {
+            if (kind == OfficeChartKind.Bubble) {
+                return new OfficeChartData(new[] { "1", "2", "3", "4" }, new[] {
+                    OfficeChartSeries.CreateBubble("Portfolio",
+                        new[] { 1D, 2D, 3D, 4D },
+                        new[] { 2D, 4D, 3D, 5D },
+                        new[] { 12D, 28D, 18D, 42D },
+                        OfficeColor.Parse("#0B7FAB"))
+                });
+            }
             if (kind == OfficeChartKind.Scatter) {
                 return new OfficeChartData(new[] { "1", "2", "3", "4" }, new[] {
                     new OfficeChartSeries("Observed", new[] { 2D, 4D, 3D, 5D },

--- a/OfficeIMO.PowerPoint/Imaging/PowerPointSlideImageRenderer.Charts.cs
+++ b/OfficeIMO.PowerPoint/Imaging/PowerPointSlideImageRenderer.Charts.cs
@@ -48,16 +48,19 @@ namespace OfficeIMO.PowerPoint {
             var series = new List<OfficeChartSeries>(snapshot.Data.Series.Count);
             for (int i = 0; i < snapshot.Data.Series.Count; i++) {
                 PowerPointChartSeries item = snapshot.Data.Series[i];
-                series.Add(new OfficeChartSeries(
-                    item.Name,
-                    item.Values,
-                    item.XValues,
-                    color: item.Color,
-                    pointColors: null,
-                    showMarkers: true,
-                    strokeWidth: item.StrokeWidth,
-                    renderKind: MapChartKind(item.ChartKind ?? snapshot.ChartKind),
-                    axisGroup: item.AxisGroup));
+                series.Add(item.BubbleSizes != null
+                    ? OfficeChartSeries.CreateBubble(item.Name, item.XValues!, item.Values,
+                        item.BubbleSizes, item.Color, item.PointColors)
+                    : new OfficeChartSeries(
+                        item.Name,
+                        item.Values,
+                        item.XValues,
+                        color: item.Color,
+                        pointColors: null,
+                        showMarkers: true,
+                        strokeWidth: item.StrokeWidth,
+                        renderKind: MapChartKind(item.ChartKind ?? snapshot.ChartKind),
+                        axisGroup: item.AxisGroup));
             }
 
             return new OfficeChartSnapshot(
@@ -91,6 +94,8 @@ namespace OfficeIMO.PowerPoint {
                     return OfficeChartKind.LineStacked100;
                 case PowerPointChartSnapshotKind.Scatter:
                     return OfficeChartKind.Scatter;
+                case PowerPointChartSnapshotKind.Bubble:
+                    return OfficeChartKind.Bubble;
                 case PowerPointChartSnapshotKind.Pie:
                     return OfficeChartKind.Pie;
                 case PowerPointChartSnapshotKind.Doughnut:

--- a/OfficeIMO.PowerPoint/Imaging/PowerPointSlideImageRenderer.Charts.cs
+++ b/OfficeIMO.PowerPoint/Imaging/PowerPointSlideImageRenderer.Charts.cs
@@ -51,6 +51,7 @@ namespace OfficeIMO.PowerPoint {
                 series.Add(item.BubbleSizes != null
                     ? OfficeChartSeries.CreateBubble(item.Name, item.XValues!, item.Values,
                         item.BubbleSizes, item.Color, item.PointColors,
+                        showInLegend: item.ShowInLegend,
                         markerOutlineColor: item.StrokeColor ?? item.Color,
                         markerOutlineWidth: item.StrokeWidth,
                         showMarkerOutline: item.ShowStroke)
@@ -61,6 +62,7 @@ namespace OfficeIMO.PowerPoint {
                         color: item.Color,
                         pointColors: null,
                         showMarkers: true,
+                        showInLegend: item.ShowInLegend,
                         strokeWidth: item.StrokeWidth,
                         renderKind: MapChartKind(item.ChartKind ?? snapshot.ChartKind),
                         axisGroup: item.AxisGroup));

--- a/OfficeIMO.PowerPoint/Imaging/PowerPointSlideImageRenderer.Charts.cs
+++ b/OfficeIMO.PowerPoint/Imaging/PowerPointSlideImageRenderer.Charts.cs
@@ -50,7 +50,8 @@ namespace OfficeIMO.PowerPoint {
                 PowerPointChartSeries item = snapshot.Data.Series[i];
                 series.Add(item.BubbleSizes != null
                     ? OfficeChartSeries.CreateBubble(item.Name, item.XValues!, item.Values,
-                        item.BubbleSizes, item.Color, item.PointColors)
+                        item.BubbleSizes, item.Color, item.PointColors,
+                        markerOutlineColor: item.Color, markerOutlineWidth: item.StrokeWidth)
                     : new OfficeChartSeries(
                         item.Name,
                         item.Values,

--- a/OfficeIMO.PowerPoint/Imaging/PowerPointSlideImageRenderer.Charts.cs
+++ b/OfficeIMO.PowerPoint/Imaging/PowerPointSlideImageRenderer.Charts.cs
@@ -52,7 +52,8 @@ namespace OfficeIMO.PowerPoint {
                     ? OfficeChartSeries.CreateBubble(item.Name, item.XValues!, item.Values,
                         item.BubbleSizes, item.Color, item.PointColors,
                         markerOutlineColor: item.StrokeColor ?? item.Color,
-                        markerOutlineWidth: item.StrokeWidth)
+                        markerOutlineWidth: item.StrokeWidth,
+                        showMarkerOutline: item.ShowStroke)
                     : new OfficeChartSeries(
                         item.Name,
                         item.Values,

--- a/OfficeIMO.PowerPoint/Imaging/PowerPointSlideImageRenderer.Charts.cs
+++ b/OfficeIMO.PowerPoint/Imaging/PowerPointSlideImageRenderer.Charts.cs
@@ -51,7 +51,8 @@ namespace OfficeIMO.PowerPoint {
                 series.Add(item.BubbleSizes != null
                     ? OfficeChartSeries.CreateBubble(item.Name, item.XValues!, item.Values,
                         item.BubbleSizes, item.Color, item.PointColors,
-                        markerOutlineColor: item.Color, markerOutlineWidth: item.StrokeWidth)
+                        markerOutlineColor: item.StrokeColor ?? item.Color,
+                        markerOutlineWidth: item.StrokeWidth)
                     : new OfficeChartSeries(
                         item.Name,
                         item.Values,
@@ -70,7 +71,9 @@ namespace OfficeIMO.PowerPoint {
                 MapChartKind(snapshot.ChartKind),
                 new OfficeChartData(snapshot.Data.Categories, series),
                 width,
-                height);
+                height,
+                bubbleScalePercent: snapshot.BubbleScalePercent,
+                bubbleSizeMode: snapshot.BubbleSizeMode);
         }
 
         private static OfficeChartKind MapChartKind(PowerPointChartSnapshotKind kind) {

--- a/OfficeIMO.PowerPoint/Imaging/PowerPointSlideImageRenderer.Charts.cs
+++ b/OfficeIMO.PowerPoint/Imaging/PowerPointSlideImageRenderer.Charts.cs
@@ -75,6 +75,8 @@ namespace OfficeIMO.PowerPoint {
                 new OfficeChartData(snapshot.Data.Categories, series),
                 width,
                 height,
+                style: null,
+                layout: snapshot.Layout,
                 bubbleScalePercent: snapshot.BubbleScalePercent,
                 bubbleSizeMode: snapshot.BubbleSizeMode);
         }

--- a/OfficeIMO.PowerPoint/PowerPointChart.Bubbles.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Bubbles.cs
@@ -1,0 +1,63 @@
+using System;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using OfficeIMO.Drawing;
+using C = DocumentFormat.OpenXml.Drawing.Charts;
+
+namespace OfficeIMO.PowerPoint {
+    public partial class PowerPointChart {
+        /// <summary>
+        /// Sets the native bubble scale and whether bubble values represent area or width.
+        /// </summary>
+        /// <param name="scalePercent">Bubble diameter scale from zero through 300 percent.</param>
+        /// <param name="sizeMode">Whether bubble values represent area or width.</param>
+        public PowerPointChart SetBubbleSizing(
+            uint scalePercent, OfficeChartBubbleSizeMode sizeMode) {
+            if (scalePercent > 300U) {
+                throw new ArgumentOutOfRangeException(nameof(scalePercent),
+                    "Bubble scale must be from zero through 300 percent.");
+            }
+            if (!Enum.IsDefined(typeof(OfficeChartBubbleSizeMode), sizeMode)) {
+                throw new ArgumentOutOfRangeException(nameof(sizeMode));
+            }
+
+            ChartPart chartPart = GetChartPart();
+            C.BubbleChart? bubbleChart = chartPart.ChartSpace?
+                .GetFirstChild<C.Chart>()?
+                .GetFirstChild<C.PlotArea>()?
+                .GetFirstChild<C.BubbleChart>();
+            if (bubbleChart == null) {
+                throw new NotSupportedException(
+                    "Bubble sizing can only be set on a bubble chart.");
+            }
+
+            C.BubbleScale scale = bubbleChart.GetFirstChild<C.BubbleScale>() ??
+                new C.BubbleScale();
+            scale.Val = scalePercent;
+            if (scale.Parent == null) {
+                OpenXmlElement? insertBefore =
+                    bubbleChart.GetFirstChild<C.ShowNegativeBubbles>() ??
+                    (OpenXmlElement?)bubbleChart.GetFirstChild<C.SizeRepresents>() ??
+                    bubbleChart.GetFirstChild<C.AxisId>();
+                if (insertBefore == null) bubbleChart.Append(scale);
+                else bubbleChart.InsertBefore(scale, insertBefore);
+            }
+
+            C.SizeRepresents represents =
+                bubbleChart.GetFirstChild<C.SizeRepresents>() ??
+                new C.SizeRepresents();
+            represents.Val = sizeMode == OfficeChartBubbleSizeMode.Width
+                ? C.SizeRepresentsValues.Width
+                : C.SizeRepresentsValues.Area;
+            if (represents.Parent == null) {
+                OpenXmlElement? insertBefore =
+                    bubbleChart.GetFirstChild<C.AxisId>();
+                if (insertBefore == null) bubbleChart.Append(represents);
+                else bubbleChart.InsertBefore(represents, insertBefore);
+            }
+
+            Save();
+            return this;
+        }
+    }
+}

--- a/OfficeIMO.PowerPoint/PowerPointChart.Bubbles.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Bubbles.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using OfficeIMO.Drawing;
@@ -22,15 +23,27 @@ namespace OfficeIMO.PowerPoint {
             }
 
             ChartPart chartPart = GetChartPart();
-            C.BubbleChart? bubbleChart = chartPart.ChartSpace?
+            C.PlotArea? plotArea = chartPart.ChartSpace?
                 .GetFirstChild<C.Chart>()?
-                .GetFirstChild<C.PlotArea>()?
-                .GetFirstChild<C.BubbleChart>();
-            if (bubbleChart == null) {
+                .GetFirstChild<C.PlotArea>();
+            C.BubbleChart[] bubbleCharts = plotArea?
+                .Elements<C.BubbleChart>()
+                .ToArray() ?? Array.Empty<C.BubbleChart>();
+            if (bubbleCharts.Length == 0) {
                 throw new NotSupportedException(
                     "Bubble sizing can only be set on a bubble chart.");
             }
 
+            foreach (C.BubbleChart bubbleChart in bubbleCharts) {
+                ApplyBubbleSizing(bubbleChart, scalePercent, sizeMode);
+            }
+
+            Save();
+            return this;
+        }
+
+        private static void ApplyBubbleSizing(C.BubbleChart bubbleChart,
+            uint scalePercent, OfficeChartBubbleSizeMode sizeMode) {
             C.BubbleScale scale = bubbleChart.GetFirstChild<C.BubbleScale>() ??
                 new C.BubbleScale();
             scale.Val = scalePercent;
@@ -55,9 +68,6 @@ namespace OfficeIMO.PowerPoint {
                 if (insertBefore == null) bubbleChart.Append(represents);
                 else bubbleChart.InsertBefore(represents, insertBefore);
             }
-
-            Save();
-            return this;
         }
     }
 }

--- a/OfficeIMO.PowerPoint/PowerPointChart.DataLabelHelpers.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.DataLabelHelpers.cs
@@ -300,6 +300,7 @@ namespace OfficeIMO.PowerPoint {
             } else {
                 insertBefore = chartElement.GetFirstChild<C.GapWidth>();
                 insertBefore ??= chartElement.GetFirstChild<C.Overlap>();
+                insertBefore ??= chartElement.GetFirstChild<C.Bubble3D>();
                 insertBefore ??= chartElement.GetFirstChild<C.BubbleScale>();
                 insertBefore ??= chartElement.GetFirstChild<C.ShowNegativeBubbles>();
                 insertBefore ??= chartElement.GetFirstChild<C.SizeRepresents>();

--- a/OfficeIMO.PowerPoint/PowerPointChart.DataLabels.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.DataLabels.cs
@@ -47,6 +47,9 @@ namespace OfficeIMO.PowerPoint {
             foreach (C.ScatterChart scatterChart in plotArea.Elements<C.ScatterChart>()) {
                 ApplyDataLabels(scatterChart, showLegendKey, showValue, showCategoryName, showSeriesName, showPercent);
             }
+            foreach (C.BubbleChart bubbleChart in plotArea.Elements<C.BubbleChart>()) {
+                ApplyDataLabels(bubbleChart, showLegendKey, showValue, showCategoryName, showSeriesName, showPercent);
+            }
 
             Save();
             return this;
@@ -85,6 +88,9 @@ namespace OfficeIMO.PowerPoint {
             foreach (C.ScatterChart scatterChart in plotArea.Elements<C.ScatterChart>()) {
                 RemoveDataLabels(scatterChart);
             }
+            foreach (C.BubbleChart bubbleChart in plotArea.Elements<C.BubbleChart>()) {
+                RemoveDataLabels(bubbleChart);
+            }
 
             Save();
             return this;
@@ -122,6 +128,9 @@ namespace OfficeIMO.PowerPoint {
 
             foreach (C.ScatterChart scatterChart in plotArea.Elements<C.ScatterChart>()) {
                 SetDataLabelPosition(EnsureDataLabels(scatterChart), position);
+            }
+            foreach (C.BubbleChart bubbleChart in plotArea.Elements<C.BubbleChart>()) {
+                SetDataLabelPosition(EnsureDataLabels(bubbleChart), position);
             }
 
             Save();
@@ -164,6 +173,9 @@ namespace OfficeIMO.PowerPoint {
 
             foreach (C.ScatterChart scatterChart in plotArea.Elements<C.ScatterChart>()) {
                 SetDataLabelNumberFormat(EnsureDataLabels(scatterChart), formatCode, sourceLinked);
+            }
+            foreach (C.BubbleChart bubbleChart in plotArea.Elements<C.BubbleChart>()) {
+                SetDataLabelNumberFormat(EnsureDataLabels(bubbleChart), formatCode, sourceLinked);
             }
 
             Save();

--- a/OfficeIMO.PowerPoint/PowerPointChart.SeriesAndAreas.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.SeriesAndAreas.cs
@@ -195,6 +195,9 @@ namespace OfficeIMO.PowerPoint {
             foreach (C.ScatterChart scatterChart in plotArea.Elements<C.ScatterChart>()) {
                 apply(EnsureDataLabels(scatterChart));
             }
+            foreach (C.BubbleChart bubbleChart in plotArea.Elements<C.BubbleChart>()) {
+                apply(EnsureDataLabels(bubbleChart));
+            }
 
             Save();
             return this;

--- a/OfficeIMO.PowerPoint/PowerPointChart.SeriesHelpers.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.SeriesHelpers.cs
@@ -26,6 +26,7 @@ namespace OfficeIMO.PowerPoint {
             if (ApplySeriesByIndex(plotArea.Elements<C.PieChart>(), seriesIndex, apply)) return true;
             if (ApplySeriesByIndex(plotArea.Elements<C.DoughnutChart>(), seriesIndex, apply)) return true;
             if (ApplySeriesByIndex(plotArea.Elements<C.ScatterChart>(), seriesIndex, apply)) return true;
+            if (ApplySeriesByIndex(plotArea.Elements<C.BubbleChart>(), seriesIndex, apply)) return true;
 
             return false;
         }
@@ -43,6 +44,7 @@ namespace OfficeIMO.PowerPoint {
             if (ApplySeriesByName(plotArea.Elements<C.PieChart>(), seriesName, ignoreCase, apply)) return true;
             if (ApplySeriesByName(plotArea.Elements<C.DoughnutChart>(), seriesName, ignoreCase, apply)) return true;
             if (ApplySeriesByName(plotArea.Elements<C.ScatterChart>(), seriesName, ignoreCase, apply)) return true;
+            if (ApplySeriesByName(plotArea.Elements<C.BubbleChart>(), seriesName, ignoreCase, apply)) return true;
 
             return false;
         }
@@ -157,7 +159,8 @@ namespace OfficeIMO.PowerPoint {
                    element is C.LineChartSeries ||
                    element is C.AreaChartSeries ||
                    element is C.PieChartSeries ||
-                   element is C.ScatterChartSeries;
+                   element is C.ScatterChartSeries ||
+                   element is C.BubbleChartSeries;
         }
 
         private static int GetSeriesIndex(OpenXmlCompositeElement series) {

--- a/OfficeIMO.PowerPoint/PowerPointChart.ShapeStyleHelpers.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.ShapeStyleHelpers.cs
@@ -164,7 +164,7 @@ namespace OfficeIMO.PowerPoint {
             props.RemoveAllChildren<A.NoFill>();
             props.RemoveAllChildren<A.GradientFill>();
             props.RemoveAllChildren<A.PatternFill>();
-            props.Append(new A.SolidFill(new A.RgbColorModelHex { Val = color }));
+            props.AddChild(new A.SolidFill(new A.RgbColorModelHex { Val = color }), true);
         }
 
         private static void ApplyNoFill(OpenXmlCompositeElement props) {
@@ -172,7 +172,7 @@ namespace OfficeIMO.PowerPoint {
             props.RemoveAllChildren<A.GradientFill>();
             props.RemoveAllChildren<A.PatternFill>();
             props.RemoveAllChildren<A.NoFill>();
-            props.Append(new A.NoFill());
+            props.AddChild(new A.NoFill(), true);
         }
 
         private static void ApplyNoLine(OpenXmlCompositeElement props) {
@@ -330,7 +330,8 @@ namespace OfficeIMO.PowerPoint {
             return series is C.LineChartSeries
                    || series is C.BarChartSeries
                    || series is C.AreaChartSeries
-                   || series is C.ScatterChartSeries;
+                   || series is C.ScatterChartSeries
+                   || series is C.BubbleChartSeries;
         }
 
         private static void InsertTrendline(OpenXmlCompositeElement series, C.Trendline trendline) {

--- a/OfficeIMO.PowerPoint/PowerPointChart.ShapeStyleHelpers.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.ShapeStyleHelpers.cs
@@ -164,6 +164,8 @@ namespace OfficeIMO.PowerPoint {
             props.RemoveAllChildren<A.NoFill>();
             props.RemoveAllChildren<A.GradientFill>();
             props.RemoveAllChildren<A.PatternFill>();
+            props.RemoveAllChildren<A.BlipFill>();
+            props.RemoveAllChildren<A.GroupFill>();
             props.AddChild(new A.SolidFill(new A.RgbColorModelHex { Val = color }), true);
         }
 
@@ -171,6 +173,8 @@ namespace OfficeIMO.PowerPoint {
             props.RemoveAllChildren<A.SolidFill>();
             props.RemoveAllChildren<A.GradientFill>();
             props.RemoveAllChildren<A.PatternFill>();
+            props.RemoveAllChildren<A.BlipFill>();
+            props.RemoveAllChildren<A.GroupFill>();
             props.RemoveAllChildren<A.NoFill>();
             props.AddChild(new A.NoFill(), true);
         }

--- a/OfficeIMO.PowerPoint/PowerPointChart.ShapeStyleHelpers.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.ShapeStyleHelpers.cs
@@ -197,7 +197,9 @@ namespace OfficeIMO.PowerPoint {
             outline.RemoveAllChildren<A.PatternFill>();
             outline.RemoveAllChildren<A.BlipFill>();
             outline.RemoveAllChildren<A.GroupFill>();
-            outline.Append(new A.SolidFill(new A.RgbColorModelHex { Val = color }));
+            outline.AddChild(
+                new A.SolidFill(
+                    new A.RgbColorModelHex { Val = color }), true);
             if (widthPoints != null) {
                 outline.Width = (int)Math.Round(widthPoints.Value * 12700d);
             }
@@ -215,7 +217,9 @@ namespace OfficeIMO.PowerPoint {
             A.Outline outline = props.GetFirstChild<A.Outline>() ?? new A.Outline();
             if (color != null) {
                 outline.RemoveAllChildren<A.SolidFill>();
-                outline.Append(new A.SolidFill(new A.RgbColorModelHex { Val = color }));
+                outline.AddChild(
+                    new A.SolidFill(
+                        new A.RgbColorModelHex { Val = color }), true);
             }
             if (widthPoints != null) {
                 outline.Width = (int)Math.Round(widthPoints.Value * 12700d);

--- a/OfficeIMO.PowerPoint/PowerPointChart.ShapeStyleHelpers.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.ShapeStyleHelpers.cs
@@ -189,6 +189,10 @@ namespace OfficeIMO.PowerPoint {
             A.Outline outline = props.GetFirstChild<A.Outline>() ?? new A.Outline();
             outline.RemoveAllChildren<A.SolidFill>();
             outline.RemoveAllChildren<A.NoFill>();
+            outline.RemoveAllChildren<A.GradientFill>();
+            outline.RemoveAllChildren<A.PatternFill>();
+            outline.RemoveAllChildren<A.BlipFill>();
+            outline.RemoveAllChildren<A.GroupFill>();
             outline.Append(new A.SolidFill(new A.RgbColorModelHex { Val = color }));
             if (widthPoints != null) {
                 outline.Width = (int)Math.Round(widthPoints.Value * 12700d);

--- a/OfficeIMO.PowerPoint/PowerPointChart.ShapeStyleHelpers.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.ShapeStyleHelpers.cs
@@ -188,6 +188,7 @@ namespace OfficeIMO.PowerPoint {
         private static void ApplyLine(OpenXmlCompositeElement props, string color, double? widthPoints) {
             A.Outline outline = props.GetFirstChild<A.Outline>() ?? new A.Outline();
             outline.RemoveAllChildren<A.SolidFill>();
+            outline.RemoveAllChildren<A.NoFill>();
             outline.Append(new A.SolidFill(new A.RgbColorModelHex { Val = color }));
             if (widthPoints != null) {
                 outline.Width = (int)Math.Round(widthPoints.Value * 12700d);

--- a/OfficeIMO.PowerPoint/PowerPointChart.SharedContract.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.SharedContract.cs
@@ -144,7 +144,8 @@ namespace OfficeIMO.PowerPoint {
                     }
                     series.Add(OfficeChartSeries.CreateBubble(item.Name, item.XValues!,
                         item.Values, item.BubbleSizes, item.Color, item.PointColors,
-                        showInLegend: showInLegend, markerOutlineColor: item.Color,
+                        showInLegend: showInLegend,
+                        markerOutlineColor: item.StrokeColor ?? item.Color,
                         markerOutlineWidth: item.StrokeWidth));
                 } else {
                     series.Add(new OfficeChartSeries(item.Name, item.Values, item.XValues, item.Color,
@@ -157,7 +158,9 @@ namespace OfficeIMO.PowerPoint {
             }
             var data = new OfficeChartData(powerPointSnapshot.Data.Categories, series);
             snapshot = new OfficeChartSnapshot(powerPointSnapshot.Name, powerPointSnapshot.Title, kind, data,
-                powerPointSnapshot.WidthPoints, powerPointSnapshot.HeightPoints);
+                powerPointSnapshot.WidthPoints, powerPointSnapshot.HeightPoints,
+                bubbleScalePercent: powerPointSnapshot.BubbleScalePercent,
+                bubbleSizeMode: powerPointSnapshot.BubbleSizeMode);
             return true;
         }
 

--- a/OfficeIMO.PowerPoint/PowerPointChart.SharedContract.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.SharedContract.cs
@@ -144,7 +144,8 @@ namespace OfficeIMO.PowerPoint {
                     }
                     series.Add(OfficeChartSeries.CreateBubble(item.Name, item.XValues!,
                         item.Values, item.BubbleSizes, item.Color, item.PointColors,
-                        showInLegend: showInLegend));
+                        showInLegend: showInLegend, markerOutlineColor: item.Color,
+                        markerOutlineWidth: item.StrokeWidth));
                 } else {
                     series.Add(new OfficeChartSeries(item.Name, item.Values, item.XValues, item.Color,
                         pointColors: null, showMarkers: true,

--- a/OfficeIMO.PowerPoint/PowerPointChart.SharedContract.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.SharedContract.cs
@@ -14,11 +14,11 @@ namespace OfficeIMO.PowerPoint {
         /// <summary>Updates the native chart from the shared OfficeIMO chart contract.</summary>
         public PowerPointChart UpdateData(OfficeChartData data) {
             if (data == null) throw new ArgumentNullException(nameof(data));
-            if (!TryGetOfficeSnapshot(out OfficeChartSnapshot current)) {
+            if (!TryGetSnapshotForUpdate(out PowerPointChartSnapshot current)) {
                 throw new NotSupportedException(
                     "The current chart kind cannot be updated through the shared OfficeIMO chart contract.");
             }
-            OfficeChartKind chartKind = current.ChartKind;
+            OfficeChartKind chartKind = MapKind(current.ChartKind);
             PowerPointUtils.ValidateSharedChartData(data, chartKind);
 
             ChartPart chartPart = GetChartPart();
@@ -167,7 +167,8 @@ namespace OfficeIMO.PowerPoint {
             C.Legend? legend = chart.GetFirstChild<C.Legend>();
             if (legend == null) return result;
             foreach (C.LegendEntry entry in legend.Elements<C.LegendEntry>()) {
-                if (entry.GetFirstChild<C.Delete>()?.Val?.Value == true &&
+                C.Delete? delete = entry.GetFirstChild<C.Delete>();
+                if (delete != null && delete.Val?.Value != false &&
                     entry.Index?.Val?.Value is uint seriesIndex) {
                     result.Add(seriesIndex);
                 }

--- a/OfficeIMO.PowerPoint/PowerPointChart.SharedContract.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.SharedContract.cs
@@ -26,9 +26,12 @@ namespace OfficeIMO.PowerPoint {
 
             EmbeddedPackagePart? embedded = chartPart.GetPartsOfType<EmbeddedPackagePart>().FirstOrDefault();
             if (embedded != null) {
-                byte[] workbookBytes = chartKind == OfficeChartKind.Scatter
-                    ? PowerPointUtils.BuildChartWorkbook(PowerPointUtils.ToPowerPointScatterChartData(data))
-                    : PowerPointUtils.BuildChartWorkbook(PowerPointUtils.ToPowerPointChartData(data));
+                byte[] workbookBytes = chartKind switch {
+                    OfficeChartKind.Scatter =>
+                        PowerPointUtils.BuildChartWorkbook(PowerPointUtils.ToPowerPointScatterChartData(data)),
+                    OfficeChartKind.Bubble => PowerPointUtils.BuildBubbleChartWorkbook(data),
+                    _ => PowerPointUtils.BuildChartWorkbook(PowerPointUtils.ToPowerPointChartData(data))
+                };
                 using var stream = new MemoryStream(workbookBytes);
                 embedded.FeedData(stream);
             }
@@ -41,9 +44,9 @@ namespace OfficeIMO.PowerPoint {
             if (data == null) throw new ArgumentNullException(nameof(data));
             var builder = new StringBuilder();
             builder.Append("Chart kind: ").Append(chartKind).AppendLine();
-            if (chartKind == OfficeChartKind.Scatter &&
+            if ((chartKind == OfficeChartKind.Scatter || chartKind == OfficeChartKind.Bubble) &&
                 data.Series.Any(series => series.XValues != null)) {
-                AppendScatterDataSummary(builder, data);
+                AppendNumericPointDataSummary(builder, data, includeBubbleSize: chartKind == OfficeChartKind.Bubble);
                 return builder.ToString();
             }
             builder.Append("Category");
@@ -64,8 +67,9 @@ namespace OfficeIMO.PowerPoint {
             return builder.ToString();
         }
 
-        private static void AppendScatterDataSummary(StringBuilder builder, OfficeChartData data) {
-            builder.AppendLine("Series\tX\tY");
+        private static void AppendNumericPointDataSummary(StringBuilder builder, OfficeChartData data,
+            bool includeBubbleSize) {
+            builder.AppendLine(includeBubbleSize ? "Series\tX\tY\tSize" : "Series\tX\tY");
             bool firstPoint = true;
             foreach (OfficeChartSeries series in data.Series) {
                 for (int pointIndex = 0; pointIndex < series.Values.Count; pointIndex++) {
@@ -79,6 +83,13 @@ namespace OfficeIMO.PowerPoint {
                     }
                     builder.Append('\t')
                         .Append(series.Values[pointIndex].ToString("G", CultureInfo.InvariantCulture));
+                    if (includeBubbleSize) {
+                        builder.Append('\t');
+                        if (series.BubbleSizes != null && pointIndex < series.BubbleSizes.Count) {
+                            builder.Append(series.BubbleSizes[pointIndex]
+                                .ToString("G", CultureInfo.InvariantCulture));
+                        }
+                    }
                 }
             }
         }
@@ -124,12 +135,24 @@ namespace OfficeIMO.PowerPoint {
             for (int seriesIndex = 0; seriesIndex < powerPointSnapshot.Data.Series.Count; seriesIndex++) {
                 PowerPointChartSeries item = powerPointSnapshot.Data.Series[seriesIndex];
                 uint sourceIndex = item.SourceIndex ?? (uint)seriesIndex;
-                series.Add(new OfficeChartSeries(item.Name, item.Values, item.XValues, item.Color,
-                    pointColors: null, showMarkers: true,
-                    showInLegend: !hiddenLegendSeries.Contains(sourceIndex), connectLine: true,
-                    strokeWidth: item.StrokeWidth,
-                    renderKind: item.ChartKind.HasValue ? MapKind(item.ChartKind.Value) : null,
-                    axisGroup: item.AxisGroup));
+                bool showInLegend = !hiddenLegendSeries.Contains(sourceIndex);
+                if (item.BubbleSizes != null) {
+                    if (item.XValues == null || item.BubbleSizes.Any(size =>
+                            double.IsNaN(size) || double.IsInfinity(size) || size < 0D)) {
+                        snapshot = null!;
+                        return false;
+                    }
+                    series.Add(OfficeChartSeries.CreateBubble(item.Name, item.XValues!,
+                        item.Values, item.BubbleSizes, item.Color, item.PointColors,
+                        showInLegend: showInLegend));
+                } else {
+                    series.Add(new OfficeChartSeries(item.Name, item.Values, item.XValues, item.Color,
+                        pointColors: null, showMarkers: true,
+                        showInLegend: showInLegend, connectLine: true,
+                        strokeWidth: item.StrokeWidth,
+                        renderKind: item.ChartKind.HasValue ? MapKind(item.ChartKind.Value) : null,
+                        axisGroup: item.AxisGroup));
+                }
             }
             var data = new OfficeChartData(powerPointSnapshot.Data.Categories, series);
             snapshot = new OfficeChartSnapshot(powerPointSnapshot.Name, powerPointSnapshot.Title, kind, data,
@@ -168,6 +191,7 @@ namespace OfficeIMO.PowerPoint {
                 case PowerPointChartSnapshotKind.StackedArea: return OfficeChartKind.AreaStacked;
                 case PowerPointChartSnapshotKind.StackedArea100: return OfficeChartKind.AreaStacked100;
                 case PowerPointChartSnapshotKind.Scatter: return OfficeChartKind.Scatter;
+                case PowerPointChartSnapshotKind.Bubble: return OfficeChartKind.Bubble;
                 case PowerPointChartSnapshotKind.Radar: return OfficeChartKind.Radar;
                 case PowerPointChartSnapshotKind.Pie: return OfficeChartKind.Pie;
                 case PowerPointChartSnapshotKind.Doughnut: return OfficeChartKind.Doughnut;

--- a/OfficeIMO.PowerPoint/PowerPointChart.SharedContract.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.SharedContract.cs
@@ -146,7 +146,8 @@ namespace OfficeIMO.PowerPoint {
                         item.Values, item.BubbleSizes, item.Color, item.PointColors,
                         showInLegend: showInLegend,
                         markerOutlineColor: item.StrokeColor ?? item.Color,
-                        markerOutlineWidth: item.StrokeWidth));
+                        markerOutlineWidth: item.StrokeWidth,
+                        showMarkerOutline: item.ShowStroke));
                 } else {
                     series.Add(new OfficeChartSeries(item.Name, item.Values, item.XValues, item.Color,
                         pointColors: null, showMarkers: true,

--- a/OfficeIMO.PowerPoint/PowerPointChart.SharedContract.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.SharedContract.cs
@@ -22,9 +22,14 @@ namespace OfficeIMO.PowerPoint {
             PowerPointUtils.ValidateSharedChartData(data, chartKind);
 
             ChartPart chartPart = GetChartPart();
+            EmbeddedPackagePart? embedded = chartPart
+                .GetPartsOfType<EmbeddedPackagePart>().FirstOrDefault();
+            if (chartKind == OfficeChartKind.Bubble && embedded == null) {
+                throw new NotSupportedException(
+                    "Bubble chart data cannot be updated without an embedded workbook.");
+            }
             PowerPointUtils.UpdateSharedChartData(chartPart, data, chartKind);
 
-            EmbeddedPackagePart? embedded = chartPart.GetPartsOfType<EmbeddedPackagePart>().FirstOrDefault();
             if (embedded != null) {
                 byte[] workbookBytes = chartKind switch {
                     OfficeChartKind.Scatter =>

--- a/OfficeIMO.PowerPoint/PowerPointChart.SharedContract.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.SharedContract.cs
@@ -157,6 +157,8 @@ namespace OfficeIMO.PowerPoint {
             var data = new OfficeChartData(powerPointSnapshot.Data.Categories, series);
             snapshot = new OfficeChartSnapshot(powerPointSnapshot.Name, powerPointSnapshot.Title, kind, data,
                 powerPointSnapshot.WidthPoints, powerPointSnapshot.HeightPoints,
+                style: null,
+                layout: powerPointSnapshot.Layout,
                 bubbleScalePercent: powerPointSnapshot.BubbleScalePercent,
                 bubbleSizeMode: powerPointSnapshot.BubbleSizeMode);
             return true;

--- a/OfficeIMO.PowerPoint/PowerPointChart.SharedContract.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.SharedContract.cs
@@ -130,12 +130,9 @@ namespace OfficeIMO.PowerPoint {
                 return false;
             }
             OfficeChartKind kind = MapKind(powerPointSnapshot.ChartKind);
-            HashSet<uint> hiddenLegendSeries = GetHiddenLegendSeriesIndexes();
             var series = new List<OfficeChartSeries>(powerPointSnapshot.Data.Series.Count);
             for (int seriesIndex = 0; seriesIndex < powerPointSnapshot.Data.Series.Count; seriesIndex++) {
                 PowerPointChartSeries item = powerPointSnapshot.Data.Series[seriesIndex];
-                uint sourceIndex = item.SourceIndex ?? (uint)seriesIndex;
-                bool showInLegend = !hiddenLegendSeries.Contains(sourceIndex);
                 if (item.BubbleSizes != null) {
                     if (item.XValues == null || item.BubbleSizes.Any(size =>
                             double.IsNaN(size) || double.IsInfinity(size) || size < 0D)) {
@@ -144,14 +141,14 @@ namespace OfficeIMO.PowerPoint {
                     }
                     series.Add(OfficeChartSeries.CreateBubble(item.Name, item.XValues!,
                         item.Values, item.BubbleSizes, item.Color, item.PointColors,
-                        showInLegend: showInLegend,
+                        showInLegend: item.ShowInLegend,
                         markerOutlineColor: item.StrokeColor ?? item.Color,
                         markerOutlineWidth: item.StrokeWidth,
                         showMarkerOutline: item.ShowStroke));
                 } else {
                     series.Add(new OfficeChartSeries(item.Name, item.Values, item.XValues, item.Color,
                         pointColors: null, showMarkers: true,
-                        showInLegend: showInLegend, connectLine: true,
+                        showInLegend: item.ShowInLegend, connectLine: true,
                         strokeWidth: item.StrokeWidth,
                         renderKind: item.ChartKind.HasValue ? MapKind(item.ChartKind.Value) : null,
                         axisGroup: item.AxisGroup));
@@ -165,9 +162,9 @@ namespace OfficeIMO.PowerPoint {
             return true;
         }
 
-        private HashSet<uint> GetHiddenLegendSeriesIndexes() {
+        private static HashSet<uint> GetHiddenLegendSeriesIndexes(C.Chart chart) {
             var result = new HashSet<uint>();
-            C.Legend? legend = GetChart().GetFirstChild<C.Legend>();
+            C.Legend? legend = chart.GetFirstChild<C.Legend>();
             if (legend == null) return result;
             foreach (C.LegendEntry entry in legend.Elements<C.LegendEntry>()) {
                 if (entry.GetFirstChild<C.Delete>()?.Val?.Value == true &&

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.BubbleWorkbook.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.BubbleWorkbook.cs
@@ -1,0 +1,36 @@
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using C = DocumentFormat.OpenXml.Drawing.Charts;
+using S = DocumentFormat.OpenXml.Spreadsheet;
+
+namespace OfficeIMO.PowerPoint {
+    public partial class PowerPointChart {
+        private static bool HasUnsupportedBubbleSourceVisibility(
+            ChartPart chartPart, C.Chart chart) {
+            C.PlotVisibleOnly? plotVisibleOnly =
+                chart.GetFirstChild<C.PlotVisibleOnly>();
+            if (plotVisibleOnly == null ||
+                plotVisibleOnly.Val?.Value == false) {
+                return false;
+            }
+
+            EmbeddedPackagePart? embedded = chartPart
+                .GetPartsOfType<EmbeddedPackagePart>().FirstOrDefault();
+            if (embedded == null) return true;
+            try {
+                using Stream stream = embedded.GetStream(
+                    FileMode.Open, FileAccess.Read);
+                using SpreadsheetDocument workbook =
+                    SpreadsheetDocument.Open(stream, false);
+                return workbook.WorkbookPart?.WorksheetParts.Any(part =>
+                    part.Worksheet?.Descendants<S.Row>().Any(row =>
+                        row.Hidden?.Value == true) == true ||
+                    part.Worksheet?.Descendants<S.Column>().Any(column =>
+                        column.Hidden?.Value == true) == true) != false;
+            } catch {
+                return true;
+            }
+        }
+    }
+}

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.Bubbles.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.Bubbles.cs
@@ -79,6 +79,11 @@ namespace OfficeIMO.PowerPoint {
                 IReadOnlyList<double> normalizedX = xValues.Take(pointCount).ToList();
                 categoryXValues ??= normalizedX;
                 string name = ReadSeriesName(element);
+                if (!forDataUpdate && string.IsNullOrWhiteSpace(name) &&
+                    element.GetFirstChild<C.SeriesText>()?
+                        .GetFirstChild<C.StringReference>() != null) {
+                    return null;
+                }
                 if (string.IsNullOrWhiteSpace(name)) {
                     name = "Series " + (seriesIndex + 1).ToString(CultureInfo.InvariantCulture);
                 }
@@ -137,12 +142,22 @@ namespace OfficeIMO.PowerPoint {
                      or PresetDash or CustomDash));
 
         private static bool HasUnresolvedSeriesColor(
-            C.ChartShapeProperties? properties, ColorScheme? colorScheme) =>
-            !OfficeOpenXmlThemeColorResolver.ResolveColor(
-                properties?.GetFirstChild<SolidFill>(), colorScheme).HasValue ||
-            HasUnresolvedSolidFill(
-                properties?.GetFirstChild<Outline>()?.GetFirstChild<SolidFill>(),
-                colorScheme);
+            C.ChartShapeProperties? properties, ColorScheme? colorScheme) {
+            if (!OfficeOpenXmlThemeColorResolver.ResolveColor(
+                    properties?.GetFirstChild<SolidFill>(), colorScheme).HasValue) {
+                return true;
+            }
+
+            Outline? outline = properties?.GetFirstChild<Outline>();
+            if (outline == null ||
+                (outline.GetFirstChild<NoFill>() == null &&
+                 outline.GetFirstChild<SolidFill>() == null)) {
+                return true;
+            }
+
+            return HasUnresolvedSolidFill(
+                outline.GetFirstChild<SolidFill>(), colorScheme);
+        }
 
         private static bool HasUnresolvedPointColor(
             C.ChartShapeProperties? properties, ColorScheme? colorScheme) =>

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.Bubbles.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.Bubbles.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using DocumentFormat.OpenXml.Drawing;
+using C = DocumentFormat.OpenXml.Drawing.Charts;
+
+namespace OfficeIMO.PowerPoint {
+    public partial class PowerPointChart {
+        private static PowerPointChartData? ReadBubbleSeriesData(
+            IEnumerable<C.BubbleChartSeries> seriesElements, ColorScheme? colorScheme = null) {
+            List<C.BubbleChartSeries> source = seriesElements.ToList();
+            if (source.Count == 0) return null;
+
+            var series = new List<PowerPointChartSeries>();
+            IReadOnlyList<double>? categoryXValues = null;
+            for (int seriesIndex = 0; seriesIndex < source.Count; seriesIndex++) {
+                C.BubbleChartSeries element = source[seriesIndex];
+                IReadOnlyList<double> xValues =
+                    ReadCachedNumbers(element.GetFirstChild<C.XValues>());
+                IReadOnlyList<double> yValues =
+                    ReadCachedNumbers(element.GetFirstChild<C.YValues>());
+                IReadOnlyList<double> bubbleSizes =
+                    ReadCachedNumbers(element.GetFirstChild<C.BubbleSize>());
+                int pointCount = Math.Min(xValues.Count,
+                    Math.Min(yValues.Count, bubbleSizes.Count));
+                if (pointCount == 0) continue;
+
+                IReadOnlyList<double> normalizedY = NormalizeValues(yValues, pointCount);
+                IReadOnlyList<double> normalizedSizes = NormalizeValues(bubbleSizes, pointCount);
+                if (normalizedY.Count == 0 || normalizedSizes.Count == 0) continue;
+
+                IReadOnlyList<double> normalizedX = xValues.Take(pointCount).ToList();
+                categoryXValues ??= normalizedX;
+                string name = ReadSeriesName(element);
+                if (string.IsNullOrWhiteSpace(name)) {
+                    name = "Series " + (seriesIndex + 1).ToString(CultureInfo.InvariantCulture);
+                }
+
+                var item = new PowerPointChartSeries(name, normalizedY, normalizedX,
+                    PowerPointChartSnapshotKind.Bubble,
+                    ReadSeriesColor(element, PowerPointChartSnapshotKind.Bubble, colorScheme),
+                    ReadSeriesStrokeWidth(element)) {
+                    BubbleSizes = normalizedSizes,
+                    PointColors = ReadBubblePointColors(element, pointCount, colorScheme),
+                    SourceIndex = element.GetFirstChild<C.Index>()?.Val?.Value
+                };
+                series.Add(item);
+            }
+
+            if (series.Count == 0 || categoryXValues == null || categoryXValues.Count == 0) {
+                return null;
+            }
+
+            IReadOnlyList<string> categories = categoryXValues.Select(value =>
+                value.ToString(CultureInfo.InvariantCulture)).ToList();
+            return new PowerPointChartData(categories, series);
+        }
+
+        private static IReadOnlyList<OfficeColor?>? ReadBubblePointColors(
+            C.BubbleChartSeries series, int pointCount, ColorScheme? colorScheme) {
+            var colors = new OfficeColor?[pointCount];
+            bool found = false;
+            foreach (C.DataPoint point in series.Elements<C.DataPoint>()) {
+                uint? sourceIndex = point.GetFirstChild<C.Index>()?.Val?.Value;
+                if (!sourceIndex.HasValue || sourceIndex.Value >= (uint)pointCount) continue;
+                C.ChartShapeProperties? properties =
+                    point.GetFirstChild<C.ChartShapeProperties>();
+                OfficeColor? color = OfficeOpenXmlThemeColorResolver.ResolveColor(
+                    properties?.GetFirstChild<SolidFill>(), colorScheme);
+                if (!color.HasValue) continue;
+                colors[(int)sourceIndex.Value] = color;
+                found = true;
+            }
+            return found ? colors : null;
+        }
+    }
+}

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.Bubbles.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.Bubbles.cs
@@ -17,9 +17,10 @@ namespace OfficeIMO.PowerPoint {
             IReadOnlyList<double>? categoryXValues = null;
             for (int seriesIndex = 0; seriesIndex < source.Count; seriesIndex++) {
                 C.BubbleChartSeries element = source[seriesIndex];
-                if (HasUnsupportedFill(element.GetFirstChild<C.ChartShapeProperties>()) ||
+                if (HasUnsupportedSeriesStyle(
+                        element.GetFirstChild<C.ChartShapeProperties>()) ||
                     element.Elements<C.DataPoint>().Any(point =>
-                        HasUnsupportedFill(
+                        HasUnsupportedPointStyle(
                             point.GetFirstChild<C.ChartShapeProperties>()))) {
                     return null;
                 }
@@ -74,6 +75,20 @@ namespace OfficeIMO.PowerPoint {
         private static bool HasUnsupportedFill(C.ChartShapeProperties? properties) =>
             properties?.ChildElements.Any(child =>
                 child is NoFill or GradientFill or PatternFill or BlipFill or GroupFill) == true;
+
+        private static bool HasUnsupportedSeriesStyle(
+            C.ChartShapeProperties? properties) =>
+            HasUnsupportedFill(properties) ||
+            HasUnsupportedOutlineFill(properties?.GetFirstChild<Outline>());
+
+        private static bool HasUnsupportedPointStyle(
+            C.ChartShapeProperties? properties) =>
+            HasUnsupportedFill(properties) ||
+            properties?.GetFirstChild<Outline>() != null;
+
+        private static bool HasUnsupportedOutlineFill(Outline? outline) =>
+            outline?.ChildElements.Any(child =>
+                child is GradientFill or PatternFill or BlipFill or GroupFill) == true;
 
         private static IReadOnlyList<OfficeColor?>? ReadBubblePointColors(
             C.BubbleChartSeries series, int pointCount, ColorScheme? colorScheme) {

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.Bubbles.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.Bubbles.cs
@@ -126,7 +126,8 @@ namespace OfficeIMO.PowerPoint {
 
         private static bool HasUnresolvedSeriesColor(
             C.ChartShapeProperties? properties, ColorScheme? colorScheme) =>
-            HasUnresolvedSolidFill(properties?.GetFirstChild<SolidFill>(), colorScheme) ||
+            !OfficeOpenXmlThemeColorResolver.ResolveColor(
+                properties?.GetFirstChild<SolidFill>(), colorScheme).HasValue ||
             HasUnresolvedSolidFill(
                 properties?.GetFirstChild<Outline>()?.GetFirstChild<SolidFill>(),
                 colorScheme);

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.Bubbles.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.Bubbles.cs
@@ -17,6 +17,12 @@ namespace OfficeIMO.PowerPoint {
             IReadOnlyList<double>? categoryXValues = null;
             for (int seriesIndex = 0; seriesIndex < source.Count; seriesIndex++) {
                 C.BubbleChartSeries element = source[seriesIndex];
+                if (HasExplicitNoFill(element.GetFirstChild<C.ChartShapeProperties>()) ||
+                    element.Elements<C.DataPoint>().Any(point =>
+                        HasExplicitNoFill(
+                            point.GetFirstChild<C.ChartShapeProperties>()))) {
+                    return null;
+                }
                 if (!TryReadStrictCachedNumbers(element.GetFirstChild<C.XValues>(),
                         allowNegative: true, out IReadOnlyList<double> xValues) ||
                     !TryReadStrictCachedNumbers(element.GetFirstChild<C.YValues>(),
@@ -64,6 +70,9 @@ namespace OfficeIMO.PowerPoint {
                 value.ToString(CultureInfo.InvariantCulture)).ToList();
             return new PowerPointChartData(categories, series);
         }
+
+        private static bool HasExplicitNoFill(C.ChartShapeProperties? properties) =>
+            properties?.GetFirstChild<NoFill>() != null;
 
         private static IReadOnlyList<OfficeColor?>? ReadBubblePointColors(
             C.BubbleChartSeries series, int pointCount, ColorScheme? colorScheme) {

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.Bubbles.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.Bubbles.cs
@@ -13,6 +13,18 @@ namespace OfficeIMO.PowerPoint {
             ColorScheme? colorScheme = null, bool forDataUpdate = false) {
             List<C.BubbleChartSeries> source = seriesElements.ToList();
             if (source.Count == 0) return null;
+            if (!forDataUpdate) {
+                var orders = new HashSet<uint>();
+                foreach (C.BubbleChartSeries element in source) {
+                    uint? order =
+                        element.GetFirstChild<C.Order>()?.Val?.Value;
+                    if (!order.HasValue || !orders.Add(order.Value)) {
+                        return null;
+                    }
+                }
+                source = source.OrderBy(element =>
+                    element.GetFirstChild<C.Order>()!.Val!.Value).ToList();
+            }
 
             var series = new List<PowerPointChartSeries>();
             IReadOnlyList<double>? categoryXValues = null;

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.Bubbles.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.Bubbles.cs
@@ -16,6 +16,7 @@ namespace OfficeIMO.PowerPoint {
 
             var series = new List<PowerPointChartSeries>();
             IReadOnlyList<double>? categoryXValues = null;
+            long totalPointCount = 0L;
             for (int seriesIndex = 0; seriesIndex < source.Count; seriesIndex++) {
                 C.BubbleChartSeries element = source[seriesIndex];
                 if (!forDataUpdate &&
@@ -54,6 +55,10 @@ namespace OfficeIMO.PowerPoint {
 
                 int pointCount = xValues.Count;
                 if (pointCount == 0) continue;
+                totalPointCount += pointCount;
+                if (totalPointCount > PowerPointUtils.MaximumSharedChartPoints) {
+                    return null;
+                }
 
                 IReadOnlyList<double> normalizedY = NormalizeValues(yValues, pointCount);
                 IReadOnlyList<double> normalizedSizes = NormalizeValues(bubbleSizes, pointCount);

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.Bubbles.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.Bubbles.cs
@@ -9,7 +9,8 @@ using C = DocumentFormat.OpenXml.Drawing.Charts;
 namespace OfficeIMO.PowerPoint {
     public partial class PowerPointChart {
         private static PowerPointChartData? ReadBubbleSeriesData(
-            IEnumerable<C.BubbleChartSeries> seriesElements, ColorScheme? colorScheme = null) {
+            IEnumerable<C.BubbleChartSeries> seriesElements,
+            ColorScheme? colorScheme = null, bool forDataUpdate = false) {
             List<C.BubbleChartSeries> source = seriesElements.ToList();
             if (source.Count == 0) return null;
 
@@ -17,17 +18,19 @@ namespace OfficeIMO.PowerPoint {
             IReadOnlyList<double>? categoryXValues = null;
             for (int seriesIndex = 0; seriesIndex < source.Count; seriesIndex++) {
                 C.BubbleChartSeries element = source[seriesIndex];
-                if (element.Elements<C.Trendline>().Any() ||
-                    element.Elements<C.ErrorBars>().Any() ||
-                    HasUnsupportedSeriesStyle(
-                        element.GetFirstChild<C.ChartShapeProperties>()) ||
-                    HasUnresolvedSeriesColor(
-                        element.GetFirstChild<C.ChartShapeProperties>(), colorScheme) ||
-                    element.Elements<C.DataPoint>().Any(point =>
-                        HasUnsupportedPointStyle(
-                            point.GetFirstChild<C.ChartShapeProperties>()) ||
-                        HasUnresolvedPointColor(
-                            point.GetFirstChild<C.ChartShapeProperties>(), colorScheme))) {
+                if (!forDataUpdate &&
+                    (element.Elements<C.Trendline>().Any() ||
+                     element.Elements<C.ErrorBars>().Any() ||
+                     HasUnsupportedSeriesStyle(
+                         element.GetFirstChild<C.ChartShapeProperties>()) ||
+                     HasUnresolvedSeriesColor(
+                         element.GetFirstChild<C.ChartShapeProperties>(), colorScheme) ||
+                     element.Elements<C.DataPoint>().Any(point =>
+                         HasUnsupportedPointStyle(
+                             point.GetFirstChild<C.ChartShapeProperties>()) ||
+                         HasUnresolvedPointColor(
+                             point.GetFirstChild<C.ChartShapeProperties>(),
+                             colorScheme)))) {
                     return null;
                 }
                 if (!TryReadStrictCachedNumbers(element.GetFirstChild<C.XValues>(),
@@ -43,7 +46,7 @@ namespace OfficeIMO.PowerPoint {
                 }
                 C.InvertIfNegative? invertIfNegative =
                     element.GetFirstChild<C.InvertIfNegative>();
-                if (yValues.Any(value => value < 0D) &&
+                if (!forDataUpdate && yValues.Any(value => value < 0D) &&
                     invertIfNegative != null &&
                     invertIfNegative.Val?.Value != false) {
                     return null;
@@ -91,7 +94,10 @@ namespace OfficeIMO.PowerPoint {
 
         private static bool HasUnsupportedEffects(C.ChartShapeProperties? properties) =>
             properties?.GetFirstChild<EffectList>()?.ChildElements.Count > 0 ||
-            properties?.GetFirstChild<EffectDag>()?.ChildElements.Count > 0;
+            properties?.GetFirstChild<EffectDag>()?.ChildElements.Count > 0 ||
+            properties?.ChildElements.Any(child =>
+                child.LocalName == "scene3d" ||
+                child.LocalName == "sp3d") == true;
 
         private static bool HasUnsupportedSeriesStyle(
             C.ChartShapeProperties? properties) =>

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.Bubbles.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.Bubbles.cs
@@ -17,7 +17,8 @@ namespace OfficeIMO.PowerPoint {
             IReadOnlyList<double>? categoryXValues = null;
             for (int seriesIndex = 0; seriesIndex < source.Count; seriesIndex++) {
                 C.BubbleChartSeries element = source[seriesIndex];
-                if (HasUnsupportedSeriesStyle(
+                if (element.Elements<C.Trendline>().Any() ||
+                    HasUnsupportedSeriesStyle(
                         element.GetFirstChild<C.ChartShapeProperties>()) ||
                     element.Elements<C.DataPoint>().Any(point =>
                         HasUnsupportedPointStyle(

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.Bubbles.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.Bubbles.cs
@@ -21,9 +21,13 @@ namespace OfficeIMO.PowerPoint {
                     element.Elements<C.ErrorBars>().Any() ||
                     HasUnsupportedSeriesStyle(
                         element.GetFirstChild<C.ChartShapeProperties>()) ||
+                    HasUnresolvedSeriesColor(
+                        element.GetFirstChild<C.ChartShapeProperties>(), colorScheme) ||
                     element.Elements<C.DataPoint>().Any(point =>
                         HasUnsupportedPointStyle(
-                            point.GetFirstChild<C.ChartShapeProperties>()))) {
+                            point.GetFirstChild<C.ChartShapeProperties>()) ||
+                        HasUnresolvedPointColor(
+                            point.GetFirstChild<C.ChartShapeProperties>(), colorScheme))) {
                     return null;
                 }
                 if (!TryReadStrictCachedNumbers(element.GetFirstChild<C.XValues>(),
@@ -78,20 +82,42 @@ namespace OfficeIMO.PowerPoint {
             properties?.ChildElements.Any(child =>
                 child is NoFill or GradientFill or PatternFill or BlipFill or GroupFill) == true;
 
+        private static bool HasUnsupportedEffects(C.ChartShapeProperties? properties) =>
+            properties?.GetFirstChild<EffectList>()?.ChildElements.Count > 0 ||
+            properties?.GetFirstChild<EffectDag>()?.ChildElements.Count > 0;
+
         private static bool HasUnsupportedSeriesStyle(
             C.ChartShapeProperties? properties) =>
             HasUnsupportedFill(properties) ||
+            HasUnsupportedEffects(properties) ||
             HasUnsupportedOutlineFill(properties?.GetFirstChild<Outline>());
 
         private static bool HasUnsupportedPointStyle(
             C.ChartShapeProperties? properties) =>
             HasUnsupportedFill(properties) ||
+            HasUnsupportedEffects(properties) ||
             properties?.GetFirstChild<Outline>() != null;
 
         private static bool HasUnsupportedOutlineFill(Outline? outline) =>
             outline?.ChildElements.Any(child =>
                 child is GradientFill or PatternFill or BlipFill or GroupFill
                     or PresetDash or CustomDash) == true;
+
+        private static bool HasUnresolvedSeriesColor(
+            C.ChartShapeProperties? properties, ColorScheme? colorScheme) =>
+            HasUnresolvedSolidFill(properties?.GetFirstChild<SolidFill>(), colorScheme) ||
+            HasUnresolvedSolidFill(
+                properties?.GetFirstChild<Outline>()?.GetFirstChild<SolidFill>(),
+                colorScheme);
+
+        private static bool HasUnresolvedPointColor(
+            C.ChartShapeProperties? properties, ColorScheme? colorScheme) =>
+            HasUnresolvedSolidFill(properties?.GetFirstChild<SolidFill>(), colorScheme);
+
+        private static bool HasUnresolvedSolidFill(
+            SolidFill? fill, ColorScheme? colorScheme) =>
+            fill != null &&
+            !OfficeOpenXmlThemeColorResolver.ResolveColor(fill, colorScheme).HasValue;
 
         private static IReadOnlyList<OfficeColor?>? ReadBubblePointColors(
             C.BubbleChartSeries series, int pointCount, ColorScheme? colorScheme) {

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.Bubbles.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.Bubbles.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Drawing;
 using C = DocumentFormat.OpenXml.Drawing.Charts;
 
@@ -16,12 +17,14 @@ namespace OfficeIMO.PowerPoint {
             IReadOnlyList<double>? categoryXValues = null;
             for (int seriesIndex = 0; seriesIndex < source.Count; seriesIndex++) {
                 C.BubbleChartSeries element = source[seriesIndex];
-                IReadOnlyList<double> xValues =
-                    ReadCachedNumbers(element.GetFirstChild<C.XValues>());
-                IReadOnlyList<double> yValues =
-                    ReadCachedNumbers(element.GetFirstChild<C.YValues>());
-                IReadOnlyList<double> bubbleSizes =
-                    ReadCachedNumbers(element.GetFirstChild<C.BubbleSize>());
+                if (!TryReadStrictCachedNumbers(element.GetFirstChild<C.XValues>(),
+                        allowNegative: true, out IReadOnlyList<double> xValues) ||
+                    !TryReadStrictCachedNumbers(element.GetFirstChild<C.YValues>(),
+                        allowNegative: true, out IReadOnlyList<double> yValues) ||
+                    !TryReadStrictCachedNumbers(element.GetFirstChild<C.BubbleSize>(),
+                        allowNegative: false, out IReadOnlyList<double> bubbleSizes)) {
+                    return null;
+                }
                 if (xValues.Count != yValues.Count || xValues.Count != bubbleSizes.Count) {
                     return null;
                 }
@@ -46,6 +49,7 @@ namespace OfficeIMO.PowerPoint {
                     ReadSeriesStrokeWidth(element)) {
                     BubbleSizes = normalizedSizes,
                     PointColors = ReadBubblePointColors(element, pointCount, colorScheme),
+                    StrokeColor = ReadSeriesStrokeColor(element, colorScheme),
                     SourceIndex = element.GetFirstChild<C.Index>()?.Val?.Value
                 };
                 series.Add(item);
@@ -76,6 +80,54 @@ namespace OfficeIMO.PowerPoint {
                 found = true;
             }
             return found ? colors : null;
+        }
+
+        private static bool TryReadStrictCachedNumbers(OpenXmlElement? container,
+            bool allowNegative, out IReadOnlyList<double> values) {
+            values = Array.Empty<double>();
+            if (container == null) {
+                return false;
+            }
+
+            List<C.NumericPoint> points =
+                GetBoundedCachedPoints(container.Descendants<C.NumericPoint>());
+            if (points.Count == 0) {
+                return false;
+            }
+
+            int length = GetCachedPointLength(container, points,
+                point => point.Index?.Value);
+            if (length != points.Count) {
+                return false;
+            }
+
+            var parsed = new double[length];
+            var seen = new bool[length];
+            for (int pointIndex = 0; pointIndex < points.Count; pointIndex++) {
+                C.NumericPoint point = points[pointIndex];
+                uint rawIndex = point.Index?.Value ?? (uint)pointIndex;
+                if (rawIndex >= (uint)length || seen[(int)rawIndex]) {
+                    return false;
+                }
+
+                string? text = point.NumericValue?.Text;
+                if (!double.TryParse(text, NumberStyles.Float,
+                        CultureInfo.InvariantCulture, out double value) ||
+                    double.IsNaN(value) || double.IsInfinity(value) ||
+                    (!allowNegative && value < 0D)) {
+                    return false;
+                }
+
+                parsed[(int)rawIndex] = value;
+                seen[(int)rawIndex] = true;
+            }
+
+            if (seen.Any(present => !present)) {
+                return false;
+            }
+
+            values = parsed;
+            return true;
         }
     }
 }

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.Bubbles.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.Bubbles.cs
@@ -18,6 +18,7 @@ namespace OfficeIMO.PowerPoint {
             for (int seriesIndex = 0; seriesIndex < source.Count; seriesIndex++) {
                 C.BubbleChartSeries element = source[seriesIndex];
                 if (element.Elements<C.Trendline>().Any() ||
+                    element.Elements<C.ErrorBars>().Any() ||
                     HasUnsupportedSeriesStyle(
                         element.GetFirstChild<C.ChartShapeProperties>()) ||
                     element.Elements<C.DataPoint>().Any(point =>
@@ -89,7 +90,8 @@ namespace OfficeIMO.PowerPoint {
 
         private static bool HasUnsupportedOutlineFill(Outline? outline) =>
             outline?.ChildElements.Any(child =>
-                child is GradientFill or PatternFill or BlipFill or GroupFill) == true;
+                child is GradientFill or PatternFill or BlipFill or GroupFill
+                    or PresetDash or CustomDash) == true;
 
         private static IReadOnlyList<OfficeColor?>? ReadBubblePointColors(
             C.BubbleChartSeries series, int pointCount, ColorScheme? colorScheme) {

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.Bubbles.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.Bubbles.cs
@@ -17,9 +17,9 @@ namespace OfficeIMO.PowerPoint {
             IReadOnlyList<double>? categoryXValues = null;
             for (int seriesIndex = 0; seriesIndex < source.Count; seriesIndex++) {
                 C.BubbleChartSeries element = source[seriesIndex];
-                if (HasExplicitNoFill(element.GetFirstChild<C.ChartShapeProperties>()) ||
+                if (HasUnsupportedFill(element.GetFirstChild<C.ChartShapeProperties>()) ||
                     element.Elements<C.DataPoint>().Any(point =>
-                        HasExplicitNoFill(
+                        HasUnsupportedFill(
                             point.GetFirstChild<C.ChartShapeProperties>()))) {
                     return null;
                 }
@@ -71,8 +71,9 @@ namespace OfficeIMO.PowerPoint {
             return new PowerPointChartData(categories, series);
         }
 
-        private static bool HasExplicitNoFill(C.ChartShapeProperties? properties) =>
-            properties?.GetFirstChild<NoFill>() != null;
+        private static bool HasUnsupportedFill(C.ChartShapeProperties? properties) =>
+            properties?.ChildElements.Any(child =>
+                child is NoFill or GradientFill or PatternFill or BlipFill or GroupFill) == true;
 
         private static IReadOnlyList<OfficeColor?>? ReadBubblePointColors(
             C.BubbleChartSeries series, int pointCount, ColorScheme? colorScheme) {

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.Bubbles.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.Bubbles.cs
@@ -41,6 +41,13 @@ namespace OfficeIMO.PowerPoint {
                 if (xValues.Count != yValues.Count || xValues.Count != bubbleSizes.Count) {
                     return null;
                 }
+                C.InvertIfNegative? invertIfNegative =
+                    element.GetFirstChild<C.InvertIfNegative>();
+                if (yValues.Any(value => value < 0D) &&
+                    invertIfNegative != null &&
+                    invertIfNegative.Val?.Value != false) {
+                    return null;
+                }
 
                 int pointCount = xValues.Count;
                 if (pointCount == 0) continue;
@@ -99,9 +106,12 @@ namespace OfficeIMO.PowerPoint {
             properties?.GetFirstChild<Outline>() != null;
 
         private static bool HasUnsupportedOutlineFill(Outline? outline) =>
-            outline?.ChildElements.Any(child =>
-                child is GradientFill or PatternFill or BlipFill or GroupFill
-                    or PresetDash or CustomDash) == true;
+            outline != null &&
+            (outline.CompoundLineType?.Value is CompoundLineValues compoundLine &&
+             compoundLine != CompoundLineValues.Single ||
+             outline.ChildElements.Any(child =>
+                 child is GradientFill or PatternFill or BlipFill or GroupFill
+                     or PresetDash or CustomDash));
 
         private static bool HasUnresolvedSeriesColor(
             C.ChartShapeProperties? properties, ColorScheme? colorScheme) =>

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.Bubbles.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.Bubbles.cs
@@ -22,8 +22,11 @@ namespace OfficeIMO.PowerPoint {
                     ReadCachedNumbers(element.GetFirstChild<C.YValues>());
                 IReadOnlyList<double> bubbleSizes =
                     ReadCachedNumbers(element.GetFirstChild<C.BubbleSize>());
-                int pointCount = Math.Min(xValues.Count,
-                    Math.Min(yValues.Count, bubbleSizes.Count));
+                if (xValues.Count != yValues.Count || xValues.Count != bubbleSizes.Count) {
+                    return null;
+                }
+
+                int pointCount = xValues.Count;
                 if (pointCount == 0) continue;
 
                 IReadOnlyList<double> normalizedY = NormalizeValues(yValues, pointCount);

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.Bubbles.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.Bubbles.cs
@@ -50,6 +50,7 @@ namespace OfficeIMO.PowerPoint {
                     BubbleSizes = normalizedSizes,
                     PointColors = ReadBubblePointColors(element, pointCount, colorScheme),
                     StrokeColor = ReadSeriesStrokeColor(element, colorScheme),
+                    ShowStroke = IsSeriesStrokeVisible(element),
                     SourceIndex = element.GetFirstChild<C.Index>()?.Val?.Value
                 };
                 series.Add(item);

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.Bubbles.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.Bubbles.cs
@@ -135,11 +135,14 @@ namespace OfficeIMO.PowerPoint {
 
         private static bool HasUnsupportedOutlineFill(Outline? outline) =>
             outline != null &&
-            (outline.CompoundLineType?.Value is CompoundLineValues compoundLine &&
+            (outline.CapType?.Value is LineCapValues cap &&
+             cap != LineCapValues.Flat ||
+             outline.Alignment?.Value is PenAlignmentValues alignment &&
+             alignment != PenAlignmentValues.Center ||
+             outline.CompoundLineType?.Value is CompoundLineValues compoundLine &&
              compoundLine != CompoundLineValues.Single ||
              outline.ChildElements.Any(child =>
-                 child is GradientFill or PatternFill or BlipFill or GroupFill
-                     or PresetDash or CustomDash));
+                 child is not SolidFill and not NoFill));
 
         private static bool HasUnresolvedSeriesColor(
             C.ChartShapeProperties? properties, ColorScheme? colorScheme) {

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
@@ -470,11 +470,23 @@ namespace OfficeIMO.PowerPoint {
                             : OfficeChartLegendPosition.Right;
             bool overlay = legend?.GetFirstChild<C.Overlay>() is C.Overlay item &&
                 item.Val?.Value != false;
+            bool overlayTitle =
+                chart.GetFirstChild<C.Title>()?.GetFirstChild<C.Overlay>()
+                    is C.Overlay titleOverlay &&
+                titleOverlay.Val?.Value != false;
 
             string? horizontalAxisTitle = null;
             string? verticalAxisTitle = null;
             string? horizontalAxisNumberFormat = null;
             string? verticalAxisNumberFormat = null;
+            OfficeChartAxisTickMark horizontalMajorTickMark =
+                OfficeChartAxisTickMark.None;
+            OfficeChartAxisTickMark verticalMajorTickMark =
+                OfficeChartAxisTickMark.None;
+            OfficeChartAxisTickMark horizontalMinorTickMark =
+                OfficeChartAxisTickMark.None;
+            OfficeChartAxisTickMark verticalMinorTickMark =
+                OfficeChartAxisTickMark.None;
             if (kind == PowerPointChartSnapshotKind.Bubble &&
                 chart.GetFirstChild<C.PlotArea>() is C.PlotArea plotArea &&
                 plotArea.GetFirstChild<C.BubbleChart>() is C.BubbleChart bubble &&
@@ -487,16 +499,43 @@ namespace OfficeIMO.PowerPoint {
                     ReadAxisNumberFormat(horizontalAxis);
                 verticalAxisNumberFormat =
                     ReadAxisNumberFormat(verticalAxis);
+                horizontalMajorTickMark = ReadAxisTickMark(
+                    horizontalAxis.GetFirstChild<C.MajorTickMark>()?
+                        .Val?.Value);
+                verticalMajorTickMark = ReadAxisTickMark(
+                    verticalAxis.GetFirstChild<C.MajorTickMark>()?
+                        .Val?.Value);
+                horizontalMinorTickMark = ReadAxisTickMark(
+                    horizontalAxis.GetFirstChild<C.MinorTickMark>()?
+                        .Val?.Value);
+                verticalMinorTickMark = ReadAxisTickMark(
+                    verticalAxis.GetFirstChild<C.MinorTickMark>()?
+                        .Val?.Value);
             }
 
             return new OfficeChartLayout(overlayLegend: overlay,
+                overlayTitle: overlayTitle,
                 showLegend: legend != null,
                 legendPosition: position,
                 categoryAxisTitle: horizontalAxisTitle,
                 valueAxisTitle: verticalAxisTitle,
                 horizontalAxisNumberFormat: horizontalAxisNumberFormat,
-                verticalAxisNumberFormat: verticalAxisNumberFormat);
+                verticalAxisNumberFormat: verticalAxisNumberFormat,
+                horizontalAxisMajorTickMark: horizontalMajorTickMark,
+                verticalAxisMajorTickMark: verticalMajorTickMark,
+                horizontalAxisMinorTickMark: horizontalMinorTickMark,
+                verticalAxisMinorTickMark: verticalMinorTickMark);
         }
+
+        private static OfficeChartAxisTickMark ReadAxisTickMark(
+            C.TickMarkValues? value) =>
+            value == C.TickMarkValues.Inside
+                ? OfficeChartAxisTickMark.Inside
+                : value == C.TickMarkValues.Outside
+                    ? OfficeChartAxisTickMark.Outside
+                    : value == C.TickMarkValues.Cross
+                        ? OfficeChartAxisTickMark.Cross
+                        : OfficeChartAxisTickMark.None;
 
         private static string? ReadAxisTitle(C.ValueAxis axis) =>
             ReadChartText(

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
@@ -69,6 +69,11 @@ namespace OfficeIMO.PowerPoint {
                     return false;
                 }
 
+                if (HasUnsupportedChartGroupElements(plotArea)) {
+                    snapshot = null!;
+                    return false;
+                }
+
                 if (TryCreateMixedChartSnapshot(chart, plotArea, colorScheme, out snapshot)) {
                     return true;
                 }
@@ -226,6 +231,10 @@ namespace OfficeIMO.PowerPoint {
                  axis.GetFirstChild<C.MajorUnit>() != null ||
                  axis.GetFirstChild<C.MinorUnit>() != null ||
                  axis.GetFirstChild<C.CrossesAt>() != null ||
+                 (axis.GetFirstChild<C.TickLabelPosition>() is
+                      C.TickLabelPosition tickLabelPosition &&
+                  tickLabelPosition.Val?.Value !=
+                      C.TickLabelPositionValues.NextTo) ||
                  (axis.GetFirstChild<C.Crosses>() is C.Crosses crosses &&
                   crosses.Val?.Value != C.CrossesValues.AutoZero) ||
                  (axis.GetFirstChild<C.Scaling>() is C.Scaling scaling &&
@@ -238,8 +247,11 @@ namespace OfficeIMO.PowerPoint {
 
         private static bool HasUnsupportedBubbleLegend(C.Chart chart) {
             C.Legend? legend = chart.GetFirstChild<C.Legend>();
-            return legend?.GetFirstChild<C.LegendPosition>()?.Val?.Value ==
-                C.LegendPositionValues.TopRight;
+            return legend != null &&
+                (legend.GetFirstChild<C.LegendPosition>()?.Val?.Value ==
+                     C.LegendPositionValues.TopRight ||
+                 legend.GetFirstChild<C.Layout>()?
+                     .GetFirstChild<C.ManualLayout>() != null);
         }
 
         private static bool HasEnabledBubbleDataLabels(C.BubbleChart chart) =>
@@ -265,6 +277,18 @@ namespace OfficeIMO.PowerPoint {
                 + plotArea.Elements<C.PieChart>().Count()
                 + plotArea.Elements<C.DoughnutChart>().Count();
         }
+
+        private static bool HasUnsupportedChartGroupElements(C.PlotArea plotArea) =>
+            plotArea.ChildElements.Any(element =>
+                element.LocalName.EndsWith("Chart", StringComparison.Ordinal) &&
+                element is not C.BarChart &&
+                element is not C.LineChart &&
+                element is not C.AreaChart &&
+                element is not C.RadarChart &&
+                element is not C.ScatterChart &&
+                element is not C.BubbleChart &&
+                element is not C.PieChart &&
+                element is not C.DoughnutChart);
 
         private bool TryCreateMixedChartSnapshot(C.Chart chart, C.PlotArea plotArea, A.ColorScheme? colorScheme, out PowerPointChartSnapshot snapshot) {
             snapshot = null!;

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
@@ -147,6 +147,7 @@ namespace OfficeIMO.PowerPoint {
                              bubbleChart.GetFirstChild<C.VaryColors>()) ||
                          IsBubble3DEnabled(
                              bubbleChart.GetFirstChild<C.Bubble3D>()) ||
+                         HasUnsupportedBubbleSourceVisibility(chartPart, chart) ||
                          HasUnsupportedBubbleAxes(plotArea, bubbleChart) ||
                          HasUnsupportedBubbleLegend(chart) ||
                          HasUnsupportedBubbleAreaLayout(chartPart, plotArea) ||
@@ -526,8 +527,11 @@ namespace OfficeIMO.PowerPoint {
             for (int seriesIndex = 0; seriesIndex < data.Series.Count; seriesIndex++) {
                 PowerPointChartSeries series = data.Series[seriesIndex];
                 uint sourceIndex = series.SourceIndex ?? (uint)seriesIndex;
+                uint legendIndex = kind == PowerPointChartSnapshotKind.Bubble
+                    ? (uint)seriesIndex
+                    : sourceIndex;
                 series.ShowInLegend = hasLegend &&
-                    !hiddenLegendSeries.Contains(sourceIndex);
+                    !hiddenLegendSeries.Contains(legendIndex);
             }
 
             return new PowerPointChartSnapshot(

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
@@ -104,7 +104,18 @@ namespace OfficeIMO.PowerPoint {
                         return false;
                     }
 
-                    snapshot = CreateSnapshot(chart, PowerPointChartSnapshotKind.Bubble, data);
+                    uint bubbleScale = bubbleChart.GetFirstChild<C.BubbleScale>()?.Val?.Value ?? 100U;
+                    if (bubbleScale > 300U) {
+                        snapshot = null!;
+                        return false;
+                    }
+                    OfficeChartBubbleSizeMode bubbleSizeMode =
+                        bubbleChart.GetFirstChild<C.SizeRepresents>()?.Val?.Value ==
+                        C.SizeRepresentsValues.Width
+                            ? OfficeChartBubbleSizeMode.Width
+                            : OfficeChartBubbleSizeMode.Area;
+                    snapshot = CreateSnapshot(chart, PowerPointChartSnapshotKind.Bubble, data,
+                        bubbleSizeMode, bubbleScale);
                     return true;
                 }
 
@@ -242,14 +253,19 @@ namespace OfficeIMO.PowerPoint {
                 : OfficeChartAxisGroup.Primary;
         }
 
-        private PowerPointChartSnapshot CreateSnapshot(C.Chart chart, PowerPointChartSnapshotKind kind, PowerPointChartData data) {
+        private PowerPointChartSnapshot CreateSnapshot(C.Chart chart,
+            PowerPointChartSnapshotKind kind, PowerPointChartData data,
+            OfficeChartBubbleSizeMode bubbleSizeMode = OfficeChartBubbleSizeMode.Area,
+            double bubbleScalePercent = 100D) {
             return new PowerPointChartSnapshot(
                 Name ?? string.Empty,
                 ReadTitle(chart),
                 kind,
                 data,
                 WidthPoints,
-                HeightPoints);
+                HeightPoints,
+                bubbleSizeMode,
+                bubbleScalePercent);
         }
 
         private static PowerPointChartSnapshotKind GetBarChartSnapshotKind(C.BarChart chart) {
@@ -431,6 +447,15 @@ namespace OfficeIMO.PowerPoint {
             return widthEmus.HasValue && widthEmus.Value > 0L
                 ? PowerPointUnits.ToPoints(widthEmus.Value)
                 : null;
+        }
+
+        private static OfficeColor? ReadSeriesStrokeColor(
+            OpenXmlCompositeElement seriesElement, A.ColorScheme? colorScheme) {
+            C.ChartShapeProperties? properties =
+                seriesElement.GetFirstChild<C.ChartShapeProperties>();
+            return OfficeOpenXmlThemeColorResolver.ResolveColor(
+                properties?.GetFirstChild<A.Outline>()?.GetFirstChild<A.SolidFill>(),
+                colorScheme);
         }
 
         private static string? ReadTitle(C.Chart chart) {

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
@@ -18,7 +18,7 @@ namespace OfficeIMO.PowerPoint {
             TryGetSnapshot(GetOwnerColorScheme(), out snapshot);
 
         private bool TryGetSnapshotForUpdate(out PowerPointChartSnapshot snapshot) =>
-            TryGetSnapshot(GetOwnerColorScheme(), ignoreBubbleDataLabels: true,
+            TryGetSnapshot(GetOwnerColorScheme(), forDataUpdate: true,
                 out snapshot);
 
         private A.ColorScheme? GetOwnerColorScheme() {
@@ -56,10 +56,10 @@ namespace OfficeIMO.PowerPoint {
 
         internal bool TryGetSnapshot(A.ColorScheme? colorScheme,
             out PowerPointChartSnapshot snapshot) =>
-            TryGetSnapshot(colorScheme, ignoreBubbleDataLabels: false, out snapshot);
+            TryGetSnapshot(colorScheme, forDataUpdate: false, out snapshot);
 
         private bool TryGetSnapshot(A.ColorScheme? colorScheme,
-            bool ignoreBubbleDataLabels, out PowerPointChartSnapshot snapshot) {
+            bool forDataUpdate, out PowerPointChartSnapshot snapshot) {
             try {
                 ChartPart chartPart = GetChartPart();
                 C.Chart? chart = chartPart.ChartSpace?.GetFirstChild<C.Chart>();
@@ -137,21 +137,25 @@ namespace OfficeIMO.PowerPoint {
                 }
 
                 if (plotArea.GetFirstChild<C.BubbleChart>() is C.BubbleChart bubbleChart) {
-                    if (IsVaryColorsEnabled(bubbleChart.GetFirstChild<C.VaryColors>()) ||
-                        IsBubble3DEnabled(bubbleChart.GetFirstChild<C.Bubble3D>()) ||
-                        HasUnsupportedBubbleAxisScaling(plotArea, bubbleChart) ||
-                        (!ignoreBubbleDataLabels &&
-                         HasEnabledBubbleDataLabels(bubbleChart)) ||
-                        bubbleChart.Elements<C.BubbleChartSeries>().Any(series =>
-                            IsBubble3DEnabled(series.GetFirstChild<C.Bubble3D>()) ||
-                            series.Elements<C.DataPoint>().Any(point =>
-                                IsBubble3DEnabled(
-                                    point.GetFirstChild<C.Bubble3D>())))) {
+                    if (!forDataUpdate &&
+                        (IsVaryColorsEnabled(
+                             bubbleChart.GetFirstChild<C.VaryColors>()) ||
+                         IsBubble3DEnabled(
+                             bubbleChart.GetFirstChild<C.Bubble3D>()) ||
+                         HasUnsupportedBubbleAxes(plotArea, bubbleChart) ||
+                         HasEnabledBubbleDataLabels(bubbleChart) ||
+                         bubbleChart.Elements<C.BubbleChartSeries>().Any(series =>
+                             IsBubble3DEnabled(
+                                 series.GetFirstChild<C.Bubble3D>()) ||
+                             series.Elements<C.DataPoint>().Any(point =>
+                                 IsBubble3DEnabled(
+                                     point.GetFirstChild<C.Bubble3D>()))))) {
                         snapshot = null!;
                         return false;
                     }
                     PowerPointChartData? data = ReadBubbleSeriesData(
-                        bubbleChart.Elements<C.BubbleChartSeries>(), colorScheme);
+                        bubbleChart.Elements<C.BubbleChartSeries>(), colorScheme,
+                        forDataUpdate);
                     if (data == null) {
                         snapshot = null!;
                         return false;
@@ -208,7 +212,7 @@ namespace OfficeIMO.PowerPoint {
         private static bool IsVaryColorsEnabled(C.VaryColors? varyColors) =>
             varyColors != null && varyColors.Val?.Value != false;
 
-        private static bool HasUnsupportedBubbleAxisScaling(
+        private static bool HasUnsupportedBubbleAxes(
             C.PlotArea plotArea, C.BubbleChart chart) {
             HashSet<uint> axisIds = new(chart.Elements<C.AxisId>()
                 .Where(axis => axis.Val?.Value != null)
@@ -216,12 +220,16 @@ namespace OfficeIMO.PowerPoint {
             return plotArea.Elements<C.ValueAxis>().Any(axis =>
                 axis.AxisId?.Val?.Value != null &&
                 axisIds.Contains(axis.AxisId.Val.Value) &&
-                axis.GetFirstChild<C.Scaling>() is C.Scaling scaling &&
-                (scaling.GetFirstChild<C.LogBase>() != null ||
-                 scaling.GetFirstChild<C.MinAxisValue>() != null ||
-                 scaling.GetFirstChild<C.MaxAxisValue>() != null ||
-                 scaling.GetFirstChild<C.Orientation>()?.Val?.Value ==
-                    C.OrientationValues.MaxMin));
+                ((axis.GetFirstChild<C.Delete>() is C.Delete delete &&
+                  delete.Val?.Value != false) ||
+                 axis.GetFirstChild<C.MajorUnit>() != null ||
+                 axis.GetFirstChild<C.MinorUnit>() != null ||
+                 (axis.GetFirstChild<C.Scaling>() is C.Scaling scaling &&
+                  (scaling.GetFirstChild<C.LogBase>() != null ||
+                   scaling.GetFirstChild<C.MinAxisValue>() != null ||
+                   scaling.GetFirstChild<C.MaxAxisValue>() != null ||
+                   scaling.GetFirstChild<C.Orientation>()?.Val?.Value ==
+                      C.OrientationValues.MaxMin))));
         }
 
         private static bool HasEnabledBubbleDataLabels(C.BubbleChart chart) =>
@@ -349,10 +357,12 @@ namespace OfficeIMO.PowerPoint {
             OfficeChartBubbleSizeMode bubbleSizeMode = OfficeChartBubbleSizeMode.Area,
             double bubbleScalePercent = 100D) {
             HashSet<uint> hiddenLegendSeries = GetHiddenLegendSeriesIndexes(chart);
+            bool hasLegend = chart.GetFirstChild<C.Legend>() != null;
             for (int seriesIndex = 0; seriesIndex < data.Series.Count; seriesIndex++) {
                 PowerPointChartSeries series = data.Series[seriesIndex];
                 uint sourceIndex = series.SourceIndex ?? (uint)seriesIndex;
-                series.ShowInLegend = !hiddenLegendSeries.Contains(sourceIndex);
+                series.ShowInLegend = hasLegend &&
+                    !hiddenLegendSeries.Contains(sourceIndex);
             }
 
             return new PowerPointChartSnapshot(

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
@@ -100,7 +100,10 @@ namespace OfficeIMO.PowerPoint {
                     if (IsVaryColorsEnabled(bubbleChart.GetFirstChild<C.VaryColors>()) ||
                         IsBubble3DEnabled(bubbleChart.GetFirstChild<C.Bubble3D>()) ||
                         bubbleChart.Elements<C.BubbleChartSeries>().Any(series =>
-                            IsBubble3DEnabled(series.GetFirstChild<C.Bubble3D>()))) {
+                            IsBubble3DEnabled(series.GetFirstChild<C.Bubble3D>()) ||
+                            series.Elements<C.DataPoint>().Any(point =>
+                                IsBubble3DEnabled(
+                                    point.GetFirstChild<C.Bubble3D>())))) {
                         snapshot = null!;
                         return false;
                     }

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
@@ -237,6 +237,7 @@ namespace OfficeIMO.PowerPoint {
                 return true;
             }
             return new[] { horizontalAxis, verticalAxis }.Any(axis =>
+                HasUnsupportedBubbleAxisPresentation(axis) ||
                 (axis.GetFirstChild<C.Delete>() is C.Delete delete &&
                   delete.Val?.Value != false) ||
                  axis.GetFirstChild<C.MajorUnit>() != null ||
@@ -257,6 +258,12 @@ namespace OfficeIMO.PowerPoint {
                    scaling.GetFirstChild<C.Orientation>()?.Val?.Value ==
                       C.OrientationValues.MaxMin)));
         }
+
+        private static bool HasUnsupportedBubbleAxisPresentation(
+            C.ValueAxis axis) =>
+            HasUnsupportedBubbleTitle(axis.GetFirstChild<C.Title>()) ||
+            HasUnsupportedBubbleTextStyle(axis) ||
+            HasUnsupportedBubbleShapeProperties(axis);
 
         private static bool HasSupportedDefaultBubbleGridlines(
             C.ValueAxis horizontalAxis, C.ValueAxis verticalAxis) {
@@ -317,20 +324,66 @@ namespace OfficeIMO.PowerPoint {
                 (legend.GetFirstChild<C.LegendPosition>()?.Val?.Value ==
                      C.LegendPositionValues.TopRight ||
                  legend.GetFirstChild<C.Layout>()?
-                     .GetFirstChild<C.ManualLayout>() != null);
+                     .GetFirstChild<C.ManualLayout>() != null ||
+                 HasUnsupportedBubbleTextStyle(legend) ||
+                 HasUnsupportedBubbleShapeProperties(legend));
         }
 
         private static bool HasUnsupportedBubbleAreaLayout(
             ChartPart chartPart, C.PlotArea plotArea) =>
-            chartPart.ChartSpace?.GetFirstChild<C.Chart>()?
-                .GetFirstChild<C.Title>()?.GetFirstChild<C.Layout>()?
-                .GetFirstChild<C.ManualLayout>() != null ||
+            HasUnsupportedBubbleTitle(
+                chartPart.ChartSpace?.GetFirstChild<C.Chart>()?
+                    .GetFirstChild<C.Title>()) ||
             plotArea.GetFirstChild<C.Layout>()?
                 .GetFirstChild<C.ManualLayout>() != null ||
             chartPart.ChartSpace?.GetFirstChild<C.ShapeProperties>()?
                 .ChildElements.Count > 0 ||
             plotArea.GetFirstChild<C.ShapeProperties>()?
                 .ChildElements.Count > 0;
+
+        private static bool HasUnsupportedBubbleTitle(C.Title? title) =>
+            title != null &&
+            (title.GetFirstChild<C.Layout>()?
+                 .GetFirstChild<C.ManualLayout>() != null ||
+             HasUnsupportedBubbleTextStyle(title) ||
+             HasUnsupportedBubbleShapeProperties(title));
+
+        private static bool HasUnsupportedBubbleTextStyle(
+            OpenXmlElement parent) =>
+            parent.Descendants<A.RunProperties>()
+                .Any(HasUnsupportedBubbleTextCharacterProperties) ||
+            parent.Descendants<A.DefaultRunProperties>()
+                .Any(HasUnsupportedBubbleTextCharacterProperties) ||
+            parent.Descendants<A.EndParagraphRunProperties>()
+                .Any(HasUnsupportedBubbleTextCharacterProperties) ||
+            parent.Descendants<A.BodyProperties>()
+                .Any(properties =>
+                    properties.HasAttributes ||
+                    properties.ChildElements.Count > 0) ||
+            parent.Descendants<A.ListStyle>()
+                .Any(style => style.ChildElements.Count > 0) ||
+            parent.Descendants<A.ParagraphProperties>()
+                .Any(properties =>
+                    properties.HasAttributes ||
+                    properties.ChildElements.Any(child =>
+                        child is not A.DefaultRunProperties));
+
+        private static bool HasUnsupportedBubbleTextCharacterProperties(
+            A.TextCharacterPropertiesType properties) =>
+            properties.ChildElements.Count > 0 ||
+            properties.GetAttributes().Any(attribute =>
+                !string.Equals(
+                    attribute.LocalName, "lang",
+                    StringComparison.Ordinal));
+
+        private static bool HasUnsupportedBubbleShapeProperties(
+            OpenXmlElement parent) {
+            C.ChartShapeProperties? properties =
+                parent.GetFirstChild<C.ChartShapeProperties>();
+            return properties != null &&
+                (properties.HasAttributes ||
+                 properties.ChildElements.Count > 0);
+        }
 
         private static bool HasEnabledBubbleDataLabels(C.BubbleChart chart) =>
             chart.Descendants<C.ShowLegendKey>().Any(item => item.Val?.Value != false) ||

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
@@ -322,6 +322,9 @@ namespace OfficeIMO.PowerPoint {
 
         private static bool HasUnsupportedBubbleAreaLayout(
             ChartPart chartPart, C.PlotArea plotArea) =>
+            chartPart.ChartSpace?.GetFirstChild<C.Chart>()?
+                .GetFirstChild<C.Title>()?.GetFirstChild<C.Layout>()?
+                .GetFirstChild<C.ManualLayout>() != null ||
             plotArea.GetFirstChild<C.Layout>()?
                 .GetFirstChild<C.ManualLayout>() != null ||
             chartPart.ChartSpace?.GetFirstChild<C.ShapeProperties>()?

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
@@ -17,7 +17,40 @@ namespace OfficeIMO.PowerPoint {
         /// Tries to create a dependency-free snapshot for rendering/export consumers.
         /// </summary>
         internal bool TryGetSnapshot(out PowerPointChartSnapshot snapshot) =>
-            TryGetSnapshot(null, out snapshot);
+            TryGetSnapshot(GetOwnerColorScheme(), out snapshot);
+
+        private A.ColorScheme? GetOwnerColorScheme() {
+            if (_ownerPart is SlidePart slidePart) {
+                return slidePart.ThemeOverridePart?.ThemeOverride?.ColorScheme
+                    ?? slidePart.SlideLayoutPart?.ThemeOverridePart?.ThemeOverride?
+                        .ColorScheme
+                    ?? slidePart.SlideLayoutPart?.SlideMasterPart?.ThemePart?.Theme?
+                        .ThemeElements?.ColorScheme;
+            }
+
+            if (_ownerPart is SlideLayoutPart layoutPart) {
+                return layoutPart.ThemeOverridePart?.ThemeOverride?.ColorScheme
+                    ?? layoutPart.SlideMasterPart?.ThemePart?.Theme?.ThemeElements?
+                        .ColorScheme;
+            }
+
+            if (_ownerPart is SlideMasterPart masterPart) {
+                return masterPart.ThemePart?.Theme?.ThemeElements?.ColorScheme;
+            }
+
+            if (_ownerPart is NotesSlidePart notesPart) {
+                return notesPart.ThemeOverridePart?.ThemeOverride?.ColorScheme
+                    ?? notesPart.NotesMasterPart?.ThemePart?.Theme?.ThemeElements?
+                        .ColorScheme;
+            }
+
+            if (_ownerPart is NotesMasterPart notesMasterPart) {
+                return notesMasterPart.ThemePart?.Theme?.ThemeElements?.ColorScheme;
+            }
+
+            return (_ownerPart as HandoutMasterPart)?.ThemePart?.Theme?
+                .ThemeElements?.ColorScheme;
+        }
 
         internal bool TryGetSnapshot(A.ColorScheme? colorScheme, out PowerPointChartSnapshot snapshot) {
             try {
@@ -99,6 +132,8 @@ namespace OfficeIMO.PowerPoint {
                 if (plotArea.GetFirstChild<C.BubbleChart>() is C.BubbleChart bubbleChart) {
                     if (IsVaryColorsEnabled(bubbleChart.GetFirstChild<C.VaryColors>()) ||
                         IsBubble3DEnabled(bubbleChart.GetFirstChild<C.Bubble3D>()) ||
+                        bubbleChart.Descendants<C.ShowBubbleSize>().Any(
+                            IsShowBubbleSizeEnabled) ||
                         bubbleChart.Elements<C.BubbleChartSeries>().Any(series =>
                             IsBubble3DEnabled(series.GetFirstChild<C.Bubble3D>()) ||
                             series.Elements<C.DataPoint>().Any(point =>
@@ -164,6 +199,9 @@ namespace OfficeIMO.PowerPoint {
 
         private static bool IsVaryColorsEnabled(C.VaryColors? varyColors) =>
             varyColors != null && varyColors.Val?.Value != false;
+
+        private static bool IsShowBubbleSizeEnabled(C.ShowBubbleSize showBubbleSize) =>
+            showBubbleSize.Val?.Value != false;
 
         private static int CountSupportedChartElements(C.PlotArea plotArea) {
             return plotArea.Elements<C.BarChart>().Count()

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
@@ -141,7 +141,7 @@ namespace OfficeIMO.PowerPoint {
                 if (plotArea.GetFirstChild<C.BubbleChart>() is C.BubbleChart bubbleChart) {
                     if (IsVaryColorsEnabled(bubbleChart.GetFirstChild<C.VaryColors>()) ||
                         IsBubble3DEnabled(bubbleChart.GetFirstChild<C.Bubble3D>()) ||
-                        HasLogarithmicBubbleAxis(plotArea, bubbleChart) ||
+                        HasUnsupportedBubbleAxisScaling(plotArea, bubbleChart) ||
                         (!ignoreBubbleDataLabels &&
                          HasEnabledBubbleDataLabels(bubbleChart)) ||
                         bubbleChart.Elements<C.BubbleChartSeries>().Any(series =>
@@ -210,7 +210,7 @@ namespace OfficeIMO.PowerPoint {
         private static bool IsVaryColorsEnabled(C.VaryColors? varyColors) =>
             varyColors != null && varyColors.Val?.Value != false;
 
-        private static bool HasLogarithmicBubbleAxis(
+        private static bool HasUnsupportedBubbleAxisScaling(
             C.PlotArea plotArea, C.BubbleChart chart) {
             HashSet<uint> axisIds = new(chart.Elements<C.AxisId>()
                 .Where(axis => axis.Val?.Value != null)
@@ -218,7 +218,10 @@ namespace OfficeIMO.PowerPoint {
             return plotArea.Elements<C.ValueAxis>().Any(axis =>
                 axis.AxisId?.Val?.Value != null &&
                 axisIds.Contains(axis.AxisId.Val.Value) &&
-                axis.GetFirstChild<C.Scaling>()?.GetFirstChild<C.LogBase>() != null);
+                axis.GetFirstChild<C.Scaling>() is C.Scaling scaling &&
+                (scaling.GetFirstChild<C.LogBase>() != null ||
+                 scaling.GetFirstChild<C.MinAxisValue>() != null ||
+                 scaling.GetFirstChild<C.MaxAxisValue>() != null));
         }
 
         private static bool HasEnabledBubbleDataLabels(C.BubbleChart chart) =>

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
@@ -143,6 +143,7 @@ namespace OfficeIMO.PowerPoint {
                          IsBubble3DEnabled(
                              bubbleChart.GetFirstChild<C.Bubble3D>()) ||
                          HasUnsupportedBubbleAxes(plotArea, bubbleChart) ||
+                         HasUnsupportedBubbleLegend(chart) ||
                          HasEnabledBubbleDataLabels(bubbleChart) ||
                          bubbleChart.Elements<C.BubbleChartSeries>().Any(series =>
                              IsBubble3DEnabled(
@@ -224,12 +225,21 @@ namespace OfficeIMO.PowerPoint {
                   delete.Val?.Value != false) ||
                  axis.GetFirstChild<C.MajorUnit>() != null ||
                  axis.GetFirstChild<C.MinorUnit>() != null ||
+                 axis.GetFirstChild<C.CrossesAt>() != null ||
+                 (axis.GetFirstChild<C.Crosses>() is C.Crosses crosses &&
+                  crosses.Val?.Value != C.CrossesValues.AutoZero) ||
                  (axis.GetFirstChild<C.Scaling>() is C.Scaling scaling &&
                   (scaling.GetFirstChild<C.LogBase>() != null ||
                    scaling.GetFirstChild<C.MinAxisValue>() != null ||
                    scaling.GetFirstChild<C.MaxAxisValue>() != null ||
                    scaling.GetFirstChild<C.Orientation>()?.Val?.Value ==
                       C.OrientationValues.MaxMin))));
+        }
+
+        private static bool HasUnsupportedBubbleLegend(C.Chart chart) {
+            C.Legend? legend = chart.GetFirstChild<C.Legend>();
+            return legend?.GetFirstChild<C.LegendPosition>()?.Val?.Value ==
+                C.LegendPositionValues.TopRight;
         }
 
         private static bool HasEnabledBubbleDataLabels(C.BubbleChart chart) =>
@@ -373,7 +383,30 @@ namespace OfficeIMO.PowerPoint {
                 WidthPoints,
                 HeightPoints,
                 bubbleSizeMode,
-                bubbleScalePercent);
+                bubbleScalePercent,
+                ReadChartLayout(chart));
+        }
+
+        private static OfficeChartLayout ReadChartLayout(C.Chart chart) {
+            C.Legend? legend = chart.GetFirstChild<C.Legend>();
+            if (legend == null) {
+                return new OfficeChartLayout(showLegend: false);
+            }
+
+            C.LegendPositionValues? nativePosition =
+                legend.GetFirstChild<C.LegendPosition>()?.Val?.Value;
+            OfficeChartLegendPosition position =
+                nativePosition == C.LegendPositionValues.Left
+                    ? OfficeChartLegendPosition.Left
+                    : nativePosition == C.LegendPositionValues.Top
+                        ? OfficeChartLegendPosition.Top
+                        : nativePosition == C.LegendPositionValues.Bottom
+                            ? OfficeChartLegendPosition.Bottom
+                            : OfficeChartLegendPosition.Right;
+            bool overlay = legend.GetFirstChild<C.Overlay>() is C.Overlay item &&
+                item.Val?.Value != false;
+            return new OfficeChartLayout(overlayLegend: overlay,
+                legendPosition: position);
         }
 
         private static PowerPointChartSnapshotKind GetBarChartSnapshotKind(C.BarChart chart) {

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
@@ -97,7 +97,8 @@ namespace OfficeIMO.PowerPoint {
                 }
 
                 if (plotArea.GetFirstChild<C.BubbleChart>() is C.BubbleChart bubbleChart) {
-                    if (IsBubble3DEnabled(bubbleChart.GetFirstChild<C.Bubble3D>()) ||
+                    if (IsVaryColorsEnabled(bubbleChart.GetFirstChild<C.VaryColors>()) ||
+                        IsBubble3DEnabled(bubbleChart.GetFirstChild<C.Bubble3D>()) ||
                         bubbleChart.Elements<C.BubbleChartSeries>().Any(series =>
                             IsBubble3DEnabled(series.GetFirstChild<C.Bubble3D>()))) {
                         snapshot = null!;
@@ -156,7 +157,10 @@ namespace OfficeIMO.PowerPoint {
         }
 
         private static bool IsBubble3DEnabled(C.Bubble3D? bubble3D) =>
-            bubble3D?.Val?.Value == true;
+            bubble3D != null && bubble3D.Val?.Value != false;
+
+        private static bool IsVaryColorsEnabled(C.VaryColors? varyColors) =>
+            varyColors != null && varyColors.Val?.Value != false;
 
         private static int CountSupportedChartElements(C.PlotArea plotArea) {
             return plotArea.Elements<C.BarChart>().Count()

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
@@ -11,8 +11,6 @@ using C = DocumentFormat.OpenXml.Drawing.Charts;
 
 namespace OfficeIMO.PowerPoint {
     public partial class PowerPointChart {
-        private const int MaxChartCachePoints = 100_000;
-
         /// <summary>
         /// Tries to create a dependency-free snapshot for rendering/export consumers.
         /// </summary>
@@ -221,7 +219,9 @@ namespace OfficeIMO.PowerPoint {
                 axis.GetFirstChild<C.Scaling>() is C.Scaling scaling &&
                 (scaling.GetFirstChild<C.LogBase>() != null ||
                  scaling.GetFirstChild<C.MinAxisValue>() != null ||
-                 scaling.GetFirstChild<C.MaxAxisValue>() != null));
+                 scaling.GetFirstChild<C.MaxAxisValue>() != null ||
+                 scaling.GetFirstChild<C.Orientation>()?.Val?.Value ==
+                    C.OrientationValues.MaxMin));
         }
 
         private static bool HasEnabledBubbleDataLabels(C.BubbleChart chart) =>
@@ -673,22 +673,23 @@ namespace OfficeIMO.PowerPoint {
         }
 
         private static List<TPoint> GetBoundedCachedPoints<TPoint>(IEnumerable<TPoint> points) {
-            List<TPoint> boundedPoints = points.Take(MaxChartCachePoints + 1).ToList();
-            if (boundedPoints.Count > MaxChartCachePoints) {
-                throw new InvalidDataException($"The chart cache exceeds the supported limit of {MaxChartCachePoints} points.");
+            List<TPoint> boundedPoints = points
+                .Take(PowerPointUtils.MaximumSharedChartPoints + 1).ToList();
+            if (boundedPoints.Count > PowerPointUtils.MaximumSharedChartPoints) {
+                throw new InvalidDataException($"The chart cache exceeds the supported limit of {PowerPointUtils.MaximumSharedChartPoints} points.");
             }
 
             return boundedPoints;
         }
 
         private static int GetCachedPointLength<TPoint>(OpenXmlElement container, IReadOnlyList<TPoint> points, Func<TPoint, uint?> getIndex) {
-            if (points.Count > MaxChartCachePoints) {
-                throw new InvalidDataException($"The chart cache exceeds the supported limit of {MaxChartCachePoints} points.");
+            if (points.Count > PowerPointUtils.MaximumSharedChartPoints) {
+                throw new InvalidDataException($"The chart cache exceeds the supported limit of {PowerPointUtils.MaximumSharedChartPoints} points.");
             }
 
             uint? pointCount = container.Descendants<C.PointCount>().FirstOrDefault()?.Val?.Value;
-            if (pointCount > MaxChartCachePoints) {
-                throw new InvalidDataException($"The chart cache declares more than the supported limit of {MaxChartCachePoints} points.");
+            if (pointCount > PowerPointUtils.MaximumSharedChartPoints) {
+                throw new InvalidDataException($"The chart cache declares more than the supported limit of {PowerPointUtils.MaximumSharedChartPoints} points.");
             }
 
             uint maxIndex = 0U;
@@ -699,8 +700,8 @@ namespace OfficeIMO.PowerPoint {
                     continue;
                 }
 
-                if (index.Value >= MaxChartCachePoints) {
-                    throw new InvalidDataException($"The chart cache point index exceeds the supported limit of {MaxChartCachePoints} points.");
+                if (index.Value >= PowerPointUtils.MaximumSharedChartPoints) {
+                    throw new InvalidDataException($"The chart cache point index exceeds the supported limit of {PowerPointUtils.MaximumSharedChartPoints} points.");
                 }
 
                 hasIndexedPoint = true;

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
@@ -141,6 +141,7 @@ namespace OfficeIMO.PowerPoint {
                 if (plotArea.GetFirstChild<C.BubbleChart>() is C.BubbleChart bubbleChart) {
                     if (IsVaryColorsEnabled(bubbleChart.GetFirstChild<C.VaryColors>()) ||
                         IsBubble3DEnabled(bubbleChart.GetFirstChild<C.Bubble3D>()) ||
+                        HasLogarithmicBubbleAxis(plotArea, bubbleChart) ||
                         (!ignoreBubbleDataLabels &&
                          HasEnabledBubbleDataLabels(bubbleChart)) ||
                         bubbleChart.Elements<C.BubbleChartSeries>().Any(series =>
@@ -208,6 +209,17 @@ namespace OfficeIMO.PowerPoint {
 
         private static bool IsVaryColorsEnabled(C.VaryColors? varyColors) =>
             varyColors != null && varyColors.Val?.Value != false;
+
+        private static bool HasLogarithmicBubbleAxis(
+            C.PlotArea plotArea, C.BubbleChart chart) {
+            HashSet<uint> axisIds = new(chart.Elements<C.AxisId>()
+                .Where(axis => axis.Val?.Value != null)
+                .Select(axis => axis.Val!.Value));
+            return plotArea.Elements<C.ValueAxis>().Any(axis =>
+                axis.AxisId?.Val?.Value != null &&
+                axisIds.Contains(axis.AxisId.Val.Value) &&
+                axis.GetFirstChild<C.Scaling>()?.GetFirstChild<C.LogBase>() != null);
+        }
 
         private static bool HasEnabledBubbleDataLabels(C.BubbleChart chart) =>
             chart.Descendants<C.ShowLegendKey>().Any(item => item.Val?.Value != false) ||

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
@@ -232,6 +232,10 @@ namespace OfficeIMO.PowerPoint {
                     C.AxisPositionValues.Left) {
                 return true;
             }
+            if (!HasSupportedDefaultBubbleGridlines(
+                    horizontalAxis, verticalAxis)) {
+                return true;
+            }
             return new[] { horizontalAxis, verticalAxis }.Any(axis =>
                 (axis.GetFirstChild<C.Delete>() is C.Delete delete &&
                   delete.Val?.Value != false) ||
@@ -252,6 +256,33 @@ namespace OfficeIMO.PowerPoint {
                    scaling.GetFirstChild<C.MaxAxisValue>() != null ||
                    scaling.GetFirstChild<C.Orientation>()?.Val?.Value ==
                       C.OrientationValues.MaxMin)));
+        }
+
+        private static bool HasSupportedDefaultBubbleGridlines(
+            C.ValueAxis horizontalAxis, C.ValueAxis verticalAxis) {
+            if (horizontalAxis.GetFirstChild<C.MajorGridlines>() != null ||
+                horizontalAxis.GetFirstChild<C.MinorGridlines>() != null ||
+                verticalAxis.GetFirstChild<C.MinorGridlines>() != null) {
+                return false;
+            }
+
+            C.MajorGridlines? gridlines =
+                verticalAxis.GetFirstChild<C.MajorGridlines>();
+            C.ChartShapeProperties? properties =
+                gridlines?.GetFirstChild<C.ChartShapeProperties>();
+            A.Outline? outline = properties?.GetFirstChild<A.Outline>();
+            if (gridlines == null || properties == null || outline == null ||
+                gridlines.ChildElements.Count != 1 ||
+                properties.ChildElements.Count != 1 ||
+                outline.ChildElements.Count != 1 ||
+                outline.Width?.Value !=
+                    PowerPointUnits.FromPoints(0.5D)) {
+                return false;
+            }
+
+            OfficeColor? color = OfficeOpenXmlThemeColorResolver.ResolveColor(
+                outline.GetFirstChild<A.SolidFill>(), colorScheme: null);
+            return color == OfficeChartStyle.Default.GridLineColor;
         }
 
         private static bool TryGetReferencedBubbleAxes(

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
@@ -314,6 +314,13 @@ namespace OfficeIMO.PowerPoint {
             PowerPointChartSnapshotKind kind, PowerPointChartData data,
             OfficeChartBubbleSizeMode bubbleSizeMode = OfficeChartBubbleSizeMode.Area,
             double bubbleScalePercent = 100D) {
+            HashSet<uint> hiddenLegendSeries = GetHiddenLegendSeriesIndexes(chart);
+            for (int seriesIndex = 0; seriesIndex < data.Series.Count; seriesIndex++) {
+                PowerPointChartSeries series = data.Series[seriesIndex];
+                uint sourceIndex = series.SourceIndex ?? (uint)seriesIndex;
+                series.ShowInLegend = !hiddenLegendSeries.Contains(sourceIndex);
+            }
+
             return new PowerPointChartSnapshot(
                 Name ?? string.Empty,
                 ReadTitle(chart),

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
@@ -96,6 +96,18 @@ namespace OfficeIMO.PowerPoint {
                     return true;
                 }
 
+                if (plotArea.GetFirstChild<C.BubbleChart>() is C.BubbleChart bubbleChart) {
+                    PowerPointChartData? data = ReadBubbleSeriesData(
+                        bubbleChart.Elements<C.BubbleChartSeries>(), colorScheme);
+                    if (data == null) {
+                        snapshot = null!;
+                        return false;
+                    }
+
+                    snapshot = CreateSnapshot(chart, PowerPointChartSnapshotKind.Bubble, data);
+                    return true;
+                }
+
                 if (plotArea.GetFirstChild<C.PieChart>() is C.PieChart pieChart) {
                     PowerPointChartData? data = ReadCategorySeriesData(pieChart.Elements<C.PieChartSeries>().Cast<OpenXmlCompositeElement>(), PowerPointChartSnapshotKind.Pie, colorScheme);
                     if (data == null) {
@@ -132,6 +144,7 @@ namespace OfficeIMO.PowerPoint {
                 + plotArea.Elements<C.AreaChart>().Count()
                 + plotArea.Elements<C.RadarChart>().Count()
                 + plotArea.Elements<C.ScatterChart>().Count()
+                + plotArea.Elements<C.BubbleChart>().Count()
                 + plotArea.Elements<C.PieChart>().Count()
                 + plotArea.Elements<C.DoughnutChart>().Count();
         }
@@ -408,6 +421,7 @@ namespace OfficeIMO.PowerPoint {
             chartKind == PowerPointChartSnapshotKind.Area ||
             chartKind == PowerPointChartSnapshotKind.StackedArea ||
             chartKind == PowerPointChartSnapshotKind.StackedArea100 ||
+            chartKind == PowerPointChartSnapshotKind.Bubble ||
             chartKind == PowerPointChartSnapshotKind.Pie ||
             chartKind == PowerPointChartSnapshotKind.Doughnut;
 

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
@@ -900,13 +900,32 @@ namespace OfficeIMO.PowerPoint {
                 return null;
             }
 
-            string text = string.Concat(chartText.Descendants<A.Text>().Select(item => item.Text));
+            C.RichText? richText = chartText.GetFirstChild<C.RichText>();
+            string text = richText != null
+                ? string.Join(Environment.NewLine,
+                    richText.Elements<A.Paragraph>().Select(ReadChartParagraphText))
+                : string.Concat(chartText.Descendants<A.Text>()
+                    .Select(item => item.Text));
             if (!string.IsNullOrWhiteSpace(text)) {
                 return text.Trim();
             }
 
             IReadOnlyList<string> cached = ReadCachedStrings(chartText);
             return cached.Count > 0 && !string.IsNullOrWhiteSpace(cached[0]) ? cached[0].Trim() : null;
+        }
+
+        private static string ReadChartParagraphText(A.Paragraph paragraph) {
+            var builder = new System.Text.StringBuilder();
+            foreach (OpenXmlElement child in paragraph.ChildElements) {
+                if (child is A.Break) {
+                    builder.Append(Environment.NewLine);
+                } else {
+                    foreach (A.Text text in child.Descendants<A.Text>()) {
+                        builder.Append(text.Text);
+                    }
+                }
+            }
+            return builder.ToString();
         }
 
         private static string ReadSeriesName(OpenXmlElement seriesElement) {

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
@@ -19,6 +19,10 @@ namespace OfficeIMO.PowerPoint {
         internal bool TryGetSnapshot(out PowerPointChartSnapshot snapshot) =>
             TryGetSnapshot(GetOwnerColorScheme(), out snapshot);
 
+        private bool TryGetSnapshotForUpdate(out PowerPointChartSnapshot snapshot) =>
+            TryGetSnapshot(GetOwnerColorScheme(), ignoreBubbleDataLabels: true,
+                out snapshot);
+
         private A.ColorScheme? GetOwnerColorScheme() {
             if (_ownerPart is SlidePart slidePart) {
                 return slidePart.ThemeOverridePart?.ThemeOverride?.ColorScheme
@@ -52,7 +56,12 @@ namespace OfficeIMO.PowerPoint {
                 .ThemeElements?.ColorScheme;
         }
 
-        internal bool TryGetSnapshot(A.ColorScheme? colorScheme, out PowerPointChartSnapshot snapshot) {
+        internal bool TryGetSnapshot(A.ColorScheme? colorScheme,
+            out PowerPointChartSnapshot snapshot) =>
+            TryGetSnapshot(colorScheme, ignoreBubbleDataLabels: false, out snapshot);
+
+        private bool TryGetSnapshot(A.ColorScheme? colorScheme,
+            bool ignoreBubbleDataLabels, out PowerPointChartSnapshot snapshot) {
             try {
                 ChartPart chartPart = GetChartPart();
                 C.Chart? chart = chartPart.ChartSpace?.GetFirstChild<C.Chart>();
@@ -132,8 +141,8 @@ namespace OfficeIMO.PowerPoint {
                 if (plotArea.GetFirstChild<C.BubbleChart>() is C.BubbleChart bubbleChart) {
                     if (IsVaryColorsEnabled(bubbleChart.GetFirstChild<C.VaryColors>()) ||
                         IsBubble3DEnabled(bubbleChart.GetFirstChild<C.Bubble3D>()) ||
-                        bubbleChart.Descendants<C.ShowBubbleSize>().Any(
-                            IsShowBubbleSizeEnabled) ||
+                        (!ignoreBubbleDataLabels &&
+                         HasEnabledBubbleDataLabels(bubbleChart)) ||
                         bubbleChart.Elements<C.BubbleChartSeries>().Any(series =>
                             IsBubble3DEnabled(series.GetFirstChild<C.Bubble3D>()) ||
                             series.Elements<C.DataPoint>().Any(point =>
@@ -200,8 +209,13 @@ namespace OfficeIMO.PowerPoint {
         private static bool IsVaryColorsEnabled(C.VaryColors? varyColors) =>
             varyColors != null && varyColors.Val?.Value != false;
 
-        private static bool IsShowBubbleSizeEnabled(C.ShowBubbleSize showBubbleSize) =>
-            showBubbleSize.Val?.Value != false;
+        private static bool HasEnabledBubbleDataLabels(C.BubbleChart chart) =>
+            chart.Descendants<C.ShowLegendKey>().Any(item => item.Val?.Value != false) ||
+            chart.Descendants<C.ShowValue>().Any(item => item.Val?.Value != false) ||
+            chart.Descendants<C.ShowCategoryName>().Any(item => item.Val?.Value != false) ||
+            chart.Descendants<C.ShowSeriesName>().Any(item => item.Val?.Value != false) ||
+            chart.Descendants<C.ShowPercent>().Any(item => item.Val?.Value != false) ||
+            chart.Descendants<C.ShowBubbleSize>().Any(item => item.Val?.Value != false);
 
         private static int CountSupportedChartElements(C.PlotArea plotArea) {
             return plotArea.Elements<C.BarChart>().Count()

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
@@ -174,6 +174,9 @@ namespace OfficeIMO.PowerPoint {
             if (CountSupportedChartElements(plotArea) <= 1) {
                 return false;
             }
+            if (plotArea.Elements<C.BubbleChart>().Any()) {
+                return false;
+            }
 
             var parts = new List<(PowerPointChartSnapshotKind Kind, PowerPointChartData Data)>();
             foreach (OpenXmlElement element in plotArea.ChildElements) {
@@ -465,6 +468,12 @@ namespace OfficeIMO.PowerPoint {
             return OfficeOpenXmlThemeColorResolver.ResolveColor(
                 properties?.GetFirstChild<A.Outline>()?.GetFirstChild<A.SolidFill>(),
                 colorScheme);
+        }
+
+        private static bool IsSeriesStrokeVisible(OpenXmlCompositeElement seriesElement) {
+            C.ChartShapeProperties? properties =
+                seriesElement.GetFirstChild<C.ChartShapeProperties>();
+            return properties?.GetFirstChild<A.Outline>()?.GetFirstChild<A.NoFill>() == null;
         }
 
         private static string? ReadTitle(C.Chart chart) {

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
@@ -97,6 +97,12 @@ namespace OfficeIMO.PowerPoint {
                 }
 
                 if (plotArea.GetFirstChild<C.BubbleChart>() is C.BubbleChart bubbleChart) {
+                    if (IsBubble3DEnabled(bubbleChart.GetFirstChild<C.Bubble3D>()) ||
+                        bubbleChart.Elements<C.BubbleChartSeries>().Any(series =>
+                            IsBubble3DEnabled(series.GetFirstChild<C.Bubble3D>()))) {
+                        snapshot = null!;
+                        return false;
+                    }
                     PowerPointChartData? data = ReadBubbleSeriesData(
                         bubbleChart.Elements<C.BubbleChartSeries>(), colorScheme);
                     if (data == null) {
@@ -148,6 +154,9 @@ namespace OfficeIMO.PowerPoint {
                 return false;
             }
         }
+
+        private static bool IsBubble3DEnabled(C.Bubble3D? bubble3D) =>
+            bubble3D?.Val?.Value == true;
 
         private static int CountSupportedChartElements(C.PlotArea plotArea) {
             return plotArea.Elements<C.BarChart>().Count()

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
@@ -149,6 +149,7 @@ namespace OfficeIMO.PowerPoint {
                              bubbleChart.GetFirstChild<C.Bubble3D>()) ||
                          HasUnsupportedBubbleAxes(plotArea, bubbleChart) ||
                          HasUnsupportedBubbleLegend(chart) ||
+                         HasUnsupportedBubbleAreaLayout(chartPart, plotArea) ||
                          HasEnabledBubbleDataLabels(bubbleChart) ||
                          bubbleChart.Elements<C.BubbleChartSeries>().Any(series =>
                              IsBubble3DEnabled(
@@ -220,13 +221,19 @@ namespace OfficeIMO.PowerPoint {
 
         private static bool HasUnsupportedBubbleAxes(
             C.PlotArea plotArea, C.BubbleChart chart) {
-            HashSet<uint> axisIds = new(chart.Elements<C.AxisId>()
-                .Where(axis => axis.Val?.Value != null)
-                .Select(axis => axis.Val!.Value));
-            return plotArea.Elements<C.ValueAxis>().Any(axis =>
-                axis.AxisId?.Val?.Value != null &&
-                axisIds.Contains(axis.AxisId.Val.Value) &&
-                ((axis.GetFirstChild<C.Delete>() is C.Delete delete &&
+            if (!TryGetReferencedBubbleAxes(
+                    plotArea, chart, out C.ValueAxis horizontalAxis,
+                    out C.ValueAxis verticalAxis)) {
+                return true;
+            }
+            if (horizontalAxis.AxisPosition?.Val?.Value !=
+                    C.AxisPositionValues.Bottom ||
+                verticalAxis.AxisPosition?.Val?.Value !=
+                    C.AxisPositionValues.Left) {
+                return true;
+            }
+            return new[] { horizontalAxis, verticalAxis }.Any(axis =>
+                (axis.GetFirstChild<C.Delete>() is C.Delete delete &&
                   delete.Val?.Value != false) ||
                  axis.GetFirstChild<C.MajorUnit>() != null ||
                  axis.GetFirstChild<C.MinorUnit>() != null ||
@@ -242,7 +249,33 @@ namespace OfficeIMO.PowerPoint {
                    scaling.GetFirstChild<C.MinAxisValue>() != null ||
                    scaling.GetFirstChild<C.MaxAxisValue>() != null ||
                    scaling.GetFirstChild<C.Orientation>()?.Val?.Value ==
-                      C.OrientationValues.MaxMin))));
+                      C.OrientationValues.MaxMin)));
+        }
+
+        private static bool TryGetReferencedBubbleAxes(
+            C.PlotArea plotArea, C.BubbleChart chart,
+            out C.ValueAxis horizontalAxis, out C.ValueAxis verticalAxis) {
+            horizontalAxis = null!;
+            verticalAxis = null!;
+            List<C.AxisId> references =
+                chart.Elements<C.AxisId>().ToList();
+            if (references.Count != 2 ||
+                references.Any(axis => axis.Val?.Value == null)) {
+                return false;
+            }
+            uint horizontalId = references[0].Val!.Value;
+            uint verticalId = references[1].Val!.Value;
+            if (horizontalId == verticalId) return false;
+            C.ValueAxis? horizontal = plotArea.Elements<C.ValueAxis>()
+                .FirstOrDefault(axis =>
+                    axis.AxisId?.Val?.Value == horizontalId);
+            C.ValueAxis? vertical = plotArea.Elements<C.ValueAxis>()
+                .FirstOrDefault(axis =>
+                    axis.AxisId?.Val?.Value == verticalId);
+            if (horizontal == null || vertical == null) return false;
+            horizontalAxis = horizontal;
+            verticalAxis = vertical;
+            return true;
         }
 
         private static bool HasUnsupportedBubbleLegend(C.Chart chart) {
@@ -253,6 +286,15 @@ namespace OfficeIMO.PowerPoint {
                  legend.GetFirstChild<C.Layout>()?
                      .GetFirstChild<C.ManualLayout>() != null);
         }
+
+        private static bool HasUnsupportedBubbleAreaLayout(
+            ChartPart chartPart, C.PlotArea plotArea) =>
+            plotArea.GetFirstChild<C.Layout>()?
+                .GetFirstChild<C.ManualLayout>() != null ||
+            chartPart.ChartSpace?.GetFirstChild<C.ShapeProperties>()?
+                .ChildElements.Count > 0 ||
+            plotArea.GetFirstChild<C.ShapeProperties>()?
+                .ChildElements.Count > 0;
 
         private static bool HasEnabledBubbleDataLabels(C.BubbleChart chart) =>
             chart.Descendants<C.ShowLegendKey>().Any(item => item.Val?.Value != false) ||
@@ -408,17 +450,14 @@ namespace OfficeIMO.PowerPoint {
                 HeightPoints,
                 bubbleSizeMode,
                 bubbleScalePercent,
-                ReadChartLayout(chart));
+                ReadChartLayout(chart, kind));
         }
 
-        private static OfficeChartLayout ReadChartLayout(C.Chart chart) {
+        private static OfficeChartLayout ReadChartLayout(
+            C.Chart chart, PowerPointChartSnapshotKind kind) {
             C.Legend? legend = chart.GetFirstChild<C.Legend>();
-            if (legend == null) {
-                return new OfficeChartLayout(showLegend: false);
-            }
-
             C.LegendPositionValues? nativePosition =
-                legend.GetFirstChild<C.LegendPosition>()?.Val?.Value;
+                legend?.GetFirstChild<C.LegendPosition>()?.Val?.Value;
             OfficeChartLegendPosition position =
                 nativePosition == C.LegendPositionValues.Left
                     ? OfficeChartLegendPosition.Left
@@ -427,10 +466,44 @@ namespace OfficeIMO.PowerPoint {
                         : nativePosition == C.LegendPositionValues.Bottom
                             ? OfficeChartLegendPosition.Bottom
                             : OfficeChartLegendPosition.Right;
-            bool overlay = legend.GetFirstChild<C.Overlay>() is C.Overlay item &&
+            bool overlay = legend?.GetFirstChild<C.Overlay>() is C.Overlay item &&
                 item.Val?.Value != false;
+
+            string? horizontalAxisTitle = null;
+            string? verticalAxisTitle = null;
+            string? horizontalAxisNumberFormat = null;
+            string? verticalAxisNumberFormat = null;
+            if (kind == PowerPointChartSnapshotKind.Bubble &&
+                chart.GetFirstChild<C.PlotArea>() is C.PlotArea plotArea &&
+                plotArea.GetFirstChild<C.BubbleChart>() is C.BubbleChart bubble &&
+                TryGetReferencedBubbleAxes(
+                    plotArea, bubble, out C.ValueAxis horizontalAxis,
+                    out C.ValueAxis verticalAxis)) {
+                horizontalAxisTitle = ReadAxisTitle(horizontalAxis);
+                verticalAxisTitle = ReadAxisTitle(verticalAxis);
+                horizontalAxisNumberFormat =
+                    ReadAxisNumberFormat(horizontalAxis);
+                verticalAxisNumberFormat =
+                    ReadAxisNumberFormat(verticalAxis);
+            }
+
             return new OfficeChartLayout(overlayLegend: overlay,
-                legendPosition: position);
+                showLegend: legend != null,
+                legendPosition: position,
+                categoryAxisTitle: horizontalAxisTitle,
+                valueAxisTitle: verticalAxisTitle,
+                horizontalAxisNumberFormat: horizontalAxisNumberFormat,
+                verticalAxisNumberFormat: verticalAxisNumberFormat);
+        }
+
+        private static string? ReadAxisTitle(C.ValueAxis axis) =>
+            ReadChartText(
+                axis.GetFirstChild<C.Title>()?.GetFirstChild<C.ChartText>());
+
+        private static string? ReadAxisNumberFormat(C.ValueAxis axis) {
+            string? format = axis.GetFirstChild<C.NumberingFormat>()?
+                .FormatCode?.Value;
+            return string.IsNullOrWhiteSpace(format) ? null : format;
         }
 
         private static PowerPointChartSnapshotKind GetBarChartSnapshotKind(C.BarChart chart) {
@@ -630,7 +703,12 @@ namespace OfficeIMO.PowerPoint {
         }
 
         private static string? ReadTitle(C.Chart chart) {
-            C.ChartText? chartText = chart.GetFirstChild<C.Title>()?.GetFirstChild<C.ChartText>();
+            C.ChartText? chartText =
+                chart.GetFirstChild<C.Title>()?.GetFirstChild<C.ChartText>();
+            return ReadChartText(chartText);
+        }
+
+        private static string? ReadChartText(C.ChartText? chartText) {
             if (chartText == null) {
                 return null;
             }

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
@@ -237,7 +237,9 @@ namespace OfficeIMO.PowerPoint {
                   delete.Val?.Value != false) ||
                  axis.GetFirstChild<C.MajorUnit>() != null ||
                  axis.GetFirstChild<C.MinorUnit>() != null ||
+                 axis.GetFirstChild<C.DisplayUnits>() != null ||
                  axis.GetFirstChild<C.CrossesAt>() != null ||
+                 HasUnsupportedSharedAxisNumberFormat(axis) ||
                  (axis.GetFirstChild<C.TickLabelPosition>() is
                       C.TickLabelPosition tickLabelPosition &&
                   tickLabelPosition.Val?.Value !=
@@ -504,6 +506,65 @@ namespace OfficeIMO.PowerPoint {
             string? format = axis.GetFirstChild<C.NumberingFormat>()?
                 .FormatCode?.Value;
             return string.IsNullOrWhiteSpace(format) ? null : format;
+        }
+
+        private static bool HasUnsupportedSharedAxisNumberFormat(
+            C.ValueAxis axis) {
+            string? format = ReadAxisNumberFormat(axis);
+            if (string.IsNullOrWhiteSpace(format)) return false;
+            if (string.Equals(format, "General",
+                    StringComparison.OrdinalIgnoreCase)) {
+                return false;
+            }
+
+            bool inQuotedLiteral = false;
+            bool escaped = false;
+            bool sectionHasPlaceholder = false;
+            for (int index = 0; index < format!.Length; index++) {
+                char value = format[index];
+                if (escaped) {
+                    escaped = false;
+                    continue;
+                }
+                if (value == '\\') {
+                    escaped = true;
+                    continue;
+                }
+                if (value == '"') {
+                    inQuotedLiteral = !inQuotedLiteral;
+                    continue;
+                }
+                if (inQuotedLiteral) {
+                    continue;
+                }
+                if (value == '0' || value == '#' || value == '?') {
+                    sectionHasPlaceholder = true;
+                    continue;
+                }
+                if (value == ';') {
+                    if (!sectionHasPlaceholder) return true;
+                    sectionHasPlaceholder = false;
+                    continue;
+                }
+                if (value == '/' || value == '@' ||
+                    value == '[' || value == ']') {
+                    return true;
+                }
+                if (value != 'E' && value != 'e') continue;
+
+                int next = index + 1;
+                if (next < format.Length &&
+                    (format[next] == '+' || format[next] == '-')) {
+                    next++;
+                }
+                if (next < format.Length &&
+                    (format[next] == '0' || format[next] == '#' ||
+                     format[next] == '?')) {
+                    return true;
+                }
+            }
+
+            return inQuotedLiteral || escaped || !sectionHasPlaceholder;
         }
 
         private static PowerPointChartSnapshotKind GetBarChartSnapshotKind(C.BarChart chart) {

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
@@ -215,7 +215,12 @@ namespace OfficeIMO.PowerPoint {
             chart.Descendants<C.ShowCategoryName>().Any(item => item.Val?.Value != false) ||
             chart.Descendants<C.ShowSeriesName>().Any(item => item.Val?.Value != false) ||
             chart.Descendants<C.ShowPercent>().Any(item => item.Val?.Value != false) ||
-            chart.Descendants<C.ShowBubbleSize>().Any(item => item.Val?.Value != false);
+            chart.Descendants<C.ShowBubbleSize>().Any(item => item.Val?.Value != false) ||
+            chart.Descendants<C.DataLabel>().Any(label => {
+                C.Delete? delete = label.GetFirstChild<C.Delete>();
+                return label.GetFirstChild<C.ChartText>() != null &&
+                    (delete == null || delete.Val?.Value == false);
+            });
 
         private static int CountSupportedChartElements(C.PlotArea plotArea) {
             return plotArea.Elements<C.BarChart>().Count()

--- a/OfficeIMO.PowerPoint/PowerPointChartData.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChartData.cs
@@ -195,6 +195,11 @@ namespace OfficeIMO.PowerPoint {
         /// </summary>
         public double? StrokeWidth { get; private set; }
 
+        /// <summary>
+        /// Optional source-defined series outline color for exported snapshots.
+        /// </summary>
+        internal OfficeColor? StrokeColor { get; set; }
+
         /// <summary>Primary or secondary value-axis assignment detected for this series.</summary>
         public OfficeChartAxisGroup AxisGroup { get; private set; }
 

--- a/OfficeIMO.PowerPoint/PowerPointChartData.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChartData.cs
@@ -203,6 +203,9 @@ namespace OfficeIMO.PowerPoint {
         /// <summary>Whether the source series outline is enabled.</summary>
         internal bool ShowStroke { get; set; } = true;
 
+        /// <summary>Whether the source series is visible in the chart legend.</summary>
+        internal bool ShowInLegend { get; set; } = true;
+
         /// <summary>Primary or secondary value-axis assignment detected for this series.</summary>
         public OfficeChartAxisGroup AxisGroup { get; private set; }
 

--- a/OfficeIMO.PowerPoint/PowerPointChartData.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChartData.cs
@@ -200,6 +200,9 @@ namespace OfficeIMO.PowerPoint {
         /// </summary>
         internal OfficeColor? StrokeColor { get; set; }
 
+        /// <summary>Whether the source series outline is enabled.</summary>
+        internal bool ShowStroke { get; set; } = true;
+
         /// <summary>Primary or secondary value-axis assignment detected for this series.</summary>
         public OfficeChartAxisGroup AxisGroup { get; private set; }
 

--- a/OfficeIMO.PowerPoint/PowerPointChartData.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChartData.cs
@@ -46,10 +46,17 @@ namespace OfficeIMO.PowerPoint {
 
             int expected = Categories.Count;
             foreach (PowerPointChartSeries item in Series) {
-                if (item.ChartKind == PowerPointChartSnapshotKind.Scatter) {
+                if (item.ChartKind == PowerPointChartSnapshotKind.Scatter ||
+                    item.ChartKind == PowerPointChartSnapshotKind.Bubble) {
                     if (item.XValues == null || item.XValues.Count != item.Values.Count) {
                         throw new System.ArgumentException(
-                            "Each scatter series must have matching X and Y value counts.",
+                            "Each numeric-axis series must have matching X and Y value counts.",
+                            nameof(series));
+                    }
+                    if (item.ChartKind == PowerPointChartSnapshotKind.Bubble &&
+                        (item.BubbleSizes == null || item.BubbleSizes.Count != item.Values.Count)) {
+                        throw new System.ArgumentException(
+                            "Each bubble series must have matching X, Y, and size value counts.",
                             nameof(series));
                     }
                 } else if (item.Values.Count != expected) {
@@ -162,6 +169,16 @@ namespace OfficeIMO.PowerPoint {
         /// Optional numeric X-axis values for this series.
         /// </summary>
         public IReadOnlyList<double>? XValues { get; private set; }
+
+        /// <summary>
+        /// Optional per-point sizes for a bubble series.
+        /// </summary>
+        internal IReadOnlyList<double>? BubbleSizes { get; set; }
+
+        /// <summary>
+        /// Optional source-defined colors aligned with individual data points.
+        /// </summary>
+        internal IReadOnlyList<OfficeColor?>? PointColors { get; set; }
 
         /// <summary>
         /// Optional chart kind for mixed/combo chart rendering.

--- a/OfficeIMO.PowerPoint/PowerPointChartSnapshot.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChartSnapshot.cs
@@ -51,7 +51,10 @@ namespace OfficeIMO.PowerPoint {
         StackedArea100,
 
         /// <summary>Radar chart.</summary>
-        Radar
+        Radar,
+
+        /// <summary>Bubble chart.</summary>
+        Bubble
     }
 
     /// <summary>

--- a/OfficeIMO.PowerPoint/PowerPointChartSnapshot.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChartSnapshot.cs
@@ -61,7 +61,12 @@ namespace OfficeIMO.PowerPoint {
     /// Lightweight chart snapshot that consumers can render without depending on PowerPoint or Open XML chart internals.
     /// </summary>
     internal sealed class PowerPointChartSnapshot {
-        internal PowerPointChartSnapshot(string name, string? title, PowerPointChartSnapshotKind chartKind, PowerPointChartData data, double widthPoints, double heightPoints) {
+        internal PowerPointChartSnapshot(string name, string? title,
+            PowerPointChartSnapshotKind chartKind, PowerPointChartData data,
+            double widthPoints, double heightPoints,
+            OfficeIMO.Drawing.OfficeChartBubbleSizeMode bubbleSizeMode =
+                OfficeIMO.Drawing.OfficeChartBubbleSizeMode.Area,
+            double bubbleScalePercent = 100D) {
             if (data == null) {
                 throw new ArgumentNullException(nameof(data));
             }
@@ -72,6 +77,8 @@ namespace OfficeIMO.PowerPoint {
             Data = data;
             WidthPoints = widthPoints;
             HeightPoints = heightPoints;
+            BubbleSizeMode = bubbleSizeMode;
+            BubbleScalePercent = bubbleScalePercent;
         }
 
         /// <summary>Chart drawing name.</summary>
@@ -91,5 +98,11 @@ namespace OfficeIMO.PowerPoint {
 
         /// <summary>Chart height in points.</summary>
         public double HeightPoints { get; }
+
+        /// <summary>Whether bubble values represent area or width.</summary>
+        public OfficeIMO.Drawing.OfficeChartBubbleSizeMode BubbleSizeMode { get; }
+
+        /// <summary>Bubble diameter scale as a percentage.</summary>
+        public double BubbleScalePercent { get; }
     }
 }

--- a/OfficeIMO.PowerPoint/PowerPointChartSnapshot.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChartSnapshot.cs
@@ -66,7 +66,8 @@ namespace OfficeIMO.PowerPoint {
             double widthPoints, double heightPoints,
             OfficeIMO.Drawing.OfficeChartBubbleSizeMode bubbleSizeMode =
                 OfficeIMO.Drawing.OfficeChartBubbleSizeMode.Area,
-            double bubbleScalePercent = 100D) {
+            double bubbleScalePercent = 100D,
+            OfficeIMO.Drawing.OfficeChartLayout? layout = null) {
             if (data == null) {
                 throw new ArgumentNullException(nameof(data));
             }
@@ -79,6 +80,7 @@ namespace OfficeIMO.PowerPoint {
             HeightPoints = heightPoints;
             BubbleSizeMode = bubbleSizeMode;
             BubbleScalePercent = bubbleScalePercent;
+            Layout = layout ?? OfficeIMO.Drawing.OfficeChartLayout.Default;
         }
 
         /// <summary>Chart drawing name.</summary>
@@ -104,5 +106,8 @@ namespace OfficeIMO.PowerPoint {
 
         /// <summary>Bubble diameter scale as a percentage.</summary>
         public double BubbleScalePercent { get; }
+
+        /// <summary>Shared chart layout projected from native chart settings.</summary>
+        public OfficeIMO.Drawing.OfficeChartLayout Layout { get; }
     }
 }

--- a/OfficeIMO.PowerPoint/PowerPointSlide.SharedCharts.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSlide.SharedCharts.cs
@@ -19,7 +19,9 @@ namespace OfficeIMO.PowerPoint {
                 byte[] workbookBytes = PowerPointUtils.BuildChartWorkbook(scatterData);
                 chart = AddChartInternal(workbookBytes, (chartPart, embeddedRelId) => {
                     PowerPointUtils.PopulateChart(chartPart, embeddedRelId, scatterData, PowerPointChartKind.Scatter);
-                    PowerPointUtils.ApplySharedChartSeriesStyle(chartPart, data, chartKind);
+                    PowerPointUtils.ApplySharedChartSeriesStyle(
+                        chartPart, data, chartKind,
+                        materializeMissingBubbleColors: false);
                 }, left, top, width, height);
             } else if (chartKind == OfficeChartKind.Bubble) {
                 byte[] workbookBytes = PowerPointUtils.BuildBubbleChartWorkbook(data);

--- a/OfficeIMO.PowerPoint/PowerPointSlide.SharedCharts.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSlide.SharedCharts.cs
@@ -21,6 +21,11 @@ namespace OfficeIMO.PowerPoint {
                     PowerPointUtils.PopulateChart(chartPart, embeddedRelId, scatterData, PowerPointChartKind.Scatter);
                     PowerPointUtils.ApplySharedChartSeriesStyle(chartPart, data, chartKind);
                 }, left, top, width, height);
+            } else if (chartKind == OfficeChartKind.Bubble) {
+                byte[] workbookBytes = PowerPointUtils.BuildBubbleChartWorkbook(data);
+                chart = AddChartInternal(workbookBytes, (chartPart, embeddedRelId) =>
+                    PowerPointUtils.PopulateSharedChart(chartPart, embeddedRelId, data, chartKind),
+                    left, top, width, height);
             } else {
                 PowerPointChartData chartData = PowerPointUtils.ToPowerPointChartData(data);
                 byte[] workbookBytes = PowerPointUtils.BuildChartWorkbook(chartData);

--- a/OfficeIMO.PowerPoint/PowerPointUtils.Charts.Bubbles.cs
+++ b/OfficeIMO.PowerPoint/PowerPointUtils.Charts.Bubbles.cs
@@ -65,26 +65,33 @@ namespace OfficeIMO.PowerPoint {
                 IReadOnlyList<double> sharedX = data.Series.Any(series => series.XValues == null)
                     ? ParseScatterCategories(data.Categories)
                     : Array.Empty<double>();
-                for (int pointIndex = 0; pointIndex < maxPoints; pointIndex++) {
-                    uint rowIndex = (uint)(pointIndex + 2);
-                    var row = new S.Row {
-                        RowIndex = rowIndex,
-                        Spans = new ListValue<StringValue> { InnerText = $"1:{totalColumns}" }
-                    };
-                    for (int seriesIndex = 0; seriesIndex < seriesCount; seriesIndex++) {
-                        OfficeChartSeries series = data.Series[seriesIndex];
-                        IReadOnlyList<double> xValues = series.XValues ?? sharedX;
-                        int xColumn = seriesIndex * 3 + 1;
-                        if (pointIndex < series.Values.Count) {
-                            row.Append(CreateNumberCell(
-                                $"{ColumnLetter(xColumn)}{rowIndex}", xValues[pointIndex]));
-                            row.Append(CreateNumberCell(
-                                $"{ColumnLetter(xColumn + 1)}{rowIndex}", series.Values[pointIndex]));
-                            row.Append(CreateNumberCell(
-                                $"{ColumnLetter(xColumn + 2)}{rowIndex}",
-                                series.BubbleSizes![pointIndex]));
-                        }
+                var rows = new S.Row[maxPoints];
+                for (int seriesIndex = 0; seriesIndex < seriesCount; seriesIndex++) {
+                    OfficeChartSeries series = data.Series[seriesIndex];
+                    IReadOnlyList<double> xValues = series.XValues ?? sharedX;
+                    int xColumn = seriesIndex * 3 + 1;
+                    for (int pointIndex = 0;
+                         pointIndex < series.Values.Count;
+                         pointIndex++) {
+                        uint rowIndex = (uint)(pointIndex + 2);
+                        S.Row row = rows[pointIndex] ??= new S.Row {
+                            RowIndex = rowIndex,
+                            Spans = new ListValue<StringValue> {
+                                InnerText = $"1:{totalColumns}"
+                            }
+                        };
+                        row.Append(CreateNumberCell(
+                            $"{ColumnLetter(xColumn)}{rowIndex}",
+                            xValues[pointIndex]));
+                        row.Append(CreateNumberCell(
+                            $"{ColumnLetter(xColumn + 1)}{rowIndex}",
+                            series.Values[pointIndex]));
+                        row.Append(CreateNumberCell(
+                            $"{ColumnLetter(xColumn + 2)}{rowIndex}",
+                            series.BubbleSizes![pointIndex]));
                     }
+                }
+                foreach (S.Row row in rows) {
                     sheetData.Append(row);
                 }
 

--- a/OfficeIMO.PowerPoint/PowerPointUtils.Charts.Bubbles.cs
+++ b/OfficeIMO.PowerPoint/PowerPointUtils.Charts.Bubbles.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using OfficeIMO.Drawing;
+using C = DocumentFormat.OpenXml.Drawing.Charts;
+using S = DocumentFormat.OpenXml.Spreadsheet;
+
+namespace OfficeIMO.PowerPoint {
+    internal static partial class PowerPointUtils {
+        internal static byte[] BuildBubbleChartWorkbook(OfficeChartData data) {
+            if (data == null) throw new ArgumentNullException(nameof(data));
+
+            using MemoryStream stream = new();
+            using (SpreadsheetDocument document =
+                   SpreadsheetDocument.Create(stream, SpreadsheetDocumentType.Workbook)) {
+                WorkbookPart workbookPart = document.AddWorkbookPart();
+                workbookPart.Workbook = new S.Workbook();
+                WorksheetPart worksheetPart = workbookPart.AddNewPart<WorksheetPart>();
+                var sheetData = new S.SheetData();
+
+                int seriesCount = data.Series.Count;
+                int totalColumns = seriesCount * 3;
+                int maxPoints = data.Series.Max(series => series.Values.Count);
+                int totalRows = maxPoints + 1;
+                worksheetPart.Worksheet = new S.Worksheet(
+                    new S.SheetDimension {
+                        Reference = $"A1:{ColumnLetter(totalColumns)}{totalRows}"
+                    },
+                    sheetData);
+
+                SharedStringTablePart sharedStringsPart =
+                    workbookPart.AddNewPart<SharedStringTablePart>();
+                sharedStringsPart.SharedStringTable = new S.SharedStringTable();
+                var stringIndexes = new Dictionary<string, int>(StringComparer.Ordinal);
+                int GetStringIndex(string value) {
+                    if (!stringIndexes.TryGetValue(value, out int index)) {
+                        index = stringIndexes.Count;
+                        stringIndexes[value] = index;
+                        sharedStringsPart.SharedStringTable.AppendChild(
+                            new S.SharedStringItem(new S.Text(value)));
+                    }
+                    return index;
+                }
+
+                var header = new S.Row {
+                    RowIndex = 1U,
+                    Spans = new ListValue<StringValue> { InnerText = $"1:{totalColumns}" }
+                };
+                for (int seriesIndex = 0; seriesIndex < seriesCount; seriesIndex++) {
+                    OfficeChartSeries series = data.Series[seriesIndex];
+                    int xColumn = seriesIndex * 3 + 1;
+                    header.Append(CreateSharedStringCell($"{ColumnLetter(xColumn)}1",
+                        GetStringIndex($"{series.Name} X")));
+                    header.Append(CreateSharedStringCell($"{ColumnLetter(xColumn + 1)}1",
+                        GetStringIndex(series.Name)));
+                    header.Append(CreateSharedStringCell($"{ColumnLetter(xColumn + 2)}1",
+                        GetStringIndex($"{series.Name} Size")));
+                }
+                sheetData.Append(header);
+
+                IReadOnlyList<double> sharedX = data.Series.Any(series => series.XValues == null)
+                    ? ParseScatterCategories(data.Categories)
+                    : Array.Empty<double>();
+                for (int pointIndex = 0; pointIndex < maxPoints; pointIndex++) {
+                    uint rowIndex = (uint)(pointIndex + 2);
+                    var row = new S.Row {
+                        RowIndex = rowIndex,
+                        Spans = new ListValue<StringValue> { InnerText = $"1:{totalColumns}" }
+                    };
+                    for (int seriesIndex = 0; seriesIndex < seriesCount; seriesIndex++) {
+                        OfficeChartSeries series = data.Series[seriesIndex];
+                        IReadOnlyList<double> xValues = series.XValues ?? sharedX;
+                        int xColumn = seriesIndex * 3 + 1;
+                        if (pointIndex < series.Values.Count) {
+                            row.Append(CreateNumberCell(
+                                $"{ColumnLetter(xColumn)}{rowIndex}", xValues[pointIndex]));
+                            row.Append(CreateNumberCell(
+                                $"{ColumnLetter(xColumn + 1)}{rowIndex}", series.Values[pointIndex]));
+                            row.Append(CreateNumberCell(
+                                $"{ColumnLetter(xColumn + 2)}{rowIndex}",
+                                series.BubbleSizes![pointIndex]));
+                        }
+                    }
+                    sheetData.Append(row);
+                }
+
+                S.Sheets sheets = workbookPart.Workbook.AppendChild(new S.Sheets());
+                sheets.Append(new S.Sheet {
+                    Id = workbookPart.GetIdOfPart(worksheetPart),
+                    SheetId = 1U,
+                    Name = "Sheet1"
+                });
+                sharedStringsPart.SharedStringTable.Save();
+                worksheetPart.Worksheet.Save();
+                workbookPart.Workbook.Save();
+            }
+            return stream.ToArray();
+        }
+
+        private static C.BubbleChart CreateSharedBubbleChart(OfficeChartData data,
+            uint xAxisId, uint yAxisId) {
+            C.BubbleChart chart = new(
+                new C.VaryColors { Val = false });
+            for (int seriesIndex = 0; seriesIndex < data.Series.Count; seriesIndex++) {
+                chart.Append(CreateSharedBubbleSeries(data, seriesIndex));
+            }
+            chart.Append(CreateDefaultDataLabels());
+            chart.Append(new C.Bubble3D { Val = false });
+            chart.Append(new C.BubbleScale { Val = 100U });
+            chart.Append(new C.ShowNegativeBubbles { Val = false });
+            chart.Append(new C.SizeRepresents { Val = C.SizeRepresentsValues.Area });
+            chart.Append(new C.AxisId { Val = xAxisId });
+            chart.Append(new C.AxisId { Val = yAxisId });
+            return chart;
+        }
+
+        private static C.BubbleChartSeries CreateSharedBubbleSeries(OfficeChartData data,
+            int seriesIndex) {
+            OfficeChartSeries series = data.Series[seriesIndex];
+            IReadOnlyList<double> xValues = series.XValues ?? ParseScatterCategories(data.Categories);
+            int firstColumn = seriesIndex * 3 + 1;
+            int lastRow = series.Values.Count + 1;
+            string xColumn = ColumnLetter(firstColumn);
+            string yColumn = ColumnLetter(firstColumn + 1);
+            string sizeColumn = ColumnLetter(firstColumn + 2);
+            return new C.BubbleChartSeries(
+                new C.Index { Val = (uint)seriesIndex },
+                new C.Order { Val = (uint)seriesIndex },
+                new C.SeriesText(CreateStringReference(
+                    $"Sheet1!${yColumn}$1", new[] { series.Name })),
+                new C.XValues(CreateNumberReference(
+                    $"Sheet1!${xColumn}$2:${xColumn}${lastRow}", xValues)),
+                new C.YValues(CreateNumberReference(
+                    $"Sheet1!${yColumn}$2:${yColumn}${lastRow}", series.Values)),
+                new C.BubbleSize(CreateNumberReference(
+                    $"Sheet1!${sizeColumn}$2:${sizeColumn}${lastRow}", series.BubbleSizes!)),
+                new C.Bubble3D { Val = false });
+        }
+    }
+}

--- a/OfficeIMO.PowerPoint/PowerPointUtils.SharedChartFormatting.cs
+++ b/OfficeIMO.PowerPoint/PowerPointUtils.SharedChartFormatting.cs
@@ -69,16 +69,27 @@ namespace OfficeIMO.PowerPoint {
             OpenXmlCompositeElement generated) {
             List<OpenXmlCompositeElement> oldSeries = preserved.ChildElements
                 .OfType<OpenXmlCompositeElement>().Where(IsSharedSeriesElement).ToList();
+            var usedSeries = new HashSet<OpenXmlCompositeElement>();
             OpenXmlElement? insertionPoint = oldSeries.FirstOrDefault();
-            foreach (OpenXmlCompositeElement generatedSeries in generated.ChildElements
-                         .OfType<OpenXmlCompositeElement>().Where(IsSharedSeriesElement)) {
+            List<OpenXmlCompositeElement> generatedSeriesElements = generated.ChildElements
+                .OfType<OpenXmlCompositeElement>().Where(IsSharedSeriesElement).ToList();
+            for (int position = 0; position < generatedSeriesElements.Count; position++) {
+                OpenXmlCompositeElement generatedSeries =
+                    generatedSeriesElements[position];
                 uint? seriesIndex = generatedSeries.GetFirstChild<C.Index>()?.Val?.Value;
                 OpenXmlCompositeElement? sourceSeries = oldSeries.FirstOrDefault(series =>
+                    !usedSeries.Contains(series) &&
                     series.GetType() == generatedSeries.GetType() &&
                     series.GetFirstChild<C.Index>()?.Val?.Value == seriesIndex);
+                if (sourceSeries == null && position < oldSeries.Count &&
+                    !usedSeries.Contains(oldSeries[position]) &&
+                    oldSeries[position].GetType() == generatedSeries.GetType()) {
+                    sourceSeries = oldSeries[position];
+                }
                 OpenXmlCompositeElement updated = sourceSeries == null
                     ? (OpenXmlCompositeElement)generatedSeries.CloneNode(true)
                     : UpdateSharedSeriesData(sourceSeries, generatedSeries);
+                if (sourceSeries != null) usedSeries.Add(sourceSeries);
                 if (insertionPoint == null) preserved.AddChild(updated, true);
                 else preserved.InsertBefore(updated, insertionPoint);
             }
@@ -130,7 +141,46 @@ namespace OfficeIMO.PowerPoint {
         private static void PreserveSharedAxes(C.PlotArea source, C.PlotArea replacement) {
             if (UsesHorizontalSharedAxes(source) != UsesHorizontalSharedAxes(replacement)) return;
             PreserveSharedCategoryAxes(source, replacement);
-            PreserveSharedAxes<C.ValueAxis>(source, replacement);
+            if (!PreserveSharedBubbleAxes(source, replacement)) {
+                PreserveSharedAxes<C.ValueAxis>(source, replacement);
+            }
+        }
+
+        private static bool PreserveSharedBubbleAxes(
+            C.PlotArea source, C.PlotArea replacement) {
+            C.BubbleChart? sourceChart = source.GetFirstChild<C.BubbleChart>();
+            C.BubbleChart? replacementChart =
+                replacement.GetFirstChild<C.BubbleChart>();
+            if (sourceChart == null || replacementChart == null) return false;
+
+            List<C.AxisId> sourceReferences =
+                sourceChart.Elements<C.AxisId>().ToList();
+            List<C.AxisId> replacementReferences =
+                replacementChart.Elements<C.AxisId>().ToList();
+            if (sourceReferences.Count != replacementReferences.Count ||
+                sourceReferences.Count == 0) {
+                return false;
+            }
+
+            var axisPairs =
+                new List<(C.ValueAxis Source, C.ValueAxis Replacement)>();
+            for (int index = 0; index < sourceReferences.Count; index++) {
+                uint? sourceId = sourceReferences[index].Val?.Value;
+                uint? replacementId = replacementReferences[index].Val?.Value;
+                C.ValueAxis? sourceAxis = source.Elements<C.ValueAxis>()
+                    .FirstOrDefault(axis =>
+                        axis.AxisId?.Val?.Value == sourceId);
+                C.ValueAxis? replacementAxis =
+                    replacement.Elements<C.ValueAxis>().FirstOrDefault(axis =>
+                        axis.AxisId?.Val?.Value == replacementId);
+                if (sourceAxis == null || replacementAxis == null) return false;
+                axisPairs.Add((sourceAxis, replacementAxis));
+            }
+            foreach ((C.ValueAxis sourceAxis,
+                      C.ValueAxis replacementAxis) in axisPairs) {
+                ReplaceSharedAxis(replacement, sourceAxis, replacementAxis);
+            }
+            return true;
         }
 
         private static bool IsSharedCategoryAxis(OpenXmlCompositeElement axis) =>

--- a/OfficeIMO.PowerPoint/PowerPointUtils.SharedChartFormatting.cs
+++ b/OfficeIMO.PowerPoint/PowerPointUtils.SharedChartFormatting.cs
@@ -32,7 +32,8 @@ namespace OfficeIMO.PowerPoint {
 
         private static bool IsSharedChartLayer(OpenXmlCompositeElement element) =>
             element is C.BarChart || element is C.LineChart || element is C.AreaChart ||
-            element is C.RadarChart || element is C.PieChart || element is C.DoughnutChart;
+            element is C.RadarChart || element is C.PieChart || element is C.DoughnutChart ||
+            element is C.BubbleChart;
 
         private static bool AreCompatibleSharedChartLayers(OpenXmlCompositeElement source,
             OpenXmlCompositeElement replacement, C.PlotArea sourcePlotArea, C.PlotArea replacementPlotArea) {
@@ -94,6 +95,7 @@ namespace OfficeIMO.PowerPoint {
             ReplaceSharedSeriesChild<C.Values>(updated, generated);
             ReplaceSharedSeriesChild<C.XValues>(updated, generated);
             ReplaceSharedSeriesChild<C.YValues>(updated, generated);
+            ReplaceSharedSeriesChild<C.BubbleSize>(updated, generated);
             return updated;
         }
 
@@ -113,7 +115,7 @@ namespace OfficeIMO.PowerPoint {
         private static bool IsSharedSeriesElement(OpenXmlCompositeElement element) =>
             element is C.BarChartSeries || element is C.LineChartSeries ||
             element is C.AreaChartSeries || element is C.RadarChartSeries ||
-            element is C.PieChartSeries;
+            element is C.PieChartSeries || element is C.BubbleChartSeries;
 
         private static void ReplaceSharedAxisReferences(OpenXmlCompositeElement preserved,
             OpenXmlCompositeElement generated) {

--- a/OfficeIMO.PowerPoint/PowerPointUtils.SharedChartFormatting.cs
+++ b/OfficeIMO.PowerPoint/PowerPointUtils.SharedChartFormatting.cs
@@ -6,12 +6,17 @@ using C = DocumentFormat.OpenXml.Drawing.Charts;
 
 namespace OfficeIMO.PowerPoint {
     internal static partial class PowerPointUtils {
-        private static void PreserveSharedChartFormatting(C.PlotArea source, C.PlotArea replacement) {
-            PreserveSharedChartLayers(source, replacement);
+        private static void PreserveSharedChartFormatting(
+            C.PlotArea source, C.PlotArea replacement,
+            ISet<uint> preservedSeriesIndexes) {
+            PreserveSharedChartLayers(
+                source, replacement, preservedSeriesIndexes);
             PreserveSharedAxes(source, replacement);
         }
 
-        private static void PreserveSharedChartLayers(C.PlotArea source, C.PlotArea replacement) {
+        private static void PreserveSharedChartLayers(
+            C.PlotArea source, C.PlotArea replacement,
+            ISet<uint> preservedSeriesIndexes) {
             List<OpenXmlCompositeElement> sourceLayers = source.ChildElements
                 .OfType<OpenXmlCompositeElement>().Where(IsSharedChartLayer).ToList();
             var usedLayers = new HashSet<OpenXmlCompositeElement>();
@@ -24,7 +29,8 @@ namespace OfficeIMO.PowerPoint {
 
                 usedLayers.Add(match);
                 var preserved = (OpenXmlCompositeElement)match.CloneNode(true);
-                ReplaceSharedSeriesData(preserved, generated);
+                ReplaceSharedSeriesData(
+                    preserved, generated, preservedSeriesIndexes);
                 ReplaceSharedAxisReferences(preserved, generated);
                 replacement.ReplaceChild(preserved, generated);
             }
@@ -65,8 +71,10 @@ namespace OfficeIMO.PowerPoint {
             return categoryAxis?.GetFirstChild<C.Delete>()?.Val?.Value == true;
         }
 
-        private static void ReplaceSharedSeriesData(OpenXmlCompositeElement preserved,
-            OpenXmlCompositeElement generated) {
+        private static void ReplaceSharedSeriesData(
+            OpenXmlCompositeElement preserved,
+            OpenXmlCompositeElement generated,
+            ISet<uint> preservedSeriesIndexes) {
             List<OpenXmlCompositeElement> oldSeries = preserved.ChildElements
                 .OfType<OpenXmlCompositeElement>().Where(IsSharedSeriesElement).ToList();
             var usedSeries = new HashSet<OpenXmlCompositeElement>();
@@ -89,7 +97,12 @@ namespace OfficeIMO.PowerPoint {
                 OpenXmlCompositeElement updated = sourceSeries == null
                     ? (OpenXmlCompositeElement)generatedSeries.CloneNode(true)
                     : UpdateSharedSeriesData(sourceSeries, generatedSeries);
-                if (sourceSeries != null) usedSeries.Add(sourceSeries);
+                if (sourceSeries != null) {
+                    usedSeries.Add(sourceSeries);
+                    if (seriesIndex.HasValue) {
+                        preservedSeriesIndexes.Add(seriesIndex.Value);
+                    }
+                }
                 if (insertionPoint == null) preserved.AddChild(updated, true);
                 else preserved.InsertBefore(updated, insertionPoint);
             }

--- a/OfficeIMO.PowerPoint/PowerPointUtils.SharedCharts.cs
+++ b/OfficeIMO.PowerPoint/PowerPointUtils.SharedCharts.cs
@@ -468,19 +468,27 @@ namespace OfficeIMO.PowerPoint {
                     CreateSharedRgbColor(series.Color.Value)));
             }
             A.Outline outline = properties.GetFirstChild<A.Outline>() ?? new A.Outline();
-            outline.RemoveAllChildren<A.SolidFill>();
-            outline.RemoveAllChildren<A.NoFill>();
-            outline.RemoveAllChildren<A.GradientFill>();
-            outline.RemoveAllChildren<A.PatternFill>();
-            outline.RemoveAllChildren<A.BlipFill>();
-            outline.RemoveAllChildren<A.GroupFill>();
-            if (kind == OfficeChartKind.Bubble && !series.ShowMarkerOutline) {
-                outline.Append(new A.NoFill());
-            } else if (!series.ConnectLine && !IsFilledSharedKind(kind)) {
-                outline.Append(new A.NoFill());
-            } else if (outlineColor.HasValue) {
-                outline.Append(new A.SolidFill(
-                    CreateSharedRgbColor(outlineColor.Value)));
+            bool replaceOutlineFill = reenableBubbleOutline ||
+                (kind == OfficeChartKind.Bubble && !series.ShowMarkerOutline) ||
+                (!series.ConnectLine && !IsFilledSharedKind(kind)) ||
+                outlineColor.HasValue;
+            if (replaceOutlineFill) {
+                outline.RemoveAllChildren<A.SolidFill>();
+                outline.RemoveAllChildren<A.NoFill>();
+                outline.RemoveAllChildren<A.GradientFill>();
+                outline.RemoveAllChildren<A.PatternFill>();
+                outline.RemoveAllChildren<A.BlipFill>();
+                outline.RemoveAllChildren<A.GroupFill>();
+                if (kind == OfficeChartKind.Bubble &&
+                    !series.ShowMarkerOutline) {
+                    outline.Append(new A.NoFill());
+                } else if (!series.ConnectLine &&
+                           !IsFilledSharedKind(kind)) {
+                    outline.Append(new A.NoFill());
+                } else if (outlineColor.HasValue) {
+                    outline.Append(new A.SolidFill(
+                        CreateSharedRgbColor(outlineColor.Value)));
+                }
             }
             if (outlineWidth.HasValue) {
                 outline.Width = (int)Math.Min(int.MaxValue,
@@ -528,7 +536,6 @@ namespace OfficeIMO.PowerPoint {
 
         private static void ApplySharedPointColors(OpenXmlCompositeElement seriesElement, OfficeChartSeries series) {
             if (series.PointColors == null) return;
-            seriesElement.RemoveAllChildren<C.DataPoint>();
             OpenXmlElement? insertBefore = seriesElement.GetFirstChild<C.DataLabels>() ??
                 (OpenXmlElement?)seriesElement.GetFirstChild<C.CategoryAxisData>() ??
                 (OpenXmlElement?)seriesElement.GetFirstChild<C.Values>() ??
@@ -536,11 +543,31 @@ namespace OfficeIMO.PowerPoint {
             for (int index = 0; index < series.PointColors.Count; index++) {
                 OfficeColor? color = series.PointColors[index];
                 if (!color.HasValue) continue;
-                C.DataPoint point = new(new C.Index { Val = (uint)index },
-                    new C.ChartShapeProperties(new A.SolidFill(
-                        CreateSharedRgbColor(color.Value))));
-                if (insertBefore != null) seriesElement.InsertBefore(point, insertBefore);
-                else seriesElement.Append(point);
+                C.DataPoint? point = seriesElement.Elements<C.DataPoint>()
+                    .FirstOrDefault(item =>
+                        item.Index?.Val?.Value == (uint)index);
+                if (point == null) {
+                    point = new C.DataPoint(new C.Index { Val = (uint)index });
+                    if (insertBefore != null) {
+                        seriesElement.InsertBefore(point, insertBefore);
+                    } else {
+                        seriesElement.Append(point);
+                    }
+                }
+                C.ChartShapeProperties? properties =
+                    point.GetFirstChild<C.ChartShapeProperties>();
+                if (properties == null) {
+                    properties = new C.ChartShapeProperties();
+                    point.AddChild(properties, true);
+                }
+                properties.RemoveAllChildren<A.SolidFill>();
+                properties.RemoveAllChildren<A.NoFill>();
+                properties.RemoveAllChildren<A.GradientFill>();
+                properties.RemoveAllChildren<A.PatternFill>();
+                properties.RemoveAllChildren<A.BlipFill>();
+                properties.RemoveAllChildren<A.GroupFill>();
+                properties.PrependChild(new A.SolidFill(
+                    CreateSharedRgbColor(color.Value)));
             }
         }
 

--- a/OfficeIMO.PowerPoint/PowerPointUtils.SharedCharts.cs
+++ b/OfficeIMO.PowerPoint/PowerPointUtils.SharedCharts.cs
@@ -30,9 +30,14 @@ namespace OfficeIMO.PowerPoint {
                 if (series.Values.Count == 0) {
                     throw new ArgumentException("Chart series cannot be empty.", nameof(data));
                 }
-                if (defaultKind == OfficeChartKind.Scatter) {
+                if (defaultKind == OfficeChartKind.Scatter || defaultKind == OfficeChartKind.Bubble) {
                     if (series.XValues != null && series.XValues.Count != series.Values.Count) {
-                        throw new ArgumentException("Scatter X and Y value counts must match.", nameof(data));
+                        throw new ArgumentException("Numeric X and Y value counts must match.", nameof(data));
+                    }
+                    if (defaultKind == OfficeChartKind.Bubble &&
+                        (series.BubbleSizes == null || series.BubbleSizes.Count != series.Values.Count)) {
+                        throw new ArgumentException(
+                            "Every bubble series must provide one bubble size for each X/Y point.", nameof(data));
                     }
                 } else if (series.Values.Count != data.Categories.Count) {
                     throw new ArgumentException("Every chart series must match the category count.", nameof(data));
@@ -45,10 +50,13 @@ namespace OfficeIMO.PowerPoint {
                 throw new NotSupportedException("A secondary-axis chart requires at least one primary-axis series.");
             }
 
-            if (descriptors.Any(item => item.Kind == OfficeChartKind.Scatter)) {
-                if (defaultKind != OfficeChartKind.Scatter ||
-                    descriptors.Any(item => item.Kind != OfficeChartKind.Scatter) || hasSecondary) {
-                    throw new NotSupportedException("Scatter series cannot be combined with categorical or secondary-axis series.");
+            if (descriptors.Any(item => item.Kind == OfficeChartKind.Scatter ||
+                                        item.Kind == OfficeChartKind.Bubble)) {
+                bool sameNumericKind = descriptors.All(item => item.Kind == defaultKind);
+                if ((defaultKind != OfficeChartKind.Scatter && defaultKind != OfficeChartKind.Bubble) ||
+                    !sameNumericKind || hasSecondary) {
+                    throw new NotSupportedException(
+                        "Scatter and bubble series cannot be combined with other chart families or secondary axes.");
                 }
                 foreach (OfficeChartSeries series in data.Series) {
                     if (series.XValues == null) ParseScatterCategories(data.Categories);
@@ -168,6 +176,16 @@ namespace OfficeIMO.PowerPoint {
             }
             if (descriptors.All(item => item.Kind == OfficeChartKind.Doughnut)) {
                 plotArea.Append(CreateDoughnutChart(ToPowerPointChartData(data)));
+                return;
+            }
+            if (descriptors.All(item => item.Kind == OfficeChartKind.Bubble)) {
+                uint xAxisId = PowerPointChartAxisIdGenerator.GetNextId();
+                uint yAxisId = PowerPointChartAxisIdGenerator.GetNextId();
+                plotArea.Append(CreateSharedBubbleChart(data, xAxisId, yAxisId));
+                plotArea.Append(CreateSharedValueAxis(xAxisId, yAxisId,
+                    C.AxisPositionValues.Bottom, secondary: false));
+                plotArea.Append(CreateSharedValueAxis(yAxisId, xAxisId,
+                    C.AxisPositionValues.Left, secondary: false));
                 return;
             }
 
@@ -382,6 +400,7 @@ namespace OfficeIMO.PowerPoint {
                 else if (chart is C.AreaChart area) foreach (C.AreaChartSeries series in area.Elements<C.AreaChartSeries>()) yield return series;
                 else if (chart is C.RadarChart radar) foreach (C.RadarChartSeries series in radar.Elements<C.RadarChartSeries>()) yield return series;
                 else if (chart is C.ScatterChart scatter) foreach (C.ScatterChartSeries series in scatter.Elements<C.ScatterChartSeries>()) yield return series;
+                else if (chart is C.BubbleChart bubble) foreach (C.BubbleChartSeries series in bubble.Elements<C.BubbleChartSeries>()) yield return series;
                 else if (chart is C.PieChart pie) foreach (C.PieChartSeries series in pie.Elements<C.PieChartSeries>()) yield return series;
                 else if (chart is C.DoughnutChart doughnut) foreach (C.PieChartSeries series in doughnut.Elements<C.PieChartSeries>()) yield return series;
             }
@@ -390,7 +409,7 @@ namespace OfficeIMO.PowerPoint {
         private static void ApplySharedSeriesShapeStyle(OpenXmlCompositeElement seriesElement,
             OfficeChartSeries series, OfficeChartKind kind) {
             if (!series.Color.HasValue && series.StrokeWidth == null && series.StrokeDashStyle == null &&
-                series.ConnectLine) return;
+                (series.ConnectLine || IsFilledSharedKind(kind))) return;
             C.ChartShapeProperties properties = seriesElement.GetFirstChild<C.ChartShapeProperties>() ??
                 new C.ChartShapeProperties();
             if (series.Color.HasValue && IsFilledSharedKind(kind)) {
@@ -525,7 +544,7 @@ namespace OfficeIMO.PowerPoint {
 
         private static bool IsFilledSharedKind(OfficeChartKind kind) =>
             IsBarOrColumnKind(kind) || IsAreaKind(kind) || kind == OfficeChartKind.Pie ||
-            kind == OfficeChartKind.Doughnut;
+            kind == OfficeChartKind.Doughnut || kind == OfficeChartKind.Bubble;
 
         private static bool IsMarkerKind(OfficeChartKind kind) => IsLineKind(kind) ||
             kind == OfficeChartKind.Scatter || kind == OfficeChartKind.Radar;

--- a/OfficeIMO.PowerPoint/PowerPointUtils.SharedCharts.cs
+++ b/OfficeIMO.PowerPoint/PowerPointUtils.SharedCharts.cs
@@ -408,7 +408,14 @@ namespace OfficeIMO.PowerPoint {
 
         private static void ApplySharedSeriesShapeStyle(OpenXmlCompositeElement seriesElement,
             OfficeChartSeries series, OfficeChartKind kind) {
-            if (!series.Color.HasValue && series.StrokeWidth == null && series.StrokeDashStyle == null &&
+            OfficeColor? outlineColor = kind == OfficeChartKind.Bubble
+                ? series.MarkerOutlineColor ?? series.Color
+                : series.Color;
+            double? outlineWidth = kind == OfficeChartKind.Bubble
+                ? series.MarkerOutlineWidth ?? series.StrokeWidth
+                : series.StrokeWidth;
+            if (!series.Color.HasValue && !outlineColor.HasValue && outlineWidth == null &&
+                series.StrokeDashStyle == null &&
                 (series.ConnectLine || IsFilledSharedKind(kind))) return;
             C.ChartShapeProperties properties = seriesElement.GetFirstChild<C.ChartShapeProperties>() ??
                 new C.ChartShapeProperties();
@@ -423,13 +430,13 @@ namespace OfficeIMO.PowerPoint {
             outline.RemoveAllChildren<A.NoFill>();
             if (!series.ConnectLine && !IsFilledSharedKind(kind)) {
                 outline.Append(new A.NoFill());
-            } else if (series.Color.HasValue) {
+            } else if (outlineColor.HasValue) {
                 outline.Append(new A.SolidFill(
-                    new A.RgbColorModelHex { Val = series.Color.Value.ToRgbHex() }));
+                    new A.RgbColorModelHex { Val = outlineColor.Value.ToRgbHex() }));
             }
-            if (series.StrokeWidth.HasValue) {
+            if (outlineWidth.HasValue) {
                 outline.Width = (int)Math.Min(int.MaxValue,
-                    PowerPointUnits.FromPoints(series.StrokeWidth.Value));
+                    PowerPointUnits.FromPoints(outlineWidth.Value));
             }
             if (series.StrokeDashStyle.HasValue) {
                 outline.RemoveAllChildren<A.PresetDash>();

--- a/OfficeIMO.PowerPoint/PowerPointUtils.SharedCharts.cs
+++ b/OfficeIMO.PowerPoint/PowerPointUtils.SharedCharts.cs
@@ -415,6 +415,7 @@ namespace OfficeIMO.PowerPoint {
                 ? series.MarkerOutlineWidth ?? series.StrokeWidth
                 : series.StrokeWidth;
             if (!series.Color.HasValue && !outlineColor.HasValue && outlineWidth == null &&
+                (kind != OfficeChartKind.Bubble || series.ShowMarkerOutline) &&
                 series.StrokeDashStyle == null &&
                 (series.ConnectLine || IsFilledSharedKind(kind))) return;
             C.ChartShapeProperties properties = seriesElement.GetFirstChild<C.ChartShapeProperties>() ??
@@ -428,7 +429,9 @@ namespace OfficeIMO.PowerPoint {
             A.Outline outline = properties.GetFirstChild<A.Outline>() ?? new A.Outline();
             outline.RemoveAllChildren<A.SolidFill>();
             outline.RemoveAllChildren<A.NoFill>();
-            if (!series.ConnectLine && !IsFilledSharedKind(kind)) {
+            if (kind == OfficeChartKind.Bubble && !series.ShowMarkerOutline) {
+                outline.Append(new A.NoFill());
+            } else if (!series.ConnectLine && !IsFilledSharedKind(kind)) {
                 outline.Append(new A.NoFill());
             } else if (outlineColor.HasValue) {
                 outline.Append(new A.SolidFill(

--- a/OfficeIMO.PowerPoint/PowerPointUtils.SharedCharts.cs
+++ b/OfficeIMO.PowerPoint/PowerPointUtils.SharedCharts.cs
@@ -13,6 +13,7 @@ namespace OfficeIMO.PowerPoint {
         private const int SpreadsheetMaximumColumns = 16_384;
         private const int SpreadsheetMaximumRows = 1_048_576;
         private const int BubbleWorkbookColumnsPerSeries = 3;
+        internal const int MaximumSharedChartPoints = 100_000;
 
         private sealed class SharedSeriesDescriptor {
             internal SharedSeriesDescriptor(int index, OfficeChartSeries series, OfficeChartKind kind) {
@@ -98,6 +99,11 @@ namespace OfficeIMO.PowerPoint {
             if (maximumPoints > SpreadsheetMaximumRows - 1) {
                 throw new ArgumentException(
                     "Bubble chart data exceeds the embedded worksheet row limit.",
+                    "data");
+            }
+            if (maximumPoints > MaximumSharedChartPoints) {
+                throw new ArgumentException(
+                    "Bubble chart data exceeds the shared chart snapshot point limit.",
                     "data");
             }
         }

--- a/OfficeIMO.PowerPoint/PowerPointUtils.SharedCharts.cs
+++ b/OfficeIMO.PowerPoint/PowerPointUtils.SharedCharts.cs
@@ -35,7 +35,10 @@ namespace OfficeIMO.PowerPoint {
                     .Select(series => series.Values.Count)
                     .DefaultIfEmpty(0)
                     .Max();
-                ValidateBubbleWorkbookDimensions(data.Series.Count, maximumPoints);
+                long totalPoints = data.Series.Sum(series =>
+                    (long)series.Values.Count);
+                ValidateBubbleWorkbookDimensions(
+                    data.Series.Count, maximumPoints, totalPoints);
             }
             for (int index = 0; index < data.Series.Count; index++) {
                 OfficeChartSeries series = data.Series[index];
@@ -89,7 +92,7 @@ namespace OfficeIMO.PowerPoint {
         }
 
         internal static void ValidateBubbleWorkbookDimensions(
-            int seriesCount, int maximumPoints) {
+            int seriesCount, int maximumPoints, long totalPoints) {
             if (seriesCount >
                 SpreadsheetMaximumColumns / BubbleWorkbookColumnsPerSeries) {
                 throw new ArgumentException(
@@ -104,6 +107,11 @@ namespace OfficeIMO.PowerPoint {
             if (maximumPoints > MaximumSharedChartPoints) {
                 throw new ArgumentException(
                     "Bubble chart data exceeds the shared chart snapshot point limit.",
+                    "data");
+            }
+            if (totalPoints > MaximumSharedChartPoints) {
+                throw new ArgumentException(
+                    "Bubble chart data exceeds the shared chart total point limit.",
                     "data");
             }
         }

--- a/OfficeIMO.PowerPoint/PowerPointUtils.SharedCharts.cs
+++ b/OfficeIMO.PowerPoint/PowerPointUtils.SharedCharts.cs
@@ -590,6 +590,8 @@ namespace OfficeIMO.PowerPoint {
         private static void ApplySharedPointColors(OpenXmlCompositeElement seriesElement, OfficeChartSeries series) {
             if (series.PointColors == null) return;
             OpenXmlElement? insertBefore = seriesElement.GetFirstChild<C.DataLabels>() ??
+                (OpenXmlElement?)seriesElement.GetFirstChild<C.Trendline>() ??
+                (OpenXmlElement?)seriesElement.GetFirstChild<C.ErrorBars>() ??
                 (OpenXmlElement?)seriesElement.GetFirstChild<C.CategoryAxisData>() ??
                 (OpenXmlElement?)seriesElement.GetFirstChild<C.Values>() ??
                 (OpenXmlElement?)seriesElement.GetFirstChild<C.XValues>() ?? seriesElement.GetFirstChild<C.YValues>();

--- a/OfficeIMO.PowerPoint/PowerPointUtils.SharedCharts.cs
+++ b/OfficeIMO.PowerPoint/PowerPointUtils.SharedCharts.cs
@@ -10,6 +10,9 @@ using C = DocumentFormat.OpenXml.Drawing.Charts;
 
 namespace OfficeIMO.PowerPoint {
     internal static partial class PowerPointUtils {
+        private const int SpreadsheetMaximumColumns = 16_384;
+        private const int BubbleWorkbookColumnsPerSeries = 3;
+
         private sealed class SharedSeriesDescriptor {
             internal SharedSeriesDescriptor(int index, OfficeChartSeries series, OfficeChartKind kind) {
                 Index = index;
@@ -25,6 +28,13 @@ namespace OfficeIMO.PowerPoint {
 
         internal static void ValidateSharedChartData(OfficeChartData data, OfficeChartKind defaultKind) {
             if (data == null) throw new ArgumentNullException(nameof(data));
+            if (defaultKind == OfficeChartKind.Bubble &&
+                data.Series.Count >
+                SpreadsheetMaximumColumns / BubbleWorkbookColumnsPerSeries) {
+                throw new ArgumentException(
+                    "Bubble chart data exceeds the embedded worksheet column limit.",
+                    nameof(data));
+            }
             for (int index = 0; index < data.Series.Count; index++) {
                 OfficeChartSeries series = data.Series[index];
                 if (series.Values.Count == 0) {

--- a/OfficeIMO.PowerPoint/PowerPointUtils.SharedCharts.cs
+++ b/OfficeIMO.PowerPoint/PowerPointUtils.SharedCharts.cs
@@ -11,6 +11,7 @@ using C = DocumentFormat.OpenXml.Drawing.Charts;
 namespace OfficeIMO.PowerPoint {
     internal static partial class PowerPointUtils {
         private const int SpreadsheetMaximumColumns = 16_384;
+        private const int SpreadsheetMaximumRows = 1_048_576;
         private const int BubbleWorkbookColumnsPerSeries = 3;
 
         private sealed class SharedSeriesDescriptor {
@@ -28,12 +29,12 @@ namespace OfficeIMO.PowerPoint {
 
         internal static void ValidateSharedChartData(OfficeChartData data, OfficeChartKind defaultKind) {
             if (data == null) throw new ArgumentNullException(nameof(data));
-            if (defaultKind == OfficeChartKind.Bubble &&
-                data.Series.Count >
-                SpreadsheetMaximumColumns / BubbleWorkbookColumnsPerSeries) {
-                throw new ArgumentException(
-                    "Bubble chart data exceeds the embedded worksheet column limit.",
-                    nameof(data));
+            if (defaultKind == OfficeChartKind.Bubble) {
+                int maximumPoints = data.Series
+                    .Select(series => series.Values.Count)
+                    .DefaultIfEmpty(0)
+                    .Max();
+                ValidateBubbleWorkbookDimensions(data.Series.Count, maximumPoints);
             }
             for (int index = 0; index < data.Series.Count; index++) {
                 OfficeChartSeries series = data.Series[index];
@@ -83,6 +84,21 @@ namespace OfficeIMO.PowerPoint {
                 item.Kind == OfficeChartKind.Doughnut || item.Kind == OfficeChartKind.Radar);
             if (hasStandalone && (descriptors.Select(item => item.Kind).Distinct().Count() > 1 || hasSecondary)) {
                 throw new NotSupportedException("Pie, doughnut, and radar charts cannot participate in combo or secondary-axis charts.");
+            }
+        }
+
+        internal static void ValidateBubbleWorkbookDimensions(
+            int seriesCount, int maximumPoints) {
+            if (seriesCount >
+                SpreadsheetMaximumColumns / BubbleWorkbookColumnsPerSeries) {
+                throw new ArgumentException(
+                    "Bubble chart data exceeds the embedded worksheet column limit.",
+                    "data");
+            }
+            if (maximumPoints > SpreadsheetMaximumRows - 1) {
+                throw new ArgumentException(
+                    "Bubble chart data exceeds the embedded worksheet row limit.",
+                    "data");
             }
         }
 

--- a/OfficeIMO.PowerPoint/PowerPointUtils.SharedCharts.cs
+++ b/OfficeIMO.PowerPoint/PowerPointUtils.SharedCharts.cs
@@ -157,7 +157,8 @@ namespace OfficeIMO.PowerPoint {
                 });
             }
             chartPart.ChartSpace = chartSpace;
-            ApplySharedChartSeriesStyle(chartPart, data, defaultKind);
+            ApplySharedChartSeriesStyle(chartPart, data, defaultKind,
+                materializeMissingBubbleColors: true);
         }
 
         internal static void UpdateSharedChartData(ChartPart chartPart, OfficeChartData data,
@@ -188,12 +189,13 @@ namespace OfficeIMO.PowerPoint {
             }
 
             UpdateSharedLegend(chart, data);
-            ApplySharedChartSeriesStyle(chartPart, data, defaultKind);
+            ApplySharedChartSeriesStyle(chartPart, data, defaultKind,
+                materializeMissingBubbleColors: false);
             chartSpace.Save();
         }
 
         internal static void ApplySharedChartSeriesStyle(ChartPart chartPart, OfficeChartData data,
-            OfficeChartKind defaultKind) {
+            OfficeChartKind defaultKind, bool materializeMissingBubbleColors) {
             C.PlotArea? plotArea = chartPart.ChartSpace?.GetFirstChild<C.Chart>()?.GetFirstChild<C.PlotArea>();
             if (plotArea == null) return;
             foreach (OpenXmlCompositeElement seriesElement in EnumerateSharedSeriesElements(plotArea)) {
@@ -201,7 +203,14 @@ namespace OfficeIMO.PowerPoint {
                 if (index < 0 || index >= data.Series.Count) continue;
                 OfficeChartSeries series = data.Series[index];
                 OfficeChartKind kind = series.RenderKind ?? defaultKind;
-                ApplySharedSeriesShapeStyle(seriesElement, series, kind);
+                OfficeColor? fallbackBubbleColor =
+                    materializeMissingBubbleColors &&
+                    kind == OfficeChartKind.Bubble &&
+                    !series.Color.HasValue
+                        ? OfficeChartStyle.Default.GetSeriesColor(index)
+                        : null;
+                ApplySharedSeriesShapeStyle(seriesElement, series, kind,
+                    fallbackBubbleColor);
                 ApplySharedSeriesMarker(seriesElement, series, kind);
                 ApplySharedPointColors(seriesElement, series);
             }
@@ -223,9 +232,13 @@ namespace OfficeIMO.PowerPoint {
                 uint yAxisId = PowerPointChartAxisIdGenerator.GetNextId();
                 plotArea.Append(CreateSharedBubbleChart(data, xAxisId, yAxisId));
                 plotArea.Append(CreateSharedValueAxis(xAxisId, yAxisId,
-                    C.AxisPositionValues.Bottom, secondary: false));
+                    C.AxisPositionValues.Bottom, secondary: false,
+                    showMajorGridlines: false,
+                    materializeDefaultGridlineStyle: false));
                 plotArea.Append(CreateSharedValueAxis(yAxisId, xAxisId,
-                    C.AxisPositionValues.Left, secondary: false));
+                    C.AxisPositionValues.Left, secondary: false,
+                    showMajorGridlines: true,
+                    materializeDefaultGridlineStyle: true));
                 return;
             }
 
@@ -265,13 +278,17 @@ namespace OfficeIMO.PowerPoint {
                 plotArea.Append(CreateSharedCategoryAxis(primaryCategoryId, primaryValueId,
                     categoryPosition, secondary: false));
                 plotArea.Append(CreateSharedValueAxis(primaryValueId, primaryCategoryId,
-                    valuePosition, secondary: false));
+                    valuePosition, secondary: false,
+                    showMajorGridlines: true,
+                    materializeDefaultGridlineStyle: false));
             }
             if (hasSecondary) {
                 plotArea.Append(CreateSharedCategoryAxis(secondaryCategoryId, secondaryValueId,
                     C.AxisPositionValues.Top, secondary: true));
                 plotArea.Append(CreateSharedValueAxis(secondaryValueId, secondaryCategoryId,
-                    C.AxisPositionValues.Right, secondary: true));
+                    C.AxisPositionValues.Right, secondary: true,
+                    showMajorGridlines: false,
+                    materializeDefaultGridlineStyle: false));
             }
         }
 
@@ -383,13 +400,29 @@ namespace OfficeIMO.PowerPoint {
             new C.NoMultiLevelLabels { Val = false });
 
         private static C.ValueAxis CreateSharedValueAxis(uint axisId, uint crossingAxisId,
-            C.AxisPositionValues position, bool secondary) {
+            C.AxisPositionValues position, bool secondary,
+            bool showMajorGridlines,
+            bool materializeDefaultGridlineStyle) {
             C.ValueAxis axis = new(
                 new C.AxisId { Val = axisId },
                 new C.Scaling(new C.Orientation { Val = C.OrientationValues.MinMax }),
                 new C.Delete { Val = false },
                 new C.AxisPosition { Val = position });
-            if (!secondary) axis.Append(new C.MajorGridlines());
+            if (showMajorGridlines) {
+                if (materializeDefaultGridlineStyle) {
+                    OfficeChartStyle style = OfficeChartStyle.Default;
+                    var outline = new A.Outline {
+                        Width = checked((int)PowerPointUnits.FromPoints(
+                            style.GridLineWidth ?? 0.5D))
+                    };
+                    outline.Append(new A.SolidFill(
+                        CreateSharedRgbColor(style.GridLineColor)));
+                    axis.Append(new C.MajorGridlines(
+                        new C.ChartShapeProperties(outline)));
+                } else {
+                    axis.Append(new C.MajorGridlines());
+                }
+            }
             axis.Append(new C.NumberingFormat { FormatCode = "General", SourceLinked = true });
             axis.Append(new C.MajorTickMark { Val = C.TickMarkValues.None });
             axis.Append(new C.MinorTickMark { Val = C.TickMarkValues.None });
@@ -447,10 +480,12 @@ namespace OfficeIMO.PowerPoint {
         }
 
         private static void ApplySharedSeriesShapeStyle(OpenXmlCompositeElement seriesElement,
-            OfficeChartSeries series, OfficeChartKind kind) {
+            OfficeChartSeries series, OfficeChartKind kind,
+            OfficeColor? fallbackFillColor) {
+            OfficeColor? fillColor = series.Color ?? fallbackFillColor;
             OfficeColor? outlineColor = kind == OfficeChartKind.Bubble
-                ? series.MarkerOutlineColor ?? series.Color
-                : series.Color;
+                ? series.MarkerOutlineColor ?? fillColor
+                : fillColor;
             double? outlineWidth = kind == OfficeChartKind.Bubble
                 ? series.MarkerOutlineWidth ?? series.StrokeWidth
                 : series.StrokeWidth;
@@ -460,12 +495,12 @@ namespace OfficeIMO.PowerPoint {
             bool reenableBubbleOutline = kind == OfficeChartKind.Bubble &&
                 series.ShowMarkerOutline &&
                 properties.GetFirstChild<A.Outline>()?.GetFirstChild<A.NoFill>() != null;
-            if (!series.Color.HasValue && !outlineColor.HasValue && outlineWidth == null &&
+            if (!fillColor.HasValue && !outlineColor.HasValue && outlineWidth == null &&
                 (kind != OfficeChartKind.Bubble || series.ShowMarkerOutline) &&
                 series.StrokeDashStyle == null &&
                 (series.ConnectLine || IsFilledSharedKind(kind)) &&
                 !reenableBubbleOutline) return;
-            if (series.Color.HasValue && IsFilledSharedKind(kind)) {
+            if (fillColor.HasValue && IsFilledSharedKind(kind)) {
                 properties.RemoveAllChildren<A.SolidFill>();
                 properties.RemoveAllChildren<A.NoFill>();
                 properties.RemoveAllChildren<A.GradientFill>();
@@ -473,7 +508,7 @@ namespace OfficeIMO.PowerPoint {
                 properties.RemoveAllChildren<A.BlipFill>();
                 properties.RemoveAllChildren<A.GroupFill>();
                 properties.PrependChild(new A.SolidFill(
-                    CreateSharedRgbColor(series.Color.Value)));
+                    CreateSharedRgbColor(fillColor.Value)));
             }
             A.Outline outline = properties.GetFirstChild<A.Outline>() ?? new A.Outline();
             bool replaceOutlineFill = reenableBubbleOutline ||

--- a/OfficeIMO.PowerPoint/PowerPointUtils.SharedCharts.cs
+++ b/OfficeIMO.PowerPoint/PowerPointUtils.SharedCharts.cs
@@ -173,13 +173,16 @@ namespace OfficeIMO.PowerPoint {
             C.PlotArea plotArea = chart.GetFirstChild<C.PlotArea>() ??
                 throw new InvalidOperationException("Chart plot area not found.");
 
+            ISet<uint>? preservedSeriesIndexes = null;
             if (defaultKind == OfficeChartKind.Scatter) {
                 UpdateChartData(chartPart, ToPowerPointScatterChartData(data));
             } else {
+                preservedSeriesIndexes = new HashSet<uint>();
                 var replacement = new C.PlotArea();
                 replacement.Append(plotArea.GetFirstChild<C.Layout>()?.CloneNode(true) ?? new C.Layout());
                 AppendSharedChartContent(replacement, data, defaultKind);
-                PreserveSharedChartFormatting(plotArea, replacement);
+                PreserveSharedChartFormatting(
+                    plotArea, replacement, preservedSeriesIndexes);
                 foreach (OpenXmlElement child in plotArea.ChildElements) {
                     if (child is C.DataTable || child is C.ChartShapeProperties || child is C.ExtensionList) {
                         replacement.Append(child.CloneNode(true));
@@ -190,21 +193,28 @@ namespace OfficeIMO.PowerPoint {
 
             UpdateSharedLegend(chart, data);
             ApplySharedChartSeriesStyle(chartPart, data, defaultKind,
-                materializeMissingBubbleColors: false);
+                materializeMissingBubbleColors: false,
+                preservedSeriesIndexes);
             chartSpace.Save();
         }
 
         internal static void ApplySharedChartSeriesStyle(ChartPart chartPart, OfficeChartData data,
-            OfficeChartKind defaultKind, bool materializeMissingBubbleColors) {
+            OfficeChartKind defaultKind, bool materializeMissingBubbleColors,
+            ISet<uint>? preservedSeriesIndexes = null) {
             C.PlotArea? plotArea = chartPart.ChartSpace?.GetFirstChild<C.Chart>()?.GetFirstChild<C.PlotArea>();
             if (plotArea == null) return;
             foreach (OpenXmlCompositeElement seriesElement in EnumerateSharedSeriesElements(plotArea)) {
-                int index = (int)(seriesElement.GetFirstChild<C.Index>()?.Val?.Value ?? uint.MaxValue);
+                uint nativeIndex =
+                    seriesElement.GetFirstChild<C.Index>()?.Val?.Value ??
+                    uint.MaxValue;
+                int index = (int)nativeIndex;
                 if (index < 0 || index >= data.Series.Count) continue;
                 OfficeChartSeries series = data.Series[index];
                 OfficeChartKind kind = series.RenderKind ?? defaultKind;
                 OfficeColor? fallbackBubbleColor =
-                    materializeMissingBubbleColors &&
+                    (materializeMissingBubbleColors ||
+                     preservedSeriesIndexes != null &&
+                     !preservedSeriesIndexes.Contains(nativeIndex)) &&
                     kind == OfficeChartKind.Bubble &&
                     !series.Color.HasValue
                         ? OfficeChartStyle.Default.GetSeriesColor(index)

--- a/OfficeIMO.PowerPoint/PowerPointUtils.SharedCharts.cs
+++ b/OfficeIMO.PowerPoint/PowerPointUtils.SharedCharts.cs
@@ -424,7 +424,7 @@ namespace OfficeIMO.PowerPoint {
                 properties.RemoveAllChildren<A.SolidFill>();
                 properties.RemoveAllChildren<A.NoFill>();
                 properties.PrependChild(new A.SolidFill(
-                    new A.RgbColorModelHex { Val = series.Color.Value.ToRgbHex() }));
+                    CreateSharedRgbColor(series.Color.Value)));
             }
             A.Outline outline = properties.GetFirstChild<A.Outline>() ?? new A.Outline();
             outline.RemoveAllChildren<A.SolidFill>();
@@ -435,7 +435,7 @@ namespace OfficeIMO.PowerPoint {
                 outline.Append(new A.NoFill());
             } else if (outlineColor.HasValue) {
                 outline.Append(new A.SolidFill(
-                    new A.RgbColorModelHex { Val = outlineColor.Value.ToRgbHex() }));
+                    CreateSharedRgbColor(outlineColor.Value)));
             }
             if (outlineWidth.HasValue) {
                 outline.Width = (int)Math.Min(int.MaxValue,
@@ -462,14 +462,14 @@ namespace OfficeIMO.PowerPoint {
                 if (series.Color.HasValue) {
                     properties.RemoveAllChildren<A.SolidFill>();
                     properties.PrependChild(new A.SolidFill(
-                        new A.RgbColorModelHex { Val = series.Color.Value.ToRgbHex() }));
+                        CreateSharedRgbColor(series.Color.Value)));
                 }
                 A.Outline outline = properties.GetFirstChild<A.Outline>() ?? new A.Outline();
                 OfficeColor? markerColor = series.MarkerOutlineColor ?? series.Color;
                 if (markerColor.HasValue) {
                     outline.RemoveAllChildren<A.SolidFill>();
                     outline.Append(new A.SolidFill(
-                        new A.RgbColorModelHex { Val = markerColor.Value.ToRgbHex() }));
+                        CreateSharedRgbColor(markerColor.Value)));
                 }
                 if (series.MarkerOutlineWidth.HasValue) {
                     outline.Width = (int)Math.Min(int.MaxValue,
@@ -493,10 +493,22 @@ namespace OfficeIMO.PowerPoint {
                 if (!color.HasValue) continue;
                 C.DataPoint point = new(new C.Index { Val = (uint)index },
                     new C.ChartShapeProperties(new A.SolidFill(
-                        new A.RgbColorModelHex { Val = color.Value.ToRgbHex() })));
+                        CreateSharedRgbColor(color.Value))));
                 if (insertBefore != null) seriesElement.InsertBefore(point, insertBefore);
                 else seriesElement.Append(point);
             }
+        }
+
+        private static A.RgbColorModelHex CreateSharedRgbColor(OfficeColor color) {
+            var rgb = new A.RgbColorModelHex { Val = color.ToRgbHex() };
+            if (color.A < byte.MaxValue) {
+                rgb.Append(new A.Alpha {
+                    Val = checked((int)Math.Round(
+                        color.A / 255D * 100000D,
+                        MidpointRounding.AwayFromZero))
+                });
+            }
+            return rgb;
         }
 
         private static void InsertSharedSeriesProperties(OpenXmlCompositeElement series, C.ChartShapeProperties properties) {

--- a/OfficeIMO.PowerPoint/PowerPointUtils.SharedCharts.cs
+++ b/OfficeIMO.PowerPoint/PowerPointUtils.SharedCharts.cs
@@ -460,6 +460,10 @@ namespace OfficeIMO.PowerPoint {
             if (series.Color.HasValue && IsFilledSharedKind(kind)) {
                 properties.RemoveAllChildren<A.SolidFill>();
                 properties.RemoveAllChildren<A.NoFill>();
+                properties.RemoveAllChildren<A.GradientFill>();
+                properties.RemoveAllChildren<A.PatternFill>();
+                properties.RemoveAllChildren<A.BlipFill>();
+                properties.RemoveAllChildren<A.GroupFill>();
                 properties.PrependChild(new A.SolidFill(
                     CreateSharedRgbColor(series.Color.Value)));
             }

--- a/OfficeIMO.PowerPoint/PowerPointUtils.SharedCharts.cs
+++ b/OfficeIMO.PowerPoint/PowerPointUtils.SharedCharts.cs
@@ -414,12 +414,17 @@ namespace OfficeIMO.PowerPoint {
             double? outlineWidth = kind == OfficeChartKind.Bubble
                 ? series.MarkerOutlineWidth ?? series.StrokeWidth
                 : series.StrokeWidth;
+            C.ChartShapeProperties properties =
+                seriesElement.GetFirstChild<C.ChartShapeProperties>() ??
+                new C.ChartShapeProperties();
+            bool reenableBubbleOutline = kind == OfficeChartKind.Bubble &&
+                series.ShowMarkerOutline &&
+                properties.GetFirstChild<A.Outline>()?.GetFirstChild<A.NoFill>() != null;
             if (!series.Color.HasValue && !outlineColor.HasValue && outlineWidth == null &&
                 (kind != OfficeChartKind.Bubble || series.ShowMarkerOutline) &&
                 series.StrokeDashStyle == null &&
-                (series.ConnectLine || IsFilledSharedKind(kind))) return;
-            C.ChartShapeProperties properties = seriesElement.GetFirstChild<C.ChartShapeProperties>() ??
-                new C.ChartShapeProperties();
+                (series.ConnectLine || IsFilledSharedKind(kind)) &&
+                !reenableBubbleOutline) return;
             if (series.Color.HasValue && IsFilledSharedKind(kind)) {
                 properties.RemoveAllChildren<A.SolidFill>();
                 properties.RemoveAllChildren<A.NoFill>();

--- a/OfficeIMO.PowerPoint/PowerPointUtils.SharedCharts.cs
+++ b/OfficeIMO.PowerPoint/PowerPointUtils.SharedCharts.cs
@@ -470,6 +470,10 @@ namespace OfficeIMO.PowerPoint {
             A.Outline outline = properties.GetFirstChild<A.Outline>() ?? new A.Outline();
             outline.RemoveAllChildren<A.SolidFill>();
             outline.RemoveAllChildren<A.NoFill>();
+            outline.RemoveAllChildren<A.GradientFill>();
+            outline.RemoveAllChildren<A.PatternFill>();
+            outline.RemoveAllChildren<A.BlipFill>();
+            outline.RemoveAllChildren<A.GroupFill>();
             if (kind == OfficeChartKind.Bubble && !series.ShowMarkerOutline) {
                 outline.Append(new A.NoFill());
             } else if (!series.ConnectLine && !IsFilledSharedKind(kind)) {

--- a/OfficeIMO.Reader.Tests/Reader.Ocr.Core.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Ocr.Core.cs
@@ -185,7 +185,7 @@ public sealed class ReaderOcrCoreTests {
             engine,
             new OfficeDocumentOcrExecutionOptions { CandidateTimeout = TimeSpan.FromDays(30) },
             cancellation.Token);
-        Assert.True(providerStarted.Wait(TimeSpan.FromSeconds(2)));
+        Assert.True(providerStarted.Wait(TimeSpan.FromSeconds(10)));
 
         cancellation.Cancel();
 
@@ -338,13 +338,18 @@ public sealed class ReaderOcrCoreTests {
         var engine = new NonCooperativeConcurrentOcrEngine();
 
         try {
-            OfficeDocumentOcrExecutionResult execution = await CreateDocument(4).ApplyOcrAsync(
+            Task<OfficeDocumentOcrExecutionResult> executionTask = CreateDocument(4).ApplyOcrAsync(
                 engine,
                 new OfficeDocumentOcrExecutionOptions {
-                    CandidateTimeout = TimeSpan.FromMilliseconds(20),
+                    CandidateTimeout = TimeSpan.FromSeconds(5),
                     ContinueOnError = true,
                     MaxDegreeOfParallelism = 2
                 });
+            Task twoCallsStarted = await Task.WhenAny(
+                engine.TwoCallsStarted,
+                Task.Delay(TimeSpan.FromSeconds(10)));
+            Assert.Same(engine.TwoCallsStarted, twoCallsStarted);
+            OfficeDocumentOcrExecutionResult execution = await executionTask;
 
             Assert.Equal(2, engine.CallCount);
             Assert.Equal(2, engine.MaximumConcurrentCalls);
@@ -502,6 +507,7 @@ public sealed class ReaderOcrCoreTests {
 
     private sealed class NonCooperativeConcurrentOcrEngine : IOfficeOcrEngine {
         private readonly TaskCompletionSource<OfficeOcrEngineResult> _completion = new TaskCompletionSource<OfficeOcrEngineResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<object?> _twoCallsStarted = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
         private int _activeCalls;
         private int _callCount;
         private int _maximumConcurrentCalls;
@@ -517,12 +523,17 @@ public sealed class ReaderOcrCoreTests {
 
         internal int MaximumConcurrentCalls => _maximumConcurrentCalls;
 
+        internal Task TwoCallsStarted => _twoCallsStarted.Task;
+
         internal void CompleteCalls() {
             _completion.TrySetResult(new OfficeOcrEngineResult { Text = "late" });
         }
 
         public async ValueTask<OfficeOcrEngineResult> RecognizeAsync(OfficeOcrEngineRequest request, CancellationToken cancellationToken = default) {
-            Interlocked.Increment(ref _callCount);
+            int callCount = Interlocked.Increment(ref _callCount);
+            if (callCount >= 2) {
+                _twoCallsStarted.TrySetResult(null);
+            }
             int active = Interlocked.Increment(ref _activeCalls);
             while (true) {
                 int current = _maximumConcurrentCalls;

--- a/Website/content/docs/powerpoint/capabilities/index.md
+++ b/Website/content/docs/powerpoint/capabilities/index.md
@@ -15,7 +15,7 @@ OfficeIMO.PowerPoint is strongest when the output must stay editable and the wor
 | Native tables | Yes | Yes | Yes | `AddTableSlides(...)` creates deterministic continuation pages and repeats headers. |
 | Semantic story families | Yes | Yes | Yes | Executive, chart, comparison, screenshot, appendix, architecture, and closing stories each have two editable compositions. |
 | Deck rhythm inspection | Yes, before rendering | Not applicable | Not applicable | Reports repeated kinds/variants, dense streaks, long sections, weak openings, and missing closings with stable codes. |
-| All 16 shared chart kinds | Yes | Yes | Yes | Clustered/stacked/100% column and bar, line and area variants, scatter, radar, pie, and doughnut use `OfficeChartKind`. |
+| All 17 shared chart kinds | Yes | Yes | Yes | Clustered/stacked/100% column and bar, line and area variants, scatter, bubble, radar, pie, and doughnut use `OfficeChartKind`. Bubble charts preserve X, Y, and size values in native chart XML and the embedded workbook. |
 | Categorical combo charts and secondary value axes | Yes | Yes | Yes | Per-series `RenderKind` and `OfficeChartAxisGroup` stay in native chart XML with cached values and embedded workbook data. |
 | Chart accessibility and data summary | Yes | Yes | Yes | Native alt text can include a deterministic data summary; `SaveDataSummary(...)` writes a UTF-8 sidecar. |
 | Other chart XML already present in a deck | Limited edit surface | Yes | Snapshot/export support varies | Inspect and test the concrete family before promising mutation parity. |

--- a/Website/content/docs/powerpoint/slides/index.md
+++ b/Website/content/docs/powerpoint/slides/index.md
@@ -117,6 +117,30 @@ chartSlide.AddChartCm(
 chartSlide.Notes.Text = "Chart and table share the same source data.";
 ```
 
+For a native bubble chart, create each series with explicit X, Y, and size values:
+
+```csharp
+var bubbleData = new OfficeChartData(
+    new[] { "1", "2", "3" },
+    new[] {
+        OfficeChartSeries.CreateBubble(
+            "Portfolio",
+            xValues: new[] { 1D, 2D, 3D },
+            yValues: new[] { 12D, 18D, 15D },
+            bubbleSizes: new[] { 9D, 36D, 16D })
+    });
+
+chartSlide.AddChartCm(
+    OfficeChartKind.Bubble,
+    bubbleData,
+    content.LeftCm,
+    content.TopCm + 2.0,
+    content.WidthCm,
+    4.8);
+```
+
+Bubble sizes must be finite and non-negative, with one size for every X/Y point. The chart remains editable in PowerPoint, and `UpdateData(...)` refreshes both cached chart values and the embedded workbook.
+
 ## Manage slide order and reuse
 
 ```csharp

--- a/Website/content/products/powerpoint.md
+++ b/Website/content/products/powerpoint.md
@@ -21,7 +21,7 @@ OfficeIMO.PowerPoint lets you create and edit `.pptx`, `.ppt`, `.pot`, and `.pps
 - **Tables with merged cells** — rows, columns, horizontal and vertical merges, and per-cell styling
 - **Images** — insert from file path or stream in PNG, JPEG, GIF, BMP, TIFF, EMF, and WMF formats
 - **Shapes with fill, stroke & effects** — rectangles, circles, arrows, and callouts with fill, line, shadow, glow, and reflection settings
-- **Editable shared charts with formatting** — all 16 `OfficeChartKind` families, combo/secondary axes, data labels, legends, axis configuration, and accessibility summaries
+- **Editable shared charts with formatting** — all 17 `OfficeChartKind` families, including bubble charts, plus combo/secondary axes, data labels, legends, axis configuration, and accessibility summaries
 - **Slide sections & transitions** — organize slides into sections and apply transition animations
 - **Themes & layouts** — apply built-in or custom themes and choose from standard slide layouts
 - **Designer decks** — generate distinct visual directions from a brand brief, score semantic deck plans, and keep output editable

--- a/powerpoint.md
+++ b/powerpoint.md
@@ -112,7 +112,6 @@ The comparison uses representative products rather than pretending every competi
 | [Syncfusion PowerPoint Library](https://help.syncfusion.com/document-processing/powerpoint/powerpoint-library/net/supported-and-unsupported-features) | Enterprise .NET baseline: create/edit, placeholders, SmartArt, merge/copy, encryption, properties, PDF/image conversion, and notes across common application models | Competitive on core creation and several automation workflows; behind on mature conversion and SmartArt breadth |
 | [GemBox.Presentation](https://www.gemboxsoftware.com/presentation) | Compact commercial .NET API with broad format, rendering, printing, comments, masters/layouts, media, HTML loading, and macro-preservation workflows | Behind on format and rendering breadth; differentiated by MIT licensing, feature preflight, and designer/markup layers |
 | [PptxGenJS](https://gitbrent.github.io/PptxGenJS/docs/introduction/) | Open-source authoring usability: browser support, code-defined masters, broad media/text support, HTML table conversion, and a large example surface | OfficeIMO has the stronger typed .NET editing model and designer layer; PptxGenJS is ahead on authoring ergonomics in several high-value workflows |
-| [ShapeCrawler](https://github.com/ShapeCrawler/ShapeCrawler) | Direct MIT .NET comparison for a clean Open XML object model and common slide, shape, table, image, and chart manipulation | OfficeIMO is broader and more productized, but must keep its public API and docs as approachable as this simpler alternative |
 
 Three PptxGenJS capabilities are especially relevant rather than merely impressive on a checklist:
 
@@ -132,7 +131,7 @@ Those are closer to OfficeIMO's intended generated-document workflow than obscur
 | Template and brand workflow | Partial | Existing master/layout selection, placeholder editing, theme color/font updates | No first-class create-from-template/brand-kit contract or code-defined master/layout model |
 | Content fit and pagination | Weak | Count-based plan diagnostics and PowerPoint auto-fit metadata | No measured preflight, collision detection, table/text auto-splitting, or repeated-header pagination |
 | Tables | Strong on one slide | Typed binding, formatting, merges, sizing, style metadata | No overflow-to-next-slide workflow; no reusable appendix/table-story component |
-| Charts | Strong shared authoring | All 16 `OfficeChartKind` families, categorical combo charts, secondary value axes, embedded data, accessibility summaries, and shared snapshots | Bubble, stock, surface, 3D, modern, and unusual extension families remain demand-driven gaps |
+| Charts | Strong shared authoring | All 17 `OfficeChartKind` families, including native bubble charts, categorical combo charts, secondary value axes, embedded data, accessibility summaries, and shared snapshots | Stock, surface, 3D, modern, and unusual extension families remain demand-driven gaps |
 | Media and visual assets | Partial | Pictures, crop, SVG input, audio/video, poster frames, logo images | No semantic asset pipeline, annotation/callout workflow, icon strategy, or content-aware crop/focal point |
 | SmartArt and diagrams | Partial | Editable Basic Process, Basic Hierarchy, and Basic Cycle semantic workflows; Mermaid adapter | Broader SmartArt gallery semantics and a general deck-plan diagram model remain demand-driven |
 | Transitions and motion | Partial | 19 transition values, Morph fallback, media timing, and typed timing-tree inspection | Shape/text/chart animation authoring remains preserve-only |
@@ -206,13 +205,13 @@ Each family needs multiple layout variants, real image or chart inputs, content-
 
 The public PowerPoint authoring surface provides clustered column/bar, line, scatter, pie, and doughnut helpers. At the same time:
 
-- `OfficeIMO.Drawing.OfficeChartKind` already defines 16 chart families, including stacked/100% column and bar, stacked/100% line, area variants, and radar;
+- `OfficeIMO.Drawing.OfficeChartKind` defines 17 chart families, including stacked/100% column and bar, stacked/100% line, area variants, radar, and bubble;
 - the PowerPoint chart snapshot reader already understands stacked bar/column/line, area, radar, scatter, pie, doughnut, and some mixed chart content;
 - `OfficeIMO.Excel` exposes a much broader chart family and combo/secondary-axis concepts.
 
 The right fix is to converge on shared chart semantics in `OfficeIMO.Drawing` while keeping PPTX serialization in `OfficeIMO.PowerPoint`. Do not add another PowerPoint-only enum and another parallel data model.
 
-The first parity slice should author every chart family already represented by `OfficeChartKind`, then add combo/secondary-axis support. Bubble, stock, surface, modern charts, 3D, and unusual PowerPoint chart extensions can follow demand and fixture proof.
+The shared chart surface now authors every family represented by `OfficeChartKind`, including bubble charts, and supports compatible combo/secondary-axis charts. Stock, surface, modern charts, 3D, and unusual PowerPoint chart extensions can follow demand and fixture proof.
 
 ### 5. Accessibility needs a real product contract
 


### PR DESCRIPTION
## Summary

Adds first-class PowerPoint bubble charts to the shared chart contract while retaining the binary-compatible chart snapshot constructor. Callers can create bubble series with required finite X/Y coordinates, required finite non-negative sizes, RGBA series and point colors, and optional finite positive outlines, then use the existing PowerPoint chart APIs.

Bubble data survives save/reopen, `UpdateData(...)`, accessibility summaries, and the embedded workbook. Updates replace X/Y/size caches while preserving imported series styles, point formatting, outline colors during width-only changes, noncontiguous series identities, and axis formatting matched through the chart's referenced axis IDs. Snapshots honor native series order even when ChartML stores series elements in a different document order and apply hidden legend entries by plotted position. Newly added unstyled series receive an explicit shared-palette color without changing preserved series formatting. Explicit fill changes replace every mutually exclusive native fill choice and retain schema-valid outline ordering. Recreated data labels and newly colored points are inserted in schema order around bubble 3-D flags, trendlines, and error bars. Workbook generation scales with the points that actually exist in uneven series, and both authoring and imported caches enforce a 100,000-point aggregate budget before large workbook or snapshot allocations.

Shared PNG, SVG, HTML, PDF, and raster output preserves theme-resolved colors, alpha transparency, point colors, outline state/color/width, hidden or missing legends, supported legend placement and overlay, title overlay, multiline chart and horizontal/vertical axis titles, number formats, visible major/minor tick marks, shared-palette default bubble colors, and the supported vertical gridline style, zero-sized bubbles, native bubble scale, and exact area-versus-width sizing. Bubble and mixed scatter/bubble rendering uses radius- and outline-safe coordinates so extrema remain inside the plot and aligned with the axes, including compact charts with unusually wide outlines.

Semantic PowerPoint HTML round-trips X values, bubble sizes, sizing mode, scale, RGBA colors, outline settings, and chart-level legend visibility, placement, and overlay. Inventory-only entries receive valid placeholder data, malformed tables remain rejected, uneven semantic tables are budgeted by their actual point count while still enforcing series and widest-row limits, and bubble imports above the shared 100,000-point ceiling are omitted with a diagnostic before chart construction.

Snapshots fail safely when the shared model cannot preserve the native result. This includes unsupported mixed chart groups, trendlines, error bars, hidden or custom-spaced axes, display units, unsupported native number formats, non-default crossings, tick-label positions, or axis sides, logarithmic/bounded/reversed axes, manual chart/axis-title/plot/legend geometry, custom chart-title/axis/legend text presentation, custom axis lines, chart/plot-area styles, unsupported legend placement, unresolved inherited fills or outlines, non-default outline alignment, formula-backed series names without a resolvable cache, hidden workbook rows or columns under visible-only plotting, custom gridline configurations, negative-value inversion, 3-D settings, varying native point colors, custom line styles, enabled/custom labels, effects, and unsupported series or point style overrides. Bubble updates also reject charts without an embedded workbook before changing native formulas. The shared Excel entry point rejects the bubble kind explicitly; Excel callers can continue to use the native Excel bubble-chart API.

The Windows compatibility suite now waits for explicit OCR provider-start signals instead of relying on 20 ms scheduler races. This changes test synchronization only; Reader production behavior is unchanged.

## Usage

```csharp
var data = new OfficeChartData(
    new[] { "1", "2", "3" },
    new[] {
        OfficeChartSeries.CreateBubble(
            "Portfolio",
            xValues: new[] { 1D, 2D, 3D },
            yValues: new[] { 12D, 18D, 15D },
            bubbleSizes: new[] { 9D, 36D, 16D })
    });

slide.AddChartCm(OfficeChartKind.Bubble, data, 2, 3, 20, 10)
    .SetBubbleSizing(145U, OfficeChartBubbleSizeMode.Width);
```

Bubble X, Y, and size sequences are required. Coordinates must be finite, and bubble sizes must be finite and non-negative, with one size for every X/Y point. Bubble scale accepts zero through 300 percent.

## Validation

The complete .NET 8 suites pass for Drawing (1,013), PowerPoint (1,452), and HTML (1,230), plus the unchanged Excel suite (2,657) and Reader suite (884), with seven opt-in live/Desktop tests skipped. Focused .NET 10 bubble contract coverage passes 53 tests, including imported-outline, multiline-title, formula-backed-name, and missing-workbook, plotted-legend, hidden-source, and schema-order regressions. Drawing, PowerPoint, PowerPoint PDF, and PowerPoint HTML build for .NET Standard 2.0 with zero warnings.
