### PR TITLE
Restore and redesign the browser converter

### DIFF
--- a/Website/Apps/OfficeIMO.Web.Converter/Components/ConverterWorkspace.razor
+++ b/Website/Apps/OfficeIMO.Web.Converter/Components/ConverterWorkspace.razor
@@ -10,30 +10,35 @@
         <nav aria-label="Converter links"><a href="/products/word/" target="_top">Products</a><a href="/docs/" target="_top">Docs</a><a href="/api/" target="_top">API</a><a href="/downloads/" target="_top">Packages</a><a class="ocx-nav-cta" href="https://github.com/EvotecIT/OfficeIMO" target="_blank" rel="noopener">GitHub</a></nav>
     </header>
 
-    <section class="ocx-intro">
-        <p class="ocx-eyebrow">Browser document converter</p>
-        <h1>Convert documents <span>without Office.</span></h1>
-        <p>Choose a route, add your source, and download the result. Supported conversions run locally in WebAssembly in this browser tab.</p>
+    <section class="ocx-product-heading" aria-labelledby="converter-title">
+        <h1 id="converter-title">Convert documents</h1>
+        <p><span class="ocx-local-dot" aria-hidden="true"></span>Runs locally in this tab</p>
     </section>
 
+    <nav class="ocx-route-rail" aria-label="Choose a conversion route">
+        @foreach (ConversionRoute route in Routes) {
+            <button @key="route.Id"
+                    type="button"
+                    class="ocx-route-tab @route.AccentClass @(ActiveRoute.Id == route.Id ? "is-active" : null)"
+                    @onclick="() => SelectRouteAsync(route)"
+                    aria-pressed="@(ActiveRoute.Id == route.Id)"
+                    title="@route.Description">
+                <span class="ocx-route-tab__icon">@route.Source</span>
+                <span class="ocx-route-tab__label">@route.Source <b aria-hidden="true">→</b> @route.Target</span>
+            </button>
+        }
+    </nav>
+
     <section class="ocx-converter" aria-label="@ActiveRoute.Title converter">
-        <div class="ocx-route-picker" aria-label="Selected conversion route">
-            <div class="ocx-format-field">
-                <span>From</span>
-                <div><i class="@ActiveRoute.AccentClass">@ActiveRoute.Source</i><strong>@ActiveRoute.Source document</strong><small>@ActiveRoute.Accept.Split(',')[0]</small></div>
-            </div>
-            <span class="ocx-route-arrow" aria-hidden="true">→</span>
-            <div class="ocx-format-field">
-                <span>To</span>
-                <div><i class="ocx-route-card--pdf">@ActiveRoute.Target</i><strong>@ActiveRoute.Target output</strong><small>download</small></div>
-            </div>
-        </div>
-
-        <div class="ocx-local-banner"><span class="ocx-local-dot"></span><strong>Private in this demo</strong><span>Your file stays in this tab. No account, upload, or retention.</span><code>@ActiveRoute.EnginePath</code></div>
-
         <div class="ocx-workspace">
             <section class="ocx-input-panel" aria-labelledby="input-title">
-                <div class="ocx-panel-heading"><div><p>Source</p><h2 id="input-title">@(ActiveRoute.InputKind == ConversionInputKind.File ? "Add your document" : $"Add {ActiveRoute.Source} content")</h2></div><span>Up to @FormatBytes(MaxUploadBytes)</span></div>
+                <div class="ocx-panel-heading">
+                    <div>
+                        <p>Source</p>
+                        <h2 id="input-title">@(ActiveRoute.InputKind == ConversionInputKind.File ? $"Upload a {ActiveRoute.Source} file" : $"Paste {ActiveRoute.Source} content")</h2>
+                    </div>
+                    <span>Up to @FormatBytes(MaxUploadBytes)</span>
+                </div>
 
                 @if (ActiveRoute.InputKind == ConversionInputKind.File) {
                     <label class="ocx-dropzone" @key="ActiveRoute.Id">
@@ -41,35 +46,49 @@
                         <span class="ocx-dropzone__icon @ActiveRoute.AccentClass"><i></i><b>@ActiveRoute.Source</b></span>
                         <strong>@(SelectedFile is null ? $"Drop a {ActiveRoute.Source} file here" : SelectedFile.Name)</strong>
                         <small>@(SelectedFile is null ? "or choose one from your device" : $"{SelectedFile.FormatLabel} · {FormatBytes(SelectedFile.Size)} · ready locally")</small>
-                        <span class="ocx-button">Choose file</span>
+                        <span class="ocx-button ocx-button--choose">Choose file</span>
                     </label>
                     <div class="ocx-input-actions">
-                        <button type="button" class="ocx-text-action" @onclick="LoadSampleAsync">Try a sample @ActiveRoute.Source</button>
-                        @if (ActiveRoute.Id == "xlsx-pdf") { <label class="ocx-toggle"><input type="checkbox" @bind="LimitExcelRows" /><span>Limit PDF to 250 rows per sheet</span></label> }
+                        <button type="button" class="ocx-text-action" @onclick="LoadSampleAsync">Try a sample</button>
+                        @if (ActiveRoute.Id == "xlsx-pdf") {
+                            <label class="ocx-toggle"><input type="checkbox" @bind="LimitExcelRows" /><span>Limit PDF to 250 rows per sheet</span></label>
+                        }
                     </div>
                 } else {
-                    <div class="ocx-editor-shell"><div class="ocx-editor-shell__bar"><span>@ActiveRoute.Source source</span><button type="button" @onclick="LoadTextSampleAsync">Reset sample</button></div><textarea class="ocx-textarea" aria-label="@ActiveRoute.Source input" maxlength="@BrowserConversionService.MaxTextInputChars" @bind="TextInput" @bind:event="oninput"></textarea></div>
+                    <div class="ocx-editor-shell">
+                        <div class="ocx-editor-shell__bar"><span>@ActiveRoute.Source source</span><button type="button" @onclick="LoadTextSampleAsync">Reset sample</button></div>
+                        <textarea class="ocx-textarea" aria-label="@ActiveRoute.Source input" maxlength="@BrowserConversionService.MaxTextInputChars" @bind="TextInput" @bind:event="oninput"></textarea>
+                    </div>
                 }
 
                 @if (IsPdfRoute) {
-                    <div class="ocx-profile-panel">
-                        <label for="pdf-profile"><span>PDF profile</span><select id="pdf-profile" @bind="SelectedProfileId">@foreach (BrowserPdfProfile profile in PdfProfiles) { <option value="@profile.Id">@profile.Label</option> }</select></label>
-                        <p>@SelectedProfile.Description</p>
-                        <label class="ocx-toggle"><input type="checkbox" @bind="GenerateDebugOverlay" /><span>Generate first-page layout overlay</span></label>
-                    </div>
+                    <details class="ocx-settings">
+                        <summary>
+                            <span class="ocx-settings__icon" aria-hidden="true">⚙</span>
+                            <span><strong>Conversion settings</strong><small>PDF profile: @SelectedProfile.Label · Layout overlay: @(GenerateDebugOverlay ? "On" : "Off")</small></span>
+                            <span class="ocx-settings__chevron" aria-hidden="true"></span>
+                        </summary>
+                        <div class="ocx-settings__body">
+                            <label for="pdf-profile"><span>PDF profile</span><select id="pdf-profile" @bind="SelectedProfileId">@foreach (BrowserPdfProfile profile in PdfProfiles) { <option value="@profile.Id">@profile.Label</option> }</select></label>
+                            <p>@SelectedProfile.Description</p>
+                            <label class="ocx-toggle"><input type="checkbox" @bind="GenerateDebugOverlay" /><span>Generate first-page layout overlay</span></label>
+                        </div>
+                    </details>
                 }
-
-                <button type="button" class="ocx-convert-button" disabled="@(!CanConvert)" @onclick="ConvertAsync"><span>@(IsBusy ? "Converting locally…" : $"Convert to {ActiveRoute.Target}")</span><b aria-hidden="true">→</b></button>
             </section>
 
             <section class="ocx-output-panel" aria-labelledby="output-title">
-                <div class="ocx-panel-heading ocx-panel-heading--output"><div><p>Result</p><h2 id="output-title">@OutputHeading</h2></div></div>
+                <div class="ocx-panel-heading ocx-panel-heading--output">
+                    <div><p>Result</p><h2 id="output-title">@OutputHeading</h2></div>
+                </div>
+
                 @if (ReviewWarnings.Count > 0) {
                     <div class="ocx-warning-summary" role="status">
                         <strong>Review @ReviewWarnings.Count conversion warning@(ReviewWarnings.Count == 1 ? null : "s") before download</strong>
                         <span>@(ReviewWarnings.Any(static warning => warning.CanChangePagination) ? "At least one warning can change text fit or pagination." : "The output is usable, but one or more constructs were substituted or approximated.")</span>
                     </div>
                 }
+
                 <div class="ocx-output-actions">
                     @if (!string.IsNullOrWhiteSpace(OutputOverlayUrl)) { <a class="ocx-button ocx-button--secondary" href="@OutputOverlayUrl" download="@OutputOverlayFileName">Layout overlay</a> }
                     @if (!string.IsNullOrWhiteSpace(OutputReportUrl)) { <a class="ocx-button ocx-button--secondary" href="@OutputReportUrl" download="@OutputReportFileName">Conversion report</a> }
@@ -77,14 +96,16 @@
                     @if (!string.IsNullOrWhiteSpace(OutputSupportUrl)) { <a class="ocx-button ocx-button--secondary" href="@OutputSupportUrl" download="@OutputSupportFileName">Download support bundle</a> }
                     @if (!string.IsNullOrWhiteSpace(OutputUrl)) { <a class="ocx-button ocx-button--primary" href="@OutputUrl" download="@OutputFileName">Download result</a> }
                 </div>
+
                 @if (Output is not null && IsPdfRoute) {
                     <label class="ocx-toggle ocx-support-content"><input type="checkbox" @bind="IncludeDocumentContentInSupportBundle" @bind:after="InvalidateSupportBundleAsync" /><span>Include source and PDF in support bundle (off by default)</span></label>
                 }
+
                 <div class="ocx-preview-stage">
                     @if (IsBusy) {
                         <div class="ocx-empty-state"><span class="ocx-spinner" aria-hidden="true"></span><strong>Converting in your browser</strong><p>The OfficeIMO engine is preparing the result.</p></div>
                     } else if (Output is null) {
-                        <div class="ocx-empty-state"><div class="ocx-empty-state__files" aria-hidden="true"><i class="@ActiveRoute.AccentClass">@ActiveRoute.Source</i><b>→</b><i>@ActiveRoute.Target</i></div><strong>Your result will appear here</strong><p>Add a source and run the conversion.</p></div>
+                        <div class="ocx-empty-state"><div class="ocx-empty-state__files" aria-hidden="true"><i class="@ActiveRoute.AccentClass">@ActiveRoute.Source</i><b>→</b><i>@ActiveRoute.Target</i></div><strong>Your result will appear here</strong><p>Run the conversion to preview and download it.</p></div>
                     } else if (Output.ContentType == "application/pdf" && PreviewOutput) {
                         <iframe class="ocx-pdf-preview" src="@OutputUrl" title="Converted PDF preview"></iframe>
                     } else if (!string.IsNullOrWhiteSpace(Output.HtmlPreview)) {
@@ -93,9 +114,11 @@
                         <pre class="ocx-text-output"><code>@Output.Text</code></pre>
                     }
                 </div>
+
                 @if (Output is not null) {
                     <div class="ocx-output-summary"><span><small>FILE</small><strong>@Output.FileName</strong></span><span><small>SIZE</small><strong>@FormatBytes(Output.Bytes.Length)</strong></span><span><small>TIME</small><strong>@ElapsedLabel</strong></span></div>
                 }
+
                 <div class="ocx-diagnostics" aria-live="polite">
                     @foreach (IGrouping<string, ConversionWarningView> group in WarningGroups) {
                         <div class="ocx-diagnostic-group">
@@ -119,22 +142,20 @@
                 </div>
             </section>
         </div>
+
+        <footer class="ocx-actionbar">
+            <span>@ActiveRoute.Source → @ActiveRoute.Target</span>
+            <button type="button" class="ocx-convert-button" disabled="@(!CanConvert)" @onclick="ConvertAsync">
+                <span>@(IsBusy ? "Converting locally…" : $"Convert to {ActiveRoute.Target}")</span>
+                <b aria-hidden="true">↻</b>
+            </button>
+        </footer>
     </section>
 
-    <section class="ocx-routes" aria-labelledby="route-title">
-        <div class="ocx-section-heading"><div><p class="ocx-eyebrow">Popular conversions</p><h2 id="route-title">Choose another route</h2></div><span>@Routes.Count browser-local routes</span></div>
-        <div class="ocx-route-grid">
-            @foreach (ConversionRoute route in Routes) {
-                <button @key="route.Id" type="button" class="ocx-route-card @route.AccentClass @(ActiveRoute.Id == route.Id ? "is-active" : null)" @onclick="() => SelectRouteAsync(route)" aria-pressed="@(ActiveRoute.Id == route.Id)">
-                    <span class="ocx-route-card__formats"><i>@route.Source</i><b aria-hidden="true">→</b><i>@route.Target</i></span>
-                    <strong>@route.Title</strong><small>@route.Description</small>
-                </button>
-            }
-        </div>
-    </section>
-
-    <section class="ocx-developer" aria-labelledby="developer-title">
-        <div><p class="ocx-eyebrow">Use it in your app</p><h2 id="developer-title">The demo uses the same document engines.</h2><p>Bring the library into your .NET service or PowerShell automation when you need authenticated jobs, queues, storage, or larger inputs under policies you control.</p><div class="ocx-developer__links"><a href="/docs/" target="_top">Read the guides →</a><a href="/api/" target="_top">Browse the API →</a></div></div>
-        <div class="ocx-code-card"><div><span>C#</span><small>@ActiveRoute.Title</small></div><code>@ActiveRoute.EnginePath</code><p>Browser demo: local and ephemeral<br />Your deployment: your authentication, storage, logging, and retention</p></div>
+    <section class="ocx-utility-rail" aria-label="Converter details">
+        <div><span class="ocx-utility-icon ocx-utility-icon--private" aria-hidden="true">✓</span><span><strong>Browser-local</strong><small>Files stay in this tab</small></span></div>
+        <div><span class="ocx-utility-icon" aria-hidden="true">□</span><span><strong>Up to @FormatBytes(MaxUploadBytes)</strong><small>Per file</small></span></div>
+        <div><span class="ocx-utility-icon" aria-hidden="true">&lt;/&gt;</span><span><strong>OfficeIMO engine</strong><small>WebAssembly</small></span></div>
+        <a href="/convert/guides/" target="_top"><strong>Need server or legacy formats?</strong><span>View conversion guides →</span></a>
     </section>
 </main>

--- a/Website/Apps/OfficeIMO.Web.Converter/Components/ConverterWorkspace.razor.cs
+++ b/Website/Apps/OfficeIMO.Web.Converter/Components/ConverterWorkspace.razor.cs
@@ -58,7 +58,7 @@ This **Markdown** becomes a browser preview or an editable Word document.
     private bool PreviewOutput { get; set; } = true;
     private bool IsBusy { get; set; }
     private long ElapsedMilliseconds { get; set; }
-    private List<ConversionDiagnostic> Diagnostics { get; } = [ReadyDiagnostic()];
+    private List<ConversionDiagnostic> Diagnostics { get; } = [];
 
     private static IReadOnlyList<ConversionRoute> Routes => ConversionRouteCatalog.All;
     private static IReadOnlyList<BrowserPdfProfile> PdfProfiles => BrowserPdfProfileCatalog.All;
@@ -99,7 +99,6 @@ This **Markdown** becomes a browser preview or an editable Word document.
         GenerateDebugOverlay = false;
         IncludeDocumentContentInSupportBundle = false;
         Diagnostics.Clear();
-        Diagnostics.Add(ReadyDiagnostic());
         Navigation.NavigateTo($"?route={Uri.EscapeDataString(route.Id)}", replace: true);
     }
 
@@ -284,9 +283,6 @@ This **Markdown** becomes a browser preview or an editable Word document.
         ex.GetType().Name.Contains("PdfTextEncodingPreflightException", StringComparison.Ordinal)
             ? "This document uses text that needs an embedded font not available to the browser conversion. " + ex.Message
             : ex.Message;
-
-    private static ConversionDiagnostic ReadyDiagnostic() =>
-        new("Ready", "Choose a source and run the conversion. Nothing is uploaded.", "ocx-dot--good");
 
     private static IEnumerable<IGrouping<string, ConversionWarningView>> GroupWarnings(
         IEnumerable<ConversionWarningView> warnings) =>

--- a/Website/Apps/OfficeIMO.Web.Converter/wwwroot/converter.css
+++ b/Website/Apps/OfficeIMO.Web.Converter/wwwroot/converter.css
@@ -92,6 +92,7 @@
 .ocx-embedded .ocx-appbar { display: none; }
 
 .ocx-embedded .ocx-intro { padding-top: 2.8rem; }
+.ocx-embedded .ocx-shell { min-height: 0; }
 
 .ocx-brand {
   display: flex;
@@ -570,4 +571,399 @@
 
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after { animation-duration: 0.01ms !important; animation-iteration-count: 1 !important; transition-duration: 0.01ms !important; }
+}
+
+/* Product workspace redesign: keep the converter task above the marketing layer. */
+.ocx-product-heading,
+.ocx-route-rail,
+.ocx-converter,
+.ocx-utility-rail {
+  width: min(100% - 2rem, 1312px);
+}
+
+.ocx-product-heading {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin: 0 auto;
+  padding: 2.25rem 0 1.15rem;
+}
+
+.ocx-product-heading h1 {
+  margin: 0;
+  font-size: clamp(1.45rem, 2.1vw, 2rem);
+  line-height: 1.1;
+  letter-spacing: -0.04em;
+}
+
+.ocx-product-heading p {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  margin: 0;
+  color: var(--ocx-green);
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+
+.ocx-route-rail {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  margin: 0 auto 1.15rem;
+  overflow: hidden;
+  border: 1px solid var(--ocx-border);
+  border-radius: 13px;
+  background: var(--ocx-panel);
+  box-shadow: 0 8px 24px rgba(20, 33, 58, 0.05);
+}
+
+.ocx-route-tab {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.7rem;
+  min-width: 0;
+  min-height: 64px;
+  padding: 0.7rem 0.8rem;
+  border: 0;
+  border-right: 1px solid var(--ocx-border);
+  background: transparent;
+  color: var(--ocx-muted);
+  font-family: inherit;
+  cursor: pointer;
+  transition: color 160ms, background 160ms, box-shadow 160ms;
+}
+
+.ocx-route-tab:last-child { border-right: 0; }
+.ocx-route-tab:hover { color: var(--ocx-text); background: var(--ocx-bg-alt); }
+.ocx-route-tab.is-active {
+  position: relative;
+  z-index: 1;
+  color: var(--ocx-text);
+  background: color-mix(in srgb, var(--ocx-blue) 4%, var(--ocx-panel));
+  box-shadow: inset 0 0 0 2px var(--ocx-blue);
+}
+
+.ocx-route-tab__icon {
+  display: grid;
+  place-items: center;
+  flex: 0 0 auto;
+  min-width: 35px;
+  min-height: 37px;
+  padding: 0.2rem;
+  border: 1px solid color-mix(in srgb, currentColor 20%, var(--ocx-border));
+  border-radius: 7px;
+  background: color-mix(in srgb, currentColor 7%, var(--ocx-panel));
+  color: var(--ocx-blue);
+  font-size: 0.66rem;
+  font-weight: 900;
+  letter-spacing: 0.02em;
+}
+
+.ocx-route-tab.ocx-route-card--excel .ocx-route-tab__icon { color: #059669; }
+.ocx-route-tab.ocx-route-card--powerpoint .ocx-route-tab__icon { color: #e25024; }
+.ocx-route-tab.ocx-route-card--markdown .ocx-route-tab__icon { color: #6d28d9; }
+.ocx-route-tab.ocx-route-card--html .ocx-route-tab__icon { color: #c2410c; }
+
+.ocx-route-tab__label {
+  overflow: hidden;
+  font-size: 0.84rem;
+  font-weight: 760;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ocx-route-tab__label b { color: var(--ocx-muted); font-weight: 600; }
+
+.ocx-converter {
+  margin: 0 auto;
+  border-radius: 17px;
+  box-shadow: 0 22px 58px rgba(20, 33, 58, 0.12);
+}
+
+.ocx-workspace {
+  position: relative;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.ocx-workspace::after {
+  content: "→";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  z-index: 2;
+  display: grid;
+  place-items: center;
+  width: 42px;
+  height: 42px;
+  border: 1px solid var(--ocx-border);
+  border-radius: 50%;
+  background: var(--ocx-panel);
+  color: var(--ocx-blue);
+  box-shadow: 0 8px 18px rgba(20, 33, 58, 0.1);
+  transform: translate(-50%, -50%);
+}
+
+.ocx-input-panel,
+.ocx-output-panel {
+  display: flex;
+  flex-direction: column;
+  padding: 1.55rem;
+}
+
+.ocx-output-panel { background: color-mix(in srgb, var(--ocx-bg-alt) 58%, var(--ocx-panel)); }
+.ocx-panel-heading { min-height: 48px; margin-bottom: 1rem; }
+.ocx-panel-heading p { color: var(--ocx-muted); font-size: 0.7rem; font-weight: 850; letter-spacing: 0.1em; text-transform: uppercase; }
+.ocx-panel-heading h2 { font-size: 1.05rem; }
+
+.ocx-dropzone {
+  flex: 1 1 auto;
+  min-height: 350px;
+  border-radius: 12px;
+  background: var(--ocx-panel);
+}
+
+.ocx-dropzone:hover {
+  border-color: var(--ocx-blue);
+  background:
+    radial-gradient(circle at 50% 36%, color-mix(in srgb, var(--ocx-blue) 8%, transparent), transparent 34%),
+    var(--ocx-panel);
+}
+
+.ocx-button--choose {
+  min-width: 145px;
+  min-height: 44px;
+  border-color: var(--ocx-blue);
+  background: var(--ocx-action-bg);
+  color: var(--ocx-action-text);
+  box-shadow: 0 10px 22px rgba(37, 99, 235, 0.18);
+}
+
+.ocx-button--choose:hover { background: var(--ocx-action-hover); }
+.ocx-input-actions { justify-content: center; min-height: 36px; margin: 0.45rem 0 0; }
+.ocx-text-action { min-height: 34px; padding: 0 0.65rem; }
+
+.ocx-settings {
+  margin-top: 0.55rem;
+  overflow: hidden;
+  border: 1px solid var(--ocx-border);
+  border-radius: 11px;
+  background: var(--ocx-panel);
+}
+
+.ocx-settings summary {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.75rem;
+  min-height: 58px;
+  padding: 0.65rem 0.85rem;
+  list-style: none;
+  cursor: pointer;
+}
+
+.ocx-settings summary::-webkit-details-marker { display: none; }
+.ocx-settings summary > span:nth-child(2) { display: grid; gap: 0.12rem; }
+.ocx-settings summary strong { font-size: 0.8rem; }
+.ocx-settings summary small { color: var(--ocx-muted); font-size: 0.7rem; }
+.ocx-settings__icon { color: var(--ocx-muted); font-size: 1.15rem; }
+.ocx-settings__chevron {
+  width: 8px;
+  height: 8px;
+  border-right: 2px solid var(--ocx-muted);
+  border-bottom: 2px solid var(--ocx-muted);
+  transform: rotate(45deg);
+  transition: transform 160ms;
+}
+.ocx-settings[open] .ocx-settings__chevron { transform: rotate(225deg); }
+
+.ocx-settings__body {
+  display: grid;
+  gap: 0.55rem;
+  padding: 0.8rem;
+  border-top: 1px solid var(--ocx-border);
+}
+
+.ocx-settings__body > label:first-child {
+  display: grid;
+  grid-template-columns: auto minmax(150px, 1fr);
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.78rem;
+  font-weight: 760;
+}
+
+.ocx-settings__body select {
+  width: 100%;
+  padding: 0.5rem 0.6rem;
+  border: 1px solid var(--ocx-border-strong);
+  border-radius: 7px;
+  background: var(--ocx-bg);
+  color: var(--ocx-text);
+  font: inherit;
+}
+
+.ocx-settings__body p { margin: 0; color: var(--ocx-muted); font-size: 0.72rem; line-height: 1.45; }
+
+.ocx-output-actions:empty { display: none; }
+.ocx-preview-stage { flex: 1 1 auto; min-height: 430px; border-radius: 12px; }
+.ocx-empty-state { min-height: 430px; }
+
+.ocx-diagnostics {
+  max-height: 180px;
+  overflow: auto;
+}
+
+.ocx-actionbar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 1rem;
+  min-height: 78px;
+  padding: 0.9rem 1.55rem;
+  border-top: 1px solid var(--ocx-border);
+  background: var(--ocx-panel);
+}
+
+.ocx-actionbar > span {
+  margin-right: auto;
+  color: var(--ocx-muted);
+  font-size: 0.78rem;
+  font-weight: 740;
+}
+
+.ocx-actionbar .ocx-convert-button {
+  width: min(100%, 285px);
+  min-height: 48px;
+  margin: 0;
+  padding: 0.8rem 1rem;
+  border-radius: 9px;
+  font-size: 0.88rem;
+}
+
+.ocx-actionbar .ocx-convert-button b { order: -1; font-size: 1rem; }
+
+.ocx-utility-rail {
+  display: grid;
+  grid-template-columns: 0.9fr 0.8fr 1fr 1.25fr;
+  gap: 0;
+  margin: 1.15rem auto 3rem;
+  overflow: hidden;
+  border: 1px solid var(--ocx-border);
+  border-radius: 13px;
+  background: var(--ocx-panel);
+  box-shadow: 0 9px 24px rgba(20, 33, 58, 0.05);
+}
+
+.ocx-utility-rail > div,
+.ocx-utility-rail > a {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  min-width: 0;
+  padding: 0.9rem 1rem;
+  border-right: 1px solid var(--ocx-border);
+}
+
+.ocx-utility-rail > a {
+  display: grid;
+  gap: 0.18rem;
+  border-right: 0;
+  color: var(--ocx-blue);
+}
+
+.ocx-utility-rail > div > span:last-child { display: grid; gap: 0.12rem; min-width: 0; }
+.ocx-utility-rail strong { font-size: 0.78rem; }
+.ocx-utility-rail small,
+.ocx-utility-rail a span { color: var(--ocx-muted); font-size: 0.7rem; }
+.ocx-utility-rail a span { color: var(--ocx-blue); }
+.ocx-utility-icon { color: var(--ocx-muted); font-size: 0.88rem; font-weight: 850; }
+.ocx-utility-icon--private { color: var(--ocx-green); }
+
+@media (max-width: 1040px) {
+  .ocx-route-rail {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+  .ocx-route-tab:nth-child(3) { border-right: 0; }
+  .ocx-route-tab:nth-child(-n + 3) { border-bottom: 1px solid var(--ocx-border); }
+  .ocx-utility-rail { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .ocx-utility-rail > :nth-child(2) { border-right: 0; }
+  .ocx-utility-rail > :nth-child(-n + 2) { border-bottom: 1px solid var(--ocx-border); }
+}
+
+@media (max-width: 760px) {
+  .ocx-product-heading,
+  .ocx-route-rail,
+  .ocx-converter,
+  .ocx-utility-rail {
+    width: min(100% - 1rem, 1312px);
+  }
+
+  .ocx-product-heading {
+    align-items: center;
+    flex-direction: row;
+    gap: 0.6rem;
+    padding: 1.35rem 0 0.9rem;
+  }
+
+  .ocx-product-heading h1 { font-size: 1.28rem; }
+  .ocx-product-heading p { font-size: 0.72rem; }
+
+  .ocx-route-rail {
+    display: flex;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    scrollbar-width: thin;
+  }
+
+  .ocx-route-tab {
+    flex: 0 0 158px;
+    min-height: 60px;
+    border-right: 1px solid var(--ocx-border) !important;
+    border-bottom: 0 !important;
+    scroll-snap-align: start;
+  }
+
+  .ocx-workspace { grid-template-columns: 1fr; }
+  .ocx-workspace::after { display: none; }
+
+  .ocx-input-panel {
+    border-right: 0;
+    border-bottom: 1px solid var(--ocx-border);
+  }
+
+  .ocx-input-panel,
+  .ocx-output-panel { padding: 1rem; }
+  .ocx-dropzone { min-height: 330px; }
+  .ocx-preview-stage,
+  .ocx-empty-state { min-height: 330px; }
+
+  .ocx-actionbar {
+    position: sticky;
+    bottom: 0;
+    z-index: 4;
+    align-items: stretch;
+    flex-direction: column;
+    gap: 0.45rem;
+    padding: 0.75rem 1rem;
+    box-shadow: 0 -10px 30px rgba(20, 33, 58, 0.09);
+  }
+
+  .ocx-actionbar > span { display: none; }
+  .ocx-actionbar .ocx-convert-button { width: 100%; max-width: none; }
+  .ocx-utility-rail { grid-template-columns: 1fr; }
+  .ocx-utility-rail > div,
+  .ocx-utility-rail > a {
+    border-right: 0;
+    border-bottom: 1px solid var(--ocx-border);
+  }
+  .ocx-utility-rail > a { border-bottom: 0; }
+}
+
+@media (max-width: 340px) {
+  .ocx-product-heading {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
 }

--- a/Website/Apps/OfficeIMO.Web.Converter/wwwroot/converter.css
+++ b/Website/Apps/OfficeIMO.Web.Converter/wwwroot/converter.css
@@ -892,6 +892,8 @@
 }
 
 @media (max-width: 760px) {
+  .ocx-shell { padding-bottom: 5.5rem; }
+
   .ocx-product-heading,
   .ocx-route-rail,
   .ocx-converter,
@@ -939,14 +941,19 @@
   .ocx-empty-state { min-height: 330px; }
 
   .ocx-actionbar {
-    position: sticky;
-    bottom: 0;
-    z-index: 4;
+    position: fixed;
+    right: 0.5rem;
+    bottom: max(0.5rem, env(safe-area-inset-bottom));
+    left: 0.5rem;
+    z-index: 10;
     align-items: stretch;
     flex-direction: column;
     gap: 0.45rem;
     padding: 0.75rem 1rem;
-    box-shadow: 0 -10px 30px rgba(20, 33, 58, 0.09);
+    min-height: 0;
+    border: 1px solid var(--ocx-border);
+    border-radius: 12px;
+    box-shadow: 0 12px 36px rgba(20, 33, 58, 0.18);
   }
 
   .ocx-actionbar > span { display: none; }

--- a/Website/content/blog/choosing-document-conversion-fidelity.md
+++ b/Website/content/blog/choosing-document-conversion-fidelity.md
@@ -76,4 +76,4 @@ Choose verification in proportion to the consequences of a wrong result.
 
 Commercial suites may cover more rendering and conversion cases. Open-source libraries may offer source visibility and more control over policy. Whichever library you use, ask for operation-level evidence and make the fallback decision part of the application.
 
-OfficeIMO's [compatibility page](/compatibility/) shows current tracked states for DOC, XLS, PPT, and modern formats. The [conversion hub](/convert/) turns those states into concrete .NET workflows.
+OfficeIMO's [compatibility page](/compatibility/) shows current tracked states for DOC, XLS, PPT, and modern formats. The [conversion guide hub](/convert/guides/) turns those states into concrete .NET workflows.

--- a/Website/content/blog/officeimo-vs-competitors.md
+++ b/Website/content/blog/officeimo-vs-competitors.md
@@ -72,7 +72,7 @@ That is usually a healthier architecture decision than picking the heaviest opti
 
 - [Comparison page](/comparison/) for the site-level summary of licensing, deployment, and package-shape tradeoffs.
 - [Compatibility dashboard](/compatibility/) for DOC, XLS, XLSB, PPT, and modern-format evidence.
-- [Conversion routes](/convert/) for task-specific examples and fidelity guidance.
+- [Conversion routes](/convert/guides/) for task-specific examples and fidelity guidance.
 - [Documentation hub](/docs/) for the actual package surface and installation guidance.
 - [Platform support](/docs/getting-started/platform-support/) if deployment shape is part of the decision.
 - [Downloads](/downloads/) to see the current package family and release flow in one place.

--- a/Website/content/conversions/guides.md
+++ b/Website/content/conversions/guides.md
@@ -1,0 +1,53 @@
+---
+title: "Document Conversion Guides for .NET"
+description: "Choose .NET routes for DOC, DOCX, XLS, XLSX, XLSB, PPT, PPTX, PDF, and web formats, with documented PSWriteOffice routes called out separately."
+layout: solution
+meta.eyebrow: "Conversion workflows"
+meta.outcome: "Move documents without hiding fidelity decisions"
+meta.primary_label: "Check format support"
+meta.primary_url: "/compatibility/"
+meta.social_card_badge: "Office conversion"
+---
+
+OfficeIMO conversion is built for .NET applications that need more than a file-extension switch. Each focused package owns a document family, while adapters add PDF, HTML, Markdown, OpenDocument, Google Workspace, and normalized extraction only when the workflow needs them.
+
+## Start with the route you need
+
+| Input and output | Best starting point | What you can inspect |
+|---|---|---|
+| [DOC and DOCX](/convert/doc-docx/) | `OfficeIMO.Word` | Feature-level compatibility, preservation, and conversion diagnostics |
+| [XLS and XLSX](/convert/xls-xlsx/) | `OfficeIMO.Excel` | Worksheets, formulas, styles, charts, and legacy BIFF decisions |
+| [XLSB and XLSX](/convert/xlsb-xlsx/) | `OfficeIMO.Excel` | Native binary-workbook parsing and write diagnostics |
+| [PPT and PPTX](/convert/ppt-pptx/) | `OfficeIMO.PowerPoint` | Slides, shapes, text, media, notes, charts, and fallback decisions |
+| [Word to PDF](/convert/word-to-pdf/) | `OfficeIMO.Word.Pdf` | Publishing warnings, fonts, images, tables, sections, and output status |
+| [Excel to PDF](/convert/excel-to-pdf/) | `OfficeIMO.Excel.Pdf` | Worksheet selection, pagination, page setup, styles, and export warnings |
+
+For HTML, Markdown, RTF, OpenDocument, Google Docs, Sheets, and Slides, use the focused adapter shown in the [package catalog](/downloads/). This keeps dependencies and deployment behavior explicit.
+
+## PowerShell routes are documented separately
+
+PSWriteOffice exposes dedicated DOC/DOCX and XLS/XLSX conversion cmdlets and a much broader set of authoring, inspection, validation, and publishing commands. It does not imply that every .NET conversion route in the table is available as a cmdlet. Start with the [PSWriteOffice product page](/products/pswriteoffice/), then verify the exact command and parameters in the [PowerShell API reference](/api/powershell/).
+
+## Conversion is a policy decision
+
+A document can be readable even when every source feature is not editable in the destination. OfficeIMO distinguishes:
+
+- **Native** content represented directly by the destination format.
+- **Editable approximation** when the closest destination feature is still useful.
+- **Visual fallback** when appearance matters more than editability.
+- **Preserved source** when recovery is safer than pretending a conversion was complete.
+- **Blocked output** when continuing would silently misrepresent the result.
+
+The [format compatibility page](/compatibility/) exposes those states from the same contracts used by the libraries. For governed migrations, analyze first, decide which states your workflow accepts, then write the output.
+
+## Browser, server, and desktop choices
+
+The browser playground intentionally supports a smaller modern-format route set because files stay in the browser. Legacy DOC, XLS, and PPT migration belongs in a .NET service, desktop application, or CLI. PSWriteOffice additionally provides the documented DOC/DOCX and XLS/XLSX cmdlet routes described above. That boundary is explicit so a browser demo—or the .NET package matrix—is never mistaken for the PowerShell command surface.
+
+## Need a broader workflow?
+
+- [Browse all solution guides](/solutions/)
+- [Modernize a legacy Office archive](/solutions/legacy-office-modernization/)
+- [Publish Office content to PDF and web formats](/solutions/document-publishing/)
+- [Normalize documents for search and AI](/solutions/document-ingestion/)
+- [Automate recurring document jobs with PowerShell](/solutions/powershell-document-automation/)

--- a/Website/content/docs/capabilities/conversions/index.md
+++ b/Website/content/docs/capabilities/conversions/index.md
@@ -38,7 +38,7 @@ Do not treat “a file was written” as proof that the conversion preserved eve
 
 ## Browser-local routes
 
-The [browser converter](/playground/) exposes only routes that can execute safely inside the WebAssembly application. That is intentionally smaller than the managed server-side conversion surface. A missing browser route does not mean that no .NET adapter exists; consult the [complete component index](/docs/capabilities/packages/) and the adapter API.
+The [browser converter](/convert/) exposes only routes that can execute safely inside the WebAssembly application. That is intentionally smaller than the managed server-side conversion surface. A missing browser route does not mean that no .NET adapter exists; consult the [complete component index](/docs/capabilities/packages/) and the adapter API.
 
 ## Loss policy
 

--- a/Website/content/docs/converters/browser-playground/index.md
+++ b/Website/content/docs/converters/browser-playground/index.md
@@ -4,7 +4,7 @@ description: Run supported OfficeIMO conversions locally through the WebAssembly
 order: 90
 ---
 
-The [browser converter](/playground/) is a static Blazor WebAssembly application. Supported conversions execute inside the current tab; selected files are not uploaded to OfficeIMO.
+The [browser converter](/convert/) is a static Blazor WebAssembly application. Supported conversions execute inside the current tab; selected files are not uploaded to OfficeIMO.
 
 ## Supported browser routes
 

--- a/Website/content/pages/comparison.md
+++ b/Website/content/pages/comparison.md
@@ -86,4 +86,4 @@ Before standardizing on any library stack, it helps to answer a few concrete que
 
 If you need open-source, COM-free document automation with a friendly .NET and PowerShell story, OfficeIMO is a strong starting point. If you later discover that your workload needs broader format coverage, tighter vendor guarantees, or specialized rendering, a commercial library may still be the right complement.
 
-[Get started with OfficeIMO](/docs/getting-started/), [check format compatibility](/compatibility/), or [explore conversion routes](/convert/).
+[Get started with OfficeIMO](/docs/getting-started/), [check format compatibility](/compatibility/), or [explore conversion routes](/convert/guides/).

--- a/Website/content/pages/convert.md
+++ b/Website/content/pages/convert.md
@@ -1,53 +1,16 @@
 ---
-title: "Document Conversion for .NET"
-description: "Choose .NET routes for DOC, DOCX, XLS, XLSX, XLSB, PPT, PPTX, PDF, and web formats, with documented PSWriteOffice routes called out separately."
-layout: solution
-meta.eyebrow: "Conversion workflows"
-meta.outcome: "Move documents without hiding fidelity decisions"
-meta.primary_label: "Check format support"
-meta.primary_url: "/compatibility/"
-meta.social_card_badge: "Office conversion"
+title: "Browser Converter"
+description: "Convert supported Office, Markdown, and HTML content locally in your browser with OfficeIMO WebAssembly."
+layout: playground
+meta.seo_title: "Browser document converter | OfficeIMO"
+meta.head_html: '<link rel="alternate" hreflang="en" href="https://officeimo.com/convert/" /><link rel="alternate" hreflang="x-default" href="https://officeimo.com/convert/" />'
 ---
 
-OfficeIMO conversion is built for .NET applications that need more than a file-extension switch. Each focused package owns a document family, while adapters add PDF, HTML, Markdown, OpenDocument, Google Workspace, and normalized extraction only when the workflow needs them.
-
-## Start with the route you need
-
-| Input and output | Best starting point | What you can inspect |
-|---|---|---|
-| [DOC and DOCX](/convert/doc-docx/) | `OfficeIMO.Word` | Feature-level compatibility, preservation, and conversion diagnostics |
-| [XLS and XLSX](/convert/xls-xlsx/) | `OfficeIMO.Excel` | Worksheets, formulas, styles, charts, and legacy BIFF decisions |
-| [XLSB and XLSX](/convert/xlsb-xlsx/) | `OfficeIMO.Excel` | Native binary-workbook parsing and write diagnostics |
-| [PPT and PPTX](/convert/ppt-pptx/) | `OfficeIMO.PowerPoint` | Slides, shapes, text, media, notes, charts, and fallback decisions |
-| [Word to PDF](/convert/word-to-pdf/) | `OfficeIMO.Word.Pdf` | Publishing warnings, fonts, images, tables, sections, and output status |
-| [Excel to PDF](/convert/excel-to-pdf/) | `OfficeIMO.Excel.Pdf` | Worksheet selection, pagination, page setup, styles, and export warnings |
-
-For HTML, Markdown, RTF, OpenDocument, Google Docs, Sheets, and Slides, use the focused adapter shown in the [package catalog](/downloads/). This keeps dependencies and deployment behavior explicit.
-
-## PowerShell routes are documented separately
-
-PSWriteOffice exposes dedicated DOC/DOCX and XLS/XLSX conversion cmdlets and a much broader set of authoring, inspection, validation, and publishing commands. It does not imply that every .NET conversion route in the table is available as a cmdlet. Start with the [PSWriteOffice product page](/products/pswriteoffice/), then verify the exact command and parameters in the [PowerShell API reference](/api/powershell/).
-
-## Conversion is a policy decision
-
-A document can be readable even when every source feature is not editable in the destination. OfficeIMO distinguishes:
-
-- **Native** content represented directly by the destination format.
-- **Editable approximation** when the closest destination feature is still useful.
-- **Visual fallback** when appearance matters more than editability.
-- **Preserved source** when recovery is safer than pretending a conversion was complete.
-- **Blocked output** when continuing would silently misrepresent the result.
-
-The [format compatibility page](/compatibility/) exposes those states from the same contracts used by the libraries. For governed migrations, analyze first, decide which states your workflow accepts, then write the output.
-
-## Browser, server, and desktop choices
-
-The browser playground intentionally supports a smaller modern-format route set because files stay in the browser. Legacy DOC, XLS, and PPT migration belongs in a .NET service, desktop application, or CLI. PSWriteOffice additionally provides the documented DOC/DOCX and XLS/XLSX cmdlet routes described above. That boundary is explicit so a browser demo—or the .NET package matrix—is never mistaken for the PowerShell command surface.
-
-## Need a broader workflow?
-
-- [Browse all solution guides](/solutions/)
-- [Modernize a legacy Office archive](/solutions/legacy-office-modernization/)
-- [Publish Office content to PDF and web formats](/solutions/document-publishing/)
-- [Normalize documents for search and AI](/solutions/document-ingestion/)
-- [Automate recurring document jobs with PowerShell](/solutions/powershell-document-automation/)
+<section class="imo-converter-launch">
+  <div class="imo-container imo-converter-launch__intro">
+    <div><p class="imo-converter-launch__eyebrow">Local WebAssembly converter</p><h1>Convert documents<br><span>without uploading them.</span></h1><p>Use the interactive converter for Word, Excel, and PowerPoint to PDF, Markdown to HTML or Word, and HTML to Markdown. The current browser routes run in this tab. Need a server-side or legacy route? <a href="/convert/guides/">Browse the .NET conversion guides</a>.</p></div>
+    <aside><strong>Privacy boundary</strong><p>Files remain in the browser session. OfficeIMO does not receive or retain them.</p></aside>
+  </div>
+  <div class="imo-container imo-converter-launch__frame-shell"><iframe class="imo-converter-launch__frame" src="/apps/officeimo-converter/?embedded=1" title="OfficeIMO browser converter" loading="lazy"></iframe></div>
+  <noscript><div class="imo-container"><p><a href="/apps/officeimo-converter/">Open the converter application</a></p></div></noscript>
+</section>

--- a/Website/content/pages/playground.md
+++ b/Website/content/pages/playground.md
@@ -3,6 +3,7 @@ title: "Browser Converter"
 description: "Convert supported Office, Markdown, and HTML content locally in your browser with OfficeIMO WebAssembly."
 layout: playground
 canonical: "https://officeimo.com/convert/"
+robots: "noindex,follow"
 meta.seo_title: "Browser document converter | OfficeIMO"
 meta.head_html: '<link rel="alternate" hreflang="en" href="https://officeimo.com/convert/" /><link rel="alternate" hreflang="x-default" href="https://officeimo.com/convert/" />'
 ---

--- a/Website/content/pages/playground.md
+++ b/Website/content/pages/playground.md
@@ -2,13 +2,14 @@
 title: "Browser Converter"
 description: "Convert supported Office, Markdown, and HTML content locally in your browser with OfficeIMO WebAssembly."
 layout: playground
+canonical: "https://officeimo.com/convert/"
 meta.seo_title: "Browser document converter | OfficeIMO"
-meta.head_html: '<link rel="alternate" hreflang="en" href="https://officeimo.com/playground/" /><link rel="alternate" hreflang="x-default" href="https://officeimo.com/playground/" />'
+meta.head_html: '<link rel="alternate" hreflang="en" href="https://officeimo.com/convert/" /><link rel="alternate" hreflang="x-default" href="https://officeimo.com/convert/" />'
 ---
 
 <section class="imo-converter-launch">
   <div class="imo-container imo-converter-launch__intro">
-    <div><p class="imo-converter-launch__eyebrow">Local WebAssembly converter</p><h1>Convert documents<br><span>without uploading them.</span></h1><p>Use the interactive converter for Word, Excel, and PowerPoint to PDF, Markdown to HTML or Word, and HTML to Markdown. The current browser routes run in this tab.</p></div>
+    <div><p class="imo-converter-launch__eyebrow">Local WebAssembly converter</p><h1>Convert documents<br><span>without uploading them.</span></h1><p>Use the interactive converter for Word, Excel, and PowerPoint to PDF, Markdown to HTML or Word, and HTML to Markdown. The current browser routes run in this tab. Need a server-side or legacy route? <a href="/convert/guides/">Browse the .NET conversion guides</a>.</p></div>
     <aside><strong>Privacy boundary</strong><p>Files remain in the browser session. OfficeIMO does not receive or retain them.</p></aside>
   </div>
   <div class="imo-container imo-converter-launch__frame-shell"><iframe class="imo-converter-launch__frame" src="/apps/officeimo-converter/?embedded=1" title="OfficeIMO browser converter" loading="lazy"></iframe></div>

--- a/Website/content/pages/solutions.md
+++ b/Website/content/pages/solutions.md
@@ -37,4 +37,4 @@ Translate Word, Excel, and PowerPoint content to and from Docs, Sheets, and Slid
 
 OfficeIMO runs as libraries and tools in your application boundary. Files do not need to be uploaded to a third-party conversion service. You choose where documents are stored, which credentials are used, how findings are logged, and whether a conversion should continue.
 
-Start with [format support](/compatibility/) when file fidelity is the first concern, the [conversion routes](/convert/) when input and output are already known, or the [package catalog](/downloads/) when you are ready to assemble a deployment.
+Start with [format support](/compatibility/) when file fidelity is the first concern, the [conversion routes](/convert/guides/) when input and output are already known, or the [package catalog](/downloads/) when you are ready to assemble a deployment.

--- a/Website/content/solutions/legacy-office-modernization.md
+++ b/Website/content/solutions/legacy-office-modernization.md
@@ -4,7 +4,7 @@ description: "Build a governed .NET migration for Word DOC, Excel XLS and XLSB, 
 meta.eyebrow: "Legacy Office modernization"
 meta.outcome: "A migration you can explain file by file"
 meta.primary_label: "Browse conversion routes"
-meta.primary_url: "/convert/"
+meta.primary_url: "/convert/guides/"
 ---
 
 Legacy Office archives are rarely uniform. A folder may contain ordinary reports, macro-enabled templates, embedded objects, damaged files, hand-built charts, and documents that only ever opened correctly in one desktop Office version. A reliable migration therefore needs more than a loop that changes extensions.

--- a/Website/data/hero.json
+++ b/Website/data/hero.json
@@ -5,7 +5,7 @@
   "tagline": "Use typed .NET packages for the full DOC, XLS, XLSB, PPT, and modern Office surface. Use PSWriteOffice for its documented PowerShell authoring, inspection, and conversion workflows — all without Microsoft Office.",
   "ctas": [
     { "label": "Check format support", "href": "/compatibility/", "style": "primary" },
-    { "label": "Explore conversions", "href": "/convert/", "style": "ghost" }
+    { "label": "Try the converter", "href": "/convert/", "style": "ghost" }
   ],
   "install": {
     "dotnet": "dotnet add package OfficeIMO.Word",

--- a/Website/pipeline.json
+++ b/Website/pipeline.json
@@ -1141,7 +1141,7 @@
       "navCanonicalPath": "index.html",
       "navCanonicalRequired": true,
       "ignoreNav": "apps/officeimo-converter/**,sitemap/index.html",
-      "requiredRoutes": "/,/docs/,/404.html,/api/,/api/powershell/,/api/powerpoint/,/api/csv/,/api/visio/,/api/pdf/,/api/html/,/api/email/,/api/onenote/,/api/open-document/,/api/reader/,/api/google-workspace/,/api/google-workspace-drive/,/api/google-workspace-auth/,/api/google-workspace-sync/,/blog/,/showcase/,/playground/,/compatibility/,/convert/,/convert/doc-docx/,/convert/xls-xlsx/,/convert/ppt-pptx/,/solutions/,/solutions/legacy-office-modernization/,/solutions/document-publishing/,/products/word/,/products/excel/,/products/powerpoint/,/products/pdf/,/products/email/,/products/onenote/,/products/open-document/,/products/google-workspace/,/products/html/"
+      "requiredRoutes": "/,/docs/,/404.html,/api/,/api/powershell/,/api/powerpoint/,/api/csv/,/api/visio/,/api/pdf/,/api/html/,/api/email/,/api/onenote/,/api/open-document/,/api/reader/,/api/google-workspace/,/api/google-workspace-drive/,/api/google-workspace-auth/,/api/google-workspace-sync/,/blog/,/showcase/,/playground/,/compatibility/,/convert/,/convert/guides/,/convert/doc-docx/,/convert/xls-xlsx/,/convert/ppt-pptx/,/solutions/,/solutions/legacy-office-modernization/,/solutions/document-publishing/,/products/word/,/products/excel/,/products/powerpoint/,/products/pdf/,/products/email/,/products/onenote/,/products/open-document/,/products/google-workspace/,/products/html/"
     },
     {
       "task": "doctor",
@@ -1156,7 +1156,7 @@
       "navCanonicalPath": "index.html",
       "navCanonicalRequired": true,
       "ignoreNav": "apps/officeimo-converter/**,sitemap/index.html",
-      "requiredRoutes": "/,/docs/,/404.html,/api/,/api/powershell/,/api/powerpoint/,/api/csv/,/api/visio/,/api/pdf/,/api/html/,/api/email/,/api/onenote/,/api/open-document/,/api/reader/,/api/google-workspace/,/api/google-workspace-drive/,/api/google-workspace-auth/,/api/google-workspace-sync/,/blog/,/showcase/,/playground/,/products/word/,/products/pdf/,/products/email/,/products/onenote/,/products/open-document/,/products/google-workspace/,/products/html/"
+      "requiredRoutes": "/,/docs/,/404.html,/api/,/api/powershell/,/api/powerpoint/,/api/csv/,/api/visio/,/api/pdf/,/api/html/,/api/email/,/api/onenote/,/api/open-document/,/api/reader/,/api/google-workspace/,/api/google-workspace-drive/,/api/google-workspace-auth/,/api/google-workspace-sync/,/blog/,/showcase/,/playground/,/convert/,/convert/guides/,/products/word/,/products/pdf/,/products/email/,/products/onenote/,/products/open-document/,/products/google-workspace/,/products/html/"
     }
   ]
 }

--- a/Website/scripts/Test-ConverterPublish.ps1
+++ b/Website/scripts/Test-ConverterPublish.ps1
@@ -15,11 +15,41 @@ $appAssemblyPath = Get-ChildItem -LiteralPath $frameworkRoot -File -Filter 'Offi
 $runtimeWasmPath = Get-ChildItem -LiteralPath $frameworkRoot -File -Filter 'dotnet.native*.wasm' -ErrorAction SilentlyContinue |
     Where-Object { $_.Name -notmatch '\.(br|gz)$' } |
     Select-Object -First 1 -ExpandProperty FullName
+$convertPagePath = Join-Path $SiteRoot 'convert/index.html'
+$conversionGuidesPath = Join-Path $SiteRoot 'convert/guides/index.html'
+$playgroundPagePath = Join-Path $SiteRoot 'playground/index.html'
 
-foreach ($path in @($indexPath, $modulePath, $appAssemblyPath, $runtimeWasmPath)) {
+foreach ($path in @(
+        $indexPath,
+        $modulePath,
+        $appAssemblyPath,
+        $runtimeWasmPath,
+        $convertPagePath,
+        $conversionGuidesPath,
+        $playgroundPagePath
+    )) {
     if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
         throw "Converter publish is missing '$path'."
     }
+}
+
+$converterFramePattern = 'src="/apps/officeimo-converter/\?embedded=1"'
+$convertPage = Get-Content -LiteralPath $convertPagePath -Raw
+if ($convertPage -notmatch $converterFramePattern) {
+    throw "The primary /convert/ route does not host the browser converter."
+}
+
+$conversionGuides = Get-Content -LiteralPath $conversionGuidesPath -Raw
+if ($conversionGuides -notmatch '<h1>Document Conversion Guides for \.NET</h1>') {
+    throw "The /convert/guides/ route does not contain the conversion guide."
+}
+
+$playgroundPage = Get-Content -LiteralPath $playgroundPagePath -Raw
+if ($playgroundPage -notmatch $converterFramePattern) {
+    throw "The compatibility /playground/ route does not host the browser converter."
+}
+if ($playgroundPage -notmatch '<link rel="canonical" href="https://officeimo\.com/convert/"') {
+    throw "The compatibility /playground/ route does not canonicalize to /convert/."
 }
 
 $runtimeWasm = [System.Text.Encoding]::ASCII.GetString(

--- a/Website/scripts/Test-ConverterPublish.ps1
+++ b/Website/scripts/Test-ConverterPublish.ps1
@@ -48,7 +48,15 @@ $playgroundPage = Get-Content -LiteralPath $playgroundPagePath -Raw
 if ($playgroundPage -notmatch $converterFramePattern) {
     throw "The compatibility /playground/ route does not host the browser converter."
 }
-if ($playgroundPage -notmatch '<link rel="canonical" href="https://officeimo\.com/convert/"') {
+$canonicalLink = [regex]::Matches(
+    $playgroundPage,
+    '<link\b[^>]*>',
+    [System.Text.RegularExpressions.RegexOptions]::IgnoreCase
+) | Where-Object {
+    $_.Value -match '\brel\s*=\s*(?:"canonical"|''canonical''|canonical)(?:\s|/?>)' -and
+    $_.Value -match '\bhref\s*=\s*(?:"https://officeimo\.com/convert/"|''https://officeimo\.com/convert/''|https://officeimo\.com/convert/)(?:\s|/?>)'
+} | Select-Object -First 1
+if (-not $canonicalLink) {
     throw "The compatibility /playground/ route does not canonicalize to /convert/."
 }
 

--- a/Website/scripts/Test-ConverterPublish.ps1
+++ b/Website/scripts/Test-ConverterPublish.ps1
@@ -59,6 +59,17 @@ $canonicalLink = [regex]::Matches(
 if (-not $canonicalLink) {
     throw "The compatibility /playground/ route does not canonicalize to /convert/."
 }
+$robotsMeta = [regex]::Matches(
+    $playgroundPage,
+    '<meta\b[^>]*>',
+    [System.Text.RegularExpressions.RegexOptions]::IgnoreCase
+) | Where-Object {
+    $_.Value -match '\bname\s*=\s*(?:"robots"|''robots''|robots)(?:\s|/?>)' -and
+    $_.Value -match '\bcontent\s*=\s*(?:"[^"]*\bnoindex\b[^"]*"|''[^'']*\bnoindex\b[^'']*''|[^\s>]*\bnoindex\b[^\s>]*)(?:\s|/?>)'
+} | Select-Object -First 1
+if (-not $robotsMeta) {
+    throw "The compatibility /playground/ route is indexable instead of being a noindex alias."
+}
 
 $runtimeWasm = [System.Text.Encoding]::ASCII.GetString(
     [System.IO.File]::ReadAllBytes($runtimeWasmPath)

--- a/Website/site.json
+++ b/Website/site.json
@@ -439,7 +439,7 @@
                 "Title": "By deployment",
                 "Items": [
                   { "Title": "Cross-platform .NET", "Url": "/docs/getting-started/platform-support/", "Description": "Choose packages for services, apps, and AOT" },
-                  { "Title": "Browser conversion", "Url": "/playground/", "Description": "Run supported routes locally with WebAssembly" },
+                  { "Title": "Browser conversion", "Url": "/convert/", "Description": "Run supported routes locally with WebAssembly" },
                   { "Title": "Server workflows", "Url": "/docs/", "Description": "Keep authentication, storage, and retention in your stack" }
                 ]
               }
@@ -562,9 +562,9 @@
           { "Title": "Changelog", "Url": "/changelog/" },
           { "Title": "Benchmarks", "Url": "/benchmarks/" },
           { "Title": "Compatibility", "Url": "/compatibility/" },
-          { "Title": "Conversions", "Url": "/convert/" },
+          { "Title": "Conversion guides", "Url": "/convert/guides/" },
           { "Title": "Comparison", "Url": "/comparison/" },
-          { "Title": "Playground", "Url": "/playground/" },
+          { "Title": "Browser converter", "Url": "/convert/" },
           { "Title": "Support", "Url": "/pricing/" },
           { "Title": "Showcase", "Url": "/showcase/" },
           { "Title": "Blog", "Url": "/blog/" }

--- a/Website/static/js/site.js
+++ b/Website/static/js/site.js
@@ -328,6 +328,7 @@
     if (!frame) return;
 
     var observer = null;
+    var compactViewport = window.matchMedia('(max-width: 760px)');
 
     function syncTheme() {
       try {
@@ -342,6 +343,11 @@
     }
 
     function syncHeight() {
+      if (compactViewport.matches) {
+        frame.style.removeProperty('height');
+        return;
+      }
+
       try {
         var frameDocument = frame.contentDocument;
         if (!frameDocument) return;
@@ -353,6 +359,12 @@
       } catch (error) {
         // The converter is same-origin in production. Keep the CSS fallback if a preview host changes that.
       }
+    }
+
+    if (typeof compactViewport.addEventListener === 'function') {
+      compactViewport.addEventListener('change', syncHeight);
+    } else if (typeof compactViewport.addListener === 'function') {
+      compactViewport.addListener(syncHeight);
     }
 
     function observeFrame() {

--- a/Website/themes/officeimo/assets/visual-system.css
+++ b/Website/themes/officeimo/assets/visual-system.css
@@ -1438,6 +1438,7 @@ body.pf-api-docs {
 .imo-converter-launch__frame {
   display: block;
   width: 100%;
+  height: auto;
   min-height: 720px;
   border: 0;
   background: var(--imo-bg);

--- a/Website/themes/officeimo/assets/visual-system.css
+++ b/Website/themes/officeimo/assets/visual-system.css
@@ -2137,6 +2137,9 @@ body.pf-api-docs {
 }
 
 @media (max-width: 760px) {
+  html:has(.imo-body--playground),
+  .imo-body--playground { overflow: hidden; }
+  .imo-body--playground .imo-footer { display: none; }
   .imo-container { padding-inline: 1rem; }
   .imo-header__actions .nav-cta { display: none; }
   .imo-hero { min-height: 0; padding: 3rem 0 2.25rem; }
@@ -2182,7 +2185,15 @@ body.pf-api-docs {
   .imo-api-component-row nav { justify-content: flex-start; }
   .imo-blog-featured__copy { padding: 1.3rem; }
   .imo-footer__grid { grid-template-columns: 1fr 1fr; }
-  .imo-converter-launch__frame { min-height: 900px; }
+  .imo-converter-launch__frame-shell {
+    width: 100%;
+    padding-inline: 0;
+  }
+  .imo-converter-launch__frame {
+    height: calc(100dvh - var(--imo-header-height));
+    min-height: 640px;
+    border-radius: 0;
+  }
   .imo-proof-card { grid-template-columns: 1fr; gap: 0.75rem; }
   .imo-proof-card__format { align-items: center; }
   .imo-proof-card__format span { padding-top: 0; }

--- a/Website/themes/officeimo/assets/visual-system.css
+++ b/Website/themes/officeimo/assets/visual-system.css
@@ -2191,7 +2191,7 @@ body.pf-api-docs {
   }
   .imo-converter-launch__frame {
     height: calc(100dvh - var(--imo-header-height));
-    min-height: 640px;
+    min-height: 0;
     border-radius: 0;
   }
   .imo-proof-card { grid-template-columns: 1fr; gap: 0.75rem; }

--- a/Website/themes/officeimo/layouts/conversion.html
+++ b/Website/themes/officeimo/layouts/conversion.html
@@ -67,7 +67,7 @@
           <div><dt>Microsoft Office</dt><dd>Not required</dd></div>
           <div><dt>License</dt><dd>MIT</dd></div>
         </dl>
-        <a href="/convert/">Browse all conversion routes</a>
+        <a href="/convert/guides/">Browse all conversion routes</a>
       </aside>
     </div>
   </main>

--- a/Website/themes/officeimo/layouts/product.html
+++ b/Website/themes/officeimo/layouts/product.html
@@ -35,7 +35,7 @@
     <section class="imo-product-next">
       <div class="imo-container imo-product-next__inner">
         <div><p class="imo-product-next__eyebrow">Next step</p><h2>Turn the package into a working document.</h2><p>Follow a focused guide, inspect the generated API reference, or try a browser-safe conversion.</p></div>
-        <div class="imo-product-next__actions"><a class="imo-btn imo-btn-primary" href="{{ page.docs_url ?? page.meta.docs_url ?? "/docs/" }}">Open the guide</a><a class="imo-btn imo-btn-ghost" href="/playground/">Open converter</a></div>
+        <div class="imo-product-next__actions"><a class="imo-btn imo-btn-primary" href="{{ page.docs_url ?? page.meta.docs_url ?? "/docs/" }}">Open the guide</a><a class="imo-btn imo-btn-ghost" href="/convert/">Open converter</a></div>
       </div>
     </section>
   </main>

--- a/Website/themes/officeimo/partials/product-subnav.html
+++ b/Website/themes/officeimo/partials/product-subnav.html
@@ -1,7 +1,7 @@
 <nav class="imo-product-subnav" aria-label="Product navigation">
   <div class="imo-container imo-product-subnav__inner">
     <a href="/products/word/">Create</a>
-    <a href="/playground/">Browser converter</a>
+    <a href="/convert/">Browser converter</a>
     <a href="/products/reader/">Extract</a>
     <a href="/products/pswriteoffice/">Automate</a>
     <a href="/products/google-workspace/">Integrate</a>

--- a/Website/themes/officeimo/templates/sitemap.html
+++ b/Website/themes/officeimo/templates/sitemap.html
@@ -69,7 +69,7 @@
           </div>
         </div>
         <a href="/docs/">Docs</a>
-        <a href="/playground/">Playground</a>
+        <a href="/convert/">Browser converter</a>
         <a href="/blog/">Blog</a>
         <div class="imo-nav__item">
           <button type="button" aria-expanded="false" aria-haspopup="true">API


### PR DESCRIPTION
## Summary

- restore the working browser converter as the primary `/convert/` experience
- move the detailed .NET conversion guidance to `/convert/guides/` and update affected navigation and content links
- redesign the converter around a compact route rail, focused two-pane workspace, collapsed settings, and responsive light/dark layouts
- retain `/playground/` as a compatibility route canonicalized to `/convert/`
- add publish-time route guards so the converter cannot be replaced by a static content page unnoticed

## Validation

- converter tests: 17 passed
- WebAssembly publish, overlay, and route verification passed
- browser sample conversion produced downloadable PDF and report output
- desktop/mobile and light/dark layouts inspected with no browser console errors