### PR TITLE
Restore browser converter package expansion limits

### DIFF
--- a/Website/Apps/OfficeIMO.Web.Converter.Tests/BrowserConversionServiceTests.cs
+++ b/Website/Apps/OfficeIMO.Web.Converter.Tests/BrowserConversionServiceTests.cs
@@ -177,16 +177,17 @@ public sealed class BrowserConversionServiceTests {
     }
 
     [Fact]
-    public void BrowserPackageSecurity_AllowsExpandedWorksheetWithinAdvertisedPackageLimit() {
+    public void BrowserPackageSecurity_RejectsExpandedWorksheetBeyondBrowserPartLimit() {
         byte[] bytes = CreateExpandedWorksheetPackage();
+        OfficePackageSecurityOptions options = BrowserConversionService.CreateBrowserPackageSecurity();
 
-        OfficePackageSecurityReport report = OfficePackageSecurityInspector.Validate(
-            bytes,
-            BrowserConversionService.CreateBrowserPackageSecurity());
+        OfficePackageSecurityException exception = Assert.Throws<OfficePackageSecurityException>(() =>
+            OfficePackageSecurityInspector.Validate(bytes, options));
 
         Assert.True(bytes.LongLength < BrowserConversionService.MaxPackageBytes);
-        Assert.True(report.TotalUncompressedBytes > 32L * 1024L * 1024L);
-        Assert.DoesNotContain(report.Findings, finding => finding.Severity == OfficePackageSecuritySeverity.Error);
+        Assert.Equal(32L * 1024L * 1024L, options.MaxPartUncompressedBytes);
+        Assert.Equal(128L * 1024L * 1024L, options.MaxTotalUncompressedBytes);
+        Assert.Equal(OfficePackageSecurityRule.PartSize, exception.Rule);
     }
 
     [Fact]

--- a/Website/Apps/OfficeIMO.Web.Converter/Services/BrowserConversionService.cs
+++ b/Website/Apps/OfficeIMO.Web.Converter/Services/BrowserConversionService.cs
@@ -24,8 +24,8 @@ public sealed class BrowserConversionService {
     internal const long MaxFullWorksheetCells = 50_000L;
     internal const int MaxPreviewRowsPerSheet = 250;
     internal const int MaxPackagePartCount = 5_000;
-    internal const long MaxPartUncompressedBytes = 256L * 1024L * 1024L;
-    internal const long MaxTotalUncompressedBytes = 512L * 1024L * 1024L;
+    internal const long MaxPartUncompressedBytes = 32L * 1024L * 1024L;
+    internal const long MaxTotalUncompressedBytes = 128L * 1024L * 1024L;
     internal const double MaxCompressionRatio = 200D;
 
     public ConversionResult ConvertFile(

--- a/Website/content/docs/converters/browser-playground/index.md
+++ b/Website/content/docs/converters/browser-playground/index.md
@@ -17,7 +17,9 @@ The [browser converter](/convert/) is a static Blazor WebAssembly application. S
 | HTML | Markdown | `OfficeIMO.Markdown.Html` |
 | Markdown | DOCX | `OfficeIMO.Word.Markdown` |
 
-The app includes sample inputs for every route. Uploads are limited to 25 MB so the browser tab remains responsive. Conversion warnings stay visible with the result instead of being hidden behind a successful download.
+The app includes sample inputs for every route. Files are limited to 25 MiB. Before a DOCX, XLSX, or PPTX file is parsed, the app also rejects packages with more than 5,000 parts, an individual expanded part over 32 MiB, more than 128 MiB expanded in total, or a part compression ratio over 200:1.
+
+Excel workbooks that pass those package checks are converted in full while every sheet's used range stays within 50,000 cells. If a sheet exceeds that budget, the app automatically generates a preview of up to 250 rows per sheet. Conversion warnings stay visible with the result instead of being hidden behind a successful download.
 
 ## Privacy and hosting
 


### PR DESCRIPTION
## Summary

- restore the browser-specific 32 MiB per-part and 128 MiB aggregate expansion limits for Office packages
- retain the 25 MiB compressed file, 5,000-part, and 200:1 compression-ratio checks across DOCX, XLSX, and PPTX
- replace the permissive expanded-worksheet test with a regression that proves oversized expanded content is rejected before parsing
- document the pre-parse package checks and the separate Excel worksheet-preview budget

This keeps the recent Excel bounded-read and rendering-fidelity behavior while preventing attacker-crafted Office packages from consuming hundreds of MiB in the browser tab.