### PR TITLE
Harden document processing and benchmark evidence boundaries

### DIFF
--- a/Build/Run-LibraryComparisonBenchmarks.ps1
+++ b/Build/Run-LibraryComparisonBenchmarks.ps1
@@ -30,6 +30,8 @@ if ([string]::IsNullOrWhiteSpace($PowerForgeRoot)) {
 }
 
 $repositoryRoot = Split-Path -Parent $PSScriptRoot
+$OutputRoot = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath(
+    $OutputRoot)
 $platform = if ([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform(
         [System.Runtime.InteropServices.OSPlatform]::Windows)) {
     'windows'
@@ -212,11 +214,6 @@ if (($measurements.Count -ne $selected.Count) -or
 
 if ($catalogEligible) {
     foreach ($measurement in $measurements) {
-        if (-not $Publish) {
-            Write-BenchmarkEvidenceResult `
-                -Path $measurement.EvidenceLocation.Path `
-                -InputObject $measurement.Result
-        }
         Update-BenchmarkEvidenceCatalog `
             -InputObject $measurement.Result `
             -Path $catalogPath `

--- a/OfficeIMO.Excel.Tests/Excel.StructuralRows.MutationPlan.cs
+++ b/OfficeIMO.Excel.Tests/Excel.StructuralRows.MutationPlan.cs
@@ -360,6 +360,33 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_StructuralRows_MutationPlanBudgetsThreadedCommentsBeforeCollectingThem() {
+            using var document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet sheet = document.AddWorksheet("Data");
+            WorksheetThreadedCommentsPart threadedPart =
+                sheet.WorksheetPart.AddNewPart<WorksheetThreadedCommentsPart>();
+            var threadedComments = new Threaded.ThreadedComments();
+            for (int index = 0; index < 128; index++) {
+                threadedComments.Append(new Threaded.ThreadedComment(
+                    new Threaded.ThreadedCommentText($"Comment {index}")) {
+                    Id = $"{{00000000-0000-0000-0000-{index:D12}}}",
+                    Ref = "A3"
+                });
+            }
+            threadedPart.ThreadedComments = threadedComments;
+
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+                sheet.PlanDeleteRows(
+                    3,
+                    options: new ExcelMutationPlanOptions {
+                        MaximumScannedElements = 64
+                    }));
+
+            Assert.Contains("exceeded its limit", exception.Message, StringComparison.Ordinal);
+            Assert.Equal(128, threadedPart.ThreadedComments.Elements<Threaded.ThreadedComment>().Count());
+        }
+
+        [Fact]
         public void Test_StructuralRows_MutationPlanIncludesChartsHostedOnOtherSheets() {
             using var document = ExcelDocument.Create(new MemoryStream());
             ExcelSheet data = document.AddWorksheet("Data");
@@ -398,6 +425,29 @@ namespace OfficeIMO.Tests {
                 plan.Impacts,
                 impact => impact.Category == "pivots");
             Assert.True(pivots.ItemCount >= 1);
+        }
+
+        [Fact]
+        public void Test_StructuralRows_MutationPlanBudgetsEveryPivotDefinitionElement() {
+            using var document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet sheet = CreatePivotSheet(document);
+            PivotTablePart pivotPart = Assert.Single(sheet.WorksheetPart.PivotTableParts);
+            PivotFields pivotFields = Assert.IsType<PivotFields>(
+                pivotPart.PivotTableDefinition!.GetFirstChild<PivotFields>());
+            for (int index = 0; index < 256; index++) {
+                pivotFields.Append(new PivotField());
+            }
+            pivotFields.Count = (uint)pivotFields.ChildElements.Count;
+
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+                sheet.PlanInsertRows(
+                    2,
+                    options: new ExcelMutationPlanOptions {
+                        MaximumScannedElements = 128
+                    }));
+
+            Assert.Contains("exceeded its limit", exception.Message, StringComparison.Ordinal);
+            Assert.Equal(258, pivotFields.ChildElements.Count);
         }
 
         [Fact]

--- a/OfficeIMO.Excel.Tests/Excel.StructuralRows.MutationPlan.cs
+++ b/OfficeIMO.Excel.Tests/Excel.StructuralRows.MutationPlan.cs
@@ -164,6 +164,54 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_StructuralRows_MutationPlanAppliesCharacterBudgetToUnloadedVml() {
+            string path = Path.Combine(
+                Path.GetTempPath(),
+                $"OfficeIMO.Excel.MutationVmlCharacterBudget.{Guid.NewGuid():N}.xlsx");
+            try {
+                using (var source = ExcelDocument.Create(path)) {
+                    ExcelSheet sourceSheet = source.AddWorksheet("Data");
+                    sourceSheet.CellAt(2, 1).SetValue("Commented");
+                    sourceSheet.SetComment(2, 1, "Review", author: "Tester");
+                    source.Save();
+                }
+
+                using (SpreadsheetDocument package = SpreadsheetDocument.Open(path, true)) {
+                    VmlDrawingPart vmlPart = Assert.Single(
+                        package.WorkbookPart!.WorksheetParts.Single().VmlDrawingParts);
+                    XDocument vml;
+                    using (Stream source = vmlPart.GetStream()) {
+                        vml = XDocument.Load(source);
+                    }
+                    vml.Root!.SetAttributeValue(
+                        "data-mutation-budget-padding",
+                        new string('x', 100_000));
+                    using Stream destination = vmlPart.GetStream(FileMode.Create, FileAccess.Write);
+                    vml.Save(destination);
+                }
+
+                using var document = ExcelDocument.Load(path);
+                ExcelSheet sheet = document["Data"];
+                VmlDrawingPart unloadedVmlPart = Assert.Single(sheet.WorksheetPart.VmlDrawingParts);
+                Assert.False(unloadedVmlPart.IsRootElementLoaded);
+
+                InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+                    sheet.PlanInsertRows(
+                        2,
+                        options: new ExcelMutationPlanOptions {
+                            MaximumScannedElements = 10_000,
+                            MaximumScannedCharacters = 64_000
+                        }));
+
+                Assert.Contains("decompressed XML bytes", exception.Message, StringComparison.Ordinal);
+                Assert.False(unloadedVmlPart.IsRootElementLoaded);
+                Assert.Equal("Commented", sheet.CellAt(2, 1).GetValue<string>());
+            } finally {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
         public void Test_StructuralRows_MutationPlanPreservesPendingDirectCellBuffer() {
             using var document = ExcelDocument.Create(new MemoryStream());
             ExcelSheet sheet = document.AddWorksheet("Data");

--- a/OfficeIMO.Excel.Tests/Excel.StructuralRows.ReviewRegressions.cs
+++ b/OfficeIMO.Excel.Tests/Excel.StructuralRows.ReviewRegressions.cs
@@ -1,6 +1,5 @@
 using System.IO;
 using System.Linq;
-using System.Xml;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
@@ -197,7 +196,7 @@ namespace OfficeIMO.Tests {
                     .GetPartById(unrelatedSheet.Id!);
                 Assert.False(unrelatedPart.IsRootElementLoaded);
 
-                Assert.Throws<XmlException>(() =>
+                InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
                     document["Target"].PlanInsertRows(
                         1,
                         options: new ExcelMutationPlanOptions {
@@ -205,7 +204,51 @@ namespace OfficeIMO.Tests {
                             MaximumScannedCharacters = 1024
                         }));
 
+                Assert.Contains("decompressed XML bytes", exception.Message);
                 Assert.False(unrelatedPart.IsRootElementLoaded);
+            } finally {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public void Test_StructuralRows_MutationPlanBoundsAggregateLazyXmlCharacters() {
+            string path = Path.Combine(
+                Path.GetTempPath(),
+                $"OfficeIMO.Excel.AggregateMutationCharacterBudget.{Guid.NewGuid():N}.xlsx");
+            try {
+                using (var source = ExcelDocument.Create(path)) {
+                    source.AddWorksheet("Target").CellValue(1, 1, "Value");
+                    foreach (string name in new[] { "First", "Second" }) {
+                        ExcelSheet unrelated = source.AddWorksheet(name);
+                        unrelated.CellValue(1, 1, "placeholder");
+                        Cell cell = Assert.Single(
+                            unrelated.WorksheetPart.Worksheet.Descendants<Cell>());
+                        cell.DataType = CellValues.InlineString;
+                        cell.CellValue = null;
+                        cell.InlineString = new InlineString(new Text(new string('x', 900)));
+                    }
+                    source.Save();
+                }
+
+                using var document = ExcelDocument.Load(path);
+                WorksheetPart[] unrelatedParts = document.WorkbookRoot.Sheets!
+                    .Elements<Sheet>()
+                    .Where(sheet => sheet.Name?.Value is "First" or "Second")
+                    .Select(sheet => (WorksheetPart)document.WorkbookPartRoot.GetPartById(sheet.Id!))
+                    .ToArray();
+                Assert.All(unrelatedParts, part => Assert.False(part.IsRootElementLoaded));
+
+                InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+                    document["Target"].PlanInsertRows(
+                        1,
+                        options: new ExcelMutationPlanOptions {
+                            MaximumScannedElements = 1000,
+                            MaximumScannedCharacters = 1700
+                        }));
+
+                Assert.Contains("decompressed XML bytes", exception.Message);
+                Assert.All(unrelatedParts, part => Assert.False(part.IsRootElementLoaded));
             } finally {
                 File.Delete(path);
             }

--- a/OfficeIMO.Excel/ExcelRowMutationPlan.cs
+++ b/OfficeIMO.Excel/ExcelRowMutationPlan.cs
@@ -16,14 +16,16 @@ namespace OfficeIMO.Excel {
     /// <summary>Controls resource use while an Excel structural mutation plan is inspected.</summary>
     public sealed class ExcelMutationPlanOptions {
         /// <summary>
-        /// Maximum Open XML elements inspected while building a dry-run impact summary.
-        /// The bounded scan completes before semantic mutation preflight is allowed to run.
+        /// Maximum Open XML parts and elements admitted for one dry-run inspection phase.
+        /// Unloaded package XML is bounded before materialization, and the impact scan applies
+        /// the same limit independently before semantic mutation preflight is allowed to run.
         /// </summary>
         public int MaximumScannedElements { get; set; } = 250_000;
 
         /// <summary>
-        /// Maximum XML characters read while pre-scanning one lazily loaded worksheet.
-        /// This bounds decompressed worksheet text before its Open XML DOM is materialized.
+        /// Maximum XML characters admitted per lazily loaded part before semantic inspection. The same value is
+        /// also applied as a conservative aggregate decompressed-byte ceiling across all lazily loaded XML parts,
+        /// before any Open XML DOM is materialized.
         /// </summary>
         public long MaximumScannedCharacters { get; set; } = 64_000_000;
 

--- a/OfficeIMO.Excel/ExcelSheet.StructuralMutationPlan.Dependencies.cs
+++ b/OfficeIMO.Excel/ExcelSheet.StructuralMutationPlan.Dependencies.cs
@@ -607,14 +607,14 @@ namespace OfficeIMO.Excel {
                 }
 
                 budget.Consume();
-                List<Threaded.ThreadedComment> allComments = root
-                    .Elements<Threaded.ThreadedComment>()
-                    .ToList();
+                var allComments = new List<Threaded.ThreadedComment>();
                 var removedIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                 var childrenByParentId =
                     new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
-                foreach (Threaded.ThreadedComment comment in allComments) {
+                foreach (Threaded.ThreadedComment comment in
+                    root.Elements<Threaded.ThreadedComment>()) {
                     budget.Consume();
+                    allComments.Add(comment);
                     if (comment.Id?.Value is string commentId
                         && comment.ParentId?.Value is string parentId) {
                         if (!childrenByParentId.TryGetValue(

--- a/OfficeIMO.Excel/ExcelSheet.StructuralMutationPlan.Security.cs
+++ b/OfficeIMO.Excel/ExcelSheet.StructuralMutationPlan.Security.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Xml;
+using DocumentFormat.OpenXml.Packaging;
+
+namespace OfficeIMO.Excel {
+    public partial class ExcelSheet {
+        /// <summary>
+        /// Bounds every unloaded XML part before mutation planning can materialize it.
+        /// The impact scan separately accounts for the elements it semantically inspects.
+        /// </summary>
+        private void EnsureMutationPlanPartsFitWithinBudget(
+            ExcelMutationPlanOptions options) {
+            var budget = new MutationPlanScanBudget(
+                options.MaximumScannedElements,
+                options.MaximumScannedCharacters);
+            var visited = new HashSet<OpenXmlPart>();
+            var pending = new Stack<OpenXmlPart>();
+            foreach (IdPartPair relationship in _spreadSheetDocument.Parts) {
+                budget.Consume();
+                pending.Push(relationship.OpenXmlPart);
+            }
+
+            while (pending.Count > 0) {
+                OpenXmlPart part = pending.Pop();
+                if (!visited.Add(part)) {
+                    continue;
+                }
+
+                EnsureMutationPlanPartXmlFitsWithinBudget(part, budget);
+                foreach (IdPartPair relationship in part.Parts) {
+                    budget.Consume();
+                    pending.Push(relationship.OpenXmlPart);
+                }
+            }
+        }
+
+        private static void EnsureMutationPlanPartXmlFitsWithinBudget(
+            OpenXmlPart part,
+            MutationPlanScanBudget budget) {
+            if (!part.IsRootElementLoaded && IsXmlContentType(part.ContentType)) {
+                using Stream stream = part.GetStream(FileMode.Open, FileAccess.Read);
+                if (!stream.CanSeek || stream.Length > 0L) {
+                    using var boundedStream = new MutationPlanBudgetedReadStream(
+                        stream,
+                        budget);
+                    using XmlReader reader = XmlReader.Create(
+                        boundedStream,
+                        new XmlReaderSettings {
+                            DtdProcessing = DtdProcessing.Prohibit,
+                            XmlResolver = null,
+                            IgnoreComments = true,
+                            IgnoreProcessingInstructions = true,
+                            MaxCharactersInDocument = budget.MaximumCharacters
+                        });
+                    while (reader.Read()) {
+                        if (reader.NodeType == XmlNodeType.Element) {
+                            budget.Consume();
+                        }
+                    }
+                }
+            }
+        }
+
+        private sealed class MutationPlanBudgetedReadStream : Stream {
+            private readonly Stream _inner;
+            private readonly MutationPlanScanBudget _budget;
+
+            internal MutationPlanBudgetedReadStream(
+                Stream inner,
+                MutationPlanScanBudget budget) {
+                _inner = inner;
+                _budget = budget;
+            }
+
+            public override bool CanRead => _inner.CanRead;
+            public override bool CanSeek => _inner.CanSeek;
+            public override bool CanWrite => false;
+            public override long Length => _inner.Length;
+            public override long Position {
+                get => _inner.Position;
+                set => _inner.Position = value;
+            }
+
+            public override void Flush() => _inner.Flush();
+
+            public override int Read(byte[] buffer, int offset, int count) {
+                int read = _inner.Read(
+                    buffer,
+                    offset,
+                    _budget.GetBudgetedReadSize(count));
+                _budget.ConsumeXmlBytes(read);
+                return read;
+            }
+
+            public override int Read(Span<byte> buffer) {
+                int read = _inner.Read(
+                    buffer[.._budget.GetBudgetedReadSize(buffer.Length)]);
+                _budget.ConsumeXmlBytes(read);
+                return read;
+            }
+
+            public override int ReadByte() {
+                int value = _inner.ReadByte();
+                if (value >= 0) {
+                    _budget.ConsumeXmlBytes(1);
+                }
+                return value;
+            }
+
+            public override long Seek(long offset, SeekOrigin origin) =>
+                _inner.Seek(offset, origin);
+
+            public override void SetLength(long value) =>
+                throw new NotSupportedException();
+
+            public override void Write(byte[] buffer, int offset, int count) =>
+                throw new NotSupportedException();
+        }
+
+        private static bool IsXmlContentType(string contentType) =>
+            contentType.EndsWith("+xml", StringComparison.OrdinalIgnoreCase)
+            || contentType.Equals("application/xml", StringComparison.OrdinalIgnoreCase)
+            || contentType.Equals("text/xml", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/OfficeIMO.Excel/ExcelSheet.StructuralMutationPlan.Security.cs
+++ b/OfficeIMO.Excel/ExcelSheet.StructuralMutationPlan.Security.cs
@@ -39,7 +39,7 @@ namespace OfficeIMO.Excel {
         private static void EnsureMutationPlanPartXmlFitsWithinBudget(
             OpenXmlPart part,
             MutationPlanScanBudget budget) {
-            if (!part.IsRootElementLoaded && IsXmlContentType(part.ContentType)) {
+            if (!part.IsRootElementLoaded && IsXmlPart(part)) {
                 using Stream stream = part.GetStream(FileMode.Open, FileAccess.Read);
                 if (!stream.CanSeek || stream.Length > 0L) {
                     using var boundedStream = new MutationPlanBudgetedReadStream(
@@ -94,13 +94,6 @@ namespace OfficeIMO.Excel {
                 return read;
             }
 
-            public override int Read(Span<byte> buffer) {
-                int read = _inner.Read(
-                    buffer[.._budget.GetBudgetedReadSize(buffer.Length)]);
-                _budget.ConsumeXmlBytes(read);
-                return read;
-            }
-
             public override int ReadByte() {
                 int value = _inner.ReadByte();
                 if (value >= 0) {
@@ -118,6 +111,9 @@ namespace OfficeIMO.Excel {
             public override void Write(byte[] buffer, int offset, int count) =>
                 throw new NotSupportedException();
         }
+
+        private static bool IsXmlPart(OpenXmlPart part) =>
+            part is VmlDrawingPart || IsXmlContentType(part.ContentType);
 
         private static bool IsXmlContentType(string contentType) =>
             contentType.EndsWith("+xml", StringComparison.OrdinalIgnoreCase)

--- a/OfficeIMO.Excel/ExcelSheet.StructuralMutationPlan.cs
+++ b/OfficeIMO.Excel/ExcelSheet.StructuralMutationPlan.cs
@@ -20,6 +20,7 @@ namespace OfficeIMO.Excel {
             ExcelMutationPlanOptions effective = (options ?? new ExcelMutationPlanOptions()).CloneAndValidate();
             return Locking.ExecuteRead(_excelDocument.EnsureLock(), () => {
                 EnsureMutationPlanCanInspectWithoutMaterializing();
+                EnsureMutationPlanPartsFitWithinBudget(effective);
                 ExcelRowMutationPlan plan = BuildRowMutationPlan(
                     ExcelRowMutationKind.Insert,
                     firstRow,
@@ -42,6 +43,7 @@ namespace OfficeIMO.Excel {
             ExcelMutationPlanOptions effective = (options ?? new ExcelMutationPlanOptions()).CloneAndValidate();
             return Locking.ExecuteRead(_excelDocument.EnsureLock(), () => {
                 EnsureMutationPlanCanInspectWithoutMaterializing();
+                EnsureMutationPlanPartsFitWithinBudget(effective);
                 ExcelRowMutationPlan plan = BuildRowMutationPlan(
                     ExcelRowMutationKind.Delete,
                     firstRow,
@@ -434,8 +436,16 @@ namespace OfficeIMO.Excel {
 
             foreach (PivotTablePart pivotPart in _worksheetPart.PivotTableParts) {
                 budget.Consume();
+                PivotTableDefinition? definition = pivotPart.PivotTableDefinition;
+                if (definition == null) {
+                    continue;
+                }
+                budget.Consume();
+                foreach (OpenXmlElement _ in definition.Descendants()) {
+                    budget.Consume();
+                }
                 if (ReferenceListChangesForPlan(
-                        pivotPart.PivotTableDefinition?.Location?.Reference?.Value,
+                        definition.Location?.Reference?.Value,
                         kind,
                         firstRow,
                         lastRow,
@@ -1125,10 +1135,12 @@ namespace OfficeIMO.Excel {
 
         private sealed class MutationPlanScanBudget {
             private readonly int _maximum;
+            private long _remainingXmlBytes;
 
             internal MutationPlanScanBudget(int maximum, long maximumCharacters) {
                 _maximum = maximum;
                 MaximumCharacters = maximumCharacters;
+                _remainingXmlBytes = maximumCharacters;
             }
 
             internal int Scanned { get; private set; }
@@ -1143,6 +1155,26 @@ namespace OfficeIMO.Excel {
                 }
 
                 Scanned++;
+            }
+
+            internal int GetBudgetedReadSize(int requestedBytes) {
+                if (requestedBytes < 0) {
+                    throw new ArgumentOutOfRangeException(nameof(requestedBytes));
+                }
+                long probeLimit = _remainingXmlBytes == long.MaxValue
+                    ? long.MaxValue
+                    : _remainingXmlBytes + 1L;
+                long probeSize = Math.Min(requestedBytes, probeLimit);
+                return checked((int)probeSize);
+            }
+
+            internal void ConsumeXmlBytes(int count) {
+                if (count > _remainingXmlBytes) {
+                    throw new InvalidOperationException(
+                        $"Excel mutation impact analysis exceeded its limit of {MaximumCharacters} decompressed XML bytes. " +
+                        "Increase ExcelMutationPlanOptions.MaximumScannedCharacters explicitly for this workbook.");
+                }
+                _remainingXmlBytes -= count;
             }
         }
     }

--- a/OfficeIMO.Html.Pdf/HtmlPdfRenderedConverter.Fonts.cs
+++ b/OfficeIMO.Html.Pdf/HtmlPdfRenderedConverter.Fonts.cs
@@ -103,6 +103,45 @@ internal static partial class HtmlPdfRenderedConverter {
         }
     }
 
+    private static void RegisterLibrarySelectedDefaultSystemFontFamily(
+        PdfCore.PdfDocument pdf,
+        HtmlRenderDocument rendered,
+        ISet<string> activeWebFontFamilies,
+        ISet<PdfCore.PdfStandardFont> reservedFontSlots,
+        CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (pdf.Options.HasEmbeddedStandardFontFamily(PdfCore.PdfStandardFont.Helvetica)) {
+            return;
+        }
+
+        List<HtmlRenderText> textRuns = EnumerateVisuals(
+                rendered.Pages.SelectMany(page => page.Visuals))
+            .OfType<HtmlRenderText>()
+            .Where(text => !EnumerateFamilies(text.Font.FamilyName).Any(activeWebFontFamilies.Contains))
+            .ToList();
+        if (textRuns.Count == 0) {
+            return;
+        }
+
+        foreach (string familyName in PdfCore.PdfOptions.DefaultDocumentFontFamilyFallback.Split(
+                     new[] { ',', ';' },
+                     StringSplitOptions.RemoveEmptyEntries)) {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!PdfCore.PdfEmbeddedFontFamily.TryFromSystem(
+                    familyName.Trim(),
+                    out PdfCore.PdfEmbeddedFontFamily? family)
+                || family == null) {
+                continue;
+            }
+
+            pdf.Options.RegisterFontFamily(
+                PdfCore.PdfStandardFont.Helvetica,
+                CreateCoverageSafeFontFamily(family, textRuns));
+            reservedFontSlots.Add(PdfCore.PdfStandardFont.Helvetica);
+            return;
+        }
+    }
+
     private static PdfCore.PdfEmbeddedFontFamily CreateCoverageSafeFontFamily(
         PdfCore.PdfEmbeddedFontFamily family,
         IEnumerable<HtmlRenderText> textRuns) {

--- a/OfficeIMO.Html.Pdf/HtmlPdfRenderedConverter.cs
+++ b/OfficeIMO.Html.Pdf/HtmlPdfRenderedConverter.cs
@@ -123,9 +123,17 @@ internal static partial class HtmlPdfRenderedConverter {
             StringComparer.OrdinalIgnoreCase);
         PdfCore.PdfTextFallbackFeatures activeTextFallbacks = ResolveTextFallbackFeatures(rendered, options.TextFallbacks);
         if (activeTextFallbacks != PdfCore.PdfTextFallbackFeatures.None &&
-            options.ResourcePolicy.AllowSystemFontEmbedding &&
-            options.ResourcePolicy.AllowDocumentFontEmbedding) {
-            RegisterUsedSystemFontFamilies(pdf, rendered, activeWebFontFamilies, reservedFontSlots, cancellationToken);
+            options.ResourcePolicy.AllowSystemFontEmbedding) {
+            if (options.ResourcePolicy.AllowDocumentFontEmbedding) {
+                RegisterUsedSystemFontFamilies(pdf, rendered, activeWebFontFamilies, reservedFontSlots, cancellationToken);
+            } else if (options.FontFamily == null) {
+                RegisterLibrarySelectedDefaultSystemFontFamily(
+                    pdf,
+                    rendered,
+                    activeWebFontFamilies,
+                    reservedFontSlots,
+                    cancellationToken);
+            }
         }
         ReserveUsedStandardFontSlots(rendered, activeWebFontFamilies, reservedFontSlots);
         foreach (PdfCore.PdfStandardFont slot in webFonts.Slots.Values) {

--- a/OfficeIMO.Html.Tests/Html.Rendering.cs
+++ b/OfficeIMO.Html.Tests/Html.Rendering.cs
@@ -408,7 +408,7 @@ public sealed partial class HtmlRenderingTests {
 
         Assert.True(summary.HasResourceResolver);
         Assert.True(summary.AllowSystemFontEmbedding);
-        Assert.True(summary.AllowDocumentFontEmbedding);
+        Assert.False(summary.AllowDocumentFontEmbedding);
         Assert.False(summary.AllowLocalFileAccess);
         Assert.False(summary.AllowRemoteResourceResolution);
         Assert.True(summary.AllowDataUris);
@@ -432,7 +432,6 @@ public sealed partial class HtmlRenderingTests {
         var options = new HtmlPdfSaveOptions {
             ResourcePolicy = PdfCore.PdfResourcePolicy.CreateDefault()
         };
-        options.ResourcePolicy.AllowDocumentFontEmbedding = false;
 
         PdfCore.PdfDocumentConversionResult result = HtmlConversionDocument
             .Parse("<p style=\"font-family:'" + installedFamily + "'\">Document font boundary</p>")

--- a/OfficeIMO.Html.Tests/Html.Rendering.cs
+++ b/OfficeIMO.Html.Tests/Html.Rendering.cs
@@ -1531,7 +1531,7 @@ public sealed partial class HtmlRenderingTests {
         Assert.Contains(marker, PdfCore.PdfReadDocument.Open(pdf).ExtractText(), StringComparison.Ordinal);
         Assert.Contains(report.Fonts, font =>
             font.HasEmbeddedFontFile
-            && font.BaseFont?.Contains("Arial", StringComparison.OrdinalIgnoreCase) == true);
+            && font.BaseFont?.Contains("CallerUnicode", StringComparison.OrdinalIgnoreCase) == true);
     }
 
     [Fact]

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfConverterOptionsApiTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfConverterOptionsApiTests.cs
@@ -270,7 +270,7 @@ public sealed class PdfConverterOptionsApiTests {
 
     private static void AssertBalancedDefault(PdfResourcePolicy policy) {
         Assert.True(policy.AllowSystemFontEmbedding);
-        Assert.True(policy.AllowDocumentFontEmbedding);
+        Assert.False(policy.AllowDocumentFontEmbedding);
         Assert.False(policy.AllowLocalFileAccess);
         Assert.False(policy.AllowRemoteResourceResolution);
         Assert.True(policy.AllowDataUris);

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfRenderingProfileTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfRenderingProfileTests.cs
@@ -1437,6 +1437,40 @@ public sealed class PdfRenderingProfileTests {
     }
 
     [Fact]
+    public void OverlayPromotesSameNamedCompatibilityFallbacksToDistinctFamilies() {
+        byte[] sharedData = ManagedTextShapingTestAssets.CreateFont('A', 'B');
+        var onlyA = new OfficeFontUnicodeRangeSet(new[] {
+            new OfficeFontUnicodeRange('A', 'A')
+        });
+        var onlyB = new OfficeFontUnicodeRangeSet(new[] {
+            new OfficeFontUnicodeRange('B', 'B')
+        });
+        var options = new PdfOptions()
+            .RegisterEmbeddedFontFallbacks(new PdfEmbeddedFontFallbackSet(
+                new[] {
+                    new PdfEmbeddedFontFallbackCandidate("Shared", sharedData, onlyA),
+                    new PdfEmbeddedFontFallbackCandidate("Shared", sharedData, onlyB)
+                },
+                new[] { PdfStandardFont.Helvetica, PdfStandardFont.TimesRoman }));
+        var fonts = new OfficeFontFaceCollection()
+            .Add("Profile", ManagedTextShapingTestAssets.CreateFont('C'));
+
+        options.UseRenderingProfile(
+            new OfficeRenderingProfile("same-name-slot-fallbacks", fonts),
+            OfficeRenderingProfileApplyMode.Overlay);
+
+        PdfEmbeddedFontFallbackSet promoted = Assert.IsType<PdfEmbeddedFontFallbackSet>(
+            options.EmbeddedFontFallbacks);
+        Assert.True(promoted.UsesNamedFontFamilies);
+        Assert.Equal(2, promoted.Candidates.Count);
+        Assert.False(string.Equals(
+            promoted.Candidates[0].FontName,
+            promoted.Candidates[1].FontName,
+            StringComparison.OrdinalIgnoreCase));
+        Assert.True(promoted.PlanText("AB").IsFullyCovered);
+    }
+
+    [Fact]
     public void EncodingPreflightUsesRangeScopedAuthoredFamilyPlanner() {
         var onlyA = new OfficeFontUnicodeRangeSet(new[] {
             new OfficeFontUnicodeRange('A', 'A')

--- a/OfficeIMO.Pdf/Options/PdfOptions.RenderingProfile.cs
+++ b/OfficeIMO.Pdf/Options/PdfOptions.RenderingProfile.cs
@@ -607,17 +607,23 @@ public sealed partial class PdfOptions {
 
         var promoted = new List<PdfEmbeddedFontFallbackCandidate>(
             fallbackSet.Candidates.Count);
+        var promotedFamilyKeys = new HashSet<string>(StringComparer.Ordinal);
         for (int index = 0; index < fallbackSet.Candidates.Count; index++) {
             PdfEmbeddedFontFallbackCandidate candidate = fallbackSet.Candidates[index];
             string familyName = candidate.FontName;
             string key = NormalizeNamedFontFamilyKey(familyName);
-            if (prospectiveFamilies.TryGetValue(key, out PdfEmbeddedFontFamily? existing)
-                && !NamedFamilyMatchesFallbackCandidate(existing, candidate)) {
-                familyName = FindReusablePromotedFallbackFamilyName(
-                        candidate,
-                        fallbackSet.FontSlots[index],
-                        prospectiveFamilies)
-                    ?? CreatePromotedFallbackFamilyName(
+            if (promotedFamilyKeys.Contains(key)
+                || (prospectiveFamilies.TryGetValue(key, out PdfEmbeddedFontFamily? existing)
+                    && !NamedFamilyMatchesFallbackCandidate(existing, candidate))) {
+                string? reusableFamilyName = FindReusablePromotedFallbackFamilyName(
+                    candidate,
+                    fallbackSet.FontSlots[index],
+                    prospectiveFamilies);
+                familyName = reusableFamilyName != null
+                        && !promotedFamilyKeys.Contains(
+                            NormalizeNamedFontFamilyKey(reusableFamilyName))
+                    ? reusableFamilyName
+                    : CreatePromotedFallbackFamilyName(
                         candidate.FontName,
                         fallbackSet.FontSlots[index],
                         prospectiveFamilies);
@@ -631,6 +637,7 @@ public sealed partial class PdfOptions {
                 candidate.Style,
                 candidate.PlannerFamilyName);
             promoted.Add(promotedCandidate);
+            promotedFamilyKeys.Add(key);
             if (!prospectiveFamilies.ContainsKey(key)) {
                 prospectiveFamilies[key] = new PdfEmbeddedFontFamily(
                     familyName,

--- a/OfficeIMO.Pdf/Options/PdfResourcePolicy.cs
+++ b/OfficeIMO.Pdf/Options/PdfResourcePolicy.cs
@@ -6,12 +6,12 @@ namespace OfficeIMO.Pdf;
 /// </summary>
 public sealed class PdfResourcePolicy {
     /// <summary>
-    /// Creates the balanced document-conversion default. Installed fonts and bounded in-source resources are allowed
-    /// for Unicode fidelity, while arbitrary local-file and remote-resource reads remain disabled.
+    /// Creates the balanced document-conversion default. Library-selected installed fonts and bounded in-source
+    /// resources are allowed for Unicode fidelity, while document-selected host fonts, arbitrary local files,
+    /// and remote resources remain disabled.
     /// </summary>
     public static PdfResourcePolicy CreateDefault() => new PdfResourcePolicy {
         AllowSystemFontEmbedding = true,
-        AllowDocumentFontEmbedding = true,
         AllowDataUris = true,
         AllowEmbeddedPackageResources = true
     };
@@ -43,7 +43,8 @@ public sealed class PdfResourcePolicy {
 
     /// <summary>
     /// When true, Office converters may use font family names from the source document to locate and embed installed
-    /// system fonts. Enabled by the balanced document-conversion default and disabled by the portable deterministic policy.
+    /// system fonts. Disabled by default; enable it explicitly only for trusted documents or use
+    /// <see cref="CreateTrustedHost"/>.
     /// </summary>
     public bool AllowDocumentFontEmbedding { get; set; }
 

--- a/OfficeIMO.Rtf.Tests/Rtf/RtfPdfConverterTests.cs
+++ b/OfficeIMO.Rtf.Tests/Rtf/RtfPdfConverterTests.cs
@@ -33,12 +33,14 @@ public class RtfPdfConverterTests {
         PdfCore.PdfDocument portable = document.ToPdfDocument(new RtfPdfSaveOptions {
             ResourcePolicy = PdfCore.PdfResourcePolicy.CreatePortableDeterministic()
         });
-        PdfCore.PdfDocument balanced = document.ToPdfDocument();
+        PdfCore.PdfDocument trusted = document.ToPdfDocument(new RtfPdfSaveOptions {
+            ResourcePolicy = PdfCore.PdfResourcePolicy.CreateTrustedHost()
+        });
 
         Assert.Empty(portable.Options.EmbeddedFonts);
-        Assert.NotEmpty(balanced.Options.EmbeddedFonts);
+        Assert.NotEmpty(trusted.Options.EmbeddedFonts);
         Assert.Contains("RTF font policy marker", PdfCore.PdfReadDocument.Open(portable.ToBytes()).ExtractText(), StringComparison.Ordinal);
-        Assert.Contains("RTF font policy marker", PdfCore.PdfReadDocument.Open(balanced.ToBytes()).ExtractText(), StringComparison.Ordinal);
+        Assert.Contains("RTF font policy marker", PdfCore.PdfReadDocument.Open(trusted.ToBytes()).ExtractText(), StringComparison.Ordinal);
     }
 
     [Fact]
@@ -100,7 +102,8 @@ public class RtfPdfConverterTests {
         };
 
         PdfCore.PdfDocumentConversionResult result = document.ToPdfDocumentResult(new RtfPdfSaveOptions {
-            PdfOptions = callerPdfOptions
+            PdfOptions = callerPdfOptions,
+            ResourcePolicy = PdfCore.PdfResourcePolicy.CreateTrustedHost()
         });
 
         Assert.False(callerPdfOptions.HasExplicitDefaultFont);

--- a/OfficeIMO.Word.Tests/Pdf/Word.SaveAsPdf.Defaults.cs
+++ b/OfficeIMO.Word.Tests/Pdf/Word.SaveAsPdf.Defaults.cs
@@ -11,11 +11,11 @@ using Xunit;
 namespace OfficeIMO.Tests {
     public partial class Word {
         [Fact]
-        public void SaveAsPdf_DefaultsEmbedDocumentFontsWithoutAllowingArbitraryResourceReads() {
+        public void SaveAsPdf_DefaultsDoNotEmbedDocumentNamedHostFontsOrAllowArbitraryResourceReads() {
             var options = new WordPdfSaveOptions();
 
             Assert.True(options.ResourcePolicy.AllowSystemFontEmbedding);
-            Assert.True(options.ResourcePolicy.AllowDocumentFontEmbedding);
+            Assert.False(options.ResourcePolicy.AllowDocumentFontEmbedding);
             Assert.False(options.ResourcePolicy.AllowLocalFileAccess);
             Assert.False(options.ResourcePolicy.AllowRemoteResourceResolution);
         }

--- a/Website/scripts/Test-BenchmarkPage.ps1
+++ b/Website/scripts/Test-BenchmarkPage.ps1
@@ -79,6 +79,11 @@ if ($comparisonRunnerText -notmatch 'if \(\$catalogEligible -and \$gitDirty\)' -
     $comparisonRunnerText -notmatch 'Cataloged benchmark evidence requires a clean Git worktree') {
     throw 'Catalog-eligible benchmark runs do not enforce source-commit provenance from a clean worktree.'
 }
+if ($comparisonRunnerText -notmatch 'GetUnresolvedProviderPathFromPSPath' -or
+    $comparisonRunnerText -notmatch '-ResultArtifactPath \$measurement\.EvidenceLocation\.Path' -or
+    $comparisonRunnerText -match '-Path \$measurement\.EvidenceLocation\.Path') {
+    throw 'The benchmark runner does not preserve caller-relative output roots and atomic evidence publication.'
+}
 
 $caseIdentity = Get-BenchmarkEvidenceCaseIdentity -Row ([pscustomobject]@{
     Scenario = 'OfficeIMO_WriteDataReader'


### PR DESCRIPTION
## Summary

- bound Excel structural-mutation planning across unloaded package XML, pivot definitions, and threaded-comment collection before semantic preflight
- make document-selected host font embedding an explicit trusted-input opt-in while keeping library-selected multilingual fallbacks coverage-safe
- preserve unique PDF fallback identities during rendering-profile overlays
- resolve benchmark output paths before working-directory changes and let PowerForge publish result artifacts atomically in every cataloged mode

## Security findings addressed

This single change set addresses all seven open OfficeIMO findings supplied for the review: the four Excel/PDF resource-boundary findings and the three benchmark/rendering correctness findings.

## Compatibility

`PdfResourcePolicy.CreateDefault()` no longer permits source documents to select installed host fonts. Library-selected Unicode fallback families remain available when system-font embedding is enabled. Trusted callers can retain document-selected host fonts with `PdfResourcePolicy.CreateTrustedHost()` or by explicitly enabling `AllowDocumentFontEmbedding`.

## Validation

- complete Excel tests on .NET 10: 3,018 passed, 5 environment-specific skips
- complete PDF tests on .NET 10: 3,396 passed
- complete HTML tests on .NET 10: 1,478 passed; focused fallback coverage also passed on .NET 8
- complete RTF tests on .NET 10: 725 passed; focused resource-policy coverage also passed on .NET 8
- portable Excel, HTML/PDF, and RTF/PDF builds targeting `netstandard2.0`
- focused Excel, PDF, Word, and HTML regressions on .NET 8 and .NET 10
- PowerForge atomic benchmark artifact-write contract and PowerShell runner contract checks
- independent read-only security review, with all reported Excel hardening gaps remediated