### PR TITLE
Keep the benchmark explorer readable at every viewport

### DIFF
--- a/Website/scripts/Test-BenchmarkPage.ps1
+++ b/Website/scripts/Test-BenchmarkPage.ps1
@@ -8,6 +8,7 @@ $resolvedSiteRoot = [System.IO.Path]::GetFullPath((Join-Path (Get-Location) $Sit
 $dataPath = Join-Path $resolvedSiteRoot 'data\benchmarks-excel.json'
 $pagePath = Join-Path $resolvedSiteRoot 'benchmarks\index.html'
 $scriptPath = Join-Path $resolvedSiteRoot 'js\benchmarks.js'
+$stylePath = Join-Path $PSScriptRoot '..\themes\officeimo\assets\app.css'
 
 if (-not (Test-Path -LiteralPath $dataPath -PathType Leaf)) {
     throw "Benchmark data JSON was not published to '$dataPath'."
@@ -19,6 +20,10 @@ if (-not (Test-Path -LiteralPath $pagePath -PathType Leaf)) {
 
 if (-not (Test-Path -LiteralPath $scriptPath -PathType Leaf)) {
     throw "Benchmark sort/filter script was not published to '$scriptPath'."
+}
+
+if (-not (Test-Path -LiteralPath $stylePath -PathType Leaf)) {
+    throw "Benchmark layout styles were not found at '$stylePath'."
 }
 
 $data = Get-Content -LiteralPath $dataPath -Raw -Encoding UTF8 | ConvertFrom-Json
@@ -63,6 +68,20 @@ if ($pageHtml -notmatch 'data-benchmark-sort="scenario"' -or $pageHtml -notmatch
 $scriptText = Get-Content -LiteralPath $scriptPath -Raw -Encoding UTF8
 if ($scriptText -notmatch 'OfficeImoBenchmarkMatrix' -or $scriptText -notmatch 'sortBy' -or $scriptText -notmatch 'setFilter' -or $scriptText -notmatch 'setSortMetric' -or $scriptText -notmatch 'data-ratio-to-fastest') {
     throw "Benchmark sort/filter script does not expose the expected matrix behaviors."
+}
+
+$styleText = Get-Content -LiteralPath $stylePath -Raw -Encoding UTF8
+if ($styleText -notmatch '\.imo-benchmark-hub\{[^}]*grid-template-columns:minmax\(0,1fr\)') {
+    throw "Benchmark hub does not constrain wide children to a responsive grid track."
+}
+
+if ($styleText -notmatch '\.imo-benchmark-explorer\{[^}]*justify-self:center[^}]*width:min\(1600px,calc\(100vw - 3rem\)\)') {
+    throw "Benchmark explorer does not own the centered wide layout."
+}
+
+if ($styleText -notmatch '\.imo-benchmark-dashboard\{width:100%;margin:0 0 3rem\}' -or
+    $styleText -match '\.imo-benchmark-dashboard\{[^}]*100vw') {
+    throw "Benchmark dashboard can overflow and be clipped by its explorer."
 }
 
 if ($pageHtml -match 'Loading benchmark data') {

--- a/Website/themes/officeimo/assets/app.css
+++ b/Website/themes/officeimo/assets/app.css
@@ -435,7 +435,7 @@ pre code{background:none;padding:0;color:inherit}
 @media(max-width:620px){.imo-converter-launch__intro h1{font-size:3.1rem}.imo-converter-launch__frame-shell{width:100%}.imo-converter-launch__frame{height:2100px;border-inline:0;border-radius:0}}
 :focus-visible{outline:2px solid var(--imo-accent);outline-offset:2px}
 @media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important}}
-.imo-benchmark-hub{display:grid;gap:clamp(3rem,6vw,5rem)}
+.imo-benchmark-hub{display:grid;grid-template-columns:minmax(0,1fr);gap:clamp(3rem,6vw,5rem)}
 .imo-benchmark-hub__hero{display:grid;gap:1rem;max-width:900px;padding:1.5rem 0 0}
 .imo-benchmark-hub__hero h2,.imo-benchmark-section-heading h2,.imo-benchmark-evidence__intro h2,.imo-benchmark-method h2{margin:0;font-size:clamp(2rem,4vw,3.45rem);line-height:1.04;letter-spacing:-.045em}
 .imo-benchmark-hub__hero>p:not(.imo-benchmark-eyebrow),.imo-benchmark-section-heading>p:last-child,.imo-benchmark-evidence__intro>p:last-child,.imo-benchmark-method>p:last-child{max-width:780px;margin:0;color:var(--imo-text-secondary);font-size:1rem;line-height:1.75}
@@ -469,7 +469,7 @@ pre code{background:none;padding:0;color:inherit}
 .imo-benchmark-highlight tbody th{color:var(--imo-text);font-weight:700}
 .imo-benchmark-highlight tr.is-officeimo{background:var(--imo-primary-light)}
 .imo-benchmark-highlight tbody tr:last-child :is(th,td){border-bottom:0}
-.imo-benchmark-explorer{scroll-margin-top:calc(var(--imo-header-height) + 1rem);border:1px solid var(--imo-border);border-radius:12px;background:var(--imo-bg-elevated);overflow:hidden}
+.imo-benchmark-explorer{justify-self:center;width:min(1600px,calc(100vw - 3rem));scroll-margin-top:calc(var(--imo-header-height) + 1rem);border:1px solid var(--imo-border);border-radius:12px;background:var(--imo-bg-elevated);overflow:hidden}
 .imo-benchmark-explorer>summary{display:flex;align-items:center;justify-content:space-between;gap:1rem;padding:1.2rem 1.35rem;cursor:pointer;list-style:none}
 .imo-benchmark-explorer>summary::-webkit-details-marker{display:none}
 .imo-benchmark-explorer:not([open])>:not(summary){display:none}
@@ -480,9 +480,9 @@ pre code{background:none;padding:0;color:inherit}
 .imo-benchmark-explorer[open]>summary{border-bottom:1px solid var(--imo-border)}
 .imo-benchmark-explorer[open]>summary>span:last-child{font-size:0}
 .imo-benchmark-explorer[open]>summary>span:last-child::after{content:"Close explorer";font-size:.78rem}
-.imo-benchmark-explorer>.imo-benchmark-dashboard{margin-top:1.25rem;margin-bottom:1.25rem}
+.imo-benchmark-explorer>.imo-benchmark-dashboard{margin-top:0;margin-bottom:0;padding:1.25rem}
 .imo-benchmark-method{display:grid;gap:.8rem;padding:2rem;border:1px solid var(--imo-border);border-radius:12px;background:linear-gradient(135deg,var(--imo-primary-light),var(--imo-bg-elevated))}
-.imo-benchmark-dashboard{width:min(1600px,calc(100vw - 3rem));margin:0 0 3rem 50%;transform:translateX(-50%)}
+.imo-benchmark-dashboard{width:100%;margin:0 0 3rem}
 .imo-benchmark-dashboard code{font-size:.92em}
 .imo-benchmark-hero{display:block;border:1px solid var(--imo-border);border-radius:8px;background:var(--imo-surface);padding:1rem}
 .imo-benchmark-eyebrow{margin:0 0 .35rem;color:var(--imo-text-secondary);font-size:.76rem;font-weight:800;text-transform:uppercase;letter-spacing:.08em}
@@ -536,7 +536,7 @@ pre code{background:none;padding:0;color:inherit}
 .imo-benchmark-value--mid{background:rgba(245,158,11,.06)}
 .imo-benchmark-value--slow{background:rgba(244,63,94,.055)}
 .imo-benchmark-missing{color:var(--imo-text-muted)}
-@media(max-width:1500px){.imo-benchmark-dashboard{width:calc(100vw - 3rem)}.imo-benchmark-table--matrix{min-width:1190px}.imo-benchmark-table--matrix th:nth-child(1),.imo-benchmark-table--matrix td:nth-child(1){width:245px}.imo-benchmark-table--matrix th:nth-child(2),.imo-benchmark-table--matrix td:nth-child(2){width:112px}.imo-benchmark-table--matrix th:nth-child(n+3),.imo-benchmark-table--matrix td:nth-child(n+3){width:104px}}
+@media(max-width:1500px){.imo-benchmark-explorer{width:calc(100vw - 3rem)}.imo-benchmark-table--matrix{min-width:1190px}.imo-benchmark-table--matrix th:nth-child(1),.imo-benchmark-table--matrix td:nth-child(1){width:245px}.imo-benchmark-table--matrix th:nth-child(2),.imo-benchmark-table--matrix td:nth-child(2){width:112px}.imo-benchmark-table--matrix th:nth-child(n+3),.imo-benchmark-table--matrix td:nth-child(n+3){width:104px}}
 @media(max-width:1180px){.imo-benchmark-tools{grid-template-columns:repeat(3,minmax(0,1fr))}.imo-benchmark-tools label:first-child{grid-column:1/-1}.imo-benchmark-count{white-space:normal}}
-@media(max-width:900px){.imo-benchmark-coverage__grid{grid-template-columns:repeat(2,minmax(0,1fr))}.imo-benchmark-family__header{grid-template-columns:1fr;gap:.8rem}.imo-benchmark-highlight-grid{grid-template-columns:1fr}.imo-benchmark-dashboard{width:calc(100vw - 2rem)}.imo-benchmark-kpis{grid-template-columns:repeat(2,minmax(0,1fr))}.imo-benchmark-tools{grid-template-columns:repeat(2,minmax(0,1fr))}.imo-benchmark-reset{min-height:36px}.imo-benchmark-table-wrap{overflow-x:auto}.imo-benchmark-table--matrix{min-width:1190px;font-size:.84rem}}
-@media(max-width:600px){.imo-benchmark-hub{gap:3rem}.imo-benchmark-coverage__grid{grid-template-columns:1fr}.imo-benchmark-coverage__grid article{min-height:0}.imo-benchmark-highlight{padding:1rem}.imo-benchmark-highlight__heading{display:grid}.imo-benchmark-highlight__heading>span{max-width:none;text-align:left}.imo-benchmark-explorer>summary{align-items:flex-start;padding:1rem}.imo-benchmark-explorer>summary>span:last-child{display:none}.imo-benchmark-dashboard{width:100%;margin-left:0;transform:none}.imo-benchmark-hero{border-left:0;border-right:0;border-radius:0}.imo-benchmark-kpis{grid-template-columns:1fr}.imo-benchmark-tools{grid-template-columns:1fr}.imo-benchmark-count{text-align:left}.imo-benchmark-method{padding:1.35rem}}
+@media(max-width:900px){.imo-benchmark-coverage__grid{grid-template-columns:repeat(2,minmax(0,1fr))}.imo-benchmark-family__header{grid-template-columns:1fr;gap:.8rem}.imo-benchmark-highlight-grid{grid-template-columns:1fr}.imo-benchmark-explorer{width:calc(100vw - 2rem)}.imo-benchmark-kpis{grid-template-columns:repeat(2,minmax(0,1fr))}.imo-benchmark-tools{grid-template-columns:repeat(2,minmax(0,1fr))}.imo-benchmark-reset{min-height:36px}.imo-benchmark-table-wrap{overflow-x:auto}.imo-benchmark-table--matrix{min-width:1190px;font-size:.84rem}}
+@media(max-width:600px){.imo-benchmark-hub{gap:3rem}.imo-benchmark-coverage__grid{grid-template-columns:1fr}.imo-benchmark-coverage__grid article{min-height:0}.imo-benchmark-highlight{padding:1rem}.imo-benchmark-highlight__heading{display:grid}.imo-benchmark-highlight__heading>span{max-width:none;text-align:left}.imo-benchmark-explorer{width:calc(100vw - 1rem)}.imo-benchmark-explorer>summary{align-items:flex-start;padding:1rem}.imo-benchmark-explorer>summary>span:last-child{display:none}.imo-benchmark-explorer>.imo-benchmark-dashboard{padding:.75rem}.imo-benchmark-hero{border-left:0;border-right:0;border-radius:0}.imo-benchmark-kpis{grid-template-columns:1fr}.imo-benchmark-tools{grid-template-columns:1fr}.imo-benchmark-count{text-align:left}.imo-benchmark-method{padding:1.35rem}}


### PR DESCRIPTION
## What this fixes

- gives the wide Excel explorer its own centered responsive frame instead of letting a viewport-wide child overflow a narrower clipping parent
- keeps headings, metadata, summary cards, filters, and controls inside the visible explorer
- preserves the wide comparison matrix and limits horizontal scrolling to the table on smaller screens
- adds a focused layout contract so the clipped-dashboard regression cannot silently return

Benchmark values, scenarios, and comparison copy are unchanged.

## Validation

- generated and verified the benchmark page with the PowerForge revision pinned by OfficeIMO
- confirmed 274 scenario rows, 1,106 measurements, and 54 summary rows
- verified rendered layout at 390px, 1024px, 1440px, and 3840px viewports with no document-level horizontal overflow
- simulated a merge with PR #2183 current head; there are no overlapping files or merge conflicts