### PR TITLE
Classify browser PDF font substitutions accurately

### DIFF
--- a/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.Planning.cs
+++ b/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.Planning.cs
@@ -173,18 +173,16 @@ namespace OfficeIMO.Excel.Pdf {
                         trimmedFamilyName,
                         out PdfCore.PdfFontFamilySubstitution? substitution) &&
                     substitution != null) {
-                    if (reportSubstitution) {
-                        options.Report.Add(pdfOptions.CreateFontFamilySubstitutionWarning(
-                            "OfficeIMO.Excel.Pdf",
-                            "WorksheetFontFamilySubstituted",
-                            sheetName,
-                            trimmedFamilyName,
-                            fallbackSlot: null,
-                            resolvedFontFamily: substitution.TargetFontFamily,
-                            additionalDetails: new Dictionary<string, string> {
-                                ["sheetName"] = sheetName
-                            }));
-                    }
+                    options.Report.Add(pdfOptions.CreateFontFamilySubstitutionWarning(
+                        "OfficeIMO.Excel.Pdf",
+                        "WorksheetFontFamilySubstituted",
+                        sheetName,
+                        trimmedFamilyName,
+                        fallbackSlot: null,
+                        resolvedFontFamily: substitution.TargetFontFamily,
+                        additionalDetails: new Dictionary<string, string> {
+                            ["sheetName"] = sheetName
+                        }));
                     return;
                 }
 

--- a/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.Planning.cs
+++ b/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.Planning.cs
@@ -169,6 +169,25 @@ namespace OfficeIMO.Excel.Pdf {
             string sheetName,
             bool reportSubstitution = true) {
             if (PdfCore.PdfOptions.TryAddOfficeFontFamilyKey(familyName, registeredFamilies, normalizeKey: null, out string trimmedFamilyName)) {
+                if (pdfOptions.TryResolveFontFamilySubstitution(
+                        trimmedFamilyName,
+                        out PdfCore.PdfFontFamilySubstitution? substitution) &&
+                    substitution != null) {
+                    if (reportSubstitution) {
+                        options.Report.Add(pdfOptions.CreateFontFamilySubstitutionWarning(
+                            "OfficeIMO.Excel.Pdf",
+                            "WorksheetFontFamilySubstituted",
+                            sheetName,
+                            trimmedFamilyName,
+                            fallbackSlot: null,
+                            resolvedFontFamily: substitution.TargetFontFamily,
+                            additionalDetails: new Dictionary<string, string> {
+                                ["sheetName"] = sheetName
+                            }));
+                    }
+                    return;
+                }
+
                 if (pdfOptions.HasNamedFontFamily(trimmedFamilyName)) {
                     return;
                 }
@@ -194,16 +213,15 @@ namespace OfficeIMO.Excel.Pdf {
                     PdfCore.PdfStandardFont reportedFallback = mapped
                         ? fallback
                         : PdfCore.PdfStandardFont.Helvetica;
-                    PdfCore.PdfStandardFont normalizedFallback = PdfCore.PdfStandardFontMapper.GetFontFamily(reportedFallback);
-                    options.Report.Add(new PdfCore.PdfConversionWarning(
+                    options.Report.Add(pdfOptions.CreateFontFamilySubstitutionWarning(
                         "OfficeIMO.Excel.Pdf",
                         "WorksheetFontFamilySubstituted",
                         sheetName,
-                        "The source font family '" + trimmedFamilyName + "' was unavailable or could not be embedded; generated text uses the mapped PDF family " + normalizedFallback + ".",
-                        details: new Dictionary<string, string> {
-                            ["sheetName"] = sheetName,
-                            ["fontFamily"] = trimmedFamilyName,
-                            ["fallbackSlot"] = normalizedFallback.ToString()
+                        trimmedFamilyName,
+                        reportedFallback,
+                        pdfOptions.GetEmbeddedFontFamilyName(reportedFallback),
+                        new Dictionary<string, string> {
+                            ["sheetName"] = sheetName
                         }));
                 }
             }

--- a/OfficeIMO.Excel.Tests/Pdf/Excel.SaveAsPdf.CellStyleFormatTests.cs
+++ b/OfficeIMO.Excel.Tests/Pdf/Excel.SaveAsPdf.CellStyleFormatTests.cs
@@ -2,6 +2,7 @@ using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using OfficeIMO.Excel;
 using OfficeIMO.Excel.Pdf;
+using OfficeIMO.TestAssets;
 using System.Globalization;
 using System.Reflection;
 using System.Text;
@@ -168,6 +169,49 @@ public partial class Excel {
             item => item.Code == "WorksheetFontFamilySubstituted");
         Assert.Equal("Arial", warning.Details["fontFamily"]);
         Assert.Equal("Helvetica", warning.Details["fallbackSlot"]);
+    }
+
+    [Fact]
+    public void SaveAsPdf_ExcelWorkbook_ReportsConfiguredSubstitutionForInheritedWorksheetFont() {
+        const string targetFamily = "OfficeIMO Portable Worksheet";
+        string workbookPath = Path.Combine(_directoryWithFiles, "ExcelPdfInheritedFontSubstitution.xlsx");
+
+        PdfCore.PdfDocumentConversionResult result;
+        using (ExcelDocument document = ExcelDocument.Create(workbookPath, "Fonts")) {
+            ExcelSheet sheet = document.Sheets[0];
+            sheet.CellAt(1, 1).SetValue("AB");
+            document.Save();
+
+            ExcelCellStyleSnapshot inheritedStyle = sheet.CellAt(1, 1).GetStyle();
+            Assert.False(inheritedStyle.IsFontFamilyExplicit);
+            string sourceFamily = Assert.IsType<string>(inheritedStyle.FontName);
+
+            var configured = new PdfCore.PdfOptions();
+            configured
+                .RegisterNamedFontFamily(new PdfCore.PdfEmbeddedFontFamily(
+                    targetFamily,
+                    ManagedTextShapingTestAssets.CreateFont(' ', 'A', 'B')))
+                .RegisterFontFamilySubstitution(
+                    sourceFamily,
+                    targetFamily,
+                    PdfCore.PdfFontFamilySubstitutionImpact.LayoutSensitive);
+
+            result = document.ToPdfDocumentResult(new ExcelPdfSaveOptions {
+                PdfOptions = configured,
+                IncludeSheetHeadings = false,
+                HeaderRowCount = 0
+            });
+            _ = result.ToBytes();
+
+            PdfCore.PdfConversionWarning warning = Assert.Single(result.Warnings, item =>
+                item.Code == "WorksheetFontFamilySubstituted" &&
+                item.Details.TryGetValue("fontFamily", out string? family) &&
+                family == sourceFamily);
+            Assert.Equal(PdfCore.PdfConversionWarningSeverity.Warning, warning.Severity);
+            Assert.Equal(targetFamily, warning.Details["resolvedFontFamily"]);
+            Assert.Equal(bool.TrueString, warning.Details["plannedSubstitution"]);
+            Assert.False(warning.Details.ContainsKey("fallbackSlot"));
+        }
     }
 
     [Fact]

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfConverterOptionsApiTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfConverterOptionsApiTests.cs
@@ -158,6 +158,59 @@ public sealed class PdfConverterOptionsApiTests {
         Assert.True(configuredClone.HasExplicitFooterFont);
     }
 
+    [Fact]
+    public void PdfOptionsExposeAndClonePlannedFontFamilySubstitutions() {
+        var options = new PdfOptions()
+            .RegisterNamedFontFamily(new PdfEmbeddedFontFamily("Portable Latin", [1]))
+            .RegisterFontFamilySubstitution(
+                "Source Sans",
+                "Portable Latin",
+                PdfFontFamilySubstitutionImpact.Compatible);
+
+        PdfOptions clone = options.Clone();
+        PdfFontFamilySubstitution substitution = Assert.Single(options.FontFamilySubstitutions);
+        PdfFontFamilySubstitution clonedSubstitution = Assert.Single(clone.FontFamilySubstitutions);
+
+        Assert.Equal("Source Sans", substitution.SourceFontFamily);
+        Assert.Equal("Portable Latin", substitution.TargetFontFamily);
+        Assert.Equal(PdfFontFamilySubstitutionImpact.Compatible, substitution.Impact);
+        Assert.True(options.HasNamedFontFamily("Source Sans"));
+        Assert.True(clone.HasNamedFontFamily("Source Sans"));
+        Assert.Equal(substitution.SourceFontFamily, clonedSubstitution.SourceFontFamily);
+        Assert.Equal(substitution.TargetFontFamily, clonedSubstitution.TargetFontFamily);
+        Assert.Equal(substitution.Impact, clonedSubstitution.Impact);
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            options.RegisterFontFamilySubstitution(
+                "Unknown impact source",
+                "Portable Latin",
+                (PdfFontFamilySubstitutionImpact)999));
+
+        options.RegisterNamedFontFamily(new PdfEmbeddedFontFamily("Source Sans", [2]));
+        Assert.True(options.TryResolveNamedFontFace("Source Sans", bold: false, italic: false, out PdfNamedFontFace face));
+        Assert.Equal("Portable Latin", face.FamilyName);
+    }
+
+    [Fact]
+    public void UnresolvedFontFamilySubstitutionRemainsAWarning() {
+        var options = new PdfOptions()
+            .RegisterFontFamilySubstitution(
+                "Source Sans",
+                "Missing Portable Latin",
+                PdfFontFamilySubstitutionImpact.Compatible);
+
+        PdfConversionWarning warning = options.CreateFontFamilySubstitutionWarning(
+            "OfficeIMO.Tests",
+            "FontFamilySubstituted",
+            "document",
+            "Source Sans",
+            PdfStandardFont.Helvetica,
+            resolvedFontFamily: null);
+
+        Assert.Equal(PdfConversionWarningSeverity.Warning, warning.Severity);
+        Assert.False(warning.Details.ContainsKey("plannedSubstitution"));
+        Assert.DoesNotContain("Missing Portable Latin", warning.Message, StringComparison.Ordinal);
+    }
+
     private static void AssertPortable(PdfResourcePolicy policy) {
         Assert.False(policy.AllowSystemFontEmbedding);
         Assert.False(policy.AllowDocumentFontEmbedding);

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfConverterOptionsApiTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfConverterOptionsApiTests.cs
@@ -211,6 +211,40 @@ public sealed class PdfConverterOptionsApiTests {
         Assert.DoesNotContain("Missing Portable Latin", warning.Message, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void ResolvedFallbackListSubstitutionUsesItsOwnImpactClassification() {
+        const string resolvedFamily = "Portable Calibri";
+        var options = new PdfOptions()
+            .RegisterNamedFontFamily(new PdfEmbeddedFontFamily(resolvedFamily, [1]))
+            .RegisterFontFamilySubstitution(
+                "Primary",
+                "Missing Primary",
+                PdfFontFamilySubstitutionImpact.LayoutSensitive)
+            .RegisterFontFamilySubstitution(
+                "Calibri",
+                resolvedFamily,
+                PdfFontFamilySubstitutionImpact.Compatible);
+
+        Assert.True(options.TryResolveFontFamilySubstitution(
+            "Primary, Calibri",
+            out PdfFontFamilySubstitution? substitution));
+        Assert.Equal("Calibri", substitution!.SourceFontFamily);
+
+        PdfConversionWarning warning = options.CreateFontFamilySubstitutionWarning(
+            "OfficeIMO.Tests",
+            "FontFamilySubstituted",
+            "document",
+            "Primary, Calibri",
+            fallbackSlot: null,
+            resolvedFontFamily: resolvedFamily);
+
+        Assert.Equal(PdfConversionWarningSeverity.Information, warning.Severity);
+        Assert.Equal(bool.TrueString, warning.Details["plannedSubstitution"]);
+        Assert.Equal(PdfFontFamilySubstitutionImpact.Compatible.ToString(), warning.Details["substitutionImpact"]);
+        Assert.Contains(resolvedFamily, warning.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("Missing Primary", warning.Message, StringComparison.Ordinal);
+    }
+
     private static void AssertPortable(PdfResourcePolicy policy) {
         Assert.False(policy.AllowSystemFontEmbedding);
         Assert.False(policy.AllowDocumentFontEmbedding);

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfFontFamilyTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfFontFamilyTests.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using OfficeIMO.Pdf;
+using OfficeIMO.TestAssets;
 using Xunit;
 
 namespace OfficeIMO.Tests.Pdf;
@@ -1104,6 +1105,29 @@ public class PdfFontFamilyTests {
                 TextRun.Italicized("Italic Łódź"),
                 TextRun.BoldItalic("Bold italic Łódź")
             },
+            options,
+            PdfStandardFont.Helvetica,
+            "body");
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void PdfTextDiagnostics_UsesEmbeddedFallbacksForNamedFontRuns() {
+        const string primaryFamily = "OfficeIMO Named Primary";
+        var options = new PdfOptions()
+            .RegisterNamedFontFamily(new PdfEmbeddedFontFamily(
+                primaryFamily,
+                ManagedTextShapingTestAssets.CreateFont(' ', 'A')))
+            .RegisterEmbeddedFontFallbacks(new PdfEmbeddedFontFallbackSet(
+                new[] {
+                    new PdfEmbeddedFontFallbackCandidate(
+                        "OfficeIMO Arabic Fallback",
+                        ManagedTextShapingTestAssets.CreateFont(0x0645))
+                }));
+
+        IReadOnlyList<PdfTextEncodingDiagnostic> diagnostics = PdfTextDiagnostics.AnalyzeGeneratedTextRuns(
+            new[] { new TextRun("A\u0645", fontFamily: primaryFamily) },
             options,
             PdfStandardFont.Helvetica,
             "body");

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfPublicApiContractTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfPublicApiContractTests.cs
@@ -128,7 +128,7 @@ public sealed class PdfPublicApiContractTests {
                 BindingFlags.Static |
                 BindingFlags.DeclaredOnly).Length);
 
-        Assert.InRange(exportedTypes.Length, 1, 500);
+        Assert.InRange(exportedTypes.Length, 1, 502);
         Assert.InRange(publicMemberCount, 1, 9950);
 
         string[] officeReferences = assembly.GetReferencedAssemblies()

--- a/OfficeIMO.Pdf/Enums/PdfFontFamilySubstitutionImpact.cs
+++ b/OfficeIMO.Pdf/Enums/PdfFontFamilySubstitutionImpact.cs
@@ -1,0 +1,17 @@
+namespace OfficeIMO.Pdf;
+
+/// <summary>
+/// Describes the expected layout impact of a configured embedded font-family substitution.
+/// </summary>
+public enum PdfFontFamilySubstitutionImpact {
+    /// <summary>
+    /// The caller accepts the substitute as layout-compatible for the intended document profile.
+    /// The generated appearance can still differ from the source font.
+    /// </summary>
+    Compatible,
+
+    /// <summary>
+    /// The substitute can change glyph appearance, text fit, wrapping, or pagination.
+    /// </summary>
+    LayoutSensitive
+}

--- a/OfficeIMO.Pdf/Model/PdfFontFamilySubstitution.cs
+++ b/OfficeIMO.Pdf/Model/PdfFontFamilySubstitution.cs
@@ -1,0 +1,48 @@
+namespace OfficeIMO.Pdf;
+
+/// <summary>
+/// Maps a source document font family to an embedded PDF family with an explicit layout-impact contract.
+/// </summary>
+public sealed class PdfFontFamilySubstitution {
+    /// <summary>
+    /// Creates a font-family substitution.
+    /// </summary>
+    /// <param name="sourceFontFamily">Source family declared by the input document.</param>
+    /// <param name="targetFontFamily">Registered embedded family used in generated PDF text.</param>
+    /// <param name="impact">Expected layout impact of the substitution.</param>
+    public PdfFontFamilySubstitution(
+        string sourceFontFamily,
+        string targetFontFamily,
+        PdfFontFamilySubstitutionImpact impact) {
+        if (string.IsNullOrWhiteSpace(sourceFontFamily)) {
+            throw new ArgumentException("Source font family cannot be empty.", nameof(sourceFontFamily));
+        }
+        if (string.IsNullOrWhiteSpace(targetFontFamily)) {
+            throw new ArgumentException("Target font family cannot be empty.", nameof(targetFontFamily));
+        }
+
+        SourceFontFamily = sourceFontFamily.Trim();
+        TargetFontFamily = targetFontFamily.Trim();
+        if (string.Equals(SourceFontFamily, TargetFontFamily, StringComparison.OrdinalIgnoreCase)) {
+            throw new ArgumentException("Source and target font families must be different.", nameof(targetFontFamily));
+        }
+        if (impact != PdfFontFamilySubstitutionImpact.Compatible &&
+            impact != PdfFontFamilySubstitutionImpact.LayoutSensitive) {
+            throw new ArgumentOutOfRangeException(nameof(impact), impact, "Unknown font substitution impact.");
+        }
+
+        Impact = impact;
+    }
+
+    /// <summary>Source family declared by the input document.</summary>
+    public string SourceFontFamily { get; }
+
+    /// <summary>Registered embedded family used in generated PDF text.</summary>
+    public string TargetFontFamily { get; }
+
+    /// <summary>Expected layout impact of the substitution.</summary>
+    public PdfFontFamilySubstitutionImpact Impact { get; }
+
+    internal PdfFontFamilySubstitution Clone() =>
+        new(SourceFontFamily, TargetFontFamily, Impact);
+}

--- a/OfficeIMO.Pdf/Model/PdfTextDiagnostics.cs
+++ b/OfficeIMO.Pdf/Model/PdfTextDiagnostics.cs
@@ -169,29 +169,49 @@ internal static class PdfTextDiagnostics {
             }
 
             string runLocation = AppendRunLocation(location, runIndex);
+            PdfEmbeddedFontFallbackSet? fallbackSet = options.EmbeddedFontFallbacksSnapshot;
+            PdfTextShapingMode shapingMode = options.TextShapingModeSnapshot;
             if (options.TryResolveNamedFontFace(run.FontFamily, run.Bold, run.Italic, out PdfNamedFontFace namedFace)) {
                 if (options.TryGetNamedFontProgram(namedFace, out PdfTrueTypeFontProgram? namedFontProgram) &&
                     namedFontProgram != null) {
-                    diagnostics.AddRange(AnalyzeEmbeddedFontText(
-                        run.Text,
-                        namedFontProgram,
-                        source,
-                        runLocation,
-                        runIndex,
-                        options.TextShapingModeSnapshot));
+                    diagnostics.AddRange(fallbackSet != null
+                        ? AnalyzeGeneratedTextWithFallback(
+                            run.Text,
+                            fallbackSet,
+                            source,
+                            runLocation,
+                            runIndex,
+                            shapingMode,
+                            (string value, int index, out int length) => TryGetCoveredTextLength(value, index, namedFontProgram, shapingMode, out length))
+                        : AnalyzeEmbeddedFontText(
+                            run.Text,
+                            namedFontProgram,
+                            source,
+                            runLocation,
+                            runIndex,
+                            shapingMode));
                     runIndex++;
                     continue;
                 }
 
                 if (options.TryGetNamedOpenTypeCffFontProgram(namedFace, out PdfOpenTypeCffFontProgram? namedCffFontProgram) &&
                     namedCffFontProgram != null) {
-                    diagnostics.AddRange(AnalyzeEmbeddedFontText(
-                        run.Text,
-                        namedCffFontProgram,
-                        source,
-                        runLocation,
-                        runIndex,
-                        options.TextShapingModeSnapshot));
+                    diagnostics.AddRange(fallbackSet != null
+                        ? AnalyzeGeneratedTextWithFallback(
+                            run.Text,
+                            fallbackSet,
+                            source,
+                            runLocation,
+                            runIndex,
+                            shapingMode,
+                            (string value, int index, out int length) => TryGetCoveredTextLength(value, index, namedCffFontProgram, shapingMode, out length))
+                        : AnalyzeEmbeddedFontText(
+                            run.Text,
+                            namedCffFontProgram,
+                            source,
+                            runLocation,
+                            runIndex,
+                            shapingMode));
                     runIndex++;
                     continue;
                 }

--- a/OfficeIMO.Pdf/Options/PdfOptions.Clone.cs
+++ b/OfficeIMO.Pdf/Options/PdfOptions.Clone.cs
@@ -61,6 +61,7 @@ public sealed partial class PdfOptions {
             _diagnosticsConverter = _diagnosticsConverter,
             _embeddedFonts = CloneEmbeddedFonts(_embeddedFonts),
             _namedFontFamilies = CloneNamedFontFamilies(_namedFontFamilies),
+            _fontFamilySubstitutions = CloneFontFamilySubstitutions(_fontFamilySubstitutions),
             _embeddedFiles = CloneEmbeddedFiles(_embeddedFiles),
             Portfolio = _portfolio?.Clone(),
             ShowHeader = ShowHeader,

--- a/OfficeIMO.Pdf/Options/PdfOptions.FontSubstitutions.cs
+++ b/OfficeIMO.Pdf/Options/PdfOptions.FontSubstitutions.cs
@@ -67,9 +67,28 @@ public sealed partial class PdfOptions {
     internal bool TryResolveFontFamilySubstitution(
         string? sourceFontFamily,
         out PdfFontFamilySubstitution? substitution) {
-        return TryGetFontFamilySubstitution(sourceFontFamily, out substitution) &&
-               substitution != null &&
-               TryGetNamedFontFamilyDirect(substitution.TargetFontFamily, out _);
+        substitution = null;
+        if (string.IsNullOrWhiteSpace(sourceFontFamily) || _fontFamilySubstitutions == null) {
+            return false;
+        }
+
+        foreach (string candidate in EnumerateOfficeFontFamilyCandidates(sourceFontFamily!)) {
+            if (_fontFamilySubstitutions.TryGetValue(
+                    NormalizeOfficeFontFamilyKey(candidate),
+                    out PdfFontFamilySubstitution? configured) &&
+                TryGetNamedFontFamilyDirect(configured.TargetFontFamily, out _)) {
+                substitution = configured;
+                return true;
+            }
+
+            // A directly registered family earlier in an Office/CSS fallback list
+            // takes precedence over substitutions configured for later candidates.
+            if (TryGetNamedFontFamilyDirect(candidate, out _)) {
+                return false;
+            }
+        }
+
+        return false;
     }
 
     internal PdfConversionWarning CreateFontFamilySubstitutionWarning(

--- a/OfficeIMO.Pdf/Options/PdfOptions.FontSubstitutions.cs
+++ b/OfficeIMO.Pdf/Options/PdfOptions.FontSubstitutions.cs
@@ -1,0 +1,179 @@
+using System.Collections.ObjectModel;
+
+namespace OfficeIMO.Pdf;
+
+public sealed partial class PdfOptions {
+    private Dictionary<string, PdfFontFamilySubstitution>? _fontFamilySubstitutions;
+
+    /// <summary>
+    /// Configured source-to-embedded font substitutions ordered by source family.
+    /// </summary>
+    public IReadOnlyList<PdfFontFamilySubstitution> FontFamilySubstitutions {
+        get {
+            if (_fontFamilySubstitutions == null || _fontFamilySubstitutions.Count == 0) {
+                return Array.Empty<PdfFontFamilySubstitution>();
+            }
+
+            return new ReadOnlyCollection<PdfFontFamilySubstitution>(
+                _fontFamilySubstitutions.Values
+                    .OrderBy(static substitution => substitution.SourceFontFamily, StringComparer.OrdinalIgnoreCase)
+                    .Select(static substitution => substitution.Clone())
+                    .ToList());
+        }
+    }
+
+    /// <summary>
+    /// Registers a source document family as a planned substitute for an embedded named PDF family.
+    /// </summary>
+    /// <remarks>
+    /// The target family must be registered through <see cref="RegisterNamedFontFamily"/> before conversion.
+    /// Compatible substitutions are informational diagnostics; layout-sensitive substitutions remain warnings.
+    /// </remarks>
+    /// <param name="sourceFontFamily">Source family declared by the input document.</param>
+    /// <param name="targetFontFamily">Registered embedded family used in generated PDF text.</param>
+    /// <param name="impact">Expected layout impact of the substitution.</param>
+    /// <returns>The current options instance.</returns>
+    public PdfOptions RegisterFontFamilySubstitution(
+        string sourceFontFamily,
+        string targetFontFamily,
+        PdfFontFamilySubstitutionImpact impact = PdfFontFamilySubstitutionImpact.LayoutSensitive) {
+        var substitution = new PdfFontFamilySubstitution(sourceFontFamily, targetFontFamily, impact);
+        string key = NormalizeOfficeFontFamilyKey(substitution.SourceFontFamily);
+        (_fontFamilySubstitutions ??=
+            new Dictionary<string, PdfFontFamilySubstitution>(StringComparer.OrdinalIgnoreCase))[key] = substitution;
+        return this;
+    }
+
+    internal bool TryGetFontFamilySubstitution(
+        string? sourceFontFamily,
+        out PdfFontFamilySubstitution? substitution) {
+        substitution = null;
+        if (string.IsNullOrWhiteSpace(sourceFontFamily) || _fontFamilySubstitutions == null) {
+            return false;
+        }
+
+        foreach (string candidate in EnumerateOfficeFontFamilyCandidates(sourceFontFamily!)) {
+            if (_fontFamilySubstitutions.TryGetValue(
+                    NormalizeOfficeFontFamilyKey(candidate),
+                    out PdfFontFamilySubstitution? configured)) {
+                substitution = configured;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    internal bool TryResolveFontFamilySubstitution(
+        string? sourceFontFamily,
+        out PdfFontFamilySubstitution? substitution) {
+        return TryGetFontFamilySubstitution(sourceFontFamily, out substitution) &&
+               substitution != null &&
+               TryGetNamedFontFamilyDirect(substitution.TargetFontFamily, out _);
+    }
+
+    internal PdfConversionWarning CreateFontFamilySubstitutionWarning(
+        string converter,
+        string code,
+        string source,
+        string sourceFontFamily,
+        PdfStandardFont? fallbackSlot,
+        string? resolvedFontFamily,
+        IReadOnlyDictionary<string, string>? additionalDetails = null) {
+        var details = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (additionalDetails != null) {
+            foreach (KeyValuePair<string, string> detail in additionalDetails) {
+                details[detail.Key] = detail.Value;
+            }
+        }
+        details["fontFamily"] = sourceFontFamily;
+
+        PdfStandardFont? normalizedSlot = fallbackSlot.HasValue
+            ? PdfStandardFontMapper.GetFontFamily(fallbackSlot.Value)
+            : null;
+        if (normalizedSlot.HasValue) {
+            details["fallbackSlot"] = normalizedSlot.Value.ToString();
+        }
+        if (!string.IsNullOrWhiteSpace(resolvedFontFamily)) {
+            details["resolvedFontFamily"] = resolvedFontFamily!;
+        }
+
+        if (TryGetFontFamilySubstitution(sourceFontFamily, out PdfFontFamilySubstitution? substitution) &&
+            substitution != null &&
+            !string.IsNullOrWhiteSpace(resolvedFontFamily) &&
+            string.Equals(
+                 NormalizeOfficeFontFamilyKey(substitution.TargetFontFamily),
+                 NormalizeOfficeFontFamilyKey(resolvedFontFamily!),
+                 StringComparison.OrdinalIgnoreCase)) {
+            details["substitutionImpact"] = substitution.Impact.ToString();
+            details["plannedSubstitution"] = bool.TrueString;
+            PdfConversionWarningSeverity severity =
+                substitution.Impact == PdfFontFamilySubstitutionImpact.Compatible
+                    ? PdfConversionWarningSeverity.Information
+                    : PdfConversionWarningSeverity.Warning;
+            string message = substitution.Impact == PdfFontFamilySubstitutionImpact.Compatible
+                ? "The source font family '" + sourceFontFamily +
+                  "' uses the configured compatible embedded substitute '" +
+                  substitution.TargetFontFamily + "'."
+                : "The source font family '" + sourceFontFamily +
+                  "' uses the configured embedded substitute '" +
+                  substitution.TargetFontFamily + "'.";
+            return new PdfConversionWarning(
+                converter,
+                code,
+                source,
+                message,
+                severity,
+                details: details);
+        }
+
+        string fallbackDescription;
+        if (!string.IsNullOrWhiteSpace(resolvedFontFamily)) {
+            fallbackDescription = "the embedded family '" + resolvedFontFamily + "'" +
+                (normalizedSlot.HasValue ? " through the logical " + normalizedSlot.Value + " PDF slot" : string.Empty);
+        } else {
+            fallbackDescription = normalizedSlot.HasValue
+                ? "the mapped PDF family " + normalizedSlot.Value
+                : "the configured default PDF family";
+        }
+
+        string fallbackCandidates = FormatEmbeddedFallbackFamilyNames();
+        if (!string.IsNullOrWhiteSpace(fallbackCandidates)) {
+            details["embeddedFallbackFamilies"] = fallbackCandidates;
+        }
+        string fallbackNote = string.IsNullOrWhiteSpace(fallbackCandidates)
+            ? string.Empty
+            : " Glyphs outside that family may use the embedded fallback families " + fallbackCandidates + ".";
+        return new PdfConversionWarning(
+            converter,
+            code,
+            source,
+            "The source font family '" + sourceFontFamily +
+            "' was unavailable or could not be embedded; generated text uses " +
+            fallbackDescription + "." + fallbackNote,
+            details: details);
+    }
+
+    private string FormatEmbeddedFallbackFamilyNames() {
+        PdfEmbeddedFontFallbackSet? fallbackSet = EmbeddedFontFallbacksSnapshot;
+        if (fallbackSet?.UsesNamedFontFamilies != true || fallbackSet.FontFamilyNames.Count == 0) {
+            return string.Empty;
+        }
+
+        return string.Join(", ", fallbackSet.FontFamilyNames.Select(static family => "'" + family + "'"));
+    }
+
+    private static Dictionary<string, PdfFontFamilySubstitution>? CloneFontFamilySubstitutions(
+        Dictionary<string, PdfFontFamilySubstitution>? substitutions) {
+        if (substitutions == null) {
+            return null;
+        }
+
+        var clone = new Dictionary<string, PdfFontFamilySubstitution>(StringComparer.OrdinalIgnoreCase);
+        foreach (KeyValuePair<string, PdfFontFamilySubstitution> substitution in substitutions) {
+            clone[substitution.Key] = substitution.Value.Clone();
+        }
+
+        return clone;
+    }
+}

--- a/OfficeIMO.Pdf/Options/PdfOptions.FontSubstitutions.cs
+++ b/OfficeIMO.Pdf/Options/PdfOptions.FontSubstitutions.cs
@@ -117,7 +117,7 @@ public sealed partial class PdfOptions {
             details["resolvedFontFamily"] = resolvedFontFamily!;
         }
 
-        if (TryGetFontFamilySubstitution(sourceFontFamily, out PdfFontFamilySubstitution? substitution) &&
+        if (TryResolveFontFamilySubstitution(sourceFontFamily, out PdfFontFamilySubstitution? substitution) &&
             substitution != null &&
             !string.IsNullOrWhiteSpace(resolvedFontFamily) &&
             string.Equals(

--- a/OfficeIMO.Pdf/Options/PdfOptions.NamedFonts.cs
+++ b/OfficeIMO.Pdf/Options/PdfOptions.NamedFonts.cs
@@ -74,6 +74,16 @@ public sealed partial class PdfOptions {
     public bool HasNamedFontFamily(string? familyName) =>
         TryGetNamedFontFamily(familyName, out _);
 
+    internal bool TryResolveNamedOfficeFontFamily(string? familyNames, out string? registeredFamilyName) {
+        registeredFamilyName = null;
+        if (!TryGetNamedFontFamily(familyNames, out PdfEmbeddedFontFamily? family) || family == null) {
+            return false;
+        }
+
+        registeredFamilyName = family.FamilyName;
+        return true;
+    }
+
     /// <summary>Removes every embedded named family and its parsed program cache.</summary>
     public PdfOptions ClearNamedFontFamilies() {
         _namedFontFamilies?.Clear();

--- a/OfficeIMO.Pdf/Options/PdfOptions.NamedFonts.cs
+++ b/OfficeIMO.Pdf/Options/PdfOptions.NamedFonts.cs
@@ -221,12 +221,23 @@ public sealed partial class PdfOptions {
         }
 
         foreach (string candidate in EnumerateOfficeFontFamilyCandidates(familyName!)) {
-            if (_namedFontFamilies.TryGetValue(NormalizeNamedFontFamilyKey(candidate), out family)) {
+            if (TryGetFontFamilySubstitution(candidate, out PdfFontFamilySubstitution? substitution) &&
+                substitution != null &&
+                TryGetNamedFontFamilyDirect(substitution.TargetFontFamily, out family)) {
+                return true;
+            }
+            if (TryGetNamedFontFamilyDirect(candidate, out family)) {
                 return true;
             }
         }
 
         return false;
+    }
+
+    private bool TryGetNamedFontFamilyDirect(string familyName, out PdfEmbeddedFontFamily? family) {
+        family = null;
+        return _namedFontFamilies != null &&
+               _namedFontFamilies.TryGetValue(NormalizeNamedFontFamilyKey(familyName), out family);
     }
 
     internal bool TryGetNamedFontData(PdfNamedFontFace face, out byte[]? data, out string? fontName) {

--- a/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.Fonts.cs
+++ b/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.Fonts.cs
@@ -287,18 +287,16 @@ public static partial class PowerPointPdfConverterExtensions {
                     trimmedFamilyName,
                     out PdfCore.PdfFontFamilySubstitution? substitution) &&
                 substitution != null) {
-                if (reportSubstitution) {
-                    options.Report.Add(pdfOptions.CreateFontFamilySubstitutionWarning(
-                        "OfficeIMO.PowerPoint.Pdf",
-                        "font-family-substitution",
-                        "Slide " + slideNumber.ToString(System.Globalization.CultureInfo.InvariantCulture),
-                        trimmedFamilyName,
-                        fallbackSlot: null,
-                        resolvedFontFamily: substitution.TargetFontFamily,
-                        additionalDetails: new Dictionary<string, string> {
-                            ["slideNumber"] = slideNumber.ToString(System.Globalization.CultureInfo.InvariantCulture)
-                        }));
-                }
+                options.Report.Add(pdfOptions.CreateFontFamilySubstitutionWarning(
+                    "OfficeIMO.PowerPoint.Pdf",
+                    "font-family-substitution",
+                    "Slide " + slideNumber.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                    trimmedFamilyName,
+                    fallbackSlot: null,
+                    resolvedFontFamily: substitution.TargetFontFamily,
+                    additionalDetails: new Dictionary<string, string> {
+                        ["slideNumber"] = slideNumber.ToString(System.Globalization.CultureInfo.InvariantCulture)
+                    }));
                 return;
             }
 

--- a/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.Fonts.cs
+++ b/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.Fonts.cs
@@ -283,6 +283,25 @@ public static partial class PowerPointPdfConverterExtensions {
         int slideNumber,
         bool reportSubstitution = true) {
         if (PdfCore.PdfOptions.TryAddOfficeFontFamilyKey(familyName, registeredFamilies, normalizeKey: null, out string trimmedFamilyName)) {
+            if (pdfOptions.TryResolveFontFamilySubstitution(
+                    trimmedFamilyName,
+                    out PdfCore.PdfFontFamilySubstitution? substitution) &&
+                substitution != null) {
+                if (reportSubstitution) {
+                    options.Report.Add(pdfOptions.CreateFontFamilySubstitutionWarning(
+                        "OfficeIMO.PowerPoint.Pdf",
+                        "font-family-substitution",
+                        "Slide " + slideNumber.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                        trimmedFamilyName,
+                        fallbackSlot: null,
+                        resolvedFontFamily: substitution.TargetFontFamily,
+                        additionalDetails: new Dictionary<string, string> {
+                            ["slideNumber"] = slideNumber.ToString(System.Globalization.CultureInfo.InvariantCulture)
+                        }));
+                }
+                return;
+            }
+
             if (pdfOptions.HasNamedFontFamily(trimmedFamilyName)) {
                 return;
             }
@@ -307,16 +326,15 @@ public static partial class PowerPointPdfConverterExtensions {
                 PdfCore.PdfStandardFont reportedFallback = mapped
                     ? fallback
                     : PdfCore.PdfStandardFont.Helvetica;
-                PdfCore.PdfStandardFont normalizedFallback = PdfCore.PdfStandardFontMapper.GetFontFamily(reportedFallback);
-                options.Report.Add(new PdfCore.PdfConversionWarning(
+                options.Report.Add(pdfOptions.CreateFontFamilySubstitutionWarning(
                     "OfficeIMO.PowerPoint.Pdf",
                     "font-family-substitution",
                     "Slide " + slideNumber.ToString(System.Globalization.CultureInfo.InvariantCulture),
-                    "The source font family '" + trimmedFamilyName + "' was unavailable or could not be embedded; generated text uses the mapped PDF family " + normalizedFallback + ".",
-                    details: new Dictionary<string, string> {
-                        ["slideNumber"] = slideNumber.ToString(System.Globalization.CultureInfo.InvariantCulture),
-                        ["fontFamily"] = trimmedFamilyName,
-                        ["fallbackSlot"] = normalizedFallback.ToString()
+                    trimmedFamilyName,
+                    reportedFallback,
+                    pdfOptions.GetEmbeddedFontFamilyName(reportedFallback),
+                    new Dictionary<string, string> {
+                        ["slideNumber"] = slideNumber.ToString(System.Globalization.CultureInfo.InvariantCulture)
                     }));
             }
         }

--- a/OfficeIMO.PowerPoint.Tests/Pdf/PowerPoint.SaveAsPdf.cs
+++ b/OfficeIMO.PowerPoint.Tests/Pdf/PowerPoint.SaveAsPdf.cs
@@ -119,6 +119,46 @@ public class PowerPointSaveAsPdfTests {
     }
 
     [Fact]
+    public void SaveAsPdf_PowerPointPresentation_Reports_Configured_Substitution_For_Used_Theme_Font() {
+        const string sourceFamily = "OfficeIMO Theme Body Source";
+        const string targetFamily = "OfficeIMO Portable Theme";
+        using var stream = new MemoryStream();
+        using PowerPointPresentation presentation = PowerPointPresentation.Create(stream);
+        presentation.SlideSize.SetSizePoints(240, 160);
+        presentation.SetThemeLatinFonts("OfficeIMO Theme Heading Source", sourceFamily);
+        presentation.AddSlide().AddTextBoxPoints("Theme font marker", 20, 24, 180, 40);
+
+        var configured = new PdfCore.PdfOptions();
+        configured
+            .RegisterNamedFontFamily(new PdfCore.PdfEmbeddedFontFamily(
+                targetFamily,
+                OfficeIMO.TestAssets.PdfTestFontAssets.LoadBundledOpenTypeCffFont()))
+            .RegisterFontFamilySubstitution(
+                sourceFamily,
+                targetFamily,
+                PdfCore.PdfFontFamilySubstitutionImpact.Compatible);
+
+        PdfCore.PdfDocumentConversionResult result = presentation.ToPdfDocumentResult(new PowerPointPdfSaveOptions {
+            PdfOptions = configured,
+            ResourcePolicy = PdfCore.PdfResourcePolicy.CreatePortableDeterministic()
+        });
+        byte[] bytes = result.ToBytes();
+
+        PdfCore.PdfConversionWarning diagnostic = Assert.Single(result.Warnings, item =>
+            item.Code == "font-family-substitution" &&
+            item.Details.TryGetValue("fontFamily", out string? family) &&
+            family == sourceFamily);
+        Assert.Equal(PdfCore.PdfConversionWarningSeverity.Information, diagnostic.Severity);
+        Assert.Equal(targetFamily, diagnostic.Details["resolvedFontFamily"]);
+        Assert.Equal(bool.TrueString, diagnostic.Details["plannedSubstitution"]);
+        using var pdf = PdfPigDocument.Open(new MemoryStream(bytes));
+        Assert.Contains(
+            pdf.GetPage(1).Letters,
+            letter => letter.FontName?.Contains(targetFamily.Replace(" ", string.Empty), StringComparison.OrdinalIgnoreCase) == true ||
+                      letter.FontName?.Contains("OfficeIMO", StringComparison.OrdinalIgnoreCase) == true);
+    }
+
+    [Fact]
     public void SaveAsPdf_PowerPointPresentation_PreservesTextRunHyperlinks() {
         using var stream = new MemoryStream();
         using PowerPointPresentation presentation = PowerPointPresentation.Create(stream);

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.Fonts.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.Fonts.cs
@@ -140,30 +140,23 @@ namespace OfficeIMO.Word.Pdf {
                     details: details));
             }
 
-            public void ReportFontSubstitution(string familyName, PdfCore.PdfStandardFont fallbackSlot, string? resolvedFontFamily = null) {
+            public void ReportFontSubstitution(
+                PdfCore.PdfOptions options,
+                string familyName,
+                PdfCore.PdfStandardFont fallbackSlot,
+                string? resolvedFontFamily = null) {
                 string normalizedFamily = NormalizeNativeFontFamily(familyName);
                 if (_report == null || !_reportedFontSubstitution.Add(normalizedFamily)) {
                     return;
                 }
 
-                PdfCore.PdfStandardFont normalizedSlot = PdfCore.PdfStandardFontMapper.GetFontFamily(fallbackSlot);
-                string message = string.IsNullOrWhiteSpace(resolvedFontFamily)
-                    ? "The source font family '" + familyName + "' was unavailable or could not be embedded; generated text uses the mapped PDF family " + normalizedSlot + "."
-                    : "The source font family '" + familyName + "' was unavailable or could not be embedded; generated text uses the embedded family '" + resolvedFontFamily + "' through the logical " + normalizedSlot + " PDF slot.";
-                var details = new Dictionary<string, string> {
-                    ["fontFamily"] = familyName,
-                    ["fallbackSlot"] = normalizedSlot.ToString()
-                };
-                if (!string.IsNullOrWhiteSpace(resolvedFontFamily)) {
-                    details["resolvedFontFamily"] = resolvedFontFamily!;
-                }
-
-                _report.Add(new PdfCore.PdfConversionWarning(
+                _report.Add(options.CreateFontFamilySubstitutionWarning(
                     "OfficeIMO.Word.Pdf",
                     "NativeFontFamilySubstituted",
                     "word:font[" + familyName + "]",
-                    message,
-                    details: details));
+                    familyName,
+                    fallbackSlot,
+                    resolvedFontFamily));
             }
         }
 

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.Fonts.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.Fonts.cs
@@ -143,7 +143,7 @@ namespace OfficeIMO.Word.Pdf {
             public void ReportFontSubstitution(
                 PdfCore.PdfOptions options,
                 string familyName,
-                PdfCore.PdfStandardFont fallbackSlot,
+                PdfCore.PdfStandardFont? fallbackSlot,
                 string? resolvedFontFamily = null) {
                 string normalizedFamily = NormalizeNativeFontFamily(familyName);
                 if (_report == null || !_reportedFontSubstitution.Add(normalizedFamily)) {

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.OptionsAndToc.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.OptionsAndToc.cs
@@ -46,6 +46,7 @@ namespace OfficeIMO.Word.Pdf {
                     nativeFontMap);
             }
             bool hasResolvedDocumentDefaultSubstitution =
+                string.IsNullOrWhiteSpace(options?.FontFamily) &&
                 !string.IsNullOrWhiteSpace(defaults.FontFamily) &&
                 pdfOptions.TryResolveFontFamilySubstitution(
                     defaults.FontFamily,
@@ -350,13 +351,19 @@ namespace OfficeIMO.Word.Pdf {
                 }
             }
 
-            RegisterNativeFontCandidate(
-                DocumentTraversal.GetListInfo(paragraph)?.MarkerFontFamily,
-                pdfOptions,
-                registeredFamilies,
-                registeredFontSlots,
-                allowSystemFontEmbedding,
-                nativeFontMap);
+            DocumentTraversal.ListInfo? listInfo = DocumentTraversal.GetListInfo(paragraph);
+            if (listInfo.HasValue &&
+                !ShouldUseNativeListTextFontForNormalizedMarker(
+                    listInfo.Value,
+                    NormalizeNativeBulletMarker(listInfo.Value.LevelText ?? string.Empty))) {
+                RegisterNativeFontCandidate(
+                    listInfo.Value.MarkerFontFamily,
+                    pdfOptions,
+                    registeredFamilies,
+                    registeredFontSlots,
+                    allowSystemFontEmbedding,
+                    nativeFontMap);
+            }
         }
 
         private static void RegisterNativeEffectiveParagraphFont(
@@ -402,6 +409,14 @@ namespace OfficeIMO.Word.Pdf {
                     trimmedFamilyName,
                     fallbackSlot: null,
                     substitution.TargetFontFamily);
+                return;
+            }
+
+            if (pdfOptions.TryResolveNamedOfficeFontFamily(
+                    trimmedFamilyName,
+                    out string? registeredNamedFamily) &&
+                registeredNamedFamily != null) {
+                nativeFontMap.RegisterNamed(trimmedFamilyName, registeredNamedFamily);
                 return;
             }
 

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.OptionsAndToc.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.OptionsAndToc.cs
@@ -45,7 +45,15 @@ namespace OfficeIMO.Word.Pdf {
                     allowDocumentFontEmbedding,
                     nativeFontMap);
             }
-            if (hasConfiguredPdfOptions && !appliedNativeDefaultFont) {
+            bool hasResolvedDocumentDefaultSubstitution =
+                !string.IsNullOrWhiteSpace(defaults.FontFamily) &&
+                pdfOptions.TryResolveFontFamilySubstitution(
+                    defaults.FontFamily,
+                    out PdfCore.PdfFontFamilySubstitution? documentDefaultSubstitution) &&
+                documentDefaultSubstitution != null;
+            if (hasConfiguredPdfOptions &&
+                !appliedNativeDefaultFont &&
+                !hasResolvedDocumentDefaultSubstitution) {
                 nativeFontMap.PreferPdfDefaultForDocumentDefaultFont();
             }
 

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.OptionsAndToc.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.OptionsAndToc.cs
@@ -154,6 +154,7 @@ namespace OfficeIMO.Word.Pdf {
                  PdfCore.PdfStandardFontMapper.IsStandardPdfFamilyEquivalent(familyName, pdfOptions.DefaultFont));
             if (!representedExactly) {
                 nativeFontMap.ReportFontSubstitution(
+                    pdfOptions,
                     familyName,
                     pdfOptions.DefaultFont,
                     GetEmbeddedFontFamilyName(pdfOptions, pdfOptions.DefaultFont));
@@ -383,6 +384,25 @@ namespace OfficeIMO.Word.Pdf {
                 return;
             }
 
+            if (pdfOptions.TryResolveFontFamilySubstitution(
+                    trimmedFamilyName,
+                    out PdfCore.PdfFontFamilySubstitution? substitution) &&
+                substitution != null) {
+                nativeFontMap.RegisterNamed(trimmedFamilyName, substitution.TargetFontFamily);
+                PdfCore.PdfStandardFont substitutionSlot =
+                    PdfCore.PdfStandardFontMapper.TryMapFontFamily(
+                        trimmedFamilyName,
+                        out PdfCore.PdfStandardFont mappedSubstitutionSlot)
+                        ? mappedSubstitutionSlot
+                        : PdfCore.PdfStandardFont.Helvetica;
+                nativeFontMap.ReportFontSubstitution(
+                    pdfOptions,
+                    trimmedFamilyName,
+                    substitutionSlot,
+                    substitution.TargetFontFamily);
+                return;
+            }
+
             if (allowSystemFontEmbedding &&
                 pdfOptions.TryRegisterNamedOfficeFontFamily(trimmedFamilyName, out string? registeredFamilyName) &&
                 registeredFamilyName != null) {
@@ -417,6 +437,7 @@ namespace OfficeIMO.Word.Pdf {
                      PdfCore.PdfStandardFontMapper.IsStandardPdfFamilyEquivalent(trimmedFamilyName, fontFamily));
                 if (!representedExactly) {
                     nativeFontMap.ReportFontSubstitution(
+                        pdfOptions,
                         trimmedFamilyName,
                         fontFamily,
                         GetEmbeddedFontFamilyName(pdfOptions, fontFamily));
@@ -438,6 +459,7 @@ namespace OfficeIMO.Word.Pdf {
                 ? mappedFallback
                 : PdfCore.PdfStandardFont.Helvetica;
             nativeFontMap.ReportFontSubstitution(
+                pdfOptions,
                 trimmedFamilyName,
                 fallback,
                 GetEmbeddedFontFamilyName(pdfOptions, fallback));

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.OptionsAndToc.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.OptionsAndToc.cs
@@ -397,16 +397,10 @@ namespace OfficeIMO.Word.Pdf {
                     out PdfCore.PdfFontFamilySubstitution? substitution) &&
                 substitution != null) {
                 nativeFontMap.RegisterNamed(trimmedFamilyName, substitution.TargetFontFamily);
-                PdfCore.PdfStandardFont substitutionSlot =
-                    PdfCore.PdfStandardFontMapper.TryMapFontFamily(
-                        trimmedFamilyName,
-                        out PdfCore.PdfStandardFont mappedSubstitutionSlot)
-                        ? mappedSubstitutionSlot
-                        : PdfCore.PdfStandardFont.Helvetica;
                 nativeFontMap.ReportFontSubstitution(
                     pdfOptions,
                     trimmedFamilyName,
-                    substitutionSlot,
+                    fallbackSlot: null,
                     substitution.TargetFontFamily);
                 return;
             }

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.Rendering.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.Rendering.cs
@@ -1117,8 +1117,18 @@ namespace OfficeIMO.Word.Pdf {
                 tableRunStyleDefaults.FontFamily,
                 nativeFontMap.UsePdfDefaultForDocumentDefaultFont ? null : nativeDefaults.FontFamily
             }) {
+                if (string.IsNullOrWhiteSpace(familyName)) {
+                    continue;
+                }
+
                 if (nativeFontMap.TryGetNamedFontFamily(familyName, out string? registeredFamilyName)) {
                     return registeredFamilyName;
+                }
+
+                // A standard-family match at a higher-precedence source must stop
+                // lower-precedence named defaults from overriding the run.
+                if (TryResolveNativeMappedFont(familyName, nativeFontMap, out _)) {
+                    return null;
                 }
             }
 

--- a/OfficeIMO.Word.Tests/Pdf/Word.SaveAsPdf.ListTests.cs
+++ b/OfficeIMO.Word.Tests/Pdf/Word.SaveAsPdf.ListTests.cs
@@ -1,6 +1,7 @@
 using OfficeIMO.Word;
 using OfficeIMO.Word.Pdf;
 using OfficeIMO.Pdf;
+using OfficeIMO.TestAssets;
 using DocumentFormat.OpenXml.Wordprocessing;
 using System.IO;
 using System.Linq;
@@ -48,7 +49,6 @@ namespace OfficeIMO.Tests {
         [Fact]
         public void SaveAsPdf_OfficeIMOEngine_UsesBodyFontForNormalizedLegacySymbolBullet() {
             string docPath = Path.Combine(_directoryWithFiles, "PdfNativeLegacySymbolBullet.docx");
-            string pdfPath = Path.Combine(_directoryWithFiles, "PdfNativeLegacySymbolBullet.pdf");
 
             using (WordDocument document = WordDocument.Create(docPath)) {
                 WordList bulletList = document.AddCustomList();
@@ -56,19 +56,34 @@ namespace OfficeIMO.Tests {
                 bulletList.AddItem("Normalized legacy bullet");
 
                 document.Save();
-                document.SaveAsPdf(pdfPath, new PdfSaveOptions {
+                var configured = new PdfOptions()
+                    .RegisterNamedFontFamily(new PdfEmbeddedFontFamily(
+                        "OfficeIMO Portable Symbols",
+                        ManagedTextShapingTestAssets.CreateFont('•')))
+                    .RegisterFontFamilySubstitution(
+                        "Symbol",
+                        "OfficeIMO Portable Symbols",
+                        PdfFontFamilySubstitutionImpact.LayoutSensitive);
+                PdfDocumentConversionResult result = document.ToPdfDocumentResult(new PdfSaveOptions {
                     IncludePageNumbers = false,
                     FontFamily = "Helvetica",
+                    PdfOptions = configured,
                     ResourcePolicy = PdfResourcePolicy.CreatePortableDeterministic()
                 });
+                byte[] bytes = result.ToBytes();
+
+                Assert.DoesNotContain(result.Warnings, warning =>
+                    warning.Code == "NativeFontFamilySubstituted" &&
+                    warning.Details.TryGetValue("fontFamily", out string? family) &&
+                    family == "Symbol");
+
+                using PdfPigDocument pdf = PdfPigDocument.Open(bytes);
+                var page = pdf.GetPage(1);
+                var markerLetter = Assert.Single(page.Letters, letter => letter.Value == "•" || letter.Value == "·");
+
+                Assert.Contains("Helvetica", markerLetter.FontName, StringComparison.OrdinalIgnoreCase);
+                Assert.Contains("Normalized legacy bullet", page.Text, StringComparison.Ordinal);
             }
-
-            using PdfPigDocument pdf = PdfPigDocument.Open(pdfPath);
-            var page = pdf.GetPage(1);
-            var markerLetter = Assert.Single(page.Letters, letter => letter.Value == "•" || letter.Value == "·");
-
-            Assert.Contains("Helvetica", markerLetter.FontName, StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("Normalized legacy bullet", page.Text, StringComparison.Ordinal);
         }
 
         [Fact]

--- a/OfficeIMO.Word.Tests/Pdf/Word.SaveAsPdf.ParagraphFormatting.cs
+++ b/OfficeIMO.Word.Tests/Pdf/Word.SaveAsPdf.ParagraphFormatting.cs
@@ -1251,6 +1251,7 @@ namespace OfficeIMO.Tests {
                 HighAnsi = sourceFamily
             };
             document.AddParagraph("AB");
+            document.AddParagraph("CD").SetFontFamily("Arial");
 
             var configured = new PdfOptions();
             configured
@@ -1276,11 +1277,16 @@ namespace OfficeIMO.Tests {
             Assert.Equal(PdfConversionWarningSeverity.Information, diagnostic.Severity);
             Assert.Equal(targetFamily, diagnostic.Details["resolvedFontFamily"]);
             Assert.Equal(bool.TrueString, diagnostic.Details["plannedSubstitution"]);
+            Assert.False(diagnostic.Details.ContainsKey("fallbackSlot"));
             using PdfPigDocument pdf = PdfPigDocument.Open(bytes);
             Assert.Contains(
                 pdf.GetPage(1).Letters,
                 letter => letter.FontName?.Contains(targetFamily.Replace(" ", string.Empty), StringComparison.OrdinalIgnoreCase) == true ||
                           letter.FontName?.Contains("OfficeIMO", StringComparison.OrdinalIgnoreCase) == true);
+            Assert.Contains(
+                pdf.GetPage(1).Letters,
+                letter => (letter.Value == "C" || letter.Value == "D") &&
+                          letter.FontName?.Contains("Helvetica", StringComparison.OrdinalIgnoreCase) == true);
         }
 
         [Fact]

--- a/OfficeIMO.Word.Tests/Pdf/Word.SaveAsPdf.ParagraphFormatting.cs
+++ b/OfficeIMO.Word.Tests/Pdf/Word.SaveAsPdf.ParagraphFormatting.cs
@@ -1238,6 +1238,52 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void SaveAsPdf_OfficeIMOEngine_Uses_Configured_Substitution_For_Document_Default_Font() {
+            const string sourceFamily = "OfficeIMO Document Default Source";
+            const string targetFamily = "OfficeIMO Portable Default";
+            using WordDocument document = WordDocument.Create(Path.Combine(_directoryWithFiles, "PdfNativeConfiguredDocumentDefaultSubstitution.docx"));
+            Styles styles = document._wordprocessingDocument.MainDocumentPart!.StyleDefinitionsPart!.Styles!;
+            styles.DocDefaults ??= new DocDefaults();
+            RunPropertiesDefault runDefaults = styles.DocDefaults.GetFirstChild<RunPropertiesDefault>() ?? styles.DocDefaults.AppendChild(new RunPropertiesDefault());
+            RunPropertiesBaseStyle runProperties = runDefaults.GetFirstChild<RunPropertiesBaseStyle>() ?? runDefaults.AppendChild(new RunPropertiesBaseStyle());
+            runProperties.RunFonts = new RunFonts {
+                Ascii = sourceFamily,
+                HighAnsi = sourceFamily
+            };
+            document.AddParagraph("AB");
+
+            var configured = new PdfOptions();
+            configured
+                .RegisterNamedFontFamily(new PdfEmbeddedFontFamily(
+                    targetFamily,
+                    ManagedTextShapingTestAssets.CreateFont(' ', 'A', 'B')))
+                .RegisterFontFamilySubstitution(
+                    sourceFamily,
+                    targetFamily,
+                    PdfFontFamilySubstitutionImpact.Compatible);
+
+            PdfDocumentConversionResult result = document.ToPdfDocumentResult(new PdfSaveOptions {
+                IncludePageNumbers = false,
+                PdfOptions = configured,
+                ResourcePolicy = PdfResourcePolicy.CreatePortableDeterministic()
+            });
+            byte[] bytes = result.ToBytes();
+
+            PdfConversionWarning diagnostic = Assert.Single(result.Warnings, item =>
+                item.Code == "NativeFontFamilySubstituted" &&
+                item.Details.TryGetValue("fontFamily", out string? family) &&
+                family == sourceFamily);
+            Assert.Equal(PdfConversionWarningSeverity.Information, diagnostic.Severity);
+            Assert.Equal(targetFamily, diagnostic.Details["resolvedFontFamily"]);
+            Assert.Equal(bool.TrueString, diagnostic.Details["plannedSubstitution"]);
+            using PdfPigDocument pdf = PdfPigDocument.Open(bytes);
+            Assert.Contains(
+                pdf.GetPage(1).Letters,
+                letter => letter.FontName?.Contains(targetFamily.Replace(" ", string.Empty), StringComparison.OrdinalIgnoreCase) == true ||
+                          letter.FontName?.Contains("OfficeIMO", StringComparison.OrdinalIgnoreCase) == true);
+        }
+
+        [Fact]
         public void SaveAsPdf_OfficeIMOEngine_Preserves_Explicit_PdfOptions_Font_Profile_Over_Document_Defaults() {
             using WordDocument document = WordDocument.Create(Path.Combine(_directoryWithFiles, "PdfNativeConfiguredFontProfile.docx"));
             Styles styles = document._wordprocessingDocument.MainDocumentPart!.StyleDefinitionsPart!.Styles!;

--- a/OfficeIMO.Word.Tests/Pdf/Word.SaveAsPdf.ParagraphFormatting.cs
+++ b/OfficeIMO.Word.Tests/Pdf/Word.SaveAsPdf.ParagraphFormatting.cs
@@ -1290,6 +1290,92 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void SaveAsPdf_OfficeIMOEngine_PreservesExplicitFontFamilyPrecedenceOverDocumentDefaultSubstitution() {
+            const string sourceFamily = "OfficeIMO Document Default Source";
+            const string targetFamily = "OfficeIMO Portable Default";
+            using WordDocument document = WordDocument.Create(Path.Combine(_directoryWithFiles, "PdfNativeExplicitFontPrecedence.docx"));
+            Styles styles = document._wordprocessingDocument.MainDocumentPart!.StyleDefinitionsPart!.Styles!;
+            styles.DocDefaults ??= new DocDefaults();
+            RunPropertiesDefault runDefaults = styles.DocDefaults.GetFirstChild<RunPropertiesDefault>() ?? styles.DocDefaults.AppendChild(new RunPropertiesDefault());
+            RunPropertiesBaseStyle runProperties = runDefaults.GetFirstChild<RunPropertiesBaseStyle>() ?? runDefaults.AppendChild(new RunPropertiesBaseStyle());
+            runProperties.RunFonts = new RunFonts {
+                Ascii = sourceFamily,
+                HighAnsi = sourceFamily
+            };
+            document.AddParagraph("AB");
+
+            var configured = new PdfOptions {
+                DefaultFont = PdfStandardFont.TimesRoman
+            };
+            configured
+                .RegisterNamedFontFamily(new PdfEmbeddedFontFamily(
+                    targetFamily,
+                    ManagedTextShapingTestAssets.CreateFont(' ', 'A', 'B')))
+                .RegisterFontFamilySubstitution(
+                    sourceFamily,
+                    targetFamily,
+                    PdfFontFamilySubstitutionImpact.Compatible);
+
+            PdfDocumentConversionResult result = document.ToPdfDocumentResult(new PdfSaveOptions {
+                IncludePageNumbers = false,
+                FontFamily = "OfficeIMO Unavailable Explicit Family",
+                PdfOptions = configured,
+                ResourcePolicy = PdfResourcePolicy.CreatePortableDeterministic()
+            });
+            byte[] bytes = result.ToBytes();
+
+            Assert.DoesNotContain(result.Warnings, warning =>
+                warning.Code == "NativeFontFamilySubstituted" &&
+                warning.Details.TryGetValue("fontFamily", out string? family) &&
+                family == sourceFamily);
+            using PdfPigDocument pdf = PdfPigDocument.Open(bytes);
+            Assert.All(
+                pdf.GetPage(1).Letters.Where(letter => letter.Value == "A" || letter.Value == "B"),
+                letter => Assert.Contains("Times", letter.FontName, StringComparison.OrdinalIgnoreCase));
+        }
+
+        [Fact]
+        public void SaveAsPdf_OfficeIMOEngine_UsesFirstRegisteredFamilyBeforeLaterFallbackSubstitution() {
+            const string primaryFamily = "OfficeIMO Primary Portable";
+            const string sourceFallback = "Calibri";
+            const string substitutedFamily = "OfficeIMO Portable Calibri";
+            using WordDocument document = WordDocument.Create(Path.Combine(_directoryWithFiles, "PdfNativeOrderedFamilyFallbacks.docx"));
+            document.AddParagraph("AB").SetFontFamily(primaryFamily + ", " + sourceFallback);
+
+            var configured = new PdfOptions();
+            configured
+                .RegisterNamedFontFamily(new PdfEmbeddedFontFamily(
+                    primaryFamily,
+                    ManagedTextShapingTestAssets.CreateFont(' ', 'A', 'B')))
+                .RegisterNamedFontFamily(new PdfEmbeddedFontFamily(
+                    substitutedFamily,
+                    ManagedTextShapingTestAssets.CreateFont(' ', 'A', 'B')))
+                .RegisterFontFamilySubstitution(
+                    sourceFallback,
+                    substitutedFamily,
+                    PdfFontFamilySubstitutionImpact.Compatible);
+
+            PdfDocumentConversionResult result = document.ToPdfDocumentResult(new PdfSaveOptions {
+                IncludePageNumbers = false,
+                PdfOptions = configured,
+                ResourcePolicy = PdfResourcePolicy.CreatePortableDeterministic()
+            });
+            byte[] bytes = result.ToBytes();
+
+            Assert.DoesNotContain(result.Warnings, warning =>
+                warning.Code == "NativeFontFamilySubstituted" &&
+                warning.Details.TryGetValue("fontFamily", out string? family) &&
+                family == primaryFamily + ", " + sourceFallback);
+            using PdfPigDocument pdf = PdfPigDocument.Open(bytes);
+            Assert.All(
+                pdf.GetPage(1).Letters.Where(letter => letter.Value == "A" || letter.Value == "B"),
+                letter => Assert.Contains("Primary", letter.FontName, StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(
+                pdf.GetPage(1).Letters,
+                letter => letter.FontName?.Contains("Calibri", StringComparison.OrdinalIgnoreCase) == true);
+        }
+
+        [Fact]
         public void SaveAsPdf_OfficeIMOEngine_Preserves_Explicit_PdfOptions_Font_Profile_Over_Document_Defaults() {
             using WordDocument document = WordDocument.Create(Path.Combine(_directoryWithFiles, "PdfNativeConfiguredFontProfile.docx"));
             Styles styles = document._wordprocessingDocument.MainDocumentPart!.StyleDefinitionsPart!.Styles!;

--- a/Website/Apps/OfficeIMO.Web.Converter.Tests/BrowserConversionServiceTests.cs
+++ b/Website/Apps/OfficeIMO.Web.Converter.Tests/BrowserConversionServiceTests.cs
@@ -122,13 +122,84 @@ public sealed class BrowserConversionServiceTests {
         JsonElement root = manifest.RootElement;
         Assert.Equal("officeimo-browser-compact-2026.07", root.GetProperty("fontPack").GetProperty("id").GetString());
         Assert.Equal(
-            "99fe9605fae25324712287bc2212236771b67515ec77dab263a35fc48079e72f",
+            "58d48fe49e16ffa209a594a905260e81c7bcd5fb10aaced1e76601d2f18cea68",
             root.GetProperty("fontPack").GetProperty("fingerprint").GetString());
+        JsonElement substitutions = root.GetProperty("fontPack").GetProperty("substitutions");
+        Assert.Contains(
+            substitutions.EnumerateArray(),
+            substitution =>
+                substitution.GetProperty("source").GetString() == "Calibri Light" &&
+                substitution.GetProperty("target").GetString() == "Carlito" &&
+                substitution.GetProperty("impact").GetString() == "Compatible");
+        Assert.Contains(
+            substitutions.EnumerateArray(),
+            substitution =>
+                substitution.GetProperty("source").GetString() == "Symbol" &&
+                substitution.GetProperty("target").GetString() == "Noto Sans Symbols 2" &&
+                substitution.GetProperty("impact").GetString() == "LayoutSensitive");
         Assert.True(root.GetProperty("output").GetProperty("tagged").GetBoolean());
         Assert.Equal(result.FidelityStatus, root.GetProperty("fidelityStatus").GetString());
         Assert.False(string.IsNullOrWhiteSpace(root.GetProperty("conversionId").GetString()));
         Assert.Empty(root.GetProperty("warnings").EnumerateArray());
         Assert.Empty(result.Warnings);
+    }
+
+    [Fact]
+    public void WordConversion_ClassifiesCompatibleAndLayoutSensitiveFontSubstitutions() {
+        using WordDocument source = WordDocument.Create();
+        source.AddParagraph("Compatible business text").FontFamily = "Calibri Light";
+        source.AddParagraph("✓").FontFamily = "Symbol";
+        byte[] bytes = source.ToBytes();
+        var document = new SelectedDocument("substitutions.docx", ".docx", "DOCX", bytes.LongLength, bytes);
+
+        ConversionResult result = _service.ConvertFile(
+            ConversionRouteCatalog.Find("docx-pdf"),
+            document,
+            limitExcelRows: false);
+
+        ConversionWarningView compatible = Assert.Single(
+            result.StructuredWarnings,
+            warning =>
+                warning.Code == "NativeFontFamilySubstituted" &&
+                warning.Message.Contains("'Calibri Light'", StringComparison.Ordinal));
+        ConversionWarningView symbol = Assert.Single(
+            result.StructuredWarnings,
+            warning =>
+                warning.Code == "NativeFontFamilySubstituted" &&
+                warning.Message.Contains("'Symbol'", StringComparison.Ordinal));
+
+        Assert.Equal("Information", compatible.Severity);
+        Assert.False(compatible.CanChangePagination);
+        Assert.Contains("'Carlito'", compatible.Message, StringComparison.Ordinal);
+        Assert.Equal("Warning", symbol.Severity);
+        Assert.True(symbol.CanChangePagination);
+        Assert.Contains("'Noto Sans Symbols 2'", symbol.Message, StringComparison.Ordinal);
+        Assert.Equal("FaithfulWithSubstitutions", result.FidelityStatus);
+        Assert.Contains("NotoSansSymbols2", Encoding.ASCII.GetString(result.Bytes), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WordConversion_CompatibleSubstitutionRemainsFaithful() {
+        using WordDocument source = WordDocument.Create();
+        source.AddParagraph("Compatible business text").FontFamily = "Calibri";
+        byte[] bytes = source.ToBytes();
+        var document = new SelectedDocument("compatible.docx", ".docx", "DOCX", bytes.LongLength, bytes);
+
+        ConversionResult result = _service.ConvertFile(
+            ConversionRouteCatalog.Find("docx-pdf"),
+            document,
+            limitExcelRows: false);
+
+        ConversionWarningView warning = Assert.Single(result.StructuredWarnings);
+        Assert.Equal("NativeFontFamilySubstituted", warning.Code);
+        Assert.Equal("Information", warning.Severity);
+        Assert.False(warning.CanChangePagination);
+        Assert.Equal("Faithful", result.FidelityStatus);
+        Assert.Contains("Carlito", Encoding.ASCII.GetString(result.Bytes), StringComparison.Ordinal);
+        using JsonDocument manifest = JsonDocument.Parse(result.CompanionReport!.Bytes);
+        JsonElement manifestWarning = Assert.Single(manifest.RootElement.GetProperty("warnings").EnumerateArray());
+        Assert.Equal("Information", manifestWarning.GetProperty("severity").GetString());
+        Assert.False(manifestWarning.GetProperty("canChangePagination").GetBoolean());
     }
 
     [Fact]
@@ -270,11 +341,17 @@ public sealed class BrowserConversionServiceTests {
     public void ExcelConversion_UsesThePortableTaggedPdfProfile() {
         using ExcelDocument workbook = ExcelDocument.Create();
         var sheet = workbook.AddWorksheet("Delivery");
-        sheet.CellValue(1, 1, "Workstream");
+        sheet.CellAt(1, 1).SetValue("Workstream").SetFontName("Calibri Light");
         sheet.CellValue(1, 2, "Status");
         sheet.CellValue(2, 1, "Platform");
         sheet.CellValue(2, 2, "Ready");
+        Assert.Equal("Calibri Light", sheet.CellAt(1, 1).GetStyle().FontName);
+        Assert.True(sheet.CellAt(1, 1).GetStyle().IsFontFamilyExplicit);
         byte[] bytes = workbook.ToBytes();
+        using (ExcelDocument reloaded = ExcelDocument.Load(new MemoryStream(bytes))) {
+            Assert.Equal("Calibri Light", reloaded.Sheets[0].CellAt(1, 1).GetStyle().FontName);
+            Assert.True(reloaded.Sheets[0].CellAt(1, 1).GetStyle().IsFontFamilyExplicit);
+        }
         var document = new SelectedDocument("delivery.xlsx", ".xlsx", "XLSX", bytes.LongLength, bytes);
 
         ConversionResult result = _service.ConvertFile(
@@ -286,6 +363,14 @@ public sealed class BrowserConversionServiceTests {
         Assert.True(pdf.HasTaggedContent);
         Assert.Contains("Workstream", pdf.ExtractText(), StringComparison.Ordinal);
         Assert.Contains("Platform", pdf.ExtractText(), StringComparison.Ordinal);
+        ConversionWarningView fontSubstitution = Assert.Single(
+            result.StructuredWarnings,
+            warning =>
+                warning.Code == "WorksheetFontFamilySubstituted" &&
+                warning.Message.Contains("'Calibri Light'", StringComparison.Ordinal));
+        Assert.Equal("Information", fontSubstitution.Severity);
+        Assert.False(fontSubstitution.CanChangePagination);
+        Assert.Contains("'Carlito'", fontSubstitution.Message, StringComparison.Ordinal);
         BrowserConversionArtifact report = Assert.IsType<BrowserConversionArtifact>(result.CompanionReport);
         Assert.Equal("delivery.conversion.json", report.FileName);
         Assert.Contains("OfficeIMO.Excel.Pdf", Encoding.UTF8.GetString(report.Bytes), StringComparison.Ordinal);
@@ -310,7 +395,8 @@ public sealed class BrowserConversionServiceTests {
     [Fact]
     public void PowerPointConversion_UsesThePortableTaggedPdfProfile() {
         using PowerPointPresentation presentation = PowerPointPresentation.Create();
-        presentation.AddSlide().AddTextBoxPoints("Delivery readiness", 36, 36, 320, 64);
+        PowerPointTextBox textBox = presentation.AddSlide().AddTextBoxPoints("Delivery readiness", 36, 36, 320, 64);
+        textBox.FontName = "Calibri";
         byte[] bytes = presentation.ToBytes();
         var document = new SelectedDocument("readiness.pptx", ".pptx", "PPTX", bytes.LongLength, bytes);
 
@@ -322,6 +408,14 @@ public sealed class BrowserConversionServiceTests {
         PdfReadDocument pdf = PdfReadDocument.Open(result.Bytes);
         Assert.True(pdf.HasTaggedContent);
         Assert.Contains("Delivery readiness", pdf.ExtractText(), StringComparison.Ordinal);
+        ConversionWarningView fontSubstitution = Assert.Single(
+            result.StructuredWarnings,
+            warning =>
+                warning.Code == "font-family-substitution" &&
+                warning.Message.Contains("'Calibri'", StringComparison.Ordinal));
+        Assert.Equal("Information", fontSubstitution.Severity);
+        Assert.False(fontSubstitution.CanChangePagination);
+        Assert.Contains("'Carlito'", fontSubstitution.Message, StringComparison.Ordinal);
         BrowserConversionArtifact report = Assert.IsType<BrowserConversionArtifact>(result.CompanionReport);
         Assert.Equal("readiness.conversion.json", report.FileName);
         Assert.Contains("OfficeIMO.PowerPoint.Pdf", Encoding.UTF8.GetString(report.Bytes), StringComparison.Ordinal);

--- a/Website/Apps/OfficeIMO.Web.Converter.Tests/BrowserConversionServiceTests.cs
+++ b/Website/Apps/OfficeIMO.Web.Converter.Tests/BrowserConversionServiceTests.cs
@@ -140,8 +140,12 @@ public sealed class BrowserConversionServiceTests {
         Assert.True(root.GetProperty("output").GetProperty("tagged").GetBoolean());
         Assert.Equal(result.FidelityStatus, root.GetProperty("fidelityStatus").GetString());
         Assert.False(string.IsNullOrWhiteSpace(root.GetProperty("conversionId").GetString()));
-        Assert.Empty(root.GetProperty("warnings").EnumerateArray());
-        Assert.Empty(result.Warnings);
+        Assert.DoesNotContain(
+            root.GetProperty("warnings").EnumerateArray(),
+            warning => warning.GetProperty("severity").GetString() != "Information");
+        Assert.DoesNotContain(
+            result.StructuredWarnings,
+            warning => warning.Severity != "Information");
     }
 
     [Fact]

--- a/Website/Apps/OfficeIMO.Web.Converter/Assets/Fonts/font-pack.json
+++ b/Website/Apps/OfficeIMO.Web.Converter/Assets/Fonts/font-pack.json
@@ -5,7 +5,6 @@
     {
       "family": "Carlito",
       "purpose": "Default Latin Office document family and metric-compatible substitute for Calibri.",
-      "aliases": [ "Calibri", "Calibri Light", "Aptos", "Aptos Display" ],
       "license": "SIL Open Font License 1.1",
       "sourceRepository": "https://github.com/google/fonts",
       "sourceCommit": "9fab8b6cc7b2f20376914fd765d918c698c66d75",
@@ -35,6 +34,33 @@
       "files": [
         { "name": "NotoSansSymbols2-Regular.ttf", "sha256": "7d5fb73b7ca67a6798101741f5d280a3d016a56a197afcd4199dbb57b4b82a21" }
       ]
+    }
+  ],
+  "substitutions": [
+    {
+      "source": "Calibri",
+      "target": "Carlito",
+      "impact": "Compatible"
+    },
+    {
+      "source": "Calibri Light",
+      "target": "Carlito",
+      "impact": "Compatible"
+    },
+    {
+      "source": "Aptos",
+      "target": "Carlito",
+      "impact": "LayoutSensitive"
+    },
+    {
+      "source": "Aptos Display",
+      "target": "Carlito",
+      "impact": "LayoutSensitive"
+    },
+    {
+      "source": "Symbol",
+      "target": "Noto Sans Symbols 2",
+      "impact": "LayoutSensitive"
     }
   ]
 }

--- a/Website/Apps/OfficeIMO.Web.Converter/Components/ConverterWorkspace.razor
+++ b/Website/Apps/OfficeIMO.Web.Converter/Components/ConverterWorkspace.razor
@@ -64,10 +64,10 @@
 
             <section class="ocx-output-panel" aria-labelledby="output-title">
                 <div class="ocx-panel-heading ocx-panel-heading--output"><div><p>Result</p><h2 id="output-title">@OutputHeading</h2></div></div>
-                @if (Output?.StructuredWarnings.Count > 0) {
+                @if (ReviewWarnings.Count > 0) {
                     <div class="ocx-warning-summary" role="status">
-                        <strong>Review @Output.StructuredWarnings.Count conversion warning@(Output.StructuredWarnings.Count == 1 ? null : "s") before download</strong>
-                        <span>@(Output.StructuredWarnings.Any(static warning => warning.CanChangePagination) ? "At least one warning can change text fit or pagination." : "The output is usable, but one or more constructs were substituted or approximated.")</span>
+                        <strong>Review @ReviewWarnings.Count conversion warning@(ReviewWarnings.Count == 1 ? null : "s") before download</strong>
+                        <span>@(ReviewWarnings.Any(static warning => warning.CanChangePagination) ? "At least one warning can change text fit or pagination." : "The output is usable, but one or more constructs were substituted or approximated.")</span>
                     </div>
                 }
                 <div class="ocx-output-actions">
@@ -102,6 +102,14 @@
                             <strong>@group.Key</strong>
                             @foreach (ConversionWarningView warning in group) {
                                 <div class="ocx-diagnostic ocx-diagnostic--warning"><span class="ocx-dot ocx-dot--warn"></span><div><strong>@warning.Construct · @warning.Code</strong><span>@warning.Message@(warning.CanChangePagination ? " May affect text fit or pagination." : null)</span></div></div>
+                            }
+                        </div>
+                    }
+                    @foreach (IGrouping<string, ConversionWarningView> group in InformationGroups) {
+                        <div class="ocx-diagnostic-group">
+                            <strong>@group.Key</strong>
+                            @foreach (ConversionWarningView information in group) {
+                                <div class="ocx-diagnostic"><span class="ocx-dot ocx-dot--good"></span><div><strong>@information.Construct · @information.Code</strong><span>@information.Message</span></div></div>
                             }
                         </div>
                     }

--- a/Website/Apps/OfficeIMO.Web.Converter/Components/ConverterWorkspace.razor.cs
+++ b/Website/Apps/OfficeIMO.Web.Converter/Components/ConverterWorkspace.razor.cs
@@ -64,21 +64,20 @@ This **Markdown** becomes a browser preview or an editable Word document.
     private static IReadOnlyList<BrowserPdfProfile> PdfProfiles => BrowserPdfProfileCatalog.All;
     private BrowserPdfProfile SelectedProfile => BrowserPdfProfileCatalog.Find(SelectedProfileId);
     private bool IsPdfRoute => string.Equals(ActiveRoute.Target, "PDF", StringComparison.OrdinalIgnoreCase);
-    private IEnumerable<IGrouping<string, ConversionWarningView>> WarningGroups {
-        get {
-            if (Output is null) {
-                return Enumerable.Empty<IGrouping<string, ConversionWarningView>>();
-            }
-
-            return Output.StructuredWarnings
-                .GroupBy(
-                    static warning => warning.PageNumber.HasValue
-                        ? $"Page {warning.PageNumber.Value} · {warning.Construct}"
-                        : $"Document · {warning.Construct}",
-                    StringComparer.Ordinal)
-                .OrderBy(static group => group.Key, StringComparer.Ordinal);
-        }
-    }
+    private IReadOnlyList<ConversionWarningView> ReviewWarnings =>
+        Output?.StructuredWarnings
+            .Where(static warning =>
+                !string.Equals(warning.Severity, "Information", StringComparison.OrdinalIgnoreCase))
+            .ToArray()
+        ?? [];
+    private IEnumerable<IGrouping<string, ConversionWarningView>> WarningGroups =>
+        GroupWarnings(ReviewWarnings);
+    private IEnumerable<IGrouping<string, ConversionWarningView>> InformationGroups =>
+        GroupWarnings(
+            Output?.StructuredWarnings
+                .Where(static warning =>
+                    string.Equals(warning.Severity, "Information", StringComparison.OrdinalIgnoreCase))
+            ?? Enumerable.Empty<ConversionWarningView>());
     private bool CanConvert => !IsBusy && (ActiveRoute.InputKind == ConversionInputKind.File ? SelectedFile is not null : !string.IsNullOrWhiteSpace(TextInput));
     private string OutputHeading => Output?.FileName ?? $"{ActiveRoute.Target} output";
     private string ElapsedLabel => ElapsedMilliseconds < 1000 ? $"{ElapsedMilliseconds} ms" : $"{ElapsedMilliseconds / 1000d:0.0} s";
@@ -288,6 +287,16 @@ This **Markdown** becomes a browser preview or an editable Word document.
 
     private static ConversionDiagnostic ReadyDiagnostic() =>
         new("Ready", "Choose a source and run the conversion. Nothing is uploaded.", "ocx-dot--good");
+
+    private static IEnumerable<IGrouping<string, ConversionWarningView>> GroupWarnings(
+        IEnumerable<ConversionWarningView> warnings) =>
+        warnings
+            .GroupBy(
+                static warning => warning.PageNumber.HasValue
+                    ? $"Page {warning.PageNumber.Value} · {warning.Construct}"
+                    : $"Document · {warning.Construct}",
+                StringComparer.Ordinal)
+            .OrderBy(static group => group.Key, StringComparer.Ordinal);
 
     public async ValueTask DisposeAsync() {
         if (_interop is not null) {

--- a/Website/Apps/OfficeIMO.Web.Converter/OfficeIMO.Web.Converter.csproj
+++ b/Website/Apps/OfficeIMO.Web.Converter/OfficeIMO.Web.Converter.csproj
@@ -28,6 +28,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Assets\Fonts\*.ttf" />
+    <EmbeddedResource Include="Assets\Fonts\font-pack.json" />
     <None Update="Assets\Fonts\*.txt" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
     <None Update="Assets\Fonts\font-pack.json" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
   </ItemGroup>

--- a/Website/Apps/OfficeIMO.Web.Converter/Services/BrowserConversionService.cs
+++ b/Website/Apps/OfficeIMO.Web.Converter/Services/BrowserConversionService.cs
@@ -222,12 +222,13 @@ public sealed class BrowserConversionService {
                     ? feature
                     : warning.Code);
         bool canChangePagination =
-            warning.Code.Contains("font", StringComparison.OrdinalIgnoreCase) ||
-            warning.Code.Contains("pagination", StringComparison.OrdinalIgnoreCase) ||
-            warning.Code.Contains("overflow", StringComparison.OrdinalIgnoreCase) ||
-            warning.LayoutDiagnostic?.Kind is PdfLayoutDiagnosticKind.AdjustedGeometry
-                or PdfLayoutDiagnosticKind.ClippedContent
-                or PdfLayoutDiagnosticKind.Overflow;
+            warning.Severity != PdfConversionWarningSeverity.Information &&
+            (warning.Code.Contains("font", StringComparison.OrdinalIgnoreCase) ||
+             warning.Code.Contains("pagination", StringComparison.OrdinalIgnoreCase) ||
+             warning.Code.Contains("overflow", StringComparison.OrdinalIgnoreCase) ||
+             warning.LayoutDiagnostic?.Kind is PdfLayoutDiagnosticKind.AdjustedGeometry
+                 or PdfLayoutDiagnosticKind.ClippedContent
+                 or PdfLayoutDiagnosticKind.Overflow);
         return new ConversionWarningView(
             warning.Code,
             warning.Source,

--- a/Website/Apps/OfficeIMO.Web.Converter/Services/BrowserPdfConversionManifest.cs
+++ b/Website/Apps/OfficeIMO.Web.Converter/Services/BrowserPdfConversionManifest.cs
@@ -70,7 +70,13 @@ internal static class BrowserPdfConversionManifest {
                 id = BrowserPortablePdfProfile.FontPackId,
                 fingerprint = BrowserPortablePdfProfile.FontPackFingerprint,
                 defaultFamily = BrowserPortablePdfProfile.DefaultFontFamily,
-                coverage = new[] { "Latin", "Arabic glyphs", "common symbols" }
+                coverage = new[] { "Latin", "Arabic glyphs", "common symbols" },
+                substitutions = BrowserPortablePdfProfile.FontFamilySubstitutions.Select(
+                    static substitution => new {
+                        source = substitution.SourceFontFamily,
+                        target = substitution.TargetFontFamily,
+                        impact = substitution.Impact.ToString()
+                    }).ToArray()
             },
             policy = new {
                 resources = "portable-deterministic",
@@ -111,12 +117,13 @@ internal static class BrowserPdfConversionManifest {
                 pageNumber = TryReadPositiveInt(warning.Details, "pageNumber")
                     ?? TryReadPositiveInt(warning.Details, "page"),
                 canChangePagination =
-                    warning.Code.Contains("font", StringComparison.OrdinalIgnoreCase) ||
-                    warning.Code.Contains("pagination", StringComparison.OrdinalIgnoreCase) ||
-                    warning.Code.Contains("overflow", StringComparison.OrdinalIgnoreCase) ||
-                    warning.LayoutDiagnostic?.Kind is PdfLayoutDiagnosticKind.AdjustedGeometry
-                        or PdfLayoutDiagnosticKind.ClippedContent
-                        or PdfLayoutDiagnosticKind.Overflow,
+                    warning.Severity != PdfConversionWarningSeverity.Information &&
+                    (warning.Code.Contains("font", StringComparison.OrdinalIgnoreCase) ||
+                     warning.Code.Contains("pagination", StringComparison.OrdinalIgnoreCase) ||
+                     warning.Code.Contains("overflow", StringComparison.OrdinalIgnoreCase) ||
+                     warning.LayoutDiagnostic?.Kind is PdfLayoutDiagnosticKind.AdjustedGeometry
+                         or PdfLayoutDiagnosticKind.ClippedContent
+                         or PdfLayoutDiagnosticKind.Overflow),
                 details = warning.Details.OrderBy(pair => pair.Key, StringComparer.Ordinal)
                     .ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.Ordinal)
             }).ToArray()

--- a/Website/Apps/OfficeIMO.Web.Converter/Services/BrowserPortablePdfProfile.cs
+++ b/Website/Apps/OfficeIMO.Web.Converter/Services/BrowserPortablePdfProfile.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.Json;
 using OfficeIMO.Drawing.HarfBuzz;
 using OfficeIMO.Pdf;
 using OfficeIMO.Web.Converter.Models;
@@ -11,13 +12,15 @@ namespace OfficeIMO.Web.Converter.Services;
 /// Supplies the explicit, host-independent PDF font profile used by browser conversions.
 /// </summary>
 internal static class BrowserPortablePdfProfile {
-    internal const string FontPackId = "officeimo-browser-compact-2026.07";
     internal const string DefaultFontFamily = "Carlito";
-    internal const string ExpectedFontPackFingerprint = "99fe9605fae25324712287bc2212236771b67515ec77dab263a35fc48079e72f";
+    internal const string ExpectedFontPackFingerprint = "58d48fe49e16ffa209a594a905260e81c7bcd5fb10aaced1e76601d2f18cea68";
 
     private static readonly Lazy<FontPackData> Data = new(LoadFontPack, isThreadSafe: true);
 
+    internal static string FontPackId => Data.Value.Id;
     internal static string FontPackFingerprint => Data.Value.Fingerprint;
+    internal static IReadOnlyList<PdfFontFamilySubstitution> FontFamilySubstitutions =>
+        Data.Value.Substitutions;
 
     internal static PdfOptions CreateOptions(BrowserPdfProfile profile) {
         ArgumentNullException.ThrowIfNull(profile);
@@ -58,11 +61,22 @@ internal static class BrowserPortablePdfProfile {
                 new PdfEmbeddedFontFallbackCandidate("Noto Sans Arabic", data.NotoSansArabic),
                 new PdfEmbeddedFontFallbackCandidate("Noto Sans Symbols 2", data.NotoSansSymbols)
             ]));
+        foreach (PdfFontFamilySubstitution substitution in data.Substitutions) {
+            options.RegisterFontFamilySubstitution(
+                substitution.SourceFontFamily,
+                substitution.TargetFontFamily,
+                substitution.Impact);
+        }
 
         return options;
     }
 
     private static FontPackData LoadFontPack() {
+        byte[] manifestBytes = ReadResource("font-pack.json");
+        FontPackManifest manifest = JsonSerializer.Deserialize<FontPackManifest>(
+            manifestBytes,
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
+            ?? throw new InvalidOperationException("The embedded browser PDF font pack manifest is invalid.");
         byte[] carlitoRegular = ReadResource("Carlito-Regular.ttf");
         byte[] carlitoBold = ReadResource("Carlito-Bold.ttf");
         byte[] carlitoItalic = ReadResource("Carlito-Italic.ttf");
@@ -70,15 +84,21 @@ internal static class BrowserPortablePdfProfile {
         byte[] notoSansArabic = ReadResource("NotoSansArabic-Regular.ttf");
         byte[] notoSansSymbols = ReadResource("NotoSansSymbols2-Regular.ttf");
 
+        byte[] normalizedManifestBytes = Encoding.UTF8.GetBytes(
+            Encoding.UTF8.GetString(manifestBytes)
+                .Replace("\r\n", "\n", StringComparison.Ordinal)
+                .Replace("\r", "\n", StringComparison.Ordinal));
         var assets = new Dictionary<string, byte[]>(StringComparer.Ordinal) {
             ["Carlito-Bold.ttf"] = carlitoBold,
             ["Carlito-BoldItalic.ttf"] = carlitoBoldItalic,
             ["Carlito-Italic.ttf"] = carlitoItalic,
             ["Carlito-Regular.ttf"] = carlitoRegular,
             ["NotoSansArabic-Regular.ttf"] = notoSansArabic,
-            ["NotoSansSymbols2-Regular.ttf"] = notoSansSymbols
+            ["NotoSansSymbols2-Regular.ttf"] = notoSansSymbols,
+            ["font-pack.json"] = normalizedManifestBytes
         };
 
+        IReadOnlyList<PdfFontFamilySubstitution> substitutions = ValidateManifest(manifest);
         string fingerprint = ComputeFingerprint(assets);
         if (!string.Equals(fingerprint, ExpectedFontPackFingerprint, StringComparison.Ordinal)) {
             throw new InvalidOperationException(
@@ -86,13 +106,57 @@ internal static class BrowserPortablePdfProfile {
         }
 
         return new FontPackData(
+            manifest.Id,
             carlitoRegular,
             carlitoBold,
             carlitoItalic,
             carlitoBoldItalic,
             notoSansArabic,
             notoSansSymbols,
+            substitutions,
             fingerprint);
+    }
+
+    private static IReadOnlyList<PdfFontFamilySubstitution> ValidateManifest(FontPackManifest manifest) {
+        if (string.IsNullOrWhiteSpace(manifest.Id)) {
+            throw new InvalidOperationException("The embedded browser PDF font pack manifest has no id.");
+        }
+
+        var targetFamilies = new HashSet<string>(
+            manifest.Fonts
+                .Where(static font => !string.IsNullOrWhiteSpace(font.Family))
+                .Select(static font => font.Family.Trim()),
+            StringComparer.OrdinalIgnoreCase);
+        var sourceFamilies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var substitutions = new List<PdfFontFamilySubstitution>();
+        foreach (FontPackSubstitution declared in manifest.Substitutions) {
+            if (string.IsNullOrWhiteSpace(declared.Source) ||
+                string.IsNullOrWhiteSpace(declared.Target) ||
+                !targetFamilies.Contains(declared.Target.Trim())) {
+                throw new InvalidOperationException(
+                    "The embedded browser PDF font pack contains an invalid substitution declaration.");
+            }
+            if (!sourceFamilies.Add(declared.Source.Trim())) {
+                throw new InvalidOperationException(
+                    "The embedded browser PDF font pack contains duplicate substitution sources.");
+            }
+            if (!Enum.TryParse(
+                    declared.Impact,
+                    ignoreCase: true,
+                    out PdfFontFamilySubstitutionImpact impact) ||
+                (impact != PdfFontFamilySubstitutionImpact.Compatible &&
+                 impact != PdfFontFamilySubstitutionImpact.LayoutSensitive)) {
+                throw new InvalidOperationException(
+                    "The embedded browser PDF font pack contains an invalid substitution impact.");
+            }
+
+            substitutions.Add(new PdfFontFamilySubstitution(
+                declared.Source,
+                declared.Target,
+                impact));
+        }
+
+        return substitutions.AsReadOnly();
     }
 
     private static byte[] ReadResource(string fileName) {
@@ -119,11 +183,22 @@ internal static class BrowserPortablePdfProfile {
     }
 
     private sealed record FontPackData(
+        string Id,
         byte[] CarlitoRegular,
         byte[] CarlitoBold,
         byte[] CarlitoItalic,
         byte[] CarlitoBoldItalic,
         byte[] NotoSansArabic,
         byte[] NotoSansSymbols,
+        IReadOnlyList<PdfFontFamilySubstitution> Substitutions,
         string Fingerprint);
+
+    private sealed record FontPackManifest(
+        string Id,
+        IReadOnlyList<FontPackFont> Fonts,
+        IReadOnlyList<FontPackSubstitution> Substitutions);
+
+    private sealed record FontPackFont(string Family);
+
+    private sealed record FontPackSubstitution(string Source, string Target, string Impact);
 }


### PR DESCRIPTION
## What changed

- Added an explicit font-family substitution contract in OfficeIMO.Pdf and used it consistently from the Word, Excel, and PowerPoint PDF adapters.
- Made the browser font pack declare its supported mappings and expected layout impact, including Calibri/Calibri Light to Carlito and Symbol to Noto Sans Symbols 2.
- Separated compatible informational substitutions from warnings that need review in both the UI and downloaded conversion report.

## Customer impact

The converter still runs entirely in the browser with no upload or server-side document processing. Metric-compatible substitutions no longer inflate the amber warning count or claim they can change pagination. Layout-sensitive substitutions remain visible, and Symbol content now resolves to the embedded symbol family instead of Carlito.

## Validation

Validated the shared PDF core on all supported target frameworks, the focused Word/Excel/PowerPoint adapter contracts, the full browser converter test suite, the final WebAssembly publish artifact including native HarfBuzz symbols, and the affected DOCX flow in a real browser.