### PR TITLE
Improve HTML-to-Word fidelity and typed insertion

### DIFF
--- a/Docs/officeimo.word-html-roadmap.md
+++ b/Docs/officeimo.word-html-roadmap.md
@@ -10,14 +10,19 @@ The library should preserve the content people expect from real documents, expos
 
 - Bidirectional conversion exists: HTML to `WordDocument` and `WordDocument` to HTML.
 - The HTML import path already handles headings, paragraphs, inline formatting, links, images, SVG, lists, tables, captions, notes, headers, footers, and sections.
-- CSS support covers inline declarations, stylesheet content, stylesheet files, remote stylesheets, class-to-style mapping, paragraph spacing, indentation, colors, line height, white space, list styles, table widths, borders, cell spacing, and physical plus logical alignment.
-- Resource handling already has caller-provided `HttpClient`, timeout support, data URI images, embedded images, external image links, SVG support, per-image/image-total/CSS-total byte limits, declared image and stylesheet content-type validation, and URI scheme/host policy controls.
+- CSS support covers inline declarations, stylesheet content, stylesheet files, remote stylesheets, class-to-style mapping, paragraph spacing, physical and logical margin/padding, exact text backgrounds, block frames, colors, line height, white space, list styles, table widths, borders, cell spacing, and physical plus logical alignment.
+- Resource handling already has caller-provided `HttpClient`, timeout support, bounded remote-image prefetch, data URI images, embedded images, external image links, SVG support, per-image/image-total/CSS-total byte limits, declared image and stylesheet content-type validation, and URI scheme/host policy controls.
 - The export path already emits metadata, footnotes, endnotes, optional headers/footers, optional comments, images, SVG, lists, tables, paragraph/run classes, inline run colors/highlights, spacing, indentation, and optional default CSS.
 - Existing tests cover many real contracts across HTML import, Word export, style mapping, table behavior, image handling, links, notes, async/cancellation, and whitespace.
 - The current supported feature set is documented in `Docs/officeimo.word-html-support-matrix.md`.
 
 ## Recently Fixed Issues
 
+- HTML import now resolves logical margin and padding properties against inherited text direction while preserving declaration-order precedence with physical properties.
+- Block backgrounds, borders, margins, and padding now map to native paragraph frames, including one continuous frame across multi-paragraph containers.
+- Inline CSS backgrounds now preserve arbitrary colors through exact run shading by default; callers can explicitly request nearest Word-highlight mapping and receive diagnostics for approximated colors.
+- Remote image candidates now prefetch with configurable bounded concurrency, while aggregate byte-budget imports remain sequential for deterministic pre-read enforcement.
+- `WordTableCell.AddHtml` and `AddHtmlAsync` now provide typed insertion into existing cells, including nested lists, tables, images, and saved-package relationships.
 - The shared `OfficeIMO.Html` layer now exposes `HtmlConversionDocumentBuilder`, giving adapters one canonical document contract that combines the source HTML, profile contract, logical model, computed-style summary, resource manifest, resource dependency plan, and normalized HTML output.
 - `OfficeIMO.Word.Html`, `OfficeIMO.Markdown.Html`, and `OfficeIMO.Html.Pdf` now accept the shared conversion document through thin adapter overloads while keeping target-specific rendering in the owning packages.
 - Normalized HTML output now provides a policy-aware review/export lane that resolves allowed URLs against the base URI, removes disallowed URL targets, normalizes boolean attributes, strips event-handler attributes by default, and skips executable non-document elements.
@@ -113,7 +118,7 @@ The library should preserve the content people expect from real documents, expos
 - Layout and page controls: cover remaining margin and flow placement cases around constrained containers.
 - Lists: cover CSS formats that Word does not expose as native numbering, richer nested restart/continuation rules, and robust non-standard list markup produced by editors.
 - Tables: continue hardening irregular row/column spans, malformed nested tables in list items, richer collapsed/separate border conflict behavior, multiple-row footer semantics, and table width inside constrained containers.
-- Images and resources: add safer prefetching and broader raster/vector formats.
+- Images and resources: extend the bounded pipeline to linked CSS and future resource kinds, and cover broader raster/vector formats.
 - Semantics and forms: deepen support for `abbr`, `cite`, `dfn`, `q`, `time`, structural elements, bidirectional text, richer specialized form export where practical, native-style multi-select export where practical, and richer reciprocal form behavior; continue expanding richer nested `blockquote` content and richer non-image `figure` content where Word has a durable representation.
 - Word-to-HTML fidelity: preserve richer comment range fidelity, round-trip richer header/footer content, style definitions, richer list definitions, table styles, images, richer note formatting, and accessibility metadata more completely.
 - Security and reliability: keep parser/resource limits current, prevent regex and CSS parsing DoS paths, and continue expanding warning coverage for skipped or degraded content as new unsupported HTML/resource cases are identified.

--- a/Docs/officeimo.word-html-support-matrix.md
+++ b/Docs/officeimo.word-html-support-matrix.md
@@ -14,7 +14,7 @@ This matrix documents the current `OfficeIMO.Word.Html` conversion surface. It i
 | Area | Status | Current behavior |
 | --- | --- | --- |
 | Document root | Supported | `html` and `body` are parsed through AngleSharp; document-level `lang` / `xml:lang` maps to `WordDocument.Settings.Language`; body-level inline and stylesheet CSS can flow into descendants. |
-| Basic blocks | Supported | `p`, `div`, `br`, and `hr` map to Word paragraphs, runs, line breaks, and horizontal-rule style paragraphs. |
+| Basic blocks | Supported | `p`, `div`, `br`, and `hr` map to Word paragraphs, runs, line breaks, and horizontal-rule style paragraphs. Block background, border, margin, and padding map to native paragraph shading, borders, spacing, and indentation; multi-paragraph containers keep one visual frame. |
 | Headings | Supported | `h1` through `h6` map to Word heading styles, with optional heading numbering. |
 | Structural sections | Supported | `section`, `article`, `aside`, `nav`, `header`, `footer`, and `main` preserve content; structural IDs can round-trip through bookmarks. |
 | Definition lists | Supported | `dl`, `dt`, and `dd` import as semantic term/description paragraphs, with `dd` indented and marker styles preserved for Word-to-HTML round-trip export. |
@@ -44,9 +44,9 @@ This matrix documents the current `OfficeIMO.Word.Html` conversion surface. It i
 | Cascade sources | Supported | Inline styles, embedded stylesheets, configured stylesheets, linked stylesheets, and body/ancestor inherited styles are applied. |
 | Selectors | Partial | Common selectors, classes, specificity, inheritance, and `!important` are handled for supported properties; full browser selector/layout behavior is not the target yet. |
 | Fonts | Supported | `font`, `font-family`, `font-size`, `font-style`, `font-variant`, `font-weight`, and legacy `font` attributes map to Word run formatting. |
-| Colors | Supported | Hex, named colors, `rgb()`, modern space-separated `rgb()`, percentage channels, slash alpha syntax, and background colors map to Word colors where possible. |
+| Colors | Supported | Hex, named colors, `rgb()`, modern space-separated `rgb()`, percentage channels, and slash alpha syntax map to Word colors. Inline text backgrounds use exact run shading by default; `HtmlTextBackgroundMode.NearestHighlight` provides an explicit palette approximation mode with diagnostics. |
 | Text decoration | Supported | Bold, italic, underline, CSS underline style variants, strike, highlight, superscript, subscript, small caps, uppercase transforms, and code font mapping are supported. `text-decoration:none` clears inherited underline/strike formatting. |
-| Paragraph alignment | Supported | Physical `text-align` values plus logical `start`/`end` values, direction/RTL, indentation, text indent, margins, line height, paragraph spacing, and white-space behavior map to Word paragraph formatting. |
+| Paragraph alignment | Supported | Physical `text-align` values plus logical `start`/`end` values, direction/RTL, indentation, text indent, physical and logical margin/padding properties, line height, paragraph spacing, and white-space behavior map to Word paragraph formatting. Logical inline start/end values resolve against inherited direction. |
 | Page breaks | Supported | `break-before`, `break-after`, and legacy page-break declarations map to Word page breaks. |
 | Tables | Supported | Table/cell width, borders, background color, horizontal and table-cell vertical alignment, padding, margins, `border-collapse`, `border-spacing`, captions, and colgroup widths are handled for common document tables. |
 | Lists | Supported | `list-style-type` maps to native Word list formats where OpenXML has a matching numbering style. |
@@ -62,7 +62,7 @@ This matrix documents the current `OfficeIMO.Word.Html` conversion surface. It i
 | External image links | Supported | `ImageProcessingMode.LinkExternal` can preserve external references when the source and dimensions are usable. |
 | Data URI images | Supported | Base64 data URI images are supported; SVG text data URIs are supported. |
 | Local and file URL images | Supported | Local paths and `file:` URLs resolve directly or relative to `HtmlToWordOptions.BasePath`. |
-| Remote images | Supported | HTTP/HTTPS images load through the configured or default HTTP pipeline with optional timeout. |
+| Remote images | Supported | HTTP/HTTPS images load through the configured or default HTTP pipeline with optional timeout and bounded concurrency through `MaxConcurrentResourceLoads`. Imports with an aggregate image budget load sequentially to preserve deterministic pre-read budget checks. |
 | SVG | Supported | Inline SVG, SVG files, remote SVG, and SVG data URIs can be embedded. |
 | Duplicate resources | Supported | Duplicate image sources are cached inside a conversion operation while preserving per-image `alt` and `title` metadata. |
 | Per-image byte limit | Supported | `MaxImageBytes` rejects oversized image resources with `ImageResourceTooLarge`. |
@@ -76,7 +76,7 @@ This matrix documents the current `OfficeIMO.Word.Html` conversion surface. It i
 | CSS aggregate byte budget | Supported | `MaxTotalCssBytes` rejects configured, embedded, local, and remote CSS that would exceed the conversion budget with `CssTotalSizeLimitExceeded`. |
 | Stylesheet parse cache | Supported | Parsed stylesheet rules are cached by CSS content hash, reusing identical CSS across conversions without reusing stale rules when a local path or remote URL returns changed content. |
 | Other non-image aggregate resource budgets | Planned | Non-CSS embedded media and future resource types do not yet share an aggregate byte-budget pipeline. |
-| Parallel prefetch | Planned | Resource loading is deterministic today; parallel prefetching remains a performance roadmap item. |
+| Parallel prefetch | Supported | Remote image candidates are deduplicated and prefetched with bounded concurrency while preserving deterministic projection order. |
 
 ## Table Conversion
 
@@ -128,7 +128,8 @@ This matrix documents the current `OfficeIMO.Word.Html` conversion surface. It i
 
 | Option surface | Status | Key controls |
 | --- | --- | --- |
-| `HtmlToWordOptions` | Supported | Named profiles through `CreateOfficeIMOProfile()`, `CreateUntrustedHtmlProfile()`, and `CreateTrustedDocumentProfile()`; cloneable reusable templates; font family, quote text, default page size/orientation, class styles, list styles, numbering continuation, heading numbering, base path, notes, raw HTML comment import and author metadata, image processing mode, `HttpClient`, resource timeout, image limits, HTML/CSS/table limits, image and stylesheet content-type validation, image and stylesheet URI policy, diagnostics, opt-in accessibility diagnostics, unsupported CSS handling, stylesheet paths/contents, pre rendering mode, caption placement, and section handling. |
+| `HtmlToWordOptions` | Supported | Named profiles through `CreateOfficeIMOProfile()`, `CreateUntrustedHtmlProfile()`, and `CreateTrustedDocumentProfile()`; cloneable reusable templates; font family, quote text, default page size/orientation, class styles, list styles, numbering continuation, heading numbering, base path, notes, raw HTML comment import and author metadata, image processing mode, `HttpClient`, resource timeout and concurrency, exact or highlight-palette text backgrounds, image limits, HTML/CSS/table limits, image and stylesheet content-type validation, image and stylesheet URI policy, diagnostics, opt-in accessibility diagnostics, unsupported CSS handling, stylesheet paths/contents, pre rendering mode, caption placement, and section handling. |
+| Existing-container insertion | Supported | Parsed HTML can be appended through typed APIs to a document body, section header/footer, or `WordTableCell`; table-cell insertion preserves nested paragraphs, lists, tables, images, and package relationships. |
 | `WordToHtmlOptions` | Supported | Font family, font styles, list styles, list definitions, paragraph/run classes, run color/highlight styles, paragraph spacing/indentation styles, footnote and endnote export, header/footer export, comment export, custom property metadata export, section metadata export, table column-group export, image embedding mode, additional meta/link tags, and default CSS. |
 | `ReaderHtmlOptions` | Supported | `OfficeIMO.Reader.Html` exposes named adapter profiles for OfficeIMO-default, portable, and bounded untrusted HTML ingestion; nested `HtmlToMarkdownOptions` pass-through for markdown writer profiles, input limits, transforms, custom element converters, and visual round-trip hints; and `Clone()` for reusable registration templates. |
 

--- a/OfficeIMO.Html.Tests/Html.CssAdditionalProperties.cs
+++ b/OfficeIMO.Html.Tests/Html.CssAdditionalProperties.cs
@@ -30,7 +30,7 @@ namespace OfficeIMO.Tests {
             string html = "<p style=\"background-color:#ffff00\">Mark</p>";
             var doc = OfficeIMO.Html.HtmlConversionDocument.Parse(html).ToWordDocument(new HtmlToWordOptions());
             var paragraph = doc.Paragraphs[0];
-            Assert.Equal(HighlightColorValues.Yellow, paragraph.Highlight);
+            Assert.Equal("FFFF00", paragraph.ShadingFillColorHex);
         }
 
         [Fact]

--- a/OfficeIMO.Html.Tests/Html.ParagraphStyles.cs
+++ b/OfficeIMO.Html.Tests/Html.ParagraphStyles.cs
@@ -14,7 +14,7 @@ namespace OfficeIMO.Tests {
 
             Assert.Equal("FF0000", paragraph.ColorHex);
             Assert.Equal(24, paragraph.FontSize);
-            Assert.Equal(HighlightColorValues.Yellow, paragraph.Highlight);
+            Assert.Equal("FFFF00", paragraph.ShadingFillColorHex);
         }
 
         [Fact]
@@ -26,7 +26,7 @@ namespace OfficeIMO.Tests {
 
             Assert.Equal("FF0000", paragraph.ColorHex);
             Assert.Equal(20, paragraph.FontSize);
-            Assert.Equal(HighlightColorValues.Cyan, paragraph.Highlight);
+            Assert.Equal("00FFFF", paragraph.ShadingFillColorHex);
         }
     }
 }

--- a/OfficeIMO.Html.Tests/Html.SpanStyles.cs
+++ b/OfficeIMO.Html.Tests/Html.SpanStyles.cs
@@ -32,7 +32,7 @@ namespace OfficeIMO.Tests {
             Assert.Equal(UnderlineValues.Single, underRun.Underline);
 
             var markRun = runs.First(r => r.Text == "mark");
-            Assert.Equal(HighlightColorValues.Yellow, markRun.Highlight);
+            Assert.Equal("FFFF00", markRun.RunShadingFillColorHex);
         }
 
         [Fact]

--- a/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewContracts.cs
+++ b/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewContracts.cs
@@ -1,3 +1,4 @@
+using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Html;
 using OfficeIMO.Word;
@@ -13,6 +14,84 @@ using Xunit;
 namespace OfficeIMO.Tests;
 
 public partial class HtmlWordGapClosure {
+    [Theory]
+    [InlineData("section")]
+    [InlineData("article")]
+    [InlineData("aside")]
+    [InlineData("nav")]
+    [InlineData("header")]
+    [InlineData("footer")]
+    [InlineData("main")]
+    public void HtmlToWord_StyledEmptySemanticBlock_MaterializesItsWordFrame(string tagName) {
+        string html = $"<{tagName} style=\"border:1px solid #123456;background-color:#abcdef;padding:4px\"></{tagName}>";
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph paragraph = Assert.Single(document.Paragraphs);
+
+        Assert.Equal("ABCDEF", paragraph.ShadingFillColorHex);
+        Assert.Equal(BorderValues.Single, paragraph.Borders.TopStyle);
+        Assert.Equal("123456", paragraph.Borders.TopColorHex);
+        Assert.Equal(60, paragraph.IndentationBefore);
+        Assert.Equal(60, paragraph.IndentationAfter);
+    }
+
+    [Fact]
+    public void HtmlToWord_ZeroWidthBlockBorders_RemainInvisible() {
+        const string html = """
+            <p style="border:0px solid red">Zero shorthand</p>
+            <p style="border-left:1px solid red;border-left-width:0px">Zero longhand</p>
+            <p style="border:0 solid red">Unitless zero</p>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph shorthand = Assert.Single(
+            document.Paragraphs,
+            candidate => candidate.Text == "Zero shorthand");
+        WordParagraph longhand = Assert.Single(
+            document.Paragraphs,
+            candidate => candidate.Text == "Zero longhand");
+        WordParagraph unitless = Assert.Single(
+            document.Paragraphs,
+            candidate => candidate.Text == "Unitless zero");
+
+        Assert.Null(shorthand.Borders.TopStyle);
+        Assert.Null(shorthand.Borders.LeftStyle);
+        Assert.Null(longhand.Borders.LeftStyle);
+        Assert.Null(unitless.Borders.TopStyle);
+    }
+
+    [Fact]
+    public void WordTableCell_AddHtml_BelowTableCaptionReusesTheTrailingParagraph() {
+        using WordDocument document = WordDocument.Create();
+        WordTableCell cell = document.AddTable(1, 1).Rows[0].Cells[0];
+        var options = new HtmlToWordOptions { TableCaptionPosition = TableCaptionPosition.Below };
+
+        cell.AddHtml(
+            HtmlConversionDocument.Parse(
+                """<table><caption>Nested caption</caption><tr><td>Value</td></tr></table>"""),
+            options);
+
+        OpenXmlElement[] elements = cell._tableCell.ChildElements
+            .Where(element => element is Table or Paragraph)
+            .ToArray();
+        Assert.Collection(
+            elements,
+            element => Assert.IsType<Table>(element),
+            element => Assert.Equal("Nested caption", Assert.IsType<Paragraph>(element).InnerText));
+    }
+
+    [Fact]
+    public void WordTableCell_AddHtml_RejectedImageDoesNotLeaveAnEmptyParagraph() {
+        using WordDocument document = WordDocument.Create();
+        WordTableCell cell = document.AddTable(1, 1).Rows[0].Cells[0];
+        cell.Paragraphs[0].Text = "Existing";
+
+        cell.AddHtml(HtmlConversionDocument.Parse("""<img alt="">"""));
+
+        Paragraph paragraph = Assert.Single(cell._tableCell.Elements<Paragraph>());
+        Assert.Equal("Existing", paragraph.InnerText);
+    }
+
     [Fact]
     public void WordTableCell_AddHtml_PreservesFormattedEmptyParagraphs() {
         using WordDocument document = WordDocument.Create();

--- a/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewContracts.cs
+++ b/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewContracts.cs
@@ -411,6 +411,41 @@ public partial class HtmlWordGapClosure {
     }
 
     [Fact]
+    public void WordToHtml_SolidRunShading_UsesForegroundColorInsteadOfFill() {
+        using WordDocument document = WordDocument.Create();
+        WordParagraph run = document.AddParagraph("Solid");
+        run.RunShadingFillColorHex = "0000FF";
+        run._runProperties!.Shading!.Val = ShadingPatternValues.Solid;
+        run._runProperties.Shading.Color = "FF0000";
+
+        string html = document.ToHtml(new WordToHtmlOptions { IncludeRunHighlightStyles = true });
+        WordDocumentVisualSnapshot snapshot = document.CreateVisualSnapshot();
+        OfficeIMO.Drawing.OfficeRichTextRun renderedRun = Assert.Single(
+            snapshot.Drawing.Elements
+                .OfType<OfficeIMO.Drawing.OfficeDrawingRichText>()
+                .SelectMany(richText => richText.Runs),
+            candidate => candidate.Text == "Solid");
+
+        Assert.Contains("background-color:#ff0000", html, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("background-color:#0000ff", html, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(OfficeIMO.Drawing.OfficeColor.Red, renderedRun.BackgroundColor);
+    }
+
+    [Fact]
+    public void HtmlToWord_TransparentBlockBackground_PassesStrictDiagnosticsAndClearsFill() {
+        using WordDocument document = HtmlConversionDocument
+            .Parse("""<div style="background-color:#ff0000;background-color:transparent"><p>Cleared</p></div>""")
+            .ToWordDocument(new HtmlToWordOptions {
+                UnsupportedCssHandling = HtmlUnsupportedCssHandling.Error
+            });
+        WordParagraph paragraph = Assert.Single(
+            document.Paragraphs,
+            candidate => candidate.Text == "Cleared");
+
+        Assert.True(string.IsNullOrEmpty(paragraph.ShadingFillColorHex));
+    }
+
+    [Fact]
     public void HtmlToWord_CssWideBoxValues_ResetEarlierPhysicalAndLogicalSpacing() {
         const string html = """
             <p style="margin-left:10px;margin-left:initial;padding-right:12px;padding-right:unset">Physical reset</p>
@@ -455,12 +490,17 @@ public partial class HtmlWordGapClosure {
     [Fact]
     public void WordToHtml_ExactTextBackground_ExportsBesideAnEquation() {
         using WordDocument document = WordDocument.Create();
+        A.ColorScheme scheme = document.MainDocumentPartRoot.ThemePart!.Theme!.ThemeElements!.ColorScheme!;
+        A.Accent1Color accent = scheme.GetFirstChild<A.Accent1Color>()!;
+        accent.RemoveAllChildren();
+        accent.Append(new A.RgbColorModelHex { Val = "123456" });
         WordParagraph paragraph = document.AddParagraph();
         paragraph._paragraph.Append(new Hyperlink(
             new Run(
                 new RunProperties(new Shading {
                     Val = ShadingPatternValues.Clear,
                     Fill = "ABCDEF",
+                    ThemeFill = ThemeColorValues.Accent1,
                 }),
                 new Text("shaded")),
             new M.OfficeMath(new M.Run(new M.Text("x")))) {
@@ -469,7 +509,8 @@ public partial class HtmlWordGapClosure {
 
         string html = document.ToHtml(new WordToHtmlOptions { IncludeRunHighlightStyles = true });
 
-        Assert.Contains("background-color:#abcdef", html, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("background-color:#123456", html, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("background-color:#abcdef", html, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("<math", html, StringComparison.OrdinalIgnoreCase);
     }
 

--- a/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewContracts.cs
+++ b/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewContracts.cs
@@ -14,6 +14,89 @@ namespace OfficeIMO.Tests;
 
 public partial class HtmlWordGapClosure {
     [Fact]
+    public void WordTableCell_AddHtml_PreservesFormattedEmptyParagraphs() {
+        using WordDocument document = WordDocument.Create();
+        WordTableCell cell = document.AddTable(1, 1).Rows[0].Cells[0];
+        cell.Paragraphs[0].PageBreakBefore = true;
+
+        cell.AddHtml(HtmlConversionDocument.Parse("""<p>Added</p>"""));
+
+        Paragraph[] paragraphs = cell._tableCell.Elements<Paragraph>().ToArray();
+        Assert.Equal(2, paragraphs.Length);
+        Assert.NotNull(paragraphs[0].ParagraphProperties?.GetFirstChild<PageBreakBefore>());
+        Assert.Equal(string.Empty, paragraphs[0].InnerText);
+        Assert.Equal("Added", paragraphs[1].InnerText);
+    }
+
+    [Fact]
+    public void HtmlToWord_InheritedLogicalPadding_UsesTheParentComputedValue() {
+        const string html = """
+            <div style="padding-inline-start:10px">
+              <p style="padding-inline-start:inherit">Inherited padding</p>
+            </div>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph paragraph = Assert.Single(
+            document.Paragraphs,
+            candidate => candidate.Text == "Inherited padding");
+
+        Assert.Equal(300, paragraph.IndentationBefore);
+        Assert.Null(paragraph.IndentationAfter);
+    }
+
+    [Fact]
+    public void HtmlToWord_NegativeLogicalPadding_DoesNotOverrideValidPhysicalPadding() {
+        const string html = """
+            <p style="padding-left:20px;padding-inline-start:-5px">Negative longhand</p>
+            <p style="padding-top:20px;padding-block:-5px 4px">Negative pair</p>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph longhand = Assert.Single(
+            document.Paragraphs,
+            candidate => candidate.Text == "Negative longhand");
+        WordParagraph pair = Assert.Single(
+            document.Paragraphs,
+            candidate => candidate.Text == "Negative pair");
+        CssStyleMapper.CssProperties negativeMargin = CssStyleMapper.ParseStyles("margin:-5px");
+
+        Assert.Equal(300, longhand.IndentationBefore);
+        Assert.Equal(300, pair.LineSpacingBefore);
+        Assert.Null(pair.LineSpacingAfter);
+        Assert.Equal(-75, negativeMargin.MarginLeft);
+    }
+
+    [Fact]
+    public void HtmlToWord_StyledEmptyBlock_MaterializesItsWordFrame() {
+        const string html = """
+            <div style="border:1px solid #123456;background-color:#abcdef;padding:4px"></div>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph paragraph = Assert.Single(document.Paragraphs);
+
+        Assert.Equal("ABCDEF", paragraph.ShadingFillColorHex);
+        Assert.Equal(BorderValues.Single, paragraph.Borders.TopStyle);
+        Assert.Equal("123456", paragraph.Borders.TopColorHex);
+        Assert.Equal(60, paragraph.IndentationBefore);
+        Assert.Equal(60, paragraph.IndentationAfter);
+    }
+
+    [Fact]
+    public void WordToHtml_VisibleHighlight_TakesPrecedenceOverExactRunShading() {
+        using WordDocument document = WordDocument.Create();
+        WordParagraph run = document.AddParagraph("Layered");
+        run.RunShadingFillColorHex = "ABCDEF";
+        run.Highlight = HighlightColorValues.Cyan;
+
+        string html = document.ToHtml(new WordToHtmlOptions { IncludeRunHighlightStyles = true });
+
+        Assert.Contains("background-color:#00ffff", html, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("background-color:#abcdef", html, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void HtmlToWord_CssWideBoxValues_ResetEarlierPhysicalAndLogicalSpacing() {
         const string html = """
             <p style="margin-left:10px;margin-left:initial;padding-right:12px;padding-right:unset">Physical reset</p>

--- a/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewContracts.cs
+++ b/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewContracts.cs
@@ -1,0 +1,118 @@
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Html;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+using M = DocumentFormat.OpenXml.Math;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public partial class HtmlWordGapClosure {
+    [Fact]
+    public void HtmlToWord_CssWideBoxValues_ResetEarlierPhysicalAndLogicalSpacing() {
+        const string html = """
+            <p style="margin-left:10px;margin-left:initial;padding-right:12px;padding-right:unset">Physical reset</p>
+            <p style="margin-inline-start:10px;margin-inline-start:revert;padding-block:5px;padding-block:revert-layer">Logical reset</p>
+            <p style="margin:10px;margin:inherit;padding:8px;padding:initial">Shorthand reset</p>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph physical = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "Physical reset");
+        WordParagraph logical = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "Logical reset");
+        WordParagraph shorthand = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "Shorthand reset");
+
+        Assert.Null(physical.IndentationBefore);
+        Assert.Null(physical.IndentationAfter);
+        Assert.Null(logical.IndentationBefore);
+        Assert.Null(logical.LineSpacingBefore);
+        Assert.Null(logical.LineSpacingAfter);
+        Assert.Null(shorthand.IndentationBefore);
+        Assert.Null(shorthand.IndentationAfter);
+        Assert.Null(shorthand.LineSpacingBefore);
+        Assert.Null(shorthand.LineSpacingAfter);
+    }
+
+    [Fact]
+    public void HtmlToWord_BlockBorders_PreserveResetComponentsAndUseCurrentTextColor() {
+        const string html = """
+            <p style="border-left:1px red;border-left-style:solid">Restored components</p>
+            <p style="color:#123456;border:1px solid">Current color</p>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph restored = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "Restored components");
+        WordParagraph currentColor = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "Current color");
+
+        Assert.Equal(BorderValues.Single, restored.Borders.LeftStyle);
+        Assert.Equal((uint)6, restored.Borders.LeftSize?.Value);
+        Assert.Equal("FF0000", restored.Borders.LeftColorHex);
+        Assert.Equal(BorderValues.Single, currentColor.Borders.TopStyle);
+        Assert.Equal("123456", currentColor.Borders.TopColorHex);
+    }
+
+    [Fact]
+    public void WordToHtml_ExactTextBackground_ExportsBesideAnEquation() {
+        using WordDocument document = WordDocument.Create();
+        WordParagraph paragraph = document.AddParagraph();
+        paragraph._paragraph.Append(new Hyperlink(
+            new Run(
+                new RunProperties(new Shading {
+                    Val = ShadingPatternValues.Clear,
+                    Fill = "ABCDEF",
+                }),
+                new Text("shaded")),
+            new M.OfficeMath(new M.Run(new M.Text("x")))) {
+            Anchor = "target",
+        });
+
+        string html = document.ToHtml(new WordToHtmlOptions { IncludeRunHighlightStyles = true });
+
+        Assert.Contains("background-color:#abcdef", html, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("<math", html, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task HtmlToWord_RemoteImages_DeduplicateCanonicalUris() {
+        int requestCount = 0;
+        byte[] imageBytes = Convert.FromBase64String(ValidPng);
+        using var httpClient = new HttpClient(new TrackingHandler(_ => {
+            Interlocked.Increment(ref requestCount);
+            var response = new HttpResponseMessage(HttpStatusCode.OK) {
+                Content = new ByteArrayContent(imageBytes),
+            };
+            response.Content.Headers.ContentType = new MediaTypeHeaderValue("image/png");
+            return Task.FromResult(response);
+        }));
+        var options = new HtmlToWordOptions {
+            HttpClient = httpClient,
+            ImageProcessing = ImageProcessingMode.Embed,
+            MaxConcurrentResourceLoads = 2,
+        };
+        const string html = """
+            <img src="https://EXAMPLE.test:443/shared.png" alt="First">
+            <img src="https://example.test/shared.png" alt="Second">
+            """;
+
+        using WordDocument document = await HtmlConversionDocument.Parse(html).ToWordDocumentAsync(options);
+
+        Assert.Equal(1, Volatile.Read(ref requestCount));
+        Assert.NotEmpty(document.Images);
+    }
+
+    [Fact]
+    public void WordTableCell_AddHtml_ListReplacesTheFreshPlaceholder() {
+        using WordDocument document = WordDocument.Create();
+        WordTableCell cell = document.AddTable(1, 1).Rows[0].Cells[0];
+
+        cell.AddHtml(HtmlConversionDocument.Parse("""<ul><li>Only item</li></ul>"""));
+
+        Paragraph paragraph = Assert.Single(cell._tableCell.Elements<Paragraph>());
+        Assert.Equal("Only item", paragraph.InnerText);
+        Assert.Contains(cell.Paragraphs, item => item.IsListItem && item.Text == "Only item");
+    }
+}

--- a/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewContracts.cs
+++ b/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewContracts.cs
@@ -131,6 +131,47 @@ public partial class HtmlWordGapClosure {
     }
 
     [Fact]
+    public void HtmlToWord_AncestorBackground_DoesNotOverrideNestedMarkHighlight() {
+        using WordDocument document = HtmlConversionDocument
+            .Parse("""<p><span style="background-color:#ff0000"><mark>Marked</mark></span></p>""")
+            .ToWordDocument();
+        WordParagraph run = Assert.Single(
+            document.Paragraphs[0].GetRuns(),
+            candidate => candidate.Text == "Marked");
+
+        Assert.Equal(HighlightColorValues.Yellow, run.Highlight);
+        Assert.Equal(string.Empty, run.RunShadingFillColorHex);
+    }
+
+    [Fact]
+    public void HtmlToWord_SupportedTableSpacing_PassesStrictDiagnostics() {
+        using WordDocument document = HtmlConversionDocument
+            .Parse("""<table style="margin:0 auto;padding:4px"><tr><td>Cell</td></tr></table>""")
+            .ToWordDocument(new HtmlToWordOptions {
+                UnsupportedCssHandling = HtmlUnsupportedCssHandling.Error
+            });
+        WordTable table = Assert.Single(document.Tables);
+
+        Assert.Equal(TableRowAlignmentValues.Center, table.Alignment);
+    }
+
+    [Fact]
+    public void HtmlToWord_ListItemContainerFrame_IncludesReusedNumberedParagraph() {
+        using WordDocument document = HtmlConversionDocument
+            .Parse("""<ol><li><div style="border:1px solid #123456;background-color:#abcdef">Framed</div></li></ol>""")
+            .ToWordDocument();
+        WordParagraph paragraph = Assert.Single(
+            document.Paragraphs,
+            candidate => candidate.Text == "Framed");
+
+        Assert.True(paragraph.IsListItem);
+        Assert.Equal("ABCDEF", paragraph.ShadingFillColorHex);
+        Assert.Equal(BorderValues.Single, paragraph.Borders.TopStyle);
+        Assert.Equal(BorderValues.Single, paragraph.Borders.BottomStyle);
+        Assert.Equal("123456", paragraph.Borders.LeftColorHex);
+    }
+
+    [Fact]
     public void HtmlToWord_NegativeLogicalBlockMargins_AreExplicitlyDiagnosed() {
         HtmlUnsupportedCssException exception = Assert.Throws<HtmlUnsupportedCssException>(() =>
             HtmlConversionDocument

--- a/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewContracts.cs
+++ b/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewContracts.cs
@@ -14,6 +14,93 @@ using Xunit;
 namespace OfficeIMO.Tests;
 
 public partial class HtmlWordGapClosure {
+    [Fact]
+    public void HtmlToWord_CssWideFrameValues_ResetEarlierDeclarations() {
+        const string html = """
+            <div style="background-color:red;background-color:initial">Background reset</div>
+            <p style="border:1px solid red;border:unset">Border reset</p>
+            <p style="border-left:1px solid red;border-left:revert-layer">Side reset</p>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph background = Assert.Single(
+            document.Paragraphs,
+            paragraph => paragraph.Text == "Background reset");
+        WordParagraph border = Assert.Single(
+            document.Paragraphs,
+            paragraph => paragraph.Text == "Border reset");
+        WordParagraph side = Assert.Single(
+            document.Paragraphs,
+            paragraph => paragraph.Text == "Side reset");
+
+        Assert.True(string.IsNullOrEmpty(background.ShadingFillColorHex));
+        Assert.Null(border.Borders.TopStyle);
+        Assert.Null(border.Borders.LeftStyle);
+        Assert.Null(side.Borders.LeftStyle);
+    }
+
+    [Fact]
+    public void HtmlToWord_FrameValues_CanExplicitlyInheritFromTheParent() {
+        const string html = """
+            <div style="background-color:#abcdef;border:1px solid #123456">
+              <p style="background-color:inherit;border:inherit">Inherited frame</p>
+            </div>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph paragraph = Assert.Single(
+            document.Paragraphs,
+            candidate => candidate.Text == "Inherited frame");
+
+        Assert.Equal("ABCDEF", paragraph.ShadingFillColorHex);
+        Assert.Equal(BorderValues.Single, paragraph.Borders.TopStyle);
+        Assert.Equal("123456", paragraph.Borders.LeftColorHex);
+    }
+
+    [Fact]
+    public void HtmlToWord_NegativeLogicalMargins_AreAppliedToParagraphIndentation() {
+        const string html = """
+            <p style="margin-inline-start:-10px">LTR start</p>
+            <p dir="rtl" style="margin-inline-start:-12px">RTL start</p>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph ltr = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "LTR start");
+        WordParagraph rtl = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "RTL start");
+
+        Assert.Equal(-150, ltr.IndentationBefore);
+        Assert.Null(ltr.IndentationAfter);
+        Assert.Null(rtl.IndentationBefore);
+        Assert.Equal(-180, rtl.IndentationAfter);
+    }
+
+    [Theory]
+    [InlineData("div")]
+    [InlineData("address")]
+    [InlineData("dl")]
+    public void HtmlToWord_MixedContainerTextFollowsItsLastBlockChild(string tagName) {
+        string html = $"<{tagName}><p>One</p><p>Two</p>tail</{tagName}>";
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+
+        Assert.Equal(
+            new[] { "One", "Two", "tail" },
+            document.Paragraphs.Select(paragraph => paragraph.Text).ToArray());
+    }
+
+    [Fact]
+    public void HtmlToWord_EmptyBlock_UsesTheWinningPageBreakDeclaration() {
+        const string html = """
+            <div style="break-before:page;break-before:auto"></div>
+            <div style="break-before:page!important;break-before:auto"></div>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph paragraph = Assert.Single(document.Paragraphs);
+
+        Assert.True(paragraph.PageBreakBefore);
+    }
+
     [Theory]
     [InlineData("section")]
     [InlineData("article")]

--- a/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewContracts.cs
+++ b/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewContracts.cs
@@ -15,6 +15,60 @@ namespace OfficeIMO.Tests;
 
 public partial class HtmlWordGapClosure {
     [Fact]
+    public void WordTableCell_AddHtml_ListPreservesAFormattedEmptyParagraph() {
+        using WordDocument document = WordDocument.Create();
+        WordTableCell cell = document.AddTable(1, 1).Rows[0].Cells[0];
+        cell.Paragraphs[0].PageBreakBefore = true;
+
+        cell.AddHtml(HtmlConversionDocument.Parse("""<ul><li>First</li></ul>"""));
+
+        WordParagraph formatted = Assert.Single(
+            cell.Paragraphs,
+            paragraph => paragraph.PageBreakBefore && paragraph.Text == string.Empty);
+        WordParagraph item = Assert.Single(
+            cell.Paragraphs,
+            paragraph => paragraph.IsListItem && paragraph.Text == "First");
+        Assert.NotSame(formatted, item);
+    }
+
+    [Fact]
+    public void WordTableCell_AddHtml_RejectedInlineSvgDoesNotLeaveAnEmptyParagraph() {
+        using WordDocument document = WordDocument.Create();
+        WordTableCell cell = document.AddTable(1, 1).Rows[0].Cells[0];
+        cell.Paragraphs[0].Text = "Existing";
+        var options = new HtmlToWordOptions { MaxImageBytes = 1 };
+
+        cell.AddHtml(
+            HtmlConversionDocument.Parse(
+                """<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"><rect width="10" height="10"/></svg>"""),
+            options);
+
+        WordParagraph paragraph = Assert.Single(cell.Paragraphs);
+        Assert.Equal("Existing", paragraph.Text);
+    }
+
+    [Theory]
+    [InlineData("border-left-style", "groove")]
+    [InlineData("border-right-width", "-1px")]
+    [InlineData("border-top-color", "not-a-color")]
+    public void HtmlToWord_InvalidBlockBorderLonghands_CanStopConversion(
+        string propertyName,
+        string propertyValue) {
+        var options = new HtmlToWordOptions {
+            UnsupportedCssHandling = HtmlUnsupportedCssHandling.Error,
+        };
+
+        HtmlUnsupportedCssException exception = Assert.Throws<HtmlUnsupportedCssException>(() =>
+            HtmlConversionDocument
+                .Parse($"<p style=\"{propertyName}:{propertyValue}\">Text</p>")
+                .ToWordDocument(options));
+
+        Assert.Equal("UnsupportedCssValue", exception.Code);
+        Assert.Equal($"p:{propertyName}", exception.CssSource);
+        Assert.Contains(propertyValue, exception.Detail, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void HtmlToWord_CssWideFrameValues_ResetEarlierDeclarations() {
         const string html = """
             <div style="background-color:red;background-color:initial">Background reset</div>

--- a/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewContracts.cs
+++ b/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewContracts.cs
@@ -3,11 +3,13 @@ using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Html;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Html;
+using System.Globalization;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
+using A = DocumentFormat.OpenXml.Drawing;
 using M = DocumentFormat.OpenXml.Math;
 using Xunit;
 
@@ -126,6 +128,38 @@ public partial class HtmlWordGapClosure {
         Assert.Null(ltr.IndentationAfter);
         Assert.Null(rtl.IndentationBefore);
         Assert.Equal(-180, rtl.IndentationAfter);
+    }
+
+    [Fact]
+    public void HtmlToWord_NegativeLogicalBlockMargins_AreExplicitlyDiagnosed() {
+        HtmlUnsupportedCssException exception = Assert.Throws<HtmlUnsupportedCssException>(() =>
+            HtmlConversionDocument
+                .Parse("""<p style="margin-block-start:-10px">Unsupported vertical overlap</p>""")
+                .ToWordDocument(new HtmlToWordOptions {
+                    UnsupportedCssHandling = HtmlUnsupportedCssHandling.Error
+                }));
+
+        Assert.Equal("UnsupportedCssValue", exception.Code);
+        Assert.Equal("p:margin-block-start", exception.CssSource);
+        Assert.Contains("negative vertical margins", exception.Detail, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void HtmlToWord_FractionalBlockBorderWidth_UsesInvariantCulture() {
+        CultureInfo previousCulture = CultureInfo.CurrentCulture;
+        try {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
+
+            using WordDocument document = HtmlConversionDocument
+                .Parse("""<p style="border:1.5px solid #123456">Fractional</p>""")
+                .ToWordDocument();
+            WordParagraph paragraph = Assert.Single(document.Paragraphs);
+
+            Assert.Equal((uint)9, paragraph.Borders.TopSize?.Value);
+            Assert.Equal((uint)9, paragraph.Borders.LeftSize?.Value);
+        } finally {
+            CultureInfo.CurrentCulture = previousCulture;
+        }
     }
 
     [Theory]
@@ -314,6 +348,25 @@ public partial class HtmlWordGapClosure {
 
         Assert.Contains("background-color:#00ffff", html, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("background-color:#abcdef", html, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void WordToHtml_ThemeRunShading_UsesResolvedThemeColorInsteadOfFallbackFill() {
+        using WordDocument document = WordDocument.Create();
+        A.ColorScheme scheme = document.MainDocumentPartRoot.ThemePart!.Theme!.ThemeElements!.ColorScheme!;
+        A.Accent1Color accent = scheme.GetFirstChild<A.Accent1Color>()!;
+        accent.RemoveAllChildren();
+        accent.Append(new A.RgbColorModelHex { Val = "000000" });
+
+        WordParagraph run = document.AddParagraph("Themed");
+        run.RunShadingFillColorHex = "FFFFFF";
+        run._runProperties!.Shading!.ThemeFill = ThemeColorValues.Accent1;
+        run._runProperties.Shading.ThemeFillTint = "80";
+
+        string html = document.ToHtml(new WordToHtmlOptions { IncludeRunHighlightStyles = true });
+
+        Assert.Contains("background-color:#7f7f7f", html, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("background-color:#ffffff", html, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewWave14Contracts.cs
+++ b/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewWave14Contracts.cs
@@ -1,0 +1,94 @@
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Html;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public partial class HtmlWordGapClosure {
+    [Fact]
+    public void HtmlToWord_TopLevelInlineImageStaysInTheSurroundingTextParagraph() {
+        string html = $"""
+            <body>before<img src="data:image/png;base64,{ValidPng}" alt="Inline">after</body>
+        """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph before = Assert.Single(
+            document.Paragraphs,
+            candidate => candidate.Text == "before");
+        WordParagraph after = Assert.Single(
+            document.Paragraphs,
+            candidate => candidate.Text == "after");
+
+        Assert.Same(before._paragraph, after._paragraph);
+        Assert.Single(before._paragraph.Descendants<DocumentFormat.OpenXml.Wordprocessing.Drawing>());
+        Assert.Single(document.Images);
+    }
+
+    [Fact]
+    public void HtmlToWord_InlineBackgroundAlphaIsPreservedThroughTransparencyOrCompositing() {
+        const string html = """
+            <p><span style="background-color:rgba(255,0,0,0)">transparent</span><span style="background-color:rgba(255,0,0,0.5)">half</span></p>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph transparent = Assert.Single(
+            document.Paragraphs,
+            run => run.Text == "transparent");
+        WordParagraph half = Assert.Single(
+            document.Paragraphs,
+            run => run.Text == "half");
+
+        Assert.Same(transparent._paragraph, half._paragraph);
+        Assert.Equal(string.Empty, transparent.RunShadingFillColorHex);
+        Assert.Equal("FF8080", half.RunShadingFillColorHex);
+    }
+
+    [Fact]
+    public void WordToHtml_PercentageRunShadingUsesTheVisibleBlendedColor() {
+        using WordDocument document = WordDocument.Create();
+        WordParagraph run = document.AddParagraph("Pattern");
+        run.RunShadingFillColorHex = "0000FF";
+        run._runProperties!.Shading!.Val = ShadingPatternValues.Percent50;
+        run._runProperties.Shading.Color = "FF0000";
+
+        string html = document.ToHtml(new WordToHtmlOptions { IncludeRunHighlightStyles = true });
+        WordDocumentVisualSnapshot snapshot = document.CreateVisualSnapshot();
+        OfficeIMO.Drawing.OfficeRichTextRun renderedRun = Assert.Single(
+            snapshot.Drawing.Elements
+                .OfType<OfficeIMO.Drawing.OfficeDrawingRichText>()
+                .SelectMany(richText => richText.Runs),
+            candidate => candidate.Text == "Pattern");
+
+        Assert.Contains("background-color:#800080", html, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(OfficeIMO.Drawing.OfficeColor.FromRgb(128, 0, 128), renderedRun.BackgroundColor);
+    }
+
+    [Fact]
+    public void HtmlToWord_LogicalSpacingConvertsEveryAcceptedAbsoluteUnit() {
+        const string html = """
+            <p style="margin-inline-start:1rem">rem</p>
+            <p style="padding-block-start:1in">in</p>
+            <p style="margin-inline-start:1cm">cm</p>
+            <p style="margin-inline-start:1mm">mm</p>
+            <p style="margin-inline-start:1pc">pc</p>
+            <p style="margin-inline-start:1q">q</p>
+            """;
+        var options = new HtmlToWordOptions {
+            UnsupportedCssHandling = HtmlUnsupportedCssHandling.Error,
+        };
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument(options);
+
+        Assert.Equal(240, FindParagraph(document, "rem").IndentationBefore);
+        Assert.Equal(1440, FindParagraph(document, "in").LineSpacingBefore);
+        Assert.Equal(567, FindParagraph(document, "cm").IndentationBefore);
+        Assert.Equal(57, FindParagraph(document, "mm").IndentationBefore);
+        Assert.Equal(240, FindParagraph(document, "pc").IndentationBefore);
+        Assert.Equal(14, FindParagraph(document, "q").IndentationBefore);
+    }
+
+    private static WordParagraph FindParagraph(WordDocument document, string text) =>
+        Assert.Single(document.Paragraphs, paragraph => paragraph.Text == text);
+}

--- a/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewWave15Contracts.cs
+++ b/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewWave15Contracts.cs
@@ -1,0 +1,52 @@
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Html;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public partial class HtmlWordGapClosure {
+    [Fact]
+    public void HtmlToWord_StylesheetBlockImageStartsItsOwnParagraph() {
+        string html = $$"""
+            <style>.hero { display:block; }</style>
+            <body>before<img class="hero" src="data:image/png;base64,{{ValidPng}}" alt="Hero">after</body>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph before = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "before");
+        WordParagraph image = Assert.Single(
+            document.Paragraphs,
+            paragraph => paragraph._paragraph.Descendants<DocumentFormat.OpenXml.Wordprocessing.Drawing>().Any());
+        WordParagraph after = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "after");
+
+        Assert.NotSame(before._paragraph, image._paragraph);
+        Assert.NotSame(image._paragraph, after._paragraph);
+        Assert.NotSame(before._paragraph, after._paragraph);
+    }
+
+    [Fact]
+    public void HtmlToWord_TableOnlyContainerFramesTheTableWithoutAnEmptyParagraph() {
+        const string html = """
+            <div style="background-color:#abcdef;border:2px solid #123456">
+              <table><tr><td>First</td><td>Second</td></tr></table>
+            </div>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordTable table = Assert.Single(document.Sections[0].Tables);
+        WordTableCell first = table.Rows[0].Cells[0];
+        WordTableCell last = table.Rows[0].Cells[1];
+
+        Assert.Empty(document.Sections[0].Paragraphs);
+        Assert.Equal("ABCDEF", first.ShadingFillColorHex);
+        Assert.Equal("ABCDEF", last.ShadingFillColorHex);
+        Assert.Equal(BorderValues.Single, first.Borders.TopStyle);
+        Assert.Equal(BorderValues.Single, first.Borders.LeftStyle);
+        Assert.Equal(BorderValues.Single, last.Borders.TopStyle);
+        Assert.Equal(BorderValues.Single, last.Borders.RightStyle);
+        Assert.Equal("123456", first.Borders.LeftColorHex);
+        Assert.Equal("123456", last.Borders.RightColorHex);
+    }
+}

--- a/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewWave16Contracts.cs
+++ b/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewWave16Contracts.cs
@@ -1,0 +1,75 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Html;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public partial class HtmlWordGapClosure {
+    [Theory]
+    [InlineData("break-before:page", true)]
+    [InlineData("break-after:page", false)]
+    public void HtmlToWord_TableOnlyContainerPreservesPageBreakBoundary(string style, bool breakBefore) {
+        string html = $"""
+            <div style="{style}"><table><tr><td>Cell</td></tr></table></div>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        OpenXmlElement[] blocks = document.OpenXmlDocument.MainDocumentPart!.Document.Body!
+            .ChildElements
+            .Where(element => element is Paragraph or Table)
+            .ToArray();
+
+        Assert.Equal(2, blocks.Length);
+        Assert.IsType<Paragraph>(blocks[breakBefore ? 0 : 1]);
+        Assert.IsType<Table>(blocks[breakBefore ? 1 : 0]);
+        Break pageBreak = Assert.Single(blocks.OfType<Paragraph>().Single().Descendants<Break>());
+        Assert.Equal(BreakValues.Page, pageBreak.Type?.Value);
+    }
+
+    [Fact]
+    public void HtmlToWord_StrictCssAcceptsTransparentInlineBackground() {
+        const string html = """<p><span style="background-color:transparent">Clear</span></p>""";
+        var options = new HtmlToWordOptions {
+            UnsupportedCssHandling = HtmlUnsupportedCssHandling.Error,
+        };
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument(options);
+        WordParagraph run = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "Clear");
+
+        Assert.Equal(string.Empty, run.RunShadingFillColorHex);
+    }
+
+    [Fact]
+    public void HtmlToWord_NestedContainerKeepsTheDescendantBorder() {
+        const string html = """
+            <div style="border:1px solid red">
+              <div style="border:2px solid blue">Nested</div>
+            </div>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph paragraph = Assert.Single(document.Paragraphs, candidate => candidate.Text == "Nested");
+
+        Assert.Equal(BorderValues.Single, paragraph.Borders.LeftStyle);
+        Assert.Equal("0000FF", paragraph.Borders.LeftColorHex);
+        Assert.Equal(12U, paragraph.Borders.LeftSize?.Value);
+    }
+
+    [Fact]
+    public void WordTableCell_AddHtml_NumberedHeadingKeepsInlinePlaceholderContent() {
+        using WordDocument document = WordDocument.Create();
+        WordTableCell cell = document.AddTable(1, 1).Rows[0].Cells[0];
+        var options = new HtmlToWordOptions { SupportsHeadingNumbering = true };
+
+        cell.AddHtml(HtmlConversionDocument.Parse("Intro<h1>Heading</h1>"), options);
+
+        Assert.Equal(
+            new[] { "Intro", "Heading" },
+            cell._tableCell.Elements<Paragraph>().Select(paragraph => paragraph.InnerText).ToArray());
+        WordParagraph heading = Assert.Single(cell.Paragraphs, paragraph => paragraph.Text == "Heading");
+        Assert.Equal(WordListStyle.Headings111, heading.ListStyle);
+    }
+}

--- a/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewWave17Contracts.cs
+++ b/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewWave17Contracts.cs
@@ -1,0 +1,88 @@
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Html;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public partial class HtmlWordGapClosure {
+    [Fact]
+    public void HtmlToWord_InlineCodeStaysInTheSurroundingContainerParagraph() {
+        const string html = """<div>before<code>x</code>after</div>""";
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph before = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "before");
+        WordParagraph code = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "x");
+        WordParagraph after = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "after");
+
+        Assert.Same(before._paragraph, code._paragraph);
+        Assert.Same(code._paragraph, after._paragraph);
+    }
+
+    [Fact]
+    public void HtmlToWord_ParagraphBackgroundAlphaUsesTheEffectiveBackdrop() {
+        const string html = """
+            <p style="background-color:rgba(255,0,0,0)">Transparent</p>
+            <div style="background-color:#0000ff">
+              <p style="background-color:rgba(255,0,0,0.5)">Blended</p>
+            </div>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph transparent = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "Transparent");
+        WordParagraph blended = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "Blended");
+
+        Assert.Equal(string.Empty, transparent.ShadingFillColorHex);
+        Assert.Equal("800080", blended.ShadingFillColorHex);
+    }
+
+    [Fact]
+    public void WordRunShading_ExactFillResetsPatternAndForegroundState() {
+        using WordDocument document = WordDocument.Create();
+        WordParagraph run = document.AddParagraph("Pattern");
+        run.RunShadingFillColorHex = "0000FF";
+        Shading shading = run._runProperties!.Shading!;
+        shading.Val = ShadingPatternValues.Percent50;
+        shading.Color = "FF0000";
+        shading.ThemeColor = ThemeColorValues.Accent1;
+        shading.ThemeTint = "44";
+        shading.ThemeShade = "77";
+
+        run.RunShadingFillColorHex = "ABCDEF";
+
+        Assert.Equal("ABCDEF", run.RunShadingFillColorHex);
+        Assert.Equal(ShadingPatternValues.Clear, shading.Val?.Value);
+        Assert.Null(shading.Color);
+        Assert.Null(shading.ThemeColor);
+        Assert.Null(shading.ThemeTint);
+        Assert.Null(shading.ThemeShade);
+    }
+
+    [Fact]
+    public void HtmlToWord_ContainerSpacingAppliesOncePerPhysicalParagraph() {
+        const string html = """<div style="margin-left:10px"><p>a<strong>b</strong></p></div>""";
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph firstRun = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "a");
+        WordParagraph secondRun = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "b");
+
+        Assert.Same(firstRun._paragraph, secondRun._paragraph);
+        Assert.Equal(150, firstRun.IndentationBefore);
+    }
+
+    [Fact]
+    public void HtmlToWord_ContainerBorderUsesTheContainersCurrentColor() {
+        const string html = """
+            <div style="color:red;border:1px solid"><span style="color:blue">Text</span></div>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph paragraph = Assert.Single(document.Paragraphs, candidate => candidate.Text == "Text");
+
+        Assert.Equal("FF0000", paragraph.Borders.LeftColorHex);
+        Assert.Equal("FF0000", paragraph.Borders.RightColorHex);
+        Assert.Equal("FF0000", paragraph.Borders.TopColorHex);
+        Assert.Equal("FF0000", paragraph.Borders.BottomColorHex);
+    }
+}

--- a/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewWave18Contracts.cs
+++ b/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewWave18Contracts.cs
@@ -1,0 +1,79 @@
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Html;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public partial class HtmlWordGapClosure {
+    [Fact]
+    public void HtmlToWord_ContainerFramePreservesExistingTableCellBorders() {
+        const string html = """
+            <div style="border:2px solid red">
+              <table><tr><td style="border:1px solid blue">Cell</td></tr></table>
+            </div>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordTableCell cell = Assert.Single(Assert.Single(document.Tables).Rows).Cells[0];
+
+        Assert.Equal("0000FF", cell.Borders.LeftColorHex);
+        Assert.Equal("0000FF", cell.Borders.RightColorHex);
+        Assert.Equal("0000FF", cell.Borders.TopColorHex);
+        Assert.Equal("0000FF", cell.Borders.BottomColorHex);
+    }
+
+    [Fact]
+    public void WordToHtml_CharacterStyleHighlightTakesPrecedenceOverRunShading() {
+        using WordDocument document = WordDocument.Create();
+        document._wordprocessingDocument.MainDocumentPart!.StyleDefinitionsPart!.Styles!.Append(
+            new Style(
+                new StyleName { Val = "Styled highlight" },
+                new StyleRunProperties(new Highlight { Val = HighlightColorValues.Yellow })) {
+                Type = StyleValues.Character,
+                StyleId = "StyledHighlight"
+            });
+        WordParagraph run = document.AddParagraph("Layered");
+        run.SetCharacterStyleId("StyledHighlight");
+        run.RunShadingFillColorHex = "FF0000";
+
+        string html = document.ToHtml(new WordToHtmlOptions { IncludeRunHighlightStyles = true });
+
+        Assert.Contains("background-color:#ffff00", html, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("background-color:#ff0000", html, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void HtmlToWord_BlockBorderAlphaIsPreservedVisually() {
+        const string html = """
+            <div style="background-color:#0000ff;border-left-style:solid;border-left-width:1px;border-left-color:rgba(255,0,0,0)">Transparent</div>
+            <div style="background-color:#0000ff;border-left-style:solid;border-left-width:1px;border-left-color:rgba(255,0,0,0.5)">Blended</div>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph transparent = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "Transparent");
+        WordParagraph blended = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "Blended");
+
+        Assert.Null(transparent.Borders.LeftStyle);
+        Assert.Equal(BorderValues.Single, blended.Borders.LeftStyle);
+        Assert.Equal("800080", blended.Borders.LeftColorHex);
+    }
+
+    [Fact]
+    public void HtmlToWord_MarginOnlyEmptyBlockMaterializesSpacing() {
+        const string html = """
+            <p>Before</p>
+            <div style="margin-block:20px"></div>
+            <p>After</p>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph spacing = Assert.Single(
+            document.Paragraphs,
+            paragraph => string.IsNullOrEmpty(paragraph.Text));
+
+        Assert.Equal(300, spacing.LineSpacingBefore);
+        Assert.Equal(300, spacing.LineSpacingAfter);
+    }
+}

--- a/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewWave19Contracts.cs
+++ b/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewWave19Contracts.cs
@@ -1,0 +1,59 @@
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Html;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public partial class HtmlWordGapClosure {
+    [Fact]
+    public void WordTableCell_AddHtml_TableOnlyContainerUsesTheTableBoundaryForFramesAndBreaks() {
+        using WordDocument document = WordDocument.Create();
+        WordTableCell cell = document.AddTable(1, 1).Rows[0].Cells[0];
+
+        cell.AddHtml(HtmlConversionDocument.Parse("""
+            <div style="break-before:page;border:1px solid #123456;background-color:#abcdef">
+              <table><tr><td>Value</td></tr></table>
+            </div>
+            """));
+
+        var elements = cell._tableCell.ChildElements
+            .Where(element => element is Table or Paragraph)
+            .ToArray();
+        Assert.Equal(3, elements.Length);
+        Paragraph breakParagraph = Assert.IsType<Paragraph>(elements[0]);
+        Break pageBreak = Assert.Single(breakParagraph.Descendants<Break>());
+        Assert.Equal(BreakValues.Page, pageBreak.Type?.Value);
+        Assert.IsType<Table>(elements[1]);
+        Paragraph trailing = Assert.IsType<Paragraph>(elements[2]);
+        Assert.Null(trailing.ParagraphProperties?.GetFirstChild<ParagraphBorders>());
+        Assert.Null(trailing.ParagraphProperties?.GetFirstChild<Shading>());
+
+        WordTableCell nestedCell = Assert.Single(Assert.Single(cell.DirectNestedTables).Rows).Cells[0];
+        Assert.Equal("ABCDEF", nestedCell.ShadingFillColorHex);
+        Assert.Equal("123456", nestedCell.Borders.LeftColorHex);
+        Assert.Equal("123456", nestedCell.Borders.RightColorHex);
+        Assert.Equal("123456", nestedCell.Borders.TopColorHex);
+        Assert.Equal("123456", nestedCell.Borders.BottomColorHex);
+    }
+
+    [Fact]
+    public void WordToHtml_HyperlinkRunBackgroundsUseTheHyperlinksRunProperties() {
+        using WordDocument document = WordDocument.Create();
+        WordParagraph highlightedParagraph = document.AddParagraph();
+        highlightedParagraph.AddHyperLink("Highlighted", new Uri("https://example.test/highlight"));
+        WordParagraph highlightedRun = Assert.Single(highlightedParagraph.GetRuns());
+        highlightedRun.Highlight = HighlightColorValues.Yellow;
+
+        WordParagraph shadedParagraph = document.AddParagraph();
+        shadedParagraph.AddHyperLink("Shaded", new Uri("https://example.test/shading"));
+        WordParagraph shadedRun = Assert.Single(shadedParagraph.GetRuns());
+        shadedRun.RunShadingFillColorHex = "ABCDEF";
+
+        string html = document.ToHtml(new WordToHtmlOptions { IncludeRunHighlightStyles = true });
+
+        Assert.Contains("background-color:#ffff00", html, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("background-color:#abcdef", html, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewWave20Contracts.cs
+++ b/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewWave20Contracts.cs
@@ -1,0 +1,141 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Html;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public partial class HtmlWordGapClosure {
+    [Fact]
+    public void HtmlToWord_TableOnlyContainerAppliesItsBoxSpacingToTheTableBoundary() {
+        const string html = """
+            <div style="margin-top:10px;padding-left:20px">
+              <table><tr><td>Value</td></tr></table>
+            </div>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordTable table = Assert.Single(document.Tables);
+        Paragraph spacing = Assert.IsType<Paragraph>(
+            table._table.PreviousSibling());
+
+        Assert.Equal((short)300, table.StyleDetails?.TableIndentationWidth);
+        Assert.Equal("150", spacing.ParagraphProperties?
+            .GetFirstChild<SpacingBetweenLines>()?.After?.Value);
+    }
+
+    [Fact]
+    public void HtmlToWord_InlineAlphaCompositesAgainstTheParagraphBackground() {
+        const string html = """
+            <p style="background-color:#0000ff">
+              plain <span style="background-color:rgba(255,0,0,0.5)">blended</span>
+            </p>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph paragraph = Assert.Single(
+            document.Paragraphs,
+            candidate => candidate.Text == "blended");
+
+        Assert.Equal("0000FF", paragraph.ShadingFillColorHex);
+        Assert.Equal("800080", paragraph.RunShadingFillColorHex);
+    }
+
+    [Fact]
+    public void HtmlToWord_BodyLogicalSpacingIsDiagnosedAsUnsupported() {
+        HtmlUnsupportedCssException exception = Assert.Throws<HtmlUnsupportedCssException>(() =>
+            HtmlConversionDocument
+                .Parse("""<body style="margin:0;margin-inline-start:10px"><p>Text</p></body>""")
+                .ToWordDocument(new HtmlToWordOptions {
+                    UnsupportedCssHandling = HtmlUnsupportedCssHandling.Error
+                }));
+
+        Assert.Equal("UnsupportedCssDeclaration", exception.Code);
+        Assert.Equal("body:margin-inline-start", exception.CssSource);
+    }
+
+    [Fact]
+    public void HtmlToWord_TransparentAndAlphaTableBackgroundsUseTheExistingBackdrop() {
+        const string html = """
+            <table style="background-color:#0000ff">
+              <tr>
+                <td style="background-color:transparent">transparent</td>
+                <td style="background-color:rgba(255,0,0,0.5)">blended</td>
+              </tr>
+            </table>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        List<WordTableCell> cells = Assert.Single(document.Tables).Rows[0].Cells;
+
+        Assert.Equal("0000FF", cells[0].ShadingFillColorHex);
+        Assert.Equal("800080", cells[1].ShadingFillColorHex);
+    }
+
+    [Fact]
+    public void WordTableCell_AddHtml_BelowCaptionClearsSyntheticDirectSpacing() {
+        using WordDocument document = WordDocument.Create();
+        WordTableCell cell = document.AddTable(1, 1).Rows[0].Cells[0];
+
+        cell.AddHtml(
+            HtmlConversionDocument.Parse(
+                """<table><caption>Nested caption</caption><tr><td>Value</td></tr></table>"""),
+            new HtmlToWordOptions { TableCaptionPosition = TableCaptionPosition.Below });
+
+        Paragraph caption = Assert.Single(
+            cell._tableCell.Elements<Paragraph>(),
+            paragraph => paragraph.InnerText == "Nested caption");
+        Assert.Equal("Caption", caption.ParagraphProperties?.ParagraphStyleId?.Val?.Value);
+        Assert.Null(caption.ParagraphProperties?.GetFirstChild<SpacingBetweenLines>());
+    }
+
+    [Fact]
+    public void HtmlToWord_MixedContainerBreaksUseTheTrueContentBoundaries() {
+        using WordDocument tableFirst = HtmlConversionDocument
+            .Parse("""
+                <div style="break-before:page">
+                  <table><tr><td>Value</td></tr></table>
+                  <p>Tail</p>
+                </div>
+                """)
+            .ToWordDocument();
+        OpenXmlElement[] tableFirstBlocks = GetBodyBlocks(tableFirst);
+        int tableIndex = Array.FindIndex(tableFirstBlocks, element => element is Table);
+        int tailIndex = Array.FindIndex(
+            tableFirstBlocks,
+            element => element is Paragraph paragraph && paragraph.InnerText == "Tail");
+        int breakBeforeIndex = Array.FindIndex(
+            tableFirstBlocks,
+            element => element.Descendants<Break>().Any());
+
+        Assert.True(breakBeforeIndex < tableIndex);
+        Assert.True(tableIndex < tailIndex);
+
+        using WordDocument tableLast = HtmlConversionDocument
+            .Parse("""
+                <div style="break-after:page">
+                  <p>Lead</p>
+                  <table><tr><td>Value</td></tr></table>
+                </div>
+                """)
+            .ToWordDocument();
+        OpenXmlElement[] tableLastBlocks = GetBodyBlocks(tableLast);
+        int leadIndex = Array.FindIndex(
+            tableLastBlocks,
+            element => element is Paragraph paragraph && paragraph.InnerText == "Lead");
+        int lastTableIndex = Array.FindIndex(tableLastBlocks, element => element is Table);
+        int breakAfterIndex = Array.FindLastIndex(
+            tableLastBlocks,
+            element => element.Descendants<Break>().Any());
+
+        Assert.True(leadIndex < lastTableIndex);
+        Assert.True(lastTableIndex < breakAfterIndex);
+    }
+
+    private static OpenXmlElement[] GetBodyBlocks(WordDocument document) =>
+        document.OpenXmlDocument.MainDocumentPart!.Document.Body!.ChildElements
+            .Where(element => element is Paragraph or Table)
+            .ToArray();
+}

--- a/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewWave21Contracts.cs
+++ b/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewWave21Contracts.cs
@@ -1,0 +1,101 @@
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Html;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public partial class HtmlWordGapClosure {
+    [Theory]
+    [InlineData("background-color:rgba(255,0,0,0.5)", "", "")]
+    [InlineData("", "background-color:rgba(255,0,0,0.5)", "")]
+    [InlineData("", "", "background-color:rgba(255,0,0,0.5)")]
+    public void HtmlToWord_TableAlphaUsesThePaintedAncestorBackdrop(
+        string tableStyle,
+        string rowStyle,
+        string cellStyle) {
+        string html = $"""
+            <div style="background-color:#0000ff">
+              <table style="{tableStyle}">
+                <tr style="{rowStyle}">
+                  <td style="{cellStyle}">Value</td>
+                </tr>
+              </table>
+            </div>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordTableCell cell = Assert.Single(Assert.Single(document.Tables).Rows).Cells[0];
+
+        Assert.Equal("800080", cell.ShadingFillColorHex);
+    }
+
+    [Fact]
+    public void HtmlToWord_ResourceClassificationDoesNotRerunSelectorsAgainstSyntheticStyles() {
+        string html = $$"""
+            <style>
+              img { display:inline; }
+              [style] { height:1px; }
+            </style>
+            <img width="100" src="data:image/png;base64,{{ValidPng}}" alt="Sized">
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordImage image = Assert.Single(document.Images);
+
+        Assert.Equal(100D, Math.Round(image.Width!.Value));
+        Assert.Equal(100D, Math.Round(image.Height!.Value));
+    }
+
+    [Fact]
+    public void HtmlToWord_MixedContainerFrameUsesOnlyTheOuterBlockEdges() {
+        const string html = """
+            <div style="border:1px solid #123456">
+              <p>Lead</p>
+              <table><tr><td>Middle</td></tr></table>
+              <table><tr><td>Last</td></tr></table>
+            </div>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph lead = Assert.Single(
+            document.Paragraphs,
+            paragraph => paragraph.Text == "Lead");
+        WordTableCell middle = Assert.Single(document.Tables[0].Rows).Cells[0];
+        WordTableCell last = Assert.Single(document.Tables[1].Rows).Cells[0];
+
+        Assert.Equal(BorderValues.Single, lead.Borders.TopStyle);
+        Assert.Null(lead.Borders.BottomStyle);
+        Assert.Null(middle.Borders.TopStyle);
+        Assert.Null(middle.Borders.BottomStyle);
+        Assert.Null(last.Borders.TopStyle);
+        Assert.Equal(BorderValues.Single, last.Borders.BottomStyle);
+        Assert.Equal("123456", lead.Borders.LeftColorHex);
+        Assert.Equal("123456", middle.Borders.LeftColorHex);
+        Assert.Equal("123456", last.Borders.RightColorHex);
+    }
+
+    [Fact]
+    public void HtmlToWord_BlockquoteVerticalSpacingAppliesOnlyAtTheOuterBoundaries() {
+        const string html = """
+            <blockquote style="margin-block:10px">
+              <p>One</p>
+              <p>Two</p>
+            </blockquote>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph one = Assert.Single(
+            document.Paragraphs,
+            paragraph => paragraph.Text == "One");
+        WordParagraph two = Assert.Single(
+            document.Paragraphs,
+            paragraph => paragraph.Text == "Two");
+
+        Assert.Equal(150, one.LineSpacingBefore);
+        Assert.Null(one.LineSpacingAfter);
+        Assert.Null(two.LineSpacingBefore);
+        Assert.Equal(150, two.LineSpacingAfter);
+    }
+}

--- a/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewWave22Contracts.cs
+++ b/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewWave22Contracts.cs
@@ -1,3 +1,4 @@
+using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Html;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Html;
@@ -47,5 +48,68 @@ public partial class HtmlWordGapClosure {
             candidate => candidate.Text == "Text");
 
         Assert.Equal(480, paragraph.IndentationBefore);
+    }
+
+    [Fact]
+    public void HtmlToWord_TopLevelInlineCodeStaysInTheBodyParagraph() {
+        using WordDocument document = HtmlConversionDocument
+            .Parse("""before<code>x</code>after""")
+            .ToWordDocument();
+
+        WordParagraph before = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "before");
+        WordParagraph code = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "x");
+        WordParagraph after = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "after");
+
+        Assert.Same(before._paragraph, code._paragraph);
+        Assert.Same(code._paragraph, after._paragraph);
+    }
+
+    [Fact]
+    public void HtmlToWord_TableContainerEndSpacingConstrainsFullWidthTables() {
+        const string html = """
+            <div style="padding-inline-end:20px">
+              <table style="width:100%"><tr><td>Value</td></tr></table>
+            </div>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordTable table = Assert.Single(document.Tables);
+        WordSection section = Assert.Single(document.Sections);
+        int pageWidth = (int)(section.PageSettings.Width?.Value ?? WordPageSizes.A4.Width!.Value);
+        int contentWidth = pageWidth - (int)section.Margins.Left.Value - (int)section.Margins.Right.Value;
+
+        Assert.Equal(TableWidthUnitValues.Dxa, table.WidthType);
+        Assert.Equal(contentWidth - 300, table.Width);
+    }
+
+    [Fact]
+    public void HtmlToWord_EmLogicalSpacingUsesTheFontShorthandSize() {
+        const string html = """
+            <div style="font:32px Arial;margin-inline-start:1em">Text</div>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph paragraph = Assert.Single(
+            document.Paragraphs,
+            candidate => candidate.Text == "Text");
+
+        Assert.Equal(480, paragraph.IndentationBefore);
+    }
+
+    [Theory]
+    [InlineData("font-size:20px;font:32px Arial", 480)]
+    [InlineData("font:32px Arial;font-size:20px", 300)]
+    [InlineData("font-size:20px !important;font:32px Arial", 300)]
+    public void HtmlToWord_FontSizeLonghandAndShorthandFollowTheCascade(
+        string style,
+        int expectedIndentation) {
+        string html = $"""<div style="{style};margin-inline-start:1em">Text</div>""";
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph paragraph = Assert.Single(
+            document.Paragraphs,
+            candidate => candidate.Text == "Text");
+
+        Assert.Equal(expectedIndentation, paragraph.IndentationBefore);
     }
 }

--- a/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewWave22Contracts.cs
+++ b/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewWave22Contracts.cs
@@ -1,0 +1,51 @@
+using OfficeIMO.Html;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public partial class HtmlWordGapClosure {
+    [Theory]
+    [InlineData("""<html style="font-size:32px"><body><div style="margin-inline-start:1rem">Text</div></body></html>""")]
+    [InlineData("""<style>html { font-size:32px; }</style><div style="margin-inline-start:1rem">Text</div>""")]
+    public void HtmlToWord_RemLogicalSpacingUsesTheComputedRootFontSize(string html) {
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph paragraph = Assert.Single(
+            document.Paragraphs,
+            candidate => candidate.Text == "Text");
+
+        Assert.Equal(480, paragraph.IndentationBefore);
+    }
+
+    [Fact]
+    public void HtmlToWord_EmLogicalSpacingUsesTheComputedElementFontSize() {
+        const string html = """
+            <div style="font-size:20px;margin-inline-start:1em">Text</div>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph paragraph = Assert.Single(
+            document.Paragraphs,
+            candidate => candidate.Text == "Text");
+
+        Assert.Equal(300, paragraph.IndentationBefore);
+    }
+
+    [Fact]
+    public void HtmlToWord_InheritedEmLogicalSpacingUsesTheParentsComputedFontSizeOnce() {
+        const string html = """
+            <style>.parent { font-size:2em; }</style>
+            <div class="parent">
+              <div style="margin-inline-start:1em">Text</div>
+            </div>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph paragraph = Assert.Single(
+            document.Paragraphs,
+            candidate => candidate.Text == "Text");
+
+        Assert.Equal(480, paragraph.IndentationBefore);
+    }
+}

--- a/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewWave23Contracts.cs
+++ b/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewWave23Contracts.cs
@@ -1,0 +1,62 @@
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Html;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public partial class HtmlWordGapClosure {
+    [Fact]
+    public void HtmlToWord_BlockBorderCurrentColorResolvesInheritedCssWideColor() {
+        const string html = """
+            <div style="color:red">
+              <div style="color:inherit;border:1px solid">Text</div>
+            </div>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph paragraph = Assert.Single(
+            document.Paragraphs,
+            candidate => candidate.Text == "Text");
+
+        Assert.Equal("FF0000", paragraph.Borders.LeftColorHex);
+        Assert.Equal("FF0000", paragraph.Borders.RightColorHex);
+    }
+
+    [Fact]
+    public void HtmlToWord_TransparentMarkClearsItsDefaultHighlightAndRoundTrips() {
+        using WordDocument document = HtmlConversionDocument
+            .Parse("""<mark style="background-color:transparent">Text</mark>""")
+            .ToWordDocument();
+        WordParagraph run = Assert.Single(
+            document.Paragraphs,
+            candidate => candidate.Text == "Text");
+
+        Assert.Equal(HighlightColorValues.None, run.Highlight);
+        Assert.Equal(string.Empty, run.RunShadingFillColorHex);
+        Assert.Contains(
+            """<mark style="background-color:transparent">Text</mark>""",
+            document.ToHtml());
+    }
+
+    [Fact]
+    public void AddHtmlToBody_TableContainerWidthUsesTheOwningSection() {
+        using WordDocument document = WordDocument.Create();
+        document.Sections[0].PageSettings.Width = 12000;
+        WordSection target = document.AddSection();
+        target.PageSettings.Width = 9000;
+        target.Margins.Left = 1000;
+        target.Margins.Right = 1000;
+
+        document.AddHtmlToBody(HtmlConversionDocument.Parse("""
+            <div style="padding-inline-end:20px">
+              <table style="width:100%"><tr><td>Value</td></tr></table>
+            </div>
+            """));
+
+        WordTable table = Assert.Single(document.Tables);
+        Assert.Equal(TableWidthUnitValues.Dxa, table.WidthType);
+        Assert.Equal(6700, table.Width);
+    }
+}

--- a/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewWave24Contracts.cs
+++ b/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewWave24Contracts.cs
@@ -1,0 +1,104 @@
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Html;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using Xunit;
+using M = DocumentFormat.OpenXml.Math;
+
+namespace OfficeIMO.Tests;
+
+public partial class HtmlWordGapClosure {
+    [Fact]
+    public void HtmlToWord_DirDoesNotCreateSelectorVisibleStyleAttributes() {
+        const string html = """
+            <style>[style] span { color:red; }</style>
+            <div dir="rtl"><span>Text</span></div>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph paragraph = Assert.Single(
+            document.Paragraphs,
+            candidate => candidate.Text == "Text");
+        WordParagraph run = Assert.Single(paragraph.GetRuns());
+
+        Assert.True(paragraph.BiDi);
+        Assert.NotEqual("FF0000", run.ColorHex);
+    }
+
+    [Fact]
+    public void HtmlToWord_NestedContainerSpacingAccumulatesForFullWidthTables() {
+        const string html = """
+            <div style="padding-inline-end:20px">
+              <div style="padding-inline-end:20px">
+                <table style="width:100%"><tr><td>Value</td></tr></table>
+              </div>
+            </div>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordTable table = Assert.Single(document.Tables);
+        WordSection section = Assert.Single(document.Sections);
+        int pageWidth = (int)(section.PageSettings.Width?.Value ?? WordPageSizes.A4.Width!.Value);
+        int contentWidth = pageWidth - (int)section.Margins.Left.Value - (int)section.Margins.Right.Value;
+
+        Assert.Equal(TableWidthUnitValues.Dxa, table.WidthType);
+        Assert.Equal(contentWidth - 600, table.Width);
+    }
+
+    [Fact]
+    public void WordToHtml_ExactMarkedTextShadingIsAppliedToTheMarkElement() {
+        using WordDocument document = HtmlConversionDocument
+            .Parse("""<mark style="background-color:#ff0000">Text</mark>""")
+            .ToWordDocument();
+
+        string html = document.ToHtml(new WordToHtmlOptions { IncludeRunHighlightStyles = true });
+
+        Assert.Contains(
+            """<mark style="background-color:#ff0000">Text</mark>""",
+            html,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(
+            """background-color:#ff0000"><mark""",
+            html,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void WordToHtml_ExactMarkedTextShadingBesideAnEquationIsAppliedToTheMarkElement() {
+        using WordDocument document = WordDocument.Create();
+        WordParagraph paragraph = document.AddParagraph();
+        paragraph._paragraph.Append(
+            new Run(
+                new RunProperties(
+                    new RunStyle { Val = "HtmlMarkedText" },
+                    new Shading { Val = ShadingPatternValues.Clear, Fill = "FF0000" }),
+                new Text("Text")),
+            new M.OfficeMath(new M.Run(new M.Text("x"))));
+
+        string html = document.ToHtml(new WordToHtmlOptions { IncludeRunHighlightStyles = true });
+
+        Assert.Contains(
+            """<mark style="background-color:#ff0000">Text</mark>""",
+            html,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("<math", html, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("margin-left:20px;margin-left:auto")]
+    [InlineData("margin:20px;margin:auto")]
+    [InlineData("margin-inline-start:20px;margin-inline-start:auto")]
+    public void HtmlToWord_AutoMarginsClearEarlierNumericValues(string style) {
+        string html = $"""<div style="{style}">Text</div>""";
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph paragraph = Assert.Single(
+            document.Paragraphs,
+            candidate => candidate.Text == "Text");
+
+        Assert.Null(paragraph.IndentationBefore);
+        Assert.Null(paragraph.IndentationAfter);
+        Assert.Null(paragraph.LineSpacingBefore);
+        Assert.Null(paragraph.LineSpacingAfter);
+    }
+}

--- a/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewWave25Contracts.cs
+++ b/OfficeIMO.Html.Tests/Html.WordGapClosure.ReviewWave25Contracts.cs
@@ -1,0 +1,104 @@
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Html;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using Xunit;
+using M = DocumentFormat.OpenXml.Math;
+
+namespace OfficeIMO.Tests;
+
+public partial class HtmlWordGapClosure {
+    [Fact]
+    public void HtmlToWord_TransparentContainersPreserveTheEffectiveBackdrop() {
+        const string html = """
+            <div style="background-color:#0000ff">
+              <div style="background-color:transparent">
+                <div style="background-color:rgba(255,0,0,0.5)">Text</div>
+              </div>
+            </div>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph paragraph = Assert.Single(
+            document.Paragraphs,
+            candidate => candidate.Text == "Text");
+
+        Assert.Equal("800080", paragraph.ShadingFillColorHex);
+    }
+
+    [Fact]
+    public void WordToHtml_NonDefaultMarkedTextHighlightIsAppliedToTheMarkElement() {
+        using WordDocument document = WordDocument.Create();
+        document._wordprocessingDocument.MainDocumentPart!.StyleDefinitionsPart!.Styles!.Append(
+            new Style(
+                new StyleName { Val = "Marked text" },
+                new StyleRunProperties(new Highlight { Val = HighlightColorValues.Green })) {
+                Type = StyleValues.Character,
+                StyleId = "HtmlMarkedText"
+            });
+        WordParagraph regular = document.AddParagraph("Regular");
+        regular.SetCharacterStyleId("HtmlMarkedText");
+        WordParagraph equationAdjacent = document.AddParagraph();
+        equationAdjacent._paragraph.Append(
+            new Run(
+                new RunProperties(new RunStyle { Val = "HtmlMarkedText" }),
+                new Text("Adjacent")),
+            new M.OfficeMath(new M.Run(new M.Text("x"))));
+
+        string html = document.ToHtml(new WordToHtmlOptions { IncludeRunHighlightStyles = true });
+
+        Assert.Contains(
+            """<mark style="background-color:#00ff00">Regular</mark>""",
+            html,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(
+            """<mark style="background-color:#00ff00">Adjacent</mark>""",
+            html,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void WordTableCell_AddHtml_PercentageImageUsesTheCellContentWidth() {
+        using WordDocument document = WordDocument.Create();
+        WordTableCell cell = document.AddTable(1, 2).Rows[0].Cells[0];
+        int expectedContentWidth = Assert.IsType<int>(
+            WordTable.EstimateCellContentWidthInDxa(document, cell._tableCell));
+        WordSection laterSection = document.AddSection();
+        laterSection.PageSettings.Width = 20000;
+        laterSection.Margins.Left = 500;
+        laterSection.Margins.Right = 500;
+
+        cell.AddHtml(HtmlConversionDocument.Parse(
+            $"""<img style="width:100%" src="data:image/png;base64,{ValidPng}" alt="Cell image">"""));
+
+        WordImage image = Assert.Single(document.Images);
+        Assert.Equal(expectedContentWidth / 15D, image.Width!.Value, precision: 3);
+    }
+
+    [Fact]
+    public void HtmlToWord_ModernRgbBackgroundSyntaxPreservesColorAndAlpha() {
+        using WordDocument document = HtmlConversionDocument
+            .Parse("""<div style="background-color:rgb(100% 0% 50% / 0.5)">Text</div>""")
+            .ToWordDocument();
+        WordParagraph paragraph = Assert.Single(
+            document.Paragraphs,
+            candidate => candidate.Text == "Text");
+
+        Assert.Equal("FF80C0", paragraph.ShadingFillColorHex);
+    }
+
+    [Theory]
+    [InlineData("border:solid red")]
+    [InlineData("border-left-style:solid;border-left-color:red")]
+    public void HtmlToWord_OmittedBlockBorderWidthUsesCssMedium(string style) {
+        string html = $"""<div style="{style}">Text</div>""";
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph paragraph = Assert.Single(
+            document.Paragraphs,
+            candidate => candidate.Text == "Text");
+
+        Assert.Equal(BorderValues.Single, paragraph.Borders.LeftStyle);
+        Assert.Equal(18U, paragraph.Borders.LeftSize?.Value);
+    }
+}

--- a/OfficeIMO.Html.Tests/Html.WordGapClosure.cs
+++ b/OfficeIMO.Html.Tests/Html.WordGapClosure.cs
@@ -81,6 +81,23 @@ public class HtmlWordGapClosure {
     }
 
     [Fact]
+    public void HtmlToWord_LogicalSpacing_RespectsImportantPriorityBeforeDeclarationOrder() {
+        const string html = """
+            <p style="margin-left:30px!important;margin-inline-start:10px">Important physical</p>
+            <p style="margin-left:30px;margin-inline-start:10px ! important">Important logical</p>
+            <p style="margin-inline-start:10px!important;margin-left:30px!important">Important physical last</p>
+            <p style="padding-left:30px!important;padding-inline-start:10px">Important padding</p>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+
+        Assert.Equal(450, Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "Important physical").IndentationBefore);
+        Assert.Equal(150, Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "Important logical").IndentationBefore);
+        Assert.Equal(450, Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "Important physical last").IndentationBefore);
+        Assert.Equal(450, Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "Important padding").IndentationBefore);
+    }
+
+    [Fact]
     public void HtmlToWord_CssDirection_OverridesDirForLogicalSpacing() {
         const string html = """
             <style>
@@ -145,6 +162,36 @@ public class HtmlWordGapClosure {
     }
 
     [Fact]
+    public void HtmlToWord_BlockChild_StartsANewFramedParagraphAfterInlineContent() {
+        const string html = """
+            <span>Before</span><div style="border:1px solid #123456">Inside</div>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph before = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "Before");
+        WordParagraph inside = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "Inside");
+
+        Assert.NotSame(before, inside);
+        Assert.Equal(BorderValues.Single, inside.Borders.TopStyle);
+        Assert.Equal(BorderValues.Single, inside.Borders.BottomStyle);
+        Assert.Equal("123456", inside.Borders.LeftColorHex);
+    }
+
+    [Fact]
+    public void WordTableCell_AddHtml_DirectTextBlockStartsANewFramedParagraph() {
+        using WordDocument document = WordDocument.Create();
+        WordTableCell cell = document.AddTable(1, 1).Rows[0].Cells[0];
+
+        cell.AddHtml(HtmlConversionDocument.Parse(
+            """<div style="border:1px solid #123456">Inside cell</div>"""));
+
+        WordParagraph inside = Assert.Single(cell.Paragraphs, paragraph => paragraph.Text == "Inside cell");
+        Assert.Equal(BorderValues.Single, inside.Borders.TopStyle);
+        Assert.Equal(BorderValues.Single, inside.Borders.BottomStyle);
+        Assert.Equal("123456", inside.Borders.LeftColorHex);
+    }
+
+    [Fact]
     public void HtmlToWord_BorderColorLonghand_DoesNotSynthesizeVisibleBorder() {
         const string html = """<p style="border-left-color:#ff0000">No border style</p>""";
 
@@ -152,6 +199,24 @@ public class HtmlWordGapClosure {
         WordParagraph paragraph = Assert.Single(document.Paragraphs, candidate => candidate.Text == "No border style");
 
         Assert.Null(paragraph.Borders.LeftStyle);
+    }
+
+    [Fact]
+    public void HtmlToWord_BorderShorthandWithoutStyle_DoesNotSynthesizeVisibleBorder() {
+        const string html = """
+            <p style="border:1px red">All sides</p>
+            <p style="border-left:2px #00ff00">One side</p>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph allSides = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "All sides");
+        WordParagraph oneSide = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "One side");
+
+        Assert.Null(allSides.Borders.LeftStyle);
+        Assert.Null(allSides.Borders.TopStyle);
+        Assert.Null(allSides.Borders.RightStyle);
+        Assert.Null(allSides.Borders.BottomStyle);
+        Assert.Null(oneSide.Borders.LeftStyle);
     }
 
     [Fact]
@@ -183,6 +248,15 @@ public class HtmlWordGapClosure {
             "background-color:#abcdef",
             reloaded.ToHtml(new WordToHtmlOptions { IncludeRunHighlightStyles = true }),
             StringComparison.OrdinalIgnoreCase);
+
+        WordDocumentVisualSnapshot snapshot = reloaded.CreateVisualSnapshot();
+        OfficeIMO.Drawing.OfficeDrawingRichText richText = Assert.Single(
+            snapshot.Drawing.Elements.OfType<OfficeIMO.Drawing.OfficeDrawingRichText>());
+        OfficeIMO.Drawing.OfficeRichTextRun renderedRun = Assert.Single(
+            richText.Runs,
+            run => run.Text.Contains("exact", StringComparison.Ordinal));
+        Assert.Equal(OfficeIMO.Drawing.OfficeColor.Parse("#ABCDEF"), renderedRun.BackgroundColor);
+        Assert.Contains("#ABCDEF", reloaded.ToSvg(), StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/OfficeIMO.Html.Tests/Html.WordGapClosure.cs
+++ b/OfficeIMO.Html.Tests/Html.WordGapClosure.cs
@@ -98,6 +98,19 @@ public class HtmlWordGapClosure {
     }
 
     [Fact]
+    public void HtmlToWord_InvalidLogicalPair_DoesNotOverridePhysicalSpacing() {
+        const string html = """
+            <p style="margin-left:30px;margin-inline:10px bogus">Invalid pair</p>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph paragraph = Assert.Single(document.Paragraphs, candidate => candidate.Text == "Invalid pair");
+
+        Assert.Equal(450, paragraph.IndentationBefore);
+        Assert.Null(paragraph.IndentationAfter);
+    }
+
+    [Fact]
     public void HtmlToWord_CssDirection_OverridesDirForLogicalSpacing() {
         const string html = """
             <style>
@@ -118,6 +131,20 @@ public class HtmlWordGapClosure {
         Assert.Null(paragraph.IndentationAfter);
         Assert.Null(ownDir.IndentationBefore);
         Assert.Equal(150, ownDir.IndentationAfter);
+    }
+
+    [Fact]
+    public void HtmlToWord_ImportantDirection_MapsLogicalSpacingToTheResolvedSide() {
+        const string html = """
+            <p style="direction:rtl!important;direction:ltr;margin-inline-start:10px">Important direction</p>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph paragraph = Assert.Single(document.Paragraphs, candidate => candidate.Text == "Important direction");
+
+        Assert.True(paragraph.BiDi);
+        Assert.Null(paragraph.IndentationBefore);
+        Assert.Equal(150, paragraph.IndentationAfter);
     }
 
     [Fact]
@@ -180,6 +207,22 @@ public class HtmlWordGapClosure {
     }
 
     [Fact]
+    public void HtmlToWord_Blockquote_AppliesBoxSpacingOnce() {
+        const string html = """
+            <blockquote style="margin-left:10px;padding-left:2px;margin-top:4px;padding-top:3px;margin-bottom:5px;padding-bottom:2px">
+              <p>Quoted spacing</p>
+            </blockquote>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph paragraph = Assert.Single(document.Paragraphs, candidate => candidate.Text == "Quoted spacing");
+
+        Assert.Equal(180, paragraph.IndentationBefore);
+        Assert.Equal(105, paragraph.LineSpacingBefore);
+        Assert.Equal(105, paragraph.LineSpacingAfter);
+    }
+
+    [Fact]
     public void HtmlToWord_BlockChild_StartsANewFramedParagraphAfterInlineContent() {
         const string html = """
             <span>Before</span><div style="border:1px solid #123456">Inside</div>
@@ -229,6 +272,24 @@ public class HtmlWordGapClosure {
         using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
         WordParagraph allSides = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "All sides");
         WordParagraph oneSide = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "One side");
+
+        Assert.Null(allSides.Borders.LeftStyle);
+        Assert.Null(allSides.Borders.TopStyle);
+        Assert.Null(allSides.Borders.RightStyle);
+        Assert.Null(allSides.Borders.BottomStyle);
+        Assert.Null(oneSide.Borders.LeftStyle);
+    }
+
+    [Fact]
+    public void HtmlToWord_LaterStylelessBorderShorthand_ResetsEarlierVisibleBorder() {
+        const string html = """
+            <p style="border:1px solid red;border:1px red">Reset all sides</p>
+            <p style="border-left:1px solid red;border-left:1px red">Reset one side</p>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph allSides = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "Reset all sides");
+        WordParagraph oneSide = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "Reset one side");
 
         Assert.Null(allSides.Borders.LeftStyle);
         Assert.Null(allSides.Borders.TopStyle);
@@ -303,6 +364,9 @@ public class HtmlWordGapClosure {
             run => run.Text.Contains("exact", StringComparison.Ordinal));
         Assert.Equal(OfficeIMO.Drawing.OfficeColor.Parse("#ABCDEF"), renderedRun.BackgroundColor);
         Assert.Contains("#ABCDEF", document.ToSvg(), StringComparison.OrdinalIgnoreCase);
+        string roundTrip = document.ToHtml(new WordToHtmlOptions { IncludeRunHighlightStyles = true });
+        Assert.Contains("<mark", roundTrip, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("background-color:#abcdef", roundTrip, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -491,6 +555,54 @@ public class HtmlWordGapClosure {
         Assert.Contains(reloadedCell.Paragraphs, paragraph => paragraph.Text == "Existing");
         Assert.Contains(reloadedCell.Paragraphs, paragraph => paragraph.Text.Contains("Preformatted", StringComparison.Ordinal));
         Assert.Contains(reloadedCell.Elements, element => element is WordTable);
+    }
+
+    [Fact]
+    public void WordTableCell_AddHtml_HonorsHeadingNumberingWithoutReplacingExistingContent() {
+        using WordDocument document = WordDocument.Create();
+        WordTableCell cell = document.AddTable(1, 1).Rows[0].Cells[0];
+        cell.Paragraphs[0].Text = "Existing";
+        var options = new HtmlToWordOptions { SupportsHeadingNumbering = true };
+
+        cell.AddHtml(HtmlConversionDocument.Parse("<h1>One</h1><h2>Two</h2>"), options);
+
+        Assert.Contains(cell.Paragraphs, paragraph => paragraph.Text == "Existing");
+        WordParagraph[] headings = cell.Paragraphs
+            .Where(paragraph => paragraph.Text == "One" || paragraph.Text == "Two")
+            .ToArray();
+        Assert.Equal(2, headings.Length);
+        Assert.All(headings, paragraph => Assert.Equal(WordListStyle.Headings111, paragraph.ListStyle));
+        Assert.Equal(new int?[] { 0, 1 }, headings.Select(paragraph => paragraph.ListItemLevel).ToArray());
+
+        using var stream = new MemoryStream();
+        document.Save(stream);
+        using WordDocument reloaded = WordDocument.Load(new MemoryStream(stream.ToArray()));
+        WordTableCell reloadedCell = reloaded.Tables[0].Rows[0].Cells[0];
+        WordParagraph[] reloadedHeadings = reloadedCell.Paragraphs
+            .Where(paragraph => paragraph.Text == "One" || paragraph.Text == "Two")
+            .ToArray();
+
+        Assert.Contains(reloadedCell.Paragraphs, paragraph => paragraph.Text == "Existing");
+        Assert.Equal(2, reloadedHeadings.Length);
+        Assert.All(reloadedHeadings, paragraph => Assert.Equal(WordListStyle.Headings111, paragraph.ListStyle));
+        Assert.Equal(new int?[] { 0, 1 }, reloadedHeadings.Select(paragraph => paragraph.ListItemLevel).ToArray());
+    }
+
+    [Fact]
+    public void WordTableCell_AddHtml_NumberedHeadingsReplaceTheFreshPlaceholder() {
+        using WordDocument document = WordDocument.Create();
+        WordTableCell cell = document.AddTable(1, 1).Rows[0].Cells[0];
+        var options = new HtmlToWordOptions { SupportsHeadingNumbering = true };
+
+        cell.AddHtml(HtmlConversionDocument.Parse("<h1>One</h1><h2>Two</h2>"), options);
+
+        Paragraph[] paragraphs = cell._tableCell.Elements<Paragraph>().ToArray();
+        Assert.Equal(2, paragraphs.Length);
+        Assert.Equal(new[] { "One", "Two" }, paragraphs.Select(paragraph => paragraph.InnerText).ToArray());
+        Assert.DoesNotContain(document.Sections[0].Paragraphs, paragraph => paragraph.Text == "One" || paragraph.Text == "Two");
+        Assert.All(
+            cell.Paragraphs.Where(paragraph => paragraph.Text == "One" || paragraph.Text == "Two"),
+            paragraph => Assert.Equal(WordListStyle.Headings111, paragraph.ListStyle));
     }
 
     [Fact]

--- a/OfficeIMO.Html.Tests/Html.WordGapClosure.cs
+++ b/OfficeIMO.Html.Tests/Html.WordGapClosure.cs
@@ -162,6 +162,24 @@ public class HtmlWordGapClosure {
     }
 
     [Fact]
+    public void HtmlToWord_BlockFrame_ResolvesImportantDeclarationsBeforeNormalDeclarations() {
+        const string html = """
+            <p style="background-color:#abcdef!important;background-color:#ffffff;border:1px solid #123456!important;border:4px dashed #ffffff">
+              Important frame
+            </p>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph paragraph = Assert.Single(
+            document.Paragraphs,
+            candidate => candidate.Text.Contains("Important frame", StringComparison.Ordinal));
+
+        Assert.Equal("ABCDEF", paragraph.ShadingFillColorHex);
+        Assert.Equal(BorderValues.Single, paragraph.Borders.LeftStyle);
+        Assert.Equal("123456", paragraph.Borders.LeftColorHex);
+    }
+
+    [Fact]
     public void HtmlToWord_BlockChild_StartsANewFramedParagraphAfterInlineContent() {
         const string html = """
             <span>Before</span><div style="border:1px solid #123456">Inside</div>
@@ -257,6 +275,34 @@ public class HtmlWordGapClosure {
             run => run.Text.Contains("exact", StringComparison.Ordinal));
         Assert.Equal(OfficeIMO.Drawing.OfficeColor.Parse("#ABCDEF"), renderedRun.BackgroundColor);
         Assert.Contains("#ABCDEF", reloaded.ToSvg(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void HtmlToWord_ExactTextBackground_OverridesInheritedHighlight() {
+        const string html = """
+            <p><mark>marked <span style="background-color:#abcdef!important">exact</span></mark></p>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph markedRun = Assert.Single(
+            document.Paragraphs[0].GetRuns(),
+            run => run.Text.Contains("marked", StringComparison.Ordinal));
+        WordParagraph exactRun = Assert.Single(
+            document.Paragraphs[0].GetRuns(),
+            run => run.Text.Contains("exact", StringComparison.Ordinal));
+
+        Assert.Equal(HighlightColorValues.Yellow, markedRun.Highlight);
+        Assert.Null(exactRun.Highlight);
+        Assert.Equal("ABCDEF", exactRun.RunShadingFillColorHex);
+
+        WordDocumentVisualSnapshot snapshot = document.CreateVisualSnapshot();
+        OfficeIMO.Drawing.OfficeRichTextRun renderedRun = Assert.Single(
+            snapshot.Drawing.Elements
+                .OfType<OfficeIMO.Drawing.OfficeDrawingRichText>()
+                .SelectMany(richText => richText.Runs),
+            run => run.Text.Contains("exact", StringComparison.Ordinal));
+        Assert.Equal(OfficeIMO.Drawing.OfficeColor.Parse("#ABCDEF"), renderedRun.BackgroundColor);
+        Assert.Contains("#ABCDEF", document.ToSvg(), StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -397,6 +443,54 @@ public class HtmlWordGapClosure {
         Assert.Single(reloaded.Images);
         Assert.Contains(reloadedCell.Paragraphs, paragraph => paragraph.IsImage);
         Assert.Contains(reloadedCell.Paragraphs, paragraph => paragraph.Text == "Appended");
+    }
+
+    [Fact]
+    public void WordTableCell_AddHtml_ReplacesOnlyTheFreshEmptyRunPlaceholder() {
+        using WordDocument document = WordDocument.Create();
+        WordTableCell cell = document.AddTable(1, 1).Rows[0].Cells[0];
+
+        cell.AddHtml(HtmlConversionDocument.Parse("""<p>Imported paragraph</p>"""));
+
+        Paragraph paragraph = Assert.Single(cell._tableCell.Elements<Paragraph>());
+        Assert.Equal("Imported paragraph", paragraph.InnerText);
+
+        using var stream = new MemoryStream();
+        document.Save(stream);
+        using WordDocument reloaded = WordDocument.Load(new MemoryStream(stream.ToArray()));
+        WordTableCell reloadedCell = reloaded.Tables[0].Rows[0].Cells[0];
+        Paragraph reloadedParagraph = Assert.Single(reloadedCell._tableCell.Elements<Paragraph>());
+        Assert.Equal("Imported paragraph", reloadedParagraph.InnerText);
+    }
+
+    [Fact]
+    public void WordTableCell_AddHtml_PreservesExistingContentAcrossBlockHandlers() {
+        using WordDocument document = WordDocument.Create();
+        WordTableCell cell = document.AddTable(1, 1).Rows[0].Cells[0];
+        cell.Paragraphs[0].Text = "Existing";
+
+        cell.AddHtml(HtmlConversionDocument.Parse("""
+            <hr>
+            <input type="text" value="Form value">
+            <pre>Preformatted</pre>
+            <table>
+              <caption>Nested caption</caption>
+              <tr><td>Nested value</td></tr>
+            </table>
+            """));
+
+        Assert.Contains(cell.Paragraphs, paragraph => paragraph.Text == "Existing");
+        Assert.Contains(cell.Paragraphs, paragraph => paragraph.Text.Contains("Preformatted", StringComparison.Ordinal));
+        Assert.Contains(cell.Elements, element => element is WordTable);
+
+        using var stream = new MemoryStream();
+        document.Save(stream);
+        using WordDocument reloaded = WordDocument.Load(new MemoryStream(stream.ToArray()));
+        WordTableCell reloadedCell = reloaded.Tables[0].Rows[0].Cells[0];
+
+        Assert.Contains(reloadedCell.Paragraphs, paragraph => paragraph.Text == "Existing");
+        Assert.Contains(reloadedCell.Paragraphs, paragraph => paragraph.Text.Contains("Preformatted", StringComparison.Ordinal));
+        Assert.Contains(reloadedCell.Elements, element => element is WordTable);
     }
 
     [Fact]

--- a/OfficeIMO.Html.Tests/Html.WordGapClosure.cs
+++ b/OfficeIMO.Html.Tests/Html.WordGapClosure.cs
@@ -1,0 +1,246 @@
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Validation;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Html;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public class HtmlWordGapClosure {
+    private const string ValidPng =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+
+    [Theory]
+    [InlineData("ltr", 150, 300)]
+    [InlineData("rtl", 300, 150)]
+    public void HtmlToWord_LogicalSpacing_ResolvesAgainstEffectiveDirection(
+        string direction,
+        int expectedBefore,
+        int expectedAfter) {
+        string html = $"""
+            <div dir="{direction}">
+              <p style="margin-inline-start:10px;margin-inline-end:20px;padding-block:4px 6px">
+                Logical spacing
+              </p>
+            </div>
+            """;
+
+        HtmlToWordResult conversion = HtmlConversionDocument.Parse(html).ToWordDocumentResult();
+        using WordDocument document = conversion.Value;
+        WordParagraph paragraph = Assert.Single(
+            document.Paragraphs,
+            candidate => candidate.Text.Contains("Logical spacing", StringComparison.Ordinal));
+
+        Assert.Equal(expectedBefore, paragraph.IndentationBefore);
+        Assert.Equal(expectedAfter, paragraph.IndentationAfter);
+        Assert.Equal(60, paragraph.LineSpacingBefore);
+        Assert.Equal(90, paragraph.LineSpacingAfter);
+        Assert.DoesNotContain(
+            conversion.Report.Diagnostics,
+            diagnostic => diagnostic.Code == "UnsupportedCssDeclaration" &&
+                          diagnostic.Source?.Contains("inline", StringComparison.OrdinalIgnoreCase) == true);
+    }
+
+    [Fact]
+    public void HtmlToWord_LogicalSpacing_RespectsDeclarationOrderWithPhysicalProperties() {
+        const string html = """
+            <p style="margin-inline-start:10px;margin-left:30px">Physical last</p>
+            <p style="margin-left:30px;margin-inline-start:10px">Logical last</p>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph physicalLast = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "Physical last");
+        WordParagraph logicalLast = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "Logical last");
+
+        Assert.Equal(450, physicalLast.IndentationBefore);
+        Assert.Equal(150, logicalLast.IndentationBefore);
+    }
+
+    [Fact]
+    public void HtmlToWord_BlockContainer_PreservesOneNativeFrameAcrossParagraphs() {
+        const string html = """
+            <style>.frame { background-color:#abcdef; border:1px solid #123456; padding:4px 8px; }</style>
+            <div class="frame"><p>First</p><p>Second</p></div>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph first = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "First");
+        WordParagraph second = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "Second");
+
+        Assert.Equal("ABCDEF", first.ShadingFillColorHex);
+        Assert.Equal("ABCDEF", second.ShadingFillColorHex);
+        Assert.Equal(BorderValues.Single, first.Borders.TopStyle);
+        Assert.Null(first.Borders.BottomStyle);
+        Assert.Null(second.Borders.TopStyle);
+        Assert.Equal(BorderValues.Single, second.Borders.BottomStyle);
+        Assert.Equal(BorderValues.Single, first.Borders.LeftStyle);
+        Assert.Equal(BorderValues.Single, second.Borders.RightStyle);
+        Assert.Equal("123456", first.Borders.LeftColorHex);
+        Assert.Equal(120, first.IndentationBefore);
+        Assert.Equal(120, second.IndentationAfter);
+    }
+
+    [Fact]
+    public void HtmlToWord_ExactTextBackground_SurvivesSaveReloadAndHtmlExport() {
+        const string html = """<p>Before <span style="background-color:#abcdef">exact</span> after</p>""";
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph exactRun = Assert.Single(
+            document.Paragraphs[0].GetRuns(),
+            run => run.Text.Contains("exact", StringComparison.Ordinal));
+
+        Assert.Equal("ABCDEF", exactRun.RunShadingFillColorHex);
+        Assert.Null(exactRun.Highlight);
+
+        using var stream = new MemoryStream();
+        document.Save(stream);
+        using (WordprocessingDocument package = WordprocessingDocument.Open(new MemoryStream(stream.ToArray()), false)) {
+            var validationErrors = new OpenXmlValidator().Validate(package).ToList();
+            Assert.True(
+                validationErrors.Count == 0,
+                OpenXmlValidationFormatting.FormatValidationErrors(validationErrors));
+        }
+        using WordDocument reloaded = WordDocument.Load(new MemoryStream(stream.ToArray()));
+        WordParagraph reloadedRun = Assert.Single(
+            reloaded.Paragraphs[0].GetRuns(),
+            run => run.Text.Contains("exact", StringComparison.Ordinal));
+
+        Assert.Equal("ABCDEF", reloadedRun.RunShadingFillColorHex);
+        Assert.Contains(
+            "background-color:#abcdef",
+            reloaded.ToHtml(new WordToHtmlOptions { IncludeRunHighlightStyles = true }),
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void HtmlToWord_NearestHighlightMode_ReportsColorApproximation() {
+        var options = new HtmlToWordOptions {
+            TextBackgroundMode = HtmlTextBackgroundMode.NearestHighlight
+        };
+
+        HtmlToWordResult conversion = HtmlConversionDocument
+            .Parse("""<p><span style="background-color:#abcdef">approximate</span></p>""")
+            .ToWordDocumentResult(options);
+        using WordDocument document = conversion.Value;
+        WordParagraph run = Assert.Single(document.Paragraphs[0].GetRuns());
+
+        Assert.NotNull(run.Highlight);
+        Assert.Equal(string.Empty, run.RunShadingFillColorHex);
+        Assert.Contains(
+            conversion.Report.Diagnostics,
+            diagnostic => diagnostic.Code == "TextBackgroundColorApproximated");
+    }
+
+    [Fact]
+    public async Task HtmlToWord_RemoteImages_UseConfiguredBoundedConcurrency() {
+        int active = 0;
+        int maximum = 0;
+        byte[] imageBytes = Convert.FromBase64String(ValidPng);
+        using var httpClient = new HttpClient(new TrackingHandler(async cancellationToken => {
+            int current = Interlocked.Increment(ref active);
+            UpdateMaximum(ref maximum, current);
+            try {
+                await Task.Delay(75, cancellationToken);
+                var response = new HttpResponseMessage(HttpStatusCode.OK) {
+                    Content = new ByteArrayContent(imageBytes)
+                };
+                response.Content.Headers.ContentType = new MediaTypeHeaderValue("image/png");
+                return response;
+            } finally {
+                Interlocked.Decrement(ref active);
+            }
+        }));
+        var options = new HtmlToWordOptions {
+            HttpClient = httpClient,
+            ImageProcessing = ImageProcessingMode.Embed,
+            MaxConcurrentResourceLoads = 2
+        };
+        const string html = """
+            <img src="https://example.test/one.png" alt="One">
+            <img src="https://example.test/two.png" alt="Two">
+            <img src="https://example.test/three.png" alt="Three">
+            """;
+
+        using WordDocument document = await HtmlConversionDocument.Parse(html).ToWordDocumentAsync(options);
+
+        Assert.Equal(3, document.Images.Count);
+        Assert.Equal(2, maximum);
+    }
+
+    [Fact]
+    public void HtmlToWordOptions_Clone_PreservesNewConversionContracts() {
+        var options = new HtmlToWordOptions {
+            MaxConcurrentResourceLoads = 3,
+            TextBackgroundMode = HtmlTextBackgroundMode.NearestHighlight
+        };
+
+        HtmlToWordOptions clone = options.Clone();
+
+        Assert.Equal(3, clone.MaxConcurrentResourceLoads);
+        Assert.Equal(HtmlTextBackgroundMode.NearestHighlight, clone.TextBackgroundMode);
+    }
+
+    [Fact]
+    public async Task HtmlToWord_InvalidResourceConcurrency_IsRejectedBeforeNetworkAccess() {
+        var options = new HtmlToWordOptions {
+            ImageProcessing = ImageProcessingMode.Embed,
+            MaxConcurrentResourceLoads = 0
+        };
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+            HtmlConversionDocument
+                .Parse("""<img src="https://example.test/image.png">""")
+                .ToWordDocumentAsync(options));
+    }
+
+    [Fact]
+    public async Task WordTableCell_AddHtmlAsync_PreservesTypedContainerAndArtifact() {
+        using WordDocument document = WordDocument.Create();
+        WordTableCell cell = document.AddTable(1, 1).Rows[0].Cells[0];
+        await cell.AddHtmlAsync(HtmlConversionDocument.Parse("""
+            <h2>Cell heading</h2>
+            <ul><li>First item</li><li>Second item</li></ul>
+            <table><tr><td>Nested</td></tr></table>
+            """));
+
+        Assert.Contains(cell.Paragraphs, paragraph => paragraph.Text.Contains("Cell heading", StringComparison.Ordinal));
+        Assert.Contains(cell.Elements, element => element is WordTable);
+
+        using var stream = new MemoryStream();
+        document.Save(stream);
+        using WordDocument reloaded = WordDocument.Load(new MemoryStream(stream.ToArray()));
+        WordTableCell reloadedCell = reloaded.Tables[0].Rows[0].Cells[0];
+
+        Assert.Contains(reloadedCell.Paragraphs, paragraph => paragraph.Text.Contains("Cell heading", StringComparison.Ordinal));
+        Assert.Contains(reloadedCell.Elements, element => element is WordTable);
+        Assert.Contains(reloadedCell.Paragraphs, paragraph => paragraph.Text.Contains("First item", StringComparison.Ordinal));
+    }
+
+    private static void UpdateMaximum(ref int maximum, int candidate) {
+        int observed;
+        while (candidate > (observed = Volatile.Read(ref maximum))) {
+            if (Interlocked.CompareExchange(ref maximum, candidate, observed) == observed) {
+                return;
+            }
+        }
+    }
+
+    private sealed class TrackingHandler : HttpMessageHandler {
+        private readonly Func<CancellationToken, Task<HttpResponseMessage>> _handler;
+
+        internal TrackingHandler(Func<CancellationToken, Task<HttpResponseMessage>> handler) {
+            _handler = handler;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) =>
+            _handler(cancellationToken);
+    }
+}

--- a/OfficeIMO.Html.Tests/Html.WordGapClosure.cs
+++ b/OfficeIMO.Html.Tests/Html.WordGapClosure.cs
@@ -302,6 +302,30 @@ public class HtmlWordGapClosure {
     }
 
     [Fact]
+    public void WordTableCell_AddHtml_DoesNotReplaceSoleImageParagraph() {
+        using WordDocument document = WordDocument.Create();
+        WordTableCell cell = document.AddTable(1, 1).Rows[0].Cells[0];
+        using (var imageStream = new MemoryStream(Convert.FromBase64String(ValidPng))) {
+            cell.Paragraphs[0].AddImage(imageStream, "existing.png", 10, 10);
+        }
+
+        cell.AddHtml(HtmlConversionDocument.Parse("""<span>Appended</span>"""));
+
+        Assert.Single(document.Images);
+        Assert.Contains(cell.Paragraphs, paragraph => paragraph.IsImage);
+        Assert.Contains(cell.Paragraphs, paragraph => paragraph.Text == "Appended");
+
+        using var stream = new MemoryStream();
+        document.Save(stream);
+        using WordDocument reloaded = WordDocument.Load(new MemoryStream(stream.ToArray()));
+        WordTableCell reloadedCell = reloaded.Tables[0].Rows[0].Cells[0];
+
+        Assert.Single(reloaded.Images);
+        Assert.Contains(reloadedCell.Paragraphs, paragraph => paragraph.IsImage);
+        Assert.Contains(reloadedCell.Paragraphs, paragraph => paragraph.Text == "Appended");
+    }
+
+    [Fact]
     public async Task WordTableCell_AddHtmlAsync_KeepsSectionsImagesAndSvgInCellScope() {
         using WordDocument document = WordDocument.Create();
         WordTableCell cell = document.AddTable(1, 1).Rows[0].Cells[0];

--- a/OfficeIMO.Html.Tests/Html.WordGapClosure.cs
+++ b/OfficeIMO.Html.Tests/Html.WordGapClosure.cs
@@ -13,7 +13,7 @@ using Xunit;
 
 namespace OfficeIMO.Tests;
 
-public class HtmlWordGapClosure {
+public partial class HtmlWordGapClosure {
     private const string ValidPng =
         "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
 

--- a/OfficeIMO.Html.Tests/Html.WordGapClosure.cs
+++ b/OfficeIMO.Html.Tests/Html.WordGapClosure.cs
@@ -186,6 +186,27 @@ public class HtmlWordGapClosure {
     }
 
     [Fact]
+    public void HtmlToWord_CssWideDirectionValues_ResolveBeforeLogicalSpacing() {
+        const string html = """
+            <p dir="rtl" style="direction:rtl;direction:initial;margin-inline-start:10px">Initial</p>
+            <div dir="rtl">
+              <p dir="ltr" style="direction:inherit;margin-inline-start:10px">Inherited</p>
+            </div>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph initial = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "Initial");
+        WordParagraph inherited = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "Inherited");
+
+        Assert.False(initial.BiDi);
+        Assert.Equal(150, initial.IndentationBefore);
+        Assert.Null(initial.IndentationAfter);
+        Assert.True(inherited.BiDi);
+        Assert.Null(inherited.IndentationBefore);
+        Assert.Equal(150, inherited.IndentationAfter);
+    }
+
+    [Fact]
     public void HtmlToWord_BlockContainer_PreservesOneNativeFrameAcrossParagraphs() {
         const string html = """
             <style>.frame { background-color:#abcdef; border:1px solid #123456; padding:4px 8px; }</style>
@@ -291,6 +312,22 @@ public class HtmlWordGapClosure {
     }
 
     [Fact]
+    public void WordTableCell_AddHtml_FramesAContainerThatReplacesTheFreshPlaceholder() {
+        using WordDocument document = WordDocument.Create();
+        WordTableCell cell = document.AddTable(1, 1).Rows[0].Cells[0];
+
+        cell.AddHtml(HtmlConversionDocument.Parse(
+            """<div style="border:1px solid #123456;break-before:page">Framed</div>"""));
+
+        Paragraph paragraph = Assert.Single(cell._tableCell.Elements<Paragraph>());
+        WordParagraph framed = Assert.Single(cell.Paragraphs, candidate => candidate.Text == "Framed");
+        Assert.Equal("Framed", paragraph.InnerText);
+        Assert.Equal(BorderValues.Single, framed.Borders.TopStyle);
+        Assert.Equal(BorderValues.Single, framed.Borders.BottomStyle);
+        Assert.True(framed.PageBreakBefore);
+    }
+
+    [Fact]
     public void HtmlToWord_BorderColorLonghand_DoesNotSynthesizeVisibleBorder() {
         const string html = """<p style="border-left-color:#ff0000">No border style</p>""";
 
@@ -334,6 +371,33 @@ public class HtmlWordGapClosure {
         Assert.Null(allSides.Borders.RightStyle);
         Assert.Null(allSides.Borders.BottomStyle);
         Assert.Null(oneSide.Borders.LeftStyle);
+    }
+
+    [Fact]
+    public void HtmlToWord_InvalidFrameDeclarations_DoNotReplaceEarlierValidValues() {
+        const string html = """
+            <div style="background-color:red;background-color:bogus"><p>Background</p></div>
+            <div style="border:1px solid red;border:1px solid bogus"><p>Border</p></div>
+            <div style="background-color:red;background-color:transparent"><p>Transparent</p></div>
+            <p style="border:1px solid rgb(1, 2, 3)">Functional color</p>
+            """;
+
+        HtmlToWordResult conversion = HtmlConversionDocument.Parse(html).ToWordDocumentResult(
+            new HtmlToWordOptions { UnsupportedCssHandling = HtmlUnsupportedCssHandling.Warn });
+        using WordDocument document = conversion.Value;
+        WordParagraph background = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "Background");
+        WordParagraph border = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "Border");
+        WordParagraph transparent = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "Transparent");
+        WordParagraph functionalColor = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "Functional color");
+
+        Assert.Equal("FF0000", background.ShadingFillColorHex);
+        Assert.Equal(BorderValues.Single, border.Borders.TopStyle);
+        Assert.Equal("FF0000", border.Borders.TopColorHex);
+        Assert.True(string.IsNullOrEmpty(transparent.ShadingFillColorHex));
+        Assert.Equal("010203", functionalColor.Borders.TopColorHex);
+        Assert.Contains(conversion.Report.Diagnostics, diagnostic =>
+            diagnostic.Code == "UnsupportedCssValue" &&
+            diagnostic.Source == "div:border");
     }
 
     [Fact]
@@ -695,6 +759,21 @@ public class HtmlWordGapClosure {
         WordTableCell reloadedCell = reloaded.Sections[0].Header.Default!.Tables[0].Rows[0].Cells[0];
         Assert.Contains(reloadedCell.Paragraphs, paragraph => paragraph.IsImage);
         Assert.Empty(reloaded.Images);
+    }
+
+    [Fact]
+    public void WordTableCell_AddHtml_CreatesTopBookmarkForATableOnlyDocument() {
+        using WordDocument document = WordDocument.Create();
+        WordTableCell cell = document.AddTable(1, 1).Rows[0].Cells[0];
+
+        cell.AddHtml(HtmlConversionDocument.Parse("""<p><a href="#top">Back</a></p>"""));
+
+        Assert.Contains(document.Bookmarks, bookmark =>
+            string.Equals(bookmark.Name, "_top", StringComparison.OrdinalIgnoreCase));
+        WordParagraph hyperlinkParagraph = Assert.Single(
+            cell.Paragraphs,
+            paragraph => paragraph.Hyperlink != null);
+        Assert.Equal("_top", hyperlinkParagraph.Hyperlink!.Anchor);
     }
 
     private static void UpdateMaximum(ref int maximum, int candidate) {

--- a/OfficeIMO.Html.Tests/Html.WordGapClosure.cs
+++ b/OfficeIMO.Html.Tests/Html.WordGapClosure.cs
@@ -64,6 +64,46 @@ public class HtmlWordGapClosure {
     }
 
     [Fact]
+    public void HtmlToWord_LogicalPadding_RespectsDeclarationOrderWithPhysicalProperties() {
+        const string html = """
+            <p style="padding-left:30px;padding-inline-start:10px;padding-top:40px;padding-block-start:20px">Logical last</p>
+            <p style="padding-inline-start:10px;padding-left:30px;padding-block-start:20px;padding-top:40px">Physical last</p>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph logicalLast = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "Logical last");
+        WordParagraph physicalLast = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "Physical last");
+
+        Assert.Equal(150, logicalLast.IndentationBefore);
+        Assert.Equal(300, logicalLast.LineSpacingBefore);
+        Assert.Equal(450, physicalLast.IndentationBefore);
+        Assert.Equal(600, physicalLast.LineSpacingBefore);
+    }
+
+    [Fact]
+    public void HtmlToWord_CssDirection_OverridesDirForLogicalSpacing() {
+        const string html = """
+            <style>
+              .ltr { direction:ltr; }
+              .ancestor { direction:ltr; }
+            </style>
+            <p class="ltr" dir="rtl" style="margin-inline-start:10px">CSS direction</p>
+            <div class="ancestor">
+              <p dir="rtl" style="margin-inline-start:10px">Own dir</p>
+            </div>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph paragraph = Assert.Single(document.Paragraphs, candidate => candidate.Text == "CSS direction");
+        WordParagraph ownDir = Assert.Single(document.Paragraphs, candidate => candidate.Text == "Own dir");
+
+        Assert.Equal(150, paragraph.IndentationBefore);
+        Assert.Null(paragraph.IndentationAfter);
+        Assert.Null(ownDir.IndentationBefore);
+        Assert.Equal(150, ownDir.IndentationAfter);
+    }
+
+    [Fact]
     public void HtmlToWord_BlockContainer_PreservesOneNativeFrameAcrossParagraphs() {
         const string html = """
             <style>.frame { background-color:#abcdef; border:1px solid #123456; padding:4px 8px; }</style>
@@ -85,6 +125,33 @@ public class HtmlWordGapClosure {
         Assert.Equal("123456", first.Borders.LeftColorHex);
         Assert.Equal(120, first.IndentationBefore);
         Assert.Equal(120, second.IndentationAfter);
+    }
+
+    [Fact]
+    public void HtmlToWord_BlockContainer_PreservesMoreSpecificDescendantBackground() {
+        const string html = """
+            <div style="background-color:#0000ff">
+              <p style="background-color:#ff0000">Specific</p>
+              <p>Inherited frame</p>
+            </div>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph specific = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "Specific");
+        WordParagraph inherited = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "Inherited frame");
+
+        Assert.Equal("FF0000", specific.ShadingFillColorHex);
+        Assert.Equal("0000FF", inherited.ShadingFillColorHex);
+    }
+
+    [Fact]
+    public void HtmlToWord_BorderColorLonghand_DoesNotSynthesizeVisibleBorder() {
+        const string html = """<p style="border-left-color:#ff0000">No border style</p>""";
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph paragraph = Assert.Single(document.Paragraphs, candidate => candidate.Text == "No border style");
+
+        Assert.Null(paragraph.Borders.LeftStyle);
     }
 
     [Fact]
@@ -220,6 +287,68 @@ public class HtmlWordGapClosure {
         Assert.Contains(reloadedCell.Paragraphs, paragraph => paragraph.Text.Contains("Cell heading", StringComparison.Ordinal));
         Assert.Contains(reloadedCell.Elements, element => element is WordTable);
         Assert.Contains(reloadedCell.Paragraphs, paragraph => paragraph.Text.Contains("First item", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void WordTableCell_AddHtml_AppendsTopLevelInlineSiblingsWithoutDeletingContent() {
+        using WordDocument document = WordDocument.Create();
+        WordTableCell cell = document.AddTable(1, 1).Rows[0].Cells[0];
+        cell.Paragraphs[0].Text = "Existing";
+
+        cell.AddHtml(HtmlConversionDocument.Parse("""<span>First</span><span>Second</span>"""));
+
+        Assert.Contains(cell.Paragraphs, paragraph => paragraph.Text == "Existing");
+        Assert.Equal("ExistingFirstSecond", string.Concat(cell.Paragraphs.Select(paragraph => paragraph.Text)));
+    }
+
+    [Fact]
+    public async Task WordTableCell_AddHtmlAsync_KeepsSectionsImagesAndSvgInCellScope() {
+        using WordDocument document = WordDocument.Create();
+        WordTableCell cell = document.AddTable(1, 1).Rows[0].Cells[0];
+        string html = $"""
+            <section><p>Scoped section</p></section>
+            <img src="data:image/png;base64,{ValidPng}" alt="Scoped PNG">
+            <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">
+              <rect width="10" height="10" fill="#123456"/>
+            </svg>
+            """;
+
+        await cell.AddHtmlAsync(HtmlConversionDocument.Parse(html));
+
+        Assert.Contains(cell.Paragraphs, paragraph => paragraph.Text == "Scoped section");
+        Assert.Equal(2, document.Images.Count);
+        Assert.DoesNotContain(document.Sections[0].Paragraphs, paragraph => paragraph.Text == "Scoped section");
+        Assert.DoesNotContain(document.Sections[0].Paragraphs, paragraph => paragraph.IsImage);
+
+        using var stream = new MemoryStream();
+        document.Save(stream);
+        using WordDocument reloaded = WordDocument.Load(new MemoryStream(stream.ToArray()));
+        WordTableCell reloadedCell = reloaded.Tables[0].Rows[0].Cells[0];
+
+        Assert.Contains(reloadedCell.Paragraphs, paragraph => paragraph.Text == "Scoped section");
+        Assert.Equal(2, reloaded.Images.Count);
+    }
+
+    [Fact]
+    public async Task WordTableCell_AddHtmlAsync_UsesHeaderPartForTopLevelImage() {
+        using WordDocument document = WordDocument.Create();
+        document.AddHeadersAndFooters();
+        WordHeader header = document.Sections[0].Header.Default!;
+        WordTableCell cell = header.AddTable(1, 1).Rows[0].Cells[0];
+        string html = $"""<img src="data:image/png;base64,{ValidPng}" alt="Header PNG">""";
+
+        await cell.AddHtmlAsync(HtmlConversionDocument.Parse(html));
+
+        Assert.Contains(cell.Paragraphs, paragraph => paragraph.IsImage);
+        Assert.Empty(document.Images);
+
+        using var stream = new MemoryStream();
+        document.Save(stream);
+        using WordDocument reloaded = WordDocument.Load(new MemoryStream(stream.ToArray()));
+
+        WordTableCell reloadedCell = reloaded.Sections[0].Header.Default!.Tables[0].Rows[0].Cells[0];
+        Assert.Contains(reloadedCell.Paragraphs, paragraph => paragraph.IsImage);
+        Assert.Empty(reloaded.Images);
     }
 
     private static void UpdateMaximum(ref int maximum, int candidate) {

--- a/OfficeIMO.Html.Tests/Html.WordGapClosure.cs
+++ b/OfficeIMO.Html.Tests/Html.WordGapClosure.cs
@@ -81,6 +81,44 @@ public class HtmlWordGapClosure {
     }
 
     [Fact]
+    public void HtmlToWord_StylesheetCascade_ReplaysWinningBoxDeclarationsInCascadeOrder() {
+        const string html = """
+            <style>
+              .x { margin-left:5px; }
+              .x { margin:10px; }
+              .x { margin-left:30px; }
+              #specific { margin-left:30px; }
+              .y { margin:10px; }
+            </style>
+            <p class="x">Source order</p>
+            <p id="specific" class="y">Specificity</p>
+            """;
+
+        using WordDocument document = HtmlConversionDocument.Parse(html).ToWordDocument();
+        WordParagraph sourceOrder = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "Source order");
+        WordParagraph specificity = Assert.Single(document.Paragraphs, paragraph => paragraph.Text == "Specificity");
+
+        Assert.Equal(450, sourceOrder.IndentationBefore);
+        Assert.Equal(150, sourceOrder.IndentationAfter);
+        Assert.Equal(450, specificity.IndentationBefore);
+        Assert.Equal(150, specificity.IndentationAfter);
+    }
+
+    [Fact]
+    public void HtmlToWord_InlineLogicalSpacing_IsReportedAsUnsupported() {
+        const string html = """<p>Before <span style="margin-inline-start:10px">inline</span> after</p>""";
+        var options = new HtmlToWordOptions {
+            UnsupportedCssHandling = HtmlUnsupportedCssHandling.Error,
+        };
+
+        HtmlUnsupportedCssException exception = Assert.Throws<HtmlUnsupportedCssException>(
+            () => HtmlConversionDocument.Parse(html).ToWordDocument(options));
+
+        Assert.Equal("UnsupportedCssDeclaration", exception.Code);
+        Assert.Equal("span:margin-inline-start", exception.CssSource);
+    }
+
+    [Fact]
     public void HtmlToWord_LogicalSpacing_RespectsImportantPriorityBeforeDeclarationOrder() {
         const string html = """
             <p style="margin-left:30px!important;margin-inline-start:10px">Important physical</p>
@@ -564,9 +602,11 @@ public class HtmlWordGapClosure {
         cell.Paragraphs[0].Text = "Existing";
         var options = new HtmlToWordOptions { SupportsHeadingNumbering = true };
 
-        cell.AddHtml(HtmlConversionDocument.Parse("<h1>One</h1><h2>Two</h2>"), options);
+        cell.AddHtml(HtmlConversionDocument.Parse("<h1>One</h1><p>Middle</p><h2>Two</h2>"), options);
 
-        Assert.Contains(cell.Paragraphs, paragraph => paragraph.Text == "Existing");
+        Assert.Equal(
+            new[] { "Existing", "One", "Middle", "Two" },
+            cell._tableCell.Elements<Paragraph>().Select(paragraph => paragraph.InnerText).ToArray());
         WordParagraph[] headings = cell.Paragraphs
             .Where(paragraph => paragraph.Text == "One" || paragraph.Text == "Two")
             .ToArray();
@@ -582,7 +622,9 @@ public class HtmlWordGapClosure {
             .Where(paragraph => paragraph.Text == "One" || paragraph.Text == "Two")
             .ToArray();
 
-        Assert.Contains(reloadedCell.Paragraphs, paragraph => paragraph.Text == "Existing");
+        Assert.Equal(
+            new[] { "Existing", "One", "Middle", "Two" },
+            reloadedCell._tableCell.Elements<Paragraph>().Select(paragraph => paragraph.InnerText).ToArray());
         Assert.Equal(2, reloadedHeadings.Length);
         Assert.All(reloadedHeadings, paragraph => Assert.Equal(WordListStyle.Headings111, paragraph.ListStyle));
         Assert.Equal(new int?[] { 0, 1 }, reloadedHeadings.Select(paragraph => paragraph.ListItemLevel).ToArray());

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockColors.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockColors.cs
@@ -1,0 +1,66 @@
+using SixColor = OfficeIMO.Drawing.OfficeColor;
+
+namespace OfficeIMO.Word.Html {
+    internal partial class HtmlToWordConverter {
+        private static string? ResolveBlockBackground(string styleText, string? inheritedBackground) {
+            string? background = null;
+            for (int priorityPass = 0; priorityPass < 2; priorityPass++) {
+                bool important = priorityPass == 1;
+                foreach (string part in styleText.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)) {
+                    if (!CssStyleMapper.TryParseDeclaration(
+                            part,
+                            out string name,
+                            out string value,
+                            out bool declarationIsImportant) ||
+                        declarationIsImportant != important ||
+                        name != "background-color") {
+                        continue;
+                    }
+
+                    if (IsCssInheritanceValue(value)) {
+                        background = inheritedBackground;
+                    } else if (IsCssWideResetValue(value) ||
+                               value.Equals("transparent", StringComparison.OrdinalIgnoreCase)) {
+                        background = null;
+                    } else {
+                        CssStyleMapper.CssProperties parsed =
+                            CssStyleMapper.ParseStyles("background-color:" + value);
+                        if (!string.IsNullOrEmpty(parsed.BackgroundColor)) {
+                            double alpha = parsed.BackgroundColorAlpha ?? 1d;
+                            background = alpha <= 0d
+                                ? null
+                                : ResolveOpaqueTextBackground(
+                                    parsed.BackgroundColor!,
+                                    alpha,
+                                    inheritedBackground);
+                        }
+                    }
+                }
+            }
+
+            return background;
+        }
+
+        private static bool TryResolveBlockBorderColor(
+            string value,
+            string? backdrop,
+            out SixColor color,
+            out bool transparent) {
+            CssStyleMapper.CssProperties parsed =
+                CssStyleMapper.ParseStyles("background-color:" + value);
+            if (string.IsNullOrEmpty(parsed.BackgroundColor)) {
+                color = SixColor.Black;
+                transparent = false;
+                return false;
+            }
+
+            double alpha = parsed.BackgroundColorAlpha ?? 1d;
+            transparent = alpha <= 0d;
+            string resolved = transparent
+                ? SixColor.Black.ToRgbHex()
+                : ResolveOpaqueTextBackground(parsed.BackgroundColor!, alpha, backdrop);
+            color = SixColor.Parse("#" + resolved);
+            return true;
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockFrames.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockFrames.cs
@@ -83,17 +83,45 @@ namespace OfficeIMO.Word.Html {
                 return true;
             }
 
-            string? styleText = element.GetAttribute("style");
-            if (string.IsNullOrWhiteSpace(styleText)) {
+            if (string.IsNullOrWhiteSpace(element.GetAttribute("style"))) {
                 return false;
             }
 
-            ParseBlockFrameStyles(styleText!, out string? background, out var sideBorders);
+            ParseElementBlockFrameStyles(element, out string? background, out var sideBorders);
             return background != null || sideBorders.Values.Any(border => border.Materialize().HasValue);
+        }
+
+        private static void ParseElementBlockFrameStyles(
+            IElement element,
+            out string? background,
+            out Dictionary<BlockBorderSide, BlockBorderState> sideBorders) {
+            var lineage = new Stack<IElement>();
+            for (IElement? current = element; current != null; current = current.ParentElement) {
+                lineage.Push(current);
+            }
+
+            string? inheritedBackground = null;
+            var inheritedBorders = new Dictionary<BlockBorderSide, BlockBorderState>();
+            while (lineage.Count > 0) {
+                IElement current = lineage.Pop();
+                ParseBlockFrameStyles(
+                    current.GetAttribute("style") ?? string.Empty,
+                    inheritedBackground,
+                    inheritedBorders,
+                    out background,
+                    out sideBorders);
+                inheritedBackground = background;
+                inheritedBorders = sideBorders;
+            }
+
+            background = inheritedBackground;
+            sideBorders = inheritedBorders;
         }
 
         private static void ParseBlockFrameStyles(
             string styleText,
+            string? inheritedBackground,
+            IReadOnlyDictionary<BlockBorderSide, BlockBorderState> inheritedBorders,
             out string? background,
             out Dictionary<BlockBorderSide, BlockBorderState> sideBorders) {
             background = null;
@@ -111,7 +139,10 @@ namespace OfficeIMO.Word.Html {
                     }
 
                     if (name == "background-color") {
-                        if (value.Equals("transparent", StringComparison.OrdinalIgnoreCase)) {
+                        if (IsCssInheritanceValue(value)) {
+                            background = inheritedBackground;
+                        } else if (IsCssWideResetValue(value) ||
+                                   value.Equals("transparent", StringComparison.OrdinalIgnoreCase)) {
                             background = null;
                         } else {
                             string? normalizedBackground = NormalizeColor(value);
@@ -119,6 +150,10 @@ namespace OfficeIMO.Word.Html {
                                 background = normalizedBackground;
                             }
                         }
+                    } else if (name == "border" && IsCssInheritanceValue(value)) {
+                        CopyAllBlockBorders(inheritedBorders, sideBorders);
+                    } else if (name == "border" && IsCssWideResetValue(value)) {
+                        ResetAllBlockBorders(sideBorders);
                     } else if (name == "border" &&
                                TryParseBlockBorder(
                                    value,
@@ -136,6 +171,12 @@ namespace OfficeIMO.Word.Html {
                         sideBorders[BlockBorderSide.Top] = border;
                         sideBorders[BlockBorderSide.Bottom] = border;
                     } else if (TryGetBlockBorderSide(name, out BlockBorderSide side) &&
+                               IsCssInheritanceValue(value)) {
+                        CopyBlockBorder(inheritedBorders, sideBorders, side);
+                    } else if (TryGetBlockBorderSide(name, out side) &&
+                               IsCssWideResetValue(value)) {
+                        sideBorders[side] = default;
+                    } else if (TryGetBlockBorderSide(name, out side) &&
                                TryParseBlockBorder(
                                    value,
                                    out var sideStyle,
@@ -148,7 +189,12 @@ namespace OfficeIMO.Word.Html {
                             sideSize,
                             hasSideColor ? sideColor : null);
                     } else if (TryGetBlockBorderLonghand(name, out side, out string component)) {
-                        ApplyBlockBorderLonghand(sideBorders, side, component, value);
+                        ApplyBlockBorderLonghand(
+                            sideBorders,
+                            inheritedBorders,
+                            side,
+                            component,
+                            value);
                     }
                 }
             }
@@ -174,7 +220,7 @@ namespace OfficeIMO.Word.Html {
                 return;
             }
 
-            ParseBlockFrameStyles(styleText!, out string? background, out var sideBorders);
+            ParseElementBlockFrameStyles(element, out string? background, out var sideBorders);
 
             if (!string.IsNullOrEmpty(background)) {
                 foreach (WordParagraph paragraph in paragraphs) {
@@ -234,12 +280,50 @@ namespace OfficeIMO.Word.Html {
 
         private static void ApplyBlockBorderLonghand(
             IDictionary<BlockBorderSide, BlockBorderState> sideBorders,
+            IReadOnlyDictionary<BlockBorderSide, BlockBorderState> inheritedBorders,
             BlockBorderSide side,
             string component,
             string value) {
             BlockBorderState border = sideBorders.TryGetValue(side, out BlockBorderState existing)
                 ? existing
                 : default;
+            if (IsCssInheritanceValue(value)) {
+                BlockBorderState inherited = inheritedBorders.TryGetValue(side, out BlockBorderState inheritedBorder)
+                    ? inheritedBorder
+                    : default;
+                switch (component) {
+                    case "style":
+                        border.Style = inherited.Style;
+                        break;
+                    case "width":
+                        border.Size = inherited.Size;
+                        break;
+                    case "color":
+                        border.Color = inherited.Color;
+                        break;
+                    default:
+                        return;
+                }
+                sideBorders[side] = border;
+                return;
+            }
+            if (IsCssWideResetValue(value)) {
+                switch (component) {
+                    case "style":
+                        border.Style = BorderValues.None;
+                        break;
+                    case "width":
+                        border.Size = null;
+                        break;
+                    case "color":
+                        border.Color = null;
+                        break;
+                    default:
+                        return;
+                }
+                sideBorders[side] = border;
+                return;
+            }
             switch (component) {
                 case "style":
                     if (!TryParseBlockBorderStyle(value, out BorderValues style)) {
@@ -264,6 +348,37 @@ namespace OfficeIMO.Word.Html {
                     return;
             }
             sideBorders[side] = border;
+        }
+
+        private static bool IsCssInheritanceValue(string value) =>
+            value.Trim().Equals("inherit", StringComparison.OrdinalIgnoreCase);
+
+        private static bool IsCssWideResetValue(string value) {
+            string normalized = value.Trim().ToLowerInvariant();
+            return normalized is "initial" or "unset" or "revert" or "revert-layer";
+        }
+
+        private static void CopyAllBlockBorders(
+            IReadOnlyDictionary<BlockBorderSide, BlockBorderState> source,
+            IDictionary<BlockBorderSide, BlockBorderState> destination) {
+            foreach (BlockBorderSide side in Enum.GetValues(typeof(BlockBorderSide))) {
+                CopyBlockBorder(source, destination, side);
+            }
+        }
+
+        private static void CopyBlockBorder(
+            IReadOnlyDictionary<BlockBorderSide, BlockBorderState> source,
+            IDictionary<BlockBorderSide, BlockBorderState> destination,
+            BlockBorderSide side) {
+            destination[side] = source.TryGetValue(side, out BlockBorderState inherited)
+                ? inherited
+                : default;
+        }
+
+        private static void ResetAllBlockBorders(IDictionary<BlockBorderSide, BlockBorderState> sideBorders) {
+            foreach (BlockBorderSide side in Enum.GetValues(typeof(BlockBorderSide))) {
+                sideBorders[side] = default;
+            }
         }
 
         private static bool TryParseBlockBorder(

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockFrames.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockFrames.cs
@@ -80,7 +80,14 @@ namespace OfficeIMO.Word.Html {
                     }
 
                     if (name == "background-color") {
-                        background = NormalizeColor(value);
+                        if (value.Equals("transparent", StringComparison.OrdinalIgnoreCase)) {
+                            background = null;
+                        } else {
+                            string? normalizedBackground = NormalizeColor(value);
+                            if (normalizedBackground != null) {
+                                background = normalizedBackground;
+                            }
+                        }
                     } else if (name == "border" &&
                                TryParseBorder(value, out var borderStyle, out var borderSize, out var borderColor, out bool hasBorderStyle)) {
                         if (hasBorderStyle) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockFrames.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockFrames.cs
@@ -51,11 +51,11 @@ namespace OfficeIMO.Word.Html {
                     : null;
         }
 
-        private static void ApplyParagraphFrameFromCss(WordParagraph paragraph, IElement element) {
+        private void ApplyParagraphFrameFromCss(WordParagraph paragraph, IElement element) {
             ApplyBlockFrameFromCss(element, new[] { paragraph }, applyContainerSpacing: false);
         }
 
-        private static CssStyleMapper.CssProperties ParseElementBoxStyles(IElement element) {
+        private CssStyleMapper.CssProperties ParseElementBoxStyles(IElement element) {
             var lineage = new Stack<IElement>();
             for (IElement? current = element; current != null; current = current.ParentElement) {
                 lineage.Push(current);
@@ -65,19 +65,22 @@ namespace OfficeIMO.Word.Html {
             bool inheritedRightToLeft = false;
             while (lineage.Count > 0) {
                 IElement current = lineage.Pop();
+                double elementFontSizePixels = ResolveComputedFontSizePixels(current);
                 bool rightToLeft = GetBidiFromDir(current) == true;
                 inheritedBox = CssStyleMapper.ParseStyles(
                     current.GetAttribute("style"),
                     rightToLeft,
                     inheritedBox,
-                    inheritedRightToLeft);
+                    inheritedRightToLeft,
+                    _rootFontSizePixels,
+                    elementFontSizePixels);
                 inheritedRightToLeft = rightToLeft;
             }
 
             return inheritedBox ?? new CssStyleMapper.CssProperties();
         }
 
-        private static bool RequiresEmptyBlockParagraph(IElement element) {
+        private bool RequiresEmptyBlockParagraph(IElement element) {
             if (StyleRequestsPageBreakBefore(element) || StyleRequestsPageBreakAfter(element)) {
                 return true;
             }
@@ -206,7 +209,7 @@ namespace OfficeIMO.Word.Html {
             }
         }
 
-        private static void ApplyContainerFrameFromCss(
+        private void ApplyContainerFrameFromCss(
             IElement element,
             IReadOnlyList<WordParagraph> paragraphs,
             bool applyContainerSpacing = true) {
@@ -217,7 +220,7 @@ namespace OfficeIMO.Word.Html {
             ApplyBlockFrameFromCss(element, paragraphs, applyContainerSpacing);
         }
 
-        private static void ApplyContainerFrameFromCss(
+        private void ApplyContainerFrameFromCss(
             IElement element,
             IReadOnlyList<WordParagraph> paragraphs,
             IReadOnlyList<WordTable> tables) {
@@ -337,7 +340,7 @@ namespace OfficeIMO.Word.Html {
                    SixColor.Black.ToRgbHex();
         }
 
-        private static void ApplyBlockFrameFromCss(
+        private void ApplyBlockFrameFromCss(
             IElement element,
             IReadOnlyList<WordParagraph> paragraphs,
             bool applyContainerSpacing,

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockFrames.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockFrames.cs
@@ -13,7 +13,7 @@ namespace OfficeIMO.Word.Html {
         }
 
         private readonly struct BlockBorder {
-            internal BlockBorder(BorderValues style, UInt32Value size, SixColor color) {
+            internal BlockBorder(BorderValues style, UInt32Value size, SixColor? color) {
                 Style = style;
                 Size = size;
                 Color = color;
@@ -21,11 +21,11 @@ namespace OfficeIMO.Word.Html {
 
             internal BorderValues Style { get; }
             internal UInt32Value Size { get; }
-            internal SixColor Color { get; }
+            internal SixColor? Color { get; }
         }
 
         private struct BlockBorderState {
-            internal BlockBorderState(BorderValues style, UInt32Value size, SixColor color) {
+            internal BlockBorderState(BorderValues style, UInt32Value size, SixColor? color) {
                 Style = style;
                 Size = size;
                 Color = color;
@@ -36,8 +36,8 @@ namespace OfficeIMO.Word.Html {
             internal SixColor? Color { get; set; }
 
             internal BlockBorder? Materialize() =>
-                Style.HasValue
-                    ? new BlockBorder(Style.Value, Size ?? 4U, Color ?? SixColor.Black)
+                Style.HasValue && Style.Value != BorderValues.None
+                    ? new BlockBorder(Style.Value, Size ?? 4U, Color)
                     : null;
         }
 
@@ -89,23 +89,33 @@ namespace OfficeIMO.Word.Html {
                             }
                         }
                     } else if (name == "border" &&
-                               TryParseBorder(value, out var borderStyle, out var borderSize, out var borderColor, out bool hasBorderStyle)) {
-                        if (hasBorderStyle) {
-                            var border = new BlockBorderState(borderStyle, borderSize, borderColor);
-                            sideBorders[BlockBorderSide.Left] = border;
-                            sideBorders[BlockBorderSide.Right] = border;
-                            sideBorders[BlockBorderSide.Top] = border;
-                            sideBorders[BlockBorderSide.Bottom] = border;
-                        } else {
-                            sideBorders.Clear();
-                        }
+                               TryParseBorder(
+                                   value,
+                                   out var borderStyle,
+                                   out var borderSize,
+                                   out var borderColor,
+                                   out bool hasBorderStyle,
+                                   out bool hasBorderColor)) {
+                        var border = new BlockBorderState(
+                            hasBorderStyle ? borderStyle : BorderValues.None,
+                            borderSize,
+                            hasBorderColor ? borderColor : null);
+                        sideBorders[BlockBorderSide.Left] = border;
+                        sideBorders[BlockBorderSide.Right] = border;
+                        sideBorders[BlockBorderSide.Top] = border;
+                        sideBorders[BlockBorderSide.Bottom] = border;
                     } else if (TryGetBlockBorderSide(name, out BlockBorderSide side) &&
-                               TryParseBorder(value, out var sideStyle, out var sideSize, out var sideColor, out bool hasSideStyle)) {
-                        if (hasSideStyle) {
-                            sideBorders[side] = new BlockBorderState(sideStyle, sideSize, sideColor);
-                        } else {
-                            sideBorders.Remove(side);
-                        }
+                               TryParseBorder(
+                                   value,
+                                   out var sideStyle,
+                                   out var sideSize,
+                                   out var sideColor,
+                                   out bool hasSideStyle,
+                                   out bool hasSideColor)) {
+                        sideBorders[side] = new BlockBorderState(
+                            hasSideStyle ? sideStyle : BorderValues.None,
+                            sideSize,
+                            hasSideColor ? sideColor : null);
                     } else if (TryGetBlockBorderLonghand(name, out side, out string component)) {
                         ApplyBlockBorderLonghand(sideBorders, side, component, value);
                     }
@@ -294,7 +304,7 @@ namespace OfficeIMO.Word.Html {
             }
 
             BlockBorder value = border.Value;
-            string color = value.Color.ToRgbHex();
+            string color = value.Color?.ToRgbHex() ?? ResolveParagraphTextColor(paragraph);
             switch (side) {
                 case BlockBorderSide.Left:
                     paragraph.Borders.LeftStyle = value.Style;
@@ -317,6 +327,11 @@ namespace OfficeIMO.Word.Html {
                     paragraph.Borders.BottomColorHex = color;
                     break;
             }
+        }
+
+        private static string ResolveParagraphTextColor(WordParagraph paragraph) {
+            string? normalized = NormalizeColor(paragraph.ColorHex);
+            return normalized ?? SixColor.Black.ToRgbHex();
         }
     }
 }

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockFrames.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockFrames.cs
@@ -211,6 +211,95 @@ namespace OfficeIMO.Word.Html {
             ApplyBlockFrameFromCss(element, paragraphs, applyContainerSpacing);
         }
 
+        private static void ApplyContainerFrameFromCss(
+            IElement element,
+            IReadOnlyList<WordParagraph> paragraphs,
+            IReadOnlyList<WordTable> tables) {
+            ApplyContainerFrameFromCss(element, paragraphs);
+            foreach (WordTable table in tables) {
+                ApplyTableContainerFrameFromCss(element, table);
+            }
+        }
+
+        private static void ApplyTableContainerFrameFromCss(IElement element, WordTable table) {
+            List<WordTableRow> rows = table.Rows;
+            if (rows.Count == 0) {
+                return;
+            }
+
+            ParseElementBlockFrameStyles(element, out string? background, out var sideBorders);
+            foreach (WordTableRow row in rows) {
+                foreach (WordTableCell cell in row.Cells) {
+                    if (!string.IsNullOrEmpty(background) && string.IsNullOrEmpty(cell.ShadingFillColorHex)) {
+                        cell.ShadingFillColorHex = background!;
+                    }
+                }
+            }
+
+            BlockBorder? left = GetBlockBorder(sideBorders, BlockBorderSide.Left);
+            BlockBorder? right = GetBlockBorder(sideBorders, BlockBorderSide.Right);
+            BlockBorder? top = GetBlockBorder(sideBorders, BlockBorderSide.Top);
+            BlockBorder? bottom = GetBlockBorder(sideBorders, BlockBorderSide.Bottom);
+            string fallbackColor = ResolveElementTextColor(element);
+
+            foreach (WordTableCell cell in rows[0].Cells) {
+                ApplyTableCellBorder(cell, BlockBorderSide.Top, top, fallbackColor);
+            }
+            foreach (WordTableCell cell in rows[rows.Count - 1].Cells) {
+                ApplyTableCellBorder(cell, BlockBorderSide.Bottom, bottom, fallbackColor);
+            }
+            foreach (WordTableRow row in rows) {
+                List<WordTableCell> cells = row.Cells;
+                if (cells.Count == 0) {
+                    continue;
+                }
+                ApplyTableCellBorder(cells[0], BlockBorderSide.Left, left, fallbackColor);
+                ApplyTableCellBorder(cells[cells.Count - 1], BlockBorderSide.Right, right, fallbackColor);
+            }
+        }
+
+        private static void ApplyTableCellBorder(
+            WordTableCell cell,
+            BlockBorderSide side,
+            BlockBorder? border,
+            string fallbackColor) {
+            if (!border.HasValue) {
+                return;
+            }
+
+            BlockBorder value = border.Value;
+            string color = value.Color?.ToRgbHex() ?? fallbackColor;
+            switch (side) {
+                case BlockBorderSide.Left:
+                    cell.Borders.LeftStyle = value.Style;
+                    cell.Borders.LeftSize = value.Size;
+                    cell.Borders.LeftColorHex = color;
+                    break;
+                case BlockBorderSide.Right:
+                    cell.Borders.RightStyle = value.Style;
+                    cell.Borders.RightSize = value.Size;
+                    cell.Borders.RightColorHex = color;
+                    break;
+                case BlockBorderSide.Top:
+                    cell.Borders.TopStyle = value.Style;
+                    cell.Borders.TopSize = value.Size;
+                    cell.Borders.TopColorHex = color;
+                    break;
+                case BlockBorderSide.Bottom:
+                    cell.Borders.BottomStyle = value.Style;
+                    cell.Borders.BottomSize = value.Size;
+                    cell.Borders.BottomColorHex = color;
+                    break;
+            }
+        }
+
+        private static string ResolveElementTextColor(IElement element) {
+            string styleText = element.GetAttribute("style") ?? string.Empty;
+            var declaration = ParseInlineDeclaration(styleText);
+            return NormalizeColor(GetInlinePropertyValue(declaration, styleText, "color")) ??
+                   SixColor.Black.ToRgbHex();
+        }
+
         private static void ApplyBlockFrameFromCss(
             IElement element,
             IReadOnlyList<WordParagraph> paragraphs,

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockFrames.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockFrames.cs
@@ -45,12 +45,15 @@ namespace OfficeIMO.Word.Html {
             ApplyBlockFrameFromCss(element, new[] { paragraph }, applyContainerSpacing: false);
         }
 
-        private static void ApplyContainerFrameFromCss(IElement element, IReadOnlyList<WordParagraph> paragraphs) {
+        private static void ApplyContainerFrameFromCss(
+            IElement element,
+            IReadOnlyList<WordParagraph> paragraphs,
+            bool applyContainerSpacing = true) {
             if (paragraphs.Count == 0) {
                 return;
             }
 
-            ApplyBlockFrameFromCss(element, paragraphs, applyContainerSpacing: true);
+            ApplyBlockFrameFromCss(element, paragraphs, applyContainerSpacing);
         }
 
         private static void ApplyBlockFrameFromCss(
@@ -79,17 +82,23 @@ namespace OfficeIMO.Word.Html {
                     if (name == "background-color") {
                         background = NormalizeColor(value);
                     } else if (name == "border" &&
-                               TryParseBorder(value, out var borderStyle, out var borderSize, out var borderColor, out bool hasBorderStyle) &&
-                               hasBorderStyle) {
-                        var border = new BlockBorderState(borderStyle, borderSize, borderColor);
-                        sideBorders[BlockBorderSide.Left] = border;
-                        sideBorders[BlockBorderSide.Right] = border;
-                        sideBorders[BlockBorderSide.Top] = border;
-                        sideBorders[BlockBorderSide.Bottom] = border;
+                               TryParseBorder(value, out var borderStyle, out var borderSize, out var borderColor, out bool hasBorderStyle)) {
+                        if (hasBorderStyle) {
+                            var border = new BlockBorderState(borderStyle, borderSize, borderColor);
+                            sideBorders[BlockBorderSide.Left] = border;
+                            sideBorders[BlockBorderSide.Right] = border;
+                            sideBorders[BlockBorderSide.Top] = border;
+                            sideBorders[BlockBorderSide.Bottom] = border;
+                        } else {
+                            sideBorders.Clear();
+                        }
                     } else if (TryGetBlockBorderSide(name, out BlockBorderSide side) &&
-                               TryParseBorder(value, out var sideStyle, out var sideSize, out var sideColor, out bool hasSideStyle) &&
-                               hasSideStyle) {
-                        sideBorders[side] = new BlockBorderState(sideStyle, sideSize, sideColor);
+                               TryParseBorder(value, out var sideStyle, out var sideSize, out var sideColor, out bool hasSideStyle)) {
+                        if (hasSideStyle) {
+                            sideBorders[side] = new BlockBorderState(sideStyle, sideSize, sideColor);
+                        } else {
+                            sideBorders.Remove(side);
+                        }
                     } else if (TryGetBlockBorderLonghand(name, out side, out string component)) {
                         ApplyBlockBorderLonghand(sideBorders, side, component, value);
                     }

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockFrames.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockFrames.cs
@@ -145,9 +145,16 @@ namespace OfficeIMO.Word.Html {
                                    value.Equals("transparent", StringComparison.OrdinalIgnoreCase)) {
                             background = null;
                         } else {
-                            string? normalizedBackground = NormalizeColor(value);
-                            if (normalizedBackground != null) {
-                                background = normalizedBackground;
+                            CssStyleMapper.CssProperties parsedBackground =
+                                CssStyleMapper.ParseStyles("background-color:" + value);
+                            if (!string.IsNullOrEmpty(parsedBackground.BackgroundColor)) {
+                                double alpha = parsedBackground.BackgroundColorAlpha ?? 1d;
+                                background = alpha <= 0d
+                                    ? null
+                                    : ResolveOpaqueTextBackground(
+                                        parsedBackground.BackgroundColor!,
+                                        alpha,
+                                        inheritedBackground);
                             }
                         }
                     } else if (name == "border" && IsCssInheritanceValue(value)) {
@@ -309,6 +316,7 @@ namespace OfficeIMO.Word.Html {
                 return;
             }
 
+            paragraphs = DistinctPhysicalParagraphs(paragraphs);
             ParseElementBlockFrameStyles(element, out string? background, out var sideBorders);
 
             if (!string.IsNullOrEmpty(background)) {
@@ -323,15 +331,16 @@ namespace OfficeIMO.Word.Html {
             BlockBorder? right = GetBlockBorder(sideBorders, BlockBorderSide.Right);
             BlockBorder? top = GetBlockBorder(sideBorders, BlockBorderSide.Top);
             BlockBorder? bottom = GetBlockBorder(sideBorders, BlockBorderSide.Bottom);
+            string fallbackColor = ResolveElementTextColor(element);
             for (int index = 0; index < paragraphs.Count; index++) {
                 WordParagraph paragraph = paragraphs[index];
-                ApplyParagraphBorder(paragraph, BlockBorderSide.Left, left);
-                ApplyParagraphBorder(paragraph, BlockBorderSide.Right, right);
+                ApplyParagraphBorder(paragraph, BlockBorderSide.Left, left, fallbackColor);
+                ApplyParagraphBorder(paragraph, BlockBorderSide.Right, right, fallbackColor);
                 if (index == 0) {
-                    ApplyParagraphBorder(paragraph, BlockBorderSide.Top, top);
+                    ApplyParagraphBorder(paragraph, BlockBorderSide.Top, top, fallbackColor);
                 }
                 if (index == paragraphs.Count - 1) {
-                    ApplyParagraphBorder(paragraph, BlockBorderSide.Bottom, bottom);
+                    ApplyParagraphBorder(paragraph, BlockBorderSide.Bottom, bottom, fallbackColor);
                 }
             }
 
@@ -360,6 +369,17 @@ namespace OfficeIMO.Word.Html {
                 WordParagraph last = paragraphs[paragraphs.Count - 1];
                 last.LineSpacingAfter = (last.LineSpacingAfter ?? 0) + verticalEnd;
             }
+        }
+
+        private static IReadOnlyList<WordParagraph> DistinctPhysicalParagraphs(
+            IReadOnlyList<WordParagraph> paragraphs) {
+            var result = new List<WordParagraph>(paragraphs.Count);
+            foreach (WordParagraph paragraph in paragraphs) {
+                if (!result.Any(existing => ReferenceEquals(existing._paragraph, paragraph._paragraph))) {
+                    result.Add(paragraph);
+                }
+            }
+            return result;
         }
 
         private static BlockBorder? GetBlockBorder(
@@ -625,13 +645,14 @@ namespace OfficeIMO.Word.Html {
         private static void ApplyParagraphBorder(
             WordParagraph paragraph,
             BlockBorderSide side,
-            BlockBorder? border) {
+            BlockBorder? border,
+            string fallbackColor) {
             if (!border.HasValue || HasParagraphBorder(paragraph, side)) {
                 return;
             }
 
             BlockBorder value = border.Value;
-            string color = value.Color?.ToRgbHex() ?? ResolveParagraphTextColor(paragraph);
+            string color = value.Color?.ToRgbHex() ?? fallbackColor;
             switch (side) {
                 case BlockBorderSide.Left:
                     paragraph.Borders.LeftStyle = value.Style;
@@ -665,9 +686,5 @@ namespace OfficeIMO.Word.Html {
                 _ => false,
             };
 
-        private static string ResolveParagraphTextColor(WordParagraph paragraph) {
-            string? normalized = NormalizeColor(paragraph.ColorHex);
-            return normalized ?? SixColor.Black.ToRgbHex();
-        }
     }
 }

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockFrames.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockFrames.cs
@@ -47,7 +47,7 @@ namespace OfficeIMO.Word.Html {
                 Style.HasValue &&
                 Style.Value != BorderValues.None &&
                 (Size == null || Size.Value > 0)
-                    ? new BlockBorder(Style.Value, Size ?? 4U, Color)
+                    ? new BlockBorder(Style.Value, Size ?? 18U, Color)
                     : null;
         }
 
@@ -112,21 +112,24 @@ namespace OfficeIMO.Word.Html {
                 lineage.Push(current);
             }
 
-            string? inheritedBackground = null;
+            string? effectiveBackdrop = null;
+            string? currentBackground = null;
             var inheritedBorders = new Dictionary<BlockBorderSide, BlockBorderState>();
             while (lineage.Count > 0) {
                 IElement current = lineage.Pop();
                 ParseBlockFrameStyles(
                     current.GetAttribute("style") ?? string.Empty,
-                    inheritedBackground,
+                    effectiveBackdrop,
                     inheritedBorders,
-                    out background,
+                    out currentBackground,
                     out sideBorders);
-                inheritedBackground = background;
+                if (currentBackground != null) {
+                    effectiveBackdrop = currentBackground;
+                }
                 inheritedBorders = sideBorders;
             }
 
-            background = inheritedBackground;
+            background = currentBackground;
             sideBorders = inheritedBorders;
         }
 
@@ -577,6 +580,7 @@ namespace OfficeIMO.Word.Html {
                 return false;
             }
 
+            bool hasExplicitWidth = false;
             foreach (string token in tokens) {
                 if (!TryParseRawBlockBorderWidth(token, out double width)) {
                     if (hasExplicitColor &&
@@ -590,6 +594,7 @@ namespace OfficeIMO.Word.Html {
                         hasTransparentColor = transparentColor;
                     }
                 } else {
+                    hasExplicitWidth = true;
                     if (width < 0) {
                         return false;
                     }
@@ -599,6 +604,9 @@ namespace OfficeIMO.Word.Html {
                 }
             }
 
+            if (!hasExplicitWidth) {
+                size = 18U;
+            }
             return true;
         }
 

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockFrames.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockFrames.cs
@@ -12,16 +12,33 @@ namespace OfficeIMO.Word.Html {
             Bottom
         }
 
-        private struct BlockBorder {
+        private readonly struct BlockBorder {
             internal BlockBorder(BorderValues style, UInt32Value size, SixColor color) {
                 Style = style;
                 Size = size;
                 Color = color;
             }
 
-            internal BorderValues Style { get; set; }
-            internal UInt32Value Size { get; set; }
-            internal SixColor Color { get; set; }
+            internal BorderValues Style { get; }
+            internal UInt32Value Size { get; }
+            internal SixColor Color { get; }
+        }
+
+        private struct BlockBorderState {
+            internal BlockBorderState(BorderValues style, UInt32Value size, SixColor color) {
+                Style = style;
+                Size = size;
+                Color = color;
+            }
+
+            internal BorderValues? Style { get; set; }
+            internal UInt32Value? Size { get; set; }
+            internal SixColor? Color { get; set; }
+
+            internal BlockBorder? Materialize() =>
+                Style.HasValue
+                    ? new BlockBorder(Style.Value, Size ?? 4U, Color ?? SixColor.Black)
+                    : null;
         }
 
         private static void ApplyParagraphFrameFromCss(WordParagraph paragraph, IElement element) {
@@ -46,7 +63,7 @@ namespace OfficeIMO.Word.Html {
             }
 
             string? background = null;
-            var sideBorders = new Dictionary<BlockBorderSide, BlockBorder>();
+            var sideBorders = new Dictionary<BlockBorderSide, BlockBorderState>();
             foreach (string part in styleText!.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)) {
                 string[] pieces = part.Split(new[] { ':' }, 2);
                 if (pieces.Length != 2) {
@@ -58,14 +75,14 @@ namespace OfficeIMO.Word.Html {
                 if (name == "background-color") {
                     background = NormalizeColor(value);
                 } else if (name == "border" && TryParseBorder(value, out var borderStyle, out var borderSize, out var borderColor)) {
-                    var border = new BlockBorder(borderStyle, borderSize, borderColor);
+                    var border = new BlockBorderState(borderStyle, borderSize, borderColor);
                     sideBorders[BlockBorderSide.Left] = border;
                     sideBorders[BlockBorderSide.Right] = border;
                     sideBorders[BlockBorderSide.Top] = border;
                     sideBorders[BlockBorderSide.Bottom] = border;
                 } else if (TryGetBlockBorderSide(name, out BlockBorderSide side) &&
                            TryParseBorder(value, out var sideStyle, out var sideSize, out var sideColor)) {
-                    sideBorders[side] = new BlockBorder(sideStyle, sideSize, sideColor);
+                    sideBorders[side] = new BlockBorderState(sideStyle, sideSize, sideColor);
                 } else if (TryGetBlockBorderLonghand(name, out side, out string component)) {
                     ApplyBlockBorderLonghand(sideBorders, side, component, value);
                 }
@@ -73,7 +90,9 @@ namespace OfficeIMO.Word.Html {
 
             if (!string.IsNullOrEmpty(background)) {
                 foreach (WordParagraph paragraph in paragraphs) {
-                    paragraph.ShadingFillColorHex = background!;
+                    if (string.IsNullOrEmpty(paragraph.ShadingFillColorHex)) {
+                        paragraph.ShadingFillColorHex = background!;
+                    }
                 }
             }
 
@@ -121,18 +140,18 @@ namespace OfficeIMO.Word.Html {
         }
 
         private static BlockBorder? GetBlockBorder(
-            IReadOnlyDictionary<BlockBorderSide, BlockBorder> sideBorders,
+            IReadOnlyDictionary<BlockBorderSide, BlockBorderState> sideBorders,
             BlockBorderSide side) =>
-            sideBorders.TryGetValue(side, out BlockBorder border) ? border : null;
+            sideBorders.TryGetValue(side, out BlockBorderState border) ? border.Materialize() : null;
 
         private static void ApplyBlockBorderLonghand(
-            IDictionary<BlockBorderSide, BlockBorder> sideBorders,
+            IDictionary<BlockBorderSide, BlockBorderState> sideBorders,
             BlockBorderSide side,
             string component,
             string value) {
-            BlockBorder border = sideBorders.TryGetValue(side, out BlockBorder existing)
+            BlockBorderState border = sideBorders.TryGetValue(side, out BlockBorderState existing)
                 ? existing
-                : new BlockBorder(BorderValues.Single, 4U, SixColor.Black);
+                : default;
             switch (component) {
                 case "style":
                     if (!TryParseBlockBorderStyle(value, out BorderValues style)) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockFrames.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockFrames.cs
@@ -1,6 +1,7 @@
 using AngleSharp.Dom;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Wordprocessing;
+using System.Globalization;
 using SixColor = OfficeIMO.Drawing.OfficeColor;
 
 namespace OfficeIMO.Word.Html {
@@ -36,7 +37,9 @@ namespace OfficeIMO.Word.Html {
             internal SixColor? Color { get; set; }
 
             internal BlockBorder? Materialize() =>
-                Style.HasValue && Style.Value != BorderValues.None
+                Style.HasValue &&
+                Style.Value != BorderValues.None &&
+                (Size == null || Size.Value > 0)
                     ? new BlockBorder(Style.Value, Size ?? 4U, Color)
                     : null;
         }
@@ -117,7 +120,7 @@ namespace OfficeIMO.Word.Html {
                             }
                         }
                     } else if (name == "border" &&
-                               TryParseBorder(
+                               TryParseBlockBorder(
                                    value,
                                    out var borderStyle,
                                    out var borderSize,
@@ -133,7 +136,7 @@ namespace OfficeIMO.Word.Html {
                         sideBorders[BlockBorderSide.Top] = border;
                         sideBorders[BlockBorderSide.Bottom] = border;
                     } else if (TryGetBlockBorderSide(name, out BlockBorderSide side) &&
-                               TryParseBorder(
+                               TryParseBlockBorder(
                                    value,
                                    out var sideStyle,
                                    out var sideSize,
@@ -245,7 +248,7 @@ namespace OfficeIMO.Word.Html {
                     border.Style = style;
                     break;
                 case "width":
-                    if (!TryParseBorderWidth(value, out UInt32Value size)) {
+                    if (!TryParseBlockBorderWidth(value, out UInt32Value size)) {
                         return;
                     }
                     border.Size = size;
@@ -261,6 +264,75 @@ namespace OfficeIMO.Word.Html {
                     return;
             }
             sideBorders[side] = border;
+        }
+
+        private static bool TryParseBlockBorder(
+            string value,
+            out BorderValues style,
+            out UInt32Value size,
+            out SixColor color,
+            out bool hasExplicitStyle,
+            out bool hasExplicitColor) {
+            string[] tokens = SplitBorderTokens(value).ToArray();
+            string normalized = string.Join(
+                " ",
+                tokens.Select(token => token.Trim() == "0" ? "0px" : token));
+            if (!TryParseBorder(
+                    normalized,
+                    out style,
+                    out size,
+                    out color,
+                    out hasExplicitStyle,
+                    out hasExplicitColor)) {
+                return false;
+            }
+
+            foreach (string token in tokens) {
+                if (!TryParseRawBlockBorderWidth(token, out double width)) {
+                    continue;
+                }
+                if (width < 0) {
+                    return false;
+                }
+                if (width == 0) {
+                    size = 0U;
+                }
+            }
+
+            return true;
+        }
+
+        private static bool TryParseBlockBorderWidth(string value, out UInt32Value size) {
+            if (!TryParseRawBlockBorderWidth(value, out double width) || width < 0) {
+                size = 0U;
+                return false;
+            }
+            if (width == 0) {
+                size = 0U;
+                return true;
+            }
+
+            return TryParseBorderWidth(value, out size);
+        }
+
+        private static bool TryParseRawBlockBorderWidth(string value, out double width) {
+            string normalized = value.Trim().ToLowerInvariant();
+            if (normalized == "0") {
+                width = 0;
+                return true;
+            }
+
+            if (normalized.EndsWith("px", StringComparison.Ordinal) ||
+                normalized.EndsWith("pt", StringComparison.Ordinal)) {
+                return double.TryParse(
+                    normalized.Substring(0, normalized.Length - 2),
+                    NumberStyles.Float,
+                    CultureInfo.InvariantCulture,
+                    out width);
+            }
+
+            width = 0;
+            return false;
         }
 
         private static bool TryParseBlockBorderStyle(string value, out BorderValues style) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockFrames.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockFrames.cs
@@ -626,7 +626,7 @@ namespace OfficeIMO.Word.Html {
             WordParagraph paragraph,
             BlockBorderSide side,
             BlockBorder? border) {
-            if (!border.HasValue) {
+            if (!border.HasValue || HasParagraphBorder(paragraph, side)) {
                 return;
             }
 
@@ -655,6 +655,15 @@ namespace OfficeIMO.Word.Html {
                     break;
             }
         }
+
+        private static bool HasParagraphBorder(WordParagraph paragraph, BlockBorderSide side) =>
+            side switch {
+                BlockBorderSide.Left => paragraph.Borders.LeftStyle.HasValue,
+                BlockBorderSide.Right => paragraph.Borders.RightStyle.HasValue,
+                BlockBorderSide.Top => paragraph.Borders.TopStyle.HasValue,
+                BlockBorderSide.Bottom => paragraph.Borders.BottomStyle.HasValue,
+                _ => false,
+            };
 
         private static string ResolveParagraphTextColor(WordParagraph paragraph) {
             string? normalized = NormalizeColor(paragraph.ColorHex);

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockFrames.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockFrames.cs
@@ -221,14 +221,31 @@ namespace OfficeIMO.Word.Html {
             IElement element,
             IReadOnlyList<WordParagraph> paragraphs,
             IReadOnlyList<WordTable> tables) {
-            ApplyContainerFrameFromCss(element, paragraphs, applyContainerSpacing: false);
+            OpenXmlElement? first = GetGeneratedBlockBoundary(paragraphs, tables, first: true);
+            OpenXmlElement? last = GetGeneratedBlockBoundary(paragraphs, tables, first: false);
+            ApplyBlockFrameFromCss(
+                element,
+                paragraphs,
+                applyContainerSpacing: false,
+                applyTopBorder: paragraphs.Any(
+                    paragraph => ReferenceEquals(paragraph._paragraph, first)),
+                applyBottomBorder: paragraphs.Any(
+                    paragraph => ReferenceEquals(paragraph._paragraph, last)));
             foreach (WordTable table in tables) {
-                ApplyTableContainerFrameFromCss(element, table);
+                ApplyTableContainerFrameFromCss(
+                    element,
+                    table,
+                    applyTopBorder: ReferenceEquals(table._table, first),
+                    applyBottomBorder: ReferenceEquals(table._table, last));
             }
             ApplyContainerSpacingFromCss(element, paragraphs, tables);
         }
 
-        private static void ApplyTableContainerFrameFromCss(IElement element, WordTable table) {
+        private static void ApplyTableContainerFrameFromCss(
+            IElement element,
+            WordTable table,
+            bool applyTopBorder = true,
+            bool applyBottomBorder = true) {
             List<WordTableRow> rows = table.Rows;
             if (rows.Count == 0) {
                 return;
@@ -249,11 +266,15 @@ namespace OfficeIMO.Word.Html {
             BlockBorder? bottom = GetBlockBorder(sideBorders, BlockBorderSide.Bottom);
             string fallbackColor = ResolveElementTextColor(element);
 
-            foreach (WordTableCell cell in rows[0].Cells) {
-                ApplyTableCellBorder(cell, BlockBorderSide.Top, top, fallbackColor);
+            if (applyTopBorder) {
+                foreach (WordTableCell cell in rows[0].Cells) {
+                    ApplyTableCellBorder(cell, BlockBorderSide.Top, top, fallbackColor);
+                }
             }
-            foreach (WordTableCell cell in rows[rows.Count - 1].Cells) {
-                ApplyTableCellBorder(cell, BlockBorderSide.Bottom, bottom, fallbackColor);
+            if (applyBottomBorder) {
+                foreach (WordTableCell cell in rows[rows.Count - 1].Cells) {
+                    ApplyTableCellBorder(cell, BlockBorderSide.Bottom, bottom, fallbackColor);
+                }
             }
             foreach (WordTableRow row in rows) {
                 List<WordTableCell> cells = row.Cells;
@@ -319,7 +340,9 @@ namespace OfficeIMO.Word.Html {
         private static void ApplyBlockFrameFromCss(
             IElement element,
             IReadOnlyList<WordParagraph> paragraphs,
-            bool applyContainerSpacing) {
+            bool applyContainerSpacing,
+            bool applyTopBorder = true,
+            bool applyBottomBorder = true) {
             string? styleText = element.GetAttribute("style");
             if (string.IsNullOrWhiteSpace(styleText) || paragraphs.Count == 0) {
                 return;
@@ -345,10 +368,10 @@ namespace OfficeIMO.Word.Html {
                 WordParagraph paragraph = paragraphs[index];
                 ApplyParagraphBorder(paragraph, BlockBorderSide.Left, left, fallbackColor);
                 ApplyParagraphBorder(paragraph, BlockBorderSide.Right, right, fallbackColor);
-                if (index == 0) {
+                if (index == 0 && applyTopBorder) {
                     ApplyParagraphBorder(paragraph, BlockBorderSide.Top, top, fallbackColor);
                 }
-                if (index == paragraphs.Count - 1) {
+                if (index == paragraphs.Count - 1 && applyBottomBorder) {
                     ApplyParagraphBorder(paragraph, BlockBorderSide.Bottom, bottom, fallbackColor);
                 }
             }

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockFrames.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockFrames.cs
@@ -244,7 +244,7 @@ namespace OfficeIMO.Word.Html {
             ApplyContainerSpacingFromCss(element, paragraphs, tables);
         }
 
-        private static void ApplyTableContainerFrameFromCss(
+        private void ApplyTableContainerFrameFromCss(
             IElement element,
             WordTable table,
             bool applyTopBorder = true,
@@ -333,11 +333,32 @@ namespace OfficeIMO.Word.Html {
                 _ => false,
             };
 
-        private static string ResolveElementTextColor(IElement element) {
-            string styleText = element.GetAttribute("style") ?? string.Empty;
-            var declaration = ParseInlineDeclaration(styleText);
-            return NormalizeColor(GetInlinePropertyValue(declaration, styleText, "color")) ??
-                   SixColor.Black.ToRgbHex();
+        private string ResolveElementTextColor(IElement element) {
+            for (IElement? current = element; current != null; current = current.ParentElement) {
+                var declarations = CollectCssDeclarations(current, inheritedOnly: false);
+                if (!declarations.TryGetValue("color", out var declaration)) {
+                    continue;
+                }
+
+                string value = declaration.Value.Trim();
+                if (value.Equals("inherit", StringComparison.OrdinalIgnoreCase) ||
+                    value.Equals("unset", StringComparison.OrdinalIgnoreCase) ||
+                    value.Equals("currentcolor", StringComparison.OrdinalIgnoreCase)) {
+                    continue;
+                }
+                if (value.Equals("initial", StringComparison.OrdinalIgnoreCase) ||
+                    value.Equals("revert", StringComparison.OrdinalIgnoreCase) ||
+                    value.Equals("revert-layer", StringComparison.OrdinalIgnoreCase)) {
+                    return SixColor.Black.ToRgbHex();
+                }
+
+                string? normalized = NormalizeColor(value);
+                if (normalized != null) {
+                    return normalized;
+                }
+            }
+
+            return SixColor.Black.ToRgbHex();
         }
 
         private void ApplyBlockFrameFromCss(

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockFrames.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockFrames.cs
@@ -64,30 +64,35 @@ namespace OfficeIMO.Word.Html {
 
             string? background = null;
             var sideBorders = new Dictionary<BlockBorderSide, BlockBorderState>();
-            foreach (string part in styleText!.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)) {
-                string[] pieces = part.Split(new[] { ':' }, 2);
-                if (pieces.Length != 2) {
-                    continue;
-                }
+            for (int priorityPass = 0; priorityPass < 2; priorityPass++) {
+                bool important = priorityPass == 1;
+                foreach (string part in styleText!.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)) {
+                    if (!CssStyleMapper.TryParseDeclaration(
+                            part,
+                            out string name,
+                            out string value,
+                            out bool declarationIsImportant) ||
+                        declarationIsImportant != important) {
+                        continue;
+                    }
 
-                string name = pieces[0].Trim().ToLowerInvariant();
-                string value = pieces[1].Trim();
-                if (name == "background-color") {
-                    background = NormalizeColor(value);
-                } else if (name == "border" &&
-                           TryParseBorder(value, out var borderStyle, out var borderSize, out var borderColor, out bool hasBorderStyle) &&
-                           hasBorderStyle) {
-                    var border = new BlockBorderState(borderStyle, borderSize, borderColor);
-                    sideBorders[BlockBorderSide.Left] = border;
-                    sideBorders[BlockBorderSide.Right] = border;
-                    sideBorders[BlockBorderSide.Top] = border;
-                    sideBorders[BlockBorderSide.Bottom] = border;
-                } else if (TryGetBlockBorderSide(name, out BlockBorderSide side) &&
-                           TryParseBorder(value, out var sideStyle, out var sideSize, out var sideColor, out bool hasSideStyle) &&
-                           hasSideStyle) {
-                    sideBorders[side] = new BlockBorderState(sideStyle, sideSize, sideColor);
-                } else if (TryGetBlockBorderLonghand(name, out side, out string component)) {
-                    ApplyBlockBorderLonghand(sideBorders, side, component, value);
+                    if (name == "background-color") {
+                        background = NormalizeColor(value);
+                    } else if (name == "border" &&
+                               TryParseBorder(value, out var borderStyle, out var borderSize, out var borderColor, out bool hasBorderStyle) &&
+                               hasBorderStyle) {
+                        var border = new BlockBorderState(borderStyle, borderSize, borderColor);
+                        sideBorders[BlockBorderSide.Left] = border;
+                        sideBorders[BlockBorderSide.Right] = border;
+                        sideBorders[BlockBorderSide.Top] = border;
+                        sideBorders[BlockBorderSide.Bottom] = border;
+                    } else if (TryGetBlockBorderSide(name, out BlockBorderSide side) &&
+                               TryParseBorder(value, out var sideStyle, out var sideSize, out var sideColor, out bool hasSideStyle) &&
+                               hasSideStyle) {
+                        sideBorders[side] = new BlockBorderState(sideStyle, sideSize, sideColor);
+                    } else if (TryGetBlockBorderLonghand(name, out side, out string component)) {
+                        ApplyBlockBorderLonghand(sideBorders, side, component, value);
+                    }
                 }
             }
 

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockFrames.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockFrames.cs
@@ -221,10 +221,11 @@ namespace OfficeIMO.Word.Html {
             IElement element,
             IReadOnlyList<WordParagraph> paragraphs,
             IReadOnlyList<WordTable> tables) {
-            ApplyContainerFrameFromCss(element, paragraphs);
+            ApplyContainerFrameFromCss(element, paragraphs, applyContainerSpacing: false);
             foreach (WordTable table in tables) {
                 ApplyTableContainerFrameFromCss(element, table);
             }
+            ApplyContainerSpacingFromCss(element, paragraphs, tables);
         }
 
         private static void ApplyTableContainerFrameFromCss(IElement element, WordTable table) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockFrames.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockFrames.cs
@@ -1,0 +1,279 @@
+using AngleSharp.Dom;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Wordprocessing;
+using SixColor = OfficeIMO.Drawing.OfficeColor;
+
+namespace OfficeIMO.Word.Html {
+    internal partial class HtmlToWordConverter {
+        private enum BlockBorderSide {
+            Left,
+            Right,
+            Top,
+            Bottom
+        }
+
+        private struct BlockBorder {
+            internal BlockBorder(BorderValues style, UInt32Value size, SixColor color) {
+                Style = style;
+                Size = size;
+                Color = color;
+            }
+
+            internal BorderValues Style { get; set; }
+            internal UInt32Value Size { get; set; }
+            internal SixColor Color { get; set; }
+        }
+
+        private static void ApplyParagraphFrameFromCss(WordParagraph paragraph, IElement element) {
+            ApplyBlockFrameFromCss(element, new[] { paragraph }, applyContainerSpacing: false);
+        }
+
+        private static void ApplyContainerFrameFromCss(IElement element, IReadOnlyList<WordParagraph> paragraphs) {
+            if (paragraphs.Count == 0) {
+                return;
+            }
+
+            ApplyBlockFrameFromCss(element, paragraphs, applyContainerSpacing: true);
+        }
+
+        private static void ApplyBlockFrameFromCss(
+            IElement element,
+            IReadOnlyList<WordParagraph> paragraphs,
+            bool applyContainerSpacing) {
+            string? styleText = element.GetAttribute("style");
+            if (string.IsNullOrWhiteSpace(styleText) || paragraphs.Count == 0) {
+                return;
+            }
+
+            string? background = null;
+            var sideBorders = new Dictionary<BlockBorderSide, BlockBorder>();
+            foreach (string part in styleText!.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)) {
+                string[] pieces = part.Split(new[] { ':' }, 2);
+                if (pieces.Length != 2) {
+                    continue;
+                }
+
+                string name = pieces[0].Trim().ToLowerInvariant();
+                string value = pieces[1].Trim();
+                if (name == "background-color") {
+                    background = NormalizeColor(value);
+                } else if (name == "border" && TryParseBorder(value, out var borderStyle, out var borderSize, out var borderColor)) {
+                    var border = new BlockBorder(borderStyle, borderSize, borderColor);
+                    sideBorders[BlockBorderSide.Left] = border;
+                    sideBorders[BlockBorderSide.Right] = border;
+                    sideBorders[BlockBorderSide.Top] = border;
+                    sideBorders[BlockBorderSide.Bottom] = border;
+                } else if (TryGetBlockBorderSide(name, out BlockBorderSide side) &&
+                           TryParseBorder(value, out var sideStyle, out var sideSize, out var sideColor)) {
+                    sideBorders[side] = new BlockBorder(sideStyle, sideSize, sideColor);
+                } else if (TryGetBlockBorderLonghand(name, out side, out string component)) {
+                    ApplyBlockBorderLonghand(sideBorders, side, component, value);
+                }
+            }
+
+            if (!string.IsNullOrEmpty(background)) {
+                foreach (WordParagraph paragraph in paragraphs) {
+                    paragraph.ShadingFillColorHex = background!;
+                }
+            }
+
+            BlockBorder? left = GetBlockBorder(sideBorders, BlockBorderSide.Left);
+            BlockBorder? right = GetBlockBorder(sideBorders, BlockBorderSide.Right);
+            BlockBorder? top = GetBlockBorder(sideBorders, BlockBorderSide.Top);
+            BlockBorder? bottom = GetBlockBorder(sideBorders, BlockBorderSide.Bottom);
+            for (int index = 0; index < paragraphs.Count; index++) {
+                WordParagraph paragraph = paragraphs[index];
+                ApplyParagraphBorder(paragraph, BlockBorderSide.Left, left);
+                ApplyParagraphBorder(paragraph, BlockBorderSide.Right, right);
+                if (index == 0) {
+                    ApplyParagraphBorder(paragraph, BlockBorderSide.Top, top);
+                }
+                if (index == paragraphs.Count - 1) {
+                    ApplyParagraphBorder(paragraph, BlockBorderSide.Bottom, bottom);
+                }
+            }
+
+            if (!applyContainerSpacing) {
+                return;
+            }
+
+            CssStyleMapper.CssProperties box = CssStyleMapper.ParseStyles(styleText, GetBidiFromDir(element) == true);
+            int horizontalStart = (box.MarginLeft ?? 0) + (box.PaddingLeft ?? 0);
+            int horizontalEnd = (box.MarginRight ?? 0) + (box.PaddingRight ?? 0);
+            foreach (WordParagraph paragraph in paragraphs) {
+                if (horizontalStart != 0) {
+                    paragraph.IndentationBefore = (paragraph.IndentationBefore ?? 0) + horizontalStart;
+                }
+                if (horizontalEnd != 0) {
+                    paragraph.IndentationAfter = (paragraph.IndentationAfter ?? 0) + horizontalEnd;
+                }
+            }
+
+            int verticalStart = (box.MarginTop ?? 0) + (box.PaddingTop ?? 0);
+            if (verticalStart != 0) {
+                paragraphs[0].LineSpacingBefore = (paragraphs[0].LineSpacingBefore ?? 0) + verticalStart;
+            }
+            int verticalEnd = (box.MarginBottom ?? 0) + (box.PaddingBottom ?? 0);
+            if (verticalEnd != 0) {
+                WordParagraph last = paragraphs[paragraphs.Count - 1];
+                last.LineSpacingAfter = (last.LineSpacingAfter ?? 0) + verticalEnd;
+            }
+        }
+
+        private static BlockBorder? GetBlockBorder(
+            IReadOnlyDictionary<BlockBorderSide, BlockBorder> sideBorders,
+            BlockBorderSide side) =>
+            sideBorders.TryGetValue(side, out BlockBorder border) ? border : null;
+
+        private static void ApplyBlockBorderLonghand(
+            IDictionary<BlockBorderSide, BlockBorder> sideBorders,
+            BlockBorderSide side,
+            string component,
+            string value) {
+            BlockBorder border = sideBorders.TryGetValue(side, out BlockBorder existing)
+                ? existing
+                : new BlockBorder(BorderValues.Single, 4U, SixColor.Black);
+            switch (component) {
+                case "style":
+                    if (!TryParseBlockBorderStyle(value, out BorderValues style)) {
+                        return;
+                    }
+                    border.Style = style;
+                    break;
+                case "width":
+                    if (!TryParseBorderWidth(value, out UInt32Value size)) {
+                        return;
+                    }
+                    border.Size = size;
+                    break;
+                case "color":
+                    string? color = NormalizeColor(value);
+                    if (color == null) {
+                        return;
+                    }
+                    border.Color = SixColor.Parse("#" + color);
+                    break;
+                default:
+                    return;
+            }
+            sideBorders[side] = border;
+        }
+
+        private static bool TryParseBlockBorderStyle(string value, out BorderValues style) {
+            switch (value.Trim().ToLowerInvariant()) {
+                case "solid":
+                    style = BorderValues.Single;
+                    return true;
+                case "dotted":
+                    style = BorderValues.Dotted;
+                    return true;
+                case "dashed":
+                    style = BorderValues.Dashed;
+                    return true;
+                case "double":
+                    style = BorderValues.Double;
+                    return true;
+                case "none":
+                    style = BorderValues.None;
+                    return true;
+                default:
+                    style = BorderValues.Single;
+                    return false;
+            }
+        }
+
+        private static bool TryGetBlockBorderLonghand(
+            string propertyName,
+            out BlockBorderSide side,
+            out string component) {
+            string[] pieces = propertyName.Split('-');
+            if (pieces.Length == 3 &&
+                pieces[0].Equals("border", StringComparison.OrdinalIgnoreCase) &&
+                TryParseBlockBorderSide(pieces[1], out side) &&
+                (pieces[2].Equals("style", StringComparison.OrdinalIgnoreCase) ||
+                 pieces[2].Equals("width", StringComparison.OrdinalIgnoreCase) ||
+                 pieces[2].Equals("color", StringComparison.OrdinalIgnoreCase))) {
+                component = pieces[2].ToLowerInvariant();
+                return true;
+            }
+
+            side = default;
+            component = string.Empty;
+            return false;
+        }
+
+        private static bool TryParseBlockBorderSide(string value, out BlockBorderSide side) {
+            switch (value.ToLowerInvariant()) {
+                case "left":
+                    side = BlockBorderSide.Left;
+                    return true;
+                case "right":
+                    side = BlockBorderSide.Right;
+                    return true;
+                case "top":
+                    side = BlockBorderSide.Top;
+                    return true;
+                case "bottom":
+                    side = BlockBorderSide.Bottom;
+                    return true;
+                default:
+                    side = default;
+                    return false;
+            }
+        }
+
+        private static bool TryGetBlockBorderSide(string propertyName, out BlockBorderSide side) {
+            switch (propertyName) {
+                case "border-left":
+                    side = BlockBorderSide.Left;
+                    return true;
+                case "border-right":
+                    side = BlockBorderSide.Right;
+                    return true;
+                case "border-top":
+                    side = BlockBorderSide.Top;
+                    return true;
+                case "border-bottom":
+                    side = BlockBorderSide.Bottom;
+                    return true;
+                default:
+                    side = default;
+                    return false;
+            }
+        }
+
+        private static void ApplyParagraphBorder(
+            WordParagraph paragraph,
+            BlockBorderSide side,
+            BlockBorder? border) {
+            if (!border.HasValue) {
+                return;
+            }
+
+            BlockBorder value = border.Value;
+            string color = value.Color.ToRgbHex();
+            switch (side) {
+                case BlockBorderSide.Left:
+                    paragraph.Borders.LeftStyle = value.Style;
+                    paragraph.Borders.LeftSize = value.Size;
+                    paragraph.Borders.LeftColorHex = color;
+                    break;
+                case BlockBorderSide.Right:
+                    paragraph.Borders.RightStyle = value.Style;
+                    paragraph.Borders.RightSize = value.Size;
+                    paragraph.Borders.RightColorHex = color;
+                    break;
+                case BlockBorderSide.Top:
+                    paragraph.Borders.TopStyle = value.Style;
+                    paragraph.Borders.TopSize = value.Size;
+                    paragraph.Borders.TopColorHex = color;
+                    break;
+                case BlockBorderSide.Bottom:
+                    paragraph.Borders.BottomStyle = value.Style;
+                    paragraph.Borders.BottomSize = value.Size;
+                    paragraph.Borders.BottomColorHex = color;
+                    break;
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockFrames.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockFrames.cs
@@ -26,17 +26,24 @@ namespace OfficeIMO.Word.Html {
         }
 
         private struct BlockBorderState {
-            internal BlockBorderState(BorderValues style, UInt32Value size, SixColor? color) {
+            internal BlockBorderState(
+                BorderValues style,
+                UInt32Value size,
+                SixColor? color,
+                bool transparentColor = false) {
                 Style = style;
                 Size = size;
                 Color = color;
+                TransparentColor = transparentColor;
             }
 
             internal BorderValues? Style { get; set; }
             internal UInt32Value? Size { get; set; }
             internal SixColor? Color { get; set; }
+            internal bool TransparentColor { get; set; }
 
             internal BlockBorder? Materialize() =>
+                !TransparentColor &&
                 Style.HasValue &&
                 Style.Value != BorderValues.None &&
                 (Size == null || Size.Value > 0)
@@ -76,7 +83,9 @@ namespace OfficeIMO.Word.Html {
             }
 
             CssStyleMapper.CssProperties box = ParseElementBoxStyles(element);
-            if ((box.PaddingTop ?? 0) != 0 ||
+            if ((box.MarginTop ?? 0) != 0 ||
+                (box.MarginBottom ?? 0) != 0 ||
+                (box.PaddingTop ?? 0) != 0 ||
                 (box.PaddingRight ?? 0) != 0 ||
                 (box.PaddingBottom ?? 0) != 0 ||
                 (box.PaddingLeft ?? 0) != 0) {
@@ -124,7 +133,7 @@ namespace OfficeIMO.Word.Html {
             IReadOnlyDictionary<BlockBorderSide, BlockBorderState> inheritedBorders,
             out string? background,
             out Dictionary<BlockBorderSide, BlockBorderState> sideBorders) {
-            background = null;
+            background = ResolveBlockBackground(styleText, inheritedBackground);
             sideBorders = new Dictionary<BlockBorderSide, BlockBorderState>();
             for (int priorityPass = 0; priorityPass < 2; priorityPass++) {
                 bool important = priorityPass == 1;
@@ -139,24 +148,7 @@ namespace OfficeIMO.Word.Html {
                     }
 
                     if (name == "background-color") {
-                        if (IsCssInheritanceValue(value)) {
-                            background = inheritedBackground;
-                        } else if (IsCssWideResetValue(value) ||
-                                   value.Equals("transparent", StringComparison.OrdinalIgnoreCase)) {
-                            background = null;
-                        } else {
-                            CssStyleMapper.CssProperties parsedBackground =
-                                CssStyleMapper.ParseStyles("background-color:" + value);
-                            if (!string.IsNullOrEmpty(parsedBackground.BackgroundColor)) {
-                                double alpha = parsedBackground.BackgroundColorAlpha ?? 1d;
-                                background = alpha <= 0d
-                                    ? null
-                                    : ResolveOpaqueTextBackground(
-                                        parsedBackground.BackgroundColor!,
-                                        alpha,
-                                        inheritedBackground);
-                            }
-                        }
+                        continue;
                     } else if (name == "border" && IsCssInheritanceValue(value)) {
                         CopyAllBlockBorders(inheritedBorders, sideBorders);
                     } else if (name == "border" && IsCssWideResetValue(value)) {
@@ -168,11 +160,14 @@ namespace OfficeIMO.Word.Html {
                                    out var borderSize,
                                    out var borderColor,
                                    out bool hasBorderStyle,
-                                   out bool hasBorderColor)) {
+                                   out bool hasBorderColor,
+                                   out bool hasTransparentBorderColor,
+                                   background ?? inheritedBackground)) {
                         var border = new BlockBorderState(
                             hasBorderStyle ? borderStyle : BorderValues.None,
                             borderSize,
-                            hasBorderColor ? borderColor : null);
+                            hasBorderColor ? borderColor : null,
+                            hasTransparentBorderColor);
                         sideBorders[BlockBorderSide.Left] = border;
                         sideBorders[BlockBorderSide.Right] = border;
                         sideBorders[BlockBorderSide.Top] = border;
@@ -190,18 +185,22 @@ namespace OfficeIMO.Word.Html {
                                    out var sideSize,
                                    out var sideColor,
                                    out bool hasSideStyle,
-                                   out bool hasSideColor)) {
+                                   out bool hasSideColor,
+                                   out bool hasTransparentSideColor,
+                                   background ?? inheritedBackground)) {
                         sideBorders[side] = new BlockBorderState(
                             hasSideStyle ? sideStyle : BorderValues.None,
                             sideSize,
-                            hasSideColor ? sideColor : null);
+                            hasSideColor ? sideColor : null,
+                            hasTransparentSideColor);
                     } else if (TryGetBlockBorderLonghand(name, out side, out string component)) {
                         ApplyBlockBorderLonghand(
                             sideBorders,
                             inheritedBorders,
                             side,
                             component,
-                            value);
+                            value,
+                            background ?? inheritedBackground);
                     }
                 }
             }
@@ -270,7 +269,7 @@ namespace OfficeIMO.Word.Html {
             BlockBorderSide side,
             BlockBorder? border,
             string fallbackColor) {
-            if (!border.HasValue) {
+            if (!border.HasValue || HasTableCellBorder(cell, side)) {
                 return;
             }
 
@@ -299,6 +298,15 @@ namespace OfficeIMO.Word.Html {
                     break;
             }
         }
+
+        private static bool HasTableCellBorder(WordTableCell cell, BlockBorderSide side) =>
+            side switch {
+                BlockBorderSide.Left => cell.Borders.LeftStyle.HasValue,
+                BlockBorderSide.Right => cell.Borders.RightStyle.HasValue,
+                BlockBorderSide.Top => cell.Borders.TopStyle.HasValue,
+                BlockBorderSide.Bottom => cell.Borders.BottomStyle.HasValue,
+                _ => false,
+            };
 
         private static string ResolveElementTextColor(IElement element) {
             string styleText = element.GetAttribute("style") ?? string.Empty;
@@ -392,7 +400,8 @@ namespace OfficeIMO.Word.Html {
             IReadOnlyDictionary<BlockBorderSide, BlockBorderState> inheritedBorders,
             BlockBorderSide side,
             string component,
-            string value) {
+            string value,
+            string? backdrop) {
             BlockBorderState border = sideBorders.TryGetValue(side, out BlockBorderState existing)
                 ? existing
                 : default;
@@ -409,6 +418,7 @@ namespace OfficeIMO.Word.Html {
                         break;
                     case "color":
                         border.Color = inherited.Color;
+                        border.TransparentColor = inherited.TransparentColor;
                         break;
                     default:
                         return;
@@ -426,6 +436,7 @@ namespace OfficeIMO.Word.Html {
                         break;
                     case "color":
                         border.Color = null;
+                        border.TransparentColor = false;
                         break;
                     default:
                         return;
@@ -447,11 +458,15 @@ namespace OfficeIMO.Word.Html {
                     border.Size = size;
                     break;
                 case "color":
-                    string? color = NormalizeColor(value);
-                    if (color == null) {
+                    if (!TryResolveBlockBorderColor(
+                            value,
+                            backdrop,
+                            out SixColor color,
+                            out bool transparentColor)) {
                         return;
                     }
-                    border.Color = SixColor.Parse("#" + color);
+                    border.Color = transparentColor ? null : color;
+                    border.TransparentColor = transparentColor;
                     break;
                 default:
                     return;
@@ -496,7 +511,10 @@ namespace OfficeIMO.Word.Html {
             out UInt32Value size,
             out SixColor color,
             out bool hasExplicitStyle,
-            out bool hasExplicitColor) {
+            out bool hasExplicitColor,
+            out bool hasTransparentColor,
+            string? backdrop) {
+            hasTransparentColor = false;
             string[] tokens = SplitBorderTokens(value).ToArray();
             string normalized = string.Join(
                 " ",
@@ -513,13 +531,23 @@ namespace OfficeIMO.Word.Html {
 
             foreach (string token in tokens) {
                 if (!TryParseRawBlockBorderWidth(token, out double width)) {
-                    continue;
-                }
-                if (width < 0) {
-                    return false;
-                }
-                if (width == 0) {
-                    size = 0U;
+                    if (hasExplicitColor &&
+                        !TryParseBlockBorderStyle(token, out _) &&
+                        TryResolveBlockBorderColor(
+                            token,
+                            backdrop,
+                            out SixColor resolvedColor,
+                            out bool transparentColor)) {
+                        color = resolvedColor;
+                        hasTransparentColor = transparentColor;
+                    }
+                } else {
+                    if (width < 0) {
+                        return false;
+                    }
+                    if (width == 0) {
+                        size = 0U;
+                    }
                 }
             }
 

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockFrames.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockFrames.cs
@@ -74,14 +74,17 @@ namespace OfficeIMO.Word.Html {
                 string value = pieces[1].Trim();
                 if (name == "background-color") {
                     background = NormalizeColor(value);
-                } else if (name == "border" && TryParseBorder(value, out var borderStyle, out var borderSize, out var borderColor)) {
+                } else if (name == "border" &&
+                           TryParseBorder(value, out var borderStyle, out var borderSize, out var borderColor, out bool hasBorderStyle) &&
+                           hasBorderStyle) {
                     var border = new BlockBorderState(borderStyle, borderSize, borderColor);
                     sideBorders[BlockBorderSide.Left] = border;
                     sideBorders[BlockBorderSide.Right] = border;
                     sideBorders[BlockBorderSide.Top] = border;
                     sideBorders[BlockBorderSide.Bottom] = border;
                 } else if (TryGetBlockBorderSide(name, out BlockBorderSide side) &&
-                           TryParseBorder(value, out var sideStyle, out var sideSize, out var sideColor)) {
+                           TryParseBorder(value, out var sideStyle, out var sideSize, out var sideColor, out bool hasSideStyle) &&
+                           hasSideStyle) {
                     sideBorders[side] = new BlockBorderState(sideStyle, sideSize, sideColor);
                 } else if (TryGetBlockBorderLonghand(name, out side, out string component)) {
                     ApplyBlockBorderLonghand(sideBorders, side, component, value);

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockFrames.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockFrames.cs
@@ -45,31 +45,59 @@ namespace OfficeIMO.Word.Html {
             ApplyBlockFrameFromCss(element, new[] { paragraph }, applyContainerSpacing: false);
         }
 
-        private static void ApplyContainerFrameFromCss(
-            IElement element,
-            IReadOnlyList<WordParagraph> paragraphs,
-            bool applyContainerSpacing = true) {
-            if (paragraphs.Count == 0) {
-                return;
+        private static CssStyleMapper.CssProperties ParseElementBoxStyles(IElement element) {
+            var lineage = new Stack<IElement>();
+            for (IElement? current = element; current != null; current = current.ParentElement) {
+                lineage.Push(current);
             }
 
-            ApplyBlockFrameFromCss(element, paragraphs, applyContainerSpacing);
+            CssStyleMapper.CssProperties? inheritedBox = null;
+            bool inheritedRightToLeft = false;
+            while (lineage.Count > 0) {
+                IElement current = lineage.Pop();
+                bool rightToLeft = GetBidiFromDir(current) == true;
+                inheritedBox = CssStyleMapper.ParseStyles(
+                    current.GetAttribute("style"),
+                    rightToLeft,
+                    inheritedBox,
+                    inheritedRightToLeft);
+                inheritedRightToLeft = rightToLeft;
+            }
+
+            return inheritedBox ?? new CssStyleMapper.CssProperties();
         }
 
-        private static void ApplyBlockFrameFromCss(
-            IElement element,
-            IReadOnlyList<WordParagraph> paragraphs,
-            bool applyContainerSpacing) {
-            string? styleText = element.GetAttribute("style");
-            if (string.IsNullOrWhiteSpace(styleText) || paragraphs.Count == 0) {
-                return;
+        private static bool RequiresEmptyBlockParagraph(IElement element) {
+            if (StyleRequestsPageBreakBefore(element) || StyleRequestsPageBreakAfter(element)) {
+                return true;
             }
 
-            string? background = null;
-            var sideBorders = new Dictionary<BlockBorderSide, BlockBorderState>();
+            CssStyleMapper.CssProperties box = ParseElementBoxStyles(element);
+            if ((box.PaddingTop ?? 0) != 0 ||
+                (box.PaddingRight ?? 0) != 0 ||
+                (box.PaddingBottom ?? 0) != 0 ||
+                (box.PaddingLeft ?? 0) != 0) {
+                return true;
+            }
+
+            string? styleText = element.GetAttribute("style");
+            if (string.IsNullOrWhiteSpace(styleText)) {
+                return false;
+            }
+
+            ParseBlockFrameStyles(styleText!, out string? background, out var sideBorders);
+            return background != null || sideBorders.Values.Any(border => border.Materialize().HasValue);
+        }
+
+        private static void ParseBlockFrameStyles(
+            string styleText,
+            out string? background,
+            out Dictionary<BlockBorderSide, BlockBorderState> sideBorders) {
+            background = null;
+            sideBorders = new Dictionary<BlockBorderSide, BlockBorderState>();
             for (int priorityPass = 0; priorityPass < 2; priorityPass++) {
                 bool important = priorityPass == 1;
-                foreach (string part in styleText!.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)) {
+                foreach (string part in styleText.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)) {
                     if (!CssStyleMapper.TryParseDeclaration(
                             part,
                             out string name,
@@ -121,6 +149,29 @@ namespace OfficeIMO.Word.Html {
                     }
                 }
             }
+        }
+
+        private static void ApplyContainerFrameFromCss(
+            IElement element,
+            IReadOnlyList<WordParagraph> paragraphs,
+            bool applyContainerSpacing = true) {
+            if (paragraphs.Count == 0) {
+                return;
+            }
+
+            ApplyBlockFrameFromCss(element, paragraphs, applyContainerSpacing);
+        }
+
+        private static void ApplyBlockFrameFromCss(
+            IElement element,
+            IReadOnlyList<WordParagraph> paragraphs,
+            bool applyContainerSpacing) {
+            string? styleText = element.GetAttribute("style");
+            if (string.IsNullOrWhiteSpace(styleText) || paragraphs.Count == 0) {
+                return;
+            }
+
+            ParseBlockFrameStyles(styleText!, out string? background, out var sideBorders);
 
             if (!string.IsNullOrEmpty(background)) {
                 foreach (WordParagraph paragraph in paragraphs) {
@@ -150,7 +201,7 @@ namespace OfficeIMO.Word.Html {
                 return;
             }
 
-            CssStyleMapper.CssProperties box = CssStyleMapper.ParseStyles(styleText, GetBidiFromDir(element) == true);
+            CssStyleMapper.CssProperties box = ParseElementBoxStyles(element);
             int horizontalStart = (box.MarginLeft ?? 0) + (box.PaddingLeft ?? 0);
             int horizontalEnd = (box.MarginRight ?? 0) + (box.PaddingRight ?? 0);
             foreach (WordParagraph paragraph in paragraphs) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Code.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Code.cs
@@ -35,7 +35,13 @@ namespace OfficeIMO.Word.Html {
             } else {
                 for (int i = start; i < end; i++) {
                     var line = lines[i];
-                    var paragraph = cell != null ? cell.AddParagraph("", i == start) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
+                    var paragraph = cell != null
+                        ? i == start
+                            ? AddParagraphInScope(section, cell, headerFooter)
+                            : cell.AddParagraph("")
+                        : headerFooter != null
+                            ? headerFooter.AddParagraph("")
+                            : section.AddParagraph("");
                     AddPreformattedLine(element, paragraph, line, mono, ref bookmarkAdded, options);
                 }
             }
@@ -58,7 +64,7 @@ namespace OfficeIMO.Word.Html {
         }
 
         private void ProcessInlineCodeElement(IElement element, WordDocument doc, WordSection section, HtmlToWordOptions options, WordParagraph? currentParagraph, Stack<WordList> listStack, TextFormatting formatting, WordTableCell? cell, WordHeaderFooter? headerFooter, WordList? headingList) {
-            currentParagraph ??= cell != null ? cell.AddParagraph("", true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
+            currentParagraph ??= AddParagraphInScope(section, cell, headerFooter);
 
             var fmt = formatting;
             ApplySpanStyles(element, ref fmt);

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Comments.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Comments.cs
@@ -77,7 +77,7 @@ namespace OfficeIMO.Word.Html {
                 return false;
             }
 
-            currentParagraph ??= cell != null ? cell.AddParagraph("", true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
+            currentParagraph ??= AddParagraphInScope(section, cell, headerFooter);
             if (!currentParagraph.GetRuns().Any()) {
                 currentParagraph.AddText(string.Empty);
             }
@@ -118,7 +118,7 @@ namespace OfficeIMO.Word.Html {
                 return;
             }
 
-            currentParagraph ??= cell != null ? cell.AddParagraph("", true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
+            currentParagraph ??= AddParagraphInScope(section, cell, headerFooter);
             if (!currentParagraph.GetRuns().Any()) {
                 currentParagraph.AddText(string.Empty);
             }

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.ContainerScopes.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.ContainerScopes.cs
@@ -61,6 +61,8 @@ namespace OfficeIMO.Word.Html {
             int paragraphStartIndex,
             int tableStartIndex) {
             List<WordParagraph> paragraphs = GetGeneratedParagraphs(section, cell, headerFooter, paragraphStartIndex);
+            List<WordTable> tables = GetGeneratedTables(section, cell, headerFooter, tableStartIndex);
+            paragraphs.RemoveAll(paragraph => IsGeneratedNestedTableTrailingAnchor(paragraph, tables));
             if (paragraphs.Count == 0 &&
                 currentParagraph != null &&
                 GetParagraphsInScope(section, cell, headerFooter)
@@ -69,13 +71,31 @@ namespace OfficeIMO.Word.Html {
             }
             if (paragraphs.Count == 0 &&
                 currentParagraph == null &&
-                GetGeneratedTables(section, cell, headerFooter, tableStartIndex).Count == 0 &&
+                tables.Count == 0 &&
                 RequiresEmptyBlockParagraph(element)) {
                 AddParagraphInScope(section, cell, headerFooter);
                 paragraphs = GetGeneratedParagraphs(section, cell, headerFooter, paragraphStartIndex);
             }
 
             return paragraphs;
+        }
+
+        private static bool IsGeneratedNestedTableTrailingAnchor(
+            WordParagraph paragraph,
+            IReadOnlyList<WordTable> generatedTables) {
+            if (!string.IsNullOrEmpty(paragraph._paragraph.InnerText) ||
+                paragraph._paragraph.PreviousSibling() is not Table previousTable ||
+                !generatedTables.Any(table => ReferenceEquals(table._table, previousTable))) {
+                return false;
+            }
+
+            ParagraphProperties? properties = paragraph._paragraph.ParagraphProperties;
+            SpacingBetweenLines? spacing = properties?.GetFirstChild<SpacingBetweenLines>();
+            return paragraph._paragraph.ChildElements.All(element => element is ParagraphProperties) &&
+                   properties?.ChildElements.Count == 1 &&
+                   spacing?.Before?.Value == "0" &&
+                   spacing.After?.Value == "0" &&
+                   spacing.Line?.Value == "0";
         }
 
         private static bool ShouldReuseInitialWordSection(IElement element, WordDocument doc, WordSection section) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.ContainerScopes.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.ContainerScopes.cs
@@ -52,7 +52,7 @@ namespace OfficeIMO.Word.Html {
         private static List<WordTable> GetGeneratedTables(WordSection section, WordTableCell? cell, WordHeaderFooter? headerFooter, int startIndex) =>
             GetTablesInScope(section, cell, headerFooter).Skip(startIndex).ToList();
 
-        private static List<WordParagraph> GetMaterializedContainerParagraphs(
+        private List<WordParagraph> GetMaterializedContainerParagraphs(
             IElement element,
             WordSection section,
             WordTableCell? cell,

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.ContainerScopes.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.ContainerScopes.cs
@@ -1,0 +1,112 @@
+using AngleSharp.Dom;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Wordprocessing;
+
+namespace OfficeIMO.Word.Html {
+    internal partial class HtmlToWordConverter {
+        private static WordParagraph AddParagraphInScope(WordSection section, WordTableCell? cell, WordHeaderFooter? headerFooter) {
+            if (cell != null) {
+                var paragraphs = cell.Paragraphs;
+                bool removeExisting = paragraphs.Count == 1 && IsReplaceableEmptyCellParagraph(paragraphs[0]);
+                return cell.AddParagraph("", removeExisting);
+            }
+
+            return headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
+        }
+
+        private static bool IsReplaceableEmptyCellParagraph(WordParagraph paragraph) =>
+            !paragraph._paragraph.ChildElements.Any(IsMeaningfulCellParagraphChild);
+
+        private static bool IsMeaningfulCellParagraphChild(OpenXmlElement child) {
+            if (child is ParagraphProperties properties) {
+                return properties.HasChildren || properties.HasAttributes;
+            }
+
+            if (child is Run run) {
+                return run.ChildElements.Any(runChild =>
+                    runChild is not RunProperties &&
+                    (runChild is not Text text || !string.IsNullOrEmpty(text.Text)));
+            }
+
+            return true;
+        }
+
+        private static List<WordParagraph> GetParagraphsInScope(WordSection section, WordTableCell? cell, WordHeaderFooter? headerFooter) =>
+            cell?.Paragraphs ?? headerFooter?.Paragraphs ?? section.Paragraphs;
+
+        private static int GetGeneratedParagraphStartIndex(WordSection section, WordTableCell? cell, WordHeaderFooter? headerFooter) {
+            List<WordParagraph> paragraphs = GetParagraphsInScope(section, cell, headerFooter);
+            return cell != null &&
+                   paragraphs.Count == 1 &&
+                   IsReplaceableEmptyCellParagraph(paragraphs[0])
+                ? 0
+                : paragraphs.Count;
+        }
+
+        private static List<WordParagraph> GetGeneratedParagraphs(WordSection section, WordTableCell? cell, WordHeaderFooter? headerFooter, int startIndex) =>
+            GetParagraphsInScope(section, cell, headerFooter).Skip(startIndex).ToList();
+
+        private static List<WordTable> GetTablesInScope(WordSection section, WordTableCell? cell, WordHeaderFooter? headerFooter) =>
+            cell?.DirectNestedTables ?? headerFooter?.Tables ?? section.Tables;
+
+        private static List<WordTable> GetGeneratedTables(WordSection section, WordTableCell? cell, WordHeaderFooter? headerFooter, int startIndex) =>
+            GetTablesInScope(section, cell, headerFooter).Skip(startIndex).ToList();
+
+        private static List<WordParagraph> GetMaterializedContainerParagraphs(
+            IElement element,
+            WordSection section,
+            WordTableCell? cell,
+            WordHeaderFooter? headerFooter,
+            WordParagraph? currentParagraph,
+            int paragraphStartIndex,
+            int tableStartIndex) {
+            List<WordParagraph> paragraphs = GetGeneratedParagraphs(section, cell, headerFooter, paragraphStartIndex);
+            if (paragraphs.Count == 0 &&
+                currentParagraph != null &&
+                GetParagraphsInScope(section, cell, headerFooter)
+                    .Any(paragraph => ReferenceEquals(paragraph._paragraph, currentParagraph._paragraph))) {
+                paragraphs.Add(currentParagraph);
+            }
+            if (paragraphs.Count == 0 &&
+                currentParagraph == null &&
+                GetGeneratedTables(section, cell, headerFooter, tableStartIndex).Count == 0 &&
+                RequiresEmptyBlockParagraph(element)) {
+                AddParagraphInScope(section, cell, headerFooter);
+                paragraphs = GetGeneratedParagraphs(section, cell, headerFooter, paragraphStartIndex);
+            }
+
+            return paragraphs;
+        }
+
+        private static bool ShouldReuseInitialWordSection(IElement element, WordDocument doc, WordSection section) {
+            if (!string.Equals(element.GetAttribute("data-word-section"), "1", StringComparison.OrdinalIgnoreCase)) {
+                return false;
+            }
+
+            if (!element.ClassList.Contains("word-section")) {
+                return false;
+            }
+
+            if (doc.Sections.Count != 1 || !ReferenceEquals(doc.Sections[0], section)) {
+                return false;
+            }
+
+            return section.Tables.Count == 0 &&
+                   section.Paragraphs.All(paragraph => string.IsNullOrWhiteSpace(paragraph.Text) && !paragraph.GetRuns().Any());
+        }
+
+        private static void ApplyContainerPageBreaksFromCss(IElement element, IReadOnlyList<WordParagraph> paragraphs) {
+            if (paragraphs.Count == 0) {
+                return;
+            }
+
+            if (StyleRequestsPageBreakBefore(element)) {
+                paragraphs[0].PageBreakBefore = true;
+            }
+
+            if (StyleRequestsPageBreakAfter(element)) {
+                AddPageBreakAfter(paragraphs[paragraphs.Count - 1]);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.ContainerScopes.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.ContainerScopes.cs
@@ -95,17 +95,39 @@ namespace OfficeIMO.Word.Html {
                    section.Paragraphs.All(paragraph => string.IsNullOrWhiteSpace(paragraph.Text) && !paragraph.GetRuns().Any());
         }
 
-        private static void ApplyContainerPageBreaksFromCss(IElement element, IReadOnlyList<WordParagraph> paragraphs) {
-            if (paragraphs.Count == 0) {
+        private static void ApplyContainerPageBreaksFromCss(
+            IElement element,
+            IReadOnlyList<WordParagraph> paragraphs,
+            IReadOnlyList<WordTable> tables) {
+            bool breakBefore = StyleRequestsPageBreakBefore(element);
+            bool breakAfter = StyleRequestsPageBreakAfter(element);
+            if (paragraphs.Count > 0) {
+                if (breakBefore) {
+                    paragraphs[0].PageBreakBefore = true;
+                }
+                if (breakAfter) {
+                    AddPageBreakAfter(paragraphs[paragraphs.Count - 1]);
+                }
                 return;
             }
 
-            if (StyleRequestsPageBreakBefore(element)) {
-                paragraphs[0].PageBreakBefore = true;
+            if (tables.Count == 0) {
+                return;
             }
+            if (breakBefore) {
+                InsertPageBreakAdjacentToTable(tables[0], before: true);
+            }
+            if (breakAfter) {
+                InsertPageBreakAdjacentToTable(tables[tables.Count - 1], before: false);
+            }
+        }
 
-            if (StyleRequestsPageBreakAfter(element)) {
-                AddPageBreakAfter(paragraphs[paragraphs.Count - 1]);
+        private static void InsertPageBreakAdjacentToTable(WordTable table, bool before) {
+            var paragraph = new Paragraph(new Run(new Break { Type = BreakValues.Page }));
+            if (before) {
+                table._table.InsertBeforeSelf(paragraph);
+            } else {
+                table._table.InsertAfterSelf(paragraph);
             }
         }
     }

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.ContainerScopes.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.ContainerScopes.cs
@@ -121,25 +121,71 @@ namespace OfficeIMO.Word.Html {
             IReadOnlyList<WordTable> tables) {
             bool breakBefore = StyleRequestsPageBreakBefore(element);
             bool breakAfter = StyleRequestsPageBreakAfter(element);
-            if (paragraphs.Count > 0) {
-                if (breakBefore) {
-                    paragraphs[0].PageBreakBefore = true;
-                }
-                if (breakAfter) {
-                    AddPageBreakAfter(paragraphs[paragraphs.Count - 1]);
-                }
+            OpenXmlElement? first = GetGeneratedBlockBoundary(paragraphs, tables, first: true);
+            OpenXmlElement? last = GetGeneratedBlockBoundary(paragraphs, tables, first: false);
+            if (first == null || last == null) {
                 return;
             }
 
-            if (tables.Count == 0) {
-                return;
-            }
             if (breakBefore) {
-                InsertPageBreakAdjacentToTable(tables[0], before: true);
+                WordParagraph? paragraph = paragraphs.FirstOrDefault(
+                    candidate => ReferenceEquals(candidate._paragraph, first));
+                if (paragraph != null) {
+                    paragraph.PageBreakBefore = true;
+                } else {
+                    WordTable? table = tables.FirstOrDefault(
+                        candidate => ReferenceEquals(candidate._table, first));
+                    if (table != null) {
+                        InsertPageBreakAdjacentToTable(table, before: true);
+                    }
+                }
             }
+
             if (breakAfter) {
-                InsertPageBreakAdjacentToTable(tables[tables.Count - 1], before: false);
+                WordParagraph? paragraph = paragraphs.FirstOrDefault(
+                    candidate => ReferenceEquals(candidate._paragraph, last));
+                if (paragraph != null) {
+                    AddPageBreakAfter(paragraph);
+                } else {
+                    WordTable? table = tables.FirstOrDefault(
+                        candidate => ReferenceEquals(candidate._table, last));
+                    if (table != null) {
+                        InsertPageBreakAdjacentToTable(table, before: false);
+                    }
+                }
             }
+        }
+
+        private static OpenXmlElement? GetGeneratedBlockBoundary(
+            IReadOnlyList<WordParagraph> paragraphs,
+            IReadOnlyList<WordTable> tables,
+            bool first) {
+            var candidates = new List<OpenXmlElement>(paragraphs.Count + tables.Count);
+            foreach (WordParagraph paragraph in paragraphs) {
+                if (!candidates.Any(candidate => ReferenceEquals(candidate, paragraph._paragraph))) {
+                    candidates.Add(paragraph._paragraph);
+                }
+            }
+            foreach (WordTable table in tables) {
+                if (!candidates.Any(candidate => ReferenceEquals(candidate, table._table))) {
+                    candidates.Add(table._table);
+                }
+            }
+            if (candidates.Count == 0) {
+                return null;
+            }
+
+            OpenXmlElement? parent = candidates[0].Parent;
+            if (parent == null) {
+                return first ? candidates[0] : candidates[candidates.Count - 1];
+            }
+
+            IEnumerable<OpenXmlElement> siblings = first
+                ? parent.ChildElements
+                : parent.ChildElements.Reverse();
+            return siblings.FirstOrDefault(
+                       sibling => candidates.Any(candidate => ReferenceEquals(candidate, sibling))) ??
+                   (first ? candidates[0] : candidates[candidates.Count - 1]);
         }
 
         private static void InsertPageBreakAdjacentToTable(WordTable table, bool before) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.ContainerSpacing.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.ContainerSpacing.cs
@@ -5,7 +5,7 @@ using System.Globalization;
 
 namespace OfficeIMO.Word.Html {
     internal partial class HtmlToWordConverter {
-        private static void ApplyContainerSpacingFromCss(
+        private void ApplyContainerSpacingFromCss(
             IElement element,
             IReadOnlyList<WordParagraph> paragraphs,
             IReadOnlyList<WordTable> tables) {
@@ -37,7 +37,7 @@ namespace OfficeIMO.Word.Html {
             ApplyContainerVerticalSpacingFromCss(element, paragraphs, tables);
         }
 
-        private static void ApplyContainerVerticalSpacingFromCss(
+        private void ApplyContainerVerticalSpacingFromCss(
             IElement element,
             IReadOnlyList<WordParagraph> paragraphs,
             IReadOnlyList<WordTable> tables) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.ContainerSpacing.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.ContainerSpacing.cs
@@ -1,0 +1,111 @@
+using AngleSharp.Dom;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Wordprocessing;
+using System.Globalization;
+
+namespace OfficeIMO.Word.Html {
+    internal partial class HtmlToWordConverter {
+        private static void ApplyContainerSpacingFromCss(
+            IElement element,
+            IReadOnlyList<WordParagraph> paragraphs,
+            IReadOnlyList<WordTable> tables) {
+            if (paragraphs.Count == 0 && tables.Count == 0) {
+                return;
+            }
+
+            CssStyleMapper.CssProperties box = ParseElementBoxStyles(element);
+            int horizontalStart = (box.MarginLeft ?? 0) + (box.PaddingLeft ?? 0);
+            int horizontalEnd = (box.MarginRight ?? 0) + (box.PaddingRight ?? 0);
+            foreach (WordParagraph paragraph in DistinctPhysicalParagraphs(paragraphs)) {
+                if (horizontalStart != 0) {
+                    paragraph.IndentationBefore = (paragraph.IndentationBefore ?? 0) + horizontalStart;
+                }
+                if (horizontalEnd != 0) {
+                    paragraph.IndentationAfter = (paragraph.IndentationAfter ?? 0) + horizontalEnd;
+                }
+            }
+
+            foreach (WordTable table in tables) {
+                WordTableStyleDetails? styleDetails = table.StyleDetails;
+                if (horizontalStart != 0 && styleDetails != null) {
+                    int indentation = (styleDetails.TableIndentationWidth ?? 0) + horizontalStart;
+                    indentation = Math.Max(short.MinValue, Math.Min(short.MaxValue, indentation));
+                    styleDetails.TableIndentationWidth = checked((short)indentation);
+                }
+            }
+
+            OpenXmlElement? first = GetGeneratedBlockBoundary(paragraphs, tables, first: true);
+            int verticalStart = (box.MarginTop ?? 0) + (box.PaddingTop ?? 0);
+            if (verticalStart != 0 && first != null) {
+                WordParagraph? paragraph = paragraphs.FirstOrDefault(
+                    candidate => ReferenceEquals(candidate._paragraph, first));
+                if (paragraph != null) {
+                    paragraph.LineSpacingBefore = (paragraph.LineSpacingBefore ?? 0) + verticalStart;
+                } else {
+                    WordTable? table = tables.FirstOrDefault(
+                        candidate => ReferenceEquals(candidate._table, first));
+                    if (table != null) {
+                        ApplySpacingAdjacentToTable(table, verticalStart, before: true);
+                    }
+                }
+            }
+
+            OpenXmlElement? last = GetGeneratedBlockBoundary(paragraphs, tables, first: false);
+            int verticalEnd = (box.MarginBottom ?? 0) + (box.PaddingBottom ?? 0);
+            if (verticalEnd != 0 && last != null) {
+                WordParagraph? paragraph = paragraphs.FirstOrDefault(
+                    candidate => ReferenceEquals(candidate._paragraph, last));
+                if (paragraph != null) {
+                    paragraph.LineSpacingAfter = (paragraph.LineSpacingAfter ?? 0) + verticalEnd;
+                } else {
+                    WordTable? table = tables.FirstOrDefault(
+                        candidate => ReferenceEquals(candidate._table, last));
+                    if (table != null) {
+                        ApplySpacingAdjacentToTable(table, verticalEnd, before: false);
+                    }
+                }
+            }
+        }
+
+        private static void ApplySpacingAdjacentToTable(WordTable table, int spacing, bool before) {
+            Paragraph? paragraph = before ? null : table._table.NextSibling<Paragraph>();
+            if (paragraph == null || !HasOnlySyntheticZeroSpacing(paragraph)) {
+                paragraph = new Paragraph(
+                    new ParagraphProperties(
+                        new SpacingBetweenLines {
+                            Before = "0",
+                            After = "0",
+                            Line = "0"
+                        }));
+                if (before) {
+                    table._table.InsertBeforeSelf(paragraph);
+                } else {
+                    table._table.InsertAfterSelf(paragraph);
+                }
+            }
+
+            ParagraphProperties properties =
+                paragraph.ParagraphProperties ?? paragraph.PrependChild(new ParagraphProperties());
+            SpacingBetweenLines spacingElement =
+                properties.GetFirstChild<SpacingBetweenLines>() ??
+                properties.AppendChild(new SpacingBetweenLines());
+            if (before) {
+                spacingElement.After = spacing.ToString(CultureInfo.InvariantCulture);
+            } else {
+                spacingElement.Before = spacing.ToString(CultureInfo.InvariantCulture);
+            }
+            spacingElement.Line ??= "0";
+        }
+
+        private static bool HasOnlySyntheticZeroSpacing(Paragraph paragraph) {
+            ParagraphProperties? properties = paragraph.ParagraphProperties;
+            SpacingBetweenLines? spacing = properties?.GetFirstChild<SpacingBetweenLines>();
+            return string.IsNullOrEmpty(paragraph.InnerText) &&
+                   paragraph.ChildElements.All(element => element is ParagraphProperties) &&
+                   properties?.ChildElements.Count == 1 &&
+                   spacing?.Before?.Value == "0" &&
+                   spacing.After?.Value == "0" &&
+                   spacing.Line?.Value == "0";
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.ContainerSpacing.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.ContainerSpacing.cs
@@ -38,7 +38,7 @@ namespace OfficeIMO.Word.Html {
             ApplyContainerVerticalSpacingFromCss(element, paragraphs, tables);
         }
 
-        private static void ApplyTableContainerWidth(
+        private void ApplyTableContainerWidth(
             WordTable table,
             int horizontalStart,
             int horizontalEnd) {
@@ -46,8 +46,14 @@ namespace OfficeIMO.Word.Html {
                 return;
             }
 
+            int accumulatedSpacing = horizontalStart + horizontalEnd;
+            if (_tableContainerHorizontalSpacing.TryGetValue(table._table, out int priorSpacing)) {
+                accumulatedSpacing += priorSpacing;
+            }
+            _tableContainerHorizontalSpacing[table._table] = accumulatedSpacing;
+
             int availableWidth = table.EstimateAvailableContainerWidthInDxa();
-            long constrainedWidth = (long)availableWidth - horizontalStart - horizontalEnd;
+            long constrainedWidth = (long)availableWidth - accumulatedSpacing;
             if (constrainedWidth <= 0) {
                 constrainedWidth = 1;
             } else if (constrainedWidth > int.MaxValue) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.ContainerSpacing.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.ContainerSpacing.cs
@@ -32,9 +32,35 @@ namespace OfficeIMO.Word.Html {
                     indentation = Math.Max(short.MinValue, Math.Min(short.MaxValue, indentation));
                     styleDetails.TableIndentationWidth = checked((short)indentation);
                 }
+                ApplyTableContainerWidth(table, horizontalStart, horizontalEnd);
             }
 
             ApplyContainerVerticalSpacingFromCss(element, paragraphs, tables);
+        }
+
+        private static void ApplyTableContainerWidth(
+            WordTable table,
+            int horizontalStart,
+            int horizontalEnd) {
+            if (horizontalStart == 0 && horizontalEnd == 0) {
+                return;
+            }
+
+            int availableWidth = table.EstimateAvailableContainerWidthInDxa();
+            long constrainedWidth = (long)availableWidth - horizontalStart - horizontalEnd;
+            if (constrainedWidth <= 0) {
+                constrainedWidth = 1;
+            } else if (constrainedWidth > int.MaxValue) {
+                constrainedWidth = int.MaxValue;
+            }
+
+            int currentWidth = table.EstimateTableWidthInDxa();
+            if (currentWidth <= constrainedWidth) {
+                return;
+            }
+
+            table.WidthType = TableWidthUnitValues.Dxa;
+            table.Width = (int)constrainedWidth;
         }
 
         private void ApplyContainerVerticalSpacingFromCss(

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.ContainerSpacing.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.ContainerSpacing.cs
@@ -34,6 +34,14 @@ namespace OfficeIMO.Word.Html {
                 }
             }
 
+            ApplyContainerVerticalSpacingFromCss(element, paragraphs, tables);
+        }
+
+        private static void ApplyContainerVerticalSpacingFromCss(
+            IElement element,
+            IReadOnlyList<WordParagraph> paragraphs,
+            IReadOnlyList<WordTable> tables) {
+            CssStyleMapper.CssProperties box = ParseElementBoxStyles(element);
             OpenXmlElement? first = GetGeneratedBlockBoundary(paragraphs, tables, first: true);
             int verticalStart = (box.MarginTop ?? 0) + (box.PaddingTop ?? 0);
             if (verticalStart != 0 && first != null) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.CssDiagnostics.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.CssDiagnostics.cs
@@ -314,7 +314,22 @@ namespace OfficeIMO.Word.Html {
                         reason = $"Unsupported {propertyName} value '{value}'.";
                         return true;
                     }
-                    return false;
+                return false;
+            }
+
+            if (IsBlockFrameElement(elementName) &&
+                TryGetBlockBorderLonghand(propertyName, out _, out string borderComponent)) {
+                bool supported = borderComponent switch {
+                    "style" => TryParseBlockBorderStyle(value, out _),
+                    "width" => TryParseBlockBorderWidth(value, out _),
+                    "color" => NormalizeColor(value) != null,
+                    _ => false,
+                };
+                if (!supported) {
+                    reason = $"Unsupported {propertyName} value '{value}'.";
+                    return true;
+                }
+                return false;
             }
 
             if (propertyName.StartsWith("margin", StringComparison.OrdinalIgnoreCase) ||

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.CssDiagnostics.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.CssDiagnostics.cs
@@ -62,6 +62,17 @@ namespace OfficeIMO.Word.Html {
             "padding-top",
         };
 
+        private static readonly HashSet<string> _tableSpacingCssDiagnosticProperties = new(StringComparer.OrdinalIgnoreCase) {
+            "margin",
+            "margin-left",
+            "margin-right",
+            "padding",
+            "padding-bottom",
+            "padding-left",
+            "padding-right",
+            "padding-top",
+        };
+
         private void ReportUnsupportedInlineCssDiagnostics(IElement element) {
             var style = element.GetAttribute("style");
             if (string.IsNullOrWhiteSpace(style)) {
@@ -76,11 +87,20 @@ namespace OfficeIMO.Word.Html {
             }
 
             var hasRawFontShorthand = rawPropertyNames.Contains("font");
+            bool isTable = element.TagName.Equals("table", StringComparison.OrdinalIgnoreCase);
+            bool hasRawTableMarginShorthand = isTable && rawPropertyNames.Contains("margin");
+            bool hasRawTablePaddingShorthand = isTable && rawPropertyNames.Contains("padding");
             foreach (var property in ParseInlineDeclaration(style)) {
                 if (rawPropertyNames.Contains(property.Name)) {
                     continue;
                 }
                 if (hasRawFontShorthand && property.Name.StartsWith("font-", StringComparison.OrdinalIgnoreCase)) {
+                    continue;
+                }
+                if (hasRawTableMarginShorthand && property.Name.StartsWith("margin-", StringComparison.OrdinalIgnoreCase)) {
+                    continue;
+                }
+                if (hasRawTablePaddingShorthand && property.Name.StartsWith("padding-", StringComparison.OrdinalIgnoreCase)) {
                     continue;
                 }
 
@@ -129,7 +149,9 @@ namespace OfficeIMO.Word.Html {
 
         private static bool IsSupportedCssDiagnosticProperty(string elementName, string propertyName) {
             if (_blockSpacingCssDiagnosticProperties.Contains(propertyName)) {
-                return IsBlockSpacingElement(elementName);
+                return IsBlockSpacingElement(elementName) ||
+                       elementName.Equals("table", StringComparison.OrdinalIgnoreCase) &&
+                       _tableSpacingCssDiagnosticProperties.Contains(propertyName);
             }
 
             return _supportedCssDiagnosticProperties.Contains(propertyName) ||

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.CssDiagnostics.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.CssDiagnostics.cs
@@ -26,11 +26,23 @@ namespace OfficeIMO.Word.Html {
             "list-style-type",
             "margin",
             "margin-bottom",
+            "margin-block",
+            "margin-block-end",
+            "margin-block-start",
+            "margin-inline",
+            "margin-inline-end",
+            "margin-inline-start",
             "margin-left",
             "margin-right",
             "margin-top",
             "padding",
             "padding-bottom",
+            "padding-block",
+            "padding-block-end",
+            "padding-block-start",
+            "padding-inline",
+            "padding-inline-end",
+            "padding-inline-start",
             "padding-left",
             "padding-right",
             "padding-top",
@@ -94,7 +106,7 @@ namespace OfficeIMO.Word.Html {
                 }
 
                 var elementName = element.TagName.ToLowerInvariant();
-                if (!IsSupportedCssDiagnosticProperty(propertyName)) {
+                if (!IsSupportedCssDiagnosticProperty(elementName, propertyName)) {
                     AddUnsupportedCssDiagnostic(
                         "UnsupportedCssDeclaration",
                         "CSS declaration is not currently mapped to Word output.",
@@ -112,9 +124,10 @@ namespace OfficeIMO.Word.Html {
             }
         }
 
-        private static bool IsSupportedCssDiagnosticProperty(string propertyName) =>
+        private static bool IsSupportedCssDiagnosticProperty(string elementName, string propertyName) =>
             _supportedCssDiagnosticProperties.Contains(propertyName) ||
-            IsSupportedBorderSideShorthand(propertyName);
+            IsSupportedBorderSideShorthand(propertyName) ||
+            (IsBlockFrameElement(elementName) && TryGetBlockBorderLonghand(propertyName, out _, out _));
 
         private void AddUnsupportedCssDiagnostic(string code, string message, string source, string? detail = null) {
             if (_options.UnsupportedCssHandling == HtmlUnsupportedCssHandling.Ignore) {
@@ -378,6 +391,11 @@ namespace OfficeIMO.Word.Html {
             propertyName.Equals("border-right", StringComparison.OrdinalIgnoreCase) ||
             propertyName.Equals("border-top", StringComparison.OrdinalIgnoreCase) ||
             propertyName.Equals("border-bottom", StringComparison.OrdinalIgnoreCase);
+
+        private static bool IsBlockFrameElement(string elementName) =>
+            elementName is "p" or "div" or "address" or "dl" or "dt" or "dd" or "blockquote" or
+                "section" or "article" or "aside" or "nav" or "header" or "footer" or "main" or
+                "h1" or "h2" or "h3" or "h4" or "h5" or "h6";
 
         private static bool TryUnsupportedColorValue(string value, string label, out string reason) {
             reason = string.Empty;

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.CssDiagnostics.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.CssDiagnostics.cs
@@ -190,7 +190,7 @@ namespace OfficeIMO.Word.Html {
                 case "color":
                     return TryUnsupportedColorValue(value, "color", out reason);
                 case "background-color":
-                    if (lower == "transparent" && IsBlockFrameElement(elementName)) {
+                    if (lower == "transparent") {
                         return false;
                     }
                     return TryUnsupportedColorValue(value, "background color", out reason);

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.CssDiagnostics.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.CssDiagnostics.cs
@@ -150,6 +150,8 @@ namespace OfficeIMO.Word.Html {
         private static bool IsSupportedCssDiagnosticProperty(string elementName, string propertyName) {
             if (_blockSpacingCssDiagnosticProperties.Contains(propertyName)) {
                 return IsBlockSpacingElement(elementName) ||
+                       elementName.Equals("body", StringComparison.OrdinalIgnoreCase) &&
+                       IsPhysicalBlockSpacingProperty(propertyName) ||
                        elementName.Equals("table", StringComparison.OrdinalIgnoreCase) &&
                        _tableSpacingCssDiagnosticProperties.Contains(propertyName);
             }
@@ -451,7 +453,11 @@ namespace OfficeIMO.Word.Html {
 
         private static bool IsBlockSpacingElement(string elementName) =>
             IsBlockFrameElement(elementName) ||
-            elementName is "body" or "li" or "caption" or "figcaption";
+            elementName is "li" or "caption" or "figcaption";
+
+        private static bool IsPhysicalBlockSpacingProperty(string propertyName) =>
+            propertyName is "margin" or "margin-top" or "margin-right" or "margin-bottom" or "margin-left" or
+                "padding" or "padding-top" or "padding-right" or "padding-bottom" or "padding-left";
 
         private static bool TryUnsupportedColorValue(string value, string label, out string reason) {
             reason = string.Empty;

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.CssDiagnostics.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.CssDiagnostics.cs
@@ -334,6 +334,10 @@ namespace OfficeIMO.Word.Html {
 
             if (propertyName.StartsWith("margin", StringComparison.OrdinalIgnoreCase) ||
                 propertyName.StartsWith("padding", StringComparison.OrdinalIgnoreCase)) {
+                if (HasNegativeBlockMargin(propertyName, value)) {
+                    reason = $"Unsupported {propertyName} value '{value}': negative vertical margins cannot be represented in Word paragraph spacing.";
+                    return true;
+                }
                 if (!IsSupportedBoxLengthList(value, allowAuto: propertyName.StartsWith("margin", StringComparison.OrdinalIgnoreCase))) {
                     reason = $"Unsupported {propertyName} value '{value}'.";
                     return true;
@@ -510,6 +514,49 @@ namespace OfficeIMO.Word.Html {
             }
 
             return true;
+        }
+
+        private static bool HasNegativeBlockMargin(string propertyName, string value) {
+            string normalizedProperty = propertyName.ToLowerInvariant();
+            string[] tokens = value.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            if (tokens.Length == 0) {
+                return false;
+            }
+
+            if (normalizedProperty is "margin-top" or "margin-bottom" or
+                "margin-block" or "margin-block-start" or "margin-block-end") {
+                return tokens.Any(IsNegativeCssLengthLiteral);
+            }
+
+            if (normalizedProperty != "margin" || tokens.Length > 4) {
+                return false;
+            }
+
+            return tokens.Length switch {
+                1 => IsNegativeCssLengthLiteral(tokens[0]),
+                2 => IsNegativeCssLengthLiteral(tokens[0]),
+                3 => IsNegativeCssLengthLiteral(tokens[0]) || IsNegativeCssLengthLiteral(tokens[2]),
+                4 => IsNegativeCssLengthLiteral(tokens[0]) || IsNegativeCssLengthLiteral(tokens[2]),
+                _ => false,
+            };
+        }
+
+        private static bool IsNegativeCssLengthLiteral(string value) {
+            string lower = value.Trim().ToLowerInvariant();
+            string[] units = { "px", "pt", "em", "rem", "cm", "mm", "in", "pc", "q" };
+            foreach (string unit in units) {
+                if (!lower.EndsWith(unit, StringComparison.Ordinal)) {
+                    continue;
+                }
+
+                return double.TryParse(
+                    lower.Substring(0, lower.Length - unit.Length),
+                    System.Globalization.NumberStyles.Float,
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    out double number) && number < 0;
+            }
+
+            return false;
         }
 
         private static bool IsSupportedCssLength(string value, bool allowNegative, bool allowPercent, bool allowAuto) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.CssDiagnostics.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.CssDiagnostics.cs
@@ -568,7 +568,7 @@ namespace OfficeIMO.Word.Html {
 
         private static bool IsNegativeCssLengthLiteral(string value) {
             string lower = value.Trim().ToLowerInvariant();
-            string[] units = { "px", "pt", "em", "rem", "cm", "mm", "in", "pc", "q" };
+            string[] units = { "rem", "px", "pt", "em", "cm", "mm", "in", "pc", "q" };
             foreach (string unit in units) {
                 if (!lower.EndsWith(unit, StringComparison.Ordinal)) {
                     continue;
@@ -609,7 +609,7 @@ namespace OfficeIMO.Word.Html {
         }
 
         private static bool IsSupportedCssLengthLiteral(string value, bool allowNegative) {
-            string[] units = { "px", "pt", "em", "rem", "cm", "mm", "in", "pc", "q" };
+            string[] units = { "rem", "px", "pt", "em", "cm", "mm", "in", "pc", "q" };
             foreach (var unit in units) {
                 if (!value.EndsWith(unit, StringComparison.Ordinal)) {
                     continue;
@@ -630,7 +630,7 @@ namespace OfficeIMO.Word.Html {
                 return true;
             }
 
-            string[] units = { "px", "pt", "em", "rem", "cm", "mm", "in", "pc", "q" };
+            string[] units = { "rem", "px", "pt", "em", "cm", "mm", "in", "pc", "q" };
             foreach (var unit in units) {
                 if (value.EndsWith(unit, StringComparison.Ordinal) &&
                     double.TryParse(value.Substring(0, value.Length - unit.Length), System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var number)) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.CssDiagnostics.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.CssDiagnostics.cs
@@ -24,6 +24,20 @@ namespace OfficeIMO.Word.Html {
             "line-height",
             "list-style",
             "list-style-type",
+            "page-break-after",
+            "page-break-before",
+            "text-align",
+            "text-decoration",
+            "text-decoration-line",
+            "text-decoration-style",
+            "text-indent",
+            "text-transform",
+            "vertical-align",
+            "white-space",
+            "width",
+        };
+
+        private static readonly HashSet<string> _blockSpacingCssDiagnosticProperties = new(StringComparer.OrdinalIgnoreCase) {
             "margin",
             "margin-bottom",
             "margin-block",
@@ -46,17 +60,6 @@ namespace OfficeIMO.Word.Html {
             "padding-left",
             "padding-right",
             "padding-top",
-            "page-break-after",
-            "page-break-before",
-            "text-align",
-            "text-decoration",
-            "text-decoration-line",
-            "text-decoration-style",
-            "text-indent",
-            "text-transform",
-            "vertical-align",
-            "white-space",
-            "width",
         };
 
         private void ReportUnsupportedInlineCssDiagnostics(IElement element) {
@@ -124,10 +127,15 @@ namespace OfficeIMO.Word.Html {
             }
         }
 
-        private static bool IsSupportedCssDiagnosticProperty(string elementName, string propertyName) =>
-            _supportedCssDiagnosticProperties.Contains(propertyName) ||
-            IsSupportedBorderSideShorthand(propertyName) ||
-            (IsBlockFrameElement(elementName) && TryGetBlockBorderLonghand(propertyName, out _, out _));
+        private static bool IsSupportedCssDiagnosticProperty(string elementName, string propertyName) {
+            if (_blockSpacingCssDiagnosticProperties.Contains(propertyName)) {
+                return IsBlockSpacingElement(elementName);
+            }
+
+            return _supportedCssDiagnosticProperties.Contains(propertyName) ||
+                   IsSupportedBorderSideShorthand(propertyName) ||
+                   (IsBlockFrameElement(elementName) && TryGetBlockBorderLonghand(propertyName, out _, out _));
+        }
 
         private void AddUnsupportedCssDiagnostic(string code, string message, string source, string? detail = null) {
             if (_options.UnsupportedCssHandling == HtmlUnsupportedCssHandling.Ignore) {
@@ -396,6 +404,10 @@ namespace OfficeIMO.Word.Html {
             elementName is "p" or "div" or "address" or "dl" or "dt" or "dd" or "blockquote" or
                 "section" or "article" or "aside" or "nav" or "header" or "footer" or "main" or
                 "h1" or "h2" or "h3" or "h4" or "h5" or "h6";
+
+        private static bool IsBlockSpacingElement(string elementName) =>
+            IsBlockFrameElement(elementName) ||
+            elementName is "body" or "li" or "caption" or "figcaption";
 
         private static bool TryUnsupportedColorValue(string value, string label, out string reason) {
             reason = string.Empty;

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.CssDiagnostics.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.CssDiagnostics.cs
@@ -190,6 +190,9 @@ namespace OfficeIMO.Word.Html {
                 case "color":
                     return TryUnsupportedColorValue(value, "color", out reason);
                 case "background-color":
+                    if (lower == "transparent" && IsBlockFrameElement(elementName)) {
+                        return false;
+                    }
                     return TryUnsupportedColorValue(value, "background color", out reason);
                 case "font":
                     if (!IsSupportedFontShorthand(value)) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.FontSizes.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.FontSizes.cs
@@ -1,12 +1,16 @@
+using AngleSharp.Css;
+using AngleSharp.Css.Dom;
 using AngleSharp.Css.Values;
 using AngleSharp.Dom;
 using System.Globalization;
 
 namespace OfficeIMO.Word.Html {
     internal partial class HtmlToWordConverter {
-        private static bool TryResolveRootFontSizePixels(string? text, out double pixels) {
-            return TryResolveFontSizePixels(
-                text,
+        private static bool TryResolveRootFontSizePixels(
+            IReadOnlyDictionary<string, (string Value, Priority Specificity, bool Important, int Order)> declarations,
+            out double pixels) {
+            return TryResolveDeclaredFontSizePixels(
+                GetWinningFontSizeDeclaration(declarations),
                 _renderDevice.FontSize,
                 _renderDevice.FontSize,
                 out pixels);
@@ -20,27 +24,18 @@ namespace OfficeIMO.Word.Html {
                 return cached;
             }
 
-            string? value = null;
-            if (_cssRules.Count == 0) {
-                if (TryGetInlineProperty(element.GetAttribute("style"), "font-size", out string inlineValue)) {
-                    value = inlineValue;
-                }
-            } else {
-                var declarations = CollectCssDeclarations(element, inheritedOnly: false);
-                if (declarations.TryGetValue("font-size", out var declaration)) {
-                    value = declaration.Value;
-                }
-            }
-
-            CacheComputedFontSizePixels(element, value);
+            CacheComputedFontSizePixels(
+                element,
+                CollectCssDeclarations(element, inheritedOnly: false));
             return _computedFontSizePixels[element];
         }
 
-        private void CacheComputedFontSizePixels(IElement element, string? value) {
+        private void CacheComputedFontSizePixels(
+            IElement element,
+            IReadOnlyDictionary<string, (string Value, Priority Specificity, bool Important, int Order)> declarations) {
             double inheritedFontSizePixels = ResolveComputedFontSizePixels(element.ParentElement);
-            if (string.IsNullOrWhiteSpace(value) ||
-                !TryResolveFontSizePixels(
-                    value,
+            if (!TryResolveDeclaredFontSizePixels(
+                    GetWinningFontSizeDeclaration(declarations),
                     inheritedFontSizePixels,
                     _rootFontSizePixels,
                     out double pixels)) {
@@ -48,6 +43,58 @@ namespace OfficeIMO.Word.Html {
             }
 
             _computedFontSizePixels[element] = pixels;
+        }
+
+        private static bool TryResolveDeclaredFontSizePixels(
+            string? declaration,
+            double inheritedFontSizePixels,
+            double rootFontSizePixels,
+            out double pixels) {
+            if (TryResolveFontSizePixels(
+                    declaration,
+                    inheritedFontSizePixels,
+                    rootFontSizePixels,
+                    out pixels)) {
+                return true;
+            }
+
+            foreach (string token in TokenizeFontShorthand(declaration ?? string.Empty)) {
+                string sizeToken = token;
+                int slashIndex = token.IndexOf('/');
+                if (slashIndex >= 0) {
+                    sizeToken = token.Substring(0, slashIndex);
+                }
+                if (TryResolveFontSizePixels(
+                        sizeToken,
+                        inheritedFontSizePixels,
+                        rootFontSizePixels,
+                        out pixels)) {
+                    return true;
+                }
+            }
+
+            pixels = 0d;
+            return false;
+        }
+
+        private static string? GetWinningFontSizeDeclaration(
+            IReadOnlyDictionary<string, (string Value, Priority Specificity, bool Important, int Order)> declarations) {
+            bool hasFontSize = declarations.TryGetValue("font-size", out var fontSize);
+            bool hasFont = declarations.TryGetValue("font", out var font);
+            if (!hasFontSize) {
+                return hasFont ? font.Value : null;
+            }
+            if (!hasFont) {
+                return fontSize.Value;
+            }
+
+            if (font.Important != fontSize.Important) {
+                return font.Important ? font.Value : fontSize.Value;
+            }
+            if (font.Specificity != fontSize.Specificity) {
+                return font.Specificity > fontSize.Specificity ? font.Value : fontSize.Value;
+            }
+            return font.Order >= fontSize.Order ? font.Value : fontSize.Value;
         }
 
         private static bool TryResolveFontSizePixels(

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.FontSizes.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.FontSizes.cs
@@ -1,0 +1,123 @@
+using AngleSharp.Css.Values;
+using AngleSharp.Dom;
+using System.Globalization;
+
+namespace OfficeIMO.Word.Html {
+    internal partial class HtmlToWordConverter {
+        private static bool TryResolveRootFontSizePixels(string? text, out double pixels) {
+            return TryResolveFontSizePixels(
+                text,
+                _renderDevice.FontSize,
+                _renderDevice.FontSize,
+                out pixels);
+        }
+
+        private double ResolveComputedFontSizePixels(IElement? element) {
+            if (element == null) {
+                return _rootFontSizePixels;
+            }
+            if (_computedFontSizePixels.TryGetValue(element, out double cached)) {
+                return cached;
+            }
+
+            string? value = null;
+            if (_cssRules.Count == 0) {
+                if (TryGetInlineProperty(element.GetAttribute("style"), "font-size", out string inlineValue)) {
+                    value = inlineValue;
+                }
+            } else {
+                var declarations = CollectCssDeclarations(element, inheritedOnly: false);
+                if (declarations.TryGetValue("font-size", out var declaration)) {
+                    value = declaration.Value;
+                }
+            }
+
+            CacheComputedFontSizePixels(element, value);
+            return _computedFontSizePixels[element];
+        }
+
+        private void CacheComputedFontSizePixels(IElement element, string? value) {
+            double inheritedFontSizePixels = ResolveComputedFontSizePixels(element.ParentElement);
+            if (string.IsNullOrWhiteSpace(value) ||
+                !TryResolveFontSizePixels(
+                    value,
+                    inheritedFontSizePixels,
+                    _rootFontSizePixels,
+                    out double pixels)) {
+                pixels = inheritedFontSizePixels;
+            }
+
+            _computedFontSizePixels[element] = pixels;
+        }
+
+        private static bool TryResolveFontSizePixels(
+            string? text,
+            double inheritedFontSizePixels,
+            double rootFontSizePixels,
+            out double pixels) {
+            pixels = 0d;
+            if (string.IsNullOrWhiteSpace(text)) {
+                return false;
+            }
+
+            string normalized = text!.Trim().ToLowerInvariant();
+            if (normalized is "inherit" or "unset") {
+                pixels = inheritedFontSizePixels;
+                return true;
+            }
+            if (normalized is "initial" or "revert" or "revert-layer") {
+                pixels = _renderDevice.FontSize;
+                return true;
+            }
+            if (TryParseRelativeFontSize(normalized, "rem", rootFontSizePixels, out pixels) ||
+                TryParseRelativeFontSize(normalized, "em", inheritedFontSizePixels, out pixels)) {
+                return pixels > 0d;
+            }
+            if (normalized.EndsWith("%", StringComparison.Ordinal) &&
+                double.TryParse(
+                    normalized.Substring(0, normalized.Length - 1),
+                    NumberStyles.Float,
+                    CultureInfo.InvariantCulture,
+                    out double percent)) {
+                pixels = inheritedFontSizePixels * percent / 100d;
+                return pixels > 0d;
+            }
+
+            var declaration = ParseInlineDeclaration($"font-size:{normalized}");
+            if (declaration.GetProperty("font-size")?.RawValue is CssLengthValue length) {
+                try {
+                    pixels = length.ToPixel(_renderDevice);
+                    return pixels > 0d && !double.IsInfinity(pixels) && !double.IsNaN(pixels);
+                } catch {
+                    return false;
+                }
+            }
+
+            if (_namedFontSizes.TryGetValue(normalized, out int named)) {
+                pixels = named;
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool TryParseRelativeFontSize(
+            string value,
+            string unit,
+            double basisPixels,
+            out double pixels) {
+            pixels = 0d;
+            if (!value.EndsWith(unit, StringComparison.Ordinal) ||
+                !double.TryParse(
+                    value.Substring(0, value.Length - unit.Length),
+                    NumberStyles.Float,
+                    CultureInfo.InvariantCulture,
+                    out double multiple)) {
+                return false;
+            }
+
+            pixels = basisPixels * multiple;
+            return true;
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.Colors.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.Colors.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using Color = OfficeIMO.Drawing.OfficeColor;
 
 namespace OfficeIMO.Word.Html {
@@ -16,7 +15,7 @@ namespace OfficeIMO.Word.Html {
                 return null;
             }
             if (v.StartsWith("rgb", StringComparison.OrdinalIgnoreCase)) {
-                if (TryParseRgb(v, out byte rr, out byte rg, out byte rb)) {
+                if (CssStyleMapper.TryParseRgbColor(v, out byte rr, out byte rg, out byte rb)) {
                     var color = Color.FromRgb(rr, rg, rb);
                     return color.ToRgbHex();
                 }
@@ -36,52 +35,6 @@ namespace OfficeIMO.Word.Html {
                 }
                 return null;
             }
-        }
-
-        private static bool TryParseRgb(string text, out byte r, out byte g, out byte b) {
-            r = g = b = 0;
-            int start = text.IndexOf('(');
-            int end = text.LastIndexOf(')');
-            if (start < 0 || end <= start) {
-                return false;
-            }
-
-            var content = text.Substring(start + 1, end - start - 1);
-            var slashIndex = content.IndexOf('/');
-            if (slashIndex >= 0) {
-                content = content.Substring(0, slashIndex);
-            }
-
-            string[] parts = content.IndexOf(',') >= 0
-                ? content.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
-                : content.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-            if (parts.Length < 3) {
-                return false;
-            }
-
-            return TryParseRgbChannel(parts[0], out r) &&
-                   TryParseRgbChannel(parts[1], out g) &&
-                   TryParseRgbChannel(parts[2], out b);
-        }
-
-        private static bool TryParseRgbChannel(string text, out byte value) {
-            value = 0;
-            var t = text.Trim();
-            double parsed;
-            if (t.EndsWith("%", StringComparison.Ordinal)) {
-                t = t.Substring(0, t.Length - 1);
-                if (!double.TryParse(t, NumberStyles.Float, CultureInfo.InvariantCulture, out parsed)) {
-                    return false;
-                }
-
-                parsed = parsed * 255d / 100d;
-            } else if (!double.TryParse(t, NumberStyles.Float, CultureInfo.InvariantCulture, out parsed)) {
-                return false;
-            }
-
-            parsed = parsed < 0 ? 0 : parsed > 255 ? 255 : parsed;
-            value = (byte)Math.Round(parsed);
-            return true;
         }
     }
 }

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.PageBreaks.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.PageBreaks.cs
@@ -41,25 +41,9 @@ namespace OfficeIMO.Word.Html {
                 return false;
             }
 
-            var styleText = styleAttribute!;
-            foreach (var declaration in styleText.Split(';')) {
-                var separatorIndex = declaration.IndexOf(':');
-                if (separatorIndex < 0) {
-                    continue;
-                }
-
-                var name = declaration.Substring(0, separatorIndex).Trim();
-                if (!propertyNames.Any(propertyName => string.Equals(propertyName, name, StringComparison.OrdinalIgnoreCase))) {
-                    continue;
-                }
-
-                var value = declaration.Substring(separatorIndex + 1).Trim();
-                var importantIndex = value.IndexOf("!important", StringComparison.OrdinalIgnoreCase);
-                if (importantIndex >= 0) {
-                    value = value.Substring(0, importantIndex).Trim();
-                }
-
-                if (IsPageBreakValue(value)) {
+            foreach (string propertyName in propertyNames) {
+                if (TryGetInlineProperty(styleAttribute, propertyName, out string value) &&
+                    IsPageBreakValue(value)) {
                     return true;
                 }
             }

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
@@ -242,8 +242,9 @@ namespace OfficeIMO.Word.Html {
                 paragraph.SetColorHex(colorVal);
             }
 
-            if (!string.IsNullOrEmpty(parsed.BackgroundColor)) {
-                paragraph.ShadingFillColorHex = parsed.BackgroundColor!;
+            string? paragraphBackground = ResolveParagraphBackground(element, parsed);
+            if (!string.IsNullOrEmpty(paragraphBackground)) {
+                paragraph.ShadingFillColorHex = paragraphBackground!;
             }
 
             if (parsed.LineHeight.HasValue) {
@@ -323,6 +324,41 @@ namespace OfficeIMO.Word.Html {
                 paragraph.IndentationAfter = right;
             }
             return parsed;
+        }
+
+        private static string? ResolveParagraphBackground(
+            IElement element,
+            CssStyleMapper.CssProperties parsed) {
+            if (string.IsNullOrEmpty(parsed.BackgroundColor)) {
+                return null;
+            }
+
+            double alpha = parsed.BackgroundColorAlpha ?? 1d;
+            if (alpha <= 0d) {
+                return null;
+            }
+
+            string? backdrop = null;
+            var ancestors = new Stack<IElement>();
+            for (IElement? ancestor = element.ParentElement; ancestor != null; ancestor = ancestor.ParentElement) {
+                ancestors.Push(ancestor);
+            }
+            while (ancestors.Count > 0) {
+                IElement ancestor = ancestors.Pop();
+                CssStyleMapper.CssProperties ancestorStyle = CssStyleMapper.ParseStyles(ancestor.GetAttribute("style"));
+                if (string.IsNullOrEmpty(ancestorStyle.BackgroundColor)) {
+                    continue;
+                }
+                double ancestorAlpha = ancestorStyle.BackgroundColorAlpha ?? 1d;
+                if (ancestorAlpha > 0d) {
+                    backdrop = ResolveOpaqueTextBackground(
+                        ancestorStyle.BackgroundColor!,
+                        ancestorAlpha,
+                        backdrop);
+                }
+            }
+
+            return ResolveOpaqueTextBackground(parsed.BackgroundColor!, alpha, backdrop);
         }
 
         private static bool TryMapTextAlign(string? value, bool? bidi, out JustificationValues alignment) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
@@ -225,7 +225,7 @@ namespace OfficeIMO.Word.Html {
             return null;
         }
 
-        private static CssStyleMapper.CssProperties ApplyParagraphStyleFromCss(
+        private CssStyleMapper.CssProperties ApplyParagraphStyleFromCss(
             WordParagraph paragraph,
             IElement element,
             bool applyVerticalBoxSpacing = true) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
@@ -543,8 +543,14 @@ namespace OfficeIMO.Word.Html {
                 formatting.Strike = parsed.Strike.Value;
             }
             if (!string.IsNullOrEmpty(parsed.BackgroundColor)) {
-                formatting.BackgroundColorHex = parsed.BackgroundColor;
-                formatting.PreserveHighlightOverBackground = false;
+                double alpha = parsed.BackgroundColorAlpha ?? 1d;
+                if (alpha > 0d) {
+                    formatting.BackgroundColorHex = ResolveOpaqueTextBackground(
+                        parsed.BackgroundColor!,
+                        alpha,
+                        formatting.BackgroundColorHex);
+                    formatting.PreserveHighlightOverBackground = false;
+                }
             }
             if (parsed.WhiteSpace.HasValue) {
                 formatting.WhiteSpace = parsed.WhiteSpace.Value;

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
@@ -275,10 +275,10 @@ namespace OfficeIMO.Word.Html {
                 };
             }
 
-            if (TryConvertToTwip(GetInlinePropertyRawValue(declaration, styleAttribute, "padding-left"), out int pl)) paddingLeft = pl;
-            if (TryConvertToTwip(GetInlinePropertyRawValue(declaration, styleAttribute, "padding-right"), out int pr)) paddingRight = pr;
-            if (TryConvertToTwip(GetInlinePropertyRawValue(declaration, styleAttribute, "padding-top"), out int pt)) paddingTop = pt;
-            if (TryConvertToTwip(GetInlinePropertyRawValue(declaration, styleAttribute, "padding-bottom"), out int pb)) paddingBottom = pb;
+            if (!paddingLeft.HasValue && TryConvertToTwip(GetInlinePropertyRawValue(declaration, styleAttribute, "padding-left"), out int pl)) paddingLeft = pl;
+            if (!paddingRight.HasValue && TryConvertToTwip(GetInlinePropertyRawValue(declaration, styleAttribute, "padding-right"), out int pr)) paddingRight = pr;
+            if (!paddingTop.HasValue && TryConvertToTwip(GetInlinePropertyRawValue(declaration, styleAttribute, "padding-top"), out int pt)) paddingTop = pt;
+            if (!paddingBottom.HasValue && TryConvertToTwip(GetInlinePropertyRawValue(declaration, styleAttribute, "padding-bottom"), out int pb)) paddingBottom = pb;
 
             if (TryConvertToTwipAllowNegative(GetInlinePropertyRawValue(declaration, styleAttribute, "text-indent"), out int indent)) {
                 if (indent > 0) {
@@ -664,7 +664,9 @@ namespace OfficeIMO.Word.Html {
             var parent = parser.ParseDeclaration(parentStyle ?? string.Empty);
             var child = parser.ParseDeclaration(childStyle ?? string.Empty);
             foreach (var prop in parent) {
-                if (IsPageBreakProperty(prop.Name) || IsContainerBoxProperty(prop.Name)) {
+                if (IsPageBreakProperty(prop.Name) ||
+                    IsContainerBoxProperty(prop.Name) ||
+                    prop.Name.Equals("direction", StringComparison.OrdinalIgnoreCase)) {
                     continue;
                 }
                 if (string.IsNullOrEmpty(child.GetPropertyValue(prop.Name))) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
@@ -592,6 +592,10 @@ namespace OfficeIMO.Word.Html {
                         alpha,
                         formatting.BackgroundColorHex ?? formatting.BackgroundBackdropColorHex);
                     formatting.PreserveHighlightOverBackground = false;
+                } else {
+                    formatting.BackgroundColorHex = null;
+                    formatting.Highlight = HighlightColorValues.None;
+                    formatting.PreserveHighlightOverBackground = false;
                 }
             }
             if (parsed.WhiteSpace.HasValue) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
@@ -221,7 +221,7 @@ namespace OfficeIMO.Word.Html {
                 paragraph.Style = style.Value;
             }
 
-            var parsed = CssStyleMapper.ParseStyles(styleAttribute, GetBidiFromDir(element) == true);
+            var parsed = ParseElementBoxStyles(element);
             var declaration = ParseInlineDeclaration(styleAttribute);
             int? marginLeft = parsed.MarginLeft, marginRight = parsed.MarginRight, marginTop = parsed.MarginTop, marginBottom = parsed.MarginBottom;
             int? paddingLeft = parsed.PaddingLeft, paddingRight = parsed.PaddingRight, paddingTop = parsed.PaddingTop, paddingBottom = parsed.PaddingBottom;

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
@@ -50,6 +50,7 @@ namespace OfficeIMO.Word.Html {
             internal int? FontSize { get; set; }
             internal HighlightColorValues? Highlight { get; set; }
             internal string? BackgroundColorHex { get; set; }
+            internal bool PreserveHighlightOverBackground { get; set; }
             internal CapsStyle? Caps { get; set; }
             internal int? LetterSpacing { get; set; }
             internal TextTransform Transform { get; set; }
@@ -543,6 +544,7 @@ namespace OfficeIMO.Word.Html {
             }
             if (!string.IsNullOrEmpty(parsed.BackgroundColor)) {
                 formatting.BackgroundColorHex = parsed.BackgroundColor;
+                formatting.PreserveHighlightOverBackground = false;
             }
             if (parsed.WhiteSpace.HasValue) {
                 formatting.WhiteSpace = parsed.WhiteSpace.Value;

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
@@ -106,15 +106,24 @@ namespace OfficeIMO.Word.Html {
                 return false;
             }
 
-            foreach (var part in styleText!.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)) {
-                var pieces = part.Split(new[] { ':' }, 2);
-                if (pieces.Length == 2 && string.Equals(pieces[0].Trim(), propertyName, StringComparison.OrdinalIgnoreCase)) {
-                    value = pieces[1].Trim();
-                    return true;
+            bool found = false;
+            for (int priorityPass = 0; priorityPass < 2; priorityPass++) {
+                bool important = priorityPass == 1;
+                foreach (string part in styleText!.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)) {
+                    if (CssStyleMapper.TryParseDeclaration(
+                            part,
+                            out string name,
+                            out string candidate,
+                            out bool declarationIsImportant) &&
+                        declarationIsImportant == important &&
+                        string.Equals(name, propertyName, StringComparison.OrdinalIgnoreCase)) {
+                        value = candidate;
+                        found = true;
+                    }
                 }
             }
 
-            return false;
+            return found;
         }
 
         private static bool TryParseFontSize(string? text, out int size) {
@@ -305,11 +314,11 @@ namespace OfficeIMO.Word.Html {
                 paragraph.LineSpacingAfter = after;
             }
             int left = (marginLeft ?? 0) + (paddingLeft ?? 0);
-            if (left > 0) {
+            if (left != 0) {
                 paragraph.IndentationBefore = left;
             }
             int right = (marginRight ?? 0) + (paddingRight ?? 0);
-            if (right > 0) {
+            if (right != 0) {
                 paragraph.IndentationAfter = right;
             }
             return parsed;

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
@@ -225,7 +225,10 @@ namespace OfficeIMO.Word.Html {
             return null;
         }
 
-        private static CssStyleMapper.CssProperties ApplyParagraphStyleFromCss(WordParagraph paragraph, IElement element) {
+        private static CssStyleMapper.CssProperties ApplyParagraphStyleFromCss(
+            WordParagraph paragraph,
+            IElement element,
+            bool applyVerticalBoxSpacing = true) {
             string? styleAttribute = element.GetAttribute("style");
             var style = CssStyleMapper.MapParagraphStyle(styleAttribute);
             if (style.HasValue) {
@@ -308,13 +311,15 @@ namespace OfficeIMO.Word.Html {
             if (alignment.HasValue) {
                 paragraph.ParagraphAlignment = alignment;
             }
-            int before = (marginTop ?? 0) + (paddingTop ?? 0);
-            if (before > 0) {
-                paragraph.LineSpacingBefore = before;
-            }
-            int after = (marginBottom ?? 0) + (paddingBottom ?? 0);
-            if (after > 0) {
-                paragraph.LineSpacingAfter = after;
+            if (applyVerticalBoxSpacing) {
+                int before = (marginTop ?? 0) + (paddingTop ?? 0);
+                if (before > 0) {
+                    paragraph.LineSpacingBefore = before;
+                }
+                int after = (marginBottom ?? 0) + (paddingBottom ?? 0);
+                if (after > 0) {
+                    paragraph.LineSpacingAfter = after;
+                }
             }
             int left = (marginLeft ?? 0) + (paddingLeft ?? 0);
             if (left != 0) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
@@ -50,6 +50,7 @@ namespace OfficeIMO.Word.Html {
             internal int? FontSize { get; set; }
             internal HighlightColorValues? Highlight { get; set; }
             internal string? BackgroundColorHex { get; set; }
+            internal string? BackgroundBackdropColorHex { get; set; }
             internal bool PreserveHighlightOverBackground { get; set; }
             internal CapsStyle? Caps { get; set; }
             internal int? LetterSpacing { get; set; }
@@ -584,13 +585,24 @@ namespace OfficeIMO.Word.Html {
                     formatting.BackgroundColorHex = ResolveOpaqueTextBackground(
                         parsed.BackgroundColor!,
                         alpha,
-                        formatting.BackgroundColorHex);
+                        formatting.BackgroundColorHex ?? formatting.BackgroundBackdropColorHex);
                     formatting.PreserveHighlightOverBackground = false;
                 }
             }
             if (parsed.WhiteSpace.HasValue) {
                 formatting.WhiteSpace = parsed.WhiteSpace.Value;
             }
+        }
+
+        private static void PreserveBlockBackgroundAsTextBackdrop(
+            ref TextFormatting formatting,
+            TextFormatting inheritedFormatting) {
+            string? blockBackground = formatting.BackgroundColorHex;
+            formatting.BackgroundColorHex = inheritedFormatting.BackgroundColorHex;
+            formatting.BackgroundBackdropColorHex =
+                blockBackground ??
+                inheritedFormatting.BackgroundColorHex ??
+                inheritedFormatting.BackgroundBackdropColorHex;
         }
 
         private static void ApplyFontShorthand(string font, ref TextFormatting formatting) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
@@ -18,7 +18,7 @@ namespace OfficeIMO.Word.Html {
         }
 
         private struct TextFormatting {
-            internal TextFormatting(bool bold = false, bool italic = false, bool underline = false, string? colorHex = null, string? fontFamily = null, int? fontSize = null, bool superscript = false, bool subscript = false, bool strike = false, HighlightColorValues? highlight = null, int? letterSpacing = null, TextTransform transform = TextTransform.None, WhiteSpaceMode? whiteSpace = null, string? language = null) {
+            internal TextFormatting(bool bold = false, bool italic = false, bool underline = false, string? colorHex = null, string? fontFamily = null, int? fontSize = null, bool superscript = false, bool subscript = false, bool strike = false, HighlightColorValues? highlight = null, string? backgroundColorHex = null, int? letterSpacing = null, TextTransform transform = TextTransform.None, WhiteSpaceMode? whiteSpace = null, string? language = null) {
                 Bold = bold;
                 Italic = italic;
                 Underline = underline;
@@ -30,6 +30,7 @@ namespace OfficeIMO.Word.Html {
                 FontFamily = fontFamily;
                 FontSize = fontSize;
                 Highlight = highlight;
+                BackgroundColorHex = backgroundColorHex;
                 Caps = null;
                 LetterSpacing = letterSpacing;
                 Transform = transform;
@@ -48,6 +49,7 @@ namespace OfficeIMO.Word.Html {
             internal string? FontFamily { get; set; }
             internal int? FontSize { get; set; }
             internal HighlightColorValues? Highlight { get; set; }
+            internal string? BackgroundColorHex { get; set; }
             internal CapsStyle? Caps { get; set; }
             internal int? LetterSpacing { get; set; }
             internal TextTransform Transform { get; set; }
@@ -219,7 +221,7 @@ namespace OfficeIMO.Word.Html {
                 paragraph.Style = style.Value;
             }
 
-            var parsed = CssStyleMapper.ParseStyles(styleAttribute);
+            var parsed = CssStyleMapper.ParseStyles(styleAttribute, GetBidiFromDir(element) == true);
             var declaration = ParseInlineDeclaration(styleAttribute);
             int? marginLeft = parsed.MarginLeft, marginRight = parsed.MarginRight, marginTop = parsed.MarginTop, marginBottom = parsed.MarginBottom;
             int? paddingLeft = parsed.PaddingLeft, paddingRight = parsed.PaddingRight, paddingTop = parsed.PaddingTop, paddingBottom = parsed.PaddingBottom;
@@ -231,10 +233,7 @@ namespace OfficeIMO.Word.Html {
             }
 
             if (!string.IsNullOrEmpty(parsed.BackgroundColor)) {
-                var highlight = MapColorToHighlight(parsed.BackgroundColor);
-                if (highlight.HasValue) {
-                    paragraph.SetHighlight(highlight.Value);
-                }
+                paragraph.ShadingFillColorHex = parsed.BackgroundColor!;
             }
 
             if (parsed.LineHeight.HasValue) {
@@ -412,7 +411,7 @@ namespace OfficeIMO.Word.Html {
             return collapsed;
         }
 
-        private static void ApplyFormatting(WordParagraph run, TextFormatting formatting, HtmlToWordOptions options) {
+        private void ApplyFormatting(WordParagraph run, TextFormatting formatting, HtmlToWordOptions options) {
             if (formatting.Bold) run.SetBold();
             if (formatting.Italic) run.SetItalic();
             if (formatting.Underline) run.SetUnderline(GetUnderlineValue(formatting) ?? UnderlineValues.Single);
@@ -421,6 +420,7 @@ namespace OfficeIMO.Word.Html {
             if (formatting.Subscript) run.SetSubScript();
             if (!string.IsNullOrEmpty(formatting.ColorHex)) run.SetColorHex(formatting.ColorHex!);
             if (formatting.Highlight.HasValue) run.SetHighlight(formatting.Highlight.Value);
+            ApplyTextBackground(run, formatting, options);
             if (formatting.FontSize.HasValue) run.SetFontSize(formatting.FontSize.Value);
             if (formatting.Caps.HasValue) run.SetCapsStyle(formatting.Caps.Value);
             if (formatting.LetterSpacing.HasValue) run.SetSpacing(formatting.LetterSpacing.Value);
@@ -533,10 +533,7 @@ namespace OfficeIMO.Word.Html {
                 formatting.Strike = parsed.Strike.Value;
             }
             if (!string.IsNullOrEmpty(parsed.BackgroundColor)) {
-                var highlight = MapColorToHighlight(parsed.BackgroundColor);
-                if (highlight.HasValue) {
-                    formatting.Highlight = highlight.Value;
-                }
+                formatting.BackgroundColorHex = parsed.BackgroundColor;
             }
             if (parsed.WhiteSpace.HasValue) {
                 formatting.WhiteSpace = parsed.WhiteSpace.Value;
@@ -667,7 +664,7 @@ namespace OfficeIMO.Word.Html {
             var parent = parser.ParseDeclaration(parentStyle ?? string.Empty);
             var child = parser.ParseDeclaration(childStyle ?? string.Empty);
             foreach (var prop in parent) {
-                if (IsPageBreakProperty(prop.Name)) {
+                if (IsPageBreakProperty(prop.Name) || IsContainerBoxProperty(prop.Name)) {
                     continue;
                 }
                 if (string.IsNullOrEmpty(child.GetPropertyValue(prop.Name))) {
@@ -676,6 +673,13 @@ namespace OfficeIMO.Word.Html {
             }
             return child.CssText;
         }
+
+        private static bool IsContainerBoxProperty(string propertyName) =>
+            propertyName.Equals("background", StringComparison.OrdinalIgnoreCase) ||
+            propertyName.Equals("background-color", StringComparison.OrdinalIgnoreCase) ||
+            propertyName.StartsWith("border", StringComparison.OrdinalIgnoreCase) ||
+            propertyName.StartsWith("margin", StringComparison.OrdinalIgnoreCase) ||
+            propertyName.StartsWith("padding", StringComparison.OrdinalIgnoreCase);
 
         private static bool TryParseHsl(string text, out byte r, out byte g, out byte b) {
             r = g = b = 0;
@@ -747,48 +751,5 @@ namespace OfficeIMO.Word.Html {
             return true;
         }
 
-        private static readonly Dictionary<HighlightColorValues, Color> _highlightColors = new() {
-            { HighlightColorValues.Yellow, Color.Yellow },
-            { HighlightColorValues.Green, Color.Lime },
-            { HighlightColorValues.Cyan, Color.Cyan },
-            { HighlightColorValues.Magenta, Color.Magenta },
-            { HighlightColorValues.Blue, Color.Blue },
-            { HighlightColorValues.Red, Color.Red },
-            { HighlightColorValues.DarkBlue, Color.DarkBlue },
-            { HighlightColorValues.DarkCyan, Color.DarkCyan },
-            { HighlightColorValues.DarkGreen, Color.DarkGreen },
-            { HighlightColorValues.DarkMagenta, Color.DarkMagenta },
-            { HighlightColorValues.DarkRed, Color.DarkRed },
-            { HighlightColorValues.DarkYellow, Color.Parse("#808000") },
-            { HighlightColorValues.DarkGray, Color.DarkGray },
-            { HighlightColorValues.LightGray, Color.LightGray },
-            { HighlightColorValues.Black, Color.Black },
-            { HighlightColorValues.White, Color.White }
-        };
-
-        private static HighlightColorValues? MapColorToHighlight(string? hex) {
-            if (string.IsNullOrEmpty(hex)) {
-                return null;
-            }
-            try {
-                var target = Color.Parse("#" + hex);
-                var targetRgb = target;
-                HighlightColorValues? best = null;
-                int bestDistance = int.MaxValue;
-                foreach (var pair in _highlightColors) {
-                    var rgb = pair.Value;
-                    int distance = (rgb.R - targetRgb.R) * (rgb.R - targetRgb.R) +
-                                   (rgb.G - targetRgb.G) * (rgb.G - targetRgb.G) +
-                                   (rgb.B - targetRgb.B) * (rgb.B - targetRgb.B);
-                    if (distance < bestDistance) {
-                        bestDistance = distance;
-                        best = pair.Key;
-                    }
-                }
-                return best;
-            } catch {
-                return null;
-            }
-        }
     }
 }

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Forms.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Forms.cs
@@ -30,7 +30,7 @@ namespace OfficeIMO.Word.Html {
                 return;
             }
 
-            currentParagraph ??= cell != null ? cell.AddParagraph("", true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
+            currentParagraph ??= AddParagraphInScope(section, cell, headerFooter);
             var (alias, tag) = GetInputMetadata(element);
             if (IsCheckboxInput(element)) {
                 currentParagraph.AddCheckBox(IsCheckedInput(element), alias, tag);
@@ -87,7 +87,7 @@ namespace OfficeIMO.Word.Html {
                 selected = string.Empty;
             }
 
-            currentParagraph ??= cell != null ? cell.AddParagraph("", true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
+            currentParagraph ??= AddParagraphInScope(section, cell, headerFooter);
             var (alias, tag) = GetRadioGroupMetadata(group);
             var dropDown = currentParagraph.AddDropDownList(optionTexts, alias, tag);
             dropDown.SelectedValue = selected ?? string.Empty;
@@ -109,7 +109,7 @@ namespace OfficeIMO.Word.Html {
                 return;
             }
 
-            currentParagraph ??= cell != null ? cell.AddParagraph("", true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
+            currentParagraph ??= AddParagraphInScope(section, cell, headerFooter);
             var (alias, tag) = GetInputMetadata(element);
             if (element.HasAttribute("multiple")) {
                 var selectedValues = optionsList
@@ -134,7 +134,7 @@ namespace OfficeIMO.Word.Html {
         }
 
         private void ProcessTextArea(IElement element, WordSection section, HtmlToWordOptions options, WordParagraph? currentParagraph, TextFormatting formatting, WordTableCell? cell, WordHeaderFooter? headerFooter) {
-            currentParagraph ??= cell != null ? cell.AddParagraph("", true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
+            currentParagraph ??= AddParagraphInScope(section, cell, headerFooter);
             var (alias, tag) = GetInputMetadata(element);
             currentParagraph.AddStructuredDocumentTag(NormalizeFormText(element.TextContent), alias, tag);
 
@@ -144,7 +144,7 @@ namespace OfficeIMO.Word.Html {
         }
 
         private void ProcessValueElement(IElement element, WordSection section, HtmlToWordOptions options, WordParagraph? currentParagraph, TextFormatting formatting, WordTableCell? cell, WordHeaderFooter? headerFooter) {
-            currentParagraph ??= cell != null ? cell.AddParagraph("", true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
+            currentParagraph ??= AddParagraphInScope(section, cell, headerFooter);
             var (alias, tag) = GetInputMetadata(element);
             currentParagraph.AddStructuredDocumentTag(GetValueElementText(element), alias, tag);
 

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.HeadersFooters.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.HeadersFooters.cs
@@ -38,6 +38,7 @@ namespace OfficeIMO.Word.Html {
             WordList? headingList = options.SupportsHeadingNumbering ? target.AddList(WordListStyle.Headings111) : null;
             foreach (var child in element.ChildNodes) {
                 if (!string.IsNullOrWhiteSpace(style) && child is IElement childElement) {
+                    ResolveComputedFontSizePixels(childElement);
                     var merged = MergeStyles(style, childElement.GetAttribute("style"));
                     if (!string.IsNullOrEmpty(merged)) {
                         childElement.SetAttribute("style", merged);

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Images.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Images.cs
@@ -1381,7 +1381,7 @@ namespace OfficeIMO.Word.Html {
             }
         }
 
-        private void ProcessSvgElement(AngleSharp.Dom.IElement svg, WordDocument doc, WordSection section, HtmlToWordOptions options, WordParagraph? currentParagraph, WordHeaderFooter? headerFooter) {
+        private bool ProcessSvgElement(AngleSharp.Dom.IElement svg, WordDocument doc, WordSection section, HtmlToWordOptions options, WordParagraph? currentParagraph, WordHeaderFooter? headerFooter) {
             double? width = null;
             double? height = null;
             if (double.TryParse(svg.GetAttribute("width")?.Replace("px", string.Empty), out var w)) width = w;
@@ -1393,18 +1393,20 @@ namespace OfficeIMO.Word.Html {
                 var svgByteCount = Encoding.UTF8.GetByteCount(svg.OuterHtml);
                 if (options.MaxImageBytes.HasValue && svgByteCount > options.MaxImageBytes.Value) {
                     AddDiagnostic(options, "ImageResourceTooLarge", "Inline SVG exceeded the configured byte limit and was skipped.", "svg");
-                    return;
+                    return false;
                 }
                 if (!TryReserveImageBytes(svgByteCount, options, "svg")) {
-                    return;
+                    return false;
                 }
                 reservedBytes = svgByteCount;
 
                 SvgHelper.AddSvg(paragraph, svg.OuterHtml, width, height, string.Empty);
                 reservedBytes = 0;
+                return true;
             } catch (Exception ex) {
                 ReleaseImageBytes(reservedBytes, options);
                 AddDiagnostic(options, "InlineSvgEmbedFailed", "Inline SVG could not be embedded and was skipped.", "svg", ex);
+                return false;
             }
         }
     }

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Images.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Images.cs
@@ -817,6 +817,8 @@ namespace OfficeIMO.Word.Html {
             IHtmlDocument document,
             HtmlToWordOptions options,
             CancellationToken cancellationToken) {
+            var sources = new List<string>();
+            var seen = new HashSet<string>(StringComparer.Ordinal);
             foreach (IElement element in document.QuerySelectorAll("img")) {
                 cancellationToken.ThrowIfCancellationRequested();
                 if (!(element is IHtmlImageElement image)) {
@@ -836,7 +838,38 @@ namespace OfficeIMO.Word.Html {
                     }
 
                     remoteCandidateProbeCount++;
-                    await PrefetchRemoteImageCandidateAsync(resolved, options, cancellationToken).ConfigureAwait(false);
+                    if (seen.Add(resolved)) {
+                        sources.Add(resolved);
+                    }
+                }
+            }
+
+            if (sources.Count == 0) {
+                return;
+            }
+
+            // A total byte budget requires deterministic, ordered reservations so a response whose
+            // declared length exceeds the remaining budget can be rejected before its body is read.
+            int concurrency = options.MaxTotalImageBytes.HasValue
+                ? 1
+                : Math.Min(options.MaxConcurrentResourceLoads, sources.Count);
+            int nextIndex = -1;
+            var workers = new Task[concurrency];
+            for (int workerIndex = 0; workerIndex < workers.Length; workerIndex++) {
+                workers[workerIndex] = PrefetchWorkerAsync();
+            }
+
+            await Task.WhenAll(workers).ConfigureAwait(false);
+
+            async Task PrefetchWorkerAsync() {
+                while (true) {
+                    int index = Interlocked.Increment(ref nextIndex);
+                    if (index >= sources.Count) {
+                        return;
+                    }
+
+                    cancellationToken.ThrowIfCancellationRequested();
+                    await PrefetchRemoteImageCandidateAsync(sources[index], options, cancellationToken).ConfigureAwait(false);
                 }
             }
         }
@@ -878,7 +911,7 @@ namespace OfficeIMO.Word.Html {
                 }
 
                 _remoteImageBytesCache[uri.AbsoluteUri] = bytes;
-                _remoteImageBytesFetched += bytes.LongLength;
+                Interlocked.Add(ref _remoteImageBytesFetched, bytes.LongLength);
             } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
                 throw;
             } catch (Exception ex) {
@@ -910,13 +943,13 @@ namespace OfficeIMO.Word.Html {
                 byte[] bytes = FetchBytes(uri, options);
                 reservedBytes = bytes.LongLength;
                 if (!IsEmbeddableImageData(bytes, out var detail)) {
-                    _remoteImageBytesCache.Remove(uri.AbsoluteUri);
+                    _remoteImageBytesCache.TryRemove(uri.AbsoluteUri, out _);
                     _remoteImageFailureCache[uri.AbsoluteUri] = new InvalidDataException(detail);
                     return false;
                 }
 
                 _remoteImageBytesCache[uri.AbsoluteUri] = bytes;
-                _remoteImageFailureCache.Remove(uri.AbsoluteUri);
+                _remoteImageFailureCache.TryRemove(uri.AbsoluteUri, out _);
                 return true;
             } catch (OperationCanceledException ex) when (!_cancellationToken.IsCancellationRequested) {
                 _remoteImageFailureCache[uri.AbsoluteUri] = ex;

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Images.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Images.cs
@@ -838,8 +838,9 @@ namespace OfficeIMO.Word.Html {
                     }
 
                     remoteCandidateProbeCount++;
-                    if (seen.Add(resolved)) {
-                        sources.Add(resolved);
+                    if (Uri.TryCreate(resolved, UriKind.Absolute, out Uri? canonicalUri) &&
+                        seen.Add(canonicalUri.AbsoluteUri)) {
+                        sources.Add(canonicalUri.AbsoluteUri);
                     }
                 }
             }

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Images.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Images.cs
@@ -15,7 +15,13 @@ namespace OfficeIMO.Word.Html {
         private static readonly string[] WordImageLazySourceAttributes = { "data-src", "data-original", "data-original-src", "data-lazy-src" };
         private static readonly string[] WordImageSourceAttributes = { "src" };
 
-        private void ProcessImage(IHtmlImageElement img, WordDocument doc, HtmlToWordOptions options, WordParagraph? currentParagraph, WordHeaderFooter? headerFooter) {
+        private void ProcessImage(
+            IHtmlImageElement img,
+            WordDocument doc,
+            HtmlToWordOptions options,
+            WordParagraph? currentParagraph,
+            WordHeaderFooter? headerFooter,
+            int? containerWidthTwips = null) {
             var src = ResolveWordImageSource(img, options);
             if (string.IsNullOrEmpty(src)) {
                 if (HasImageSourceCandidateAttribute(img)) {
@@ -51,14 +57,14 @@ namespace OfficeIMO.Word.Html {
             }
 
             if (src.EndsWith(".svg", StringComparison.OrdinalIgnoreCase) || src.StartsWith("data:image/svg+xml", StringComparison.OrdinalIgnoreCase)) {
-                ProcessSvgImage(src, img, doc, options, currentParagraph, headerFooter);
+                ProcessSvgImage(src, img, doc, options, currentParagraph, headerFooter, containerWidthTwips);
                 return;
             }
 
             double? width = img.DisplayWidth > 0 ? img.DisplayWidth : null;
             double? height = img.DisplayHeight > 0 ? img.DisplayHeight : null;
-            width ??= TryResolveImagePercentWidth(decl.GetPropertyValue("width"), doc);
-            width ??= TryResolveImagePercentWidth(img.GetAttribute("width"), doc);
+            width ??= TryResolveImagePercentWidth(decl.GetPropertyValue("width"), doc, containerWidthTwips);
+            width ??= TryResolveImagePercentWidth(img.GetAttribute("width"), doc, containerWidthTwips);
             width ??= TryParsePixelValue(img.GetAttribute("width"));
             height ??= TryParsePixelValue(img.GetAttribute("height"));
 
@@ -180,12 +186,19 @@ namespace OfficeIMO.Word.Html {
             }
         }
 
-        private void ProcessSvgImage(string src, IHtmlImageElement img, WordDocument doc, HtmlToWordOptions options, WordParagraph? currentParagraph, WordHeaderFooter? headerFooter) {
+        private void ProcessSvgImage(
+            string src,
+            IHtmlImageElement img,
+            WordDocument doc,
+            HtmlToWordOptions options,
+            WordParagraph? currentParagraph,
+            WordHeaderFooter? headerFooter,
+            int? containerWidthTwips) {
             var decl = _inlineParser.ParseDeclaration(img.GetAttribute("style") ?? string.Empty);
             double? width = img.DisplayWidth > 0 ? img.DisplayWidth : null;
             double? height = img.DisplayHeight > 0 ? img.DisplayHeight : null;
-            width ??= TryResolveImagePercentWidth(decl.GetPropertyValue("width"), doc);
-            width ??= TryResolveImagePercentWidth(img.GetAttribute("width"), doc);
+            width ??= TryResolveImagePercentWidth(decl.GetPropertyValue("width"), doc, containerWidthTwips);
+            width ??= TryResolveImagePercentWidth(img.GetAttribute("width"), doc, containerWidthTwips);
             width ??= TryParsePixelValue(img.GetAttribute("width"));
             height ??= TryParsePixelValue(img.GetAttribute("height"));
             var alt = img.AlternativeText;
@@ -295,7 +308,10 @@ namespace OfficeIMO.Word.Html {
             return null;
         }
 
-        private static double? TryResolveImagePercentWidth(string? value, WordDocument doc) {
+        private static double? TryResolveImagePercentWidth(
+            string? value,
+            WordDocument doc,
+            int? containerWidthTwips) {
             if (string.IsNullOrWhiteSpace(value)) {
                 return null;
             }
@@ -309,11 +325,16 @@ namespace OfficeIMO.Word.Html {
                 return null;
             }
 
-            var section = doc.Sections.Count > 0 ? doc.Sections[doc.Sections.Count - 1] : null;
-            var pageWidthTwips = section?.PageSettings.Width?.Value ?? WordPageSizes.A4.Width!.Value;
-            var leftMarginTwips = section?.Margins.Left?.Value ?? 1440U;
-            var rightMarginTwips = section?.Margins.Right?.Value ?? 1440U;
-            var contentWidthTwips = Math.Max(0D, pageWidthTwips - leftMarginTwips - rightMarginTwips);
+            double contentWidthTwips;
+            if (containerWidthTwips.HasValue && containerWidthTwips.Value > 0) {
+                contentWidthTwips = containerWidthTwips.Value;
+            } else {
+                var section = doc.Sections.Count > 0 ? doc.Sections[doc.Sections.Count - 1] : null;
+                var pageWidthTwips = section?.PageSettings.Width?.Value ?? WordPageSizes.A4.Width!.Value;
+                var leftMarginTwips = section?.Margins.Left?.Value ?? 1440U;
+                var rightMarginTwips = section?.Margins.Right?.Value ?? 1440U;
+                contentWidthTwips = Math.Max(0D, pageWidthTwips - leftMarginTwips - rightMarginTwips);
+            }
             if (contentWidthTwips <= 0) {
                 return null;
             }

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.InlineFlow.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.InlineFlow.cs
@@ -44,5 +44,22 @@ namespace OfficeIMO.Word.Html {
 
             return false;
         }
+
+        private bool ShouldStartContainerChildParagraph(IElement element) {
+            if (!_blockTags.Contains(element.TagName)) {
+                return false;
+            }
+            if (!element.TagName.Equals("code", StringComparison.OrdinalIgnoreCase)) {
+                return true;
+            }
+
+            ApplyCssToElement(element);
+            string styleText = element.GetAttribute("style") ?? string.Empty;
+            var declaration = ParseInlineDeclaration(styleText);
+            string display = GetInlinePropertyValue(declaration, styleText, "display")
+                .Trim()
+                .ToLowerInvariant();
+            return display is "block" or "flow-root" or "list-item" or "table" or "flex" or "grid";
+        }
     }
 }

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.InlineFlow.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.InlineFlow.cs
@@ -9,12 +9,7 @@ namespace OfficeIMO.Word.Html {
                 return false;
             }
 
-            ApplyCssToElement(element);
-            string styleText = element.GetAttribute("style") ?? string.Empty;
-            var declaration = ParseInlineDeclaration(styleText);
-            string display = GetInlinePropertyValue(declaration, styleText, "display")
-                .Trim()
-                .ToLowerInvariant();
+            string display = GetEffectiveDisplay(element);
             return display is "block" or "flow-root" or "list-item" or "table" or "flex" or "grid" ||
                    !HasSurroundingInlineBodyContent(node);
         }
@@ -53,13 +48,15 @@ namespace OfficeIMO.Word.Html {
                 return true;
             }
 
-            ApplyCssToElement(element);
-            string styleText = element.GetAttribute("style") ?? string.Empty;
-            var declaration = ParseInlineDeclaration(styleText);
-            string display = GetInlinePropertyValue(declaration, styleText, "display")
-                .Trim()
-                .ToLowerInvariant();
+            string display = GetEffectiveDisplay(element);
             return display is "block" or "flow-root" or "list-item" or "table" or "flex" or "grid";
+        }
+
+        private string GetEffectiveDisplay(IElement element) {
+            var declarations = CollectCssDeclarations(element, inheritedOnly: false);
+            return declarations.TryGetValue("display", out var display)
+                ? display.Value.Trim().ToLowerInvariant()
+                : string.Empty;
         }
     }
 }

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.InlineFlow.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.InlineFlow.cs
@@ -2,13 +2,14 @@ using AngleSharp.Dom;
 
 namespace OfficeIMO.Word.Html {
     internal partial class HtmlToWordConverter {
-        private static bool ShouldStartBodyResourceParagraph(INode node) {
+        private bool ShouldStartBodyResourceParagraph(INode node) {
             if (node is not IElement element ||
                 (!element.TagName.Equals("img", StringComparison.OrdinalIgnoreCase) &&
                  !element.TagName.Equals("svg", StringComparison.OrdinalIgnoreCase))) {
                 return false;
             }
 
+            ApplyCssToElement(element);
             string styleText = element.GetAttribute("style") ?? string.Empty;
             var declaration = ParseInlineDeclaration(styleText);
             string display = GetInlinePropertyValue(declaration, styleText, "display")

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.InlineFlow.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.InlineFlow.cs
@@ -1,0 +1,47 @@
+using AngleSharp.Dom;
+
+namespace OfficeIMO.Word.Html {
+    internal partial class HtmlToWordConverter {
+        private static bool ShouldStartBodyResourceParagraph(INode node) {
+            if (node is not IElement element ||
+                (!element.TagName.Equals("img", StringComparison.OrdinalIgnoreCase) &&
+                 !element.TagName.Equals("svg", StringComparison.OrdinalIgnoreCase))) {
+                return false;
+            }
+
+            string styleText = element.GetAttribute("style") ?? string.Empty;
+            var declaration = ParseInlineDeclaration(styleText);
+            string display = GetInlinePropertyValue(declaration, styleText, "display")
+                .Trim()
+                .ToLowerInvariant();
+            return display is "block" or "flow-root" or "list-item" or "table" or "flex" or "grid" ||
+                   !HasSurroundingInlineBodyContent(node);
+        }
+
+        private static bool HasSurroundingInlineBodyContent(INode node) =>
+            HasInlineBodyContent(node.PreviousSibling, previous: true) ||
+            HasInlineBodyContent(node.NextSibling, previous: false);
+
+        private static bool HasInlineBodyContent(INode? sibling, bool previous) {
+            while (sibling != null) {
+                if (sibling is IText text) {
+                    if (!string.IsNullOrWhiteSpace(text.Text)) {
+                        return true;
+                    }
+                } else if (sibling is IElement element) {
+                    if (_blockTags.Contains(element.TagName)) {
+                        return false;
+                    }
+                    if (!element.TagName.Equals("img", StringComparison.OrdinalIgnoreCase) &&
+                        !element.TagName.Equals("svg", StringComparison.OrdinalIgnoreCase)) {
+                        return true;
+                    }
+                }
+
+                sibling = previous ? sibling.PreviousSibling : sibling.NextSibling;
+            }
+
+            return false;
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Links.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Links.cs
@@ -234,6 +234,10 @@ namespace OfficeIMO.Word.Html {
 
         private static bool? GetBidiFromDir(IElement element) {
             for (IElement? current = element; current != null; current = current.ParentElement) {
+                var style = current.GetAttribute("style");
+                if (TryGetDirectionFromStyle(style, out var bidi)) {
+                    return bidi;
+                }
                 var dir = current.GetAttribute("dir");
                 if (!string.IsNullOrWhiteSpace(dir)) {
                     if (string.Equals(dir, "rtl", StringComparison.OrdinalIgnoreCase)) {
@@ -242,10 +246,6 @@ namespace OfficeIMO.Word.Html {
                     if (string.Equals(dir, "ltr", StringComparison.OrdinalIgnoreCase)) {
                         return false;
                     }
-                }
-                var style = current.GetAttribute("style");
-                if (TryGetDirectionFromStyle(style, out var bidi)) {
-                    return bidi;
                 }
             }
             return null;

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Links.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Links.cs
@@ -256,26 +256,35 @@ namespace OfficeIMO.Word.Html {
             if (string.IsNullOrWhiteSpace(style)) {
                 return false;
             }
-            foreach (var part in (style ?? string.Empty).Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)) {
-                var pieces = part.Split(new[] { ':' }, 2);
-                if (pieces.Length != 2) {
-                    continue;
+
+            bool? resolved = null;
+            for (int priorityPass = 0; priorityPass < 2; priorityPass++) {
+                bool important = priorityPass == 1;
+                foreach (string part in style!.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)) {
+                    if (!CssStyleMapper.TryParseDeclaration(
+                            part,
+                            out string name,
+                            out string value,
+                            out bool declarationIsImportant) ||
+                        declarationIsImportant != important ||
+                        !name.Equals("direction", StringComparison.OrdinalIgnoreCase)) {
+                        continue;
+                    }
+
+                    if (value.Equals("rtl", StringComparison.OrdinalIgnoreCase)) {
+                        resolved = true;
+                    } else if (value.Equals("ltr", StringComparison.OrdinalIgnoreCase)) {
+                        resolved = false;
+                    }
                 }
-                if (!string.Equals(pieces[0].Trim(), "direction", StringComparison.OrdinalIgnoreCase)) {
-                    continue;
-                }
-                var value = pieces[1].Trim();
-                if (string.Equals(value, "rtl", StringComparison.OrdinalIgnoreCase)) {
-                    bidi = true;
-                    return true;
-                }
-                if (string.Equals(value, "ltr", StringComparison.OrdinalIgnoreCase)) {
-                    bidi = false;
-                    return true;
-                }
+            }
+
+            if (!resolved.HasValue) {
                 return false;
             }
-            return false;
+
+            bidi = resolved.Value;
+            return true;
         }
 
         private static void ApplyBidiIfPresent(IElement element, WordParagraph paragraph) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Links.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Links.cs
@@ -17,6 +17,13 @@ using System.Threading.Tasks;
 
 namespace OfficeIMO.Word.Html {
     internal partial class HtmlToWordConverter {
+        private enum CssDirectionResolution {
+            LeftToRight,
+            RightToLeft,
+            Inherit,
+            Revert
+        }
+
         private static void AddBookmarkIfPresent(IElement element, WordParagraph paragraph) {
             var id = element.GetAttribute("id");
             if (string.IsNullOrEmpty(id)) {
@@ -110,11 +117,17 @@ namespace OfficeIMO.Word.Html {
                 return;
             }
 
-            var firstParagraph = doc.Paragraphs.FirstOrDefault();
-            if (firstParagraph == null) {
+            Paragraph? firstParagraphElement = doc._wordprocessingDocument
+                .MainDocumentPart?
+                .Document?
+                .Body?
+                .Descendants<Paragraph>()
+                .FirstOrDefault();
+            if (firstParagraphElement == null) {
                 return;
             }
 
+            var firstParagraph = new WordParagraph(doc, firstParagraphElement);
             WordBookmark.AddBookmark(firstParagraph, "_top");
             _pendingTopBookmark = false;
         }
@@ -235,8 +248,17 @@ namespace OfficeIMO.Word.Html {
         private static bool? GetBidiFromDir(IElement element) {
             for (IElement? current = element; current != null; current = current.ParentElement) {
                 var style = current.GetAttribute("style");
-                if (TryGetDirectionFromStyle(style, out var bidi)) {
-                    return bidi;
+                if (TryGetDirectionFromStyle(style, out CssDirectionResolution resolution)) {
+                    switch (resolution) {
+                        case CssDirectionResolution.LeftToRight:
+                            return false;
+                        case CssDirectionResolution.RightToLeft:
+                            return true;
+                        case CssDirectionResolution.Inherit:
+                            continue;
+                        case CssDirectionResolution.Revert:
+                            break;
+                    }
                 }
                 var dir = current.GetAttribute("dir");
                 if (!string.IsNullOrWhiteSpace(dir)) {
@@ -251,13 +273,13 @@ namespace OfficeIMO.Word.Html {
             return null;
         }
 
-        private static bool TryGetDirectionFromStyle(string? style, out bool bidi) {
-            bidi = false;
+        private static bool TryGetDirectionFromStyle(string? style, out CssDirectionResolution resolution) {
+            resolution = default;
             if (string.IsNullOrWhiteSpace(style)) {
                 return false;
             }
 
-            bool? resolved = null;
+            CssDirectionResolution? resolved = null;
             for (int priorityPass = 0; priorityPass < 2; priorityPass++) {
                 bool important = priorityPass == 1;
                 foreach (string part in style!.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)) {
@@ -272,9 +294,16 @@ namespace OfficeIMO.Word.Html {
                     }
 
                     if (value.Equals("rtl", StringComparison.OrdinalIgnoreCase)) {
-                        resolved = true;
-                    } else if (value.Equals("ltr", StringComparison.OrdinalIgnoreCase)) {
-                        resolved = false;
+                        resolved = CssDirectionResolution.RightToLeft;
+                    } else if (value.Equals("ltr", StringComparison.OrdinalIgnoreCase) ||
+                               value.Equals("initial", StringComparison.OrdinalIgnoreCase)) {
+                        resolved = CssDirectionResolution.LeftToRight;
+                    } else if (value.Equals("inherit", StringComparison.OrdinalIgnoreCase) ||
+                               value.Equals("unset", StringComparison.OrdinalIgnoreCase)) {
+                        resolved = CssDirectionResolution.Inherit;
+                    } else if (value.Equals("revert", StringComparison.OrdinalIgnoreCase) ||
+                               value.Equals("revert-layer", StringComparison.OrdinalIgnoreCase)) {
+                        resolved = CssDirectionResolution.Revert;
                     }
                 }
             }
@@ -283,7 +312,7 @@ namespace OfficeIMO.Word.Html {
                 return false;
             }
 
-            bidi = resolved.Value;
+            resolution = resolved.Value;
             return true;
         }
 

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Links.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Links.cs
@@ -245,8 +245,11 @@ namespace OfficeIMO.Word.Html {
             return false;
         }
 
-        private static bool? GetBidiFromDir(IElement element) {
+        private bool? GetBidiFromDir(IElement element) {
             for (IElement? current = element; current != null; current = current.ParentElement) {
+                if (_directionAttributeOverrides.TryGetValue(current, out bool attributeDirection)) {
+                    return attributeDirection;
+                }
                 var style = current.GetAttribute("style");
                 if (TryGetDirectionFromStyle(style, out CssDirectionResolution resolution)) {
                     switch (resolution) {
@@ -316,7 +319,7 @@ namespace OfficeIMO.Word.Html {
             return true;
         }
 
-        private static void ApplyBidiIfPresent(IElement element, WordParagraph paragraph) {
+        private void ApplyBidiIfPresent(IElement element, WordParagraph paragraph) {
             var bidi = GetBidiFromDir(element);
             if (bidi.HasValue) {
                 paragraph.BiDi = bidi.Value;

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
@@ -252,14 +252,18 @@ namespace OfficeIMO.Word.Html {
                             WordParagraph paragraph;
                             if (options.SupportsHeadingNumbering && headingList != null) {
                                 WordParagraph? replaceableCellPlaceholder = null;
+                                WordParagraph? insertionAnchor = null;
                                 if (cell != null) {
                                     var cellParagraphs = cell.Paragraphs;
+                                    insertionAnchor = cellParagraphs.LastOrDefault();
                                     if (cellParagraphs.Count == 1 &&
                                         IsReplaceableEmptyCellParagraph(cellParagraphs[0])) {
                                         replaceableCellPlaceholder = cellParagraphs[0];
                                     }
                                 }
-                                paragraph = headingList.AddItem("", level - 1);
+                                paragraph = insertionAnchor == null
+                                    ? headingList.AddItem("", level - 1)
+                                    : headingList.AddItemAfter("", level - 1, insertionAnchor);
                                 replaceableCellPlaceholder?.Remove();
                             } else {
                                 paragraph = AddParagraphInScope(section, cell, headerFooter);

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
@@ -121,9 +121,10 @@ namespace OfficeIMO.Word.Html {
                                 bool standaloneResource = child is IElement resourceElement &&
                                     (resourceElement.TagName.Equals("img", StringComparison.OrdinalIgnoreCase) ||
                                      resourceElement.TagName.Equals("svg", StringComparison.OrdinalIgnoreCase));
-                                ProcessNode(child, doc, section, options, standaloneResource ? null : para, listStack, fmt, cell, headerFooter, headingList);
-                                if (standaloneResource ||
-                                    child is IElement childElement && _blockTags.Contains(childElement.TagName)) {
+                                bool startsOwnParagraph = standaloneResource ||
+                                    child is IElement childElement && _blockTags.Contains(childElement.TagName);
+                                ProcessNode(child, doc, section, options, startsOwnParagraph ? null : para, listStack, fmt, cell, headerFooter, headingList);
+                                if (startsOwnParagraph) {
                                     para = null;
                                 } else if (para == null) {
                                     var scopedParagraphs = GetParagraphsInScope(section, cell, headerFooter);

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
@@ -85,6 +85,12 @@ namespace OfficeIMO.Word.Html {
             int startIndex) {
             List<WordParagraph> paragraphs = GetGeneratedParagraphs(section, cell, headerFooter, startIndex);
             if (paragraphs.Count == 0 &&
+                currentParagraph != null &&
+                GetParagraphsInScope(section, cell, headerFooter)
+                    .Any(paragraph => ReferenceEquals(paragraph._paragraph, currentParagraph._paragraph))) {
+                paragraphs.Add(currentParagraph);
+            }
+            if (paragraphs.Count == 0 &&
                 currentParagraph == null &&
                 RequiresEmptyBlockParagraph(element)) {
                 AddParagraphInScope(section, cell, headerFooter);
@@ -585,6 +591,8 @@ namespace OfficeIMO.Word.Html {
                             currentParagraph ??= AddParagraphInScope(section, cell, headerFooter);
                             var fmt = formatting;
                             fmt.Highlight = HighlightColorValues.Yellow;
+                            fmt.PreserveHighlightOverBackground = !string.IsNullOrEmpty(formatting.BackgroundColorHex);
+                            ApplySpanStyles(element, ref fmt);
                             int startRuns = currentParagraph.GetRuns().Count();
                             foreach (var child in element.ChildNodes) {
                                 ProcessNode(child, doc, section, options, currentParagraph, listStack, fmt, cell, headerFooter, headingList);

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
@@ -117,6 +117,7 @@ namespace OfficeIMO.Word.Html {
                             var mergeSectionStyleIntoChildren = !IsExportedWordSectionElement(element);
                             if (!string.IsNullOrWhiteSpace(divStyle)) {
                                 ApplySpanStyles(element, ref fmt);
+                                fmt.BackgroundColorHex = formatting.BackgroundColorHex;
                             }
                             if (options.SectionTagHandling == SectionTagHandling.WordSection) {
                                 var newSection = ShouldReuseInitialWordSection(element, doc, section) ? section : doc.AddSection();
@@ -133,13 +134,16 @@ namespace OfficeIMO.Word.Html {
                                     ProcessNode(child, doc, newSection, options, para, listStack, fmt, null, headerFooter, headingList);
                                     para = null;
                                 }
+                                if (mergeSectionStyleIntoChildren) {
+                                    ApplyContainerFrameFromCss(element, newSection.Paragraphs.Skip(startIndex).ToList());
+                                }
                                 var secId = element.GetAttribute("id");
                                 if (!string.IsNullOrEmpty(secId)) {
                                     var paragraph = newSection.Paragraphs.Count > startIndex ? newSection.Paragraphs[startIndex] : newSection.AddParagraph("");
                                     WordBookmark.AddBookmark(paragraph, $"section:{secId}");
                                 }
                             } else {
-                                int startIndex = section.Paragraphs.Count;
+                                int startIndex = GetParagraphsInScope(section, cell, headerFooter).Count;
                                 WordParagraph? para = currentParagraph;
                                 foreach (var child in element.ChildNodes) {
                                     if (mergeSectionStyleIntoChildren && !string.IsNullOrWhiteSpace(divStyle) && child is IElement childElement) {
@@ -150,6 +154,9 @@ namespace OfficeIMO.Word.Html {
                                     }
                                     ProcessNode(child, doc, section, options, para, listStack, fmt, cell, headerFooter, headingList);
                                     para = null;
+                                }
+                                if (mergeSectionStyleIntoChildren) {
+                                    ApplyContainerFrameFromCss(element, GetGeneratedParagraphs(section, cell, headerFooter, startIndex));
                                 }
                                 var secId = element.GetAttribute("id");
                                 if (!string.IsNullOrEmpty(secId)) {
@@ -171,6 +178,7 @@ namespace OfficeIMO.Word.Html {
                             var divStyle = element.GetAttribute("style");
                             if (!string.IsNullOrWhiteSpace(divStyle)) {
                                 ApplySpanStyles(element, ref fmt);
+                                fmt.BackgroundColorHex = formatting.BackgroundColorHex;
                             }
                             // Track start within this section rather than whole document
                             int startIndex = section.Paragraphs.Count;
@@ -191,7 +199,9 @@ namespace OfficeIMO.Word.Html {
                                 var paragraph = section.Paragraphs.Count > startIndex ? section.Paragraphs[startIndex] : AddParagraphInScope(section, cell, headerFooter);
                                 WordBookmark.AddBookmark(paragraph, $"{element.TagName.ToLowerInvariant()}:{id}");
                             }
-                            ApplyContainerPageBreaksFromCss(element, GetGeneratedParagraphs(section, cell, headerFooter, scopeStartIndex));
+                            var generatedParagraphs = GetGeneratedParagraphs(section, cell, headerFooter, scopeStartIndex);
+                            ApplyContainerFrameFromCss(element, generatedParagraphs);
+                            ApplyContainerPageBreaksFromCss(element, generatedParagraphs);
                             break;
                         }
                     case "h1":
@@ -211,6 +221,7 @@ namespace OfficeIMO.Word.Html {
                             var fmt = formatting;
                             ApplySpanStyles(element, ref fmt);
                             var props = ApplyParagraphStyleFromCss(paragraph, element);
+                            fmt.BackgroundColorHex = formatting.BackgroundColorHex;
                             ApplyClassStyle(element, paragraph, options);
                             ApplyBidiIfPresent(element, paragraph);
                             AddBookmarkIfPresent(element, paragraph);
@@ -220,6 +231,7 @@ namespace OfficeIMO.Word.Html {
                             foreach (var child in element.ChildNodes) {
                                 ProcessNode(child, doc, section, options, paragraph, listStack, fmt, cell, headerFooter, headingList);
                             }
+                            ApplyParagraphFrameFromCss(paragraph, element);
                             ApplyPageBreakAfterFromCss(paragraph, element);
                             break;
                         }
@@ -228,6 +240,7 @@ namespace OfficeIMO.Word.Html {
                             var fmt = formatting;
                             ApplySpanStyles(element, ref fmt);
                             var props = ApplyParagraphStyleFromCss(paragraph, element);
+                            fmt.BackgroundColorHex = formatting.BackgroundColorHex;
                             if (props.WhiteSpace.HasValue) {
                                 fmt.WhiteSpace = props.WhiteSpace.Value;
                             }
@@ -237,6 +250,7 @@ namespace OfficeIMO.Word.Html {
                             foreach (var child in element.ChildNodes) {
                                 ProcessNode(child, doc, section, options, paragraph, listStack, fmt, cell, headerFooter, headingList);
                             }
+                            ApplyParagraphFrameFromCss(paragraph, element);
                             ApplyPageBreakAfterFromCss(paragraph, element);
                             break;
                         }
@@ -245,6 +259,7 @@ namespace OfficeIMO.Word.Html {
                             var fmt = formatting;
                             ApplySpanStyles(element, ref fmt);
                             var props = ApplyParagraphStyleFromCss(paragraph, element);
+                            fmt.BackgroundColorHex = formatting.BackgroundColorHex;
                             if (props.WhiteSpace.HasValue) {
                                 fmt.WhiteSpace = props.WhiteSpace.Value;
                             }
@@ -255,6 +270,7 @@ namespace OfficeIMO.Word.Html {
                             foreach (var child in element.ChildNodes) {
                                 ProcessNode(child, doc, section, options, paragraph, listStack, fmt, cell, headerFooter, headingList);
                             }
+                            ApplyParagraphFrameFromCss(paragraph, element);
                             ApplyPageBreakAfterFromCss(paragraph, element);
                             break;
                         }
@@ -263,6 +279,7 @@ namespace OfficeIMO.Word.Html {
                             var fmt = formatting;
                             ApplySpanStyles(element, ref fmt);
                             var props = ApplyParagraphStyleFromCss(paragraph, element);
+                            fmt.BackgroundColorHex = formatting.BackgroundColorHex;
                             if (props.WhiteSpace.HasValue) {
                                 fmt.WhiteSpace = props.WhiteSpace.Value;
                             }
@@ -277,6 +294,7 @@ namespace OfficeIMO.Word.Html {
                             foreach (var child in element.ChildNodes) {
                                 ProcessNode(child, doc, section, options, paragraph, listStack, fmt, cell, headerFooter, headingList);
                             }
+                            ApplyParagraphFrameFromCss(paragraph, element);
                             ApplyPageBreakAfterFromCss(paragraph, element);
                             break;
                         }
@@ -285,6 +303,7 @@ namespace OfficeIMO.Word.Html {
                             var cite = element.GetAttribute("cite");
                             var fmt = formatting;
                             ApplySpanStyles(element, ref fmt);
+                            fmt.BackgroundColorHex = formatting.BackgroundColorHex;
                             WordParagraph? firstPara = null;
                             foreach (var child in element.ChildNodes) {
                                 ProcessNode(child, doc, section, options, firstPara, listStack, fmt, cell, headerFooter, headingList);
@@ -311,6 +330,7 @@ namespace OfficeIMO.Word.Html {
                                     AddBookmarkIfPresent(element, para);
                                 }
                             }
+                            ApplyContainerFrameFromCss(element, blockquoteParagraphs.Skip(startIndex).Take(endIndex - startIndex).ToList());
                             if (!string.IsNullOrEmpty(cite)) {
                                 HtmlSemanticMetadata.SetBlockquoteCite(firstPara!, cite);
                                 var noteRef = AddNoteReference(firstPara!, cite ?? string.Empty, options);
@@ -338,6 +358,7 @@ namespace OfficeIMO.Word.Html {
                             var divStyle = element.GetAttribute("style");
                             if (!string.IsNullOrWhiteSpace(divStyle)) {
                                 ApplySpanStyles(element, ref fmt);
+                                fmt.BackgroundColorHex = formatting.BackgroundColorHex;
                             }
                             int startIndex = GetParagraphsInScope(section, cell, headerFooter).Count;
                             WordParagraph? para = currentParagraph;
@@ -353,7 +374,9 @@ namespace OfficeIMO.Word.Html {
                                     para = doc.Paragraphs.Last();
                                 }
                             }
-                            ApplyContainerPageBreaksFromCss(element, GetGeneratedParagraphs(section, cell, headerFooter, startIndex));
+                            var generatedParagraphs = GetGeneratedParagraphs(section, cell, headerFooter, startIndex);
+                            ApplyContainerFrameFromCss(element, generatedParagraphs);
+                            ApplyContainerPageBreaksFromCss(element, generatedParagraphs);
                             break;
                         }
                     case "br": {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
@@ -37,12 +37,15 @@ namespace OfficeIMO.Word.Html {
         private static WordParagraph AddParagraphInScope(WordSection section, WordTableCell? cell, WordHeaderFooter? headerFooter) {
             if (cell != null) {
                 var paragraphs = cell.Paragraphs;
-                bool removeExisting = paragraphs.Count == 1 && string.IsNullOrEmpty(paragraphs[0].Text);
+                bool removeExisting = paragraphs.Count == 1 && IsReplaceableEmptyCellParagraph(paragraphs[0]);
                 return cell.AddParagraph("", removeExisting);
             }
 
             return headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
         }
+
+        private static bool IsReplaceableEmptyCellParagraph(WordParagraph paragraph) =>
+            !paragraph._paragraph.ChildElements.Any(child => child is not ParagraphProperties);
 
         private static List<WordParagraph> GetParagraphsInScope(WordSection section, WordTableCell? cell, WordHeaderFooter? headerFooter) =>
             cell?.Paragraphs ?? headerFooter?.Paragraphs ?? section.Paragraphs;
@@ -109,7 +112,7 @@ namespace OfficeIMO.Word.Html {
                             WordParagraph? para = currentParagraph;
                             if (para == null && cell != null) {
                                 var existingParagraphs = cell.Paragraphs;
-                                if (existingParagraphs.Count == 1 && string.IsNullOrEmpty(existingParagraphs[0].Text)) {
+                                if (existingParagraphs.Count == 1 && IsReplaceableEmptyCellParagraph(existingParagraphs[0])) {
                                     para = existingParagraphs[0];
                                 }
                             }

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
@@ -64,6 +64,15 @@ namespace OfficeIMO.Word.Html {
         private static List<WordParagraph> GetParagraphsInScope(WordSection section, WordTableCell? cell, WordHeaderFooter? headerFooter) =>
             cell?.Paragraphs ?? headerFooter?.Paragraphs ?? section.Paragraphs;
 
+        private static int GetGeneratedParagraphStartIndex(WordSection section, WordTableCell? cell, WordHeaderFooter? headerFooter) {
+            List<WordParagraph> paragraphs = GetParagraphsInScope(section, cell, headerFooter);
+            return cell != null &&
+                   paragraphs.Count == 1 &&
+                   IsReplaceableEmptyCellParagraph(paragraphs[0])
+                ? 0
+                : paragraphs.Count;
+        }
+
         private static List<WordParagraph> GetGeneratedParagraphs(WordSection section, WordTableCell? cell, WordHeaderFooter? headerFooter, int startIndex) =>
             GetParagraphsInScope(section, cell, headerFooter).Skip(startIndex).ToList();
 
@@ -181,7 +190,7 @@ namespace OfficeIMO.Word.Html {
                                     WordBookmark.AddBookmark(paragraph, $"section:{secId}");
                                 }
                             } else {
-                                int startIndex = GetParagraphsInScope(section, cell, headerFooter).Count;
+                                int startIndex = GetGeneratedParagraphStartIndex(section, cell, headerFooter);
                                 WordParagraph? para = currentParagraph;
                                 foreach (var child in element.ChildNodes) {
                                     if (mergeSectionStyleIntoChildren && !string.IsNullOrWhiteSpace(divStyle) && child is IElement childElement) {
@@ -219,7 +228,7 @@ namespace OfficeIMO.Word.Html {
                                 ApplySpanStyles(element, ref fmt);
                                 fmt.BackgroundColorHex = formatting.BackgroundColorHex;
                             }
-                            int scopeStartIndex = GetParagraphsInScope(section, cell, headerFooter).Count;
+                            int scopeStartIndex = GetGeneratedParagraphStartIndex(section, cell, headerFooter);
                             WordParagraph? para = currentParagraph;
                             foreach (var child in element.ChildNodes) {
                                 if (!string.IsNullOrWhiteSpace(divStyle) && child is IElement childElement) {
@@ -350,7 +359,7 @@ namespace OfficeIMO.Word.Html {
                             break;
                         }
                     case "blockquote": {
-                            var startIndex = GetParagraphsInScope(section, cell, headerFooter).Count;
+                            var startIndex = GetGeneratedParagraphStartIndex(section, cell, headerFooter);
                             var cite = element.GetAttribute("cite");
                             var fmt = formatting;
                             ApplySpanStyles(element, ref fmt);
@@ -418,7 +427,7 @@ namespace OfficeIMO.Word.Html {
                                 ApplySpanStyles(element, ref fmt);
                                 fmt.BackgroundColorHex = formatting.BackgroundColorHex;
                             }
-                            int startIndex = GetParagraphsInScope(section, cell, headerFooter).Count;
+                            int startIndex = GetGeneratedParagraphStartIndex(section, cell, headerFooter);
                             WordParagraph? para = currentParagraph;
                             foreach (var child in element.ChildNodes) {
                                 if (!string.IsNullOrWhiteSpace(divStyle) && child is IElement childElement) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
@@ -438,10 +438,18 @@ namespace OfficeIMO.Word.Html {
                         }
                     case "svg": {
                             WordParagraph? svgParagraph = currentParagraph;
+                            int cellParagraphCount = cell?.Paragraphs.Count ?? 0;
+                            bool createdSvgParagraph = false;
                             if (svgParagraph == null && cell != null) {
                                 svgParagraph = AddParagraphInScope(section, cell, headerFooter);
+                                createdSvgParagraph = true;
                             }
-                            ProcessSvgElement(element, doc, section, options, svgParagraph, headerFooter);
+                            if (!ProcessSvgElement(element, doc, section, options, svgParagraph, headerFooter) &&
+                                createdSvgParagraph &&
+                                cell != null &&
+                                cell.Paragraphs.Count > cellParagraphCount) {
+                                svgParagraph!.Remove();
+                            }
                             break;
                         }
                     case "pre": {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
@@ -390,15 +390,15 @@ namespace OfficeIMO.Word.Html {
                             WordParagraph? para = currentParagraph;
                             foreach (var child in element.ChildNodes) {
                                 int paragraphCount = GetParagraphsInScope(section, cell, headerFooter).Count;
-                                bool startsOwnParagraph =
-                                    child is IElement blockChild &&
-                                    _blockTags.Contains(blockChild.TagName);
                                 if (!string.IsNullOrWhiteSpace(divStyle) && child is IElement childElement) {
                                     var merged = MergeStyles(divStyle, childElement.GetAttribute("style"));
                                     if (!string.IsNullOrEmpty(merged)) {
                                         childElement.SetAttribute("style", merged);
                                     }
                                 }
+                                bool startsOwnParagraph =
+                                    child is IElement blockChild &&
+                                    ShouldStartContainerChildParagraph(blockChild);
                                 ProcessNode(
                                     child,
                                     doc,

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
@@ -45,7 +45,21 @@ namespace OfficeIMO.Word.Html {
         }
 
         private static bool IsReplaceableEmptyCellParagraph(WordParagraph paragraph) =>
-            !paragraph._paragraph.ChildElements.Any(child => child is not ParagraphProperties);
+            !paragraph._paragraph.ChildElements.Any(IsMeaningfulCellParagraphChild);
+
+        private static bool IsMeaningfulCellParagraphChild(OpenXmlElement child) {
+            if (child is ParagraphProperties) {
+                return false;
+            }
+
+            if (child is Run run) {
+                return run.ChildElements.Any(runChild =>
+                    runChild is not RunProperties &&
+                    (runChild is not Text text || !string.IsNullOrEmpty(text.Text)));
+            }
+
+            return true;
+        }
 
         private static List<WordParagraph> GetParagraphsInScope(WordSection section, WordTableCell? cell, WordHeaderFooter? headerFooter) =>
             cell?.Paragraphs ?? headerFooter?.Paragraphs ?? section.Paragraphs;
@@ -416,11 +430,7 @@ namespace OfficeIMO.Word.Html {
                             break;
                         }
                     case "hr": {
-                            if (cell != null) {
-                                cell.AddParagraph("", true).AddHorizontalLine();
-                            } else {
-                                (headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("")).AddHorizontalLine();
-                            }
+                            AddParagraphInScope(section, cell, headerFooter).AddHorizontalLine();
                             break;
                         }
                     case "strong":

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
@@ -464,16 +464,32 @@ namespace OfficeIMO.Word.Html {
                             int startIndex = GetGeneratedParagraphStartIndex(section, cell, headerFooter);
                             WordParagraph? para = currentParagraph;
                             foreach (var child in element.ChildNodes) {
+                                int paragraphCount = GetParagraphsInScope(section, cell, headerFooter).Count;
+                                bool startsOwnParagraph =
+                                    child is IElement blockChild &&
+                                    _blockTags.Contains(blockChild.TagName);
                                 if (!string.IsNullOrWhiteSpace(divStyle) && child is IElement childElement) {
                                     var merged = MergeStyles(divStyle, childElement.GetAttribute("style"));
                                     if (!string.IsNullOrEmpty(merged)) {
                                         childElement.SetAttribute("style", merged);
                                     }
                                 }
-                                ProcessNode(child, doc, section, options, para, listStack, fmt, cell, headerFooter, headingList);
-                                if (para == null) {
+                                ProcessNode(
+                                    child,
+                                    doc,
+                                    section,
+                                    options,
+                                    startsOwnParagraph ? null : para,
+                                    listStack,
+                                    fmt,
+                                    cell,
+                                    headerFooter,
+                                    headingList);
+                                if (startsOwnParagraph) {
+                                    para = null;
+                                } else if (para == null) {
                                     var scopedParagraphs = GetParagraphsInScope(section, cell, headerFooter);
-                                    if (scopedParagraphs.Count > startIndex) {
+                                    if (scopedParagraphs.Count > paragraphCount) {
                                         para = scopedParagraphs[scopedParagraphs.Count - 1];
                                     }
                                 }

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
@@ -48,8 +48,8 @@ namespace OfficeIMO.Word.Html {
             !paragraph._paragraph.ChildElements.Any(IsMeaningfulCellParagraphChild);
 
         private static bool IsMeaningfulCellParagraphChild(OpenXmlElement child) {
-            if (child is ParagraphProperties) {
-                return false;
+            if (child is ParagraphProperties properties) {
+                return properties.HasChildren || properties.HasAttributes;
             }
 
             if (child is Run run) {
@@ -439,6 +439,12 @@ namespace OfficeIMO.Word.Html {
                                 }
                             }
                             var generatedParagraphs = GetGeneratedParagraphs(section, cell, headerFooter, startIndex);
+                            if (generatedParagraphs.Count == 0 &&
+                                currentParagraph == null &&
+                                RequiresEmptyBlockParagraph(element)) {
+                                AddParagraphInScope(section, cell, headerFooter);
+                                generatedParagraphs = GetGeneratedParagraphs(section, cell, headerFooter, startIndex);
+                            }
                             ApplyContainerFrameFromCss(element, generatedParagraphs);
                             ApplyContainerPageBreaksFromCss(element, generatedParagraphs);
                             break;

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
@@ -260,20 +260,14 @@ namespace OfficeIMO.Word.Html {
                             int level = int.Parse(element.TagName.Substring(1));
                             WordParagraph paragraph;
                             if (options.SupportsHeadingNumbering && headingList != null) {
-                                WordParagraph? replaceableCellPlaceholder = null;
                                 WordParagraph? insertionAnchor = null;
                                 if (cell != null) {
                                     var cellParagraphs = cell.Paragraphs;
                                     insertionAnchor = cellParagraphs.LastOrDefault();
-                                    if (cellParagraphs.Count == 1 &&
-                                        IsReplaceableEmptyCellParagraph(cellParagraphs[0])) {
-                                        replaceableCellPlaceholder = cellParagraphs[0];
-                                    }
                                 }
                                 paragraph = insertionAnchor == null
                                     ? headingList.AddItem("", level - 1)
                                     : headingList.AddItemAfter("", level - 1, insertionAnchor);
-                                replaceableCellPlaceholder?.Remove();
                             } else {
                                 paragraph = AddParagraphInScope(section, cell, headerFooter);
                             }

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
@@ -333,17 +333,26 @@ namespace OfficeIMO.Word.Html {
                                     para.SetStyleId("Quote");
                                 }
                                 para.IndentationBefore = 720;
-                                ApplyParagraphStyleFromCss(para, element);
+                                ApplyParagraphStyleFromCss(
+                                    para,
+                                    element,
+                                    applyVerticalBoxSpacing: false);
                                 ApplyClassStyle(element, para, options);
                                 ApplyBidiIfPresent(element, para);
                                 if (para == firstPara) {
                                     AddBookmarkIfPresent(element, para);
                                 }
                             }
+                            List<WordParagraph> generatedBlockquoteParagraphs =
+                                blockquoteParagraphs.Skip(startIndex).Take(endIndex - startIndex).ToList();
                             ApplyContainerFrameFromCss(
                                 element,
-                                blockquoteParagraphs.Skip(startIndex).Take(endIndex - startIndex).ToList(),
+                                generatedBlockquoteParagraphs,
                                 applyContainerSpacing: false);
+                            ApplyContainerVerticalSpacingFromCss(
+                                element,
+                                generatedBlockquoteParagraphs,
+                                Array.Empty<WordTable>());
                             if (!string.IsNullOrEmpty(cite)) {
                                 HtmlSemanticMetadata.SetBlockquoteCite(firstPara!, cite);
                                 var noteRef = AddNoteReference(firstPara!, cite ?? string.Empty, options);

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
@@ -70,7 +70,8 @@ namespace OfficeIMO.Word.Html {
                                 int paragraphCount = GetParagraphsInScope(section, cell, headerFooter).Count;
                                 bool standaloneResource = ShouldStartBodyResourceParagraph(child);
                                 bool startsOwnParagraph = standaloneResource ||
-                                    child is IElement childElement && _blockTags.Contains(childElement.TagName);
+                                    child is IElement childElement &&
+                                    ShouldStartContainerChildParagraph(childElement);
                                 ProcessNode(child, doc, section, options, startsOwnParagraph ? null : para, listStack, fmt, cell, headerFooter, headingList);
                                 if (startsOwnParagraph) {
                                     para = null;

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
@@ -99,6 +99,7 @@ namespace OfficeIMO.Word.Html {
                                 WordParagraph? para = null;
                                 foreach (var child in element.ChildNodes) {
                                     if (mergeSectionStyleIntoChildren && !string.IsNullOrWhiteSpace(divStyle) && child is IElement childElement) {
+                                        ResolveComputedFontSizePixels(childElement);
                                         var merged = MergeStyles(divStyle, childElement.GetAttribute("style"));
                                         if (!string.IsNullOrEmpty(merged)) {
                                             childElement.SetAttribute("style", merged);
@@ -131,6 +132,7 @@ namespace OfficeIMO.Word.Html {
                                 WordParagraph? para = currentParagraph;
                                 foreach (var child in element.ChildNodes) {
                                     if (mergeSectionStyleIntoChildren && !string.IsNullOrWhiteSpace(divStyle) && child is IElement childElement) {
+                                        ResolveComputedFontSizePixels(childElement);
                                         var merged = MergeStyles(divStyle, childElement.GetAttribute("style"));
                                         if (!string.IsNullOrEmpty(merged)) {
                                             childElement.SetAttribute("style", merged);
@@ -180,6 +182,7 @@ namespace OfficeIMO.Word.Html {
                             WordParagraph? para = currentParagraph;
                             foreach (var child in element.ChildNodes) {
                                 if (!string.IsNullOrWhiteSpace(divStyle) && child is IElement childElement) {
+                                    ResolveComputedFontSizePixels(childElement);
                                     var merged = MergeStyles(divStyle, childElement.GetAttribute("style"));
                                     if (!string.IsNullOrEmpty(merged)) {
                                         childElement.SetAttribute("style", merged);
@@ -400,6 +403,7 @@ namespace OfficeIMO.Word.Html {
                             foreach (var child in element.ChildNodes) {
                                 int paragraphCount = GetParagraphsInScope(section, cell, headerFooter).Count;
                                 if (!string.IsNullOrWhiteSpace(divStyle) && child is IElement childElement) {
+                                    ResolveComputedFontSizePixels(childElement);
                                     var merged = MergeStyles(divStyle, childElement.GetAttribute("style"));
                                     if (!string.IsNullOrEmpty(merged)) {
                                         childElement.SetAttribute("style", merged);

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
@@ -89,7 +89,7 @@ namespace OfficeIMO.Word.Html {
                             var mergeSectionStyleIntoChildren = !IsExportedWordSectionElement(element);
                             if (!string.IsNullOrWhiteSpace(divStyle)) {
                                 ApplySpanStyles(element, ref fmt);
-                                fmt.BackgroundColorHex = formatting.BackgroundColorHex;
+                                PreserveBlockBackgroundAsTextBackdrop(ref fmt, formatting);
                             }
                             if (options.SectionTagHandling == SectionTagHandling.WordSection && cell == null) {
                                 var newSection = ShouldReuseInitialWordSection(element, doc, section) ? section : doc.AddSection();
@@ -173,7 +173,7 @@ namespace OfficeIMO.Word.Html {
                             var divStyle = element.GetAttribute("style");
                             if (!string.IsNullOrWhiteSpace(divStyle)) {
                                 ApplySpanStyles(element, ref fmt);
-                                fmt.BackgroundColorHex = formatting.BackgroundColorHex;
+                                PreserveBlockBackgroundAsTextBackdrop(ref fmt, formatting);
                             }
                             int scopeStartIndex = GetGeneratedParagraphStartIndex(section, cell, headerFooter);
                             int tableStartIndex = GetTablesInScope(section, cell, headerFooter).Count;
@@ -231,7 +231,7 @@ namespace OfficeIMO.Word.Html {
                             var fmt = formatting;
                             ApplySpanStyles(element, ref fmt);
                             var props = ApplyParagraphStyleFromCss(paragraph, element);
-                            fmt.BackgroundColorHex = formatting.BackgroundColorHex;
+                            PreserveBlockBackgroundAsTextBackdrop(ref fmt, formatting);
                             ApplyClassStyle(element, paragraph, options);
                             ApplyBidiIfPresent(element, paragraph);
                             AddBookmarkIfPresent(element, paragraph);
@@ -250,7 +250,7 @@ namespace OfficeIMO.Word.Html {
                             var fmt = formatting;
                             ApplySpanStyles(element, ref fmt);
                             var props = ApplyParagraphStyleFromCss(paragraph, element);
-                            fmt.BackgroundColorHex = formatting.BackgroundColorHex;
+                            PreserveBlockBackgroundAsTextBackdrop(ref fmt, formatting);
                             if (props.WhiteSpace.HasValue) {
                                 fmt.WhiteSpace = props.WhiteSpace.Value;
                             }
@@ -269,7 +269,7 @@ namespace OfficeIMO.Word.Html {
                             var fmt = formatting;
                             ApplySpanStyles(element, ref fmt);
                             var props = ApplyParagraphStyleFromCss(paragraph, element);
-                            fmt.BackgroundColorHex = formatting.BackgroundColorHex;
+                            PreserveBlockBackgroundAsTextBackdrop(ref fmt, formatting);
                             if (props.WhiteSpace.HasValue) {
                                 fmt.WhiteSpace = props.WhiteSpace.Value;
                             }
@@ -289,7 +289,7 @@ namespace OfficeIMO.Word.Html {
                             var fmt = formatting;
                             ApplySpanStyles(element, ref fmt);
                             var props = ApplyParagraphStyleFromCss(paragraph, element);
-                            fmt.BackgroundColorHex = formatting.BackgroundColorHex;
+                            PreserveBlockBackgroundAsTextBackdrop(ref fmt, formatting);
                             if (props.WhiteSpace.HasValue) {
                                 fmt.WhiteSpace = props.WhiteSpace.Value;
                             }
@@ -313,7 +313,7 @@ namespace OfficeIMO.Word.Html {
                             var cite = element.GetAttribute("cite");
                             var fmt = formatting;
                             ApplySpanStyles(element, ref fmt);
-                            fmt.BackgroundColorHex = formatting.BackgroundColorHex;
+                            PreserveBlockBackgroundAsTextBackdrop(ref fmt, formatting);
                             WordParagraph? firstPara = null;
                             foreach (var child in element.ChildNodes) {
                                 ProcessNode(child, doc, section, options, firstPara, listStack, fmt, cell, headerFooter, headingList);
@@ -383,7 +383,7 @@ namespace OfficeIMO.Word.Html {
                             var divStyle = element.GetAttribute("style");
                             if (!string.IsNullOrWhiteSpace(divStyle)) {
                                 ApplySpanStyles(element, ref fmt);
-                                fmt.BackgroundColorHex = formatting.BackgroundColorHex;
+                                PreserveBlockBackgroundAsTextBackdrop(ref fmt, formatting);
                             }
                             int startIndex = GetGeneratedParagraphStartIndex(section, cell, headerFooter);
                             int tableStartIndex = GetTablesInScope(section, cell, headerFooter).Count;

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
@@ -165,9 +165,7 @@ namespace OfficeIMO.Word.Html {
                             }
                             foreach (var child in element.ChildNodes) {
                                 int paragraphCount = GetParagraphsInScope(section, cell, headerFooter).Count;
-                                bool standaloneResource = child is IElement resourceElement &&
-                                    (resourceElement.TagName.Equals("img", StringComparison.OrdinalIgnoreCase) ||
-                                     resourceElement.TagName.Equals("svg", StringComparison.OrdinalIgnoreCase));
+                                bool standaloneResource = ShouldStartBodyResourceParagraph(child);
                                 bool startsOwnParagraph = standaloneResource ||
                                     child is IElement childElement && _blockTags.Contains(childElement.TagName);
                                 ProcessNode(child, doc, section, options, startsOwnParagraph ? null : para, listStack, fmt, cell, headerFooter, headingList);

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
@@ -106,8 +106,28 @@ namespace OfficeIMO.Word.Html {
                             if (!string.IsNullOrWhiteSpace(bodyStyle)) {
                                 ApplySpanStyles(element, ref fmt);
                             }
+                            WordParagraph? para = currentParagraph;
+                            if (para == null && cell != null) {
+                                var existingParagraphs = cell.Paragraphs;
+                                if (existingParagraphs.Count == 1 && string.IsNullOrEmpty(existingParagraphs[0].Text)) {
+                                    para = existingParagraphs[0];
+                                }
+                            }
                             foreach (var child in element.ChildNodes) {
-                                ProcessNode(child, doc, section, options, currentParagraph, listStack, fmt, cell, headerFooter, headingList);
+                                int paragraphCount = GetParagraphsInScope(section, cell, headerFooter).Count;
+                                bool standaloneResource = child is IElement resourceElement &&
+                                    (resourceElement.TagName.Equals("img", StringComparison.OrdinalIgnoreCase) ||
+                                     resourceElement.TagName.Equals("svg", StringComparison.OrdinalIgnoreCase));
+                                ProcessNode(child, doc, section, options, standaloneResource ? null : para, listStack, fmt, cell, headerFooter, headingList);
+                                if (standaloneResource ||
+                                    child is IElement childElement && _blockTags.Contains(childElement.TagName)) {
+                                    para = null;
+                                } else if (para == null) {
+                                    var scopedParagraphs = GetParagraphsInScope(section, cell, headerFooter);
+                                    if (scopedParagraphs.Count > paragraphCount) {
+                                        para = scopedParagraphs[scopedParagraphs.Count - 1];
+                                    }
+                                }
                             }
                             break;
                         }
@@ -119,7 +139,7 @@ namespace OfficeIMO.Word.Html {
                                 ApplySpanStyles(element, ref fmt);
                                 fmt.BackgroundColorHex = formatting.BackgroundColorHex;
                             }
-                            if (options.SectionTagHandling == SectionTagHandling.WordSection) {
+                            if (options.SectionTagHandling == SectionTagHandling.WordSection && cell == null) {
                                 var newSection = ShouldReuseInitialWordSection(element, doc, section) ? section : doc.AddSection();
                                 ApplyExportedSectionMetadata(element, newSection);
                                 int startIndex = newSection.Paragraphs.Count;
@@ -160,7 +180,8 @@ namespace OfficeIMO.Word.Html {
                                 }
                                 var secId = element.GetAttribute("id");
                                 if (!string.IsNullOrEmpty(secId)) {
-                                    var paragraph = section.Paragraphs.Count > startIndex ? section.Paragraphs[startIndex] : AddParagraphInScope(section, cell, headerFooter);
+                                    var scopedParagraphs = GetParagraphsInScope(section, cell, headerFooter);
+                                    var paragraph = scopedParagraphs.Count > startIndex ? scopedParagraphs[startIndex] : AddParagraphInScope(section, cell, headerFooter);
                                     WordBookmark.AddBookmark(paragraph, $"section:{secId}");
                                 }
                             }
@@ -180,8 +201,6 @@ namespace OfficeIMO.Word.Html {
                                 ApplySpanStyles(element, ref fmt);
                                 fmt.BackgroundColorHex = formatting.BackgroundColorHex;
                             }
-                            // Track start within this section rather than whole document
-                            int startIndex = section.Paragraphs.Count;
                             int scopeStartIndex = GetParagraphsInScope(section, cell, headerFooter).Count;
                             WordParagraph? para = currentParagraph;
                             foreach (var child in element.ChildNodes) {
@@ -196,7 +215,8 @@ namespace OfficeIMO.Word.Html {
                             }
                             var id = element.GetAttribute("id");
                             if (!string.IsNullOrEmpty(id)) {
-                                var paragraph = section.Paragraphs.Count > startIndex ? section.Paragraphs[startIndex] : AddParagraphInScope(section, cell, headerFooter);
+                                var scopedParagraphs = GetParagraphsInScope(section, cell, headerFooter);
+                                var paragraph = scopedParagraphs.Count > scopeStartIndex ? scopedParagraphs[scopeStartIndex] : AddParagraphInScope(section, cell, headerFooter);
                                 WordBookmark.AddBookmark(paragraph, $"{element.TagName.ToLowerInvariant()}:{id}");
                             }
                             var generatedParagraphs = GetGeneratedParagraphs(section, cell, headerFooter, scopeStartIndex);
@@ -340,7 +360,11 @@ namespace OfficeIMO.Word.Html {
                             break;
                         }
                     case "svg": {
-                            ProcessSvgElement(element, doc, section, options, currentParagraph, headerFooter);
+                            WordParagraph? svgParagraph = currentParagraph;
+                            if (svgParagraph == null && cell != null) {
+                                svgParagraph = AddParagraphInScope(section, cell, headerFooter);
+                            }
+                            ProcessSvgElement(element, doc, section, options, svgParagraph, headerFooter);
                             break;
                         }
                     case "pre": {
@@ -370,8 +394,11 @@ namespace OfficeIMO.Word.Html {
                                     }
                                 }
                                 ProcessNode(child, doc, section, options, para, listStack, fmt, cell, headerFooter, headingList);
-                                if (para == null && doc.Paragraphs.Count > 0) {
-                                    para = doc.Paragraphs.Last();
+                                if (para == null) {
+                                    var scopedParagraphs = GetParagraphsInScope(section, cell, headerFooter);
+                                    if (scopedParagraphs.Count > startIndex) {
+                                        para = scopedParagraphs[scopedParagraphs.Count - 1];
+                                    }
                                 }
                             }
                             var generatedParagraphs = GetGeneratedParagraphs(section, cell, headerFooter, startIndex);
@@ -831,7 +858,11 @@ namespace OfficeIMO.Word.Html {
                             break;
                         }
                     case "img": {
-                            ProcessImage((IHtmlImageElement)element, doc, options, currentParagraph, headerFooter);
+                            WordParagraph? imageParagraph = currentParagraph;
+                            if (imageParagraph == null && cell != null) {
+                                imageParagraph = AddParagraphInScope(section, cell, headerFooter);
+                            }
+                            ProcessImage((IHtmlImageElement)element, doc, options, imageParagraph, headerFooter);
                             break;
                         }
                     case "input":
@@ -906,7 +937,7 @@ namespace OfficeIMO.Word.Html {
                         }
                     }
                 }
-                currentParagraph ??= cell != null ? cell.AddParagraph(paragraph: null, removeExistingParagraphs: true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
+                currentParagraph ??= AddParagraphInScope(section, cell, headerFooter);
                 if (textNode.ParentElement != null) {
                     ApplyBidiIfPresent(textNode.ParentElement, currentParagraph);
                     var language = GetElementLanguage(textNode.ParentElement);

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
@@ -902,7 +902,16 @@ namespace OfficeIMO.Word.Html {
                                 imageParagraph = AddParagraphInScope(section, cell, headerFooter);
                                 createdCellParagraph = true;
                             }
-                            ProcessImage((IHtmlImageElement)element, doc, options, imageParagraph, headerFooter);
+                            int? imageContainerWidthTwips = cell == null
+                                ? null
+                                : WordTable.EstimateCellContentWidthInDxa(doc, cell._tableCell);
+                            ProcessImage(
+                                (IHtmlImageElement)element,
+                                doc,
+                                options,
+                                imageParagraph,
+                                headerFooter,
+                                imageContainerWidthTwips);
                             if (createdCellParagraph &&
                                 imageParagraph != null &&
                                 cell!.Paragraphs.Count > 1 &&

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
@@ -250,8 +250,17 @@ namespace OfficeIMO.Word.Html {
                     case "h6": {
                             int level = int.Parse(element.TagName.Substring(1));
                             WordParagraph paragraph;
-                            if (options.SupportsHeadingNumbering && headingList != null && cell == null) {
+                            if (options.SupportsHeadingNumbering && headingList != null) {
+                                WordParagraph? replaceableCellPlaceholder = null;
+                                if (cell != null) {
+                                    var cellParagraphs = cell.Paragraphs;
+                                    if (cellParagraphs.Count == 1 &&
+                                        IsReplaceableEmptyCellParagraph(cellParagraphs[0])) {
+                                        replaceableCellPlaceholder = cellParagraphs[0];
+                                    }
+                                }
                                 paragraph = headingList.AddItem("", level - 1);
+                                replaceableCellPlaceholder?.Remove();
                             } else {
                                 paragraph = AddParagraphInScope(section, cell, headerFooter);
                             }
@@ -368,7 +377,10 @@ namespace OfficeIMO.Word.Html {
                                     AddBookmarkIfPresent(element, para);
                                 }
                             }
-                            ApplyContainerFrameFromCss(element, blockquoteParagraphs.Skip(startIndex).Take(endIndex - startIndex).ToList());
+                            ApplyContainerFrameFromCss(
+                                element,
+                                blockquoteParagraphs.Skip(startIndex).Take(endIndex - startIndex).ToList(),
+                                applyContainerSpacing: false);
                             if (!string.IsNullOrEmpty(cite)) {
                                 HtmlSemanticMetadata.SetBlockquoteCite(firstPara!, cite);
                                 var noteRef = AddNoteReference(firstPara!, cite ?? string.Empty, options);

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
@@ -118,7 +118,7 @@ namespace OfficeIMO.Word.Html {
                                         tableStartIndex);
                                     List<WordTable> generatedTables = GetGeneratedTables(newSection, null, headerFooter, tableStartIndex);
                                     ApplyContainerFrameFromCss(element, generatedParagraphs, generatedTables);
-                                    ApplyContainerPageBreaksFromCss(element, generatedParagraphs);
+                                    ApplyContainerPageBreaksFromCss(element, generatedParagraphs, generatedTables);
                                 }
                                 var secId = element.GetAttribute("id");
                                 if (!string.IsNullOrEmpty(secId)) {
@@ -150,7 +150,7 @@ namespace OfficeIMO.Word.Html {
                                         tableStartIndex);
                                     List<WordTable> generatedTables = GetGeneratedTables(section, cell, headerFooter, tableStartIndex);
                                     ApplyContainerFrameFromCss(element, generatedParagraphs, generatedTables);
-                                    ApplyContainerPageBreaksFromCss(element, generatedParagraphs);
+                                    ApplyContainerPageBreaksFromCss(element, generatedParagraphs, generatedTables);
                                 }
                                 var secId = element.GetAttribute("id");
                                 if (!string.IsNullOrEmpty(secId)) {
@@ -204,7 +204,7 @@ namespace OfficeIMO.Word.Html {
                                 tableStartIndex);
                             List<WordTable> generatedTables = GetGeneratedTables(section, cell, headerFooter, tableStartIndex);
                             ApplyContainerFrameFromCss(element, generatedParagraphs, generatedTables);
-                            ApplyContainerPageBreaksFromCss(element, generatedParagraphs);
+                            ApplyContainerPageBreaksFromCss(element, generatedParagraphs, generatedTables);
                             break;
                         }
                     case "h1":
@@ -429,7 +429,7 @@ namespace OfficeIMO.Word.Html {
                                 tableStartIndex);
                             List<WordTable> generatedTables = GetGeneratedTables(section, cell, headerFooter, tableStartIndex);
                             ApplyContainerFrameFromCss(element, generatedParagraphs, generatedTables);
-                            ApplyContainerPageBreaksFromCss(element, generatedParagraphs);
+                            ApplyContainerPageBreaksFromCss(element, generatedParagraphs, generatedTables);
                             break;
                         }
                     case "br": {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
@@ -34,103 +34,6 @@ namespace OfficeIMO.Word.Html {
             return false;
         }
 
-        private static WordParagraph AddParagraphInScope(WordSection section, WordTableCell? cell, WordHeaderFooter? headerFooter) {
-            if (cell != null) {
-                var paragraphs = cell.Paragraphs;
-                bool removeExisting = paragraphs.Count == 1 && IsReplaceableEmptyCellParagraph(paragraphs[0]);
-                return cell.AddParagraph("", removeExisting);
-            }
-
-            return headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
-        }
-
-        private static bool IsReplaceableEmptyCellParagraph(WordParagraph paragraph) =>
-            !paragraph._paragraph.ChildElements.Any(IsMeaningfulCellParagraphChild);
-
-        private static bool IsMeaningfulCellParagraphChild(OpenXmlElement child) {
-            if (child is ParagraphProperties properties) {
-                return properties.HasChildren || properties.HasAttributes;
-            }
-
-            if (child is Run run) {
-                return run.ChildElements.Any(runChild =>
-                    runChild is not RunProperties &&
-                    (runChild is not Text text || !string.IsNullOrEmpty(text.Text)));
-            }
-
-            return true;
-        }
-
-        private static List<WordParagraph> GetParagraphsInScope(WordSection section, WordTableCell? cell, WordHeaderFooter? headerFooter) =>
-            cell?.Paragraphs ?? headerFooter?.Paragraphs ?? section.Paragraphs;
-
-        private static int GetGeneratedParagraphStartIndex(WordSection section, WordTableCell? cell, WordHeaderFooter? headerFooter) {
-            List<WordParagraph> paragraphs = GetParagraphsInScope(section, cell, headerFooter);
-            return cell != null &&
-                   paragraphs.Count == 1 &&
-                   IsReplaceableEmptyCellParagraph(paragraphs[0])
-                ? 0
-                : paragraphs.Count;
-        }
-
-        private static List<WordParagraph> GetGeneratedParagraphs(WordSection section, WordTableCell? cell, WordHeaderFooter? headerFooter, int startIndex) =>
-            GetParagraphsInScope(section, cell, headerFooter).Skip(startIndex).ToList();
-
-        private static List<WordParagraph> GetMaterializedContainerParagraphs(
-            IElement element,
-            WordSection section,
-            WordTableCell? cell,
-            WordHeaderFooter? headerFooter,
-            WordParagraph? currentParagraph,
-            int startIndex) {
-            List<WordParagraph> paragraphs = GetGeneratedParagraphs(section, cell, headerFooter, startIndex);
-            if (paragraphs.Count == 0 &&
-                currentParagraph != null &&
-                GetParagraphsInScope(section, cell, headerFooter)
-                    .Any(paragraph => ReferenceEquals(paragraph._paragraph, currentParagraph._paragraph))) {
-                paragraphs.Add(currentParagraph);
-            }
-            if (paragraphs.Count == 0 &&
-                currentParagraph == null &&
-                RequiresEmptyBlockParagraph(element)) {
-                AddParagraphInScope(section, cell, headerFooter);
-                paragraphs = GetGeneratedParagraphs(section, cell, headerFooter, startIndex);
-            }
-
-            return paragraphs;
-        }
-
-        private static bool ShouldReuseInitialWordSection(IElement element, WordDocument doc, WordSection section) {
-            if (!string.Equals(element.GetAttribute("data-word-section"), "1", StringComparison.OrdinalIgnoreCase)) {
-                return false;
-            }
-
-            if (!element.ClassList.Contains("word-section")) {
-                return false;
-            }
-
-            if (doc.Sections.Count != 1 || !ReferenceEquals(doc.Sections[0], section)) {
-                return false;
-            }
-
-            return section.Tables.Count == 0 &&
-                   section.Paragraphs.All(paragraph => string.IsNullOrWhiteSpace(paragraph.Text) && !paragraph.GetRuns().Any());
-        }
-
-        private static void ApplyContainerPageBreaksFromCss(IElement element, IReadOnlyList<WordParagraph> paragraphs) {
-            if (paragraphs.Count == 0) {
-                return;
-            }
-
-            if (StyleRequestsPageBreakBefore(element)) {
-                paragraphs[0].PageBreakBefore = true;
-            }
-
-            if (StyleRequestsPageBreakAfter(element)) {
-                AddPageBreakAfter(paragraphs[paragraphs.Count - 1]);
-            }
-        }
-
         private void ProcessNode(INode node, WordDocument doc, WordSection section, HtmlToWordOptions options,
             WordParagraph? currentParagraph, Stack<WordList> listStack, TextFormatting formatting, WordTableCell? cell, WordHeaderFooter? headerFooter = null, WordList? headingList = null) {
             if (node is IElement element) {
@@ -192,6 +95,7 @@ namespace OfficeIMO.Word.Html {
                                 var newSection = ShouldReuseInitialWordSection(element, doc, section) ? section : doc.AddSection();
                                 ApplyExportedSectionMetadata(element, newSection);
                                 int startIndex = newSection.Paragraphs.Count;
+                                int tableStartIndex = GetTablesInScope(newSection, null, headerFooter).Count;
                                 WordParagraph? para = null;
                                 foreach (var child in element.ChildNodes) {
                                     if (mergeSectionStyleIntoChildren && !string.IsNullOrWhiteSpace(divStyle) && child is IElement childElement) {
@@ -210,8 +114,10 @@ namespace OfficeIMO.Word.Html {
                                         null,
                                         headerFooter,
                                         null,
-                                        startIndex);
-                                    ApplyContainerFrameFromCss(element, generatedParagraphs);
+                                        startIndex,
+                                        tableStartIndex);
+                                    List<WordTable> generatedTables = GetGeneratedTables(newSection, null, headerFooter, tableStartIndex);
+                                    ApplyContainerFrameFromCss(element, generatedParagraphs, generatedTables);
                                     ApplyContainerPageBreaksFromCss(element, generatedParagraphs);
                                 }
                                 var secId = element.GetAttribute("id");
@@ -221,6 +127,7 @@ namespace OfficeIMO.Word.Html {
                                 }
                             } else {
                                 int startIndex = GetGeneratedParagraphStartIndex(section, cell, headerFooter);
+                                int tableStartIndex = GetTablesInScope(section, cell, headerFooter).Count;
                                 WordParagraph? para = currentParagraph;
                                 foreach (var child in element.ChildNodes) {
                                     if (mergeSectionStyleIntoChildren && !string.IsNullOrWhiteSpace(divStyle) && child is IElement childElement) {
@@ -239,8 +146,10 @@ namespace OfficeIMO.Word.Html {
                                         cell,
                                         headerFooter,
                                         currentParagraph,
-                                        startIndex);
-                                    ApplyContainerFrameFromCss(element, generatedParagraphs);
+                                        startIndex,
+                                        tableStartIndex);
+                                    List<WordTable> generatedTables = GetGeneratedTables(section, cell, headerFooter, tableStartIndex);
+                                    ApplyContainerFrameFromCss(element, generatedParagraphs, generatedTables);
                                     ApplyContainerPageBreaksFromCss(element, generatedParagraphs);
                                 }
                                 var secId = element.GetAttribute("id");
@@ -267,6 +176,7 @@ namespace OfficeIMO.Word.Html {
                                 fmt.BackgroundColorHex = formatting.BackgroundColorHex;
                             }
                             int scopeStartIndex = GetGeneratedParagraphStartIndex(section, cell, headerFooter);
+                            int tableStartIndex = GetTablesInScope(section, cell, headerFooter).Count;
                             WordParagraph? para = currentParagraph;
                             foreach (var child in element.ChildNodes) {
                                 if (!string.IsNullOrWhiteSpace(divStyle) && child is IElement childElement) {
@@ -290,8 +200,10 @@ namespace OfficeIMO.Word.Html {
                                 cell,
                                 headerFooter,
                                 currentParagraph,
-                                scopeStartIndex);
-                            ApplyContainerFrameFromCss(element, generatedParagraphs);
+                                scopeStartIndex,
+                                tableStartIndex);
+                            List<WordTable> generatedTables = GetGeneratedTables(section, cell, headerFooter, tableStartIndex);
+                            ApplyContainerFrameFromCss(element, generatedParagraphs, generatedTables);
                             ApplyContainerPageBreaksFromCss(element, generatedParagraphs);
                             break;
                         }
@@ -474,6 +386,7 @@ namespace OfficeIMO.Word.Html {
                                 fmt.BackgroundColorHex = formatting.BackgroundColorHex;
                             }
                             int startIndex = GetGeneratedParagraphStartIndex(section, cell, headerFooter);
+                            int tableStartIndex = GetTablesInScope(section, cell, headerFooter).Count;
                             WordParagraph? para = currentParagraph;
                             foreach (var child in element.ChildNodes) {
                                 int paragraphCount = GetParagraphsInScope(section, cell, headerFooter).Count;
@@ -512,8 +425,10 @@ namespace OfficeIMO.Word.Html {
                                 cell,
                                 headerFooter,
                                 currentParagraph,
-                                startIndex);
-                            ApplyContainerFrameFromCss(element, generatedParagraphs);
+                                startIndex,
+                                tableStartIndex);
+                            List<WordTable> generatedTables = GetGeneratedTables(section, cell, headerFooter, tableStartIndex);
+                            ApplyContainerFrameFromCss(element, generatedParagraphs, generatedTables);
                             ApplyContainerPageBreaksFromCss(element, generatedParagraphs);
                             break;
                         }

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
@@ -76,6 +76,24 @@ namespace OfficeIMO.Word.Html {
         private static List<WordParagraph> GetGeneratedParagraphs(WordSection section, WordTableCell? cell, WordHeaderFooter? headerFooter, int startIndex) =>
             GetParagraphsInScope(section, cell, headerFooter).Skip(startIndex).ToList();
 
+        private static List<WordParagraph> GetMaterializedContainerParagraphs(
+            IElement element,
+            WordSection section,
+            WordTableCell? cell,
+            WordHeaderFooter? headerFooter,
+            WordParagraph? currentParagraph,
+            int startIndex) {
+            List<WordParagraph> paragraphs = GetGeneratedParagraphs(section, cell, headerFooter, startIndex);
+            if (paragraphs.Count == 0 &&
+                currentParagraph == null &&
+                RequiresEmptyBlockParagraph(element)) {
+                AddParagraphInScope(section, cell, headerFooter);
+                paragraphs = GetGeneratedParagraphs(section, cell, headerFooter, startIndex);
+            }
+
+            return paragraphs;
+        }
+
         private static bool ShouldReuseInitialWordSection(IElement element, WordDocument doc, WordSection section) {
             if (!string.Equals(element.GetAttribute("data-word-section"), "1", StringComparison.OrdinalIgnoreCase)) {
                 return false;
@@ -182,7 +200,15 @@ namespace OfficeIMO.Word.Html {
                                     para = null;
                                 }
                                 if (mergeSectionStyleIntoChildren) {
-                                    ApplyContainerFrameFromCss(element, newSection.Paragraphs.Skip(startIndex).ToList());
+                                    List<WordParagraph> generatedParagraphs = GetMaterializedContainerParagraphs(
+                                        element,
+                                        newSection,
+                                        null,
+                                        headerFooter,
+                                        null,
+                                        startIndex);
+                                    ApplyContainerFrameFromCss(element, generatedParagraphs);
+                                    ApplyContainerPageBreaksFromCss(element, generatedParagraphs);
                                 }
                                 var secId = element.GetAttribute("id");
                                 if (!string.IsNullOrEmpty(secId)) {
@@ -203,7 +229,15 @@ namespace OfficeIMO.Word.Html {
                                     para = null;
                                 }
                                 if (mergeSectionStyleIntoChildren) {
-                                    ApplyContainerFrameFromCss(element, GetGeneratedParagraphs(section, cell, headerFooter, startIndex));
+                                    List<WordParagraph> generatedParagraphs = GetMaterializedContainerParagraphs(
+                                        element,
+                                        section,
+                                        cell,
+                                        headerFooter,
+                                        currentParagraph,
+                                        startIndex);
+                                    ApplyContainerFrameFromCss(element, generatedParagraphs);
+                                    ApplyContainerPageBreaksFromCss(element, generatedParagraphs);
                                 }
                                 var secId = element.GetAttribute("id");
                                 if (!string.IsNullOrEmpty(secId)) {
@@ -246,7 +280,13 @@ namespace OfficeIMO.Word.Html {
                                 var paragraph = scopedParagraphs.Count > scopeStartIndex ? scopedParagraphs[scopeStartIndex] : AddParagraphInScope(section, cell, headerFooter);
                                 WordBookmark.AddBookmark(paragraph, $"{element.TagName.ToLowerInvariant()}:{id}");
                             }
-                            var generatedParagraphs = GetGeneratedParagraphs(section, cell, headerFooter, scopeStartIndex);
+                            var generatedParagraphs = GetMaterializedContainerParagraphs(
+                                element,
+                                section,
+                                cell,
+                                headerFooter,
+                                currentParagraph,
+                                scopeStartIndex);
                             ApplyContainerFrameFromCss(element, generatedParagraphs);
                             ApplyContainerPageBreaksFromCss(element, generatedParagraphs);
                             break;
@@ -438,13 +478,13 @@ namespace OfficeIMO.Word.Html {
                                     }
                                 }
                             }
-                            var generatedParagraphs = GetGeneratedParagraphs(section, cell, headerFooter, startIndex);
-                            if (generatedParagraphs.Count == 0 &&
-                                currentParagraph == null &&
-                                RequiresEmptyBlockParagraph(element)) {
-                                AddParagraphInScope(section, cell, headerFooter);
-                                generatedParagraphs = GetGeneratedParagraphs(section, cell, headerFooter, startIndex);
-                            }
+                            var generatedParagraphs = GetMaterializedContainerParagraphs(
+                                element,
+                                section,
+                                cell,
+                                headerFooter,
+                                currentParagraph,
+                                startIndex);
                             ApplyContainerFrameFromCss(element, generatedParagraphs);
                             ApplyContainerPageBreaksFromCss(element, generatedParagraphs);
                             break;
@@ -898,10 +938,18 @@ namespace OfficeIMO.Word.Html {
                         }
                     case "img": {
                             WordParagraph? imageParagraph = currentParagraph;
+                            bool createdCellParagraph = false;
                             if (imageParagraph == null && cell != null) {
                                 imageParagraph = AddParagraphInScope(section, cell, headerFooter);
+                                createdCellParagraph = true;
                             }
                             ProcessImage((IHtmlImageElement)element, doc, options, imageParagraph, headerFooter);
+                            if (createdCellParagraph &&
+                                imageParagraph != null &&
+                                cell!.Paragraphs.Count > 1 &&
+                                IsReplaceableEmptyCellParagraph(imageParagraph)) {
+                                imageParagraph.Remove();
+                            }
                             break;
                         }
                     case "input":

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Notes.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Notes.cs
@@ -11,14 +11,14 @@ namespace OfficeIMO.Word.Html {
             WordTableCell? cell,
             WordHeaderFooter? headerFooter) {
             if (_footnoteMap.TryGetValue(anchor, out var fnText)) {
-                currentParagraph ??= cell != null ? cell.AddParagraph("", true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
+                currentParagraph ??= AddParagraphInScope(section, cell, headerFooter);
                 var noteRef = AddNoteReference(currentParagraph!, fnText, options, NoteReferenceType.Footnote);
                 TryLinkNoteReference(noteRef, string.Join(Environment.NewLine, fnText), options, NoteReferenceType.Footnote);
                 return true;
             }
 
             if (_endnoteMap.TryGetValue(anchor, out var enText)) {
-                currentParagraph ??= cell != null ? cell.AddParagraph("", true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
+                currentParagraph ??= AddParagraphInScope(section, cell, headerFooter);
                 var noteRef = AddNoteReference(currentParagraph!, enText, options, NoteReferenceType.Endnote);
                 TryLinkNoteReference(noteRef, string.Join(Environment.NewLine, enText), options, NoteReferenceType.Endnote);
                 return true;

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Stylesheets.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Stylesheets.cs
@@ -300,9 +300,7 @@ namespace OfficeIMO.Word.Html {
 
             var own = CollectCssDeclarations(element, inheritedOnly: false);
             if (!_computedFontSizePixels.ContainsKey(element)) {
-                CacheComputedFontSizePixels(
-                    element,
-                    own.TryGetValue("font-size", out var fontSize) ? fontSize.Value : null);
+                CacheComputedFontSizePixels(element, own);
             }
             foreach (var kvp in own) {
                 accumulated[kvp.Key] = kvp.Value;
@@ -338,8 +336,7 @@ namespace OfficeIMO.Word.Html {
             }
 
             var declarations = CollectCssDeclarations(root, inheritedOnly: false);
-            if (!declarations.TryGetValue("font-size", out var declaration) ||
-                !TryResolveRootFontSizePixels(declaration.Value, out double pixels)) {
+            if (!TryResolveRootFontSizePixels(declarations, out double pixels)) {
                 return _renderDevice.FontSize;
             }
 

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Stylesheets.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Stylesheets.cs
@@ -271,6 +271,7 @@ namespace OfficeIMO.Word.Html {
 
         private void ApplyCssToElement(IElement element) {
             if (_cssRules.Count == 0) {
+                ResolveComputedFontSizePixels(element);
                 ReportUnsupportedInlineCssDiagnostics(element);
                 return;
             }
@@ -298,6 +299,11 @@ namespace OfficeIMO.Word.Html {
             }
 
             var own = CollectCssDeclarations(element, inheritedOnly: false);
+            if (!_computedFontSizePixels.ContainsKey(element)) {
+                CacheComputedFontSizePixels(
+                    element,
+                    own.TryGetValue("font-size", out var fontSize) ? fontSize.Value : null);
+            }
             foreach (var kvp in own) {
                 accumulated[kvp.Key] = kvp.Value;
                 cascadeOrigins[kvp.Key] = cascadeOrigin;
@@ -324,6 +330,20 @@ namespace OfficeIMO.Word.Html {
                 }
                 element.SetAttribute("style", sb.ToString());
             }
+        }
+
+        private double ResolveRootFontSizePixels(IElement? root) {
+            if (root == null) {
+                return _renderDevice.FontSize;
+            }
+
+            var declarations = CollectCssDeclarations(root, inheritedOnly: false);
+            if (!declarations.TryGetValue("font-size", out var declaration) ||
+                !TryResolveRootFontSizePixels(declaration.Value, out double pixels)) {
+                return _renderDevice.FontSize;
+            }
+
+            return pixels;
         }
 
         private Dictionary<string, (string Value, Priority Specificity, bool Important, int Order)> CollectCssDeclarations(IElement element, bool inheritedOnly) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Stylesheets.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Stylesheets.cs
@@ -297,6 +297,16 @@ namespace OfficeIMO.Word.Html {
             foreach (var kvp in own) {
                 accumulated[kvp.Key] = kvp.Value;
             }
+            string? directionAttribute = element.GetAttribute("dir");
+            if (!own.ContainsKey("direction") &&
+                (directionAttribute?.Equals("ltr", StringComparison.OrdinalIgnoreCase) == true ||
+                 directionAttribute?.Equals("rtl", StringComparison.OrdinalIgnoreCase) == true)) {
+                accumulated["direction"] = (
+                    directionAttribute!.ToLowerInvariant(),
+                    default,
+                    false,
+                    int.MaxValue);
+            }
 
             if (accumulated.Count > 0) {
                 ReportUnsupportedCssDiagnostics(

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Stylesheets.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Stylesheets.cs
@@ -307,15 +307,12 @@ namespace OfficeIMO.Word.Html {
                 cascadeOrigins[kvp.Key] = cascadeOrigin;
             }
             string? directionAttribute = element.GetAttribute("dir");
-            if (!own.ContainsKey("direction") &&
-                (directionAttribute?.Equals("ltr", StringComparison.OrdinalIgnoreCase) == true ||
-                 directionAttribute?.Equals("rtl", StringComparison.OrdinalIgnoreCase) == true)) {
-                accumulated["direction"] = (
-                    directionAttribute!.ToLowerInvariant(),
-                    default,
-                    false,
-                    int.MaxValue);
-                cascadeOrigins["direction"] = cascadeOrigin;
+            if (!own.ContainsKey("direction")) {
+                if (directionAttribute?.Equals("ltr", StringComparison.OrdinalIgnoreCase) == true) {
+                    _directionAttributeOverrides[element] = false;
+                } else if (directionAttribute?.Equals("rtl", StringComparison.OrdinalIgnoreCase) == true) {
+                    _directionAttributeOverrides[element] = true;
+                }
             }
 
             if (accumulated.Count > 0) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Stylesheets.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Stylesheets.cs
@@ -277,6 +277,7 @@ namespace OfficeIMO.Word.Html {
 
             var accumulated = new Dictionary<string, (string Value, Priority Specificity, bool Important, int Order)>(
                 StringComparer.OrdinalIgnoreCase);
+            var cascadeOrigins = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
 
             var ancestors = new List<IElement>();
             var parent = element.ParentElement;
@@ -286,16 +287,20 @@ namespace OfficeIMO.Word.Html {
             }
             ancestors.Reverse();
 
+            int cascadeOrigin = 0;
             foreach (var ancestor in ancestors) {
                 var inherited = CollectCssDeclarations(ancestor, inheritedOnly: true);
                 foreach (var kvp in inherited) {
                     accumulated[kvp.Key] = kvp.Value;
+                    cascadeOrigins[kvp.Key] = cascadeOrigin;
                 }
+                cascadeOrigin++;
             }
 
             var own = CollectCssDeclarations(element, inheritedOnly: false);
             foreach (var kvp in own) {
                 accumulated[kvp.Key] = kvp.Value;
+                cascadeOrigins[kvp.Key] = cascadeOrigin;
             }
             string? directionAttribute = element.GetAttribute("dir");
             if (!own.ContainsKey("direction") &&
@@ -306,6 +311,7 @@ namespace OfficeIMO.Word.Html {
                     default,
                     false,
                     int.MaxValue);
+                cascadeOrigins["direction"] = cascadeOrigin;
             }
 
             if (accumulated.Count > 0) {
@@ -313,7 +319,7 @@ namespace OfficeIMO.Word.Html {
                     element,
                     accumulated.ToDictionary(pair => pair.Key, pair => pair.Value.Value, StringComparer.OrdinalIgnoreCase));
                 var sb = new StringBuilder();
-                foreach (var kvp in accumulated) {
+                foreach (var kvp in OrderCssDeclarationsForReplay(accumulated, cascadeOrigins)) {
                     sb.Append(kvp.Key).Append(':').Append(kvp.Value.Value).Append(';');
                 }
                 element.SetAttribute("style", sb.ToString());
@@ -323,6 +329,7 @@ namespace OfficeIMO.Word.Html {
         private Dictionary<string, (string Value, Priority Specificity, bool Important, int Order)> CollectCssDeclarations(IElement element, bool inheritedOnly) {
             var accumulated = new Dictionary<string, (string Value, Priority Specificity, bool Important, int Order)>(
                 StringComparer.OrdinalIgnoreCase);
+            int declarationOrder = 0;
 
             for (int ruleIndex = 0; ruleIndex < _cssRules.Count; ruleIndex++) {
                 var rule = _cssRules[ruleIndex];
@@ -336,7 +343,7 @@ namespace OfficeIMO.Word.Html {
                         if (inheritedOnly && !_inheritedCssProperties.Contains(property.Name)) {
                             continue;
                         }
-                        ApplyCssCandidate(accumulated, property.Name, property.Value, specificity, property.IsImportant, ruleIndex);
+                        ApplyCssCandidate(accumulated, property.Name, property.Value, specificity, property.IsImportant, declarationOrder++);
                     }
                 }
             }
@@ -349,7 +356,7 @@ namespace OfficeIMO.Word.Html {
                         if (inheritedOnly && !_inheritedCssProperties.Contains(property.Name)) {
                             continue;
                         }
-                        ApplyCssCandidate(accumulated, property.Name, property.Value, Priority.Inline, property.IsImportant, int.MaxValue);
+                        ApplyCssCandidate(accumulated, property.Name, property.Value, Priority.Inline, property.IsImportant, declarationOrder++);
                     }
                 } catch (Exception) {
                     // ignore invalid inline style
@@ -357,6 +364,39 @@ namespace OfficeIMO.Word.Html {
             }
 
             return accumulated;
+        }
+
+        private static IReadOnlyList<KeyValuePair<string, (string Value, Priority Specificity, bool Important, int Order)>>
+            OrderCssDeclarationsForReplay(
+                Dictionary<string, (string Value, Priority Specificity, bool Important, int Order)> declarations,
+                IReadOnlyDictionary<string, int> cascadeOrigins) {
+            var ordered = declarations
+                .Select((declaration, index) => (
+                    Declaration: declaration,
+                    Origin: cascadeOrigins[declaration.Key],
+                    Index: index))
+                .ToList();
+
+            ordered.Sort((left, right) => {
+                int comparison = left.Origin.CompareTo(right.Origin);
+                if (comparison != 0) {
+                    return comparison;
+                }
+
+                comparison = left.Declaration.Value.Important.CompareTo(right.Declaration.Value.Important);
+                if (comparison != 0) {
+                    return comparison;
+                }
+
+                if (left.Declaration.Value.Specificity != right.Declaration.Value.Specificity) {
+                    return left.Declaration.Value.Specificity > right.Declaration.Value.Specificity ? 1 : -1;
+                }
+
+                comparison = left.Declaration.Value.Order.CompareTo(right.Declaration.Value.Order);
+                return comparison != 0 ? comparison : left.Index.CompareTo(right.Index);
+            });
+
+            return ordered.Select(item => item.Declaration).ToList();
         }
 
         private void RecordCssRule(ICssStyleRule rule) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.TablePresentation.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.TablePresentation.cs
@@ -2,7 +2,10 @@ using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word.Html {
     internal partial class HtmlToWordConverter {
-        private static void ApplyTableBackground(WordTableCell cell, string value) {
+        private static void ApplyTableBackground(
+            WordTableCell cell,
+            string value,
+            string? ancestorBackdrop) {
             CssStyleMapper.CssProperties parsed =
                 CssStyleMapper.ParseStyles("background-color:" + value);
             if (string.IsNullOrEmpty(parsed.BackgroundColor)) {
@@ -17,7 +20,30 @@ namespace OfficeIMO.Word.Html {
             cell.ShadingFillColorHex = ResolveOpaqueTextBackground(
                 parsed.BackgroundColor!,
                 alpha,
-                cell.ShadingFillColorHex);
+                string.IsNullOrEmpty(cell.ShadingFillColorHex)
+                    ? ancestorBackdrop
+                    : cell.ShadingFillColorHex);
+        }
+
+        private static string? ResolveAncestorBlockBackground(AngleSharp.Dom.IElement element) {
+            var lineage = new Stack<AngleSharp.Dom.IElement>();
+            for (AngleSharp.Dom.IElement? current = element.ParentElement;
+                 current != null;
+                 current = current.ParentElement) {
+                lineage.Push(current);
+            }
+
+            string? backdrop = null;
+            while (lineage.Count > 0) {
+                AngleSharp.Dom.IElement ancestor = lineage.Pop();
+                string? resolved = ResolveBlockBackground(
+                    ancestor.GetAttribute("style") ?? string.Empty,
+                    backdrop);
+                if (!string.IsNullOrEmpty(resolved)) {
+                    backdrop = resolved;
+                }
+            }
+            return backdrop;
         }
 
         private static void ClearSyntheticTableTrailingSpacing(Paragraph paragraph) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.TablePresentation.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.TablePresentation.cs
@@ -1,0 +1,33 @@
+using DocumentFormat.OpenXml.Wordprocessing;
+
+namespace OfficeIMO.Word.Html {
+    internal partial class HtmlToWordConverter {
+        private static void ApplyTableBackground(WordTableCell cell, string value) {
+            CssStyleMapper.CssProperties parsed =
+                CssStyleMapper.ParseStyles("background-color:" + value);
+            if (string.IsNullOrEmpty(parsed.BackgroundColor)) {
+                return;
+            }
+
+            double alpha = parsed.BackgroundColorAlpha ?? 1d;
+            if (alpha <= 0d) {
+                return;
+            }
+
+            cell.ShadingFillColorHex = ResolveOpaqueTextBackground(
+                parsed.BackgroundColor!,
+                alpha,
+                cell.ShadingFillColorHex);
+        }
+
+        private static void ClearSyntheticTableTrailingSpacing(Paragraph paragraph) {
+            if (!HasOnlySyntheticZeroSpacing(paragraph)) {
+                return;
+            }
+
+            SpacingBetweenLines? spacing =
+                paragraph.ParagraphProperties?.GetFirstChild<SpacingBetweenLines>();
+            spacing?.Remove();
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Tables.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Tables.cs
@@ -27,7 +27,7 @@ namespace OfficeIMO.Word.Html {
             ValidateTableLimit(options, rows, cols);
             WordParagraph? captionParagraph = null;
             if (caption != null && options.TableCaptionPosition == TableCaptionPosition.Above) {
-                captionParagraph = cell != null ? cell.AddParagraph("", true)
+                captionParagraph = cell != null ? AddParagraphInScope(section, cell, headerFooter)
                     : currentParagraph != null ? currentParagraph.AddParagraphAfterSelf()
                     : headerFooter != null ? headerFooter.AddParagraph("")
                     : section.AddParagraph("");
@@ -153,7 +153,7 @@ namespace OfficeIMO.Word.Html {
             if (caption != null && options.TableCaptionPosition == TableCaptionPosition.Below) {
                 WordParagraph captionParagraphBelow;
                 if (cell != null) {
-                    captionParagraphBelow = cell.AddParagraph("", true);
+                    captionParagraphBelow = AddParagraphInScope(section, cell, headerFooter);
                 } else if (headerFooter != null) {
                     captionParagraphBelow = headerFooter.AddParagraph("");
                 } else {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Tables.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Tables.cs
@@ -539,9 +539,10 @@ namespace OfficeIMO.Word.Html {
             }
 
             if (backgroundValue != null) {
+                string? ancestorBackdrop = ResolveAncestorBlockBackground(tableElem);
                 foreach (var row in wordTable.Rows) {
                     foreach (var cell in row.Cells) {
-                        ApplyTableBackground(cell, backgroundValue);
+                        ApplyTableBackground(cell, backgroundValue, ancestorBackdrop);
                     }
                 }
             }
@@ -721,7 +722,10 @@ namespace OfficeIMO.Word.Html {
 
             foreach (var cell in row.Cells) {
                 if (backgroundValue != null) {
-                    ApplyTableBackground(cell, backgroundValue);
+                    ApplyTableBackground(
+                        cell,
+                        backgroundValue,
+                        ResolveAncestorBlockBackground(htmlRow));
                 }
                 if (borderStyle != null && borderSize != null) {
                     cell.Borders.LeftStyle = cell.Borders.RightStyle = cell.Borders.TopStyle = cell.Borders.BottomStyle = borderStyle;
@@ -812,7 +816,10 @@ namespace OfficeIMO.Word.Html {
                 }
             }
             if (backgroundValue != null) {
-                ApplyTableBackground(cell, backgroundValue);
+                ApplyTableBackground(
+                    cell,
+                    backgroundValue,
+                    ResolveAncestorBlockBackground(htmlCell));
             }
 
             if (alignment == null && !string.IsNullOrWhiteSpace(alignAttr)) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Tables.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Tables.cs
@@ -999,11 +999,21 @@ namespace OfficeIMO.Word.Html {
         private static bool TryParseBorderWidth(string token, out UInt32Value size) {
             size = 0;
             var raw = token.Trim().ToLowerInvariant();
-            if (raw.EndsWith("px") && double.TryParse(raw.Substring(0, raw.Length - 2), out double px)) {
+            if (raw.EndsWith("px") &&
+                double.TryParse(
+                    raw.Substring(0, raw.Length - 2),
+                    NumberStyles.Float,
+                    CultureInfo.InvariantCulture,
+                    out double px)) {
                 size = (UInt32Value)(uint)Math.Max(1, Math.Round(px * 6));
                 return true;
             }
-            if (raw.EndsWith("pt") && double.TryParse(raw.Substring(0, raw.Length - 2), out double pt)) {
+            if (raw.EndsWith("pt") &&
+                double.TryParse(
+                    raw.Substring(0, raw.Length - 2),
+                    NumberStyles.Float,
+                    CultureInfo.InvariantCulture,
+                    out double pt)) {
                 size = (UInt32Value)(uint)Math.Max(1, Math.Round(pt * 8));
                 return true;
             }

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Tables.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Tables.cs
@@ -153,7 +153,10 @@ namespace OfficeIMO.Word.Html {
             if (caption != null && options.TableCaptionPosition == TableCaptionPosition.Below) {
                 WordParagraph captionParagraphBelow;
                 if (cell != null) {
-                    captionParagraphBelow = AddParagraphInScope(section, cell, headerFooter);
+                    Paragraph? trailingParagraph = wordTable._table.NextSibling<Paragraph>();
+                    captionParagraphBelow = trailingParagraph != null
+                        ? new WordParagraph(doc, trailingParagraph)
+                        : AddParagraphInScope(section, cell, headerFooter);
                 } else if (headerFooter != null) {
                     captionParagraphBelow = headerFooter.AddParagraph("");
                 } else {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Tables.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Tables.cs
@@ -921,12 +921,21 @@ namespace OfficeIMO.Word.Html {
             color = SixColor.Black;
             hasExplicitStyle = false;
             bool found = false;
-            foreach (var part in value.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)) {
+            bool hasExplicitWidth = false;
+            bool hasExplicitColor = false;
+            foreach (var part in SplitBorderTokens(value)) {
                 var token = part.Trim().ToLowerInvariant();
                 if (TryParseBorderWidth(token, out var s)) {
+                    if (hasExplicitWidth) {
+                        return false;
+                    }
                     size = s;
+                    hasExplicitWidth = true;
                     found = true;
                 } else if (token == "solid" || token == "dotted" || token == "dashed" || token == "double" || token == "none") {
+                    if (hasExplicitStyle) {
+                        return false;
+                    }
                     style = token switch {
                         "dotted" => BorderValues.Dotted,
                         "dashed" => BorderValues.Dashed,
@@ -938,13 +947,41 @@ namespace OfficeIMO.Word.Html {
                     found = true;
                 } else {
                     var hex = NormalizeColor(token);
-                    if (hex != null) {
-                        color = SixColor.Parse("#" + hex);
-                        found = true;
+                    if (hex == null || hasExplicitColor) {
+                        return false;
                     }
+                    color = SixColor.Parse("#" + hex);
+                    hasExplicitColor = true;
+                    found = true;
                 }
             }
             return found;
+        }
+
+        private static IEnumerable<string> SplitBorderTokens(string value) {
+            int tokenStart = -1;
+            int parenthesisDepth = 0;
+            for (int index = 0; index < value.Length; index++) {
+                char character = value[index];
+                if (character == '(') {
+                    parenthesisDepth++;
+                } else if (character == ')' && parenthesisDepth > 0) {
+                    parenthesisDepth--;
+                }
+
+                if (char.IsWhiteSpace(character) && parenthesisDepth == 0) {
+                    if (tokenStart >= 0) {
+                        yield return value.Substring(tokenStart, index - tokenStart);
+                        tokenStart = -1;
+                    }
+                } else if (tokenStart < 0) {
+                    tokenStart = index;
+                }
+            }
+
+            if (tokenStart >= 0) {
+                yield return value.Substring(tokenStart);
+            }
         }
 
         private static bool TryParseBorderWidth(string token, out UInt32Value size) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Tables.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Tables.cs
@@ -739,7 +739,7 @@ namespace OfficeIMO.Word.Html {
             }
         }
 
-        private static JustificationValues? ApplyCellStyles(WordTableCell cell, IHtmlTableCellElement htmlCell) {
+        private JustificationValues? ApplyCellStyles(WordTableCell cell, IHtmlTableCellElement htmlCell) {
             if (htmlCell == null) {
                 return null;
             }

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Tables.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Tables.cs
@@ -908,21 +908,30 @@ namespace OfficeIMO.Word.Html {
             out BorderValues style,
             out UInt32Value size,
             out SixColor color) =>
-            TryParseBorder(value, out style, out size, out color, out _);
+            TryParseBorder(value, out style, out size, out color, out _, out _);
 
         private static bool TryParseBorder(
             string value,
             out BorderValues style,
             out UInt32Value size,
             out SixColor color,
-            out bool hasExplicitStyle) {
+            out bool hasExplicitStyle) =>
+            TryParseBorder(value, out style, out size, out color, out hasExplicitStyle, out _);
+
+        private static bool TryParseBorder(
+            string value,
+            out BorderValues style,
+            out UInt32Value size,
+            out SixColor color,
+            out bool hasExplicitStyle,
+            out bool hasExplicitColor) {
             style = BorderValues.Single;
             size = 4U;
             color = SixColor.Black;
             hasExplicitStyle = false;
             bool found = false;
             bool hasExplicitWidth = false;
-            bool hasExplicitColor = false;
+            hasExplicitColor = false;
             foreach (var part in SplitBorderTokens(value)) {
                 var token = part.Trim().ToLowerInvariant();
                 if (TryParseBorderWidth(token, out var s)) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Tables.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Tables.cs
@@ -903,10 +903,23 @@ namespace OfficeIMO.Word.Html {
             }
         }
 
-        private static bool TryParseBorder(string value, out BorderValues style, out UInt32Value size, out SixColor color) {
+        private static bool TryParseBorder(
+            string value,
+            out BorderValues style,
+            out UInt32Value size,
+            out SixColor color) =>
+            TryParseBorder(value, out style, out size, out color, out _);
+
+        private static bool TryParseBorder(
+            string value,
+            out BorderValues style,
+            out UInt32Value size,
+            out SixColor color,
+            out bool hasExplicitStyle) {
             style = BorderValues.Single;
             size = 4U;
             color = SixColor.Black;
+            hasExplicitStyle = false;
             bool found = false;
             foreach (var part in value.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)) {
                 var token = part.Trim().ToLowerInvariant();
@@ -921,6 +934,7 @@ namespace OfficeIMO.Word.Html {
                         "none" => BorderValues.None,
                         _ => BorderValues.Single
                     };
+                    hasExplicitStyle = true;
                     found = true;
                 } else {
                     var hex = NormalizeColor(token);

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Tables.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Tables.cs
@@ -154,6 +154,9 @@ namespace OfficeIMO.Word.Html {
                 WordParagraph captionParagraphBelow;
                 if (cell != null) {
                     Paragraph? trailingParagraph = wordTable._table.NextSibling<Paragraph>();
+                    if (trailingParagraph != null) {
+                        ClearSyntheticTableTrailingSpacing(trailingParagraph);
+                    }
                     captionParagraphBelow = trailingParagraph != null
                         ? new WordParagraph(doc, trailingParagraph)
                         : AddParagraphInScope(section, cell, headerFooter);
@@ -373,7 +376,7 @@ namespace OfficeIMO.Word.Html {
                 return;
             }
 
-            string? background = null;
+            string? backgroundValue = null;
             string? marginLeft = null;
             string? marginRight = null;
             int? padTop = null, padRight = null, padBottom = null, padLeft = null;
@@ -415,10 +418,7 @@ namespace OfficeIMO.Word.Html {
                             }
                             break;
                         case "background-color":
-                            var color = NormalizeColor(value);
-                            if (color != null) {
-                                background = color;
-                            }
+                            backgroundValue = value;
                             break;
                         case "border-collapse":
                             if (value.Equals("separate", StringComparison.OrdinalIgnoreCase)) {
@@ -538,10 +538,10 @@ namespace OfficeIMO.Word.Html {
                     rightColor: hasRight ? right.Color : null);
             }
 
-            if (background != null) {
+            if (backgroundValue != null) {
                 foreach (var row in wordTable.Rows) {
                     foreach (var cell in row.Cells) {
-                        cell.ShadingFillColorHex = background;
+                        ApplyTableBackground(cell, backgroundValue);
                     }
                 }
             }
@@ -684,7 +684,7 @@ namespace OfficeIMO.Word.Html {
                 return;
             }
 
-            string? background = null;
+            string? backgroundValue = null;
             BorderValues? borderStyle = null;
             UInt32Value? borderSize = null;
             SixColor borderColor = default;
@@ -699,8 +699,7 @@ namespace OfficeIMO.Word.Html {
                 var value = pieces[1].Trim();
                 switch (name) {
                     case "background-color":
-                        var color = NormalizeColor(value);
-                        if (color != null) background = color;
+                        backgroundValue = value;
                         break;
                     case "border":
                         if (TryParseBorder(value, out var bStyle, out var bSize, out var bColor)) {
@@ -721,8 +720,8 @@ namespace OfficeIMO.Word.Html {
             }
 
             foreach (var cell in row.Cells) {
-                if (background != null) {
-                    cell.ShadingFillColorHex = background;
+                if (backgroundValue != null) {
+                    ApplyTableBackground(cell, backgroundValue);
                 }
                 if (borderStyle != null && borderSize != null) {
                     cell.Borders.LeftStyle = cell.Borders.RightStyle = cell.Borders.TopStyle = cell.Borders.BottomStyle = borderStyle;
@@ -750,6 +749,7 @@ namespace OfficeIMO.Word.Html {
 
             JustificationValues? alignment = null;
             bool borderSet = false;
+            string? backgroundValue = null;
             if (TryMapTableCellVerticalAlignment(verticalAlignAttr, out var attrVerticalAlignment)) {
                 cell.VerticalAlignment = attrVerticalAlignment;
             }
@@ -765,8 +765,7 @@ namespace OfficeIMO.Word.Html {
                     var value = pieces[1].Trim();
                     switch (name) {
                         case "background-color":
-                            var color = NormalizeColor(value);
-                            if (color != null) cell.ShadingFillColorHex = color;
+                            backgroundValue = value;
                             break;
                         case "width":
                             if (TryParsePercentWidth(value, out int pctWidth)) {
@@ -811,6 +810,9 @@ namespace OfficeIMO.Word.Html {
                             break;
                     }
                 }
+            }
+            if (backgroundValue != null) {
+                ApplyTableBackground(cell, backgroundValue);
             }
 
             if (alignment == null && !string.IsNullOrWhiteSpace(alignAttr)) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.TextBackgrounds.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.TextBackgrounds.cs
@@ -1,0 +1,83 @@
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Html;
+using Color = OfficeIMO.Drawing.OfficeColor;
+
+namespace OfficeIMO.Word.Html {
+    internal partial class HtmlToWordConverter {
+        private static readonly Dictionary<HighlightColorValues, Color> _highlightColors = new() {
+            { HighlightColorValues.Yellow, Color.Yellow },
+            { HighlightColorValues.Green, Color.Lime },
+            { HighlightColorValues.Cyan, Color.Cyan },
+            { HighlightColorValues.Magenta, Color.Magenta },
+            { HighlightColorValues.Blue, Color.Blue },
+            { HighlightColorValues.Red, Color.Red },
+            { HighlightColorValues.DarkBlue, Color.DarkBlue },
+            { HighlightColorValues.DarkCyan, Color.DarkCyan },
+            { HighlightColorValues.DarkGreen, Color.DarkGreen },
+            { HighlightColorValues.DarkMagenta, Color.DarkMagenta },
+            { HighlightColorValues.DarkRed, Color.DarkRed },
+            { HighlightColorValues.DarkYellow, Color.Parse("#808000") },
+            { HighlightColorValues.DarkGray, Color.DarkGray },
+            { HighlightColorValues.LightGray, Color.LightGray },
+            { HighlightColorValues.Black, Color.Black },
+            { HighlightColorValues.White, Color.White }
+        };
+
+        private void ApplyTextBackground(
+            WordParagraph run,
+            TextFormatting formatting,
+            HtmlToWordOptions options) {
+            if (string.IsNullOrEmpty(formatting.BackgroundColorHex)) {
+                return;
+            }
+
+            if (options.TextBackgroundMode == HtmlTextBackgroundMode.ExactShading) {
+                run.SetRunShadingFillColorHex(formatting.BackgroundColorHex!);
+                return;
+            }
+
+            HighlightColorValues? highlight = MapColorToHighlight(formatting.BackgroundColorHex, out bool exact);
+            if (!highlight.HasValue) {
+                return;
+            }
+
+            run.SetHighlight(highlight.Value);
+            if (!exact) {
+                AddDiagnostic(
+                    options,
+                    "TextBackgroundColorApproximated",
+                    "CSS text background color was approximated to the nearest Word highlight color.",
+                    "background-color",
+                    lossKind: HtmlConversionLossKind.Approximation);
+            }
+        }
+
+        private static HighlightColorValues? MapColorToHighlight(string? hex, out bool exact) {
+            exact = false;
+            if (string.IsNullOrEmpty(hex)) {
+                return null;
+            }
+
+            try {
+                Color target = Color.Parse("#" + hex);
+                HighlightColorValues? best = null;
+                int bestDistance = int.MaxValue;
+                foreach (KeyValuePair<HighlightColorValues, Color> pair in _highlightColors) {
+                    Color candidate = pair.Value;
+                    int distance = (candidate.R - target.R) * (candidate.R - target.R) +
+                                   (candidate.G - target.G) * (candidate.G - target.G) +
+                                   (candidate.B - target.B) * (candidate.B - target.B);
+                    if (distance < bestDistance) {
+                        bestDistance = distance;
+                        best = pair.Key;
+                    }
+                }
+
+                exact = bestDistance == 0;
+                return best;
+            } catch {
+                return null;
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.TextBackgrounds.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.TextBackgrounds.cs
@@ -32,6 +32,7 @@ namespace OfficeIMO.Word.Html {
             }
 
             if (options.TextBackgroundMode == HtmlTextBackgroundMode.ExactShading) {
+                run.Highlight = null;
                 run.SetRunShadingFillColorHex(formatting.BackgroundColorHex!);
                 return;
             }

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.TextBackgrounds.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.TextBackgrounds.cs
@@ -31,6 +31,10 @@ namespace OfficeIMO.Word.Html {
                 return;
             }
 
+            if (formatting.PreserveHighlightOverBackground && formatting.Highlight.HasValue) {
+                return;
+            }
+
             if (options.TextBackgroundMode == HtmlTextBackgroundMode.ExactShading) {
                 run.Highlight = null;
                 run.SetRunShadingFillColorHex(formatting.BackgroundColorHex!);

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.TextBackgrounds.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.TextBackgrounds.cs
@@ -57,6 +57,33 @@ namespace OfficeIMO.Word.Html {
             }
         }
 
+        private static string ResolveOpaqueTextBackground(
+            string foregroundHex,
+            double alpha,
+            string? inheritedBackgroundHex) {
+            if (alpha >= 1d) {
+                return foregroundHex;
+            }
+
+            Color foreground = Color.Parse("#" + foregroundHex);
+            Color background;
+            try {
+                background = string.IsNullOrEmpty(inheritedBackgroundHex)
+                    ? Color.White
+                    : Color.Parse("#" + inheritedBackgroundHex);
+            } catch {
+                background = Color.White;
+            }
+
+            double foregroundRatio = Math.Max(0d, Math.Min(1d, alpha));
+            double backgroundRatio = 1d - foregroundRatio;
+            return Color.FromRgb(
+                (byte)Math.Round(foreground.R * foregroundRatio + background.R * backgroundRatio),
+                (byte)Math.Round(foreground.G * foregroundRatio + background.G * backgroundRatio),
+                (byte)Math.Round(foreground.B * foregroundRatio + background.B * backgroundRatio))
+                .ToRgbHex();
+        }
+
         private static HighlightColorValues? MapColorToHighlight(string? hex, out bool exact) {
             exact = false;
             if (string.IsNullOrEmpty(hex)) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
@@ -144,9 +144,19 @@ namespace OfficeIMO.Word.Html {
             ApplyDocumentMetadata(doc, document);
             WordSection section = doc.Sections.First();
             var listStack = new Stack<WordList>();
+            WordList? headingList = options.SupportsHeadingNumbering ? cell.AddList(WordListStyle.Headings111) : null;
             if (document.Body != null) {
                 cancellationToken.ThrowIfCancellationRequested();
-                ProcessNode(document.Body, doc, section, options, null, listStack, new TextFormatting(), cell);
+                ProcessNode(
+                    document.Body,
+                    doc,
+                    section,
+                    options,
+                    null,
+                    listStack,
+                    new TextFormatting(),
+                    cell,
+                    headingList: headingList);
             }
             InsertTopBookmarkIfNeeded(doc);
         }

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
@@ -7,6 +7,7 @@ using AngleSharp.Html.Dom;
 using AngleSharp.Io;
 using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Html;
+using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Http;
 using System.Security.Cryptography;
@@ -34,8 +35,8 @@ namespace OfficeIMO.Word.Html {
         private readonly List<ICssStyleRule> _cssRules = new();
         private readonly CssParser _cssParser = new();
         private readonly Dictionary<string, WordImage> _imageCache = new(StringComparer.OrdinalIgnoreCase);
-        private readonly Dictionary<string, byte[]> _remoteImageBytesCache = new(StringComparer.Ordinal);
-        private readonly Dictionary<string, Exception> _remoteImageFailureCache = new(StringComparer.Ordinal);
+        private readonly ConcurrentDictionary<string, byte[]> _remoteImageBytesCache = new(StringComparer.Ordinal);
+        private readonly ConcurrentDictionary<string, Exception> _remoteImageFailureCache = new(StringComparer.Ordinal);
         private readonly Dictionary<string, WordParagraphStyles> _cssClassStyles = new(StringComparer.OrdinalIgnoreCase);
         // A converter instance is scoped to one conversion. Keeping parsed sheets here avoids
         // retaining attacker-controlled stylesheet identities for the lifetime of the process.
@@ -62,15 +63,7 @@ namespace OfficeIMO.Word.Html {
         internal async Task<WordDocument> ConvertAsync(IHtmlDocument document, HtmlToWordOptions options, CancellationToken cancellationToken = default) {
             if (document == null) throw new ArgumentNullException(nameof(document));
             options ??= new HtmlToWordOptions();
-            cancellationToken.ThrowIfCancellationRequested();
-            _cancellationToken = cancellationToken;
-            _httpClient = options.HttpClient ?? _sharedHttpClient;
-            _resourceTimeout = options.ResourceTimeout;
-            _options = options;
-            _cssProcessingBudget = new HtmlCssProcessingBudget(options.Limits);
-
-            _context = document.Context;
-            ValidateDocumentLimits(document, options);
+            await PrepareImportAsync(document, options, cancellationToken).ConfigureAwait(false);
 
             var wordDoc = WordDocument.Create();
             if (!string.IsNullOrEmpty(options.FontFamily)) {
@@ -78,31 +71,6 @@ namespace OfficeIMO.Word.Html {
                 wordDoc.Settings.FontFamily = resolved;
             }
             ApplyDocumentMetadata(wordDoc, document);
-
-            _footnoteMap.Clear();
-            _endnoteMap.Clear();
-            _commentMap.Clear();
-            _unsupportedCssDiagnosticKeys.Clear();
-            _processedRadioInputs.Clear();
-            _cssRules.Clear();
-            _imageCache.Clear();
-            _remoteImageBytesCache.Clear();
-            _remoteImageFailureCache.Clear();
-            _cssClassStyles.Clear();
-            _stylesheetCache.Clear();
-            _pendingTopBookmark = false;
-            _imageBytesUsed = 0;
-            _remoteImageBytesFetched = 0;
-            _cssBytesUsed = 0;
-            ResetAccessibilityDiagnosticsState();
-
-            await LoadConfiguredStylesheetsAsync(document, options, cancellationToken).ConfigureAwait(false);
-            await LoadHeadStylesheetsAsync(document, cancellationToken).ConfigureAwait(false);
-            await LoadBodyStylesheetsAsync(document, cancellationToken).ConfigureAwait(false);
-            await PrefetchRemoteImagesAsync(document, options, cancellationToken).ConfigureAwait(false);
-
-            CaptureNoteSections(document);
-            CaptureCommentSections(document);
 
             if (options.DefaultPageSize.HasValue) {
                 wordDoc.PageSettings.PageSize = options.DefaultPageSize.Value;
@@ -127,41 +95,8 @@ namespace OfficeIMO.Word.Html {
         internal async Task AddHtmlToBodyAsync(WordDocument doc, WordSection section, IHtmlDocument document, HtmlToWordOptions options, CancellationToken cancellationToken = default) {
             if (document == null) throw new ArgumentNullException(nameof(document));
             options ??= new HtmlToWordOptions();
-            cancellationToken.ThrowIfCancellationRequested();
-            _cancellationToken = cancellationToken;
-            _httpClient = options.HttpClient ?? _sharedHttpClient;
-            _resourceTimeout = options.ResourceTimeout;
-            _options = options;
-            _cssProcessingBudget = new HtmlCssProcessingBudget(options.Limits);
-
-            _context = document.Context;
-            ValidateDocumentLimits(document, options);
+            await PrepareImportAsync(document, options, cancellationToken).ConfigureAwait(false);
             ApplyDocumentMetadata(doc, document);
-
-            _footnoteMap.Clear();
-            _endnoteMap.Clear();
-            _commentMap.Clear();
-            _unsupportedCssDiagnosticKeys.Clear();
-            _processedRadioInputs.Clear();
-            _cssRules.Clear();
-            _imageCache.Clear();
-            _remoteImageBytesCache.Clear();
-            _remoteImageFailureCache.Clear();
-            _cssClassStyles.Clear();
-            _stylesheetCache.Clear();
-            _pendingTopBookmark = false;
-            _imageBytesUsed = 0;
-            _remoteImageBytesFetched = 0;
-            _cssBytesUsed = 0;
-            ResetAccessibilityDiagnosticsState();
-
-            await LoadConfiguredStylesheetsAsync(document, options, cancellationToken).ConfigureAwait(false);
-            await LoadHeadStylesheetsAsync(document, cancellationToken).ConfigureAwait(false);
-            await LoadBodyStylesheetsAsync(document, cancellationToken).ConfigureAwait(false);
-            await PrefetchRemoteImagesAsync(document, options, cancellationToken).ConfigureAwait(false);
-
-            CaptureNoteSections(document, cancellationToken);
-            CaptureCommentSections(document, cancellationToken);
 
             var listStack = new Stack<WordList>();
             WordList? headingList = options.SupportsHeadingNumbering ? doc.AddList(WordListStyle.Headings111) : null;
@@ -183,16 +118,52 @@ namespace OfficeIMO.Word.Html {
         private async Task AddHtmlToHeaderFooterAsync(WordDocument doc, WordHeaderFooter headerFooter, IHtmlDocument document, HtmlToWordOptions options, CancellationToken cancellationToken) {
             if (document == null) throw new ArgumentNullException(nameof(document));
             options ??= new HtmlToWordOptions();
+            await PrepareImportAsync(document, options, cancellationToken).ConfigureAwait(false);
+            ApplyDocumentMetadata(doc, document);
+
+            var section = doc.Sections.First();
+            var listStack = new Stack<WordList>();
+            WordList? headingList = options.SupportsHeadingNumbering ? headerFooter.AddList(WordListStyle.Headings111) : null;
+            if (document.Body != null) {
+                cancellationToken.ThrowIfCancellationRequested();
+                ProcessNode(document.Body, doc, section, options, null, listStack, new TextFormatting(), null, headerFooter, headingList);
+            }
+        }
+
+        internal async Task AddHtmlToTableCellAsync(
+            WordTableCell cell,
+            IHtmlDocument document,
+            HtmlToWordOptions options,
+            CancellationToken cancellationToken = default) {
+            if (cell == null) throw new ArgumentNullException(nameof(cell));
+            if (document == null) throw new ArgumentNullException(nameof(document));
+            options ??= new HtmlToWordOptions();
+            await PrepareImportAsync(document, options, cancellationToken).ConfigureAwait(false);
+
+            WordDocument doc = cell.Document;
+            ApplyDocumentMetadata(doc, document);
+            WordSection section = doc.Sections.First();
+            var listStack = new Stack<WordList>();
+            if (document.Body != null) {
+                cancellationToken.ThrowIfCancellationRequested();
+                ProcessNode(document.Body, doc, section, options, null, listStack, new TextFormatting(), cell);
+            }
+            InsertTopBookmarkIfNeeded(doc);
+        }
+
+        private async Task PrepareImportAsync(
+            IHtmlDocument document,
+            HtmlToWordOptions options,
+            CancellationToken cancellationToken) {
             cancellationToken.ThrowIfCancellationRequested();
+            ValidateResourceConcurrency(options);
             _cancellationToken = cancellationToken;
             _httpClient = options.HttpClient ?? _sharedHttpClient;
             _resourceTimeout = options.ResourceTimeout;
             _options = options;
             _cssProcessingBudget = new HtmlCssProcessingBudget(options.Limits);
-
             _context = document.Context;
             ValidateDocumentLimits(document, options);
-            ApplyDocumentMetadata(doc, document);
 
             _footnoteMap.Clear();
             _endnoteMap.Clear();
@@ -215,16 +186,15 @@ namespace OfficeIMO.Word.Html {
             await LoadHeadStylesheetsAsync(document, cancellationToken).ConfigureAwait(false);
             await LoadBodyStylesheetsAsync(document, cancellationToken).ConfigureAwait(false);
             await PrefetchRemoteImagesAsync(document, options, cancellationToken).ConfigureAwait(false);
-
             CaptureNoteSections(document, cancellationToken);
             CaptureCommentSections(document, cancellationToken);
+        }
 
-            var section = doc.Sections.First();
-            var listStack = new Stack<WordList>();
-            WordList? headingList = options.SupportsHeadingNumbering ? headerFooter.AddList(WordListStyle.Headings111) : null;
-            if (document.Body != null) {
-                cancellationToken.ThrowIfCancellationRequested();
-                ProcessNode(document.Body, doc, section, options, null, listStack, new TextFormatting(), null, headerFooter, headingList);
+        private static void ValidateResourceConcurrency(HtmlToWordOptions options) {
+            if (options.MaxConcurrentResourceLoads <= 0) {
+                throw new ArgumentOutOfRangeException(
+                    nameof(options.MaxConcurrentResourceLoads),
+                    "Maximum concurrent resource loads must be positive.");
             }
         }
 

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
@@ -36,6 +36,8 @@ namespace OfficeIMO.Word.Html {
         private readonly CssParser _cssParser = new();
         private readonly Dictionary<string, WordImage> _imageCache = new(StringComparer.OrdinalIgnoreCase);
         private readonly Dictionary<IElement, double> _computedFontSizePixels = new();
+        private readonly Dictionary<IElement, bool> _directionAttributeOverrides = new();
+        private readonly Dictionary<Table, int> _tableContainerHorizontalSpacing = new();
         private readonly ConcurrentDictionary<string, byte[]> _remoteImageBytesCache = new(StringComparer.Ordinal);
         private readonly ConcurrentDictionary<string, Exception> _remoteImageFailureCache = new(StringComparer.Ordinal);
         private readonly Dictionary<string, WordParagraphStyles> _cssClassStyles = new(StringComparer.OrdinalIgnoreCase);

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
@@ -35,6 +35,7 @@ namespace OfficeIMO.Word.Html {
         private readonly List<ICssStyleRule> _cssRules = new();
         private readonly CssParser _cssParser = new();
         private readonly Dictionary<string, WordImage> _imageCache = new(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<IElement, double> _computedFontSizePixels = new();
         private readonly ConcurrentDictionary<string, byte[]> _remoteImageBytesCache = new(StringComparer.Ordinal);
         private readonly ConcurrentDictionary<string, Exception> _remoteImageFailureCache = new(StringComparer.Ordinal);
         private readonly Dictionary<string, WordParagraphStyles> _cssClassStyles = new(StringComparer.OrdinalIgnoreCase);
@@ -51,6 +52,7 @@ namespace OfficeIMO.Word.Html {
         private long _imageBytesUsed;
         private long _remoteImageBytesFetched;
         private long _cssBytesUsed;
+        private double _rootFontSizePixels = 16d;
         private HtmlCssProcessingBudget _cssProcessingBudget = new HtmlCssProcessingBudget(null);
         private HtmlToWordOptions _options = new HtmlToWordOptions();
         private static readonly Regex _classRegex = new(@"\.([a-zA-Z0-9_-]+)", RegexOptions.Compiled);
@@ -182,6 +184,7 @@ namespace OfficeIMO.Word.Html {
             _processedRadioInputs.Clear();
             _cssRules.Clear();
             _imageCache.Clear();
+            _computedFontSizePixels.Clear();
             _remoteImageBytesCache.Clear();
             _remoteImageFailureCache.Clear();
             _cssClassStyles.Clear();
@@ -195,6 +198,8 @@ namespace OfficeIMO.Word.Html {
             await LoadConfiguredStylesheetsAsync(document, options, cancellationToken).ConfigureAwait(false);
             await LoadHeadStylesheetsAsync(document, cancellationToken).ConfigureAwait(false);
             await LoadBodyStylesheetsAsync(document, cancellationToken).ConfigureAwait(false);
+            _rootFontSizePixels = ResolveRootFontSizePixels(document.DocumentElement);
+            _computedFontSizePixels[document.DocumentElement] = _rootFontSizePixels;
             await PrefetchRemoteImagesAsync(document, options, cancellationToken).ConfigureAwait(false);
             CaptureNoteSections(document, cancellationToken);
             CaptureCommentSections(document, cancellationToken);

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.Equations.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.Equations.cs
@@ -57,6 +57,7 @@ namespace OfficeIMO.Word.Html {
                 run,
                 text,
                 node,
+                options.IncludeRunHighlightStyles,
                 out bool handledHtmlStyle);
             if (options.IncludeFontStyles) {
                 string? font = run.FontFamily ?? options.FontFamily;
@@ -89,7 +90,7 @@ namespace OfficeIMO.Word.Html {
                     string? normalized = NormalizeSixDigitHexColor(run.ColorHex);
                     if (normalized != null) styles.Add($"color:#{normalized}");
                 }
-                if (options.IncludeRunHighlightStyles) {
+                if (options.IncludeRunHighlightStyles && !isHtmlMarkedText) {
                     string? normalizedRunBackground = NormalizeSixDigitHexColor(
                         WordDocumentImageRenderer.ResolveRunShadingFillColorHex(run));
                     string? highlight = GetHighlightCss(
@@ -125,11 +126,12 @@ namespace OfficeIMO.Word.Html {
             return node;
         }
 
-        private static INode ApplyHtmlSemanticCharacterStyle(
+        private INode ApplyHtmlSemanticCharacterStyle(
             IHtmlDocument htmlDocument,
             WordParagraph run,
             string text,
             INode node,
+            bool includeRunHighlightStyles,
             out bool handled) {
             handled = true;
             IElement semanticNode;
@@ -139,7 +141,17 @@ namespace OfficeIMO.Word.Html {
                 semanticNode = htmlDocument.CreateElement("ins");
             } else if (string.Equals(run.CharacterStyleId, HtmlSemanticStyleIds.MarkedText, StringComparison.OrdinalIgnoreCase)) {
                 semanticNode = htmlDocument.CreateElement("mark");
-                if (run.Highlight == HighlightColorValues.None) {
+                string? normalizedRunBackground = includeRunHighlightStyles
+                    ? NormalizeSixDigitHexColor(WordDocumentImageRenderer.ResolveRunShadingFillColorHex(run))
+                    : null;
+                string? highlightCss = includeRunHighlightStyles
+                    ? GetHighlightCss(WordDocumentImageRenderer.ResolveRunHighlight(run))
+                    : null;
+                if (!string.IsNullOrEmpty(highlightCss) && normalizedRunBackground != null) {
+                    semanticNode.SetAttribute("style", $"background-color:{highlightCss}");
+                } else if (normalizedRunBackground != null) {
+                    semanticNode.SetAttribute("style", $"background-color:#{normalizedRunBackground}");
+                } else if (run.Highlight == HighlightColorValues.None) {
                     semanticNode.SetAttribute("style", "background-color:transparent");
                 }
             } else if (string.Equals(run.CharacterStyleId, "HtmlCite", StringComparison.OrdinalIgnoreCase)) {

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.Equations.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.Equations.cs
@@ -139,6 +139,9 @@ namespace OfficeIMO.Word.Html {
                 semanticNode = htmlDocument.CreateElement("ins");
             } else if (string.Equals(run.CharacterStyleId, HtmlSemanticStyleIds.MarkedText, StringComparison.OrdinalIgnoreCase)) {
                 semanticNode = htmlDocument.CreateElement("mark");
+                if (run.Highlight == HighlightColorValues.None) {
+                    semanticNode.SetAttribute("style", "background-color:transparent");
+                }
             } else if (string.Equals(run.CharacterStyleId, "HtmlCite", StringComparison.OrdinalIgnoreCase)) {
                 semanticNode = htmlDocument.CreateElement("cite");
             } else if (string.Equals(run.CharacterStyleId, "HtmlDfn", StringComparison.OrdinalIgnoreCase)) {

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.Equations.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.Equations.cs
@@ -91,11 +91,12 @@ namespace OfficeIMO.Word.Html {
                 }
                 if (options.IncludeRunHighlightStyles) {
                     string? normalizedRunBackground = NormalizeSixDigitHexColor(run.RunShadingFillColorHex);
-                    if (normalizedRunBackground != null) {
+                    string? highlight = GetHighlightCss(run.Highlight);
+                    if (!string.IsNullOrEmpty(highlight) &&
+                        (!isHtmlMarkedText || normalizedRunBackground != null)) {
+                        styles.Add($"background-color:{highlight}");
+                    } else if (normalizedRunBackground != null) {
                         styles.Add($"background-color:#{normalizedRunBackground}");
-                    } else if (!isHtmlMarkedText) {
-                        string? highlight = GetHighlightCss(run.Highlight);
-                        if (!string.IsNullOrEmpty(highlight)) styles.Add($"background-color:{highlight}");
                     }
                 }
                 if (styles.Count > 0) {

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.Equations.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.Equations.cs
@@ -147,7 +147,12 @@ namespace OfficeIMO.Word.Html {
                 string? highlightCss = includeRunHighlightStyles
                     ? GetHighlightCss(WordDocumentImageRenderer.ResolveRunHighlight(run))
                     : null;
-                if (!string.IsNullOrEmpty(highlightCss) && normalizedRunBackground != null) {
+                bool isDefaultMarkHighlight = string.Equals(
+                    highlightCss,
+                    "#ffff00",
+                    StringComparison.OrdinalIgnoreCase);
+                if (!string.IsNullOrEmpty(highlightCss) &&
+                    (normalizedRunBackground != null || !isDefaultMarkHighlight)) {
                     semanticNode.SetAttribute("style", $"background-color:{highlightCss}");
                 } else if (normalizedRunBackground != null) {
                     semanticNode.SetAttribute("style", $"background-color:#{normalizedRunBackground}");

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.Equations.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.Equations.cs
@@ -92,7 +92,8 @@ namespace OfficeIMO.Word.Html {
                 if (options.IncludeRunHighlightStyles) {
                     string? normalizedRunBackground = NormalizeSixDigitHexColor(
                         WordDocumentImageRenderer.ResolveRunShadingFillColorHex(run));
-                    string? highlight = GetHighlightCss(run.Highlight);
+                    string? highlight = GetHighlightCss(
+                        WordDocumentImageRenderer.ResolveRunHighlight(run));
                     if (!string.IsNullOrEmpty(highlight) &&
                         (!isHtmlMarkedText || normalizedRunBackground != null)) {
                         styles.Add($"background-color:{highlight}");

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.Equations.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.Equations.cs
@@ -89,9 +89,14 @@ namespace OfficeIMO.Word.Html {
                     string? normalized = NormalizeSixDigitHexColor(run.ColorHex);
                     if (normalized != null) styles.Add($"color:#{normalized}");
                 }
-                if (options.IncludeRunHighlightStyles && !isHtmlMarkedText) {
-                    string? highlight = GetHighlightCss(run.Highlight);
-                    if (!string.IsNullOrEmpty(highlight)) styles.Add($"background-color:{highlight}");
+                if (options.IncludeRunHighlightStyles) {
+                    string? normalizedRunBackground = NormalizeSixDigitHexColor(run.RunShadingFillColorHex);
+                    if (normalizedRunBackground != null) {
+                        styles.Add($"background-color:#{normalizedRunBackground}");
+                    } else if (!isHtmlMarkedText) {
+                        string? highlight = GetHighlightCss(run.Highlight);
+                        if (!string.IsNullOrEmpty(highlight)) styles.Add($"background-color:{highlight}");
+                    }
                 }
                 if (styles.Count > 0) {
                     var span = htmlDocument.CreateElement("span");

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.Equations.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.Equations.cs
@@ -90,7 +90,8 @@ namespace OfficeIMO.Word.Html {
                     if (normalized != null) styles.Add($"color:#{normalized}");
                 }
                 if (options.IncludeRunHighlightStyles) {
-                    string? normalizedRunBackground = NormalizeSixDigitHexColor(run.RunShadingFillColorHex);
+                    string? normalizedRunBackground = NormalizeSixDigitHexColor(
+                        WordDocumentImageRenderer.ResolveRunShadingFillColorHex(run));
                     string? highlight = GetHighlightCss(run.Highlight);
                     if (!string.IsNullOrEmpty(highlight) &&
                         (!isHtmlMarkedText || normalizedRunBackground != null)) {

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
@@ -457,9 +457,14 @@ namespace OfficeIMO.Word.Html {
                             }
                         }
                         if (options.IncludeRunHighlightStyles && !isHtmlMarkedText) {
-                            var highlightCss = GetHighlightCss(run.Highlight);
-                            if (!string.IsNullOrEmpty(highlightCss)) {
-                                inlineStyles.Add($"background-color:{highlightCss}");
+                            string? normalizedRunBackground = NormalizeSixDigitHexColor(run.RunShadingFillColorHex);
+                            if (normalizedRunBackground != null) {
+                                inlineStyles.Add($"background-color:#{normalizedRunBackground}");
+                            } else {
+                                var highlightCss = GetHighlightCss(run.Highlight);
+                                if (!string.IsNullOrEmpty(highlightCss)) {
+                                    inlineStyles.Add($"background-color:{highlightCss}");
+                                }
                             }
                         }
                         if (inlineStyles.Count > 0) {

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
@@ -456,11 +456,11 @@ namespace OfficeIMO.Word.Html {
                                 }
                             }
                         }
-                        if (options.IncludeRunHighlightStyles && !isHtmlMarkedText) {
+                        if (options.IncludeRunHighlightStyles) {
                             string? normalizedRunBackground = NormalizeSixDigitHexColor(run.RunShadingFillColorHex);
                             if (normalizedRunBackground != null) {
                                 inlineStyles.Add($"background-color:#{normalizedRunBackground}");
-                            } else {
+                            } else if (!isHtmlMarkedText) {
                                 var highlightCss = GetHighlightCss(run.Highlight);
                                 if (!string.IsNullOrEmpty(highlightCss)) {
                                     inlineStyles.Add($"background-color:{highlightCss}");

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
@@ -458,13 +458,12 @@ namespace OfficeIMO.Word.Html {
                         }
                         if (options.IncludeRunHighlightStyles) {
                             string? normalizedRunBackground = NormalizeSixDigitHexColor(run.RunShadingFillColorHex);
-                            if (normalizedRunBackground != null) {
+                            string? highlightCss = GetHighlightCss(run.Highlight);
+                            if (!string.IsNullOrEmpty(highlightCss) &&
+                                (!isHtmlMarkedText || normalizedRunBackground != null)) {
+                                inlineStyles.Add($"background-color:{highlightCss}");
+                            } else if (normalizedRunBackground != null) {
                                 inlineStyles.Add($"background-color:#{normalizedRunBackground}");
-                            } else if (!isHtmlMarkedText) {
-                                var highlightCss = GetHighlightCss(run.Highlight);
-                                if (!string.IsNullOrEmpty(highlightCss)) {
-                                    inlineStyles.Add($"background-color:{highlightCss}");
-                                }
                             }
                         }
                         if (inlineStyles.Count > 0) {

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
@@ -457,7 +457,8 @@ namespace OfficeIMO.Word.Html {
                             }
                         }
                         if (options.IncludeRunHighlightStyles) {
-                            string? normalizedRunBackground = NormalizeSixDigitHexColor(run.RunShadingFillColorHex);
+                            string? normalizedRunBackground = NormalizeSixDigitHexColor(
+                                WordDocumentImageRenderer.ResolveRunShadingFillColorHex(run));
                             string? highlightCss = GetHighlightCss(run.Highlight);
                             if (!string.IsNullOrEmpty(highlightCss) &&
                                 (!isHtmlMarkedText || normalizedRunBackground != null)) {

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
@@ -412,6 +412,7 @@ namespace OfficeIMO.Word.Html {
                         run,
                         run.Text ?? string.Empty,
                         node,
+                        options.IncludeRunHighlightStyles,
                         out bool handledHtmlStyle);
 
                     if (options.IncludeFontStyles) {
@@ -456,7 +457,7 @@ namespace OfficeIMO.Word.Html {
                                 }
                             }
                         }
-                        if (options.IncludeRunHighlightStyles) {
+                        if (options.IncludeRunHighlightStyles && !isHtmlMarkedText) {
                             string? normalizedRunBackground = NormalizeSixDigitHexColor(
                                 WordDocumentImageRenderer.ResolveRunShadingFillColorHex(run));
                             string? highlightCss = GetHighlightCss(

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
@@ -459,7 +459,8 @@ namespace OfficeIMO.Word.Html {
                         if (options.IncludeRunHighlightStyles) {
                             string? normalizedRunBackground = NormalizeSixDigitHexColor(
                                 WordDocumentImageRenderer.ResolveRunShadingFillColorHex(run));
-                            string? highlightCss = GetHighlightCss(run.Highlight);
+                            string? highlightCss = GetHighlightCss(
+                                WordDocumentImageRenderer.ResolveRunHighlight(run));
                             if (!string.IsNullOrEmpty(highlightCss) &&
                                 (!isHtmlMarkedText || normalizedRunBackground != null)) {
                                 inlineStyles.Add($"background-color:{highlightCss}");

--- a/OfficeIMO.Word.Html/Helpers/CssStyleMapper.BoxResets.cs
+++ b/OfficeIMO.Word.Html/Helpers/CssStyleMapper.BoxResets.cs
@@ -1,0 +1,72 @@
+namespace OfficeIMO.Word.Html {
+    internal static partial class CssStyleMapper {
+        private static bool IsCssWideBoxReset(string value) {
+            string normalized = value.Trim().ToLowerInvariant();
+            return normalized is "inherit" or "initial" or "unset" or "revert" or "revert-layer";
+        }
+
+        private static void ResetMargin(CssProperties result) {
+            result.MarginTop = null;
+            result.MarginRight = null;
+            result.MarginBottom = null;
+            result.MarginLeft = null;
+        }
+
+        private static void ResetPadding(CssProperties result) {
+            result.PaddingTop = null;
+            result.PaddingRight = null;
+            result.PaddingBottom = null;
+            result.PaddingLeft = null;
+        }
+
+        private static void ResetLogicalBoxProperty(
+            string name,
+            string prefix,
+            bool rightToLeft,
+            CssProperties result) {
+            bool margin = prefix.Equals("margin", StringComparison.OrdinalIgnoreCase);
+            void ResetInlineStart() {
+                if (margin) {
+                    if (rightToLeft) result.MarginRight = null;
+                    else result.MarginLeft = null;
+                } else {
+                    if (rightToLeft) result.PaddingRight = null;
+                    else result.PaddingLeft = null;
+                }
+            }
+            void ResetInlineEnd() {
+                if (margin) {
+                    if (rightToLeft) result.MarginLeft = null;
+                    else result.MarginRight = null;
+                } else {
+                    if (rightToLeft) result.PaddingLeft = null;
+                    else result.PaddingRight = null;
+                }
+            }
+            void ResetBlockStart() {
+                if (margin) result.MarginTop = null;
+                else result.PaddingTop = null;
+            }
+            void ResetBlockEnd() {
+                if (margin) result.MarginBottom = null;
+                else result.PaddingBottom = null;
+            }
+
+            if (name.EndsWith("-inline", StringComparison.Ordinal)) {
+                ResetInlineStart();
+                ResetInlineEnd();
+            } else if (name.EndsWith("-inline-start", StringComparison.Ordinal)) {
+                ResetInlineStart();
+            } else if (name.EndsWith("-inline-end", StringComparison.Ordinal)) {
+                ResetInlineEnd();
+            } else if (name.EndsWith("-block", StringComparison.Ordinal)) {
+                ResetBlockStart();
+                ResetBlockEnd();
+            } else if (name.EndsWith("-block-start", StringComparison.Ordinal)) {
+                ResetBlockStart();
+            } else if (name.EndsWith("-block-end", StringComparison.Ordinal)) {
+                ResetBlockEnd();
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/Helpers/CssStyleMapper.BoxResets.cs
+++ b/OfficeIMO.Word.Html/Helpers/CssStyleMapper.BoxResets.cs
@@ -2,7 +2,24 @@ namespace OfficeIMO.Word.Html {
     internal static partial class CssStyleMapper {
         private static bool IsCssWideBoxReset(string value) {
             string normalized = value.Trim().ToLowerInvariant();
-            return normalized is "inherit" or "initial" or "unset" or "revert" or "revert-layer";
+            return normalized is "initial" or "unset" or "revert" or "revert-layer";
+        }
+
+        private static bool IsCssBoxInheritance(string value) =>
+            value.Trim().Equals("inherit", StringComparison.OrdinalIgnoreCase);
+
+        private static void CopyMargin(CssProperties? source, CssProperties result) {
+            result.MarginTop = source?.MarginTop;
+            result.MarginRight = source?.MarginRight;
+            result.MarginBottom = source?.MarginBottom;
+            result.MarginLeft = source?.MarginLeft;
+        }
+
+        private static void CopyPadding(CssProperties? source, CssProperties result) {
+            result.PaddingTop = source?.PaddingTop;
+            result.PaddingRight = source?.PaddingRight;
+            result.PaddingBottom = source?.PaddingBottom;
+            result.PaddingLeft = source?.PaddingLeft;
         }
 
         private static void ResetMargin(CssProperties result) {
@@ -66,6 +83,67 @@ namespace OfficeIMO.Word.Html {
                 ResetBlockStart();
             } else if (name.EndsWith("-block-end", StringComparison.Ordinal)) {
                 ResetBlockEnd();
+            }
+        }
+
+        private static void InheritLogicalBoxProperty(
+            string name,
+            string prefix,
+            bool rightToLeft,
+            CssProperties result,
+            CssProperties? inheritedBox,
+            bool inheritedRightToLeft) {
+            bool margin = prefix.Equals("margin", StringComparison.OrdinalIgnoreCase);
+            int? inheritedInlineStart = margin
+                ? inheritedRightToLeft ? inheritedBox?.MarginRight : inheritedBox?.MarginLeft
+                : inheritedRightToLeft ? inheritedBox?.PaddingRight : inheritedBox?.PaddingLeft;
+            int? inheritedInlineEnd = margin
+                ? inheritedRightToLeft ? inheritedBox?.MarginLeft : inheritedBox?.MarginRight
+                : inheritedRightToLeft ? inheritedBox?.PaddingLeft : inheritedBox?.PaddingRight;
+            int? inheritedBlockStart = margin ? inheritedBox?.MarginTop : inheritedBox?.PaddingTop;
+            int? inheritedBlockEnd = margin ? inheritedBox?.MarginBottom : inheritedBox?.PaddingBottom;
+
+            void SetInlineStart(int? value) {
+                if (margin) {
+                    if (rightToLeft) result.MarginRight = value;
+                    else result.MarginLeft = value;
+                } else {
+                    if (rightToLeft) result.PaddingRight = value;
+                    else result.PaddingLeft = value;
+                }
+            }
+            void SetInlineEnd(int? value) {
+                if (margin) {
+                    if (rightToLeft) result.MarginLeft = value;
+                    else result.MarginRight = value;
+                } else {
+                    if (rightToLeft) result.PaddingLeft = value;
+                    else result.PaddingRight = value;
+                }
+            }
+            void SetBlockStart(int? value) {
+                if (margin) result.MarginTop = value;
+                else result.PaddingTop = value;
+            }
+            void SetBlockEnd(int? value) {
+                if (margin) result.MarginBottom = value;
+                else result.PaddingBottom = value;
+            }
+
+            if (name.EndsWith("-inline", StringComparison.Ordinal)) {
+                SetInlineStart(inheritedInlineStart);
+                SetInlineEnd(inheritedInlineEnd);
+            } else if (name.EndsWith("-inline-start", StringComparison.Ordinal)) {
+                SetInlineStart(inheritedInlineStart);
+            } else if (name.EndsWith("-inline-end", StringComparison.Ordinal)) {
+                SetInlineEnd(inheritedInlineEnd);
+            } else if (name.EndsWith("-block", StringComparison.Ordinal)) {
+                SetBlockStart(inheritedBlockStart);
+                SetBlockEnd(inheritedBlockEnd);
+            } else if (name.EndsWith("-block-start", StringComparison.Ordinal)) {
+                SetBlockStart(inheritedBlockStart);
+            } else if (name.EndsWith("-block-end", StringComparison.Ordinal)) {
+                SetBlockEnd(inheritedBlockEnd);
             }
         }
     }

--- a/OfficeIMO.Word.Html/Helpers/CssStyleMapper.Lengths.cs
+++ b/OfficeIMO.Word.Html/Helpers/CssStyleMapper.Lengths.cs
@@ -1,0 +1,51 @@
+using System.Globalization;
+
+namespace OfficeIMO.Word.Html {
+    internal static partial class CssStyleMapper {
+        private static bool TryParseLength(string value, out int twips) {
+            twips = 0;
+            if (string.IsNullOrWhiteSpace(value)) {
+                return false;
+            }
+
+            string normalized = value.Trim().ToLowerInvariant();
+            if (TryParseLengthUnit(normalized, "rem", 16d * 15d, out twips) ||
+                TryParseLengthUnit(normalized, "em", 16d * 15d, out twips) ||
+                TryParseLengthUnit(normalized, "px", 15d, out twips) ||
+                TryParseLengthUnit(normalized, "pt", 20d, out twips) ||
+                TryParseLengthUnit(normalized, "pc", 240d, out twips) ||
+                TryParseLengthUnit(normalized, "in", 1440d, out twips) ||
+                TryParseLengthUnit(normalized, "cm", 1440d / 2.54d, out twips) ||
+                TryParseLengthUnit(normalized, "mm", 1440d / 25.4d, out twips) ||
+                TryParseLengthUnit(normalized, "q", 1440d / 101.6d, out twips)) {
+                return true;
+            }
+
+            if (double.TryParse(normalized, NumberStyles.Number, CultureInfo.InvariantCulture, out double number)) {
+                twips = (int)Math.Round(number * 15d);
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool TryParseLengthUnit(
+            string value,
+            string unit,
+            double twipsPerUnit,
+            out int twips) {
+            twips = 0;
+            if (!value.EndsWith(unit, StringComparison.Ordinal) ||
+                !double.TryParse(
+                    value.Substring(0, value.Length - unit.Length),
+                    NumberStyles.Number,
+                    CultureInfo.InvariantCulture,
+                    out double number)) {
+                return false;
+            }
+
+            twips = (int)Math.Round(number * twipsPerUnit);
+            return true;
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/Helpers/CssStyleMapper.Lengths.cs
+++ b/OfficeIMO.Word.Html/Helpers/CssStyleMapper.Lengths.cs
@@ -2,15 +2,19 @@ using System.Globalization;
 
 namespace OfficeIMO.Word.Html {
     internal static partial class CssStyleMapper {
-        private static bool TryParseLength(string value, out int twips) {
+        private static bool TryParseLength(
+            string value,
+            double rootFontSizePixels,
+            double elementFontSizePixels,
+            out int twips) {
             twips = 0;
             if (string.IsNullOrWhiteSpace(value)) {
                 return false;
             }
 
             string normalized = value.Trim().ToLowerInvariant();
-            if (TryParseLengthUnit(normalized, "rem", 16d * 15d, out twips) ||
-                TryParseLengthUnit(normalized, "em", 16d * 15d, out twips) ||
+            if (TryParseLengthUnit(normalized, "rem", rootFontSizePixels * 15d, out twips) ||
+                TryParseLengthUnit(normalized, "em", elementFontSizePixels * 15d, out twips) ||
                 TryParseLengthUnit(normalized, "px", 15d, out twips) ||
                 TryParseLengthUnit(normalized, "pt", 20d, out twips) ||
                 TryParseLengthUnit(normalized, "pc", 240d, out twips) ||

--- a/OfficeIMO.Word.Html/Helpers/CssStyleMapper.cs
+++ b/OfficeIMO.Word.Html/Helpers/CssStyleMapper.cs
@@ -61,7 +61,7 @@ namespace OfficeIMO.Word.Html {
             return null;
         }
 
-        public static CssProperties ParseStyles(string? style) {
+        public static CssProperties ParseStyles(string? style, bool rightToLeft = false) {
             CssProperties result = new();
             if (string.IsNullOrWhiteSpace(style)) {
                 return result;
@@ -69,21 +69,7 @@ namespace OfficeIMO.Word.Html {
 
             Dictionary<string, string> properties = Parse(style);
 
-            if (properties.TryGetValue("margin", out string? margin)) {
-                ApplyMarginShorthand(margin, result);
-            }
-            if (properties.TryGetValue("margin-left", out string? ml) && TryParseLength(ml, out int mL)) result.MarginLeft = mL;
-            if (properties.TryGetValue("margin-right", out string? mr) && TryParseLength(mr, out int mR)) result.MarginRight = mR;
-            if (properties.TryGetValue("margin-top", out string? mt) && TryParseLength(mt, out int mT)) result.MarginTop = mT;
-            if (properties.TryGetValue("margin-bottom", out string? mb) && TryParseLength(mb, out int mB)) result.MarginBottom = mB;
-
-            if (properties.TryGetValue("padding", out string? padding)) {
-                ApplyPaddingShorthand(padding, result);
-            }
-            if (properties.TryGetValue("padding-left", out string? pl) && TryParseLength(pl, out int pL)) result.PaddingLeft = pL;
-            if (properties.TryGetValue("padding-right", out string? pr) && TryParseLength(pr, out int pR)) result.PaddingRight = pR;
-            if (properties.TryGetValue("padding-top", out string? pt) && TryParseLength(pt, out int pT)) result.PaddingTop = pT;
-            if (properties.TryGetValue("padding-bottom", out string? pb) && TryParseLength(pb, out int pB)) result.PaddingBottom = pB;
+            ApplyBoxPropertiesInDeclarationOrder(style!, rightToLeft, result);
 
             if (properties.TryGetValue("text-decoration", out string? deco)) {
                 ApplyTextDecoration(deco, result);
@@ -117,6 +103,146 @@ namespace OfficeIMO.Word.Html {
             }
 
             return result;
+        }
+
+        private static void ApplyBoxPropertiesInDeclarationOrder(
+            string style,
+            bool rightToLeft,
+            CssProperties result) {
+            foreach (string part in style.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)) {
+                string[] pieces = part.Split(new[] { ':' }, 2);
+                if (pieces.Length != 2) {
+                    continue;
+                }
+
+                string name = pieces[0].Trim().ToLowerInvariant();
+                string value = pieces[1].Trim();
+                switch (name) {
+                    case "margin":
+                        ApplyMarginShorthand(value, result);
+                        break;
+                    case "margin-left":
+                        if (TryParseLength(value, out int marginLeft)) result.MarginLeft = marginLeft;
+                        break;
+                    case "margin-right":
+                        if (TryParseLength(value, out int marginRight)) result.MarginRight = marginRight;
+                        break;
+                    case "margin-top":
+                        if (TryParseLength(value, out int marginTop)) result.MarginTop = marginTop;
+                        break;
+                    case "margin-bottom":
+                        if (TryParseLength(value, out int marginBottom)) result.MarginBottom = marginBottom;
+                        break;
+                    case "padding":
+                        ApplyPaddingShorthand(value, result);
+                        break;
+                    case "padding-left":
+                        if (TryParseLength(value, out int paddingLeft)) result.PaddingLeft = paddingLeft;
+                        break;
+                    case "padding-right":
+                        if (TryParseLength(value, out int paddingRight)) result.PaddingRight = paddingRight;
+                        break;
+                    case "padding-top":
+                        if (TryParseLength(value, out int paddingTop)) result.PaddingTop = paddingTop;
+                        break;
+                    case "padding-bottom":
+                        if (TryParseLength(value, out int paddingBottom)) result.PaddingBottom = paddingBottom;
+                        break;
+                    default:
+                        if (name.StartsWith("margin-", StringComparison.Ordinal)) {
+                            ApplySingleLogicalBoxProperty(name, value, "margin", rightToLeft, result);
+                        } else if (name.StartsWith("padding-", StringComparison.Ordinal)) {
+                            ApplySingleLogicalBoxProperty(name, value, "padding", rightToLeft, result);
+                        }
+                        break;
+                }
+            }
+        }
+
+        private static void ApplySingleLogicalBoxProperty(
+            string name,
+            string value,
+            string prefix,
+            bool rightToLeft,
+            CssProperties result) {
+            var property = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [name] = value
+            };
+            ApplyLogicalBoxProperties(property, prefix, rightToLeft, result);
+        }
+
+        private static void ApplyLogicalBoxProperties(
+            IReadOnlyDictionary<string, string> properties,
+            string prefix,
+            bool rightToLeft,
+            CssProperties result) {
+            int? inlineStart = null;
+            int? inlineEnd = null;
+            int? blockStart = null;
+            int? blockEnd = null;
+
+            if (properties.TryGetValue($"{prefix}-inline", out string? inline)) {
+                ParseLogicalPair(inline, out inlineStart, out inlineEnd);
+            }
+            if (properties.TryGetValue($"{prefix}-block", out string? block)) {
+                ParseLogicalPair(block, out blockStart, out blockEnd);
+            }
+            if (properties.TryGetValue($"{prefix}-inline-start", out string? inlineStartText) &&
+                TryParseLength(inlineStartText, out int parsedInlineStart)) {
+                inlineStart = parsedInlineStart;
+            }
+            if (properties.TryGetValue($"{prefix}-inline-end", out string? inlineEndText) &&
+                TryParseLength(inlineEndText, out int parsedInlineEnd)) {
+                inlineEnd = parsedInlineEnd;
+            }
+            if (properties.TryGetValue($"{prefix}-block-start", out string? blockStartText) &&
+                TryParseLength(blockStartText, out int parsedBlockStart)) {
+                blockStart = parsedBlockStart;
+            }
+            if (properties.TryGetValue($"{prefix}-block-end", out string? blockEndText) &&
+                TryParseLength(blockEndText, out int parsedBlockEnd)) {
+                blockEnd = parsedBlockEnd;
+            }
+
+            if (prefix.Equals("margin", StringComparison.OrdinalIgnoreCase)) {
+                if (inlineStart.HasValue) {
+                    if (rightToLeft) result.MarginRight = inlineStart;
+                    else result.MarginLeft = inlineStart;
+                }
+                if (inlineEnd.HasValue) {
+                    if (rightToLeft) result.MarginLeft = inlineEnd;
+                    else result.MarginRight = inlineEnd;
+                }
+                if (blockStart.HasValue) result.MarginTop = blockStart;
+                if (blockEnd.HasValue) result.MarginBottom = blockEnd;
+            } else {
+                if (inlineStart.HasValue) {
+                    if (rightToLeft) result.PaddingRight = inlineStart;
+                    else result.PaddingLeft = inlineStart;
+                }
+                if (inlineEnd.HasValue) {
+                    if (rightToLeft) result.PaddingLeft = inlineEnd;
+                    else result.PaddingRight = inlineEnd;
+                }
+                if (blockStart.HasValue) result.PaddingTop = blockStart;
+                if (blockEnd.HasValue) result.PaddingBottom = blockEnd;
+            }
+        }
+
+        private static void ParseLogicalPair(string value, out int? start, out int? end) {
+            start = null;
+            end = null;
+            var parts = value.Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length == 0 || parts.Length > 2 || !TryParseLength(parts[0], out int first)) {
+                return;
+            }
+
+            start = first;
+            if (parts.Length == 1) {
+                end = first;
+            } else if (TryParseLength(parts[1], out int second)) {
+                end = second;
+            }
         }
 
         private static Dictionary<string, string> Parse(string? style) {

--- a/OfficeIMO.Word.Html/Helpers/CssStyleMapper.cs
+++ b/OfficeIMO.Word.Html/Helpers/CssStyleMapper.cs
@@ -166,7 +166,7 @@ namespace OfficeIMO.Word.Html {
             }
         }
 
-        private static bool TryParseDeclaration(
+        internal static bool TryParseDeclaration(
             string declaration,
             out string name,
             out string value,
@@ -302,13 +302,18 @@ namespace OfficeIMO.Word.Html {
             if (string.IsNullOrEmpty(style)) {
                 return dict;
             }
-            var styleText = style ?? string.Empty;
-            foreach (string part in styleText.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)) {
-                string[] pieces = part.Split(new[] { ':' }, 2);
-                if (pieces.Length == 2) {
-                    dict[pieces[0].Trim()] = pieces[1].Trim();
+
+            string styleText = style ?? string.Empty;
+            for (int priorityPass = 0; priorityPass < 2; priorityPass++) {
+                bool important = priorityPass == 1;
+                foreach (string part in styleText.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)) {
+                    if (TryParseDeclaration(part, out string name, out string value, out bool declarationIsImportant) &&
+                        declarationIsImportant == important) {
+                        dict[name] = value;
+                    }
                 }
             }
+
             return dict;
         }
 

--- a/OfficeIMO.Word.Html/Helpers/CssStyleMapper.cs
+++ b/OfficeIMO.Word.Html/Helpers/CssStyleMapper.cs
@@ -672,18 +672,10 @@ namespace OfficeIMO.Word.Html {
                 return null;
             }
             if (value.StartsWith("rgb", StringComparison.OrdinalIgnoreCase)) {
-                int start = value.IndexOf('(');
-                int end = value.IndexOf(')');
-                if (start >= 0 && end > start) {
-                    var parts = value.Substring(start + 1, end - start - 1).Split(',');
-                    if (parts.Length >= 3 &&
-                        byte.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out byte r) &&
-                        byte.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out byte g) &&
-                        byte.TryParse(parts[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out byte b)) {
-                        TryParseFunctionalColorAlpha(value, out alpha);
-                        var color = Color.FromRgb(r, g, b);
-                        return color.ToRgbHex();
-                    }
+                if (TryParseRgbColor(value, out byte r, out byte g, out byte b)) {
+                    TryParseFunctionalColorAlpha(value, out alpha);
+                    var color = Color.FromRgb(r, g, b);
+                    return color.ToRgbHex();
                 }
                 return null;
             }
@@ -703,6 +695,49 @@ namespace OfficeIMO.Word.Html {
                 }
                 return null;
             }
+        }
+
+        internal static bool TryParseRgbColor(string text, out byte r, out byte g, out byte b) {
+            r = g = b = 0;
+            int start = text.IndexOf('(');
+            int end = text.LastIndexOf(')');
+            if (start < 0 || end <= start) {
+                return false;
+            }
+
+            string content = text.Substring(start + 1, end - start - 1);
+            int slashIndex = content.IndexOf('/');
+            if (slashIndex >= 0) {
+                content = content.Substring(0, slashIndex);
+            }
+
+            string[] parts = content.IndexOf(',') >= 0
+                ? content.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
+                : content.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            return parts.Length >= 3 &&
+                   TryParseRgbChannel(parts[0], out r) &&
+                   TryParseRgbChannel(parts[1], out g) &&
+                   TryParseRgbChannel(parts[2], out b);
+        }
+
+        private static bool TryParseRgbChannel(string text, out byte value) {
+            value = 0;
+            string token = text.Trim();
+            double parsed;
+            if (token.EndsWith("%", StringComparison.Ordinal)) {
+                token = token.Substring(0, token.Length - 1);
+                if (!double.TryParse(token, NumberStyles.Float, CultureInfo.InvariantCulture, out parsed)) {
+                    return false;
+                }
+
+                parsed = parsed * 255d / 100d;
+            } else if (!double.TryParse(token, NumberStyles.Float, CultureInfo.InvariantCulture, out parsed)) {
+                return false;
+            }
+
+            parsed = parsed < 0 ? 0 : parsed > 255 ? 255 : parsed;
+            value = (byte)Math.Round(parsed);
+            return true;
         }
 
         private static bool TryParseFunctionalColorAlpha(string value, out double alpha) {

--- a/OfficeIMO.Word.Html/Helpers/CssStyleMapper.cs
+++ b/OfficeIMO.Word.Html/Helpers/CssStyleMapper.cs
@@ -109,14 +109,21 @@ namespace OfficeIMO.Word.Html {
             string style,
             bool rightToLeft,
             CssProperties result) {
+            ApplyBoxPropertiesInDeclarationOrder(style, rightToLeft, result, important: false);
+            ApplyBoxPropertiesInDeclarationOrder(style, rightToLeft, result, important: true);
+        }
+
+        private static void ApplyBoxPropertiesInDeclarationOrder(
+            string style,
+            bool rightToLeft,
+            CssProperties result,
+            bool important) {
             foreach (string part in style.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)) {
-                string[] pieces = part.Split(new[] { ':' }, 2);
-                if (pieces.Length != 2) {
+                if (!TryParseDeclaration(part, out string name, out string value, out bool declarationIsImportant) ||
+                    declarationIsImportant != important) {
                     continue;
                 }
 
-                string name = pieces[0].Trim().ToLowerInvariant();
-                string value = pieces[1].Trim();
                 switch (name) {
                     case "margin":
                         ApplyMarginShorthand(value, result);
@@ -157,6 +164,51 @@ namespace OfficeIMO.Word.Html {
                         break;
                 }
             }
+        }
+
+        private static bool TryParseDeclaration(
+            string declaration,
+            out string name,
+            out string value,
+            out bool important) {
+            string[] pieces = declaration.Split(new[] { ':' }, 2);
+            if (pieces.Length != 2) {
+                name = string.Empty;
+                value = string.Empty;
+                important = false;
+                return false;
+            }
+
+            name = pieces[0].Trim().ToLowerInvariant();
+            value = pieces[1].Trim();
+            important = TryRemoveImportantSuffix(ref value);
+            return name.Length > 0 && value.Length > 0;
+        }
+
+        private static bool TryRemoveImportantSuffix(ref string value) {
+            int end = value.Length;
+            while (end > 0 && char.IsWhiteSpace(value[end - 1])) {
+                end--;
+            }
+
+            const string importantKeyword = "important";
+            int keywordStart = end - importantKeyword.Length;
+            if (keywordStart < 0 ||
+                !value.Substring(keywordStart, importantKeyword.Length)
+                    .Equals(importantKeyword, StringComparison.OrdinalIgnoreCase)) {
+                return false;
+            }
+
+            int bangIndex = keywordStart;
+            while (bangIndex > 0 && char.IsWhiteSpace(value[bangIndex - 1])) {
+                bangIndex--;
+            }
+            if (bangIndex == 0 || value[bangIndex - 1] != '!') {
+                return false;
+            }
+
+            value = value.Substring(0, bangIndex - 1).TrimEnd();
+            return true;
         }
 
         private static void ApplySingleLogicalBoxProperty(

--- a/OfficeIMO.Word.Html/Helpers/CssStyleMapper.cs
+++ b/OfficeIMO.Word.Html/Helpers/CssStyleMapper.cs
@@ -12,6 +12,8 @@ namespace OfficeIMO.Word.Html {
 
     internal static partial class CssStyleMapper {
         internal class CssProperties {
+            internal double RootFontSizePixels { get; set; } = 16d;
+            internal double ElementFontSizePixels { get; set; } = 16d;
             internal int? MarginLeft { get; set; }
             internal int? MarginRight { get; set; }
             internal int? MarginTop { get; set; }
@@ -66,8 +68,13 @@ namespace OfficeIMO.Word.Html {
             string? style,
             bool rightToLeft = false,
             CssProperties? inheritedBox = null,
-            bool inheritedRightToLeft = false) {
-            CssProperties result = new();
+            bool inheritedRightToLeft = false,
+            double rootFontSizePixels = 16d,
+            double elementFontSizePixels = 16d) {
+            CssProperties result = new() {
+                RootFontSizePixels = rootFontSizePixels > 0d ? rootFontSizePixels : 16d,
+                ElementFontSizePixels = elementFontSizePixels > 0d ? elementFontSizePixels : 16d
+            };
             if (string.IsNullOrWhiteSpace(style)) {
                 return result;
             }
@@ -162,22 +169,22 @@ namespace OfficeIMO.Word.Html {
                     case "margin-left":
                         if (IsCssBoxInheritance(value)) result.MarginLeft = inheritedBox?.MarginLeft;
                         else if (IsCssWideBoxReset(value)) result.MarginLeft = null;
-                        else if (TryParseLength(value, out int marginLeft)) result.MarginLeft = marginLeft;
+                        else if (TryParseLength(value, result.RootFontSizePixels, result.ElementFontSizePixels, out int marginLeft)) result.MarginLeft = marginLeft;
                         break;
                     case "margin-right":
                         if (IsCssBoxInheritance(value)) result.MarginRight = inheritedBox?.MarginRight;
                         else if (IsCssWideBoxReset(value)) result.MarginRight = null;
-                        else if (TryParseLength(value, out int marginRight)) result.MarginRight = marginRight;
+                        else if (TryParseLength(value, result.RootFontSizePixels, result.ElementFontSizePixels, out int marginRight)) result.MarginRight = marginRight;
                         break;
                     case "margin-top":
                         if (IsCssBoxInheritance(value)) result.MarginTop = inheritedBox?.MarginTop;
                         else if (IsCssWideBoxReset(value)) result.MarginTop = null;
-                        else if (TryParseLength(value, out int marginTop)) result.MarginTop = marginTop;
+                        else if (TryParseLength(value, result.RootFontSizePixels, result.ElementFontSizePixels, out int marginTop)) result.MarginTop = marginTop;
                         break;
                     case "margin-bottom":
                         if (IsCssBoxInheritance(value)) result.MarginBottom = inheritedBox?.MarginBottom;
                         else if (IsCssWideBoxReset(value)) result.MarginBottom = null;
-                        else if (TryParseLength(value, out int marginBottom)) result.MarginBottom = marginBottom;
+                        else if (TryParseLength(value, result.RootFontSizePixels, result.ElementFontSizePixels, out int marginBottom)) result.MarginBottom = marginBottom;
                         break;
                     case "padding":
                         if (IsCssBoxInheritance(value)) CopyPadding(inheritedBox, result);
@@ -187,22 +194,22 @@ namespace OfficeIMO.Word.Html {
                     case "padding-left":
                         if (IsCssBoxInheritance(value)) result.PaddingLeft = inheritedBox?.PaddingLeft;
                         else if (IsCssWideBoxReset(value)) result.PaddingLeft = null;
-                        else if (TryParsePaddingLength(value, out int paddingLeft)) result.PaddingLeft = paddingLeft;
+                        else if (TryParsePaddingLength(value, result.RootFontSizePixels, result.ElementFontSizePixels, out int paddingLeft)) result.PaddingLeft = paddingLeft;
                         break;
                     case "padding-right":
                         if (IsCssBoxInheritance(value)) result.PaddingRight = inheritedBox?.PaddingRight;
                         else if (IsCssWideBoxReset(value)) result.PaddingRight = null;
-                        else if (TryParsePaddingLength(value, out int paddingRight)) result.PaddingRight = paddingRight;
+                        else if (TryParsePaddingLength(value, result.RootFontSizePixels, result.ElementFontSizePixels, out int paddingRight)) result.PaddingRight = paddingRight;
                         break;
                     case "padding-top":
                         if (IsCssBoxInheritance(value)) result.PaddingTop = inheritedBox?.PaddingTop;
                         else if (IsCssWideBoxReset(value)) result.PaddingTop = null;
-                        else if (TryParsePaddingLength(value, out int paddingTop)) result.PaddingTop = paddingTop;
+                        else if (TryParsePaddingLength(value, result.RootFontSizePixels, result.ElementFontSizePixels, out int paddingTop)) result.PaddingTop = paddingTop;
                         break;
                     case "padding-bottom":
                         if (IsCssBoxInheritance(value)) result.PaddingBottom = inheritedBox?.PaddingBottom;
                         else if (IsCssWideBoxReset(value)) result.PaddingBottom = null;
-                        else if (TryParsePaddingLength(value, out int paddingBottom)) result.PaddingBottom = paddingBottom;
+                        else if (TryParsePaddingLength(value, result.RootFontSizePixels, result.ElementFontSizePixels, out int paddingBottom)) result.PaddingBottom = paddingBottom;
                         break;
                     default:
                         if (name.StartsWith("margin-", StringComparison.Ordinal)) {
@@ -314,25 +321,25 @@ namespace OfficeIMO.Word.Html {
             int? blockEnd = null;
 
             if (properties.TryGetValue($"{prefix}-inline", out string? inline)) {
-                ParseLogicalPair(inline, prefix, out inlineStart, out inlineEnd);
+                ParseLogicalPair(inline, prefix, result.RootFontSizePixels, result.ElementFontSizePixels, out inlineStart, out inlineEnd);
             }
             if (properties.TryGetValue($"{prefix}-block", out string? block)) {
-                ParseLogicalPair(block, prefix, out blockStart, out blockEnd);
+                ParseLogicalPair(block, prefix, result.RootFontSizePixels, result.ElementFontSizePixels, out blockStart, out blockEnd);
             }
             if (properties.TryGetValue($"{prefix}-inline-start", out string? inlineStartText) &&
-                TryParseBoxLength(prefix, inlineStartText, out int parsedInlineStart)) {
+                TryParseBoxLength(prefix, inlineStartText, result.RootFontSizePixels, result.ElementFontSizePixels, out int parsedInlineStart)) {
                 inlineStart = parsedInlineStart;
             }
             if (properties.TryGetValue($"{prefix}-inline-end", out string? inlineEndText) &&
-                TryParseBoxLength(prefix, inlineEndText, out int parsedInlineEnd)) {
+                TryParseBoxLength(prefix, inlineEndText, result.RootFontSizePixels, result.ElementFontSizePixels, out int parsedInlineEnd)) {
                 inlineEnd = parsedInlineEnd;
             }
             if (properties.TryGetValue($"{prefix}-block-start", out string? blockStartText) &&
-                TryParseBoxLength(prefix, blockStartText, out int parsedBlockStart)) {
+                TryParseBoxLength(prefix, blockStartText, result.RootFontSizePixels, result.ElementFontSizePixels, out int parsedBlockStart)) {
                 blockStart = parsedBlockStart;
             }
             if (properties.TryGetValue($"{prefix}-block-end", out string? blockEndText) &&
-                TryParseBoxLength(prefix, blockEndText, out int parsedBlockEnd)) {
+                TryParseBoxLength(prefix, blockEndText, result.RootFontSizePixels, result.ElementFontSizePixels, out int parsedBlockEnd)) {
                 blockEnd = parsedBlockEnd;
             }
 
@@ -364,6 +371,8 @@ namespace OfficeIMO.Word.Html {
         private static void ParseLogicalPair(
             string value,
             string prefix,
+            double rootFontSizePixels,
+            double elementFontSizePixels,
             out int? start,
             out int? end) {
             start = null;
@@ -371,7 +380,7 @@ namespace OfficeIMO.Word.Html {
             var parts = value.Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
             if (parts.Length == 0 ||
                 parts.Length > 2 ||
-                !TryParseBoxLength(prefix, parts[0], out int first)) {
+                !TryParseBoxLength(prefix, parts[0], rootFontSizePixels, elementFontSizePixels, out int first)) {
                 return;
             }
 
@@ -381,7 +390,7 @@ namespace OfficeIMO.Word.Html {
                 return;
             }
 
-            if (!TryParseBoxLength(prefix, parts[1], out int second)) {
+            if (!TryParseBoxLength(prefix, parts[1], rootFontSizePixels, elementFontSizePixels, out int second)) {
                 return;
             }
 
@@ -494,13 +503,22 @@ namespace OfficeIMO.Word.Html {
             return size > 0;
         }
 
-        private static bool TryParsePaddingLength(string value, out int twips) =>
-            TryParseLength(value, out twips) && twips >= 0;
+        private static bool TryParsePaddingLength(
+            string value,
+            double rootFontSizePixels,
+            double elementFontSizePixels,
+            out int twips) =>
+            TryParseLength(value, rootFontSizePixels, elementFontSizePixels, out twips) && twips >= 0;
 
-        private static bool TryParseBoxLength(string prefix, string value, out int twips) =>
+        private static bool TryParseBoxLength(
+            string prefix,
+            string value,
+            double rootFontSizePixels,
+            double elementFontSizePixels,
+            out int twips) =>
             prefix.Equals("padding", StringComparison.OrdinalIgnoreCase)
-                ? TryParsePaddingLength(value, out twips)
-                : TryParseLength(value, out twips);
+                ? TryParsePaddingLength(value, rootFontSizePixels, elementFontSizePixels, out twips)
+                : TryParseLength(value, rootFontSizePixels, elementFontSizePixels, out twips);
 
         private static void ApplyMarginShorthand(string margin, CssProperties result) {
             var parts = margin.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
@@ -509,28 +527,28 @@ namespace OfficeIMO.Word.Html {
             }
             int? top = null, right = null, bottom = null, left = null;
             if (parts.Length == 1) {
-                if (TryParseLength(parts[0], out int all)) {
+                if (TryParseLength(parts[0], result.RootFontSizePixels, result.ElementFontSizePixels, out int all)) {
                     top = right = bottom = left = all;
                 }
             } else if (parts.Length == 2) {
-                if (TryParseLength(parts[0], out int tb) &&
-                    TryParseLength(parts[1], out int lr)) {
+                if (TryParseLength(parts[0], result.RootFontSizePixels, result.ElementFontSizePixels, out int tb) &&
+                    TryParseLength(parts[1], result.RootFontSizePixels, result.ElementFontSizePixels, out int lr)) {
                     top = bottom = tb;
                     left = right = lr;
                 }
             } else if (parts.Length == 3) {
-                if (TryParseLength(parts[0], out int t) &&
-                    TryParseLength(parts[1], out int rl) &&
-                    TryParseLength(parts[2], out int b)) {
+                if (TryParseLength(parts[0], result.RootFontSizePixels, result.ElementFontSizePixels, out int t) &&
+                    TryParseLength(parts[1], result.RootFontSizePixels, result.ElementFontSizePixels, out int rl) &&
+                    TryParseLength(parts[2], result.RootFontSizePixels, result.ElementFontSizePixels, out int b)) {
                     top = t;
                     bottom = b;
                     left = right = rl;
                 }
             } else {
-                if (TryParseLength(parts[0], out int t) &&
-                    TryParseLength(parts[1], out int r) &&
-                    TryParseLength(parts[2], out int b) &&
-                    TryParseLength(parts[3], out int l)) {
+                if (TryParseLength(parts[0], result.RootFontSizePixels, result.ElementFontSizePixels, out int t) &&
+                    TryParseLength(parts[1], result.RootFontSizePixels, result.ElementFontSizePixels, out int r) &&
+                    TryParseLength(parts[2], result.RootFontSizePixels, result.ElementFontSizePixels, out int b) &&
+                    TryParseLength(parts[3], result.RootFontSizePixels, result.ElementFontSizePixels, out int l)) {
                     top = t;
                     right = r;
                     bottom = b;
@@ -550,28 +568,28 @@ namespace OfficeIMO.Word.Html {
             }
             int? top = null, right = null, bottom = null, left = null;
             if (parts.Length == 1) {
-                if (TryParsePaddingLength(parts[0], out int all)) {
+                if (TryParsePaddingLength(parts[0], result.RootFontSizePixels, result.ElementFontSizePixels, out int all)) {
                     top = right = bottom = left = all;
                 }
             } else if (parts.Length == 2) {
-                if (TryParsePaddingLength(parts[0], out int tb) &&
-                    TryParsePaddingLength(parts[1], out int lr)) {
+                if (TryParsePaddingLength(parts[0], result.RootFontSizePixels, result.ElementFontSizePixels, out int tb) &&
+                    TryParsePaddingLength(parts[1], result.RootFontSizePixels, result.ElementFontSizePixels, out int lr)) {
                     top = bottom = tb;
                     left = right = lr;
                 }
             } else if (parts.Length == 3) {
-                if (TryParsePaddingLength(parts[0], out int t) &&
-                    TryParsePaddingLength(parts[1], out int rl) &&
-                    TryParsePaddingLength(parts[2], out int b)) {
+                if (TryParsePaddingLength(parts[0], result.RootFontSizePixels, result.ElementFontSizePixels, out int t) &&
+                    TryParsePaddingLength(parts[1], result.RootFontSizePixels, result.ElementFontSizePixels, out int rl) &&
+                    TryParsePaddingLength(parts[2], result.RootFontSizePixels, result.ElementFontSizePixels, out int b)) {
                     top = t;
                     bottom = b;
                     left = right = rl;
                 }
             } else {
-                if (TryParsePaddingLength(parts[0], out int t) &&
-                    TryParsePaddingLength(parts[1], out int r) &&
-                    TryParsePaddingLength(parts[2], out int b) &&
-                    TryParsePaddingLength(parts[3], out int l)) {
+                if (TryParsePaddingLength(parts[0], result.RootFontSizePixels, result.ElementFontSizePixels, out int t) &&
+                    TryParsePaddingLength(parts[1], result.RootFontSizePixels, result.ElementFontSizePixels, out int r) &&
+                    TryParsePaddingLength(parts[2], result.RootFontSizePixels, result.ElementFontSizePixels, out int b) &&
+                    TryParsePaddingLength(parts[3], result.RootFontSizePixels, result.ElementFontSizePixels, out int l)) {
                     top = t;
                     right = r;
                     bottom = b;

--- a/OfficeIMO.Word.Html/Helpers/CssStyleMapper.cs
+++ b/OfficeIMO.Word.Html/Helpers/CssStyleMapper.cs
@@ -289,12 +289,18 @@ namespace OfficeIMO.Word.Html {
                 return;
             }
 
-            start = first;
             if (parts.Length == 1) {
+                start = first;
                 end = first;
-            } else if (TryParseLength(parts[1], out int second)) {
-                end = second;
+                return;
             }
+
+            if (!TryParseLength(parts[1], out int second)) {
+                return;
+            }
+
+            start = first;
+            end = second;
         }
 
         private static Dictionary<string, string> Parse(string? style) {

--- a/OfficeIMO.Word.Html/Helpers/CssStyleMapper.cs
+++ b/OfficeIMO.Word.Html/Helpers/CssStyleMapper.cs
@@ -61,7 +61,11 @@ namespace OfficeIMO.Word.Html {
             return null;
         }
 
-        public static CssProperties ParseStyles(string? style, bool rightToLeft = false) {
+        public static CssProperties ParseStyles(
+            string? style,
+            bool rightToLeft = false,
+            CssProperties? inheritedBox = null,
+            bool inheritedRightToLeft = false) {
             CssProperties result = new();
             if (string.IsNullOrWhiteSpace(style)) {
                 return result;
@@ -69,7 +73,12 @@ namespace OfficeIMO.Word.Html {
 
             Dictionary<string, string> properties = Parse(style);
 
-            ApplyBoxPropertiesInDeclarationOrder(style!, rightToLeft, result);
+            ApplyBoxPropertiesInDeclarationOrder(
+                style!,
+                rightToLeft,
+                result,
+                inheritedBox,
+                inheritedRightToLeft);
 
             if (properties.TryGetValue("text-decoration", out string? deco)) {
                 ApplyTextDecoration(deco, result);
@@ -108,15 +117,31 @@ namespace OfficeIMO.Word.Html {
         private static void ApplyBoxPropertiesInDeclarationOrder(
             string style,
             bool rightToLeft,
-            CssProperties result) {
-            ApplyBoxPropertiesInDeclarationOrder(style, rightToLeft, result, important: false);
-            ApplyBoxPropertiesInDeclarationOrder(style, rightToLeft, result, important: true);
+            CssProperties result,
+            CssProperties? inheritedBox,
+            bool inheritedRightToLeft) {
+            ApplyBoxPropertiesInDeclarationOrder(
+                style,
+                rightToLeft,
+                result,
+                inheritedBox,
+                inheritedRightToLeft,
+                important: false);
+            ApplyBoxPropertiesInDeclarationOrder(
+                style,
+                rightToLeft,
+                result,
+                inheritedBox,
+                inheritedRightToLeft,
+                important: true);
         }
 
         private static void ApplyBoxPropertiesInDeclarationOrder(
             string style,
             bool rightToLeft,
             CssProperties result,
+            CssProperties? inheritedBox,
+            bool inheritedRightToLeft,
             bool important) {
             foreach (string part in style.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)) {
                 if (!TryParseDeclaration(part, out string name, out string value, out bool declarationIsImportant) ||
@@ -126,50 +151,74 @@ namespace OfficeIMO.Word.Html {
 
                 switch (name) {
                     case "margin":
-                        if (IsCssWideBoxReset(value)) ResetMargin(result);
+                        if (IsCssBoxInheritance(value)) CopyMargin(inheritedBox, result);
+                        else if (IsCssWideBoxReset(value)) ResetMargin(result);
                         else ApplyMarginShorthand(value, result);
                         break;
                     case "margin-left":
-                        if (IsCssWideBoxReset(value)) result.MarginLeft = null;
+                        if (IsCssBoxInheritance(value)) result.MarginLeft = inheritedBox?.MarginLeft;
+                        else if (IsCssWideBoxReset(value)) result.MarginLeft = null;
                         else if (TryParseLength(value, out int marginLeft)) result.MarginLeft = marginLeft;
                         break;
                     case "margin-right":
-                        if (IsCssWideBoxReset(value)) result.MarginRight = null;
+                        if (IsCssBoxInheritance(value)) result.MarginRight = inheritedBox?.MarginRight;
+                        else if (IsCssWideBoxReset(value)) result.MarginRight = null;
                         else if (TryParseLength(value, out int marginRight)) result.MarginRight = marginRight;
                         break;
                     case "margin-top":
-                        if (IsCssWideBoxReset(value)) result.MarginTop = null;
+                        if (IsCssBoxInheritance(value)) result.MarginTop = inheritedBox?.MarginTop;
+                        else if (IsCssWideBoxReset(value)) result.MarginTop = null;
                         else if (TryParseLength(value, out int marginTop)) result.MarginTop = marginTop;
                         break;
                     case "margin-bottom":
-                        if (IsCssWideBoxReset(value)) result.MarginBottom = null;
+                        if (IsCssBoxInheritance(value)) result.MarginBottom = inheritedBox?.MarginBottom;
+                        else if (IsCssWideBoxReset(value)) result.MarginBottom = null;
                         else if (TryParseLength(value, out int marginBottom)) result.MarginBottom = marginBottom;
                         break;
                     case "padding":
-                        if (IsCssWideBoxReset(value)) ResetPadding(result);
+                        if (IsCssBoxInheritance(value)) CopyPadding(inheritedBox, result);
+                        else if (IsCssWideBoxReset(value)) ResetPadding(result);
                         else ApplyPaddingShorthand(value, result);
                         break;
                     case "padding-left":
-                        if (IsCssWideBoxReset(value)) result.PaddingLeft = null;
-                        else if (TryParseLength(value, out int paddingLeft)) result.PaddingLeft = paddingLeft;
+                        if (IsCssBoxInheritance(value)) result.PaddingLeft = inheritedBox?.PaddingLeft;
+                        else if (IsCssWideBoxReset(value)) result.PaddingLeft = null;
+                        else if (TryParsePaddingLength(value, out int paddingLeft)) result.PaddingLeft = paddingLeft;
                         break;
                     case "padding-right":
-                        if (IsCssWideBoxReset(value)) result.PaddingRight = null;
-                        else if (TryParseLength(value, out int paddingRight)) result.PaddingRight = paddingRight;
+                        if (IsCssBoxInheritance(value)) result.PaddingRight = inheritedBox?.PaddingRight;
+                        else if (IsCssWideBoxReset(value)) result.PaddingRight = null;
+                        else if (TryParsePaddingLength(value, out int paddingRight)) result.PaddingRight = paddingRight;
                         break;
                     case "padding-top":
-                        if (IsCssWideBoxReset(value)) result.PaddingTop = null;
-                        else if (TryParseLength(value, out int paddingTop)) result.PaddingTop = paddingTop;
+                        if (IsCssBoxInheritance(value)) result.PaddingTop = inheritedBox?.PaddingTop;
+                        else if (IsCssWideBoxReset(value)) result.PaddingTop = null;
+                        else if (TryParsePaddingLength(value, out int paddingTop)) result.PaddingTop = paddingTop;
                         break;
                     case "padding-bottom":
-                        if (IsCssWideBoxReset(value)) result.PaddingBottom = null;
-                        else if (TryParseLength(value, out int paddingBottom)) result.PaddingBottom = paddingBottom;
+                        if (IsCssBoxInheritance(value)) result.PaddingBottom = inheritedBox?.PaddingBottom;
+                        else if (IsCssWideBoxReset(value)) result.PaddingBottom = null;
+                        else if (TryParsePaddingLength(value, out int paddingBottom)) result.PaddingBottom = paddingBottom;
                         break;
                     default:
                         if (name.StartsWith("margin-", StringComparison.Ordinal)) {
-                            ApplySingleLogicalBoxProperty(name, value, "margin", rightToLeft, result);
+                            ApplySingleLogicalBoxProperty(
+                                name,
+                                value,
+                                "margin",
+                                rightToLeft,
+                                result,
+                                inheritedBox,
+                                inheritedRightToLeft);
                         } else if (name.StartsWith("padding-", StringComparison.Ordinal)) {
-                            ApplySingleLogicalBoxProperty(name, value, "padding", rightToLeft, result);
+                            ApplySingleLogicalBoxProperty(
+                                name,
+                                value,
+                                "padding",
+                                rightToLeft,
+                                result,
+                                inheritedBox,
+                                inheritedRightToLeft);
                         }
                         break;
                 }
@@ -226,7 +275,19 @@ namespace OfficeIMO.Word.Html {
             string value,
             string prefix,
             bool rightToLeft,
-            CssProperties result) {
+            CssProperties result,
+            CssProperties? inheritedBox,
+            bool inheritedRightToLeft) {
+            if (IsCssBoxInheritance(value)) {
+                InheritLogicalBoxProperty(
+                    name,
+                    prefix,
+                    rightToLeft,
+                    result,
+                    inheritedBox,
+                    inheritedRightToLeft);
+                return;
+            }
             if (IsCssWideBoxReset(value)) {
                 ResetLogicalBoxProperty(name, prefix, rightToLeft, result);
                 return;
@@ -249,25 +310,25 @@ namespace OfficeIMO.Word.Html {
             int? blockEnd = null;
 
             if (properties.TryGetValue($"{prefix}-inline", out string? inline)) {
-                ParseLogicalPair(inline, out inlineStart, out inlineEnd);
+                ParseLogicalPair(inline, prefix, out inlineStart, out inlineEnd);
             }
             if (properties.TryGetValue($"{prefix}-block", out string? block)) {
-                ParseLogicalPair(block, out blockStart, out blockEnd);
+                ParseLogicalPair(block, prefix, out blockStart, out blockEnd);
             }
             if (properties.TryGetValue($"{prefix}-inline-start", out string? inlineStartText) &&
-                TryParseLength(inlineStartText, out int parsedInlineStart)) {
+                TryParseBoxLength(prefix, inlineStartText, out int parsedInlineStart)) {
                 inlineStart = parsedInlineStart;
             }
             if (properties.TryGetValue($"{prefix}-inline-end", out string? inlineEndText) &&
-                TryParseLength(inlineEndText, out int parsedInlineEnd)) {
+                TryParseBoxLength(prefix, inlineEndText, out int parsedInlineEnd)) {
                 inlineEnd = parsedInlineEnd;
             }
             if (properties.TryGetValue($"{prefix}-block-start", out string? blockStartText) &&
-                TryParseLength(blockStartText, out int parsedBlockStart)) {
+                TryParseBoxLength(prefix, blockStartText, out int parsedBlockStart)) {
                 blockStart = parsedBlockStart;
             }
             if (properties.TryGetValue($"{prefix}-block-end", out string? blockEndText) &&
-                TryParseLength(blockEndText, out int parsedBlockEnd)) {
+                TryParseBoxLength(prefix, blockEndText, out int parsedBlockEnd)) {
                 blockEnd = parsedBlockEnd;
             }
 
@@ -296,11 +357,17 @@ namespace OfficeIMO.Word.Html {
             }
         }
 
-        private static void ParseLogicalPair(string value, out int? start, out int? end) {
+        private static void ParseLogicalPair(
+            string value,
+            string prefix,
+            out int? start,
+            out int? end) {
             start = null;
             end = null;
             var parts = value.Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
-            if (parts.Length == 0 || parts.Length > 2 || !TryParseLength(parts[0], out int first)) {
+            if (parts.Length == 0 ||
+                parts.Length > 2 ||
+                !TryParseBoxLength(prefix, parts[0], out int first)) {
                 return;
             }
 
@@ -310,7 +377,7 @@ namespace OfficeIMO.Word.Html {
                 return;
             }
 
-            if (!TryParseLength(parts[1], out int second)) {
+            if (!TryParseBoxLength(prefix, parts[1], out int second)) {
                 return;
             }
 
@@ -448,6 +515,14 @@ namespace OfficeIMO.Word.Html {
             return false;
         }
 
+        private static bool TryParsePaddingLength(string value, out int twips) =>
+            TryParseLength(value, out twips) && twips >= 0;
+
+        private static bool TryParseBoxLength(string prefix, string value, out int twips) =>
+            prefix.Equals("padding", StringComparison.OrdinalIgnoreCase)
+                ? TryParsePaddingLength(value, out twips)
+                : TryParseLength(value, out twips);
+
         private static void ApplyMarginShorthand(string margin, CssProperties result) {
             var parts = margin.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
             if (parts.Length == 0) {
@@ -459,18 +534,24 @@ namespace OfficeIMO.Word.Html {
                     top = right = bottom = left = all;
                 }
             } else if (parts.Length == 2) {
-                if (TryParseLength(parts[0], out int tb) && TryParseLength(parts[1], out int lr)) {
+                if (TryParseLength(parts[0], out int tb) &&
+                    TryParseLength(parts[1], out int lr)) {
                     top = bottom = tb;
                     left = right = lr;
                 }
             } else if (parts.Length == 3) {
-                if (TryParseLength(parts[0], out int t) && TryParseLength(parts[1], out int rl) && TryParseLength(parts[2], out int b)) {
+                if (TryParseLength(parts[0], out int t) &&
+                    TryParseLength(parts[1], out int rl) &&
+                    TryParseLength(parts[2], out int b)) {
                     top = t;
                     bottom = b;
                     left = right = rl;
                 }
             } else {
-                if (TryParseLength(parts[0], out int t) && TryParseLength(parts[1], out int r) && TryParseLength(parts[2], out int b) && TryParseLength(parts[3], out int l)) {
+                if (TryParseLength(parts[0], out int t) &&
+                    TryParseLength(parts[1], out int r) &&
+                    TryParseLength(parts[2], out int b) &&
+                    TryParseLength(parts[3], out int l)) {
                     top = t;
                     right = r;
                     bottom = b;
@@ -490,22 +571,28 @@ namespace OfficeIMO.Word.Html {
             }
             int? top = null, right = null, bottom = null, left = null;
             if (parts.Length == 1) {
-                if (TryParseLength(parts[0], out int all)) {
+                if (TryParsePaddingLength(parts[0], out int all)) {
                     top = right = bottom = left = all;
                 }
             } else if (parts.Length == 2) {
-                if (TryParseLength(parts[0], out int tb) && TryParseLength(parts[1], out int lr)) {
+                if (TryParsePaddingLength(parts[0], out int tb) &&
+                    TryParsePaddingLength(parts[1], out int lr)) {
                     top = bottom = tb;
                     left = right = lr;
                 }
             } else if (parts.Length == 3) {
-                if (TryParseLength(parts[0], out int t) && TryParseLength(parts[1], out int rl) && TryParseLength(parts[2], out int b)) {
+                if (TryParsePaddingLength(parts[0], out int t) &&
+                    TryParsePaddingLength(parts[1], out int rl) &&
+                    TryParsePaddingLength(parts[2], out int b)) {
                     top = t;
                     bottom = b;
                     left = right = rl;
                 }
             } else {
-                if (TryParseLength(parts[0], out int t) && TryParseLength(parts[1], out int r) && TryParseLength(parts[2], out int b) && TryParseLength(parts[3], out int l)) {
+                if (TryParsePaddingLength(parts[0], out int t) &&
+                    TryParsePaddingLength(parts[1], out int r) &&
+                    TryParsePaddingLength(parts[2], out int b) &&
+                    TryParsePaddingLength(parts[3], out int l)) {
                     top = t;
                     right = r;
                     bottom = b;

--- a/OfficeIMO.Word.Html/Helpers/CssStyleMapper.cs
+++ b/OfficeIMO.Word.Html/Helpers/CssStyleMapper.cs
@@ -24,6 +24,7 @@ namespace OfficeIMO.Word.Html {
             internal UnderlineValues? UnderlineStyle { get; set; }
             internal bool? Strike { get; set; }
             internal string? BackgroundColor { get; set; }
+            internal double? BackgroundColorAlpha { get; set; }
             internal int? LineHeight { get; set; }
             internal LineSpacingRuleValues? LineHeightRule { get; set; }
             internal WhiteSpaceMode? WhiteSpace { get; set; }
@@ -92,7 +93,10 @@ namespace OfficeIMO.Word.Html {
             }
 
             if (properties.TryGetValue("background-color", out string? bg)) {
-                result.BackgroundColor = NormalizeColor(bg);
+                result.BackgroundColor = NormalizeColor(bg, out double alpha);
+                if (result.BackgroundColor != null) {
+                    result.BackgroundColorAlpha = alpha;
+                }
             }
 
             if (properties.TryGetValue("line-height", out string? lh) && TryParseLineHeight(lh, out int line, out LineSpacingRuleValues rule)) {
@@ -490,31 +494,6 @@ namespace OfficeIMO.Word.Html {
             return size > 0;
         }
 
-        private static bool TryParseLength(string value, out int twips) {
-            twips = 0;
-            if (string.IsNullOrWhiteSpace(value)) {
-                return false;
-            }
-            value = value.Trim().ToLowerInvariant();
-            if (value.EndsWith("pt") && double.TryParse(value.Substring(0, value.Length - 2), NumberStyles.Number, CultureInfo.InvariantCulture, out double pt)) {
-                twips = (int)Math.Round(pt * 20);
-                return true;
-            }
-            if (value.EndsWith("px") && double.TryParse(value.Substring(0, value.Length - 2), NumberStyles.Number, CultureInfo.InvariantCulture, out double px)) {
-                twips = (int)Math.Round(px * 15);
-                return true;
-            }
-            if (value.EndsWith("em") && double.TryParse(value.Substring(0, value.Length - 2), NumberStyles.Number, CultureInfo.InvariantCulture, out double em)) {
-                twips = (int)Math.Round(em * 16 * 15);
-                return true;
-            }
-            if (double.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out double number)) {
-                twips = (int)Math.Round(number * 15);
-                return true;
-            }
-            return false;
-        }
-
         private static bool TryParsePaddingLength(string value, out int twips) =>
             TryParseLength(value, out twips) && twips >= 0;
 
@@ -635,13 +614,15 @@ namespace OfficeIMO.Word.Html {
             return false;
         }
 
-        private static string? NormalizeColor(string value) {
+        private static string? NormalizeColor(string value, out double alpha) {
+            alpha = 1d;
             if (string.IsNullOrWhiteSpace(value)) {
                 return null;
             }
             value = value.Trim();
             if (value.StartsWith("hsl", StringComparison.OrdinalIgnoreCase)) {
                 if (TryParseHsl(value, out byte hr, out byte hg, out byte hb)) {
+                    TryParseFunctionalColorAlpha(value, out alpha);
                     var color = Color.FromRgb(hr, hg, hb);
                     return color.ToRgbHex();
                 }
@@ -656,6 +637,7 @@ namespace OfficeIMO.Word.Html {
                         byte.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out byte r) &&
                         byte.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out byte g) &&
                         byte.TryParse(parts[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out byte b)) {
+                        TryParseFunctionalColorAlpha(value, out alpha);
                         var color = Color.FromRgb(r, g, b);
                         return color.ToRgbHex();
                     }
@@ -664,11 +646,13 @@ namespace OfficeIMO.Word.Html {
             }
             try {
                 var parsed = Color.Parse(value);
+                alpha = parsed.A / (double)byte.MaxValue;
                 return parsed.ToRgbHex();
             } catch {
                 if (!value.StartsWith("#", StringComparison.Ordinal)) {
                     try {
                         var parsed = Color.Parse("#" + value);
+                        alpha = parsed.A / (double)byte.MaxValue;
                         return parsed.ToRgbHex();
                     } catch {
                         return null;
@@ -676,6 +660,42 @@ namespace OfficeIMO.Word.Html {
                 }
                 return null;
             }
+        }
+
+        private static bool TryParseFunctionalColorAlpha(string value, out double alpha) {
+            alpha = 1d;
+            int start = value.IndexOf('(');
+            int end = value.LastIndexOf(')');
+            if (start < 0 || end <= start) {
+                return false;
+            }
+
+            string content = value.Substring(start + 1, end - start - 1);
+            string? alphaToken = null;
+            int slashIndex = content.LastIndexOf('/');
+            if (slashIndex >= 0) {
+                alphaToken = content.Substring(slashIndex + 1).Trim();
+            } else {
+                string[] commaParts = content.Split(',');
+                if (commaParts.Length >= 4) {
+                    alphaToken = commaParts[3].Trim();
+                }
+            }
+
+            if (string.IsNullOrWhiteSpace(alphaToken)) {
+                return false;
+            }
+
+            bool percent = alphaToken!.EndsWith("%", StringComparison.Ordinal);
+            string number = percent ? alphaToken.Substring(0, alphaToken.Length - 1) : alphaToken;
+            if (!double.TryParse(number, NumberStyles.Float, CultureInfo.InvariantCulture, out double parsed)) {
+                return false;
+            }
+
+            double normalized = percent ? parsed / 100d : parsed;
+            normalized = Math.Max(0d, Math.Min(1d, normalized));
+            alpha = normalized;
+            return true;
         }
 
         private static bool TryParseHsl(string text, out byte r, out byte g, out byte b) {

--- a/OfficeIMO.Word.Html/Helpers/CssStyleMapper.cs
+++ b/OfficeIMO.Word.Html/Helpers/CssStyleMapper.cs
@@ -10,7 +10,7 @@ namespace OfficeIMO.Word.Html {
         NoWrap,
     }
 
-    internal static class CssStyleMapper {
+    internal static partial class CssStyleMapper {
         internal class CssProperties {
             internal int? MarginLeft { get; set; }
             internal int? MarginRight { get; set; }
@@ -126,34 +126,44 @@ namespace OfficeIMO.Word.Html {
 
                 switch (name) {
                     case "margin":
-                        ApplyMarginShorthand(value, result);
+                        if (IsCssWideBoxReset(value)) ResetMargin(result);
+                        else ApplyMarginShorthand(value, result);
                         break;
                     case "margin-left":
-                        if (TryParseLength(value, out int marginLeft)) result.MarginLeft = marginLeft;
+                        if (IsCssWideBoxReset(value)) result.MarginLeft = null;
+                        else if (TryParseLength(value, out int marginLeft)) result.MarginLeft = marginLeft;
                         break;
                     case "margin-right":
-                        if (TryParseLength(value, out int marginRight)) result.MarginRight = marginRight;
+                        if (IsCssWideBoxReset(value)) result.MarginRight = null;
+                        else if (TryParseLength(value, out int marginRight)) result.MarginRight = marginRight;
                         break;
                     case "margin-top":
-                        if (TryParseLength(value, out int marginTop)) result.MarginTop = marginTop;
+                        if (IsCssWideBoxReset(value)) result.MarginTop = null;
+                        else if (TryParseLength(value, out int marginTop)) result.MarginTop = marginTop;
                         break;
                     case "margin-bottom":
-                        if (TryParseLength(value, out int marginBottom)) result.MarginBottom = marginBottom;
+                        if (IsCssWideBoxReset(value)) result.MarginBottom = null;
+                        else if (TryParseLength(value, out int marginBottom)) result.MarginBottom = marginBottom;
                         break;
                     case "padding":
-                        ApplyPaddingShorthand(value, result);
+                        if (IsCssWideBoxReset(value)) ResetPadding(result);
+                        else ApplyPaddingShorthand(value, result);
                         break;
                     case "padding-left":
-                        if (TryParseLength(value, out int paddingLeft)) result.PaddingLeft = paddingLeft;
+                        if (IsCssWideBoxReset(value)) result.PaddingLeft = null;
+                        else if (TryParseLength(value, out int paddingLeft)) result.PaddingLeft = paddingLeft;
                         break;
                     case "padding-right":
-                        if (TryParseLength(value, out int paddingRight)) result.PaddingRight = paddingRight;
+                        if (IsCssWideBoxReset(value)) result.PaddingRight = null;
+                        else if (TryParseLength(value, out int paddingRight)) result.PaddingRight = paddingRight;
                         break;
                     case "padding-top":
-                        if (TryParseLength(value, out int paddingTop)) result.PaddingTop = paddingTop;
+                        if (IsCssWideBoxReset(value)) result.PaddingTop = null;
+                        else if (TryParseLength(value, out int paddingTop)) result.PaddingTop = paddingTop;
                         break;
                     case "padding-bottom":
-                        if (TryParseLength(value, out int paddingBottom)) result.PaddingBottom = paddingBottom;
+                        if (IsCssWideBoxReset(value)) result.PaddingBottom = null;
+                        else if (TryParseLength(value, out int paddingBottom)) result.PaddingBottom = paddingBottom;
                         break;
                     default:
                         if (name.StartsWith("margin-", StringComparison.Ordinal)) {
@@ -217,6 +227,11 @@ namespace OfficeIMO.Word.Html {
             string prefix,
             bool rightToLeft,
             CssProperties result) {
+            if (IsCssWideBoxReset(value)) {
+                ResetLogicalBoxProperty(name, prefix, rightToLeft, result);
+                return;
+            }
+
             var property = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
                 [name] = value
             };

--- a/OfficeIMO.Word.Html/Helpers/CssStyleMapper.cs
+++ b/OfficeIMO.Word.Html/Helpers/CssStyleMapper.cs
@@ -168,22 +168,22 @@ namespace OfficeIMO.Word.Html {
                         break;
                     case "margin-left":
                         if (IsCssBoxInheritance(value)) result.MarginLeft = inheritedBox?.MarginLeft;
-                        else if (IsCssWideBoxReset(value)) result.MarginLeft = null;
+                        else if (IsCssWideBoxReset(value) || IsAutoMargin(value)) result.MarginLeft = null;
                         else if (TryParseLength(value, result.RootFontSizePixels, result.ElementFontSizePixels, out int marginLeft)) result.MarginLeft = marginLeft;
                         break;
                     case "margin-right":
                         if (IsCssBoxInheritance(value)) result.MarginRight = inheritedBox?.MarginRight;
-                        else if (IsCssWideBoxReset(value)) result.MarginRight = null;
+                        else if (IsCssWideBoxReset(value) || IsAutoMargin(value)) result.MarginRight = null;
                         else if (TryParseLength(value, result.RootFontSizePixels, result.ElementFontSizePixels, out int marginRight)) result.MarginRight = marginRight;
                         break;
                     case "margin-top":
                         if (IsCssBoxInheritance(value)) result.MarginTop = inheritedBox?.MarginTop;
-                        else if (IsCssWideBoxReset(value)) result.MarginTop = null;
+                        else if (IsCssWideBoxReset(value) || IsAutoMargin(value)) result.MarginTop = null;
                         else if (TryParseLength(value, result.RootFontSizePixels, result.ElementFontSizePixels, out int marginTop)) result.MarginTop = marginTop;
                         break;
                     case "margin-bottom":
                         if (IsCssBoxInheritance(value)) result.MarginBottom = inheritedBox?.MarginBottom;
-                        else if (IsCssWideBoxReset(value)) result.MarginBottom = null;
+                        else if (IsCssWideBoxReset(value) || IsAutoMargin(value)) result.MarginBottom = null;
                         else if (TryParseLength(value, result.RootFontSizePixels, result.ElementFontSizePixels, out int marginBottom)) result.MarginBottom = marginBottom;
                         break;
                     case "padding":
@@ -300,6 +300,11 @@ namespace OfficeIMO.Word.Html {
                 return;
             }
             if (IsCssWideBoxReset(value)) {
+                ResetLogicalBoxProperty(name, prefix, rightToLeft, result);
+                return;
+            }
+            if (prefix.Equals("margin", StringComparison.OrdinalIgnoreCase) &&
+                IsAutoMargin(value)) {
                 ResetLogicalBoxProperty(name, prefix, rightToLeft, result);
                 return;
             }
@@ -520,45 +525,65 @@ namespace OfficeIMO.Word.Html {
                 ? TryParsePaddingLength(value, rootFontSizePixels, elementFontSizePixels, out twips)
                 : TryParseLength(value, rootFontSizePixels, elementFontSizePixels, out twips);
 
+        private static bool IsAutoMargin(string value) =>
+            value.Trim().Equals("auto", StringComparison.OrdinalIgnoreCase);
+
+        private static bool TryParseMarginLength(
+            string value,
+            double rootFontSizePixels,
+            double elementFontSizePixels,
+            out int? twips) {
+            if (IsAutoMargin(value)) {
+                twips = null;
+                return true;
+            }
+            if (TryParseLength(value, rootFontSizePixels, elementFontSizePixels, out int parsed)) {
+                twips = parsed;
+                return true;
+            }
+            twips = null;
+            return false;
+        }
+
         private static void ApplyMarginShorthand(string margin, CssProperties result) {
             var parts = margin.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-            if (parts.Length == 0) {
+            if (parts.Length == 0 || parts.Length > 4) {
                 return;
             }
             int? top = null, right = null, bottom = null, left = null;
             if (parts.Length == 1) {
-                if (TryParseLength(parts[0], result.RootFontSizePixels, result.ElementFontSizePixels, out int all)) {
+                if (TryParseMarginLength(parts[0], result.RootFontSizePixels, result.ElementFontSizePixels, out int? all)) {
                     top = right = bottom = left = all;
-                }
+                } else return;
             } else if (parts.Length == 2) {
-                if (TryParseLength(parts[0], result.RootFontSizePixels, result.ElementFontSizePixels, out int tb) &&
-                    TryParseLength(parts[1], result.RootFontSizePixels, result.ElementFontSizePixels, out int lr)) {
+                if (TryParseMarginLength(parts[0], result.RootFontSizePixels, result.ElementFontSizePixels, out int? tb) &&
+                    TryParseMarginLength(parts[1], result.RootFontSizePixels, result.ElementFontSizePixels, out int? lr)) {
                     top = bottom = tb;
                     left = right = lr;
-                }
+                } else return;
             } else if (parts.Length == 3) {
-                if (TryParseLength(parts[0], result.RootFontSizePixels, result.ElementFontSizePixels, out int t) &&
-                    TryParseLength(parts[1], result.RootFontSizePixels, result.ElementFontSizePixels, out int rl) &&
-                    TryParseLength(parts[2], result.RootFontSizePixels, result.ElementFontSizePixels, out int b)) {
+                if (TryParseMarginLength(parts[0], result.RootFontSizePixels, result.ElementFontSizePixels, out int? t) &&
+                    TryParseMarginLength(parts[1], result.RootFontSizePixels, result.ElementFontSizePixels, out int? rl) &&
+                    TryParseMarginLength(parts[2], result.RootFontSizePixels, result.ElementFontSizePixels, out int? b)) {
                     top = t;
                     bottom = b;
                     left = right = rl;
-                }
+                } else return;
             } else {
-                if (TryParseLength(parts[0], result.RootFontSizePixels, result.ElementFontSizePixels, out int t) &&
-                    TryParseLength(parts[1], result.RootFontSizePixels, result.ElementFontSizePixels, out int r) &&
-                    TryParseLength(parts[2], result.RootFontSizePixels, result.ElementFontSizePixels, out int b) &&
-                    TryParseLength(parts[3], result.RootFontSizePixels, result.ElementFontSizePixels, out int l)) {
+                if (TryParseMarginLength(parts[0], result.RootFontSizePixels, result.ElementFontSizePixels, out int? t) &&
+                    TryParseMarginLength(parts[1], result.RootFontSizePixels, result.ElementFontSizePixels, out int? r) &&
+                    TryParseMarginLength(parts[2], result.RootFontSizePixels, result.ElementFontSizePixels, out int? b) &&
+                    TryParseMarginLength(parts[3], result.RootFontSizePixels, result.ElementFontSizePixels, out int? l)) {
                     top = t;
                     right = r;
                     bottom = b;
                     left = l;
-                }
+                } else return;
             }
-            if (top.HasValue) result.MarginTop = top;
-            if (right.HasValue) result.MarginRight = right;
-            if (bottom.HasValue) result.MarginBottom = bottom;
-            if (left.HasValue) result.MarginLeft = left;
+            result.MarginTop = top;
+            result.MarginRight = right;
+            result.MarginBottom = bottom;
+            result.MarginLeft = left;
         }
 
         private static void ApplyPaddingShorthand(string padding, CssProperties result) {

--- a/OfficeIMO.Word.Html/Options/HtmlToWordOptions.cs
+++ b/OfficeIMO.Word.Html/Options/HtmlToWordOptions.cs
@@ -159,6 +159,19 @@ namespace OfficeIMO.Word.Html {
         public TimeSpan? ResourceTimeout { get; set; }
 
         /// <summary>
+        /// Maximum number of remote image requests that may be in flight during asynchronous import.
+        /// Defaults to 8. Imports with a total image byte budget remain sequential so the converter can
+        /// reject a response before reading its body when the remaining budget is too small.
+        /// </summary>
+        public int MaxConcurrentResourceLoads { get; set; } = 8;
+
+        /// <summary>
+        /// Controls how CSS text background colors are represented in Word.
+        /// Exact run shading is used by default so arbitrary CSS colors round-trip without palette loss.
+        /// </summary>
+        public HtmlTextBackgroundMode TextBackgroundMode { get; set; } = HtmlTextBackgroundMode.ExactShading;
+
+        /// <summary>
         /// Optional maximum number of bytes allowed for a single image resource, including SVG images.
         /// When exceeded, the image is skipped, alt text is inserted when available, and a diagnostic is emitted.
         /// </summary>
@@ -396,6 +409,8 @@ namespace OfficeIMO.Word.Html {
                 ImageProcessing = ImageProcessing,
                 HttpClient = HttpClient,
                 ResourceTimeout = ResourceTimeout,
+                MaxConcurrentResourceLoads = MaxConcurrentResourceLoads,
+                TextBackgroundMode = TextBackgroundMode,
                 MaxImageBytes = MaxImageBytes,
                 MaxTotalImageBytes = MaxTotalImageBytes,
                 MaxRemoteImageCandidateProbes = MaxRemoteImageCandidateProbes,
@@ -485,6 +500,22 @@ namespace OfficeIMO.Word.Html {
         /// Only embeds data URI images; external images are skipped.
         /// </summary>
         EmbedDataUriOnly
+    }
+
+    /// <summary>
+    /// Specifies how CSS background colors on inline text are represented in Word.
+    /// </summary>
+    public enum HtmlTextBackgroundMode {
+        /// <summary>
+        /// Uses native run shading, preserving the exact CSS color.
+        /// </summary>
+        ExactShading,
+
+        /// <summary>
+        /// Uses the nearest color from Word's fixed text-highlight palette.
+        /// A conversion diagnostic is emitted when the requested color must be approximated.
+        /// </summary>
+        NearestHighlight
     }
 
     /// <summary>

--- a/OfficeIMO.Word.Html/README.md
+++ b/OfficeIMO.Word.Html/README.md
@@ -32,7 +32,8 @@ HtmlTextConversionResult export = document.ToHtmlResult();
 Console.WriteLine(export.RequireValue());
 ```
 
-HTML can also be appended to an existing body, header, or footer with `AddHtmlToBody`, `AddHtmlToHeader`, and `AddHtmlToFooter`.
+HTML can also be appended to an existing body, header, footer, or table cell with
+`AddHtmlToBody`, `AddHtmlToHeader`, `AddHtmlToFooter`, and `WordTableCell.AddHtml`.
 
 Use the result API when conversion evidence matters:
 
@@ -73,6 +74,10 @@ Remote images and stylesheets require the async API:
 HtmlToWordResult remote = await source.ToWordDocumentResultAsync(options, cancellationToken);
 using WordDocument remoteDocument = remote.RequireValue();
 ```
+
+Remote image prefetch uses at most `HtmlToWordOptions.MaxConcurrentResourceLoads` requests at
+once. Imports with `MaxTotalImageBytes` stay sequential so responses that exceed the remaining
+budget can be rejected before their bodies are read.
 
 - `CreateOfficeIMOProfile()` keeps the compatibility-oriented defaults.
 - `CreateUntrustedHtmlProfile()` keeps external document resources offline by default and enables bounded conversion.

--- a/OfficeIMO.Word.Html/WordHtmlConverterExtensions.TableCells.cs
+++ b/OfficeIMO.Word.Html/WordHtmlConverterExtensions.TableCells.cs
@@ -1,0 +1,52 @@
+using OfficeIMO.Html;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OfficeIMO.Word.Html;
+
+public static partial class WordHtmlConverterExtensions {
+    /// <summary>
+    /// Appends HTML content directly to a Word table cell.
+    /// </summary>
+    /// <param name="cell">Table cell to modify.</param>
+    /// <param name="htmlDocument">Parsed HTML source to insert.</param>
+    /// <param name="options">Optional conversion options.</param>
+    public static void AddHtml(
+        this WordTableCell cell,
+        HtmlConversionDocument htmlDocument,
+        HtmlToWordOptions? options = null) {
+        if (cell == null) throw new ArgumentNullException(nameof(cell));
+        if (htmlDocument == null) throw new ArgumentNullException(nameof(htmlDocument));
+        HtmlToWordOptions resolved = ResolveWordOptionsForSharedDocument(htmlDocument, options);
+        resolved.ConversionReport.AddRange(htmlDocument.Diagnostics);
+        EnsureOfflineSynchronousImport(htmlDocument, resolved);
+        cell.AddHtmlAsync(htmlDocument, resolved).GetAwaiter().GetResult();
+    }
+
+    /// <summary>
+    /// Asynchronously appends HTML content directly to a Word table cell.
+    /// </summary>
+    /// <param name="cell">Table cell to modify.</param>
+    /// <param name="htmlDocument">Parsed HTML source to insert.</param>
+    /// <param name="options">Optional conversion options.</param>
+    /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
+    public static async Task AddHtmlAsync(
+        this WordTableCell cell,
+        HtmlConversionDocument htmlDocument,
+        HtmlToWordOptions? options = null,
+        CancellationToken cancellationToken = default) {
+        if (cell == null) throw new ArgumentNullException(nameof(cell));
+        if (htmlDocument == null) throw new ArgumentNullException(nameof(htmlDocument));
+        cancellationToken.ThrowIfCancellationRequested();
+
+        HtmlToWordOptions resolved = ResolveWordOptionsForSharedDocument(htmlDocument, options);
+        resolved.ConversionReport.AddRange(htmlDocument.Diagnostics);
+        var converter = new HtmlToWordConverter();
+        await converter.AddHtmlToTableCellAsync(
+            cell,
+            CreateWordSourceDocument(htmlDocument, resolved.ConversionReport),
+            resolved,
+            cancellationToken).ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
+    }
+}

--- a/OfficeIMO.Word.Tests/Word.ListsInEmptyTableCells.cs
+++ b/OfficeIMO.Word.Tests/Word.ListsInEmptyTableCells.cs
@@ -9,6 +9,30 @@ namespace OfficeIMO.Tests;
 
 public partial class Word {
     [Fact]
+    public void TableCell_HeadingList_KeepsSubsequentItemsInTheCell() {
+        using WordDocument document = WordDocument.Create();
+        WordTableCell cell = document.AddTable(1, 1).Rows[0].Cells[0];
+        cell.Paragraphs[0].Text = "Existing";
+
+        WordList list = cell.AddList(WordListStyle.Headings111);
+        WordParagraph first = list.AddItem("First", 0);
+        first.Style = WordParagraphStyles.Heading1;
+        WordParagraph second = list.AddItem("Second", 1);
+        second.Style = WordParagraphStyles.Heading2;
+
+        Assert.Equal(new[] { "Existing", "First", "Second" }, cell.Paragraphs.Select(paragraph => paragraph.Text).ToArray());
+        Assert.Same(cell._tableCell, first._paragraph.Parent);
+        Assert.Same(cell._tableCell, second._paragraph.Parent);
+        Assert.DoesNotContain(document.Sections[0].Paragraphs, paragraph => paragraph.Text == "First" || paragraph.Text == "Second");
+
+        using MemoryStream stream = document.ToStream();
+        stream.Position = 0;
+        using WordprocessingDocument package = WordprocessingDocument.Open(stream, false);
+        var errors = new OpenXmlValidator().Validate(package).ToList();
+        Assert.True(errors.Count == 0, string.Join(Environment.NewLine, errors.Select(error => error.Description)));
+    }
+
+    [Fact]
     public void TableCell_AddList_WorksAfterItsPlaceholderParagraphIsRemoved() {
         using WordDocument document = WordDocument.Create();
         WordTableCell cell = document.AddTable(1, 1).Rows[0].Cells[0];

--- a/OfficeIMO.Word.Tests/Word.ListsInEmptyTableCells.cs
+++ b/OfficeIMO.Word.Tests/Word.ListsInEmptyTableCells.cs
@@ -9,6 +9,22 @@ namespace OfficeIMO.Tests;
 
 public partial class Word {
     [Fact]
+    public void TableCell_AddList_PreservesAFormattedEmptyParagraph() {
+        using WordDocument document = WordDocument.Create();
+        WordTableCell cell = document.AddTable(1, 1).Rows[0].Cells[0];
+        cell.Paragraphs[0].PageBreakBefore = true;
+
+        WordList list = cell.AddList(WordListStyle.Bulleted);
+        list.AddItem("First");
+
+        Assert.Equal(2, cell.Paragraphs.Count);
+        Assert.True(cell.Paragraphs[0].PageBreakBefore);
+        Assert.Equal(string.Empty, cell.Paragraphs[0].Text);
+        Assert.Equal("First", cell.Paragraphs[1].Text);
+        Assert.True(cell.Paragraphs[1].IsListItem);
+    }
+
+    [Fact]
     public void TableCell_HeadingList_KeepsSubsequentItemsInTheCell() {
         using WordDocument document = WordDocument.Create();
         WordTableCell cell = document.AddTable(1, 1).Rows[0].Cells[0];

--- a/OfficeIMO.Word.Tests/Word.RunShading.cs
+++ b/OfficeIMO.Word.Tests/Word.RunShading.cs
@@ -1,9 +1,36 @@
+using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 using Xunit;
 
 namespace OfficeIMO.Tests;
 
 public partial class Word {
+    [Fact]
+    public void RunShadingFillColor_DisabledPatternIgnoresStaleFill() {
+        using WordDocument document = WordDocument.Create();
+        WordParagraph paragraph = document.AddParagraph("Disabled");
+        paragraph.RunShadingFillColorHex = "FF0000";
+        paragraph._runProperties!.Shading!.Val = ShadingPatternValues.Nil;
+
+        Assert.Equal(string.Empty, paragraph.RunShadingFillColorHex);
+        Assert.Null(paragraph.RunShadingFillColor);
+
+        using MemoryStream stream = document.ToStream();
+        stream.Position = 0;
+        using WordDocument reloaded = WordDocument.Load(stream);
+        WordParagraph reloadedParagraph = Assert.Single(
+            reloaded.Paragraphs,
+            candidate => candidate.Text == "Disabled");
+
+        Assert.Equal(string.Empty, reloadedParagraph.RunShadingFillColorHex);
+        Assert.Null(reloadedParagraph.RunShadingFillColor);
+
+        reloadedParagraph.RunShadingFillColorHex = "00FF00";
+
+        Assert.Equal("00FF00", reloadedParagraph.RunShadingFillColorHex);
+        Assert.Equal(ShadingPatternValues.Clear, reloadedParagraph._runProperties!.Shading!.Val?.Value);
+    }
+
     [Fact]
     public void RunShadingFillColor_AutomaticFillReturnsNull() {
         using WordDocument document = WordDocument.Create();

--- a/OfficeIMO.Word.Tests/Word.RunShading.cs
+++ b/OfficeIMO.Word.Tests/Word.RunShading.cs
@@ -6,6 +6,24 @@ namespace OfficeIMO.Tests;
 
 public partial class Word {
     [Fact]
+    public void RunShadingFillColor_ClearsThemeFillAttributes() {
+        using WordDocument document = WordDocument.Create();
+        WordParagraph paragraph = document.AddParagraph("Themed");
+        paragraph.RunShadingFillColorHex = "FFFFFF";
+        paragraph._runProperties!.Shading!.ThemeFill = ThemeColorValues.Accent1;
+        paragraph._runProperties.Shading.ThemeFillTint = "33";
+        paragraph._runProperties.Shading.ThemeFillShade = "66";
+
+        paragraph.RunShadingFillColorHex = "ABCDEF";
+
+        Assert.Equal("ABCDEF", paragraph.RunShadingFillColorHex);
+        Assert.Equal("ABCDEF", paragraph._runProperties.Shading.Fill?.Value);
+        Assert.Null(paragraph._runProperties.Shading.ThemeFill);
+        Assert.Null(paragraph._runProperties.Shading.ThemeFillTint);
+        Assert.Null(paragraph._runProperties.Shading.ThemeFillShade);
+    }
+
+    [Fact]
     public void RunShadingFillColor_DisabledPatternIgnoresStaleFill() {
         using WordDocument document = WordDocument.Create();
         WordParagraph paragraph = document.AddParagraph("Disabled");

--- a/OfficeIMO.Word.Tests/Word.RunShading.cs
+++ b/OfficeIMO.Word.Tests/Word.RunShading.cs
@@ -1,0 +1,27 @@
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public partial class Word {
+    [Fact]
+    public void RunShadingFillColor_AutomaticFillReturnsNull() {
+        using WordDocument document = WordDocument.Create();
+        WordParagraph paragraph = document.AddParagraph("Automatic");
+
+        paragraph.RunShadingFillColorHex = "auto";
+
+        Assert.Equal("AUTO", paragraph.RunShadingFillColorHex);
+        Assert.Null(paragraph.RunShadingFillColor);
+
+        using MemoryStream stream = document.ToStream();
+        stream.Position = 0;
+        using WordDocument reloaded = WordDocument.Load(stream);
+        WordParagraph reloadedParagraph = Assert.Single(
+            reloaded.Paragraphs,
+            candidate => candidate.Text == "Automatic");
+
+        Assert.Equal("AUTO", reloadedParagraph.RunShadingFillColorHex);
+        Assert.Null(reloadedParagraph.RunShadingFillColor);
+    }
+}

--- a/OfficeIMO.Word/Imaging/WordDocumentImageRenderer.Highlight.cs
+++ b/OfficeIMO.Word/Imaging/WordDocumentImageRenderer.Highlight.cs
@@ -20,6 +20,13 @@ namespace OfficeIMO.Word {
                 : null;
         }
 
+        internal static string? ResolveRunShadingFillColorHex(WordParagraph paragraph) {
+            A.ColorScheme? colorScheme = GetDocumentColorScheme(paragraph._document);
+            return TryResolveShadingFillColor(ResolveRunShading(paragraph), colorScheme, out OfficeColor shading)
+                ? shading.ToRgbHex()
+                : null;
+        }
+
         private static HighlightColorValues? ResolveRunHighlight(WordParagraph paragraph) {
             if (paragraph._runProperties?.Highlight != null) {
                 return paragraph._runProperties.Highlight.Val?.Value;

--- a/OfficeIMO.Word/Imaging/WordDocumentImageRenderer.Highlight.cs
+++ b/OfficeIMO.Word/Imaging/WordDocumentImageRenderer.Highlight.cs
@@ -27,7 +27,7 @@ namespace OfficeIMO.Word {
                 : null;
         }
 
-        private static HighlightColorValues? ResolveRunHighlight(WordParagraph paragraph) {
+        internal static HighlightColorValues? ResolveRunHighlight(WordParagraph paragraph) {
             if (paragraph._runProperties?.Highlight != null) {
                 return paragraph._runProperties.Highlight.Val?.Value;
             }

--- a/OfficeIMO.Word/Imaging/WordDocumentImageRenderer.Highlight.cs
+++ b/OfficeIMO.Word/Imaging/WordDocumentImageRenderer.Highlight.cs
@@ -1,10 +1,24 @@
 using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Drawing;
+using A = DocumentFormat.OpenXml.Drawing;
 
 namespace OfficeIMO.Word {
     internal static partial class WordDocumentImageRenderer {
-        private static bool HasRunHighlight(WordParagraph paragraph) =>
-            ResolveRunHighlightColor(ResolveRunHighlight(paragraph)).HasValue;
+        private static bool HasRunBackground(WordParagraph paragraph, A.ColorScheme? colorScheme) =>
+            ResolveRunBackgroundColor(paragraph, colorScheme).HasValue;
+
+        private static OfficeColor? ResolveRunBackgroundColor(
+            WordParagraph paragraph,
+            A.ColorScheme? colorScheme) {
+            OfficeColor? highlight = ResolveRunHighlightColor(ResolveRunHighlight(paragraph));
+            if (highlight.HasValue) {
+                return highlight;
+            }
+
+            return TryResolveShadingFillColor(ResolveRunShading(paragraph), colorScheme, out OfficeColor shading)
+                ? shading
+                : null;
+        }
 
         private static HighlightColorValues? ResolveRunHighlight(WordParagraph paragraph) {
             if (paragraph._runProperties?.Highlight != null) {
@@ -15,6 +29,21 @@ namespace OfficeIMO.Word {
                 Highlight? highlight = properties.GetFirstChild<Highlight>();
                 if (highlight != null) {
                     return highlight.Val?.Value;
+                }
+            }
+
+            return null;
+        }
+
+        private static Shading? ResolveRunShading(WordParagraph paragraph) {
+            if (paragraph._runProperties?.Shading != null) {
+                return paragraph._runProperties.Shading;
+            }
+
+            foreach (StyleRunProperties properties in EnumerateRunStyleProperties(paragraph)) {
+                Shading? shading = properties.GetFirstChild<Shading>();
+                if (shading != null) {
+                    return shading;
                 }
             }
 

--- a/OfficeIMO.Word/Imaging/WordDocumentImageRenderer.Highlight.cs
+++ b/OfficeIMO.Word/Imaging/WordDocumentImageRenderer.Highlight.cs
@@ -28,8 +28,9 @@ namespace OfficeIMO.Word {
         }
 
         internal static HighlightColorValues? ResolveRunHighlight(WordParagraph paragraph) {
-            if (paragraph._runProperties?.Highlight != null) {
-                return paragraph._runProperties.Highlight.Val?.Value;
+            RunProperties? directProperties = GetDirectRunProperties(paragraph);
+            if (directProperties?.Highlight != null) {
+                return directProperties.Highlight.Val?.Value;
             }
 
             foreach (StyleRunProperties properties in EnumerateRunStyleProperties(paragraph)) {
@@ -43,8 +44,9 @@ namespace OfficeIMO.Word {
         }
 
         private static Shading? ResolveRunShading(WordParagraph paragraph) {
-            if (paragraph._runProperties?.Shading != null) {
-                return paragraph._runProperties.Shading;
+            RunProperties? directProperties = GetDirectRunProperties(paragraph);
+            if (directProperties?.Shading != null) {
+                return directProperties.Shading;
             }
 
             foreach (StyleRunProperties properties in EnumerateRunStyleProperties(paragraph)) {
@@ -56,6 +58,11 @@ namespace OfficeIMO.Word {
 
             return null;
         }
+
+        private static RunProperties? GetDirectRunProperties(WordParagraph paragraph) =>
+            paragraph.IsHyperLink
+                ? paragraph.Hyperlink?._runProperties
+                : paragraph._runProperties;
 
         private static OfficeColor? ResolveRunHighlightColor(HighlightColorValues? highlight) {
             if (!highlight.HasValue || highlight.Value == HighlightColorValues.None) {

--- a/OfficeIMO.Word/Imaging/WordDocumentImageRenderer.Shading.cs
+++ b/OfficeIMO.Word/Imaging/WordDocumentImageRenderer.Shading.cs
@@ -1,0 +1,101 @@
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Drawing;
+using A = DocumentFormat.OpenXml.Drawing;
+
+namespace OfficeIMO.Word {
+    internal static partial class WordDocumentImageRenderer {
+        private static bool TryResolveShadingFillColor(
+            Shading? shading,
+            A.ColorScheme? colorScheme,
+            out OfficeColor fillColor) {
+            fillColor = OfficeColor.White;
+            if (shading == null || shading.Val?.Value == ShadingPatternValues.Nil) {
+                return false;
+            }
+
+            string pattern = GetWordAttribute(shading, "val") ?? "clear";
+            bool hasBackground = TryResolveShadingBackground(shading, colorScheme, out OfficeColor background);
+            if (pattern.Equals("clear", StringComparison.OrdinalIgnoreCase)) {
+                if (hasBackground) {
+                    fillColor = background;
+                }
+                return hasBackground;
+            }
+
+            OfficeColor foreground = ResolveShadingForeground(shading, colorScheme);
+            if (pattern.Equals("solid", StringComparison.OrdinalIgnoreCase)) {
+                fillColor = foreground;
+                return true;
+            }
+
+            background = hasBackground ? background : OfficeColor.White;
+            fillColor = BlendShadingPattern(
+                foreground,
+                background,
+                ResolveShadingPatternForegroundRatio(pattern));
+            return true;
+        }
+
+        private static OfficeColor ResolveShadingForeground(
+            Shading shading,
+            A.ColorScheme? colorScheme) {
+            string? resolvedThemeForeground = ResolveThemeColor(
+                GetWordAttribute(shading, "themeColor"),
+                GetWordAttribute(shading, "themeTint"),
+                GetWordAttribute(shading, "themeShade"),
+                colorScheme);
+            if (TryParseOfficeColor(resolvedThemeForeground, out OfficeColor themeForeground)) {
+                return themeForeground;
+            }
+            if (TryParseOfficeColor(shading.Color?.Value, out OfficeColor foreground)) {
+                return foreground;
+            }
+
+            return OfficeColor.Black;
+        }
+
+        private static bool TryResolveShadingBackground(
+            Shading shading,
+            A.ColorScheme? colorScheme,
+            out OfficeColor background) {
+            string? resolvedThemeBackground = ResolveThemeColor(
+                GetWordAttribute(shading, "themeFill"),
+                GetWordAttribute(shading, "themeFillTint"),
+                GetWordAttribute(shading, "themeFillShade"),
+                colorScheme);
+            if (TryParseOfficeColor(resolvedThemeBackground, out background)) {
+                return true;
+            }
+
+            return TryParseOfficeColor(shading.Fill?.Value, out background);
+        }
+
+        private static double ResolveShadingPatternForegroundRatio(string pattern) {
+            if (pattern.StartsWith("pct", StringComparison.OrdinalIgnoreCase) &&
+                int.TryParse(pattern.Substring(3), out int percentage)) {
+                return percentage switch {
+                    12 => 0.125d,
+                    37 => 0.375d,
+                    62 => 0.625d,
+                    87 => 0.875d,
+                    _ => Math.Max(0d, Math.Min(1d, percentage / 100d))
+                };
+            }
+
+            return pattern.StartsWith("thin", StringComparison.OrdinalIgnoreCase)
+                ? 0.25d
+                : 0.5d;
+        }
+
+        private static OfficeColor BlendShadingPattern(
+            OfficeColor foreground,
+            OfficeColor background,
+            double foregroundRatio) {
+            double backgroundRatio = 1d - foregroundRatio;
+            return OfficeColor.FromRgb(
+                (byte)Math.Round(foreground.R * foregroundRatio + background.R * backgroundRatio),
+                (byte)Math.Round(foreground.G * foregroundRatio + background.G * backgroundRatio),
+                (byte)Math.Round(foreground.B * foregroundRatio + background.B * backgroundRatio));
+        }
+    }
+}

--- a/OfficeIMO.Word/Imaging/WordDocumentImageRenderer.TableCellParagraphFlow.cs
+++ b/OfficeIMO.Word/Imaging/WordDocumentImageRenderer.TableCellParagraphFlow.cs
@@ -111,7 +111,7 @@ namespace OfficeIMO.Word {
                 context.ThrowIfCancellationRequested();
                 IReadOnlyList<WordParagraph> runs = paragraphRuns[i];
                 WordImageListMarker? listMarker = CreateTableCellListMarker(runs, listMarkers);
-                bool added = runs.Count == 1 && !HasRunHighlight(runs[0])
+                bool added = runs.Count == 1 && !HasRunBackground(runs[0], colorScheme)
                     ? AddTextRun(runs[0], context, diagnostics, listMarker, colorScheme)
                     : AddRichTextRuns(runs, context, diagnostics, listMarker, colorScheme);
                 if (!added || context.StoppedForPagination) {

--- a/OfficeIMO.Word/Imaging/WordDocumentImageRenderer.TableRowPagination.cs
+++ b/OfficeIMO.Word/Imaging/WordDocumentImageRenderer.TableRowPagination.cs
@@ -144,7 +144,7 @@ namespace OfficeIMO.Word {
                     cell,
                     contentWidth,
                     context.CancellationToken);
-                if (ShouldSplitTableCellAsRichText(paragraphRuns, hasListMarkers)) {
+                if (ShouldSplitTableCellAsRichText(paragraphRuns, hasListMarkers, colorScheme)) {
                     List<OfficeRichTextRun> richRuns = CreateSplitTableCellRichRuns(paragraphRuns, colorScheme, listMarkers, context);
                     if (richRuns.Count == 0) {
                         IReadOnlyList<SplitTableCellContentEntry> contentOrder = CreateSplitTableCellContentOrder(cell, context, contentWidth, 0);
@@ -357,12 +357,17 @@ namespace OfficeIMO.Word {
                     context.CancellationCheckpoint).Count);
         }
 
-        private static bool ShouldSplitTableCellAsRichText(IReadOnlyList<IReadOnlyList<WordParagraph>> paragraphRuns, bool hasListMarkers) {
+        private static bool ShouldSplitTableCellAsRichText(
+            IReadOnlyList<IReadOnlyList<WordParagraph>> paragraphRuns,
+            bool hasListMarkers,
+            A.ColorScheme? colorScheme) {
             if (paragraphRuns.Count > 1 || hasListMarkers) {
                 return true;
             }
 
-            return paragraphRuns.Count == 1 && (paragraphRuns[0].Count > 1 || HasRunHighlight(paragraphRuns[0][0]));
+            return paragraphRuns.Count == 1 &&
+                   (paragraphRuns[0].Count > 1 ||
+                    HasRunBackground(paragraphRuns[0][0], colorScheme));
         }
 
         private static List<OfficeRichTextRun> CreateSplitTableCellRichRuns(

--- a/OfficeIMO.Word/Imaging/WordDocumentImageRenderer.Tables.cs
+++ b/OfficeIMO.Word/Imaging/WordDocumentImageRenderer.Tables.cs
@@ -785,46 +785,6 @@ namespace OfficeIMO.Word {
             return OfficeColor.White;
         }
 
-        private static bool TryResolveShadingFillColor(Shading? shading, A.ColorScheme? colorScheme, out OfficeColor fillColor) {
-            fillColor = OfficeColor.White;
-            if (shading?.Val?.Value == ShadingPatternValues.Nil) {
-                return false;
-            }
-
-            if (shading?.Val?.Value == ShadingPatternValues.Solid) {
-                string? resolvedThemeForeground = ResolveThemeColor(
-                    GetWordAttribute(shading, "themeColor"),
-                    GetWordAttribute(shading, "themeTint"),
-                    GetWordAttribute(shading, "themeShade"),
-                    colorScheme);
-                if (TryParseOfficeColor(resolvedThemeForeground, out OfficeColor themeForeground)) {
-                    fillColor = themeForeground;
-                    return true;
-                }
-                if (TryParseOfficeColor(shading.Color?.Value, out OfficeColor foreground)) {
-                    fillColor = foreground;
-                    return true;
-                }
-                if (string.Equals(shading.Color?.Value, "auto", StringComparison.OrdinalIgnoreCase)) {
-                    fillColor = OfficeColor.Black;
-                    return true;
-                }
-                return false;
-            }
-
-            string? resolvedThemeColor = ResolveThemeColor(
-                GetWordAttribute(shading, "themeFill"),
-                GetWordAttribute(shading, "themeFillTint"),
-                GetWordAttribute(shading, "themeFillShade"),
-                colorScheme);
-            if (TryParseOfficeColor(resolvedThemeColor, out OfficeColor themeFill)) {
-                fillColor = themeFill;
-                return true;
-            }
-
-            return TryParseOfficeColor(shading?.Fill?.Value, out fillColor);
-        }
-
         private static OfficeBorderBox ResolveCellBorders(WordTable table, WordTableCell cell, int rowIndex, int columnIndex, int rowSpan, int columnSpan, int rowCount, int columnCount, A.ColorScheme? colorScheme) {
             TableCellBorders? borders = cell._tableCellProperties?.TableCellBorders;
             if (borders != null) {

--- a/OfficeIMO.Word/Imaging/WordDocumentImageRenderer.Tables.cs
+++ b/OfficeIMO.Word/Imaging/WordDocumentImageRenderer.Tables.cs
@@ -791,6 +791,27 @@ namespace OfficeIMO.Word {
                 return false;
             }
 
+            if (shading?.Val?.Value == ShadingPatternValues.Solid) {
+                string? resolvedThemeForeground = ResolveThemeColor(
+                    GetWordAttribute(shading, "themeColor"),
+                    GetWordAttribute(shading, "themeTint"),
+                    GetWordAttribute(shading, "themeShade"),
+                    colorScheme);
+                if (TryParseOfficeColor(resolvedThemeForeground, out OfficeColor themeForeground)) {
+                    fillColor = themeForeground;
+                    return true;
+                }
+                if (TryParseOfficeColor(shading.Color?.Value, out OfficeColor foreground)) {
+                    fillColor = foreground;
+                    return true;
+                }
+                if (string.Equals(shading.Color?.Value, "auto", StringComparison.OrdinalIgnoreCase)) {
+                    fillColor = OfficeColor.Black;
+                    return true;
+                }
+                return false;
+            }
+
             string? resolvedThemeColor = ResolveThemeColor(
                 GetWordAttribute(shading, "themeFill"),
                 GetWordAttribute(shading, "themeFillTint"),

--- a/OfficeIMO.Word/Imaging/WordDocumentImageRenderer.Tables.cs
+++ b/OfficeIMO.Word/Imaging/WordDocumentImageRenderer.Tables.cs
@@ -787,6 +787,10 @@ namespace OfficeIMO.Word {
 
         private static bool TryResolveShadingFillColor(Shading? shading, A.ColorScheme? colorScheme, out OfficeColor fillColor) {
             fillColor = OfficeColor.White;
+            if (shading?.Val?.Value == ShadingPatternValues.Nil) {
+                return false;
+            }
+
             string? resolvedThemeColor = ResolveThemeColor(
                 GetWordAttribute(shading, "themeFill"),
                 GetWordAttribute(shading, "themeFillTint"),

--- a/OfficeIMO.Word/Imaging/WordDocumentImageRenderer.cs
+++ b/OfficeIMO.Word/Imaging/WordDocumentImageRenderer.cs
@@ -412,7 +412,7 @@ namespace OfficeIMO.Word {
                 }
 
                 WordImageListMarker? currentMarker = markerRendered ? null : listMarker;
-                bool runAdded = textRuns.Count == 1 && !HasRunHighlight(textRuns[0])
+                bool runAdded = textRuns.Count == 1 && !HasRunBackground(textRuns[0], colorScheme)
                     ? AddTextRun(textRuns[0], context, diagnostics, currentMarker, colorScheme)
                     : AddRichTextRuns(textRuns, context, diagnostics, currentMarker, colorScheme);
                 if (runAdded && currentMarker.HasValue) {
@@ -631,7 +631,7 @@ namespace OfficeIMO.Word {
                 paragraph.Underline.HasValue && paragraph.Underline.Value != UnderlineValues.None,
                 paragraph.FontFamily ?? "Calibri",
                 paragraph.Strike || paragraph.DoubleStrike,
-                ResolveRunHighlightColor(ResolveRunHighlight(paragraph)));
+                ResolveRunBackgroundColor(paragraph, colorScheme));
         }
 
         private static OfficeFontInfo CreateFont(WordParagraph paragraph) {

--- a/OfficeIMO.Word/WordList.PublicMethods.cs
+++ b/OfficeIMO.Word/WordList.PublicMethods.cs
@@ -57,7 +57,9 @@ namespace OfficeIMO.Word {
                 insertionReference.InsertAfterSelf(paragraph);
                 if (_replaceInsertionAnchor &&
                     ListItems.Count == 0 &&
-                    ReferenceEquals(insertionReference, _wordParagraph?._paragraph)) {
+                    ReferenceEquals(insertionReference, _wordParagraph?._paragraph) &&
+                    insertionReference is Paragraph insertionParagraph &&
+                    !WordTableCell.HasMeaningfulParagraphContent(insertionParagraph)) {
                     insertionReference.Remove();
                 }
             } else if (_headerFooter != null) {

--- a/OfficeIMO.Word/WordList.PublicMethods.cs
+++ b/OfficeIMO.Word/WordList.PublicMethods.cs
@@ -55,6 +55,11 @@ namespace OfficeIMO.Word {
 
             if (insertionReference is not null) {
                 insertionReference.InsertAfterSelf(paragraph);
+                if (_replaceInsertionAnchor &&
+                    ListItems.Count == 0 &&
+                    ReferenceEquals(insertionReference, _wordParagraph?._paragraph)) {
+                    insertionReference.Remove();
+                }
             } else if (_headerFooter != null) {
                 if (_headerFooter._header is not null) {
                     _headerFooter._header.Append(paragraph);

--- a/OfficeIMO.Word/WordList.PublicMethods.cs
+++ b/OfficeIMO.Word/WordList.PublicMethods.cs
@@ -55,8 +55,6 @@ namespace OfficeIMO.Word {
 
             if (insertionReference is not null) {
                 insertionReference.InsertAfterSelf(paragraph);
-            } else if (_isToc || IsToc) {
-                _document.AppendBlockToBody(paragraph);
             } else if (_headerFooter != null) {
                 if (_headerFooter._header is not null) {
                     _headerFooter._header.Append(paragraph);
@@ -77,6 +75,8 @@ namespace OfficeIMO.Word {
                 } else {
                     parent.Append(paragraph);
                 }
+            } else if (_isToc || IsToc) {
+                _document.AppendBlockToBody(paragraph);
             } else {
                 _document.AppendBlockToBody(paragraph);
             }

--- a/OfficeIMO.Word/WordList.cs
+++ b/OfficeIMO.Word/WordList.cs
@@ -322,10 +322,11 @@ public partial class WordList : WordElement {
     /// <summary>
     /// Initializes a list that can append its first item directly to an empty table cell.
     /// </summary>
-    internal WordList(WordDocument wordDocument, TableCell tableCell) {
+    internal WordList(WordDocument wordDocument, TableCell tableCell, WordParagraph? insertionAnchor = null) {
         _document = wordDocument;
         _wordprocessingDocument = wordDocument._wordprocessingDocument;
         _tableCell = tableCell;
+        _wordParagraph = insertionAnchor;
     }
 
 }

--- a/OfficeIMO.Word/WordList.cs
+++ b/OfficeIMO.Word/WordList.cs
@@ -24,6 +24,7 @@ public partial class WordList : WordElement {
     private readonly bool _isToc;
 
     private WordParagraph? _wordParagraph;
+    private readonly bool _replaceInsertionAnchor;
     private readonly WordHeaderFooter? _headerFooter;
     private readonly TableCell? _tableCell;
 
@@ -322,11 +323,16 @@ public partial class WordList : WordElement {
     /// <summary>
     /// Initializes a list that can append its first item directly to an empty table cell.
     /// </summary>
-    internal WordList(WordDocument wordDocument, TableCell tableCell, WordParagraph? insertionAnchor = null) {
+    internal WordList(
+        WordDocument wordDocument,
+        TableCell tableCell,
+        WordParagraph? insertionAnchor = null,
+        bool replaceInsertionAnchor = false) {
         _document = wordDocument;
         _wordprocessingDocument = wordDocument._wordprocessingDocument;
         _tableCell = tableCell;
         _wordParagraph = insertionAnchor;
+        _replaceInsertionAnchor = replaceInsertionAnchor;
     }
 
 }

--- a/OfficeIMO.Word/WordParagraph.RunProperties.cs
+++ b/OfficeIMO.Word/WordParagraph.RunProperties.cs
@@ -390,6 +390,12 @@ namespace OfficeIMO.Word {
                 return null;
             }
             set {
+                RunProperties? existingRunProperties = IsHyperLink ? this.Hyperlink?._runProperties : _runProperties;
+                if (!value.HasValue) {
+                    existingRunProperties?.Highlight?.Remove();
+                    return;
+                }
+
                 RunProperties runProperties;
                 if (IsHyperLink) {
                     var hyperlink = this.Hyperlink!;
@@ -398,7 +404,7 @@ namespace OfficeIMO.Word {
                     runProperties = VerifyRunProperties();
                 }
                 var highlight = new Highlight {
-                    Val = value
+                    Val = value.Value
                 };
                 runProperties.Highlight = highlight;
             }

--- a/OfficeIMO.Word/WordParagraph.RunShading.cs
+++ b/OfficeIMO.Word/WordParagraph.RunShading.cs
@@ -39,9 +39,13 @@ namespace OfficeIMO.Word {
         /// Gets or sets the exact fill color applied to the current text run.
         /// </summary>
         public Color? RunShadingFillColor {
-            get => string.IsNullOrEmpty(RunShadingFillColorHex)
-                ? null
-                : Helpers.ParseColor(RunShadingFillColorHex);
+            get {
+                string fill = RunShadingFillColorHex;
+                return fill.Length == 6 &&
+                       OfficeIMO.Drawing.OfficeColor.TryParseHex(fill, out OfficeIMO.Drawing.OfficeColor color)
+                    ? color
+                    : null;
+            }
             set => RunShadingFillColorHex = value?.ToRgbHex() ?? string.Empty;
         }
 

--- a/OfficeIMO.Word/WordParagraph.RunShading.cs
+++ b/OfficeIMO.Word/WordParagraph.RunShading.cs
@@ -13,7 +13,12 @@ namespace OfficeIMO.Word {
         public string RunShadingFillColorHex {
             get {
                 RunProperties? runProperties = IsHyperLink ? Hyperlink?._runProperties : _runProperties;
-                string? fill = runProperties?.Shading?.Fill?.Value;
+                Shading? shading = runProperties?.Shading;
+                if (shading?.Val?.Value == ShadingPatternValues.Nil) {
+                    return string.Empty;
+                }
+
+                string? fill = shading?.Fill?.Value;
                 return fill != null ? fill.ToUpperInvariant() : string.Empty;
             }
             set {
@@ -28,7 +33,10 @@ namespace OfficeIMO.Word {
                 if (!string.IsNullOrWhiteSpace(value)) {
                     runProperties.Shading ??= new Shading();
                     runProperties.Shading.Fill = value.Replace("#", string.Empty).ToUpperInvariant();
-                    runProperties.Shading.Val ??= ShadingPatternValues.Clear;
+                    ShadingPatternValues? pattern = runProperties.Shading.Val?.Value;
+                    if (!pattern.HasValue || pattern.Value == ShadingPatternValues.Nil) {
+                        runProperties.Shading.Val = ShadingPatternValues.Clear;
+                    }
                 } else {
                     runProperties.Shading?.Remove();
                 }

--- a/OfficeIMO.Word/WordParagraph.RunShading.cs
+++ b/OfficeIMO.Word/WordParagraph.RunShading.cs
@@ -36,10 +36,11 @@ namespace OfficeIMO.Word {
                     runProperties.Shading.ThemeFill = null;
                     runProperties.Shading.ThemeFillTint = null;
                     runProperties.Shading.ThemeFillShade = null;
-                    ShadingPatternValues? pattern = runProperties.Shading.Val?.Value;
-                    if (!pattern.HasValue || pattern.Value == ShadingPatternValues.Nil) {
-                        runProperties.Shading.Val = ShadingPatternValues.Clear;
-                    }
+                    runProperties.Shading.Color = null;
+                    runProperties.Shading.ThemeColor = null;
+                    runProperties.Shading.ThemeTint = null;
+                    runProperties.Shading.ThemeShade = null;
+                    runProperties.Shading.Val = ShadingPatternValues.Clear;
                 } else {
                     runProperties.Shading?.Remove();
                 }

--- a/OfficeIMO.Word/WordParagraph.RunShading.cs
+++ b/OfficeIMO.Word/WordParagraph.RunShading.cs
@@ -33,6 +33,9 @@ namespace OfficeIMO.Word {
                 if (!string.IsNullOrWhiteSpace(value)) {
                     runProperties.Shading ??= new Shading();
                     runProperties.Shading.Fill = value.Replace("#", string.Empty).ToUpperInvariant();
+                    runProperties.Shading.ThemeFill = null;
+                    runProperties.Shading.ThemeFillTint = null;
+                    runProperties.Shading.ThemeFillShade = null;
                     ShadingPatternValues? pattern = runProperties.Shading.Val?.Value;
                     if (!pattern.HasValue || pattern.Value == ShadingPatternValues.Nil) {
                         runProperties.Shading.Val = ShadingPatternValues.Clear;

--- a/OfficeIMO.Word/WordParagraph.RunShading.cs
+++ b/OfficeIMO.Word/WordParagraph.RunShading.cs
@@ -1,0 +1,58 @@
+using DocumentFormat.OpenXml.Wordprocessing;
+using Color = OfficeIMO.Drawing.OfficeColor;
+
+namespace OfficeIMO.Word {
+    public partial class WordParagraph {
+        /// <summary>
+        /// Gets or sets the exact fill color applied to the current text run.
+        /// </summary>
+        /// <remarks>
+        /// Run shading supports arbitrary RGB colors, unlike Word text highlighting which is limited
+        /// to a fixed palette. The value is returned as an uppercase six-digit hexadecimal string.
+        /// </remarks>
+        public string RunShadingFillColorHex {
+            get {
+                RunProperties? runProperties = IsHyperLink ? Hyperlink?._runProperties : _runProperties;
+                string? fill = runProperties?.Shading?.Fill?.Value;
+                return fill != null ? fill.ToUpperInvariant() : string.Empty;
+            }
+            set {
+                RunProperties runProperties;
+                if (IsHyperLink) {
+                    var hyperlink = Hyperlink!;
+                    runProperties = VerifyRunProperties(hyperlink._hyperlink!, hyperlink._run!, hyperlink._runProperties);
+                } else {
+                    runProperties = VerifyRunProperties();
+                }
+
+                if (!string.IsNullOrWhiteSpace(value)) {
+                    runProperties.Shading ??= new Shading();
+                    runProperties.Shading.Fill = value.Replace("#", string.Empty).ToUpperInvariant();
+                    runProperties.Shading.Val ??= ShadingPatternValues.Clear;
+                } else {
+                    runProperties.Shading?.Remove();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the exact fill color applied to the current text run.
+        /// </summary>
+        public Color? RunShadingFillColor {
+            get => string.IsNullOrEmpty(RunShadingFillColorHex)
+                ? null
+                : Helpers.ParseColor(RunShadingFillColorHex);
+            set => RunShadingFillColorHex = value?.ToRgbHex() ?? string.Empty;
+        }
+
+        /// <summary>
+        /// Applies an exact hexadecimal fill color to the current text run.
+        /// </summary>
+        /// <param name="color">Color in hexadecimal format.</param>
+        /// <returns>The current paragraph or run wrapper.</returns>
+        public WordParagraph SetRunShadingFillColorHex(string color) {
+            RunShadingFillColorHex = color;
+            return this;
+        }
+    }
+}

--- a/OfficeIMO.Word/WordTable.Properties.cs
+++ b/OfficeIMO.Word/WordTable.Properties.cs
@@ -280,76 +280,95 @@ namespace OfficeIMO.Word {
         /// Falls back to page content width when structure cannot be determined.
         /// </summary>
         private int EstimateContainingCellContentWidthInDxa() {
+            if (_table.Parent is DocumentFormat.OpenXml.Wordprocessing.TableCell cell) {
+                int? estimated = EstimateCellContentWidthInDxa(_document, cell);
+                if (estimated.HasValue) {
+                    return estimated.Value;
+                }
+            }
+
+            return EstimateContentAreaWidthInDxa();
+        }
+
+        /// <summary>
+        /// Estimates the usable content width of a specific table cell in DXA (twips).
+        /// </summary>
+        internal static int? EstimateCellContentWidthInDxa(
+            WordDocument document,
+            DocumentFormat.OpenXml.Wordprocessing.TableCell cell) {
             try {
-                // We expect the table parent to be a TableCell when nested.
-                if (_table.Parent is DocumentFormat.OpenXml.Wordprocessing.TableCell cell) {
-                    // Parent row and table
-                    var row = cell.Parent as DocumentFormat.OpenXml.Wordprocessing.TableRow;
-                    var parentTable = row?.Parent as DocumentFormat.OpenXml.Wordprocessing.Table;
-                    if (row != null && parentTable != null) {
-                        // Determine the starting grid index of this cell by iterating row cells and
-                        // accumulating gridSpan for cells before our target.
-                        int gridIndex = 0;
-                        foreach (var c in row.Elements<DocumentFormat.OpenXml.Wordprocessing.TableCell>()) {
-                            if (object.ReferenceEquals(c, cell)) break;
-                            int span = (int)(c.TableCellProperties?.GetFirstChild<DocumentFormat.OpenXml.Wordprocessing.GridSpan>()?.Val?.Value ?? 1);
-                            gridIndex += Math.Max(1, span);
-                        }
-
-                        int spanThis = (int)(cell.TableCellProperties?.GetFirstChild<DocumentFormat.OpenXml.Wordprocessing.GridSpan>()?.Val?.Value ?? 1);
-                        spanThis = Math.Max(1, spanThis);
-
-                        var grid = parentTable.GetFirstChild<DocumentFormat.OpenXml.Wordprocessing.TableGrid>();
-                        if (grid != null) {
-                            var cols = grid.Elements<DocumentFormat.OpenXml.Wordprocessing.GridColumn>().ToList();
-                            int sum = 0;
-                            for (int i = 0; i < spanThis && (gridIndex + i) < cols.Count; i++) {
-                                if (int.TryParse(cols[gridIndex + i].Width?.Value ?? "0", out int w)) sum += w;
-                            }
-                            if (sum > 0) {
-                                // Subtract cell left/right margins and borders to get usable inner width
-                                int leftMargin = 0, rightMargin = 0;
-                                int leftBorder = 0, rightBorder = 0;
-
-                                // Margins: prefer explicit cell margins; fall back to table defaults; else Word default 108 twips
-                                var cellMar = cell.TableCellProperties?.TableCellMargin;
-                                if (cellMar?.LeftMargin?.Width?.Value != null) {
-                                    int.TryParse(cellMar.LeftMargin.Width.Value, out leftMargin);
-                                }
-                                if (cellMar?.RightMargin?.Width?.Value != null) {
-                                    int.TryParse(cellMar.RightMargin.Width.Value, out rightMargin);
-                                }
-
-                                if (leftMargin == 0 || rightMargin == 0) {
-                                    var ptProps = parentTable.GetFirstChild<DocumentFormat.OpenXml.Wordprocessing.TableProperties>();
-                                    // TableCellMarginDefault stores left/right in twips (DXA) as Int16
-                                    var dflt = ptProps?.TableCellMarginDefault;
-                                    if (leftMargin == 0 && dflt?.TableCellLeftMargin?.Width != null) leftMargin = dflt.TableCellLeftMargin.Width.Value;
-                                    if (rightMargin == 0 && dflt?.TableCellRightMargin?.Width != null) rightMargin = dflt.TableCellRightMargin.Width.Value;
-                                }
-
-                                if (leftMargin == 0) leftMargin = 108; // Word default ~0.075"
-                                if (rightMargin == 0) rightMargin = 108;
-
-                                // Borders: check explicit cell borders first; else assume style default ~10 twips per side (size=4 → 0.5pt)
-                                var cellBorders = cell.TableCellProperties?.TableCellBorders;
-                                if (cellBorders?.LeftBorder?.Size != null) leftBorder = SizeUnitsToTwips(cellBorders.LeftBorder.Size.Value);
-                                if (cellBorders?.RightBorder?.Size != null) rightBorder = SizeUnitsToTwips(cellBorders.RightBorder.Size.Value);
-                                if (leftBorder == 0) leftBorder = 10;
-                                if (rightBorder == 0) rightBorder = 10;
-
-                                int usable = Math.Max(1, sum - leftMargin - rightMargin - leftBorder - rightBorder);
-                                return usable;
-                            }
-                        }
-
-                        // Fallback to parent table estimated width when grid is unavailable
-                        var parent = new WordTable(_document, parentTable, initializeChildren: false);
-                        return Math.Max(1, parent.EstimateTableWidthInDxa());
+                var row = cell.Parent as DocumentFormat.OpenXml.Wordprocessing.TableRow;
+                var parentTable = row?.Parent as DocumentFormat.OpenXml.Wordprocessing.Table;
+                if (row != null && parentTable != null) {
+                    int gridIndex = 0;
+                    foreach (var candidate in row.Elements<DocumentFormat.OpenXml.Wordprocessing.TableCell>()) {
+                        if (ReferenceEquals(candidate, cell)) break;
+                        int span = (int)(candidate.TableCellProperties?
+                            .GetFirstChild<DocumentFormat.OpenXml.Wordprocessing.GridSpan>()?.Val?.Value ?? 1);
+                        gridIndex += Math.Max(1, span);
                     }
+
+                    int spanThis = (int)(cell.TableCellProperties?
+                        .GetFirstChild<DocumentFormat.OpenXml.Wordprocessing.GridSpan>()?.Val?.Value ?? 1);
+                    spanThis = Math.Max(1, spanThis);
+
+                    var grid = parentTable.GetFirstChild<DocumentFormat.OpenXml.Wordprocessing.TableGrid>();
+                    if (grid != null) {
+                        var columns = grid.Elements<DocumentFormat.OpenXml.Wordprocessing.GridColumn>().ToList();
+                        int sum = 0;
+                        for (int i = 0; i < spanThis && gridIndex + i < columns.Count; i++) {
+                            if (int.TryParse(columns[gridIndex + i].Width?.Value ?? "0", out int width)) {
+                                sum += width;
+                            }
+                        }
+
+                        if (sum > 0) {
+                            int leftMargin = 0, rightMargin = 0;
+                            int leftBorder = 0, rightBorder = 0;
+                            var cellMargins = cell.TableCellProperties?.TableCellMargin;
+                            if (cellMargins?.LeftMargin?.Width?.Value != null) {
+                                int.TryParse(cellMargins.LeftMargin.Width.Value, out leftMargin);
+                            }
+                            if (cellMargins?.RightMargin?.Width?.Value != null) {
+                                int.TryParse(cellMargins.RightMargin.Width.Value, out rightMargin);
+                            }
+
+                            if (leftMargin == 0 || rightMargin == 0) {
+                                var tableProperties = parentTable
+                                    .GetFirstChild<DocumentFormat.OpenXml.Wordprocessing.TableProperties>();
+                                var defaults = tableProperties?.TableCellMarginDefault;
+                                if (leftMargin == 0 && defaults?.TableCellLeftMargin?.Width != null) {
+                                    leftMargin = defaults.TableCellLeftMargin.Width.Value;
+                                }
+                                if (rightMargin == 0 && defaults?.TableCellRightMargin?.Width != null) {
+                                    rightMargin = defaults.TableCellRightMargin.Width.Value;
+                                }
+                            }
+
+                            if (leftMargin == 0) leftMargin = 108;
+                            if (rightMargin == 0) rightMargin = 108;
+
+                            var cellBorders = cell.TableCellProperties?.TableCellBorders;
+                            if (cellBorders?.LeftBorder?.Size != null) {
+                                leftBorder = SizeUnitsToTwips(cellBorders.LeftBorder.Size.Value);
+                            }
+                            if (cellBorders?.RightBorder?.Size != null) {
+                                rightBorder = SizeUnitsToTwips(cellBorders.RightBorder.Size.Value);
+                            }
+                            if (leftBorder == 0) leftBorder = 10;
+                            if (rightBorder == 0) rightBorder = 10;
+
+                            return Math.Max(
+                                1,
+                                sum - leftMargin - rightMargin - leftBorder - rightBorder);
+                        }
+                    }
+
+                    var parent = new WordTable(document, parentTable, initializeChildren: false);
+                    return Math.Max(1, parent.EstimateTableWidthInDxa());
                 }
             } catch { /* ignore */ }
-            return EstimateContentAreaWidthInDxa();
+            return null;
         }
 
         private static int SizeUnitsToTwips(UInt32Value sizeUnits) {

--- a/OfficeIMO.Word/WordTable.Properties.cs
+++ b/OfficeIMO.Word/WordTable.Properties.cs
@@ -228,11 +228,11 @@ namespace OfficeIMO.Word {
 
         /// <summary>
         /// Returns the estimated text area width (page width minus left/right margins) in DXA.
-        /// Uses the first section when the owning section can't be easily resolved.
+        /// Uses the section that contains the table when it can be resolved.
         /// </summary>
         private int EstimateContentAreaWidthInDxa() {
             try {
-                var section = _document.Sections.Count > 0 ? _document.Sections[0] : null;
+                var section = ResolveOwningSection();
                 if (section != null) {
                     var page = section.PageSettings;
                     var width = (int)(page.Width?.Value ?? WordPageSizes.A4.Width!.Value);
@@ -244,6 +244,35 @@ namespace OfficeIMO.Word {
             } catch { /* ignore */ }
             // Sensible default if anything fails
             return 9000; // ~6.25 inches
+        }
+
+        /// <summary>
+        /// Resolves the document section that owns this top-level table.
+        /// </summary>
+        private WordSection? ResolveOwningSection() {
+            var sections = _document.Sections;
+            if (sections.Count == 0) {
+                return null;
+            }
+
+            var body = _document._wordprocessingDocument.MainDocumentPart?.Document?.Body;
+            if (body == null) {
+                return sections[0];
+            }
+
+            int sectionIndex = 0;
+            foreach (var element in body.ChildElements) {
+                if (ReferenceEquals(element, _table)) {
+                    return sections[Math.Min(sectionIndex, sections.Count - 1)];
+                }
+                if (element is Paragraph paragraph &&
+                    paragraph.ParagraphProperties?.SectionProperties != null &&
+                    sectionIndex < sections.Count - 1) {
+                    sectionIndex++;
+                }
+            }
+
+            return sections[0];
         }
 
         /// <summary>

--- a/OfficeIMO.Word/WordTable.Properties.cs
+++ b/OfficeIMO.Word/WordTable.Properties.cs
@@ -188,7 +188,7 @@ namespace OfficeIMO.Word {
         /// Estimates the effective table width in DXA (twips) based on
         /// Table.Width/WidthType and the section page width/margins.
         /// </summary>
-        private int EstimateTableWidthInDxa() {
+        internal int EstimateTableWidthInDxa() {
             // For nested tables, use the containing cell's width as the reference
             if (IsNestedTable) {
                 int container = EstimateContainingCellContentWidthInDxa();
@@ -216,6 +216,15 @@ namespace OfficeIMO.Word {
             // Auto or unspecified
             return contentWidth;
         }
+
+        /// <summary>
+        /// Estimates the width available to this table in its page or containing
+        /// table cell, before the table's own authored width is applied.
+        /// </summary>
+        internal int EstimateAvailableContainerWidthInDxa() =>
+            IsNestedTable
+                ? EstimateContainingCellContentWidthInDxa()
+                : EstimateContentAreaWidthInDxa();
 
         /// <summary>
         /// Returns the estimated text area width (page width minus left/right margins) in DXA.

--- a/OfficeIMO.Word/WordTableCell.cs
+++ b/OfficeIMO.Word/WordTableCell.cs
@@ -896,7 +896,7 @@ namespace OfficeIMO.Word {
             return wordTable;
         }
 
-        private static bool HasMeaningfulParagraphContent(Paragraph paragraph) {
+        internal static bool HasMeaningfulParagraphContent(Paragraph paragraph) {
             ParagraphProperties? paragraphProperties = paragraph.ParagraphProperties;
             if (paragraphProperties != null &&
                 (paragraphProperties.HasChildren || paragraphProperties.HasAttributes)) {

--- a/OfficeIMO.Word/WordTableCell.cs
+++ b/OfficeIMO.Word/WordTableCell.cs
@@ -922,9 +922,8 @@ namespace OfficeIMO.Word {
         /// <returns>The created <see cref="WordList"/>.</returns>
         public WordList AddList(WordListStyle style) {
             var paragraphs = this.Paragraphs;
-            WordList wordList = paragraphs.Count > 0
-                ? new WordList(this._document, paragraphs[paragraphs.Count - 1])
-                : new WordList(this._document, this._tableCell);
+            WordParagraph? insertionAnchor = paragraphs.Count > 0 ? paragraphs[paragraphs.Count - 1] : null;
+            WordList wordList = new WordList(this._document, this._tableCell, insertionAnchor);
             wordList.AddList(style);
             return wordList;
         }

--- a/OfficeIMO.Word/WordTableCell.cs
+++ b/OfficeIMO.Word/WordTableCell.cs
@@ -897,6 +897,12 @@ namespace OfficeIMO.Word {
         }
 
         private static bool HasMeaningfulParagraphContent(Paragraph paragraph) {
+            ParagraphProperties? paragraphProperties = paragraph.ParagraphProperties;
+            if (paragraphProperties != null &&
+                (paragraphProperties.HasChildren || paragraphProperties.HasAttributes)) {
+                return true;
+            }
+
             foreach (var element in paragraph.Descendants()) {
                 if (element is Text text) {
                     if (!string.IsNullOrWhiteSpace(text.Text)) return true;

--- a/OfficeIMO.Word/WordTableCell.cs
+++ b/OfficeIMO.Word/WordTableCell.cs
@@ -923,7 +923,14 @@ namespace OfficeIMO.Word {
         public WordList AddList(WordListStyle style) {
             var paragraphs = this.Paragraphs;
             WordParagraph? insertionAnchor = paragraphs.Count > 0 ? paragraphs[paragraphs.Count - 1] : null;
-            WordList wordList = new WordList(this._document, this._tableCell, insertionAnchor);
+            bool replaceInsertionAnchor = paragraphs.Count == 1 &&
+                                          insertionAnchor != null &&
+                                          !HasMeaningfulParagraphContent(insertionAnchor._paragraph);
+            WordList wordList = new WordList(
+                this._document,
+                this._tableCell,
+                insertionAnchor,
+                replaceInsertionAnchor);
             wordList.AddList(style);
             return wordList;
         }


### PR DESCRIPTION
## Summary

- resolve physical and logical margin/padding declarations in cascade order, including effective text direction
- preserve block backgrounds and borders as native paragraph frames across multi-paragraph containers
- preserve arbitrary inline background colors with exact run shading by default, with an opt-in Word highlight palette and approximation diagnostics
- prefetch remote images with configurable bounded concurrency while retaining deterministic aggregate-budget enforcement
- add typed synchronous and asynchronous HTML insertion for existing table cells, including nested structures and part-correct image relationships

## Compatibility

Exact run shading is now the default representation for CSS text backgrounds. Callers that require Word highlight values can select `HtmlTextBackgroundMode.NearestHighlight`. Imports configured with `MaxTotalImageBytes` remain sequential so the total budget can reject responses before reading their bodies.

## Validation

The HTML conversion test project passes on .NET 8 and .NET 10, including OpenXML save/reload validation and body/header table-cell insertion contracts.