### PR TITLE
Harden document conversion and structural workbook edits

### DIFF
--- a/OfficeIMO.Drawing.Tests/Drawing.ChartBubbles.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.ChartBubbles.cs
@@ -27,11 +27,6 @@ public class DrawingChartBubbleTests {
             .ShowMarkerOutline);
         Assert.False(OfficeChartSeries.CreateBubble(
             "Explicit", new[] { 1D }, new[] { 2D }, new[] { 3D },
-            color: null,
-            pointColors: null,
-            showInLegend: true,
-            markerOutlineColor: null,
-            markerOutlineWidth: null,
             showMarkerOutline: false).ShowMarkerOutline);
     }
 

--- a/OfficeIMO.Drawing.Tests/Drawing.ChartBubbles.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.ChartBubbles.cs
@@ -6,6 +6,36 @@ namespace OfficeIMO.Tests;
 
 public class DrawingChartBubbleTests {
     [Fact]
+    public void OfficeChartSeries_CreateBubbleRetainsBinaryCompatibleFactory() {
+        Type[] legacyParameterTypes = {
+            typeof(string),
+            typeof(IEnumerable<double>),
+            typeof(IEnumerable<double>),
+            typeof(IEnumerable<double>),
+            typeof(OfficeColor?),
+            typeof(IEnumerable<OfficeColor?>),
+            typeof(bool),
+            typeof(OfficeColor?),
+            typeof(double?)
+        };
+
+        Assert.NotNull(typeof(OfficeChartSeries).GetMethod(
+            nameof(OfficeChartSeries.CreateBubble),
+            legacyParameterTypes));
+        Assert.True(OfficeChartSeries.CreateBubble(
+            "Legacy", new[] { 1D }, new[] { 2D }, new[] { 3D })
+            .ShowMarkerOutline);
+        Assert.False(OfficeChartSeries.CreateBubble(
+            "Explicit", new[] { 1D }, new[] { 2D }, new[] { 3D },
+            color: null,
+            pointColors: null,
+            showInLegend: true,
+            markerOutlineColor: null,
+            markerOutlineWidth: null,
+            showMarkerOutline: false).ShowMarkerOutline);
+    }
+
+    [Fact]
     public void OfficeChartSnapshot_RetainsBinaryCompatibleConstructor() {
         Assert.NotNull(typeof(OfficeChartSnapshot).GetConstructor(new[] {
             typeof(string),
@@ -283,6 +313,10 @@ public class DrawingChartBubbleTests {
                 new[] { 2D },
                 new[] { 25D },
                 color,
+                pointColors: null,
+                showInLegend: true,
+                markerOutlineColor: null,
+                markerOutlineWidth: null,
                 showMarkerOutline: false)
         });
 

--- a/OfficeIMO.Drawing/OfficeChartSeries.cs
+++ b/OfficeIMO.Drawing/OfficeChartSeries.cs
@@ -83,12 +83,32 @@ public sealed class OfficeChartSeries {
     /// <param name="showInLegend">Whether this series should appear in rendered legends.</param>
     /// <param name="markerOutlineColor">Optional source-defined bubble outline color.</param>
     /// <param name="markerOutlineWidth">Optional source-defined bubble outline width in drawing units.</param>
-    /// <param name="showMarkerOutline">Whether the bubble outline should be rendered.</param>
     public static OfficeChartSeries CreateBubble(string name, IEnumerable<double> xValues,
         IEnumerable<double> yValues, IEnumerable<double> bubbleSizes, OfficeColor? color = null,
         IEnumerable<OfficeColor?>? pointColors = null, bool showInLegend = true,
-        OfficeColor? markerOutlineColor = null, double? markerOutlineWidth = null,
-        bool showMarkerOutline = true) {
+        OfficeColor? markerOutlineColor = null, double? markerOutlineWidth = null) =>
+        CreateBubble(name, xValues, yValues, bubbleSizes, color, pointColors,
+            showInLegend, markerOutlineColor, markerOutlineWidth,
+            showMarkerOutline: true);
+
+    /// <summary>
+    /// Creates a bubble-chart series with explicit control over whether bubble outlines are rendered.
+    /// </summary>
+    /// <param name="name">Display name for the series.</param>
+    /// <param name="xValues">Numeric X-axis values.</param>
+    /// <param name="yValues">Numeric Y-axis values.</param>
+    /// <param name="bubbleSizes">Non-negative bubble sizes aligned with the X/Y values.</param>
+    /// <param name="color">Optional source-defined series color.</param>
+    /// <param name="pointColors">Optional source-defined colors aligned with individual bubbles.</param>
+    /// <param name="showInLegend">Whether this series should appear in rendered legends.</param>
+    /// <param name="markerOutlineColor">Optional source-defined bubble outline color.</param>
+    /// <param name="markerOutlineWidth">Optional source-defined bubble outline width in drawing units.</param>
+    /// <param name="showMarkerOutline">Whether the bubble outline should be rendered.</param>
+    public static OfficeChartSeries CreateBubble(string name, IEnumerable<double> xValues,
+        IEnumerable<double> yValues, IEnumerable<double> bubbleSizes, OfficeColor? color,
+        IEnumerable<OfficeColor?>? pointColors, bool showInLegend,
+        OfficeColor? markerOutlineColor, double? markerOutlineWidth,
+        bool showMarkerOutline) {
         if (xValues == null) throw new ArgumentNullException(nameof(xValues));
         if (yValues == null) throw new ArgumentNullException(nameof(yValues));
         if (bubbleSizes == null) throw new ArgumentNullException(nameof(bubbleSizes));

--- a/OfficeIMO.Drawing/OfficeChartSeries.cs
+++ b/OfficeIMO.Drawing/OfficeChartSeries.cs
@@ -84,9 +84,9 @@ public sealed class OfficeChartSeries {
     /// <param name="markerOutlineColor">Optional source-defined bubble outline color.</param>
     /// <param name="markerOutlineWidth">Optional source-defined bubble outline width in drawing units.</param>
     public static OfficeChartSeries CreateBubble(string name, IEnumerable<double> xValues,
-        IEnumerable<double> yValues, IEnumerable<double> bubbleSizes, OfficeColor? color = null,
-        IEnumerable<OfficeColor?>? pointColors = null, bool showInLegend = true,
-        OfficeColor? markerOutlineColor = null, double? markerOutlineWidth = null) =>
+        IEnumerable<double> yValues, IEnumerable<double> bubbleSizes, OfficeColor? color,
+        IEnumerable<OfficeColor?>? pointColors, bool showInLegend,
+        OfficeColor? markerOutlineColor, double? markerOutlineWidth) =>
         CreateBubble(name, xValues, yValues, bubbleSizes, color, pointColors,
             showInLegend, markerOutlineColor, markerOutlineWidth,
             showMarkerOutline: true);
@@ -105,10 +105,10 @@ public sealed class OfficeChartSeries {
     /// <param name="markerOutlineWidth">Optional source-defined bubble outline width in drawing units.</param>
     /// <param name="showMarkerOutline">Whether the bubble outline should be rendered.</param>
     public static OfficeChartSeries CreateBubble(string name, IEnumerable<double> xValues,
-        IEnumerable<double> yValues, IEnumerable<double> bubbleSizes, OfficeColor? color,
-        IEnumerable<OfficeColor?>? pointColors, bool showInLegend,
-        OfficeColor? markerOutlineColor, double? markerOutlineWidth,
-        bool showMarkerOutline) {
+        IEnumerable<double> yValues, IEnumerable<double> bubbleSizes, OfficeColor? color = null,
+        IEnumerable<OfficeColor?>? pointColors = null, bool showInLegend = true,
+        OfficeColor? markerOutlineColor = null, double? markerOutlineWidth = null,
+        bool showMarkerOutline = true) {
         if (xValues == null) throw new ArgumentNullException(nameof(xValues));
         if (yValues == null) throw new ArgumentNullException(nameof(yValues));
         if (bubbleSizes == null) throw new ArgumentNullException(nameof(bubbleSizes));

--- a/OfficeIMO.Excel.Tests/Excel.SecurityFindings.cs
+++ b/OfficeIMO.Excel.Tests/Excel.SecurityFindings.cs
@@ -1,0 +1,62 @@
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        public void DuplicateLegacyComments_DoNotCrashStructuralRowRemapping() {
+            using var document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet sheet = document.AddWorksheet("Data");
+            sheet.CellValue(3, 1, "Value");
+            sheet.SetComment(3, 1, "Duplicate", author: "Tester");
+            AppendDuplicateComment(sheet);
+
+            sheet.InsertRows(2);
+
+            string[] references = sheet.WorksheetPart.WorksheetCommentsPart!
+                .Comments!.CommentList!.Elements<Comment>()
+                .Select(comment => comment.Reference!.Value!)
+                .ToArray();
+            Assert.Equal(new[] { "A4", "A4" }, references);
+            Assert.True(sheet.HasComment(4, 1));
+        }
+
+        [Fact]
+        public void DuplicateLegacyComments_DoNotCrashSortedRowRemapping() {
+            using var document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet sheet = document.AddWorksheet("Data");
+            sheet.CellValue(1, 1, "Name");
+            sheet.CellValue(1, 2, "Score");
+            sheet.CellValue(2, 1, "High");
+            sheet.CellValue(2, 2, 10D);
+            sheet.CellValue(3, 1, "Low");
+            sheet.CellValue(3, 2, 1D);
+            sheet.SetComment(2, 1, "Duplicate", author: "Tester");
+            AppendDuplicateComment(sheet);
+
+            sheet.SortRangeByColumn(
+                "A1:B3",
+                columnOffset: 2,
+                ascending: true,
+                hasHeader: true);
+
+            string[] references = sheet.WorksheetPart.WorksheetCommentsPart!
+                .Comments!.CommentList!.Elements<Comment>()
+                .Select(comment => comment.Reference!.Value!)
+                .ToArray();
+            Assert.Equal(new[] { "A3", "A3" }, references);
+            Assert.True(sheet.HasComment(3, 1));
+        }
+
+        private static void AppendDuplicateComment(ExcelSheet sheet) {
+            Comment original = sheet.WorksheetPart.WorksheetCommentsPart!
+                .Comments!.CommentList!.Elements<Comment>().Single();
+            sheet.WorksheetPart.WorksheetCommentsPart.Comments.CommentList
+                .Append((Comment)original.CloneNode(true));
+            sheet.WorksheetPart.WorksheetCommentsPart.Comments.Save();
+        }
+    }
+}

--- a/OfficeIMO.Excel.Tests/Excel.StructuralRows.TwentyFifthWaveRegressions.cs
+++ b/OfficeIMO.Excel.Tests/Excel.StructuralRows.TwentyFifthWaveRegressions.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        public void Test_StructuralRows_FormulaQuoteScanningRemainsLinear() {
+            string quotedSheetName = "'" + new string('"', 50_000) + "'";
+            string formula = quotedSheetName + "!A5+\"A5\"+A5";
+            var stopwatch = Stopwatch.StartNew();
+
+            string rewritten = ExcelSheet.RewriteFormulaReferencesOutsideStrings(
+                formula,
+                segment => segment.Replace("A5", "A6"));
+            stopwatch.Stop();
+
+            Assert.Equal(quotedSheetName + "!A6+\"A5\"+A6", rewritten);
+            Assert.True(
+                stopwatch.Elapsed < TimeSpan.FromSeconds(5),
+                $"Formula scanning took {stopwatch.Elapsed}.");
+        }
+
+        [Fact]
+        public void Test_StructuralRows_IgnoresMalformedImplicitCellsWithoutSharedFormulas() {
+            using var document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet edited = document.AddWorksheet("Edited");
+            edited.CellAt(1, 1).SetValue("Keep");
+            ExcelSheet malformed = document.AddWorksheet("Malformed");
+            malformed.WorksheetPart.Worksheet.GetFirstChild<SheetData>()!.Append(
+                new Row(new Cell { CellValue = new CellValue("value") }) {
+                    RowIndex = uint.MaxValue
+                });
+
+            edited.InsertRows(1);
+
+            Assert.Equal("Keep", edited.CellAt(2, 1).GetValue<string>());
+        }
+
+        [Fact]
+        public void Test_StructuralRows_HandlesMalformedImplicitSharedFormulaCoordinatesWithoutOverflow() {
+            using var document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet edited = document.AddWorksheet("Edited");
+            ExcelSheet malformed = document.AddWorksheet("Malformed");
+            malformed.WorksheetPart.Worksheet.GetFirstChild<SheetData>()!.Append(
+                new Row(new Cell {
+                    CellFormula = new CellFormula("A1") {
+                        FormulaType = CellFormulaValues.Shared,
+                        SharedIndex = 9U,
+                        Reference = "A1:A1"
+                    }
+                }) {
+                    RowIndex = uint.MaxValue
+                });
+
+            edited.InsertRows(1);
+
+            CellFormula formula = Assert.Single(
+                malformed.WorksheetPart.Worksheet.Descendants<CellFormula>());
+            Assert.Equal("A1", formula.Text);
+        }
+
+        [Fact]
+        public void Test_StructuralRows_IgnoresSameNamedDefinitionsFromOtherSheetScopes() {
+            using var document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet data = CreatePivotSheet(document);
+            document.AddWorksheet("Other");
+            WorksheetSource source = Assert.Single(
+                data.WorksheetPart.PivotTableParts).PivotTableCacheDefinitionPart!
+                .PivotCacheDefinition!.CacheSource!.WorksheetSource!;
+            source.Reference = null;
+            source.Sheet = null;
+            source.Name = "PivotSource";
+            var globalName = new DefinedName("'Data'!$A$5:$B$7") {
+                Name = "PivotSource"
+            };
+            var otherLocalName = new DefinedName("$A$2:$B$3") {
+                Name = "PivotSource",
+                LocalSheetId = 1U
+            };
+            document.WorkbookRoot.DefinedNames = new DefinedNames(
+                globalName,
+                otherLocalName);
+
+            data.DeleteRows(2);
+
+            Assert.Equal("'Data'!$A$4:$B$6", globalName.Text);
+            Assert.Equal("$A$2:$B$3", otherLocalName.Text);
+        }
+
+        [Fact]
+        public void Test_StructuralRows_PreservesActiveCellIdForSingleCellSelections() {
+            using var document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet sheet = document.AddWorksheet("Data");
+            var selection = new Selection {
+                ActiveCell = "B6",
+                ActiveCellId = 1U,
+                SequenceOfReferences = new ListValue<StringValue> {
+                    InnerText = "A3 B6"
+                }
+            };
+            var views = new SheetViews(
+                new SheetView(selection) { WorkbookViewId = 0U });
+            SheetData sheetData = sheet.WorksheetPart.Worksheet.GetFirstChild<SheetData>()!;
+            sheet.WorksheetPart.Worksheet.InsertBefore(views, sheetData);
+
+            sheet.InsertRows(4);
+
+            Assert.Equal("B7", selection.ActiveCell!.Value);
+            Assert.Equal("A3 B7", selection.SequenceOfReferences!.InnerText);
+            Assert.Equal(1U, selection.ActiveCellId!.Value);
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelSheet.Comments.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Comments.cs
@@ -651,7 +651,12 @@ namespace OfficeIMO.Excel {
             int structuralRowDelta = 0,
             int? lastDeletedRow = null) {
             var removedCells = new HashSet<(int Row, int Col)>(removed);
-            var movedCells = moved.ToDictionary(pair => pair.OldCell, pair => pair.NewCell);
+            var movedCells = new Dictionary<(int Row, int Col), (int Row, int Col)>();
+            foreach (var pair in moved) {
+                if (!movedCells.ContainsKey(pair.OldCell)) {
+                    movedCells.Add(pair.OldCell, pair.NewCell);
+                }
+            }
             var movedShapes = new HashSet<(int Row, int Col)>();
             VmlDrawingPart? vmlPart = TryGetCommentVmlPart();
             if (vmlPart != null) {

--- a/OfficeIMO.Excel/ExcelSheet.Formulas.Shared.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Formulas.Shared.cs
@@ -125,14 +125,20 @@ namespace OfficeIMO.Excel {
         }
 
         private IReadOnlyList<string> ResolveSharedFormulaTextsForStructuralValidation() {
+            List<Cell> sharedCells = WorksheetRoot.Descendants<Cell>()
+                .Where(candidate => candidate.CellFormula?.FormulaType?.Value == CellFormulaValues.Shared
+                    && candidate.CellFormula.SharedIndex?.Value != null)
+                .ToList();
+            if (sharedCells.Count == 0) {
+                return Array.Empty<string>();
+            }
+
             IReadOnlyDictionary<Cell, (int Row, int Column)> effectiveCoordinates = BuildEffectiveCellCoordinates();
             IReadOnlyDictionary<uint, SharedFormulaDefinition> definitions =
                 BuildSharedFormulaDefinitions(effectiveCoordinates);
 
             var resolved = new List<string>();
-            foreach (Cell cell in WorksheetRoot.Descendants<Cell>()
-                .Where(candidate => candidate.CellFormula?.FormulaType?.Value == CellFormulaValues.Shared
-                    && candidate.CellFormula.SharedIndex?.Value != null)) {
+            foreach (Cell cell in sharedCells) {
                 string text = ResolveCellFormulaText(cell, definitions, effectiveCoordinates);
                 if (string.IsNullOrWhiteSpace(text)) {
                     throw new InvalidOperationException(
@@ -223,7 +229,8 @@ namespace OfficeIMO.Excel {
                         out int explicitColumn)) {
                         coordinates[cell] = (explicitRow, explicitColumn);
                         effectiveColumn = explicitColumn;
-                    } else {
+                    } else if (effectiveRow <= (uint)A1.MaxRows
+                        && effectiveColumn <= A1.MaxColumns) {
                         coordinates[cell] = (checked((int)effectiveRow), effectiveColumn);
                     }
 

--- a/OfficeIMO.Excel/ExcelSheet.ObjectModel.References.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ObjectModel.References.cs
@@ -351,26 +351,49 @@ namespace OfficeIMO.Excel {
             });
         }
 
-        private static string RewriteFormulaReferencesOutsideStrings(string formula, Func<string, string> rewriteSegment) {
+        /// <summary>
+        /// Rewrites non-literal formula segments in one pass while preserving escaped string
+        /// quotes and double quotes that occur inside single-quoted sheet qualifiers.
+        /// </summary>
+        internal static string RewriteFormulaReferencesOutsideStrings(string formula, Func<string, string> rewriteSegment) {
             var builder = new StringBuilder(formula.Length);
             int index = 0;
             while (index < formula.Length) {
-                int quote = formula.IndexOf('"', index);
-                while (quote >= 0
-                    && IsInsideSingleQuotedFormulaQualifier(formula, index, quote)) {
-                    quote = formula.IndexOf('"', quote + 1);
+                int segmentStart = index;
+                bool insideSingleQuotedQualifier = false;
+                while (index < formula.Length) {
+                    char character = formula[index];
+                    if (character == '\'') {
+                        if (insideSingleQuotedQualifier
+                            && index + 1 < formula.Length
+                            && formula[index + 1] == '\'') {
+                            index += 2;
+                            continue;
+                        }
+
+                        insideSingleQuotedQualifier = !insideSingleQuotedQualifier;
+                        index++;
+                        continue;
+                    }
+
+                    if (character == '"' && !insideSingleQuotedQualifier) {
+                        break;
+                    }
+
+                    index++;
                 }
-                if (quote < 0) {
-                    builder.Append(rewriteSegment(formula.Substring(index)));
+
+                if (index >= formula.Length) {
+                    builder.Append(rewriteSegment(formula.Substring(segmentStart)));
                     break;
                 }
 
-                if (quote > index) {
-                    builder.Append(rewriteSegment(formula.Substring(index, quote - index)));
+                if (index > segmentStart) {
+                    builder.Append(rewriteSegment(formula.Substring(segmentStart, index - segmentStart)));
                 }
 
-                int literalStart = quote;
-                index = quote + 1;
+                int literalStart = index;
+                index++;
                 while (index < formula.Length) {
                     if (formula[index] == '"') {
                         if (index + 1 < formula.Length && formula[index + 1] == '"') {
@@ -389,29 +412,6 @@ namespace OfficeIMO.Excel {
             }
 
             return builder.ToString();
-        }
-
-        private static bool IsInsideSingleQuotedFormulaQualifier(
-            string formula,
-            int start,
-            int position) {
-            bool insideQualifier = false;
-            for (int index = start; index < position; index++) {
-                if (formula[index] != '\'') {
-                    continue;
-                }
-
-                if (insideQualifier
-                    && index + 1 < position
-                    && formula[index + 1] == '\'') {
-                    index++;
-                    continue;
-                }
-
-                insideQualifier = !insideQualifier;
-            }
-
-            return insideQualifier;
         }
 
         private string ReplaceFormulaReferences(string segment, MatchEvaluator evaluator) {

--- a/OfficeIMO.Excel/ExcelSheet.StructuralRangeMetadata.cs
+++ b/OfficeIMO.Excel/ExcelSheet.StructuralRangeMetadata.cs
@@ -555,14 +555,14 @@ namespace OfficeIMO.Excel {
 
             string? activeCell = selection.ActiveCell?.Value;
             if (!string.IsNullOrWhiteSpace(activeCell)
-                && A1.TryParseRange(
+                && TryParseCellOrRange(
                     activeCell!.Replace("$", string.Empty),
                     out int activeRow,
                     out int activeColumn,
                     out _,
                     out _)) {
                 for (int index = 0; index < references.Count; index++) {
-                    if (A1.TryParseRange(
+                    if (TryParseCellOrRange(
                             references[index].Replace("$", string.Empty),
                             out int firstRow,
                             out int firstColumn,
@@ -579,6 +579,31 @@ namespace OfficeIMO.Excel {
             }
 
             selection.ActiveCellId = 0U;
+        }
+
+        private static bool TryParseCellOrRange(
+            string reference,
+            out int firstRow,
+            out int firstColumn,
+            out int lastRow,
+            out int lastColumn) {
+            if (A1.TryParseRange(
+                    reference,
+                    out firstRow,
+                    out firstColumn,
+                    out lastRow,
+                    out lastColumn)) {
+                return true;
+            }
+
+            if (A1.TryParseCellReferenceFast(reference, out firstRow, out firstColumn)) {
+                lastRow = firstRow;
+                lastColumn = firstColumn;
+                return true;
+            }
+
+            firstRow = firstColumn = lastRow = lastColumn = 0;
+            return false;
         }
 
         private void RemapShiftedNamedSheetViewFilters(

--- a/OfficeIMO.Excel/ExcelSheet.StructuralRows.cs
+++ b/OfficeIMO.Excel/ExcelSheet.StructuralRows.cs
@@ -252,23 +252,24 @@ namespace OfficeIMO.Excel {
                 }
                 if (string.IsNullOrWhiteSpace(source?.Id?.Value)
                     && source?.Name?.Value is string sourceName) {
-                    bool deletesResolvedHeader = TryResolveDefinedNameRange(
+                    bool resolvedNamedSource = TryResolveDefinedNameRange(
                             sourceName,
                             currentRow: null,
                             out ExcelSheet sourceSheet,
                             out int namedSourceFirstRow,
                             out _,
                             out _,
-                            out _)
+                            out _);
+                    bool deletesResolvedHeader = resolvedNamedSource
                         && (ReferenceEquals(sourceSheet._worksheetPart, _worksheetPart)
                             || string.Equals(sourceSheet.Name, Name, StringComparison.OrdinalIgnoreCase))
                         && namedSourceFirstRow >= firstDeletedRow
                         && namedSourceFirstRow <= lastDeletedRow;
                     if (deletesResolvedHeader
-                        || UnresolvedNamedPivotSourceBecomesInvalid(
+                        || (!resolvedNamedSource && UnresolvedNamedPivotSourceBecomesInvalid(
                             sourceName,
                             firstDeletedRow,
-                            lastDeletedRow)) {
+                            lastDeletedRow))) {
                         throw new InvalidOperationException(
                             $"Cannot delete the header row of named pivot cache source '{sourceName}'. Update or remove the pivot source first.");
                     }
@@ -326,23 +327,32 @@ namespace OfficeIMO.Excel {
             string sourceName,
             int firstDeletedRow,
             int lastDeletedRow) {
-            int rowDelta = -(lastDeletedRow - firstDeletedRow + 1);
-            return WorkbookRoot.DefinedNames?.Elements<DefinedName>()
-                .Where(name => string.Equals(name.Name?.Value, sourceName, StringComparison.OrdinalIgnoreCase))
-                .Any(name => {
-                    string formula = name.Text ?? string.Empty;
-                    if (formula.Length == 0 || formula.IndexOf("#REF!", StringComparison.OrdinalIgnoreCase) >= 0) {
-                        return false;
-                    }
+            var catalog = new FormulaDefinedNameResolutionCatalog(this);
+            int? localSheetIndex = catalog.TryGetSheet(Name, out int sheetIndex, out _)
+                ? sheetIndex
+                : null;
+            if (!catalog.TryGetDefinedName(
+                    localSheetIndex,
+                    sourceName,
+                    allowGlobal: true,
+                    out DefinedName definedName,
+                    out _)) {
+                return false;
+            }
 
-                    string rewritten = RewriteDeletedFormulaReferences(
-                        formula,
-                        firstDeletedRow,
-                        lastDeletedRow,
-                        rowDelta,
-                        Name);
-                    return rewritten.IndexOf("#REF!", StringComparison.OrdinalIgnoreCase) >= 0;
-                }) == true;
+            int rowDelta = -(lastDeletedRow - firstDeletedRow + 1);
+            string formula = definedName.Text ?? string.Empty;
+            if (formula.Length == 0 || formula.IndexOf("#REF!", StringComparison.OrdinalIgnoreCase) >= 0) {
+                return false;
+            }
+
+            string rewritten = RewriteDeletedFormulaReferences(
+                formula,
+                firstDeletedRow,
+                lastDeletedRow,
+                rowDelta,
+                Name);
+            return rewritten.IndexOf("#REF!", StringComparison.OrdinalIgnoreCase) >= 0;
         }
 
         private void ValidateStructuralRowReferenceMode() {

--- a/OfficeIMO.Html.Tests/Html.OfficeAdapters.cs
+++ b/OfficeIMO.Html.Tests/Html.OfficeAdapters.cs
@@ -877,6 +877,10 @@ public class HtmlOfficeAdapters {
                 new[] { 8D, 16D },
                 new[] { 3D, 7D },
                 color: OfficeColor.Parse("#AABBCC"),
+                pointColors: null,
+                showInLegend: true,
+                markerOutlineColor: null,
+                markerOutlineWidth: null,
                 showMarkerOutline: false)
         });
         slide.AddChartPoints(OfficeChartKind.Bubble, data, 72, 96, 240, 140)

--- a/OfficeIMO.Html.Tests/Html.SecurityPerformance.cs
+++ b/OfficeIMO.Html.Tests/Html.SecurityPerformance.cs
@@ -9,6 +9,9 @@ using Xunit;
 namespace OfficeIMO.Tests;
 
 public partial class Html {
+    private const string SecurityPixel =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+
     [Fact]
     public void HtmlToWord_SharedAncestorStylesAreParsedWithinBoundedTime() {
         const int paragraphCount = 200;
@@ -37,5 +40,102 @@ public partial class Html {
         Assert.True(
             stopwatch.Elapsed < TimeSpan.FromSeconds(15),
             $"HTML conversion took {stopwatch.Elapsed}.");
+    }
+
+    [Fact]
+    public void HtmlToWord_TableBackgroundAncestorsAreParsedWithinBoundedTime() {
+        const int cellCount = 200;
+        var ancestorStyle = new StringBuilder("background-color:#0000ff;");
+        while (ancestorStyle.Length < 64 * 1024) {
+            ancestorStyle.Append("--table-background-contract:0;");
+        }
+        var rowBackground = new StringBuilder("rgba(255,0,0,0.5)");
+        while (rowBackground.Length < 64 * 1024) {
+            rowBackground.Append(' ');
+        }
+        var html = new StringBuilder("<div style=\"")
+            .Append(ancestorStyle)
+            .Append("\"><table><tr style=\"background-color:")
+            .Append(rowBackground)
+            .Append("\">");
+        for (int index = 0; index < cellCount; index++) {
+            html.Append("<td>Cell</td>");
+        }
+        html.Append("</tr></table></div>");
+        HtmlToWordOptions options = HtmlToWordOptions.CreateUntrustedHtmlProfile();
+        var stopwatch = Stopwatch.StartNew();
+
+        using WordDocument document = HtmlConversionDocument.Parse(html.ToString())
+            .ToWordDocumentResult(options)
+            .RequireValue();
+        stopwatch.Stop();
+
+        WordTable table = Assert.Single(document.Tables);
+        Assert.Equal(cellCount, table.Rows[0].Cells.Count);
+        Assert.All(table.Rows[0].Cells, cell =>
+            Assert.Equal("800080", cell.ShadingFillColorHex));
+        Assert.True(
+            stopwatch.Elapsed < TimeSpan.FromSeconds(15),
+            $"HTML conversion took {stopwatch.Elapsed}.");
+    }
+
+    [Fact]
+    public void HtmlToWord_ImageContainerWidthIsResolvedOnlyForPercentageSizing() {
+        using WordDocument document = WordDocument.Create();
+        int resolverCalls = 0;
+        int? ResolveContainerWidth() {
+            resolverCalls++;
+            return 7200;
+        }
+
+        Assert.Null(HtmlToWordConverter.TryResolveImagePercentWidth(
+            "320px",
+            document,
+            ResolveContainerWidth));
+        Assert.Equal(0, resolverCalls);
+
+        double resolvedWidth = Assert.IsType<double>(
+            HtmlToWordConverter.TryResolveImagePercentWidth(
+                "50%",
+                document,
+                ResolveContainerWidth));
+        Assert.Equal(240D, resolvedWidth, precision: 3);
+        Assert.Equal(1, resolverCalls);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task HtmlToWord_PercentageTableImagesUsePrecomputedCellWidths() {
+        string html = $"""
+            <table style="width:600px">
+              <tr>
+                <td style="border:8px solid #000"><img style="width:100%" src="data:image/png;base64,{SecurityPixel}"></td>
+                <td style="border:8px solid #000"><img style="width:100%" src="data:image/png;base64,{SecurityPixel}"></td>
+                <td style="border:8px solid #000"><img style="width:100%" src="data:image/png;base64,{SecurityPixel}"></td>
+              </tr>
+            </table>
+            """;
+        var converter = new HtmlToWordConverter();
+
+        using WordDocument document = await converter.ConvertAsync(
+            HtmlConversionDocument.Parse(html).CreateDocumentForConversion(),
+            HtmlToWordOptions.CreateUntrustedHtmlProfile());
+
+        Assert.Equal(3, document.Images.Count);
+        var field = typeof(HtmlToWordConverter).GetField(
+            "_tableCellContentWidths",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        var widths = Assert.IsAssignableFrom<System.Collections.IDictionary>(field!.GetValue(converter));
+        Assert.Equal(3, widths.Count);
+        Assert.All(widths.Values.Cast<int?>(), width => Assert.True(width > 0));
+        WordTable table = Assert.Single(document.Tables);
+        var estimateMethod = typeof(WordTable).GetMethod(
+            "EstimateCellContentWidthInDxa",
+            System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic);
+        for (int index = 0; index < table.Rows[0].Cells.Count; index++) {
+            int expectedWidth = Assert.IsType<int>(estimateMethod!.Invoke(
+                null,
+                new object[] { document, table.Rows[0].Cells[index]._tableCell }));
+            Assert.Equal(expectedWidth / 15D, document.Images[index].Width!.Value, precision: 3);
+        }
     }
 }

--- a/OfficeIMO.Html.Tests/Html.SecurityPerformance.cs
+++ b/OfficeIMO.Html.Tests/Html.SecurityPerformance.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Diagnostics;
+using System.Text;
+using OfficeIMO.Html;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public partial class Html {
+    [Fact]
+    public void HtmlToWord_SharedAncestorStylesAreParsedWithinBoundedTime() {
+        const int paragraphCount = 200;
+        var ancestorStyle = new StringBuilder("background-color:#0000ff;");
+        while (ancestorStyle.Length < 64 * 1024) {
+            ancestorStyle.Append("--padding-contract:0;");
+        }
+        var html = new StringBuilder("<div style=\"")
+            .Append(ancestorStyle)
+            .Append("\">");
+        for (int index = 0; index < paragraphCount; index++) {
+            html.Append("<p style=\"background-color:rgba(255,0,0,0.5)\">Text</p>");
+        }
+        html.Append("</div>");
+        HtmlToWordOptions options = HtmlToWordOptions.CreateUntrustedHtmlProfile();
+        var stopwatch = Stopwatch.StartNew();
+
+        using WordDocument document = HtmlConversionDocument.Parse(html.ToString())
+            .ToWordDocumentResult(options)
+            .RequireValue();
+        stopwatch.Stop();
+
+        Assert.Equal(paragraphCount, document.Paragraphs.Count);
+        Assert.All(document.Paragraphs, paragraph =>
+            Assert.Equal("800080", paragraph.ShadingFillColorHex));
+        Assert.True(
+            stopwatch.Elapsed < TimeSpan.FromSeconds(15),
+            $"HTML conversion took {stopwatch.Elapsed}.");
+    }
+}

--- a/OfficeIMO.Html.Tests/Html.SecurityPerformance.cs
+++ b/OfficeIMO.Html.Tests/Html.SecurityPerformance.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics;
 using System.Text;
 using OfficeIMO.Html;
 using OfficeIMO.Word;
@@ -13,7 +12,7 @@ public partial class Html {
         "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
 
     [Fact]
-    public void HtmlToWord_SharedAncestorStylesAreParsedWithinBoundedTime() {
+    public async System.Threading.Tasks.Task HtmlToWord_SharedAncestorStylesAreParsedOncePerElement() {
         const int paragraphCount = 200;
         var ancestorStyle = new StringBuilder("background-color:#0000ff;");
         while (ancestorStyle.Length < 64 * 1024) {
@@ -27,23 +26,20 @@ public partial class Html {
         }
         html.Append("</div>");
         HtmlToWordOptions options = HtmlToWordOptions.CreateUntrustedHtmlProfile();
-        var stopwatch = Stopwatch.StartNew();
+        var converter = new HtmlToWordConverter();
 
-        using WordDocument document = HtmlConversionDocument.Parse(html.ToString())
-            .ToWordDocumentResult(options)
-            .RequireValue();
-        stopwatch.Stop();
+        using WordDocument document = await converter.ConvertAsync(
+            HtmlConversionDocument.Parse(html.ToString()).CreateDocumentForConversion(),
+            options);
 
         Assert.Equal(paragraphCount, document.Paragraphs.Count);
         Assert.All(document.Paragraphs, paragraph =>
             Assert.Equal("800080", paragraph.ShadingFillColorHex));
-        Assert.True(
-            stopwatch.Elapsed < TimeSpan.FromSeconds(15),
-            $"HTML conversion took {stopwatch.Elapsed}.");
+        Assert.Equal(3, converter.InlineStyleParseCount);
     }
 
     [Fact]
-    public void HtmlToWord_TableBackgroundAncestorsAreParsedWithinBoundedTime() {
+    public async System.Threading.Tasks.Task HtmlToWord_TableBackgroundIsParsedOncePerOwner() {
         const int cellCount = 200;
         var ancestorStyle = new StringBuilder("background-color:#0000ff;");
         while (ancestorStyle.Length < 64 * 1024) {
@@ -63,20 +59,17 @@ public partial class Html {
         }
         html.Append("</tr></table></div>");
         HtmlToWordOptions options = HtmlToWordOptions.CreateUntrustedHtmlProfile();
-        var stopwatch = Stopwatch.StartNew();
+        var converter = new HtmlToWordConverter();
 
-        using WordDocument document = HtmlConversionDocument.Parse(html.ToString())
-            .ToWordDocumentResult(options)
-            .RequireValue();
-        stopwatch.Stop();
+        using WordDocument document = await converter.ConvertAsync(
+            HtmlConversionDocument.Parse(html.ToString()).CreateDocumentForConversion(),
+            options);
 
         WordTable table = Assert.Single(document.Tables);
         Assert.Equal(cellCount, table.Rows[0].Cells.Count);
         Assert.All(table.Rows[0].Cells, cell =>
             Assert.Equal("800080", cell.ShadingFillColorHex));
-        Assert.True(
-            stopwatch.Elapsed < TimeSpan.FromSeconds(15),
-            $"HTML conversion took {stopwatch.Elapsed}.");
+        Assert.Equal(1, converter.TableBackgroundParseCount);
     }
 
     [Fact]

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.ChartSecurity.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.ChartSecurity.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using DocumentFormat.OpenXml.Packaging;
+using OfficeIMO.Drawing;
+using OfficeIMO.PowerPoint;
+using Xunit;
+using C = DocumentFormat.OpenXml.Drawing.Charts;
+
+namespace OfficeIMO.Tests;
+
+public class PowerPointChartSecurityTests {
+    [Fact]
+    public void BubbleSnapshot_RejectsOversizedNestedWorkbookPart() {
+        using var packageStream = new MemoryStream();
+        using PowerPointPresentation presentation =
+            PowerPointPresentation.Create(packageStream);
+        PowerPointChart chart = presentation.AddSlide().AddChart(
+            OfficeChartKind.Bubble,
+            CreateBubbleData(pointCount: 1));
+        ChartPart chartPart = presentation.Slides[0].SlidePart.ChartParts.Single();
+        C.Chart nativeChart = chartPart.ChartSpace!
+            .GetFirstChild<C.Chart>()!;
+        nativeChart.AddChild(new C.PlotVisibleOnly { Val = true }, true);
+
+        Assert.True(chart.TryGetOfficeSnapshot(out _));
+
+        EmbeddedPackagePart embedded =
+            Assert.Single(chartPart.GetPartsOfType<EmbeddedPackagePart>());
+        byte[] oversizedWorkbook = CreateOversizedNestedWorkbook();
+        using (Stream target = embedded.GetStream(
+                   FileMode.Create,
+                   FileAccess.Write)) {
+            target.Write(oversizedWorkbook, 0, oversizedWorkbook.Length);
+        }
+
+        Assert.False(chart.TryGetOfficeSnapshot(out _));
+    }
+
+    [Fact]
+    public void BubbleSnapshot_MalformedThemeFailsClosed() {
+        string path = Path.Combine(
+            Path.GetTempPath(),
+            Guid.NewGuid().ToString("N") + ".pptx");
+        try {
+            using (PowerPointPresentation presentation =
+                   PowerPointPresentation.Create(path)) {
+                PowerPointChart chart = presentation.AddSlide().AddChart(
+                    OfficeChartKind.Bubble,
+                    CreateBubbleData(pointCount: 1));
+                Assert.True(chart.TryGetOfficeSnapshot(out _));
+                presentation.Save();
+            }
+
+            using (var file = new FileStream(
+                       path,
+                       FileMode.Open,
+                       FileAccess.ReadWrite,
+                       FileShare.None))
+            using (var archive = new ZipArchive(
+                       file,
+                       ZipArchiveMode.Update,
+                       leaveOpen: false)) {
+                ZipArchiveEntry theme = archive.Entries.Single(entry =>
+                    entry.FullName.StartsWith(
+                        "ppt/theme/theme",
+                        StringComparison.Ordinal) &&
+                    entry.FullName.EndsWith(
+                        ".xml",
+                        StringComparison.Ordinal));
+                string themePath = theme.FullName;
+                theme.Delete();
+                using StreamWriter writer = new StreamWriter(
+                    archive.CreateEntry(themePath).Open(),
+                    new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+                writer.Write("<a:theme xmlns:a=\"http://schemas.openxmlformats.org/drawingml/2006/main\"><");
+            }
+
+            using PowerPointPresentation reopened = PowerPointPresentation.Load(
+                path,
+                new PowerPointLoadOptions {
+                    AccessMode = DocumentAccessMode.ReadOnly
+                });
+            PowerPointChart reopenedChart =
+                Assert.Single(reopened.Slides[0].Charts);
+
+            Assert.False(reopenedChart.TryGetOfficeSnapshot(out _));
+        } finally {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void BubblePointColorMaterialization_IsBoundedAtLargeSupportedScale() {
+        const int pointCount = 20_000;
+        OfficeChartData data = CreateBubbleData(pointCount);
+        var stopwatch = Stopwatch.StartNew();
+
+        using PowerPointPresentation presentation =
+            PowerPointPresentation.Create(new MemoryStream());
+        presentation.AddSlide().AddChart(OfficeChartKind.Bubble, data);
+        stopwatch.Stop();
+
+        C.BubbleChartSeries nativeSeries = presentation.Slides[0].SlidePart
+            .ChartParts.Single().ChartSpace!
+            .Descendants<C.BubbleChartSeries>().Single();
+        Assert.Equal(pointCount, nativeSeries.Elements<C.DataPoint>().Count());
+        Assert.True(
+            stopwatch.Elapsed < TimeSpan.FromSeconds(30),
+            $"Point-color materialization took {stopwatch.Elapsed}.");
+    }
+
+    private static OfficeChartData CreateBubbleData(int pointCount) {
+        double[] points = Enumerable.Range(1, pointCount)
+            .Select(index => (double)index)
+            .ToArray();
+        OfficeColor?[] colors = Enumerable.Repeat<OfficeColor?>(
+            OfficeColor.Parse("#336699"),
+            pointCount).ToArray();
+        return new OfficeChartData(
+            points.Select(value => value.ToString(
+                System.Globalization.CultureInfo.InvariantCulture)),
+            new[] {
+                OfficeChartSeries.CreateBubble(
+                    "Series",
+                    points,
+                    points,
+                    points,
+                    pointColors: colors)
+            });
+    }
+
+    private static byte[] CreateOversizedNestedWorkbook() {
+        using var stream = new MemoryStream();
+        using (var archive = new ZipArchive(
+                   stream,
+                   ZipArchiveMode.Create,
+                   leaveOpen: true)) {
+            ZipArchiveEntry worksheet = archive.CreateEntry(
+                "xl/worksheets/sheet1.xml",
+                CompressionLevel.Optimal);
+            using var writer = new StreamWriter(
+                worksheet.Open(),
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            writer.Write("<worksheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\">");
+            writer.Write(new string(' ', 2 * 1024 * 1024));
+            writer.Write("</worksheet>");
+        }
+        return stream.ToArray();
+    }
+}

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.SharedBubbleCharts.cs
@@ -1891,6 +1891,7 @@ namespace OfficeIMO.Tests {
                 new[] {
                     OfficeChartSeries.CreateBubble("Portfolio", xValues, yValues, sizes,
                         seriesColor, pointColors,
+                        showInLegend: true,
                         markerOutlineColor: markerOutlineColor,
                         markerOutlineWidth: markerOutlineWidth,
                         showMarkerOutline: showMarkerOutline)

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.BubbleWorkbook.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.BubbleWorkbook.cs
@@ -21,8 +21,14 @@ namespace OfficeIMO.PowerPoint {
             try {
                 using Stream stream = embedded.GetStream(
                     FileMode.Open, FileAccess.Read);
-                using SpreadsheetDocument workbook =
-                    SpreadsheetDocument.Open(stream, false);
+                byte[] workbookBytes =
+                    PowerPointChartWorkbookSecurity.ReadAndValidate(stream);
+                using var workbookStream =
+                    new MemoryStream(workbookBytes, writable: false);
+                using SpreadsheetDocument workbook = SpreadsheetDocument.Open(
+                    workbookStream,
+                    false,
+                    PowerPointChartWorkbookSecurity.CreateOpenSettings());
                 return workbook.WorkbookPart?.WorksheetParts.Any(part =>
                     part.Worksheet?.Descendants<S.Row>().Any(row =>
                         row.Hidden?.Value == true) == true ||

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
@@ -15,11 +15,28 @@ namespace OfficeIMO.PowerPoint {
         /// Tries to create a dependency-free snapshot for rendering/export consumers.
         /// </summary>
         internal bool TryGetSnapshot(out PowerPointChartSnapshot snapshot) =>
-            TryGetSnapshot(GetOwnerColorScheme(), out snapshot);
+            TryGetSnapshotWithOwnerColorScheme(
+                forDataUpdate: false,
+                out snapshot);
 
         private bool TryGetSnapshotForUpdate(out PowerPointChartSnapshot snapshot) =>
-            TryGetSnapshot(GetOwnerColorScheme(), forDataUpdate: true,
+            TryGetSnapshotWithOwnerColorScheme(
+                forDataUpdate: true,
                 out snapshot);
+
+        private bool TryGetSnapshotWithOwnerColorScheme(
+            bool forDataUpdate,
+            out PowerPointChartSnapshot snapshot) {
+            try {
+                return TryGetSnapshot(
+                    GetOwnerColorScheme(),
+                    forDataUpdate,
+                    out snapshot);
+            } catch {
+                snapshot = null!;
+                return false;
+            }
+        }
 
         private A.ColorScheme? GetOwnerColorScheme() {
             if (_ownerPart is SlidePart slidePart) {

--- a/OfficeIMO.PowerPoint/PowerPointChartWorkbookSecurity.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChartWorkbookSecurity.cs
@@ -1,0 +1,63 @@
+using System;
+using System.IO;
+using DocumentFormat.OpenXml.Packaging;
+using OfficeIMO.Drawing;
+
+namespace OfficeIMO.PowerPoint {
+    /// <summary>
+    /// Applies bounded nested-package validation before embedded chart workbooks are opened.
+    /// </summary>
+    internal static class PowerPointChartWorkbookSecurity {
+        private const int MaximumPackageBytes = 8 * 1024 * 1024;
+        private const long MaximumCharactersInPart = 2L * 1024L * 1024L;
+
+        internal static byte[] ReadAndValidate(Stream stream) {
+            byte[] workbookBytes = ReadBounded(stream);
+            OfficePackageSecurityInspector.Validate(
+                workbookBytes,
+                CreateSecurityOptions());
+            return workbookBytes;
+        }
+
+        internal static OpenSettings CreateOpenSettings() => new OpenSettings {
+            AutoSave = false,
+            MaxCharactersInPart = MaximumCharactersInPart
+        };
+
+        private static OfficePackageSecurityOptions CreateSecurityOptions() =>
+            new OfficePackageSecurityOptions {
+                MaxPackageBytes = MaximumPackageBytes,
+                MaxPartCount = 64,
+                MaxPartUncompressedBytes = MaximumCharactersInPart,
+                MaxTotalUncompressedBytes = MaximumPackageBytes,
+                MaxCompressionRatio = 100D,
+                Macros = OfficePackageContentPolicy.Reject,
+                EmbeddedPayloads = OfficePackageContentPolicy.Reject,
+                ActiveX = OfficePackageContentPolicy.Reject,
+                ExternalRelationships = OfficePackageContentPolicy.Reject
+            };
+
+        private static byte[] ReadBounded(Stream stream) {
+            if (stream == null) throw new ArgumentNullException(nameof(stream));
+
+            using var buffer = new MemoryStream();
+            var chunk = new byte[81920];
+            int totalBytes = 0;
+            while (true) {
+                int remaining = MaximumPackageBytes + 1 - totalBytes;
+                int read = stream.Read(chunk, 0, Math.Min(chunk.Length, remaining));
+                if (read == 0) {
+                    return buffer.ToArray();
+                }
+
+                totalBytes = checked(totalBytes + read);
+                if (totalBytes > MaximumPackageBytes) {
+                    throw new InvalidDataException(
+                        $"Embedded chart workbook exceeds the configured maximum of {MaximumPackageBytes} bytes.");
+                }
+
+                buffer.Write(chunk, 0, read);
+            }
+        }
+    }
+}

--- a/OfficeIMO.PowerPoint/PowerPointFeatureReport.cs
+++ b/OfficeIMO.PowerPoint/PowerPointFeatureReport.cs
@@ -1168,10 +1168,13 @@ namespace OfficeIMO.PowerPoint {
 
             try {
                 using Stream stream = part.GetStream(FileMode.Open, FileAccess.Read);
-                byte[] workbookBytes = ReadChartWorkbookBytes(stream);
-                OfficePackageSecurityInspector.Validate(workbookBytes, CreateChartWorkbookSecurityOptions());
+                byte[] workbookBytes =
+                    PowerPointChartWorkbookSecurity.ReadAndValidate(stream);
                 using var workbookStream = new MemoryStream(workbookBytes, writable: false);
-                using SpreadsheetDocument workbook = SpreadsheetDocument.Open(workbookStream, false);
+                using SpreadsheetDocument workbook = SpreadsheetDocument.Open(
+                    workbookStream,
+                    false,
+                    PowerPointChartWorkbookSecurity.CreateOpenSettings());
                 return IsSafeGeneratedChartWorkbook(workbook);
             } catch (FileFormatException) {
                 return false;
@@ -1181,40 +1184,6 @@ namespace OfficeIMO.PowerPoint {
                 return false;
             } catch (IOException) {
                 return false;
-            }
-        }
-
-        private static OfficePackageSecurityOptions CreateChartWorkbookSecurityOptions() =>
-            new OfficePackageSecurityOptions {
-                MaxPackageBytes = 8L * 1024L * 1024L,
-                MaxPartCount = 64,
-                MaxPartUncompressedBytes = 2L * 1024L * 1024L,
-                MaxTotalUncompressedBytes = 8L * 1024L * 1024L,
-                MaxCompressionRatio = 100D,
-                Macros = OfficePackageContentPolicy.Reject,
-                EmbeddedPayloads = OfficePackageContentPolicy.Reject,
-                ActiveX = OfficePackageContentPolicy.Reject,
-                ExternalRelationships = OfficePackageContentPolicy.Reject
-            };
-
-        private static byte[] ReadChartWorkbookBytes(Stream stream) {
-            const int maximumBytes = 8 * 1024 * 1024;
-            using var buffer = new MemoryStream();
-            var chunk = new byte[81920];
-            int totalBytes = 0;
-            while (true) {
-                int read = stream.Read(chunk, 0, Math.Min(chunk.Length, maximumBytes + 1 - totalBytes));
-                if (read == 0) {
-                    return buffer.ToArray();
-                }
-
-                totalBytes = checked(totalBytes + read);
-                if (totalBytes > maximumBytes) {
-                    throw new InvalidDataException(
-                        $"Embedded chart workbook exceeds the configured maximum of {maximumBytes} bytes.");
-                }
-
-                buffer.Write(chunk, 0, read);
             }
         }
 

--- a/OfficeIMO.PowerPoint/PowerPointUtils.SharedCharts.cs
+++ b/OfficeIMO.PowerPoint/PowerPointUtils.SharedCharts.cs
@@ -595,19 +595,25 @@ namespace OfficeIMO.PowerPoint {
                 (OpenXmlElement?)seriesElement.GetFirstChild<C.CategoryAxisData>() ??
                 (OpenXmlElement?)seriesElement.GetFirstChild<C.Values>() ??
                 (OpenXmlElement?)seriesElement.GetFirstChild<C.XValues>() ?? seriesElement.GetFirstChild<C.YValues>();
+            var pointsByIndex = new Dictionary<uint, C.DataPoint>();
+            foreach (C.DataPoint existingPoint in seriesElement.Elements<C.DataPoint>()) {
+                uint? existingIndex = existingPoint.Index?.Val?.Value;
+                if (existingIndex.HasValue && !pointsByIndex.ContainsKey(existingIndex.Value)) {
+                    pointsByIndex.Add(existingIndex.Value, existingPoint);
+                }
+            }
             for (int index = 0; index < series.PointColors.Count; index++) {
                 OfficeColor? color = series.PointColors[index];
                 if (!color.HasValue) continue;
-                C.DataPoint? point = seriesElement.Elements<C.DataPoint>()
-                    .FirstOrDefault(item =>
-                        item.Index?.Val?.Value == (uint)index);
-                if (point == null) {
+                uint pointIndex = (uint)index;
+                if (!pointsByIndex.TryGetValue(pointIndex, out C.DataPoint? point)) {
                     point = new C.DataPoint(new C.Index { Val = (uint)index });
                     if (insertBefore != null) {
                         seriesElement.InsertBefore(point, insertBefore);
                     } else {
                         seriesElement.Append(point);
                     }
+                    pointsByIndex.Add(pointIndex, point);
                 }
                 C.ChartShapeProperties? properties =
                     point.GetFirstChild<C.ChartShapeProperties>();

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockFrames.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.BlockFrames.cs
@@ -56,13 +56,25 @@ namespace OfficeIMO.Word.Html {
         }
 
         private CssStyleMapper.CssProperties ParseElementBoxStyles(IElement element) {
+            if (_computedBoxStyles.TryGetValue(element, out CssStyleMapper.CssProperties? cached)) {
+                return cached;
+            }
+
             var lineage = new Stack<IElement>();
-            for (IElement? current = element; current != null; current = current.ParentElement) {
+            CssStyleMapper.CssProperties? inheritedBox = null;
+            bool inheritedRightToLeft = false;
+            for (IElement? current = element;
+                 current != null;
+                 current = current.ParentElement) {
+                if (_computedBoxStyles.TryGetValue(
+                        current,
+                        out inheritedBox)) {
+                    inheritedRightToLeft = GetBidiFromDir(current) == true;
+                    break;
+                }
                 lineage.Push(current);
             }
 
-            CssStyleMapper.CssProperties? inheritedBox = null;
-            bool inheritedRightToLeft = false;
             while (lineage.Count > 0) {
                 IElement current = lineage.Pop();
                 double elementFontSizePixels = ResolveComputedFontSizePixels(current);
@@ -74,6 +86,7 @@ namespace OfficeIMO.Word.Html {
                     inheritedRightToLeft,
                     _rootFontSizePixels,
                     elementFontSizePixels);
+                _computedBoxStyles[current] = inheritedBox;
                 inheritedRightToLeft = rightToLeft;
             }
 

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
@@ -332,7 +332,7 @@ namespace OfficeIMO.Word.Html {
             return parsed;
         }
 
-        private static string? ResolveParagraphBackground(
+        private string? ResolveParagraphBackground(
             IElement element,
             CssStyleMapper.CssProperties parsed) {
             if (string.IsNullOrEmpty(parsed.BackgroundColor)) {
@@ -351,7 +351,8 @@ namespace OfficeIMO.Word.Html {
             }
             while (ancestors.Count > 0) {
                 IElement ancestor = ancestors.Pop();
-                CssStyleMapper.CssProperties ancestorStyle = CssStyleMapper.ParseStyles(ancestor.GetAttribute("style"));
+                CssStyleMapper.CssProperties ancestorStyle =
+                    ParseInlineStyles(ancestor);
                 if (string.IsNullOrEmpty(ancestorStyle.BackgroundColor)) {
                     continue;
                 }
@@ -365,6 +366,19 @@ namespace OfficeIMO.Word.Html {
             }
 
             return ResolveOpaqueTextBackground(parsed.BackgroundColor!, alpha, backdrop);
+        }
+
+        private CssStyleMapper.CssProperties ParseInlineStyles(IElement element) {
+            if (_inlineStyles.TryGetValue(
+                    element,
+                    out CssStyleMapper.CssProperties? cached)) {
+                return cached;
+            }
+
+            CssStyleMapper.CssProperties parsed = CssStyleMapper.ParseStyles(
+                element.GetAttribute("style"));
+            _inlineStyles[element] = parsed;
+            return parsed;
         }
 
         private static bool TryMapTextAlign(string? value, bool? bidi, out JustificationValues alignment) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
@@ -377,6 +377,7 @@ namespace OfficeIMO.Word.Html {
 
             CssStyleMapper.CssProperties parsed = CssStyleMapper.ParseStyles(
                 element.GetAttribute("style"));
+            InlineStyleParseCount++;
             _inlineStyles[element] = parsed;
             return parsed;
         }

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Images.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Images.cs
@@ -21,7 +21,7 @@ namespace OfficeIMO.Word.Html {
             HtmlToWordOptions options,
             WordParagraph? currentParagraph,
             WordHeaderFooter? headerFooter,
-            int? containerWidthTwips = null) {
+            Func<int?>? resolveContainerWidthTwips = null) {
             var src = ResolveWordImageSource(img, options);
             if (string.IsNullOrEmpty(src)) {
                 if (HasImageSourceCandidateAttribute(img)) {
@@ -57,14 +57,14 @@ namespace OfficeIMO.Word.Html {
             }
 
             if (src.EndsWith(".svg", StringComparison.OrdinalIgnoreCase) || src.StartsWith("data:image/svg+xml", StringComparison.OrdinalIgnoreCase)) {
-                ProcessSvgImage(src, img, doc, options, currentParagraph, headerFooter, containerWidthTwips);
+                ProcessSvgImage(src, img, doc, options, currentParagraph, headerFooter, resolveContainerWidthTwips);
                 return;
             }
 
             double? width = img.DisplayWidth > 0 ? img.DisplayWidth : null;
             double? height = img.DisplayHeight > 0 ? img.DisplayHeight : null;
-            width ??= TryResolveImagePercentWidth(decl.GetPropertyValue("width"), doc, containerWidthTwips);
-            width ??= TryResolveImagePercentWidth(img.GetAttribute("width"), doc, containerWidthTwips);
+            width ??= TryResolveImagePercentWidth(decl.GetPropertyValue("width"), doc, resolveContainerWidthTwips);
+            width ??= TryResolveImagePercentWidth(img.GetAttribute("width"), doc, resolveContainerWidthTwips);
             width ??= TryParsePixelValue(img.GetAttribute("width"));
             height ??= TryParsePixelValue(img.GetAttribute("height"));
 
@@ -193,12 +193,12 @@ namespace OfficeIMO.Word.Html {
             HtmlToWordOptions options,
             WordParagraph? currentParagraph,
             WordHeaderFooter? headerFooter,
-            int? containerWidthTwips) {
+            Func<int?>? resolveContainerWidthTwips) {
             var decl = _inlineParser.ParseDeclaration(img.GetAttribute("style") ?? string.Empty);
             double? width = img.DisplayWidth > 0 ? img.DisplayWidth : null;
             double? height = img.DisplayHeight > 0 ? img.DisplayHeight : null;
-            width ??= TryResolveImagePercentWidth(decl.GetPropertyValue("width"), doc, containerWidthTwips);
-            width ??= TryResolveImagePercentWidth(img.GetAttribute("width"), doc, containerWidthTwips);
+            width ??= TryResolveImagePercentWidth(decl.GetPropertyValue("width"), doc, resolveContainerWidthTwips);
+            width ??= TryResolveImagePercentWidth(img.GetAttribute("width"), doc, resolveContainerWidthTwips);
             width ??= TryParsePixelValue(img.GetAttribute("width"));
             height ??= TryParsePixelValue(img.GetAttribute("height"));
             var alt = img.AlternativeText;
@@ -308,10 +308,14 @@ namespace OfficeIMO.Word.Html {
             return null;
         }
 
-        private static double? TryResolveImagePercentWidth(
+        /// <summary>
+        /// Resolves percentage image widths against a lazily supplied container width. The
+        /// supplier is intentionally not evaluated for fixed, missing, or invalid widths.
+        /// </summary>
+        internal static double? TryResolveImagePercentWidth(
             string? value,
             WordDocument doc,
-            int? containerWidthTwips) {
+            Func<int?>? resolveContainerWidthTwips) {
             if (string.IsNullOrWhiteSpace(value)) {
                 return null;
             }
@@ -325,6 +329,7 @@ namespace OfficeIMO.Word.Html {
                 return null;
             }
 
+            int? containerWidthTwips = resolveContainerWidthTwips?.Invoke();
             double contentWidthTwips;
             if (containerWidthTwips.HasValue && containerWidthTwips.Value > 0) {
                 contentWidthTwips = containerWidthTwips.Value;

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
@@ -902,16 +902,20 @@ namespace OfficeIMO.Word.Html {
                                 imageParagraph = AddParagraphInScope(section, cell, headerFooter);
                                 createdCellParagraph = true;
                             }
-                            int? imageContainerWidthTwips = cell == null
+                            Func<int?>? resolveImageContainerWidthTwips = cell == null
                                 ? null
-                                : WordTable.EstimateCellContentWidthInDxa(doc, cell._tableCell);
+                                : () => _tableCellContentWidths.TryGetValue(
+                                        cell._tableCell,
+                                        out int? knownWidth)
+                                    ? knownWidth
+                                    : WordTable.EstimateCellContentWidthInDxa(doc, cell._tableCell);
                             ProcessImage(
                                 (IHtmlImageElement)element,
                                 doc,
                                 options,
                                 imageParagraph,
                                 headerFooter,
-                                imageContainerWidthTwips);
+                                resolveImageContainerWidthTwips);
                             if (createdCellParagraph &&
                                 imageParagraph != null &&
                                 cell!.Paragraphs.Count > 1 &&

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.TablePresentation.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.TablePresentation.cs
@@ -23,8 +23,10 @@ namespace OfficeIMO.Word.Html {
                     : cell.ShadingFillColorHex);
         }
 
-        private static CssStyleMapper.CssProperties ParseTableBackground(string value) =>
-            CssStyleMapper.ParseStyles("background-color:" + value);
+        private CssStyleMapper.CssProperties ParseTableBackground(string value) {
+            TableBackgroundParseCount++;
+            return CssStyleMapper.ParseStyles("background-color:" + value);
+        }
 
         private string? ResolveAncestorBlockBackground(AngleSharp.Dom.IElement element) {
             var lineage = new Stack<AngleSharp.Dom.IElement>();

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.TablePresentation.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.TablePresentation.cs
@@ -4,10 +4,8 @@ namespace OfficeIMO.Word.Html {
     internal partial class HtmlToWordConverter {
         private static void ApplyTableBackground(
             WordTableCell cell,
-            string value,
+            CssStyleMapper.CssProperties parsed,
             string? ancestorBackdrop) {
-            CssStyleMapper.CssProperties parsed =
-                CssStyleMapper.ParseStyles("background-color:" + value);
             if (string.IsNullOrEmpty(parsed.BackgroundColor)) {
                 return;
             }
@@ -25,15 +23,22 @@ namespace OfficeIMO.Word.Html {
                     : cell.ShadingFillColorHex);
         }
 
-        private static string? ResolveAncestorBlockBackground(AngleSharp.Dom.IElement element) {
+        private static CssStyleMapper.CssProperties ParseTableBackground(string value) =>
+            CssStyleMapper.ParseStyles("background-color:" + value);
+
+        private string? ResolveAncestorBlockBackground(AngleSharp.Dom.IElement element) {
             var lineage = new Stack<AngleSharp.Dom.IElement>();
+            string? backdrop = null;
             for (AngleSharp.Dom.IElement? current = element.ParentElement;
                  current != null;
                  current = current.ParentElement) {
+                if (_ancestorBlockBackgrounds.TryGetValue(current, out string? cached)) {
+                    backdrop = cached;
+                    break;
+                }
                 lineage.Push(current);
             }
 
-            string? backdrop = null;
             while (lineage.Count > 0) {
                 AngleSharp.Dom.IElement ancestor = lineage.Pop();
                 string? resolved = ResolveBlockBackground(
@@ -42,6 +47,7 @@ namespace OfficeIMO.Word.Html {
                 if (!string.IsNullOrEmpty(resolved)) {
                     backdrop = resolved;
                 }
+                _ancestorBlockBackgrounds[ancestor] = backdrop;
             }
             return backdrop;
         }

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Tables.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Tables.cs
@@ -59,6 +59,8 @@ namespace OfficeIMO.Word.Html {
             }
             ApplyTableStyles(wordTable, tableElem);
             ApplyColumnGroup(wordTable, tableElem, cols);
+            Func<TableCell, int, int, int?> estimateCellContentWidth =
+                WordTable.CreateCellContentWidthEstimatorInDxa(doc, wordTable._table);
             var occupied = new bool[rows, cols];
             int rIndex = 0;
             bool useRawSpanAttributes = options.MaxTableCells.HasValue;
@@ -79,7 +81,23 @@ namespace OfficeIMO.Word.Html {
                         var htmlCell = htmlRow.Cells[c];
                         ApplyCssToElement(htmlCell);
                         var wordCell = wordRow.Cells[cIndex];
+                        int rowSpan = 1;
+                        int colSpan = 1;
+                        if (htmlCell is IHtmlTableCellElement htmlTableCell) {
+                            rowSpan = GetHtmlRowSpan(htmlTableCell, useRawSpanAttributes);
+                            colSpan = GetHtmlColumnSpan(htmlTableCell, useRawSpanAttributes);
+                            if (rowSpan == 0) {
+                                rowSpan = groupRowCount - localRowIndex;
+                            }
+                        }
+
+                        rowSpan = Math.Max(1, rowSpan);
+                        colSpan = Math.Max(1, colSpan);
+                        rowSpan = Math.Min(rowSpan, rows - rIndex);
+                        colSpan = Math.Min(colSpan, cols - cIndex);
                         var alignment = ApplyCellStyles(wordCell, htmlCell as IHtmlTableCellElement);
+                        _tableCellContentWidths[wordCell._tableCell] =
+                            estimateCellContentWidth(wordCell._tableCell, cIndex, colSpan);
                         if (wordCell.Paragraphs.Count == 1 && string.IsNullOrEmpty(wordCell.Paragraphs[0].Text)) {
                             wordCell.Paragraphs[0].Remove();
                         }
@@ -99,21 +117,6 @@ namespace OfficeIMO.Word.Html {
                                 p.ParagraphAlignment = alignment.Value;
                             }
                         }
-
-                        int rowSpan = 1;
-                        int colSpan = 1;
-                        if (htmlCell is IHtmlTableCellElement htmlTableCell) {
-                            rowSpan = GetHtmlRowSpan(htmlTableCell, useRawSpanAttributes);
-                            colSpan = GetHtmlColumnSpan(htmlTableCell, useRawSpanAttributes);
-                            if (rowSpan == 0) {
-                                rowSpan = groupRowCount - localRowIndex;
-                            }
-                        }
-
-                        rowSpan = Math.Max(1, rowSpan);
-                        colSpan = Math.Max(1, colSpan);
-                        rowSpan = Math.Min(rowSpan, rows - rIndex);
-                        colSpan = Math.Min(colSpan, cols - cIndex);
 
                         if (rowSpan > 1 || colSpan > 1) {
                             wordTable.MergeCells(rIndex, cIndex, rowSpan, colSpan);
@@ -367,7 +370,7 @@ namespace OfficeIMO.Word.Html {
             return true;
         }
 
-        private static void ApplyTableStyles(WordTable wordTable, IHtmlTableElement tableElem) {
+        private void ApplyTableStyles(WordTable wordTable, IHtmlTableElement tableElem) {
             var style = tableElem.GetAttribute("style");
             var borderAttr = tableElem.GetAttribute("border");
             var alignAttr = tableElem.GetAttribute("align");
@@ -540,9 +543,11 @@ namespace OfficeIMO.Word.Html {
 
             if (backgroundValue != null) {
                 string? ancestorBackdrop = ResolveAncestorBlockBackground(tableElem);
+                CssStyleMapper.CssProperties parsedBackground =
+                    ParseTableBackground(backgroundValue);
                 foreach (var row in wordTable.Rows) {
                     foreach (var cell in row.Cells) {
-                        ApplyTableBackground(cell, backgroundValue, ancestorBackdrop);
+                        ApplyTableBackground(cell, parsedBackground, ancestorBackdrop);
                     }
                 }
             }
@@ -679,7 +684,7 @@ namespace OfficeIMO.Word.Html {
         private static bool IsCssAuto(string? value) =>
             string.Equals(value?.Trim(), "auto", StringComparison.OrdinalIgnoreCase);
 
-        private static void ApplyRowStyles(WordTableRow row, IHtmlTableRowElement htmlRow) {
+        private void ApplyRowStyles(WordTableRow row, IHtmlTableRowElement htmlRow) {
             var style = htmlRow.GetAttribute("style");
             if (string.IsNullOrWhiteSpace(style)) {
                 return;
@@ -720,12 +725,18 @@ namespace OfficeIMO.Word.Html {
                 }
             }
 
+            string? ancestorBackdrop = backgroundValue == null
+                ? null
+                : ResolveAncestorBlockBackground(htmlRow);
+            CssStyleMapper.CssProperties? parsedBackground = backgroundValue == null
+                ? null
+                : ParseTableBackground(backgroundValue);
             foreach (var cell in row.Cells) {
-                if (backgroundValue != null) {
+                if (parsedBackground != null) {
                     ApplyTableBackground(
                         cell,
-                        backgroundValue,
-                        ResolveAncestorBlockBackground(htmlRow));
+                        parsedBackground,
+                        ancestorBackdrop);
                 }
                 if (borderStyle != null && borderSize != null) {
                     cell.Borders.LeftStyle = cell.Borders.RightStyle = cell.Borders.TopStyle = cell.Borders.BottomStyle = borderStyle;
@@ -818,7 +829,7 @@ namespace OfficeIMO.Word.Html {
             if (backgroundValue != null) {
                 ApplyTableBackground(
                     cell,
-                    backgroundValue,
+                    ParseTableBackground(backgroundValue),
                     ResolveAncestorBlockBackground(htmlCell));
             }
 

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
@@ -40,6 +40,8 @@ namespace OfficeIMO.Word.Html {
         private readonly Dictionary<IElement, CssStyleMapper.CssProperties> _inlineStyles = new();
         private readonly Dictionary<IElement, string?> _ancestorBlockBackgrounds = new();
         private readonly Dictionary<TableCell, int?> _tableCellContentWidths = new();
+        internal int InlineStyleParseCount { get; private set; }
+        internal int TableBackgroundParseCount { get; private set; }
         private readonly Dictionary<IElement, bool> _directionAttributeOverrides = new();
         private readonly Dictionary<Table, int> _tableContainerHorizontalSpacing = new();
         private readonly ConcurrentDictionary<string, byte[]> _remoteImageBytesCache = new(StringComparer.Ordinal);
@@ -195,6 +197,8 @@ namespace OfficeIMO.Word.Html {
             _inlineStyles.Clear();
             _ancestorBlockBackgrounds.Clear();
             _tableCellContentWidths.Clear();
+            InlineStyleParseCount = 0;
+            TableBackgroundParseCount = 0;
             _remoteImageBytesCache.Clear();
             _remoteImageFailureCache.Clear();
             _cssClassStyles.Clear();

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
@@ -38,6 +38,8 @@ namespace OfficeIMO.Word.Html {
         private readonly Dictionary<IElement, double> _computedFontSizePixels = new();
         private readonly Dictionary<IElement, CssStyleMapper.CssProperties> _computedBoxStyles = new();
         private readonly Dictionary<IElement, CssStyleMapper.CssProperties> _inlineStyles = new();
+        private readonly Dictionary<IElement, string?> _ancestorBlockBackgrounds = new();
+        private readonly Dictionary<TableCell, int?> _tableCellContentWidths = new();
         private readonly Dictionary<IElement, bool> _directionAttributeOverrides = new();
         private readonly Dictionary<Table, int> _tableContainerHorizontalSpacing = new();
         private readonly ConcurrentDictionary<string, byte[]> _remoteImageBytesCache = new(StringComparer.Ordinal);
@@ -191,6 +193,8 @@ namespace OfficeIMO.Word.Html {
             _computedFontSizePixels.Clear();
             _computedBoxStyles.Clear();
             _inlineStyles.Clear();
+            _ancestorBlockBackgrounds.Clear();
+            _tableCellContentWidths.Clear();
             _remoteImageBytesCache.Clear();
             _remoteImageFailureCache.Clear();
             _cssClassStyles.Clear();

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
@@ -36,6 +36,8 @@ namespace OfficeIMO.Word.Html {
         private readonly CssParser _cssParser = new();
         private readonly Dictionary<string, WordImage> _imageCache = new(StringComparer.OrdinalIgnoreCase);
         private readonly Dictionary<IElement, double> _computedFontSizePixels = new();
+        private readonly Dictionary<IElement, CssStyleMapper.CssProperties> _computedBoxStyles = new();
+        private readonly Dictionary<IElement, CssStyleMapper.CssProperties> _inlineStyles = new();
         private readonly Dictionary<IElement, bool> _directionAttributeOverrides = new();
         private readonly Dictionary<Table, int> _tableContainerHorizontalSpacing = new();
         private readonly ConcurrentDictionary<string, byte[]> _remoteImageBytesCache = new(StringComparer.Ordinal);
@@ -187,6 +189,8 @@ namespace OfficeIMO.Word.Html {
             _cssRules.Clear();
             _imageCache.Clear();
             _computedFontSizePixels.Clear();
+            _computedBoxStyles.Clear();
+            _inlineStyles.Clear();
             _remoteImageBytesCache.Clear();
             _remoteImageFailureCache.Clear();
             _cssClassStyles.Clear();

--- a/OfficeIMO.Word/WordTable.Properties.cs
+++ b/OfficeIMO.Word/WordTable.Properties.cs
@@ -311,64 +311,87 @@ namespace OfficeIMO.Word {
                     int spanThis = (int)(cell.TableCellProperties?
                         .GetFirstChild<DocumentFormat.OpenXml.Wordprocessing.GridSpan>()?.Val?.Value ?? 1);
                     spanThis = Math.Max(1, spanThis);
-
-                    var grid = parentTable.GetFirstChild<DocumentFormat.OpenXml.Wordprocessing.TableGrid>();
-                    if (grid != null) {
-                        var columns = grid.Elements<DocumentFormat.OpenXml.Wordprocessing.GridColumn>().ToList();
-                        int sum = 0;
-                        for (int i = 0; i < spanThis && gridIndex + i < columns.Count; i++) {
-                            if (int.TryParse(columns[gridIndex + i].Width?.Value ?? "0", out int width)) {
-                                sum += width;
-                            }
-                        }
-
-                        if (sum > 0) {
-                            int leftMargin = 0, rightMargin = 0;
-                            int leftBorder = 0, rightBorder = 0;
-                            var cellMargins = cell.TableCellProperties?.TableCellMargin;
-                            if (cellMargins?.LeftMargin?.Width?.Value != null) {
-                                int.TryParse(cellMargins.LeftMargin.Width.Value, out leftMargin);
-                            }
-                            if (cellMargins?.RightMargin?.Width?.Value != null) {
-                                int.TryParse(cellMargins.RightMargin.Width.Value, out rightMargin);
-                            }
-
-                            if (leftMargin == 0 || rightMargin == 0) {
-                                var tableProperties = parentTable
-                                    .GetFirstChild<DocumentFormat.OpenXml.Wordprocessing.TableProperties>();
-                                var defaults = tableProperties?.TableCellMarginDefault;
-                                if (leftMargin == 0 && defaults?.TableCellLeftMargin?.Width != null) {
-                                    leftMargin = defaults.TableCellLeftMargin.Width.Value;
-                                }
-                                if (rightMargin == 0 && defaults?.TableCellRightMargin?.Width != null) {
-                                    rightMargin = defaults.TableCellRightMargin.Width.Value;
-                                }
-                            }
-
-                            if (leftMargin == 0) leftMargin = 108;
-                            if (rightMargin == 0) rightMargin = 108;
-
-                            var cellBorders = cell.TableCellProperties?.TableCellBorders;
-                            if (cellBorders?.LeftBorder?.Size != null) {
-                                leftBorder = SizeUnitsToTwips(cellBorders.LeftBorder.Size.Value);
-                            }
-                            if (cellBorders?.RightBorder?.Size != null) {
-                                rightBorder = SizeUnitsToTwips(cellBorders.RightBorder.Size.Value);
-                            }
-                            if (leftBorder == 0) leftBorder = 10;
-                            if (rightBorder == 0) rightBorder = 10;
-
-                            return Math.Max(
-                                1,
-                                sum - leftMargin - rightMargin - leftBorder - rightBorder);
-                        }
-                    }
-
-                    var parent = new WordTable(document, parentTable, initializeChildren: false);
-                    return Math.Max(1, parent.EstimateTableWidthInDxa());
+                    return CreateCellContentWidthEstimatorInDxa(document, parentTable)(
+                        cell,
+                        gridIndex,
+                        spanThis);
                 }
             } catch { /* ignore */ }
             return null;
+        }
+
+        /// <summary>
+        /// Creates a table-scoped cell-width estimator that materializes grid widths and the
+        /// fallback table width once, then resolves cells by their known grid position.
+        /// </summary>
+        internal static Func<DocumentFormat.OpenXml.Wordprocessing.TableCell, int, int, int?>
+            CreateCellContentWidthEstimatorInDxa(
+                WordDocument document,
+                DocumentFormat.OpenXml.Wordprocessing.Table table) {
+            int[] gridWidths = table
+                .GetFirstChild<DocumentFormat.OpenXml.Wordprocessing.TableGrid>()?
+                .Elements<DocumentFormat.OpenXml.Wordprocessing.GridColumn>()
+                .Select(column => int.TryParse(column.Width?.Value ?? "0", out int width)
+                    ? width
+                    : 0)
+                .ToArray() ?? Array.Empty<int>();
+            int? fallbackWidth = null;
+            try {
+                var parent = new WordTable(document, table, initializeChildren: false);
+                fallbackWidth = Math.Max(1, parent.EstimateTableWidthInDxa());
+            } catch { /* ignore */ }
+
+            var tableProperties = table
+                .GetFirstChild<DocumentFormat.OpenXml.Wordprocessing.TableProperties>();
+            var defaultMargins = tableProperties?.TableCellMarginDefault;
+            return (cell, gridIndex, gridSpan) => {
+                try {
+                    int sum = 0;
+                    int normalizedSpan = Math.Max(1, gridSpan);
+                    for (int index = 0;
+                         index < normalizedSpan && gridIndex + index < gridWidths.Length;
+                         index++) {
+                        sum += gridWidths[gridIndex + index];
+                    }
+                    if (sum <= 0) {
+                        return fallbackWidth;
+                    }
+
+                    int leftMargin = 0, rightMargin = 0;
+                    int leftBorder = 0, rightBorder = 0;
+                    var cellMargins = cell.TableCellProperties?.TableCellMargin;
+                    if (cellMargins?.LeftMargin?.Width?.Value != null) {
+                        int.TryParse(cellMargins.LeftMargin.Width.Value, out leftMargin);
+                    }
+                    if (cellMargins?.RightMargin?.Width?.Value != null) {
+                        int.TryParse(cellMargins.RightMargin.Width.Value, out rightMargin);
+                    }
+                    if (leftMargin == 0 && defaultMargins?.TableCellLeftMargin?.Width != null) {
+                        leftMargin = defaultMargins.TableCellLeftMargin.Width.Value;
+                    }
+                    if (rightMargin == 0 && defaultMargins?.TableCellRightMargin?.Width != null) {
+                        rightMargin = defaultMargins.TableCellRightMargin.Width.Value;
+                    }
+                    if (leftMargin == 0) leftMargin = 108;
+                    if (rightMargin == 0) rightMargin = 108;
+
+                    var cellBorders = cell.TableCellProperties?.TableCellBorders;
+                    if (cellBorders?.LeftBorder?.Size != null) {
+                        leftBorder = SizeUnitsToTwips(cellBorders.LeftBorder.Size.Value);
+                    }
+                    if (cellBorders?.RightBorder?.Size != null) {
+                        rightBorder = SizeUnitsToTwips(cellBorders.RightBorder.Size.Value);
+                    }
+                    if (leftBorder == 0) leftBorder = 10;
+                    if (rightBorder == 0) rightBorder = 10;
+
+                    return Math.Max(
+                        1,
+                        sum - leftMargin - rightMargin - leftBorder - rightBorder);
+                } catch {
+                    return fallbackWidth;
+                }
+            };
         }
 
         private static int SizeUnitsToTwips(UInt32Value sizeUnits) {


### PR DESCRIPTION
## Summary

- bound attacker-controlled HTML-to-Word work by caching inherited CSS/background state, parsing table backgrounds once, and precomputing table-cell widths for percentage images
- make Excel structural row edits scan quoted formulas linearly and handle malformed implicit cells, scoped defined names, single-cell selections, and duplicate legacy comments safely
- validate embedded chart workbooks before snapshot parsing, fail closed on invalid theme lookups, and replace repeated point-color searches with indexed updates
- preserve both the legacy nine-parameter OfficeChartSeries.CreateBubble CLR signature and source-compatible named showMarkerOutline calls

## Validation

- full .NET 8 suites: Drawing (1,014), Excel (2,784 passed / 5 skipped), and HTML (1,372)
- focused security, structural-row, image-sizing, and compatibility regressions pass on .NET 8 and .NET 10
- affected Drawing, Excel, and Word.Html libraries build cleanly for netstandard2.0
- independent local review completed; all actionable findings and the targeted bordered-cell sizing follow-up were addressed

The full cross-platform matrix remains covered by CI; this macOS checkout does not provide the .NET Framework 4.7.2 targeting pack.