### PR TITLE
Import PowerPoint slides from read-only presentations

### DIFF
--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.SlidesManagement.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.SlidesManagement.cs
@@ -7,6 +7,7 @@ using DocumentFormat.OpenXml.Validation;
 using OfficeIMO.PowerPoint;
 using Xunit;
 using A = DocumentFormat.OpenXml.Drawing;
+using C = DocumentFormat.OpenXml.Drawing.Charts;
 
 namespace OfficeIMO.Tests {
     public class PowerPointSlidesManagement {
@@ -247,6 +248,56 @@ namespace OfficeIMO.Tests {
 
             File.Delete(sourcePath);
             File.Delete(targetPath);
+        }
+
+        [Fact]
+        public void CanImportSlideFromReadOnlyPresentation() {
+            string sourcePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string targetPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using (PowerPointPresentation source = PowerPointPresentation.Create(sourcePath)) {
+                    PowerPointSlide sourceSlide = source.AddSlide();
+                    sourceSlide.AddTextBox("Read-only source");
+                    sourceSlide.AddChart();
+                    sourceSlide.Notes.Text = "Read-only notes";
+                    sourceSlide.Hidden = true;
+                    source.Save();
+                }
+
+                using (PowerPointPresentation source = PowerPointPresentation.Load(sourcePath,
+                           new PowerPointLoadOptions {
+                               AccessMode = OfficeIMO.Drawing.DocumentAccessMode.ReadOnly,
+                               PersistenceMode = OfficeIMO.Drawing.DocumentPersistenceMode.Explicit
+                           }))
+                using (PowerPointPresentation target = PowerPointPresentation.Create(targetPath)) {
+                    ChartPart sourceChartPart = source.OpenXmlDocument.PresentationPart!
+                        .SlideParts.Single().ChartParts.Single();
+                    sourceChartPart.ChartSpace!.RoundedCorners = new C.RoundedCorners { Val = true };
+                    PowerPointSlide imported = target.ImportSlide(source, 0);
+
+                    Assert.Equal("Read-only source", imported.TextBoxes.Single().Text);
+                    Assert.Equal("Read-only notes", imported.Notes.Text);
+                    Assert.True(imported.Hidden);
+                    Assert.True(target.OpenXmlDocument.PresentationPart!
+                        .SlideParts.Single().ChartParts.Single()
+                        .ChartSpace!.RoundedCorners!.Val!.Value);
+                    target.Save();
+                    Assert.Empty(target.ValidateDocument());
+                }
+
+                using (PowerPointPresentation target = PowerPointPresentation.Load(targetPath)) {
+                    Assert.Equal("Read-only source", target.Slides[0].TextBoxes.Single().Text);
+                    Assert.Equal("Read-only notes", target.Slides[0].Notes.Text);
+                    Assert.True(target.Slides[0].Hidden);
+                    Assert.True(target.OpenXmlDocument.PresentationPart!
+                        .SlideParts.Single().ChartParts.Single()
+                        .ChartSpace!.RoundedCorners!.Val!.Value);
+                }
+            } finally {
+                if (File.Exists(sourcePath)) File.Delete(sourcePath);
+                if (File.Exists(targetPath)) File.Delete(targetPath);
+            }
         }
 
         [Fact]

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.Parts.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.Parts.cs
@@ -434,8 +434,16 @@ namespace OfficeIMO.PowerPoint {
         }
 
         private static void CopyPartData(OpenXmlPart sourcePart, OpenXmlPart targetPart) {
-            using Stream sourceStream = sourcePart.GetStream(FileMode.Open, FileAccess.Read);
             using Stream targetStream = targetPart.GetStream(FileMode.Create, FileAccess.Write);
+            if (sourcePart.IsRootElementLoaded) {
+                OpenXmlPartRootElement? sourceRoot = sourcePart.RootElement;
+                if (sourceRoot != null) {
+                    sourceRoot.Save(targetStream);
+                    return;
+                }
+            }
+
+            using Stream sourceStream = sourcePart.GetStream(FileMode.Open, FileAccess.Read);
             sourceStream.CopyTo(targetStream);
         }
 

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.Slides.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.Slides.cs
@@ -412,7 +412,6 @@ namespace OfficeIMO.PowerPoint {
                 var mediaPartMap = new Dictionary<DataPart, MediaDataPart>();
                 for (int offset = 0; offset < importSources.Count; offset++) {
                     PowerPointSlide sourceSlide = importSources[offset];
-                    sourceSlide.Save();
                     Slide sourceRoot = sourceSlide.SlidePart.Slide
                         ?? throw new InvalidOperationException(
                             "Source slide is missing its slide definition.");
@@ -531,7 +530,6 @@ namespace OfficeIMO.PowerPoint {
         private static void ValidateSlideImportSources(
             IEnumerable<PowerPointSlide> importSources) {
             foreach (PowerPointSlide sourceSlide in importSources) {
-                sourceSlide.Save();
                 _ = sourceSlide.SlidePart.Slide
                     ?? throw new InvalidOperationException(
                         "Source slide is missing its slide definition.");


### PR DESCRIPTION
## Summary

- import slides without saving or otherwise writing to the source presentation
- preserve unsaved changes from source parts that are already loaded into the Open XML DOM
- keep untouched and binary parts on the raw-stream copy path
- cover read-only source packages with a chart-backed regression test before and after reopening the destination

## Why this belongs in OfficeIMO

Slide import is reusable package behavior. PSWriteOffice and other consumers should be able to open an existing presentation read-only and delegate copying to OfficeIMO instead of requiring a writable source or duplicating package-copy logic.

## Compatibility

This changes no public signatures. It removes an unnecessary write requirement from the source presentation.
