### PR TITLE
Accelerate Excel and CSV data reader fast paths

### DIFF
--- a/Benchmarks/MarkPflug65KFixture.cs
+++ b/Benchmarks/MarkPflug65KFixture.cs
@@ -11,6 +11,7 @@ internal static class MarkPflug65KFixture {
     internal const int ExpectedRows = 65_535;
     internal const int ExpectedColumns = 14;
     internal const string CsvFileName = "65K_Records_Data.csv";
+    internal const string XlsFileName = "65K_Records_Data.xls";
     internal const string XlsxFileName = "65K_Records_Data.xlsx";
     internal const string XlsbFileName = "65K_Records_Data.xlsb";
 
@@ -21,6 +22,7 @@ internal static class MarkPflug65KFixture {
     private static readonly IReadOnlyDictionary<string, string> Hashes =
         new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
             [CsvFileName] = "AC959F43CF1077B71D310E6E49E3C168BA63A448F1855D45F44E734273EBA490",
+            [XlsFileName] = "294102433C1527E5FCF48B6E4F1A707852633E623B8A20D184F5BAC926843DD6",
             [XlsxFileName] = "0F44D3E06454508DBD2CDBAF701B04160637162AB71471616D8ADC59D2EDD3A8",
             [XlsbFileName] = "9F03F160D32272CBE57D6023C73748D6C450783738FCD84CC552B03C00E23CC8"
         };
@@ -30,6 +32,7 @@ internal static class MarkPflug65KFixture {
         ?? Path.Combine(Path.GetTempPath(), "OfficeIMO", "Benchmarks", "Fixtures", SourceCommit);
 
     internal static string CsvPath => Path.Combine(Root, CsvFileName);
+    internal static string XlsPath => Path.Combine(Root, XlsFileName);
     internal static string XlsxPath => Path.Combine(Root, XlsxFileName);
     internal static string XlsbPath => Path.Combine(Root, XlsbFileName);
 

--- a/Build/Run-LibraryComparisonBenchmarks.ps1
+++ b/Build/Run-LibraryComparisonBenchmarks.ps1
@@ -3,7 +3,7 @@ param(
     [string] $RunMode = 'quick',
     [ValidateSet('net8.0', 'net10.0')]
     [string] $Framework = 'net10.0',
-    [ValidateSet('all', 'csv', 'csvwrite', 'xlsx', 'xlsxwrite', 'xlsb')]
+    [ValidateSet('all', 'csv', 'csvwrite', 'xls', 'xlsx', 'xlsxwrite', 'xlsb')]
     [string] $Workload = 'all',
     [string] $OutputRoot = (Join-Path ([System.IO.Path]::GetTempPath()) 'OfficeIMO\Benchmarks\Runs'),
     [string] $PowerForgeRoot = $env:POWERFORGE_ROOT,
@@ -66,6 +66,13 @@ $definitions = [ordered]@{
             'Sylvan_WriteDataReader|RowCount=25000&Shape=Quoted'
             'Sylvan_WriteDataReader|RowCount=25000&Shape=Multiline'
         )
+    }
+    xls = [pscustomobject]@{
+        Project = 'OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj'
+        Filter = '*MarkPflug65KXlsBenchmarks*'
+        ComparisonId = "markpflug-65k-xls-typed-$Framework"
+        Suite = 'OfficeIMO.Excel.Xls.MarkPflug65K'
+        ExpectedCases = @('OfficeIMO', 'Sylvan', 'ExcelDataReader')
     }
     xlsx = [pscustomobject]@{
         Project = 'OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj'

--- a/OfficeIMO.CSV/CsvParser.DataReaderRows.Stream.cs
+++ b/OfficeIMO.CSV/CsvParser.DataReaderRows.Stream.cs
@@ -346,23 +346,23 @@ internal static partial class CsvParser
             string? materialized = _materialized[ordinal];
             if (materialized is null)
             {
-                ReadOnlySpan<char> value = _buffer.AsSpan(_starts[ordinal], _lengths[ordinal]);
-                materialized = TryGetCachedString(value)
-                    ?? new string(_buffer, _starts[ordinal], _lengths[ordinal]);
+                int start = _starts[ordinal];
+                int length = _lengths[ordinal];
+                if (length == 1)
+                {
+                    char value = _buffer[start];
+                    materialized = value < SingleCharacterStrings.Length
+                        ? SingleCharacterStrings[value]
+                        : new string(_buffer, start, length);
+                }
+                else
+                {
+                    materialized = new string(_buffer, start, length);
+                }
                 _materialized[ordinal] = materialized;
             }
 
             return materialized;
-        }
-
-        private static string? TryGetCachedString(ReadOnlySpan<char> value)
-        {
-            return value.Length switch
-            {
-                0 => string.Empty,
-                1 when value[0] < SingleCharacterStrings.Length => SingleCharacterStrings[value[0]],
-                _ => null
-            };
         }
 
         private static string[] CreateSingleCharacterStrings()

--- a/OfficeIMO.CSV/CsvParser.DataReaderRows.Stream.cs
+++ b/OfficeIMO.CSV/CsvParser.DataReaderRows.Stream.cs
@@ -222,6 +222,7 @@ internal static partial class CsvParser
     private struct CsvDataReaderStreamRowVisitor : ICsvFieldSpanVisitor
     {
         private readonly char[] _buffer;
+        private static readonly string[] SingleCharacterStrings = CreateSingleCharacterStrings();
         private int[] _starts;
         private int[] _lengths;
         private string?[] _materialized;
@@ -345,11 +346,33 @@ internal static partial class CsvParser
             string? materialized = _materialized[ordinal];
             if (materialized is null)
             {
-                materialized = new string(_buffer, _starts[ordinal], _lengths[ordinal]);
+                ReadOnlySpan<char> value = _buffer.AsSpan(_starts[ordinal], _lengths[ordinal]);
+                materialized = TryGetCachedString(value)
+                    ?? new string(_buffer, _starts[ordinal], _lengths[ordinal]);
                 _materialized[ordinal] = materialized;
             }
 
             return materialized;
+        }
+
+        private static string? TryGetCachedString(ReadOnlySpan<char> value)
+        {
+            return value.Length switch
+            {
+                0 => string.Empty,
+                1 when value[0] < SingleCharacterStrings.Length => SingleCharacterStrings[value[0]],
+                _ => null
+            };
+        }
+
+        private static string[] CreateSingleCharacterStrings()
+        {
+            var values = new string[128];
+            for (int index = 0; index < values.Length; index++)
+            {
+                values[index] = new string((char)index, 1);
+            }
+            return values;
         }
 
         internal bool IsMissing(int ordinal)

--- a/OfficeIMO.Email.Tests/Compound/OfficeCompoundFileContractTests.cs
+++ b/OfficeIMO.Email.Tests/Compound/OfficeCompoundFileContractTests.cs
@@ -215,10 +215,10 @@ public sealed class OfficeCompoundFileContractTests {
             new OfficeCompoundStream("Property", new byte[] { 1 })
         });
         int directoryOffset = checked(((int)ReadUInt32(compound, 48) + 1) * 512);
-        WriteUInt64(compound, directoryOffset + 120, 512);
+        WriteUInt64(compound, directoryOffset + 120, 2048);
         var readerOptions = new EmailReaderOptions(
             maxInputBytes: 8192,
-            maxCompoundDirectoryEntries: 4,
+            maxCompoundDirectoryEntries: 32,
             maxDecodedPropertyBytes: 1,
             maxTotalAttachmentBytes: 1);
 
@@ -226,7 +226,8 @@ public sealed class OfficeCompoundFileContractTests {
             EmailCompoundReadPolicy.Create(readerOptions), out _, out string? error);
 
         Assert.False(success);
-        Assert.Contains("mini stream exceeds configured bounds", error, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("mini stream exceeds configured or physical bounds", error,
+            StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -235,9 +236,9 @@ public sealed class OfficeCompoundFileContractTests {
             new OfficeCompoundStream("Property", new byte[] { 1 })
         });
         int directoryOffset = checked(((int)ReadUInt32(compound, 48) + 1) * 512);
-        WriteUInt64(compound, directoryOffset + 120, 512);
+        WriteUInt64(compound, directoryOffset + 120, 1536);
         var options = new OfficeCompoundReadOptions(
-            maxTotalStreamBytes: 1);
+            maxTotalStreamBytes: 1024);
 
         using var source = new MemoryStream(compound);
         bool success = OfficeCompoundFileReader.TryReadSelective(source, options,
@@ -247,6 +248,28 @@ public sealed class OfficeCompoundFileContractTests {
 
         Assert.False(success);
         Assert.Contains("mini stream exceeds configured or physical bounds", error,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void SelectiveReaderRejectsMiniSectorBeyondDeclaredRootLength() {
+        byte[] compound = OfficeCompoundFileWriter.Write(new[] {
+            new OfficeCompoundStream("Property", new byte[] { 1 })
+        });
+        int directoryOffset = checked(((int)ReadUInt32(compound, 48) + 1) * 512);
+        WriteUInt64(compound, directoryOffset + 120, 0);
+
+        using var source = new MemoryStream(compound);
+        bool success = OfficeCompoundFileReader.TryReadSelective(
+            source,
+            OfficeCompoundReadOptions.Default,
+            (_, _) => false,
+            (_, _) => throw new InvalidOperationException("No stream should be externalized."),
+            out _,
+            out string? error);
+
+        Assert.False(success);
+        Assert.Contains("declared root mini stream length", error,
             StringComparison.OrdinalIgnoreCase);
     }
 

--- a/OfficeIMO.Excel.Benchmarks/MarkPflug65KXlsBenchmarks.cs
+++ b/OfficeIMO.Excel.Benchmarks/MarkPflug65KXlsBenchmarks.cs
@@ -1,0 +1,77 @@
+using System.Data.Common;
+using System.Globalization;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using OfficeIMO.Benchmarks;
+using Sylvan.Data.Excel;
+using SylvanExcelDataReader = Sylvan.Data.Excel.ExcelDataReader;
+
+namespace OfficeIMO.Excel.Benchmarks;
+
+/// <summary>
+/// Neutral typed scan of the hash-pinned 65K sales BIFF8 XLS fixture. Every
+/// compatible reader consumes the same fourteen columns and validated payload.
+/// </summary>
+[MemoryDiagnoser]
+[RankColumn]
+public class MarkPflug65KXlsBenchmarks {
+    private ExcelReadObservation _expected;
+
+    [GlobalSetup]
+    public void Setup() {
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        MarkPflug65KFixture.EnsureAuthentic(MarkPflug65KFixture.XlsFileName);
+        _expected = OfficeIMO();
+        Validate(nameof(Sylvan), Sylvan());
+        Validate(nameof(ExcelDataReader), ExcelDataReader());
+    }
+
+    [Benchmark]
+    public ExcelReadObservation OfficeIMO() {
+        using DbDataReader reader = ExcelDocument.OpenDataReader(
+            MarkPflug65KFixture.XlsPath,
+            new ExcelReadOptions { NumericAsDecimal = true });
+        return MarkPflug65KXlsxBenchmarks.Observe(reader);
+    }
+
+    [Benchmark]
+    public ExcelReadObservation Sylvan() {
+        using var stream = File.OpenRead(MarkPflug65KFixture.XlsPath);
+        using SylvanExcelDataReader reader = SylvanExcelDataReader.Create(
+            stream,
+            ExcelWorkbookType.Excel,
+            new ExcelDataReaderOptions { Schema = ExcelSchema.Default });
+        return MarkPflug65KXlsxBenchmarks.Observe(reader);
+    }
+
+    [Benchmark]
+    public ExcelReadObservation ExcelDataReader() {
+        using var stream = File.OpenRead(MarkPflug65KFixture.XlsPath);
+        using global::ExcelDataReader.IExcelDataReader reader =
+            global::ExcelDataReader.ExcelReaderFactory.CreateReader(stream);
+        if (!reader.Read()) {
+            return default;
+        }
+
+        var observation = new ExcelObservationAccumulator();
+        while (reader.Read()) {
+            MarkPflug65KXlsxBenchmarks.AddRow(
+                ref observation,
+                ordinal => Convert.ToString(reader.GetValue(ordinal), CultureInfo.InvariantCulture) ?? string.Empty,
+                ordinal => MarkPflug65KXlsxBenchmarks.ReadDate(reader.GetValue(ordinal)),
+                ordinal => Convert.ToInt32(reader.GetValue(ordinal), CultureInfo.InvariantCulture),
+                ordinal => Convert.ToDecimal(reader.GetValue(ordinal), CultureInfo.InvariantCulture));
+        }
+
+        return observation.Build();
+    }
+
+    private void Validate(string library, ExcelReadObservation actual) {
+        if (actual != _expected
+            || actual.Rows != MarkPflug65KFixture.ExpectedRows
+            || actual.Cells != MarkPflug65KFixture.ExpectedRows * MarkPflug65KFixture.ExpectedColumns) {
+            throw new InvalidDataException(
+                $"{library} did not perform the same XLS workload. Expected {_expected}; actual {actual}.");
+        }
+    }
+}

--- a/OfficeIMO.Excel.Benchmarks/README.md
+++ b/OfficeIMO.Excel.Benchmarks/README.md
@@ -43,13 +43,15 @@ BenchmarkDotNet classes:
 
 ```powershell
 dotnet run -c Release -f net10.0 --project .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -- --filter "*MarkPflug65KXlsxBenchmarks*"
+dotnet run -c Release -f net10.0 --project .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -- --filter "*MarkPflug65KXlsBenchmarks*"
 dotnet run -c Release -f net10.0 --project .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -- --filter "*MarkPflug65KXlsbBenchmarks*"
 dotnet run -c Release -f net10.0 --project .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -- --filter "*XlsbOfficeIMOPipelineBenchmarks*"
 dotnet run -c Release -f net10.0 --project .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -- --profile-markpflug65k-xlsb-officeimo 100
 dotnet run -c Release -f net10.0 --project .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -- --profile-markpflug65k-xlsb-sylvan 100
 ```
 
-The XLSX lane includes OfficeIMO, Sylvan.Data.Excel, ExcelDataReader,
+The XLS lane includes OfficeIMO, Sylvan.Data.Excel, and ExcelDataReader. The
+XLSX lane includes OfficeIMO, Sylvan.Data.Excel, ExcelDataReader,
 ClosedXML, EPPlus, and MiniExcel. The XLSB lane includes only the compatible
 readers: OfficeIMO, Sylvan.Data.Excel, and ExcelDataReader. Every implementation
 reads the same fourteen typed columns and must produce the same row count, cell

--- a/OfficeIMO.Excel.Tests/Excel.DataReaderApi.FastPathValidation.cs
+++ b/OfficeIMO.Excel.Tests/Excel.DataReaderApi.FastPathValidation.cs
@@ -62,6 +62,66 @@ public partial class Excel {
         }
     }
 
+    [Fact]
+    public void OpenDataReader_RejectsMalformedXmlDeclarationOnCompactFastPath() {
+        string path = CreateCompactFastPathWorkbook();
+        try {
+            const string entryName = "xl/worksheets/sheet1.xml";
+            string worksheetXml = Encoding.UTF8.GetString(ReadZipEntry(path, entryName));
+            int declarationEnd = worksheetXml.IndexOf("?>", StringComparison.Ordinal);
+            Assert.StartsWith("<?xml", worksheetXml, StringComparison.Ordinal);
+            Assert.True(declarationEnd > 0);
+            string malformedXml = "<?xml?>" + worksheetXml.Substring(declarationEnd + 2);
+            ReplaceZipEntry(path, entryName, Encoding.UTF8.GetBytes(malformedXml));
+
+            Assert.Throws<XmlException>(() => ExcelDocument.OpenDataReader(path));
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void OpenDataReader_RejectsAdjacentCellAttributesOnCompactFastPath() {
+        string path = CreateCompactFastPathWorkbook();
+        try {
+            const string entryName = "xl/worksheets/sheet1.xml";
+            string worksheetXml = Encoding.UTF8.GetString(ReadZipEntry(path, entryName));
+            string malformedXml = worksheetXml.Replace(
+                "r=\"A2\" t=\"n\"",
+                "r=\"A2\"t=\"n\"",
+                StringComparison.Ordinal);
+            Assert.NotEqual(worksheetXml, malformedXml);
+            ReplaceZipEntry(path, entryName, Encoding.UTF8.GetBytes(malformedXml));
+
+            Assert.Throws<XmlException>(() => ExcelDocument.OpenDataReader(path));
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Theory]
+    [InlineData("<row", "< row")]
+    [InlineData("</row>", "</ row>")]
+    public void OpenDataReader_RejectsWhitespaceInsideRowTagOpeners(
+        string validToken,
+        string malformedToken) {
+        string path = CreateCompactFastPathWorkbook();
+        try {
+            const string entryName = "xl/worksheets/sheet1.xml";
+            string worksheetXml = Encoding.UTF8.GetString(ReadZipEntry(path, entryName));
+            string malformedXml = worksheetXml.Replace(
+                validToken,
+                malformedToken,
+                StringComparison.Ordinal);
+            Assert.NotEqual(worksheetXml, malformedXml);
+            ReplaceZipEntry(path, entryName, Encoding.UTF8.GetBytes(malformedXml));
+
+            Assert.Throws<XmlException>(() => ExcelDocument.OpenDataReader(path));
+        } finally {
+            File.Delete(path);
+        }
+    }
+
     private static string CreateCompactFastPathWorkbook() {
         string path = Path.Combine(
             Path.GetTempPath(),

--- a/OfficeIMO.Excel.Tests/Excel.DataReaderApi.FastPathValidation.cs
+++ b/OfficeIMO.Excel.Tests/Excel.DataReaderApi.FastPathValidation.cs
@@ -135,6 +135,46 @@ public partial class Excel {
         }
     }
 
+    [Theory]
+    [InlineData("\ufffe")]
+    [InlineData("\uffff")]
+    public void OpenDataReader_RejectsXmlForbiddenScalarsOnIndexedRows(string forbiddenScalar) {
+        string path = CreateCompactFastPathWorkbook();
+        try {
+            const string entryName = "xl/worksheets/sheet1.xml";
+            string worksheetXml = Encoding.UTF8.GetString(ReadZipEntry(path, entryName));
+            string malformedXml = worksheetXml.Replace(
+                "<row r=\"2\"",
+                $"<row note=\"{forbiddenScalar}\" r=\"2\"");
+            Assert.NotEqual(worksheetXml, malformedXml);
+            ReplaceZipEntry(path, entryName, Encoding.UTF8.GetBytes(malformedXml));
+
+            Assert.Throws<XmlException>(() => ExcelDocument.OpenDataReader(path));
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Theory]
+    [InlineData("http://www.w3.org/XML/1998/namespace")]
+    [InlineData("http://www.w3.org/2000/xmlns/")]
+    public void OpenDataReader_RejectsReservedNamespaceBindings(string namespaceUri) {
+        string path = CreateCompactFastPathWorkbook();
+        try {
+            const string entryName = "xl/worksheets/sheet1.xml";
+            string worksheetXml = Encoding.UTF8.GetString(ReadZipEntry(path, entryName));
+            string malformedXml = worksheetXml.Replace(
+                "<worksheet ",
+                $"<worksheet xmlns:p=\"{namespaceUri}\" ");
+            Assert.NotEqual(worksheetXml, malformedXml);
+            ReplaceZipEntry(path, entryName, Encoding.UTF8.GetBytes(malformedXml));
+
+            Assert.Throws<XmlException>(() => ExcelDocument.OpenDataReader(path));
+        } finally {
+            File.Delete(path);
+        }
+    }
+
     private static string CreateCompactFastPathWorkbook() {
         string path = Path.Combine(
             Path.GetTempPath(),

--- a/OfficeIMO.Excel.Tests/Excel.DataReaderApi.FastPathValidation.cs
+++ b/OfficeIMO.Excel.Tests/Excel.DataReaderApi.FastPathValidation.cs
@@ -77,6 +77,32 @@ public partial class Excel {
         }
     }
 
+    [Theory]
+    [InlineData("UTF-16")]
+    [InlineData("bogus")]
+    public void OpenDataReader_RejectsIncompatibleXmlDeclarationEncodingOnCompactFastPath(
+        string encodingName) {
+        string path = CreateCompactFastPathWorkbook();
+        try {
+            const string entryName = "xl/worksheets/sheet1.xml";
+            string worksheetXml = Encoding.UTF8.GetString(ReadZipEntry(path, entryName));
+            const string encodingMarker = "encoding=\"";
+            int valueStart = worksheetXml.IndexOf(encodingMarker, StringComparison.Ordinal)
+                + encodingMarker.Length;
+            Assert.True(valueStart >= encodingMarker.Length);
+            int valueEnd = worksheetXml.IndexOf('"', valueStart);
+            Assert.True(valueEnd > valueStart);
+            string malformedXml = worksheetXml.Substring(0, valueStart)
+                + encodingName
+                + worksheetXml.Substring(valueEnd);
+            ReplaceZipEntry(path, entryName, Encoding.UTF8.GetBytes(malformedXml));
+
+            Assert.Throws<XmlException>(() => ExcelDocument.OpenDataReader(path));
+        } finally {
+            File.Delete(path);
+        }
+    }
+
     [Fact]
     public void OpenDataReader_RejectsAdjacentCellAttributesOnCompactFastPath() {
         string path = CreateCompactFastPathWorkbook();

--- a/OfficeIMO.Excel.Tests/Excel.DataReaderApi.FastPathValidation.cs
+++ b/OfficeIMO.Excel.Tests/Excel.DataReaderApi.FastPathValidation.cs
@@ -1,0 +1,77 @@
+using System.Text;
+using System.Xml;
+using Xunit;
+
+namespace OfficeIMO.Excel.Tests;
+
+public partial class Excel {
+    [Fact]
+    public void OpenDataReader_RejectsDuplicateCellAttributesOnCompactFastPath() {
+        string path = CreateCompactFastPathWorkbook();
+        try {
+            const string entryName = "xl/worksheets/sheet1.xml";
+            string worksheetXml = Encoding.UTF8.GetString(ReadZipEntry(path, entryName));
+            string malformedXml = worksheetXml.Replace(
+                "r=\"A2\"",
+                "r=\"A2\" r=\"A2\"",
+                StringComparison.Ordinal);
+            Assert.NotEqual(worksheetXml, malformedXml);
+            ReplaceZipEntry(path, entryName, Encoding.UTF8.GetBytes(malformedXml));
+
+            Assert.Throws<XmlException>(() => ExcelDocument.OpenDataReader(path));
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void OpenDataReader_RejectsMalformedCommentInsideFastValidatedSheetData() {
+        string path = CreateCompactFastPathWorkbook();
+        try {
+            const string entryName = "xl/worksheets/sheet1.xml";
+            string worksheetXml = Encoding.UTF8.GetString(ReadZipEntry(path, entryName));
+            string malformedXml = worksheetXml.Replace(
+                "</sheetData>",
+                "<!--invalid--comment--></sheetData>",
+                StringComparison.Ordinal);
+            Assert.NotEqual(worksheetXml, malformedXml);
+            ReplaceZipEntry(path, entryName, Encoding.UTF8.GetBytes(malformedXml));
+
+            Assert.Throws<XmlException>(() => ExcelDocument.OpenDataReader(path));
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void OpenDataReader_RejectsUnboundNamespacePrefixOutsideSheetData() {
+        string path = CreateCompactFastPathWorkbook();
+        try {
+            const string entryName = "xl/worksheets/sheet1.xml";
+            string worksheetXml = Encoding.UTF8.GetString(ReadZipEntry(path, entryName));
+            string malformedXml = worksheetXml.Replace(
+                "<sheetData>",
+                "<sheetData bad:attribute=\"value\">",
+                StringComparison.Ordinal);
+            Assert.NotEqual(worksheetXml, malformedXml);
+            ReplaceZipEntry(path, entryName, Encoding.UTF8.GetBytes(malformedXml));
+
+            Assert.Throws<XmlException>(() => ExcelDocument.OpenDataReader(path));
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    private static string CreateCompactFastPathWorkbook() {
+        string path = Path.Combine(
+            Path.GetTempPath(),
+            $"OfficeIMO.Excel.FastPathValidation.{Guid.NewGuid():N}.xlsx");
+        using (var document = ExcelDocument.Create(path)) {
+            ExcelSheet sheet = document.AddWorksheet("Data");
+            sheet.CellValue(1, 1, "Value");
+            sheet.CellValue(2, 1, 42);
+            document.Save();
+        }
+        return path;
+    }
+}

--- a/OfficeIMO.Excel.Tests/Excel.DataReaderApi.FastPathValidation.cs
+++ b/OfficeIMO.Excel.Tests/Excel.DataReaderApi.FastPathValidation.cs
@@ -13,8 +13,7 @@ public partial class Excel {
             string worksheetXml = Encoding.UTF8.GetString(ReadZipEntry(path, entryName));
             string malformedXml = worksheetXml.Replace(
                 "r=\"A2\"",
-                "r=\"A2\" r=\"A2\"",
-                StringComparison.Ordinal);
+                "r=\"A2\" r=\"A2\"");
             Assert.NotEqual(worksheetXml, malformedXml);
             ReplaceZipEntry(path, entryName, Encoding.UTF8.GetBytes(malformedXml));
 
@@ -32,8 +31,7 @@ public partial class Excel {
             string worksheetXml = Encoding.UTF8.GetString(ReadZipEntry(path, entryName));
             string malformedXml = worksheetXml.Replace(
                 "</sheetData>",
-                "<!--invalid--comment--></sheetData>",
-                StringComparison.Ordinal);
+                "<!--invalid--comment--></sheetData>");
             Assert.NotEqual(worksheetXml, malformedXml);
             ReplaceZipEntry(path, entryName, Encoding.UTF8.GetBytes(malformedXml));
 
@@ -51,8 +49,7 @@ public partial class Excel {
             string worksheetXml = Encoding.UTF8.GetString(ReadZipEntry(path, entryName));
             string malformedXml = worksheetXml.Replace(
                 "<sheetData>",
-                "<sheetData bad:attribute=\"value\">",
-                StringComparison.Ordinal);
+                "<sheetData bad:attribute=\"value\">");
             Assert.NotEqual(worksheetXml, malformedXml);
             ReplaceZipEntry(path, entryName, Encoding.UTF8.GetBytes(malformedXml));
 
@@ -88,8 +85,7 @@ public partial class Excel {
             string worksheetXml = Encoding.UTF8.GetString(ReadZipEntry(path, entryName));
             string malformedXml = worksheetXml.Replace(
                 "r=\"A2\" t=\"n\"",
-                "r=\"A2\"t=\"n\"",
-                StringComparison.Ordinal);
+                "r=\"A2\"t=\"n\"");
             Assert.NotEqual(worksheetXml, malformedXml);
             ReplaceZipEntry(path, entryName, Encoding.UTF8.GetBytes(malformedXml));
 
@@ -111,8 +107,25 @@ public partial class Excel {
             string worksheetXml = Encoding.UTF8.GetString(ReadZipEntry(path, entryName));
             string malformedXml = worksheetXml.Replace(
                 validToken,
-                malformedToken,
-                StringComparison.Ordinal);
+                malformedToken);
+            Assert.NotEqual(worksheetXml, malformedXml);
+            ReplaceZipEntry(path, entryName, Encoding.UTF8.GetBytes(malformedXml));
+
+            Assert.Throws<XmlException>(() => ExcelDocument.OpenDataReader(path));
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void OpenDataReader_RejectsUnboundNamespacePrefixOnIndexedRow() {
+        string path = CreateCompactFastPathWorkbook();
+        try {
+            const string entryName = "xl/worksheets/sheet1.xml";
+            string worksheetXml = Encoding.UTF8.GetString(ReadZipEntry(path, entryName));
+            string malformedXml = worksheetXml.Replace(
+                "<row r=\"2\"",
+                "<row bad:x=\"1\" r=\"2\"");
             Assert.NotEqual(worksheetXml, malformedXml);
             ReplaceZipEntry(path, entryName, Encoding.UTF8.GetBytes(malformedXml));
 

--- a/OfficeIMO.Excel.Tests/Excel.DataReaderApi.FastPathValidation.cs
+++ b/OfficeIMO.Excel.Tests/Excel.DataReaderApi.FastPathValidation.cs
@@ -175,6 +175,88 @@ public partial class Excel {
         }
     }
 
+    [Fact]
+    public void OpenDataReader_RejectsRawCDataTerminatorInsideFastValidatedSheetData() {
+        string path = CreateCompactFastPathWorkbook();
+        try {
+            const string entryName = "xl/worksheets/sheet1.xml";
+            string worksheetXml = Encoding.UTF8.GetString(ReadZipEntry(path, entryName));
+            string malformedXml = worksheetXml.Replace(
+                "<row r=\"2\"",
+                "]]><row r=\"2\"");
+            Assert.NotEqual(worksheetXml, malformedXml);
+            ReplaceZipEntry(path, entryName, Encoding.UTF8.GetBytes(malformedXml));
+
+            Assert.Throws<XmlException>(() => ExcelDocument.OpenDataReader(path));
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Theory]
+    [InlineData("p:")]
+    [InlineData("p:1value")]
+    [InlineData("p:value:extra")]
+    public void OpenDataReader_RejectsMalformedPrefixedAttributeNames(string attributeName) {
+        string path = CreateCompactFastPathWorkbook();
+        try {
+            const string entryName = "xl/worksheets/sheet1.xml";
+            string worksheetXml = Encoding.UTF8.GetString(ReadZipEntry(path, entryName));
+            string malformedXml = worksheetXml
+                .Replace(
+                    "<worksheet ",
+                    "<worksheet xmlns:p=\"urn:officeimo:test\" ")
+                .Replace(
+                    "<row r=\"2\"",
+                    $"<row {attributeName}=\"value\" r=\"2\"");
+            Assert.NotEqual(worksheetXml, malformedXml);
+            ReplaceZipEntry(path, entryName, Encoding.UTF8.GetBytes(malformedXml));
+
+            Assert.Throws<XmlException>(() => ExcelDocument.OpenDataReader(path));
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void OpenDataReader_RejectsDuplicateExpandedNamespaceAttributes() {
+        string path = CreateCompactFastPathWorkbook();
+        try {
+            const string entryName = "xl/worksheets/sheet1.xml";
+            string worksheetXml = Encoding.UTF8.GetString(ReadZipEntry(path, entryName));
+            string malformedXml = worksheetXml
+                .Replace(
+                    "<worksheet ",
+                    "<worksheet xmlns:p=\"urn:officeimo:test\" xmlns:q=\"urn:officeimo:test\" ")
+                .Replace(
+                    "<row r=\"2\"",
+                    "<row p:value=\"one\" q:value=\"two\" r=\"2\"");
+            Assert.NotEqual(worksheetXml, malformedXml);
+            ReplaceZipEntry(path, entryName, Encoding.UTF8.GetBytes(malformedXml));
+
+            Assert.Throws<XmlException>(() => ExcelDocument.OpenDataReader(path));
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void OpenDataReader_RejectsCharacterDataBeforeWorksheetRoot() {
+        string path = CreateCompactFastPathWorkbook();
+        try {
+            const string entryName = "xl/worksheets/sheet1.xml";
+            string worksheetXml = Encoding.UTF8.GetString(ReadZipEntry(path, entryName));
+            int rootStart = worksheetXml.IndexOf("<worksheet", StringComparison.Ordinal);
+            Assert.True(rootStart > 0);
+            string malformedXml = worksheetXml.Insert(rootStart, "junk");
+            ReplaceZipEntry(path, entryName, Encoding.UTF8.GetBytes(malformedXml));
+
+            Assert.Throws<XmlException>(() => ExcelDocument.OpenDataReader(path));
+        } finally {
+            File.Delete(path);
+        }
+    }
+
     private static string CreateCompactFastPathWorkbook() {
         string path = Path.Combine(
             Path.GetTempPath(),

--- a/OfficeIMO.Excel.Tests/Excel.DataReaderApi.ReviewContracts.cs
+++ b/OfficeIMO.Excel.Tests/Excel.DataReaderApi.ReviewContracts.cs
@@ -11,6 +11,42 @@ namespace OfficeIMO.Excel.Tests;
 
 public partial class Excel {
     [Fact]
+    public void OpenDataReader_XlsxKeepsTheOpenedFileSnapshotAfterPathReplacement() {
+        string path = Path.Combine(
+            Path.GetTempPath(),
+            $"OfficeIMO.Excel.OpenedSnapshot.{Guid.NewGuid():N}.xlsx");
+        string replacementPath = path + ".replacement";
+        try {
+            using (var document = ExcelDocument.Create(path)) {
+                ExcelSheet sheet = document.AddWorksheet("Original");
+                sheet.CellValue(1, 1, "Value");
+                sheet.CellValue(2, 1, "Original snapshot");
+                document.Save();
+            }
+            using (var document = ExcelDocument.Create(replacementPath)) {
+                ExcelSheet sheet = document.AddWorksheet("Replacement");
+                sheet.CellValue(1, 1, "Value");
+                sheet.CellValue(2, 1, "Replacement snapshot");
+                document.Save();
+            }
+
+            using DbDataReader reader = ExcelDocument.OpenDataReader(path);
+            File.Delete(path);
+            File.Move(replacementPath, path);
+
+            Assert.Equal(
+                "Original",
+                Assert.IsType<ExcelWorkbookDataReader>(reader).CurrentSheetName);
+            Assert.True(reader.Read());
+            Assert.Equal("Original snapshot", reader.GetString(0));
+            Assert.False(reader.Read());
+        } finally {
+            File.Delete(path);
+            File.Delete(replacementPath);
+        }
+    }
+
+    [Fact]
     public void OpenDataReader_RejectsMalformedWorksheetXmlAfterSheetData() {
         string path = Path.Combine(
             Path.GetTempPath(),

--- a/OfficeIMO.Excel.Tests/Excel.DataReaderApi.SchemaContracts.cs
+++ b/OfficeIMO.Excel.Tests/Excel.DataReaderApi.SchemaContracts.cs
@@ -1,0 +1,79 @@
+using System.Collections.ObjectModel;
+using System.Data;
+using System.Data.Common;
+using System.Linq;
+using Xunit;
+
+namespace OfficeIMO.Excel.Tests;
+
+public partial class Excel {
+    [Fact]
+    public void OpenDataReader_XlsbFastPathPreservesTheCanonicalSchemaContract() {
+        using DbDataReader reader = ExcelDocument.OpenDataReader(
+            GetDataReaderXlsbFixture("basic-values-formula.xlsb"));
+
+        DataReaderSchemaContractAssertions.AssertCanonicalSchema(reader);
+    }
+}
+
+internal static class DataReaderSchemaContractAssertions {
+    internal static void AssertCanonicalSchema(DbDataReader reader) {
+        string[] expectedColumns = {
+            SchemaTableColumn.ColumnName,
+            SchemaTableColumn.ColumnOrdinal,
+            SchemaTableColumn.ColumnSize,
+            SchemaTableColumn.NumericPrecision,
+            SchemaTableColumn.NumericScale,
+            SchemaTableColumn.DataType,
+            SchemaTableColumn.ProviderType,
+            SchemaTableColumn.IsLong,
+            SchemaTableColumn.AllowDBNull,
+            "IsReadOnly",
+            "IsRowVersion",
+            SchemaTableColumn.IsUnique,
+            SchemaTableColumn.IsKey,
+            "IsAutoIncrement",
+            SchemaTableColumn.BaseSchemaName,
+            "BaseCatalogName",
+            SchemaTableColumn.BaseTableName,
+            SchemaTableColumn.BaseColumnName
+        };
+
+        DataTable schema = reader.GetSchemaTable();
+        Assert.Equal(expectedColumns, schema.Columns.Cast<DataColumn>().Select(column => column.ColumnName));
+        Assert.Equal(reader.FieldCount, schema.Rows.Count);
+
+        for (int ordinal = 0; ordinal < reader.FieldCount; ordinal++) {
+            string name = reader.GetName(ordinal);
+            DataRow row = schema.Rows[ordinal];
+            Assert.Equal(name, row[SchemaTableColumn.ColumnName]);
+            Assert.Equal(ordinal, row[SchemaTableColumn.ColumnOrdinal]);
+            Assert.Equal(-1, row[SchemaTableColumn.ColumnSize]);
+            Assert.Equal(reader.GetFieldType(ordinal), row[SchemaTableColumn.DataType]);
+            Assert.Equal(true, row[SchemaTableColumn.AllowDBNull]);
+            Assert.Equal(true, row["IsReadOnly"]);
+            Assert.Equal(false, row["IsRowVersion"]);
+            Assert.Equal(false, row[SchemaTableColumn.IsUnique]);
+            Assert.Equal(false, row[SchemaTableColumn.IsKey]);
+            Assert.Equal(false, row["IsAutoIncrement"]);
+            Assert.Equal(name, row[SchemaTableColumn.BaseColumnName]);
+        }
+
+#if NET8_0_OR_GREATER
+        ReadOnlyCollection<DbColumn> columns = reader.GetColumnSchema();
+        Assert.Equal(reader.FieldCount, columns.Count);
+        for (int ordinal = 0; ordinal < columns.Count; ordinal++) {
+            DbColumn column = columns[ordinal];
+            Assert.Equal(reader.GetName(ordinal), column.ColumnName);
+            Assert.Equal(ordinal, column.ColumnOrdinal);
+            Assert.Equal(-1, column.ColumnSize);
+            Assert.True(column.AllowDBNull);
+            Assert.True(column.IsReadOnly);
+            Assert.False(column.IsUnique);
+            Assert.False(column.IsKey);
+            Assert.False(column.IsAutoIncrement);
+            Assert.Equal(reader.GetName(ordinal), column.BaseColumnName);
+        }
+#endif
+    }
+}

--- a/OfficeIMO.Excel.Tests/Excel.DataReaderApi.XlsFastPath.ReviewRegression.cs
+++ b/OfficeIMO.Excel.Tests/Excel.DataReaderApi.XlsFastPath.ReviewRegression.cs
@@ -98,6 +98,30 @@ namespace OfficeIMO.Tests {
                 StringComparison.OrdinalIgnoreCase);
         }
 
+        [Fact]
+        public void OpenDataReader_XlsFastPathBoundsDeclaredRegularWorkbookBeforeBuildingItsChain() {
+            byte[] compound = LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFileWithDeclaredWorkbookSize(
+                LegacyXlsTestWorkbookBuilder.CreatePhase2ValueWorkbookStream(),
+                1024 * 1024);
+
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+                ExcelDocument.OpenDataReader(
+                    compound,
+                    new ExcelReadOptions { HasHeaderRow = false }));
+
+            Assert.Contains("physical bounds", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void OpenDataReader_XlsFastPathPreservesTheCanonicalSchemaContract() {
+            byte[] compound = LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFile(
+                LegacyXlsTestWorkbookBuilder.CreatePhase2ValueWorkbookStream());
+
+            using DbDataReader reader = ExcelDocument.OpenDataReader(compound);
+
+            global::OfficeIMO.Excel.Tests.DataReaderSchemaContractAssertions.AssertCanonicalSchema(reader);
+        }
+
         [Theory]
         [InlineData("Workbook")]
         [InlineData("Book")]

--- a/OfficeIMO.Excel.Tests/Excel.DataReaderApi.XlsFastPath.ReviewRegression.cs
+++ b/OfficeIMO.Excel.Tests/Excel.DataReaderApi.XlsFastPath.ReviewRegression.cs
@@ -1,0 +1,159 @@
+using System.Data.Common;
+using System.Globalization;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        public void OpenDataReader_XlsFastPathFormatsMulRkDateHeaders() {
+            byte[] compound = LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFile(
+                LegacyXlsTestWorkbookBuilder.CreateMulRkDateHeaderWorkbookStream());
+
+            using DbDataReader reader = ExcelDocument.OpenDataReader(
+                compound,
+                new ExcelReadOptions { Culture = CultureInfo.InvariantCulture });
+
+            DateTime expected = DateTime.FromOADate(45293D);
+            Assert.Equal(expected.ToString(CultureInfo.InvariantCulture), reader.GetName(0));
+            Assert.True(reader.Read());
+            Assert.Equal(1D, reader.GetDouble(0));
+            Assert.False(reader.Read());
+        }
+
+        [Fact]
+        public void OpenDataReader_XlsFastPathResolvesInheritedDateStyles() {
+            byte[] compound = LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFile(
+                LegacyXlsTestWorkbookBuilder.CreateInheritedDateStyleWorkbookStream());
+
+            using DbDataReader reader = ExcelDocument.OpenDataReader(
+                compound,
+                new ExcelReadOptions { HasHeaderRow = false });
+
+            Assert.True(reader.Read());
+            Assert.Equal(DateTime.FromOADate(45293D), reader.GetDateTime(0));
+            Assert.False(reader.Read());
+        }
+
+        [Fact]
+        public void OpenDataReader_XlsFastPathKeepsInvalidDateSerialsNumeric() {
+            byte[] compound = LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFile(
+                LegacyXlsTestWorkbookBuilder.CreateInvalidDateSerialWorkbookStream());
+
+            using DbDataReader reader = ExcelDocument.OpenDataReader(
+                compound,
+                new ExcelReadOptions { HasHeaderRow = false });
+
+            Assert.True(reader.Read());
+            Assert.Equal(double.MaxValue, Assert.IsType<double>(reader.GetValue(0)));
+            Assert.Equal(double.MaxValue, reader.GetDouble(0));
+            Assert.False(reader.Read());
+        }
+
+        [Fact]
+        public void OpenDataReader_XlsFastPathRejectsTruncatedMulBlankRecords() {
+            byte[] compound = LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFile(
+                LegacyXlsTestWorkbookBuilder.CreateTruncatedMulBlankWorkbookStream());
+
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+                ExcelDocument.OpenDataReader(
+                    compound,
+                    new ExcelReadOptions { HasHeaderRow = false }));
+
+            Assert.Contains("MULBLANK", exception.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void OpenDataReader_XlsFastPathBoundsDeclaredRootMiniStreamBeforeBuildingItsChain() {
+            byte[] compound = LegacyXlsCompoundTestBuilder.CreateMiniStreamWorkbookCompoundFileWithDeclaredRootSize(
+                LegacyXlsTestWorkbookBuilder.CreatePhase2ValueWorkbookStream(),
+                uint.MaxValue);
+
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+                ExcelDocument.OpenDataReader(
+                    compound,
+                    new ExcelReadOptions { HasHeaderRow = false }));
+
+            Assert.Contains(
+                "mini stream exceeds configured or physical bounds",
+                exception.Message,
+                StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static partial class LegacyXlsTestWorkbookBuilder {
+            internal static byte[] CreateMulRkDateHeaderWorkbookStream() =>
+                CreateFastPathRegressionWorkbookStream(
+                    "MulRkHeader",
+                    globals => WriteRecord(globals, 0x00e0, BuildXfPayload(14)),
+                    worksheet => {
+                        WriteRecord(worksheet, 0x00bd, BuildMulRkPayload(
+                            0,
+                            0,
+                            (0, EncodeRkInteger(45293))));
+                        WriteRecord(worksheet, 0x0203, BuildNumberPayload(1, 0, 1D));
+                    });
+
+            internal static byte[] CreateInheritedDateStyleWorkbookStream() =>
+                CreateFastPathRegressionWorkbookStream(
+                    "InheritedDate",
+                    globals => {
+                        WriteRecord(globals, 0x00e0, BuildXfPayload(14, isStyle: true));
+                        WriteRecord(globals, 0x00e0, BuildXfPayload(
+                            0,
+                            parentStyleIndex: 0,
+                            applyNumberFormat: false));
+                    },
+                    worksheet => WriteRecord(
+                        worksheet,
+                        0x0203,
+                        BuildNumberPayload(0, 0, 45293D, styleIndex: 1)));
+
+            internal static byte[] CreateInvalidDateSerialWorkbookStream() =>
+                CreateFastPathRegressionWorkbookStream(
+                    "InvalidDate",
+                    globals => WriteRecord(globals, 0x00e0, BuildXfPayload(14)),
+                    worksheet => WriteRecord(
+                        worksheet,
+                        0x0203,
+                        BuildNumberPayload(0, 0, double.MaxValue)));
+
+            internal static byte[] CreateTruncatedMulBlankWorkbookStream() =>
+                CreateFastPathRegressionWorkbookStream(
+                    "TruncatedBlank",
+                    globals => { },
+                    worksheet => {
+                        using var payload = new MemoryStream();
+                        WriteUInt16(payload, 0);
+                        WriteUInt16(payload, 0);
+                        WriteUInt16(payload, 2);
+                        WriteRecord(worksheet, 0x00be, payload.ToArray());
+                    });
+
+            private static byte[] CreateFastPathRegressionWorkbookStream(
+                string sheetName,
+                Action<Stream> writeGlobals,
+                Action<Stream> writeWorksheet) {
+                using var stream = new MemoryStream();
+                WriteRecord(stream, 0x0809, new byte[] { 0x00, 0x06, 0x05, 0x00, 0xdb, 0x0b, 0xcc, 0x07 });
+                long boundSheetPosition = stream.Position;
+                WriteRecord(stream, 0x0085, BuildBoundSheetPayload(0, sheetName));
+                writeGlobals(stream);
+                WriteRecord(stream, 0x000a, Array.Empty<byte>());
+
+                int sheetOffset = checked((int)stream.Position);
+                WriteRecord(stream, 0x0809, new byte[] { 0x00, 0x06, 0x10, 0x00, 0xdb, 0x0b, 0xcc, 0x07 });
+                writeWorksheet(stream);
+                WriteRecord(stream, 0x000a, Array.Empty<byte>());
+
+                byte[] bytes = stream.ToArray();
+                Buffer.BlockCopy(
+                    BitConverter.GetBytes(sheetOffset),
+                    0,
+                    bytes,
+                    checked((int)boundSheetPosition + 4),
+                    4);
+                return bytes;
+            }
+        }
+    }
+}

--- a/OfficeIMO.Excel.Tests/Excel.DataReaderApi.XlsFastPath.ReviewRegression.cs
+++ b/OfficeIMO.Excel.Tests/Excel.DataReaderApi.XlsFastPath.ReviewRegression.cs
@@ -80,6 +80,23 @@ namespace OfficeIMO.Tests {
                 StringComparison.OrdinalIgnoreCase);
         }
 
+        [Theory]
+        [InlineData("Workbook")]
+        [InlineData("Book")]
+        public void OpenDataReader_XlsFastPathIgnoresNestedWorkbookNamedStreams(string nestedStreamName) {
+            byte[] compound = LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFileWithNestedWorkbookStream(
+                LegacyXlsTestWorkbookBuilder.CreatePhase2ValueWorkbookStream(),
+                nestedStreamName);
+
+            using DbDataReader reader = ExcelDocument.OpenDataReader(
+                compound,
+                new ExcelReadOptions { HasHeaderRow = false });
+
+            Assert.Equal(3, reader.FieldCount);
+            Assert.True(reader.Read());
+            Assert.Equal("Inline", reader.GetString(0));
+        }
+
         private static partial class LegacyXlsTestWorkbookBuilder {
             internal static byte[] CreateMulRkDateHeaderWorkbookStream() =>
                 CreateFastPathRegressionWorkbookStream(

--- a/OfficeIMO.Excel.Tests/Excel.DataReaderApi.XlsFastPath.ReviewRegression.cs
+++ b/OfficeIMO.Excel.Tests/Excel.DataReaderApi.XlsFastPath.ReviewRegression.cs
@@ -80,6 +80,24 @@ namespace OfficeIMO.Tests {
                 StringComparison.OrdinalIgnoreCase);
         }
 
+        [Fact]
+        public void OpenDataReader_XlsFastPathBoundsDeclaredMiniFatBeforeReadingItsChain() {
+            byte[] compound = LegacyXlsCompoundTestBuilder
+                .CreateMiniStreamWorkbookCompoundFileWithDeclaredMiniFatSectorCount(
+                    LegacyXlsTestWorkbookBuilder.CreatePhase2ValueWorkbookStream(),
+                    1024);
+
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+                ExcelDocument.OpenDataReader(
+                    compound,
+                    new ExcelReadOptions { HasHeaderRow = false }));
+
+            Assert.Contains(
+                "allocation table counts exceed configured or physical bounds",
+                exception.Message,
+                StringComparison.OrdinalIgnoreCase);
+        }
+
         [Theory]
         [InlineData("Workbook")]
         [InlineData("Book")]

--- a/OfficeIMO.Excel.Tests/Excel.DataReaderApi.XlsFastPath.ReviewRegression.cs
+++ b/OfficeIMO.Excel.Tests/Excel.DataReaderApi.XlsFastPath.ReviewRegression.cs
@@ -81,6 +81,23 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void OpenDataReader_XlsFastPathRejectsMiniSectorBeyondDeclaredRootLength() {
+            byte[] compound = LegacyXlsCompoundTestBuilder
+                .CreateMiniStreamWorkbookCompoundFileWithWorkbookBeyondDeclaredRoot(
+                    LegacyXlsTestWorkbookBuilder.CreatePhase2ValueWorkbookStream());
+
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+                ExcelDocument.OpenDataReader(
+                    compound,
+                    new ExcelReadOptions { HasHeaderRow = false }));
+
+            Assert.Contains(
+                "declared root mini stream length",
+                exception.Message,
+                StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
         public void OpenDataReader_XlsFastPathBoundsDeclaredMiniFatBeforeReadingItsChain() {
             byte[] compound = LegacyXlsCompoundTestBuilder
                 .CreateMiniStreamWorkbookCompoundFileWithDeclaredMiniFatSectorCount(

--- a/OfficeIMO.Excel.Tests/Excel.DataReaderApi.XlsFastPath.cs
+++ b/OfficeIMO.Excel.Tests/Excel.DataReaderApi.XlsFastPath.cs
@@ -96,5 +96,53 @@ namespace OfficeIMO.Tests {
                 compound,
                 new ExcelReadOptions { MaxSharedStringCharacters = 8 }));
         }
+
+        [Fact]
+        public void OpenDataReader_XlsFastPathEnforcesContainerInputLimitForPath() {
+            byte[] compound = LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFile(
+                LegacyXlsTestWorkbookBuilder.CreatePhase2ValueWorkbookStream());
+            string path = Path.Combine(
+                Path.GetTempPath(),
+                $"OfficeIMO.Excel.XlsInputLimit.{Guid.NewGuid():N}.xls");
+            try {
+                File.WriteAllBytes(path, compound);
+
+                InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+                    ExcelDocument.OpenDataReader(
+                        path,
+                        new ExcelReadOptions { MaxInputBytes = compound.LongLength - 1L }));
+
+                Assert.Contains("exceeding the configured limit", exception.Message, StringComparison.OrdinalIgnoreCase);
+            } finally {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public void OpenDataReader_XlsFastPathRejectsMissingHeaderFormulaString() {
+            byte[] compound = LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFile(
+                LegacyXlsTestWorkbookBuilder.CreateStringFormulaWithoutStringRecordWorkbookStream(
+                    formulaInFirstRow: true));
+
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+                ExcelDocument.OpenDataReader(
+                    compound,
+                    new ExcelReadOptions { HasHeaderRow = false }));
+
+            Assert.Contains("required String record", exception.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void OpenDataReader_XlsFastPathRejectsMissingDataFormulaString() {
+            byte[] compound = LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFile(
+                LegacyXlsTestWorkbookBuilder.CreateStringFormulaWithoutStringRecordWorkbookStream(
+                    formulaInFirstRow: false));
+
+            using DbDataReader reader = ExcelDocument.OpenDataReader(
+                compound,
+                new ExcelReadOptions { HasHeaderRow = false });
+            Assert.True(reader.Read());
+            Assert.Throws<InvalidDataException>(() => reader.Read());
+        }
     }
 }

--- a/OfficeIMO.Excel.Tests/Excel.DataReaderApi.XlsFastPath.cs
+++ b/OfficeIMO.Excel.Tests/Excel.DataReaderApi.XlsFastPath.cs
@@ -1,0 +1,100 @@
+using System.Data.Common;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        public void OpenDataReader_XlsFastPathReadsRegularAndMiniCompoundStreams() {
+            byte[] workbookStream = LegacyXlsTestWorkbookBuilder.CreatePhase2ValueWorkbookStream();
+            byte[][] containers = {
+                LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFile(workbookStream),
+                LegacyXlsCompoundTestBuilder.CreateMiniStreamWorkbookCompoundFile(workbookStream)
+            };
+
+            foreach (byte[] container in containers) {
+                using DbDataReader reader = ExcelDocument.OpenDataReader(
+                    container,
+                    new ExcelReadOptions { HasHeaderRow = false });
+
+                Assert.Equal(3, reader.FieldCount);
+                Assert.True(reader.Read());
+                Assert.Equal("Inline", reader.GetString(0));
+                Assert.True(reader.IsDBNull(1));
+                Assert.True(reader.Read());
+                Assert.Equal(7, reader.GetInt32(0));
+                Assert.Equal(-3, reader.GetInt32(1));
+                Assert.Equal(123.45D, reader.GetDouble(2), precision: 10);
+                Assert.True(reader.Read());
+                Assert.Equal(1, reader.GetInt32(0));
+                Assert.Equal(2, reader.GetInt32(1));
+                Assert.True(reader.Read());
+                Assert.True(reader.IsDBNull(0));
+                Assert.True(reader.IsDBNull(1));
+                Assert.True(reader.Read());
+                Assert.Equal("#DIV/0!", reader.GetString(0));
+                Assert.False(reader.Read());
+            }
+        }
+
+        [Fact]
+        public void OpenDataReader_XlsFastPathReadsAllCachedFormulaKinds() {
+            byte[] compound = LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFile(
+                LegacyXlsTestWorkbookBuilder.CreatePhase4FormulaWorkbookStream());
+
+            using DbDataReader reader = ExcelDocument.OpenDataReader(
+                compound,
+                new ExcelReadOptions { HasHeaderRow = false });
+
+            Assert.True(reader.Read());
+            Assert.Equal(42D, reader.GetDouble(0));
+            Assert.True(reader.GetBoolean(1));
+            Assert.Equal("Formula text", reader.GetString(2));
+            Assert.Equal("#VALUE!", reader.GetString(3));
+            Assert.Equal("Continued formula text", reader.GetString(4));
+            Assert.True(reader.Read());
+            Assert.Equal(42D, reader.GetDouble(2));
+            Assert.Equal(42D, reader.GetDouble(3));
+            Assert.False(reader.Read());
+        }
+
+        [Fact]
+        public void OpenDataReader_XlsFastPathReads1904DatesAndContinuedSharedStrings() {
+            byte[] dateCompound = LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFile(
+                LegacyXlsTestWorkbookBuilder.CreateDate1904DateFormattedWorkbookStream());
+            using (DbDataReader dateReader = ExcelDocument.OpenDataReader(
+                       dateCompound,
+                       new ExcelReadOptions { HasHeaderRow = false })) {
+                Assert.True(dateReader.Read());
+                Assert.Equal(new DateTime(1904, 1, 2), dateReader.GetDateTime(0));
+                Assert.False(dateReader.Read());
+            }
+
+            byte[] stringsCompound = LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFile(
+                LegacyXlsTestWorkbookBuilder.CreateContinuedSharedStringWorkbookStream());
+            using DbDataReader stringsReader = ExcelDocument.OpenDataReader(
+                stringsCompound,
+                new ExcelReadOptions { HasHeaderRow = false });
+            Assert.True(stringsReader.Read());
+            Assert.Equal("First", stringsReader.GetString(0));
+            Assert.Equal("Second", stringsReader.GetString(1));
+            Assert.False(stringsReader.Read());
+        }
+
+        [Fact]
+        public void OpenDataReader_XlsFastPathEnforcesSharedStringLimitsBeforeDecoding() {
+            byte[] compound = LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFile(
+                LegacyXlsTestWorkbookBuilder.CreateContinuedSharedStringWorkbookStream());
+
+            Assert.Throws<InvalidDataException>(() => ExcelDocument.OpenDataReader(
+                compound,
+                new ExcelReadOptions { MaxSharedStringItems = 1 }));
+            Assert.Throws<InvalidDataException>(() => ExcelDocument.OpenDataReader(
+                compound,
+                new ExcelReadOptions { MaxSharedStringItemCharacters = 5 }));
+            Assert.Throws<InvalidDataException>(() => ExcelDocument.OpenDataReader(
+                compound,
+                new ExcelReadOptions { MaxSharedStringCharacters = 8 }));
+        }
+    }
+}

--- a/OfficeIMO.Excel.Tests/Excel.LegacyXls.CompoundBuilder.cs
+++ b/OfficeIMO.Excel.Tests/Excel.LegacyXls.CompoundBuilder.cs
@@ -80,6 +80,17 @@ namespace OfficeIMO.Tests {
                 return CreateRootStreamCompoundFile(streams);
             }
 
+            internal static byte[] CreateWorkbookCompoundFileWithNestedWorkbookStream(
+                byte[] workbookStream,
+                string nestedStreamName) {
+                return OfficeCompoundFileWriter.Write(new[] {
+                    new OfficeCompoundStream("Workbook", workbookStream),
+                    new OfficeCompoundStream(
+                        "ObjectPool/" + nestedStreamName,
+                        Encoding.ASCII.GetBytes("nested non-workbook payload"))
+                });
+            }
+
             internal static byte[] CreateCompoundHeaderWithInvalidSectorChain() {
                 byte[] bytes = new byte[SectorSize];
                 byte[] signature = { 0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1 };

--- a/OfficeIMO.Excel.Tests/Excel.LegacyXls.CompoundBuilder.cs
+++ b/OfficeIMO.Excel.Tests/Excel.LegacyXls.CompoundBuilder.cs
@@ -138,6 +138,16 @@ namespace OfficeIMO.Tests {
                 return compound;
             }
 
+            internal static byte[] CreateMiniStreamWorkbookCompoundFileWithWorkbookBeyondDeclaredRoot(
+                byte[] workbookStream) {
+                byte[] compound = CreateMiniStreamWorkbookCompoundFile(workbookStream);
+                int directoryOffset = 2 * SectorSize;
+                WriteUInt64(compound, directoryOffset + 120, MiniSectorSize);
+                WriteUInt32(compound, directoryOffset + 128 + 116, 1);
+                WriteUInt64(compound, directoryOffset + 128 + 120, 1);
+                return compound;
+            }
+
             internal static byte[] CreateWorkbookCompoundFileWithDeclaredWorkbookSize(
                 byte[] workbookStream,
                 uint declaredWorkbookSize) {

--- a/OfficeIMO.Excel.Tests/Excel.LegacyXls.CompoundBuilder.cs
+++ b/OfficeIMO.Excel.Tests/Excel.LegacyXls.CompoundBuilder.cs
@@ -138,6 +138,16 @@ namespace OfficeIMO.Tests {
                 return compound;
             }
 
+            internal static byte[] CreateWorkbookCompoundFileWithDeclaredWorkbookSize(
+                byte[] workbookStream,
+                uint declaredWorkbookSize) {
+                byte[] compound = CreateWorkbookCompoundFile(workbookStream);
+                int workbookLength = PadToRegularStream(workbookStream).Length;
+                int directoryOffset = SectorSize + workbookLength;
+                WriteUInt64(compound, directoryOffset + 128 + 120, declaredWorkbookSize);
+                return compound;
+            }
+
             internal static byte[] CreateMiniStreamWorkbookCompoundFileWithDeclaredMiniFatSectorCount(
                 byte[] workbookStream,
                 uint declaredMiniFatSectorCount) {

--- a/OfficeIMO.Excel.Tests/Excel.LegacyXls.CompoundBuilder.cs
+++ b/OfficeIMO.Excel.Tests/Excel.LegacyXls.CompoundBuilder.cs
@@ -119,6 +119,14 @@ namespace OfficeIMO.Tests {
                 return output.ToArray();
             }
 
+            internal static byte[] CreateMiniStreamWorkbookCompoundFileWithDeclaredRootSize(
+                byte[] workbookStream,
+                uint declaredRootSize) {
+                byte[] compound = CreateMiniStreamWorkbookCompoundFile(workbookStream);
+                WriteUInt64(compound, (2 * SectorSize) + 120, declaredRootSize);
+                return compound;
+            }
+
             internal static byte[] CreateDifatWorkbookCompoundFile(byte[] workbookStream) {
                 const int workbookSectorCount = 8;
                 const int dataSectorCount = 13960;

--- a/OfficeIMO.Excel.Tests/Excel.LegacyXls.CompoundBuilder.cs
+++ b/OfficeIMO.Excel.Tests/Excel.LegacyXls.CompoundBuilder.cs
@@ -138,6 +138,14 @@ namespace OfficeIMO.Tests {
                 return compound;
             }
 
+            internal static byte[] CreateMiniStreamWorkbookCompoundFileWithDeclaredMiniFatSectorCount(
+                byte[] workbookStream,
+                uint declaredMiniFatSectorCount) {
+                byte[] compound = CreateMiniStreamWorkbookCompoundFile(workbookStream);
+                WriteUInt32(compound, 64, declaredMiniFatSectorCount);
+                return compound;
+            }
+
             internal static byte[] CreateDifatWorkbookCompoundFile(byte[] workbookStream) {
                 const int workbookSectorCount = 8;
                 const int dataSectorCount = 13960;

--- a/OfficeIMO.Excel.Tests/Excel.LegacyXls.cs
+++ b/OfficeIMO.Excel.Tests/Excel.LegacyXls.cs
@@ -2762,6 +2762,27 @@ namespace OfficeIMO.Tests {
                 return bytes;
             }
 
+            internal static byte[] CreateStringFormulaWithoutStringRecordWorkbookStream(bool formulaInFirstRow) {
+                using var stream = new MemoryStream();
+                WriteRecord(stream, 0x0809, new byte[] { 0x00, 0x06, 0x05, 0x00, 0xdb, 0x0b, 0xcc, 0x07 });
+                long boundSheetPosition = stream.Position;
+                WriteRecord(stream, 0x0085, BuildBoundSheetPayload(0, "Formula"));
+                WriteRecord(stream, 0x000a, Array.Empty<byte>());
+
+                int sheetOffset = checked((int)stream.Position);
+                WriteRecord(stream, 0x0809, new byte[] { 0x00, 0x06, 0x10, 0x00, 0xdb, 0x0b, 0xcc, 0x07 });
+                if (!formulaInFirstRow) {
+                    WriteRecord(stream, 0x0203, BuildNumberPayload(0, 0, 1d));
+                }
+                ushort formulaRow = formulaInFirstRow ? (ushort)0 : (ushort)1;
+                WriteRecord(stream, 0x0006, BuildFormulaSpecialPayload(formulaRow, 0, valueType: 0x00, value: 0));
+                WriteRecord(stream, 0x000a, Array.Empty<byte>());
+
+                byte[] bytes = stream.ToArray();
+                Buffer.BlockCopy(BitConverter.GetBytes(sheetOffset), 0, bytes, checked((int)boundSheetPosition + 4), 4);
+                return bytes;
+            }
+
             internal static byte[] CreatePhase2ValueWorkbookStream() {
                 using var stream = new MemoryStream();
                 WriteRecord(stream, 0x0809, new byte[] { 0x00, 0x06, 0x05, 0x00, 0xdb, 0x0b, 0xcc, 0x07 });

--- a/OfficeIMO.Excel.Tests/Excel.PerformanceReview.FastPathRegressions.cs
+++ b/OfficeIMO.Excel.Tests/Excel.PerformanceReview.FastPathRegressions.cs
@@ -127,6 +127,39 @@ namespace OfficeIMO.Tests {
             Assert.Empty(new OpenXmlValidator().Validate(spreadsheet));
         }
 
+        [Fact]
+        public void PerformanceReview_FileSnapshotKeepsAllViewsOnOneFileIdentity() {
+            string path = Path.Combine(
+                Path.GetTempPath(),
+                $"OfficeIMO.Excel.Snapshot.{Guid.NewGuid():N}.xlsx");
+            string replacementPath = path + ".replacement";
+            byte[] original = Encoding.UTF8.GetBytes("original workbook snapshot");
+            byte[] replacement = Encoding.UTF8.GetBytes("replacement workbook snapshot");
+            try {
+                File.WriteAllBytes(path, original);
+                File.WriteAllBytes(replacementPath, replacement);
+                using var snapshot = SharedReadOnlyFileSnapshot.Open(path);
+                using Stream firstView = snapshot.CreateView();
+
+                File.Delete(path);
+                File.Move(replacementPath, path);
+
+                using Stream secondView = snapshot.CreateView();
+                Assert.Equal(original, ReadSnapshot(firstView));
+                Assert.Equal(original, ReadSnapshot(secondView));
+                Assert.Equal(replacement, File.ReadAllBytes(path));
+            } finally {
+                File.Delete(path);
+                File.Delete(replacementPath);
+            }
+        }
+
+        private static byte[] ReadSnapshot(Stream stream) {
+            using var output = new MemoryStream();
+            stream.CopyTo(output);
+            return output.ToArray();
+        }
+
         private static byte[] RewriteFirstWorksheetAsUtf16(byte[] packageBytes) {
             using var package = new MemoryStream();
             package.Write(packageBytes, 0, packageBytes.Length);

--- a/OfficeIMO.Excel/LegacyXls/Biff/BiffStringReader.cs
+++ b/OfficeIMO.Excel/LegacyXls/Biff/BiffStringReader.cs
@@ -71,6 +71,84 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
                 .ToList();
         }
 
+        /// <summary>
+        /// Reads only shared-string text for forward-only tabular consumers. Rich-text run
+        /// metadata is skipped in place so the fast path does not allocate one metadata object
+        /// and formatting buffer for every string.
+        /// </summary>
+        internal static List<string> ReadSharedStringTexts(
+            IReadOnlyList<byte[]> payloads,
+            List<LegacyXlsImportDiagnostic> diagnostics,
+            int recordOffset,
+            int maxItems,
+            int maxItemCharacters,
+            long maxCharacters) {
+            var strings = new List<string>();
+            if (payloads.Count == 0 || payloads[0].Length < 8) {
+                diagnostics.Add(new LegacyXlsImportDiagnostic(
+                    LegacyXlsDiagnosticSeverity.Warning,
+                    "XLS-BIFF-SST-SHORT",
+                    "The shared string table record is too short.",
+                    recordOffset: recordOffset,
+                    recordType: (ushort)BiffRecordType.Sst));
+                return strings;
+            }
+
+            var reader = new BiffStringSegmentReader(payloads);
+            _ = reader.ReadUInt32Raw();
+            uint uniqueCount = reader.ReadUInt32Raw();
+            if (uniqueCount > maxItems) {
+                throw new InvalidDataException(
+                    $"XLS shared-string count {uniqueCount} exceeds the configured limit of {maxItems}.");
+            }
+            strings.Capacity = checked((int)uniqueCount);
+            long totalCharacters = 0;
+            for (uint index = 0; index < uniqueCount && reader.HasData; index++) {
+                int characterCount;
+                try {
+                    characterCount = reader.ReadUInt16Raw();
+                } catch (InvalidDataException ex) {
+                    diagnostics.Add(new LegacyXlsImportDiagnostic(
+                        LegacyXlsDiagnosticSeverity.Warning,
+                        "XLS-BIFF-SST-STRING-INVALID",
+                        FormattableString.Invariant($"Shared string index {index} could not be read. {ex.Message}"),
+                        recordOffset: recordOffset,
+                        recordType: (ushort)BiffRecordType.Sst));
+                    break;
+                }
+                if (characterCount > maxItemCharacters) {
+                    throw new InvalidDataException(
+                        $"Shared string index {index} declares {characterCount} characters, exceeding the configured limit of {maxItemCharacters}.");
+                }
+                totalCharacters = checked(totalCharacters + characterCount);
+                if (totalCharacters > maxCharacters) {
+                    throw new InvalidDataException(
+                        $"XLS shared strings contain more than the configured {maxCharacters} characters.");
+                }
+                try {
+                    strings.Add(ReadSegmentedUnicodeTextBody(reader, characterCount));
+                } catch (InvalidDataException ex) {
+                    diagnostics.Add(new LegacyXlsImportDiagnostic(
+                        LegacyXlsDiagnosticSeverity.Warning,
+                        "XLS-BIFF-SST-STRING-INVALID",
+                        FormattableString.Invariant($"Shared string index {index} could not be read. {ex.Message}"),
+                        recordOffset: recordOffset,
+                        recordType: (ushort)BiffRecordType.Sst));
+                    break;
+                }
+            }
+            if ((uint)strings.Count != uniqueCount && diagnostics.Count == 0) {
+                diagnostics.Add(new LegacyXlsImportDiagnostic(
+                    LegacyXlsDiagnosticSeverity.Warning,
+                    "XLS-BIFF-SST-STRING-INVALID",
+                    FormattableString.Invariant(
+                        $"The shared string table ended after {strings.Count} of {uniqueCount} declared unique strings."),
+                    recordOffset: recordOffset,
+                    recordType: (ushort)BiffRecordType.Sst));
+            }
+            return strings;
+        }
+
         internal static List<BiffStringValue> ReadSharedStringValues(IReadOnlyList<byte[]> payloads, List<LegacyXlsImportDiagnostic> diagnostics, int recordOffset) {
             var strings = new List<BiffStringValue>();
             if (payloads.Count == 0 || payloads[0].Length < 8) {
@@ -233,6 +311,19 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
             IReadOnlyList<LegacyXlsTextFormattingRun> formattingRuns = ParseFormattingRuns(formattingRunBytes, 0, richTextRuns);
             reader.SkipStringVariableBytes(checked((int)extendedSize));
             return new BiffStringValue(value, formattingRuns);
+        }
+
+        private static string ReadSegmentedUnicodeTextBody(BiffStringSegmentReader reader, int charCount) {
+            byte options = reader.ReadByteRaw();
+            bool isUtf16 = (options & 0x01) != 0;
+            bool hasExtended = (options & 0x04) != 0;
+            bool hasRichText = (options & 0x08) != 0;
+            ushort richTextRuns = hasRichText ? reader.ReadUInt16Raw() : (ushort)0;
+            uint extendedSize = hasExtended ? reader.ReadUInt32Raw() : 0U;
+            string value = reader.ReadStringCharacters(charCount, isUtf16);
+            if (richTextRuns > 0) reader.SkipStringVariableBytes(checked(richTextRuns * 4));
+            if (extendedSize > 0) reader.SkipStringVariableBytes(checked((int)extendedSize));
+            return value;
         }
 
         private static IReadOnlyList<LegacyXlsTextFormattingRun> ParseFormattingRuns(byte[] bytes, int offset, ushort count) {

--- a/OfficeIMO.Excel/LegacyXls/Biff/BiffStringReader.cs
+++ b/OfficeIMO.Excel/LegacyXls/Biff/BiffStringReader.cs
@@ -438,7 +438,18 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
             }
 
             internal void SkipStringVariableBytes(int byteCount) {
-                _ = ReadStringVariableBytes(byteCount);
+                if (byteCount < 0) {
+                    throw new InvalidDataException("The BIFF string variable data length is invalid.");
+                }
+
+                int remaining = byteCount;
+                while (remaining > 0) {
+                    EnsureRawDataAvailable();
+                    byte[] segment = _segments[_segmentIndex];
+                    int take = Math.Min(remaining, segment.Length - _offset);
+                    _offset += take;
+                    remaining -= take;
+                }
             }
 
             internal byte[] ReadStringVariableBytes(int byteCount) {

--- a/OfficeIMO.Excel/LegacyXls/Read/LegacyBiffSource.cs
+++ b/OfficeIMO.Excel/LegacyXls/Read/LegacyBiffSource.cs
@@ -1,0 +1,175 @@
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace OfficeIMO.Excel.LegacyXls.Read {
+    /// <summary>Bounded random-access view over a BIFF workbook stream.</summary>
+    internal sealed class LegacyBiffSource : IDisposable {
+        private const int PageSize = 32 * 1024;
+        private const int MaximumPooledBufferSize = 64 * 1024 * 1024;
+        private Stream? _stream;
+        private byte[]? _buffer;
+        private byte[]? _page;
+        private long _pageOffset = -1;
+        private int _pageLength;
+        private bool _disposed;
+
+        internal LegacyBiffSource(Stream stream, CancellationToken cancellationToken = default) {
+            if (stream == null) throw new ArgumentNullException(nameof(stream));
+            if (!stream.CanRead || !stream.CanSeek) {
+                stream.Dispose();
+                throw new ArgumentException("A BIFF source must be readable and seekable.", nameof(stream));
+            }
+            if (stream.Length > int.MaxValue) {
+                stream.Dispose();
+                throw new InvalidDataException("A BIFF workbook stream cannot exceed 2 GiB.");
+            }
+            Length = checked((int)stream.Length);
+            if (Length > MaximumPooledBufferSize) {
+                _stream = stream;
+                _page = new byte[PageSize];
+                return;
+            }
+
+            byte[] buffer = ArrayPool<byte>.Shared.Rent(Math.Max(1, Length));
+            try {
+                stream.Position = 0;
+                int offset = 0;
+                while (offset < Length) {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    int read = stream.Read(buffer, offset, Length - offset);
+                    if (read == 0) {
+                        throw new EndOfStreamException("The BIFF stream ended before its declared length.");
+                    }
+                    offset += read;
+                }
+                cancellationToken.ThrowIfCancellationRequested();
+                _buffer = buffer;
+            } catch {
+                ArrayPool<byte>.Shared.Return(buffer, clearArray: true);
+                throw;
+            } finally {
+                stream.Dispose();
+            }
+        }
+
+        internal int Length { get; }
+
+        internal byte this[int offset] => ReadByte(offset);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal byte ReadByte(int offset) {
+            if ((uint)offset >= (uint)Length) throw new InvalidDataException("Unexpected end of BIFF record.");
+            byte[]? buffer = _buffer;
+            if (buffer != null) return buffer[offset];
+            EnsurePage(offset);
+            return _page![offset - checked((int)_pageOffset)];
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal ushort ReadUInt16(int offset) {
+            if (offset < 0 || offset > Length - sizeof(ushort)) {
+                throw new InvalidDataException("Unexpected end of BIFF record.");
+            }
+            byte[]? buffer = _buffer;
+            return buffer != null
+                ? (ushort)(buffer[offset] | buffer[offset + 1] << 8)
+                : ReadUInt16Paged(offset);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal uint ReadUInt32(int offset) {
+            if (offset < 0 || offset > Length - sizeof(uint)) {
+                throw new InvalidDataException("Unexpected end of BIFF record.");
+            }
+            byte[]? buffer = _buffer;
+            return buffer != null
+                ? (uint)(buffer[offset]
+                    | buffer[offset + 1] << 8
+                    | buffer[offset + 2] << 16
+                    | buffer[offset + 3] << 24)
+                : ReadUInt32Paged(offset);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal double ReadDouble(int offset) {
+            if (offset < 0 || offset > Length - sizeof(long)) {
+                throw new InvalidDataException("Unexpected end of BIFF record.");
+            }
+            byte[]? buffer = _buffer;
+            if (buffer != null) {
+                return BitConverter.Int64BitsToDouble(
+                    BinaryPrimitives.ReadInt64LittleEndian(buffer.AsSpan(offset, sizeof(long))));
+            }
+            ulong bits = ReadUInt32(offset) | (ulong)ReadUInt32(checked(offset + 4)) << 32;
+            return BitConverter.Int64BitsToDouble(unchecked((long)bits));
+        }
+
+        internal byte[] Copy(int offset, int count) {
+            ThrowIfDisposed();
+            if (offset < 0 || count < 0 || offset > Length - count) {
+                throw new InvalidDataException("Unexpected end of BIFF record.");
+            }
+            var result = new byte[count];
+            if (_buffer != null) {
+                Buffer.BlockCopy(_buffer, offset, result, 0, count);
+                return result;
+            }
+            int copied = 0;
+            while (copied < count) {
+                EnsurePage(checked(offset + copied));
+                int within = checked(offset + copied - (int)_pageOffset);
+                int take = Math.Min(count - copied, _pageLength - within);
+                Buffer.BlockCopy(_page!, within, result, copied, take);
+                copied += take;
+            }
+            return result;
+        }
+
+        private void EnsurePage(int offset) {
+            ThrowIfDisposed();
+            if (_pageOffset >= 0 && offset >= _pageOffset && offset < _pageOffset + _pageLength) return;
+            long pageOffset = offset - offset % PageSize;
+            _stream!.Position = pageOffset;
+            int wanted = Math.Min(PageSize, Length - checked((int)pageOffset));
+            int total = 0;
+            while (total < wanted) {
+                int read = _stream.Read(_page!, total, wanted - total);
+                if (read <= 0) throw new EndOfStreamException("The BIFF stream ended before its declared length.");
+                total += read;
+            }
+            _pageOffset = pageOffset;
+            _pageLength = total;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private ushort ReadUInt16Paged(int offset) =>
+            (ushort)(ReadByte(offset) | ReadByte(checked(offset + 1)) << 8);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private uint ReadUInt32Paged(int offset) =>
+            (uint)(ReadByte(offset)
+                | ReadByte(checked(offset + 1)) << 8
+                | ReadByte(checked(offset + 2)) << 16
+                | ReadByte(checked(offset + 3)) << 24);
+
+        public void Dispose() {
+            if (_disposed) return;
+            _disposed = true;
+            _stream?.Dispose();
+            _stream = null;
+            byte[]? buffer = _buffer;
+            _buffer = null;
+            if (buffer != null) {
+                Array.Clear(buffer, 0, Length);
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
+            _page = null;
+        }
+
+        private void ThrowIfDisposed() {
+            if (_disposed) throw new ObjectDisposedException(nameof(LegacyBiffSource));
+        }
+    }
+}

--- a/OfficeIMO.Excel/LegacyXls/Read/LegacyXlsTabularDataReader.Values.cs
+++ b/OfficeIMO.Excel/LegacyXls/Read/LegacyXlsTabularDataReader.Values.cs
@@ -145,20 +145,8 @@ namespace OfficeIMO.Excel.LegacyXls.Read {
         public override IEnumerator GetEnumerator() => new DbEnumerator(this, closeReader: false);
 
         [UnconditionalSuppressMessage("Trimming", "IL2111", Justification = "The schema table stores Type values as data and does not reflect over Type members.")]
-        public override DataTable GetSchemaTable() {
-            var table = new DataTable("SchemaTable");
-            table.Columns.Add("ColumnName", typeof(string));
-            table.Columns.Add("ColumnOrdinal", typeof(int));
-            table.Columns.Add("DataType", typeof(Type));
-            for (int ordinal = 0; ordinal < FieldCount; ordinal++) {
-                DataRow row = table.NewRow();
-                row["ColumnName"] = GetName(ordinal);
-                row["ColumnOrdinal"] = ordinal;
-                row["DataType"] = GetFieldType(ordinal);
-                table.Rows.Add(row);
-            }
-            return table;
-        }
+        public override DataTable GetSchemaTable() =>
+            ExcelDataReaderSchemaTable.Create(FieldCount, GetName, GetFieldType);
 
         private object GetNumericValue(double value) {
             if (_options.NumericAsDecimal && !double.IsNaN(value) && !double.IsInfinity(value)) {

--- a/OfficeIMO.Excel/LegacyXls/Read/LegacyXlsTabularDataReader.Values.cs
+++ b/OfficeIMO.Excel/LegacyXls/Read/LegacyXlsTabularDataReader.Values.cs
@@ -1,0 +1,187 @@
+using OfficeIMO.Excel.LegacyXls.Projection;
+using System.Collections;
+using System.Data;
+using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
+
+namespace OfficeIMO.Excel.LegacyXls.Read {
+    internal sealed partial class LegacyXlsTabularDataReader {
+        public override string GetName(int ordinal) {
+            ValidateOrdinal(ordinal);
+            return _headers[ordinal];
+        }
+
+        public override int GetOrdinal(string name) {
+            if (name == null) throw new ArgumentNullException(nameof(name));
+            if (_ordinals.TryGetValue(name, out int ordinal)) return ordinal;
+            throw new IndexOutOfRangeException($"Column '{name}' was not found.");
+        }
+
+        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]
+        public override Type GetFieldType(int ordinal) {
+            ValidateOrdinal(ordinal);
+            return typeof(object);
+        }
+
+        public override string GetDataTypeName(int ordinal) => GetFieldType(ordinal).Name;
+
+        public override object GetValue(int ordinal) {
+            ValidateReadableOrdinal(ordinal);
+            return _kinds[ordinal] switch {
+                ValueKind.Text or ValueKind.Error => _strings[ordinal]!,
+                ValueKind.Number => GetNumericValue(_numbers[ordinal]),
+                ValueKind.Boolean => _booleans[ordinal],
+                ValueKind.Date => ConvertDate(_numbers[ordinal]),
+                _ => DBNull.Value
+            };
+        }
+
+        public override int GetValues(object[] values) {
+            if (values == null) throw new ArgumentNullException(nameof(values));
+            int count = Math.Min(values.Length, FieldCount);
+            for (int index = 0; index < count; index++) values[index] = GetValue(index);
+            return count;
+        }
+
+        public override bool IsDBNull(int ordinal) {
+            ValidateReadableOrdinal(ordinal);
+            return _kinds[ordinal] == ValueKind.Empty;
+        }
+
+        public override string GetString(int ordinal) {
+            ValidateReadableOrdinal(ordinal);
+            return _kinds[ordinal] switch {
+                ValueKind.Text or ValueKind.Error => _strings[ordinal]!,
+                ValueKind.Number => _numbers[ordinal].ToString("R", _options.Culture),
+                ValueKind.Boolean => _booleans[ordinal].ToString(),
+                ValueKind.Date => ConvertDate(_numbers[ordinal]).ToString(_options.Culture),
+                _ => throw new InvalidCastException("The XLS cell is blank.")
+            };
+        }
+
+        public override bool GetBoolean(int ordinal) {
+            ValidateReadableOrdinal(ordinal);
+            return _kinds[ordinal] == ValueKind.Boolean
+                ? _booleans[ordinal]
+                : Convert.ToBoolean(GetValue(ordinal), _options.Culture);
+        }
+
+        public override byte GetByte(int ordinal) {
+            ValidateReadableOrdinal(ordinal);
+            return _kinds[ordinal] is ValueKind.Number or ValueKind.Date
+                ? Convert.ToByte(_numbers[ordinal])
+                : Convert.ToByte(GetValue(ordinal), _options.Culture);
+        }
+
+        public override short GetInt16(int ordinal) {
+            ValidateReadableOrdinal(ordinal);
+            return _kinds[ordinal] is ValueKind.Number or ValueKind.Date
+                ? Convert.ToInt16(_numbers[ordinal])
+                : Convert.ToInt16(GetValue(ordinal), _options.Culture);
+        }
+
+        public override int GetInt32(int ordinal) {
+            ValidateReadableOrdinal(ordinal);
+            return _kinds[ordinal] is ValueKind.Number or ValueKind.Date
+                ? Convert.ToInt32(_numbers[ordinal])
+                : Convert.ToInt32(GetValue(ordinal), _options.Culture);
+        }
+
+        public override long GetInt64(int ordinal) {
+            ValidateReadableOrdinal(ordinal);
+            return _kinds[ordinal] is ValueKind.Number or ValueKind.Date
+                ? Convert.ToInt64(_numbers[ordinal])
+                : Convert.ToInt64(GetValue(ordinal), _options.Culture);
+        }
+
+        public override float GetFloat(int ordinal) {
+            ValidateReadableOrdinal(ordinal);
+            return _kinds[ordinal] is ValueKind.Number or ValueKind.Date
+                ? (float)_numbers[ordinal]
+                : Convert.ToSingle(GetValue(ordinal), _options.Culture);
+        }
+
+        public override double GetDouble(int ordinal) {
+            ValidateReadableOrdinal(ordinal);
+            return _kinds[ordinal] is ValueKind.Number or ValueKind.Date
+                ? _numbers[ordinal]
+                : Convert.ToDouble(GetValue(ordinal), _options.Culture);
+        }
+
+        public override decimal GetDecimal(int ordinal) {
+            ValidateReadableOrdinal(ordinal);
+            if (_kinds[ordinal] is ValueKind.Number or ValueKind.Date) {
+                try {
+                    return (decimal)_numbers[ordinal];
+                } catch (OverflowException) {
+                    throw new InvalidCastException($"The XLS numeric value '{_numbers[ordinal]}' cannot be represented as decimal.");
+                }
+            }
+            return Convert.ToDecimal(GetValue(ordinal), _options.Culture);
+        }
+
+        public override DateTime GetDateTime(int ordinal) {
+            ValidateReadableOrdinal(ordinal);
+            return _kinds[ordinal] == ValueKind.Date
+                ? ConvertDate(_numbers[ordinal])
+                : Convert.ToDateTime(GetValue(ordinal), _options.Culture);
+        }
+
+        public override Guid GetGuid(int ordinal) {
+            object value = GetValue(ordinal);
+            return value is Guid guid ? guid : Guid.Parse(Convert.ToString(value, _options.Culture)!);
+        }
+
+        public override char GetChar(int ordinal) => Convert.ToChar(GetValue(ordinal), _options.Culture);
+
+        public override long GetBytes(int ordinal, long dataOffset, byte[]? buffer, int bufferOffset, int length) {
+            if (GetValue(ordinal) is not byte[] bytes) throw new InvalidCastException("The XLS cell does not contain binary data.");
+            return CopySegment(bytes, dataOffset, buffer, bufferOffset, length);
+        }
+
+        public override long GetChars(int ordinal, long dataOffset, char[]? buffer, int bufferOffset, int length) =>
+            CopySegment(GetString(ordinal).ToCharArray(), dataOffset, buffer, bufferOffset, length);
+
+        public override IEnumerator GetEnumerator() => new DbEnumerator(this, closeReader: false);
+
+        [UnconditionalSuppressMessage("Trimming", "IL2111", Justification = "The schema table stores Type values as data and does not reflect over Type members.")]
+        public override DataTable GetSchemaTable() {
+            var table = new DataTable("SchemaTable");
+            table.Columns.Add("ColumnName", typeof(string));
+            table.Columns.Add("ColumnOrdinal", typeof(int));
+            table.Columns.Add("DataType", typeof(Type));
+            for (int ordinal = 0; ordinal < FieldCount; ordinal++) {
+                DataRow row = table.NewRow();
+                row["ColumnName"] = GetName(ordinal);
+                row["ColumnOrdinal"] = ordinal;
+                row["DataType"] = GetFieldType(ordinal);
+                table.Rows.Add(row);
+            }
+            return table;
+        }
+
+        private object GetNumericValue(double value) {
+            if (_options.NumericAsDecimal && !double.IsNaN(value) && !double.IsInfinity(value)) {
+                try {
+                    return (decimal)value;
+                } catch (OverflowException) {
+                    // Preserve a finite value that decimal cannot represent as double.
+                }
+            }
+            return value;
+        }
+
+        private DateTime ConvertDate(double serial) {
+            if (LegacyXlsDateSerialConverter.TryConvert(serial, _uses1904DateSystem, out DateTime value)) return value;
+            throw new InvalidCastException($"The XLS numeric value '{serial}' is not a valid Excel date.");
+        }
+
+        private static long CopySegment<T>(T[] source, long dataOffset, T[]? destination, int destinationOffset, int length) {
+            if (dataOffset < 0 || dataOffset > source.Length) throw new ArgumentOutOfRangeException(nameof(dataOffset));
+            if (destination == null) return source.Length;
+            int count = Math.Min(source.Length - checked((int)dataOffset), length);
+            Array.Copy(source, checked((int)dataOffset), destination, destinationOffset, count);
+            return count;
+        }
+    }
+}

--- a/OfficeIMO.Excel/LegacyXls/Read/LegacyXlsTabularDataReader.cs
+++ b/OfficeIMO.Excel/LegacyXls/Read/LegacyXlsTabularDataReader.cs
@@ -1,0 +1,530 @@
+using OfficeIMO.Excel.LegacyXls.Biff;
+using OfficeIMO.Excel.LegacyXls.Projection;
+using System.Data.Common;
+using System.Globalization;
+using System.Threading;
+using static OfficeIMO.Excel.LegacyXls.Read.LegacyXlsTabularWorkbook;
+
+namespace OfficeIMO.Excel.LegacyXls.Read {
+    /// <summary>
+    /// Forward-only BIFF8 worksheet reader that retains one primitive row and does not
+    /// materialize legacy cells or create an Open XML workbook projection.
+    /// </summary>
+    internal sealed partial class LegacyXlsTabularDataReader : DbDataReader {
+        private readonly LegacyBiffSource _bytes;
+        private readonly IReadOnlyList<string> _sharedStrings;
+        private readonly bool[] _dateStyles;
+        private readonly bool _uses1904DateSystem;
+        private readonly ExcelReadOptions _options;
+        private readonly CancellationToken _cancellationToken;
+        private readonly string[] _headers;
+        private readonly Dictionary<string, int> _ordinals;
+        private readonly ValueKind[] _kinds;
+        private readonly double[] _numbers;
+        private readonly bool[] _booleans;
+        private readonly string?[] _strings;
+        private readonly int _firstColumn;
+        private readonly int _firstDataRow;
+        private readonly int _lastDataRow;
+        private int _position;
+        private int _nextRow;
+        private int _recordsSinceCancellationCheck;
+        private bool _hasCurrentRow;
+        private bool _closed;
+
+        internal LegacyXlsTabularDataReader(
+            LegacyBiffSource bytes,
+            int sheetOffset,
+            IReadOnlyList<string> sharedStrings,
+            bool[] dateStyles,
+            bool uses1904DateSystem,
+            bool hasHeaderRow,
+            ExcelReadOptions options,
+            CancellationToken cancellationToken) {
+            _bytes = bytes ?? throw new ArgumentNullException(nameof(bytes));
+            _sharedStrings = sharedStrings ?? throw new ArgumentNullException(nameof(sharedStrings));
+            _dateStyles = dateStyles ?? throw new ArgumentNullException(nameof(dateStyles));
+            _uses1904DateSystem = uses1904DateSystem;
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _cancellationToken = cancellationToken;
+
+            Discover(
+                sheetOffset,
+                out int firstRow,
+                out int lastRow,
+                out int firstColumn,
+                out int lastColumn,
+                out Dictionary<int, string?>? headerValues);
+            _firstColumn = firstColumn;
+            _firstDataRow = hasHeaderRow && firstRow >= 0 ? checked(firstRow + 1) : firstRow;
+            _lastDataRow = lastRow;
+            _position = sheetOffset;
+            _nextRow = _firstDataRow;
+
+            int fieldCount = lastColumn >= firstColumn
+                ? checked(lastColumn - firstColumn + 1)
+                : 0;
+            if (fieldCount > options.MaxDataReaderColumns) {
+                throw new InvalidDataException(
+                    $"XLS table column count {fieldCount} exceeds the configured limit of {options.MaxDataReaderColumns}.");
+            }
+            _headers = ExcelHeaderNameHelper.BuildUniqueHeaders(
+                fieldCount,
+                ordinal => hasHeaderRow
+                    && headerValues != null
+                    && headerValues.TryGetValue(ordinal + firstColumn, out string? value)
+                        ? value
+                        : null,
+                options.NormalizeHeaders);
+            _ordinals = new Dictionary<string, int>(_headers.Length, StringComparer.OrdinalIgnoreCase);
+            for (int index = 0; index < _headers.Length; index++) {
+                _ordinals[_headers[index]] = index;
+            }
+
+            _kinds = new ValueKind[fieldCount];
+            _numbers = new double[fieldCount];
+            _booleans = new bool[fieldCount];
+            _strings = new string?[fieldCount];
+        }
+
+        public override object this[int ordinal] => GetValue(ordinal);
+        public override object this[string name] => GetValue(GetOrdinal(name));
+        public override int Depth => 0;
+        public override int FieldCount => _headers.Length;
+        public override bool HasRows => _firstDataRow >= 0 && _firstDataRow <= _lastDataRow;
+        public override bool IsClosed => _closed;
+        public override int RecordsAffected => -1;
+
+        public override bool Read() {
+            ThrowIfClosed();
+            _cancellationToken.ThrowIfCancellationRequested();
+            _hasCurrentRow = false;
+            if (_nextRow < 0 || _nextRow > _lastDataRow) return false;
+
+            Array.Clear(_kinds, 0, _kinds.Length);
+            Array.Clear(_strings, 0, _strings.Length);
+            int currentRow = _nextRow++;
+            int pendingFormulaOrdinal = -1;
+            ushort pendingFormulaStyle = 0;
+
+            while (true) {
+                int recordOffset = _position;
+                if (!TryReadRecord(_bytes, ref _position, out RecordSlice record)) break;
+                CheckCancellation();
+                if (record.Type == (ushort)BiffRecordType.Eof) break;
+
+                if (pendingFormulaOrdinal >= 0) {
+                    if (record.Type != (ushort)BiffRecordType.String) {
+                        throw new InvalidDataException("An XLS string formula is not followed by its required String record.");
+                    }
+                    StoreFormulaString(record, pendingFormulaOrdinal, pendingFormulaStyle, ref _position);
+                    pendingFormulaOrdinal = -1;
+                    continue;
+                }
+
+                if (!TryGetCellBounds(record, out int row, out int firstColumn, out _)) continue;
+                if (row < currentRow) continue;
+                if (row > currentRow) {
+                    _position = recordOffset;
+                    break;
+                }
+
+                StoreCellRecord(record, ref pendingFormulaOrdinal, ref pendingFormulaStyle);
+            }
+
+            _hasCurrentRow = true;
+            return true;
+        }
+
+        public override bool NextResult() => false;
+
+        public override void Close() {
+            _closed = true;
+            _hasCurrentRow = false;
+        }
+
+        protected override void Dispose(bool disposing) {
+            if (disposing) Close();
+            base.Dispose(disposing);
+        }
+
+        private void Discover(
+            int sheetOffset,
+            out int firstRow,
+            out int lastRow,
+            out int firstColumn,
+            out int lastColumn,
+            out Dictionary<int, string?>? headerValues) {
+            int offset = sheetOffset;
+            firstRow = int.MaxValue;
+            lastRow = -1;
+            firstColumn = int.MaxValue;
+            lastColumn = -1;
+            bool sawBof = false;
+            bool sawEof = false;
+            int pendingHeaderColumn = -1;
+            int previousCellRow = -1;
+            headerValues = null;
+
+            while (TryReadRecord(_bytes, ref offset, out RecordSlice record)) {
+                CheckCancellation();
+                if (!sawBof) {
+                    if (record.Type != (ushort)BiffRecordType.Bof || record.Length < 4) {
+                        throw new InvalidDataException("The XLS worksheet stream is missing a valid BOF record.");
+                    }
+                    ushort version = ReadUInt16(_bytes, record.PayloadOffset);
+                    ushort substreamType = ReadUInt16(_bytes, record.PayloadOffset + 2);
+                    if (version != 0x0600 || substreamType != 0x0010) {
+                        throw new InvalidDataException("The selected XLS substream is not a BIFF8 worksheet.");
+                    }
+                    sawBof = true;
+                    continue;
+                }
+                if (record.Type == (ushort)BiffRecordType.Eof) {
+                    sawEof = true;
+                    break;
+                }
+                if (pendingHeaderColumn >= 0) {
+                    if (record.Type != (ushort)BiffRecordType.String) {
+                        throw new InvalidDataException("An XLS string formula is not followed by its required String record.");
+                    }
+                    headerValues![pendingHeaderColumn] = ReadFormulaStringValue(record, ref offset);
+                    pendingHeaderColumn = -1;
+                    continue;
+                }
+                if (!TryGetCellBounds(record, out int row, out int recordFirstColumn, out int recordLastColumn)) {
+                    continue;
+                }
+                if (row < previousCellRow) {
+                    throw new InvalidDataException(
+                        $"The XLS worksheet contains decreasing cell row index {row} after row {previousCellRow}.");
+                }
+                previousCellRow = row;
+
+                if (row < firstRow) {
+                    firstRow = row;
+                    headerValues = new Dictionary<int, string?>();
+                }
+                if (row == firstRow) {
+                    ReadHeaderCells(record, headerValues!);
+                    if (record.Type == (ushort)BiffRecordType.Formula && FormulaExpectsString(record)) {
+                        pendingHeaderColumn = recordFirstColumn;
+                    }
+                }
+                lastRow = Math.Max(lastRow, row);
+                firstColumn = Math.Min(firstColumn, recordFirstColumn);
+                lastColumn = Math.Max(lastColumn, recordLastColumn);
+            }
+
+            if (!sawBof || !sawEof) {
+                throw new InvalidDataException("The XLS worksheet substream is truncated before EOF.");
+            }
+            if (firstRow == int.MaxValue) {
+                firstRow = -1;
+                firstColumn = 0;
+            }
+        }
+
+        private bool TryGetCellBounds(
+            RecordSlice record,
+            out int row,
+            out int firstColumn,
+            out int lastColumn) {
+            row = -1;
+            firstColumn = -1;
+            lastColumn = -1;
+            switch ((BiffRecordType)record.Type) {
+                case BiffRecordType.Blank:
+                case BiffRecordType.BoolErr:
+                case BiffRecordType.Formula:
+                case BiffRecordType.Label:
+                case BiffRecordType.LabelSst:
+                case BiffRecordType.Number:
+                case BiffRecordType.Rk:
+                    if (record.Length < 6) throw TruncatedCell(record);
+                    row = ReadUInt16(_bytes, record.PayloadOffset);
+                    firstColumn = ReadUInt16(_bytes, record.PayloadOffset + 2);
+                    lastColumn = firstColumn;
+                    return true;
+                case BiffRecordType.MulBlank:
+                case BiffRecordType.MulRk:
+                    if (record.Length < 6) throw TruncatedCell(record);
+                    row = ReadUInt16(_bytes, record.PayloadOffset);
+                    firstColumn = ReadUInt16(_bytes, record.PayloadOffset + 2);
+                    lastColumn = ReadUInt16(_bytes, record.PayloadOffset + record.Length - 2);
+                    if (lastColumn < firstColumn) throw new InvalidDataException("A BIFF multiple-cell record has an invalid column range.");
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        private void ReadHeaderCells(RecordSlice record, IDictionary<int, string?> values) {
+            if (record.Type == (ushort)BiffRecordType.MulRk) {
+                int firstColumn = ReadUInt16(_bytes, record.PayloadOffset + 2);
+                int lastColumn = ReadUInt16(_bytes, record.PayloadOffset + record.Length - 2);
+                int expectedLength = checked(4 + (lastColumn - firstColumn + 1) * 6 + 2);
+                if (expectedLength != record.Length) throw new InvalidDataException("A MULRK record has an invalid payload length.");
+                for (int column = firstColumn; column <= lastColumn; column++) {
+                    int cellOffset = record.PayloadOffset + 4 + (column - firstColumn) * 6;
+                    double value = BiffRkNumberReader.ReadRkNumber(ReadUInt32(_bytes, cellOffset + 2));
+                    values[column] = value.ToString("R", _options.Culture);
+                }
+                return;
+            }
+            if (record.Type == (ushort)BiffRecordType.MulBlank || record.Type == (ushort)BiffRecordType.Blank) return;
+
+            int columnIndex = ReadUInt16(_bytes, record.PayloadOffset + 2);
+            values[columnIndex] = ReadCellAsHeader(record);
+        }
+
+        private string? ReadCellAsHeader(RecordSlice record) {
+            int payload = record.PayloadOffset;
+            ushort style = record.Length >= 6 ? ReadUInt16(_bytes, payload + 4) : (ushort)0;
+            switch ((BiffRecordType)record.Type) {
+                case BiffRecordType.LabelSst: {
+                    if (record.Length < 10) throw TruncatedCell(record);
+                    uint index = ReadUInt32(_bytes, payload + 6);
+                    return GetSharedString(index);
+                }
+                case BiffRecordType.Label:
+                    return ReadLabel(record);
+                case BiffRecordType.Number:
+                    if (record.Length < 14) throw TruncatedCell(record);
+                    return NumberToHeader(ReadDouble(_bytes, payload + 6), style);
+                case BiffRecordType.Rk:
+                    if (record.Length < 10) throw TruncatedCell(record);
+                    return NumberToHeader(BiffRkNumberReader.ReadRkNumber(ReadUInt32(_bytes, payload + 6)), style);
+                case BiffRecordType.BoolErr:
+                    if (record.Length < 8) throw TruncatedCell(record);
+                    return _bytes[payload + 7] != 0
+                        ? BiffErrorValue.ToText(_bytes[payload + 6])
+                        : (_bytes[payload + 6] != 0).ToString();
+                case BiffRecordType.Formula:
+                    if (record.Length < 20) throw TruncatedCell(record);
+                    return ReadFormulaHeader(record, style);
+                default:
+                    return null;
+            }
+        }
+
+        private string? ReadFormulaHeader(RecordSlice record, ushort style) {
+            int result = record.PayloadOffset + 6;
+            if (ReadUInt16(_bytes, result + 6) != ushort.MaxValue) {
+                return NumberToHeader(ReadDouble(_bytes, result), style);
+            }
+            return _bytes[result] switch {
+                1 => (_bytes[result + 2] != 0).ToString(),
+                2 => BiffErrorValue.ToText(_bytes[result + 2]),
+                3 => string.Empty,
+                _ => null
+            };
+        }
+
+        private void StoreCellRecord(
+            RecordSlice record,
+            ref int pendingFormulaOrdinal,
+            ref ushort pendingFormulaStyle) {
+            int payload = record.PayloadOffset;
+            if (record.Type == (ushort)BiffRecordType.MulRk) {
+                StoreMulRk(record);
+                return;
+            }
+            if (record.Type == (ushort)BiffRecordType.MulBlank) return;
+
+            int column = ReadUInt16(_bytes, payload + 2);
+            int ordinal = column - _firstColumn;
+            if (ordinal < 0 || ordinal >= FieldCount) {
+                throw new InvalidDataException($"The XLS row contains column {column} outside its discovered schema.");
+            }
+            ushort style = ReadUInt16(_bytes, payload + 4);
+            switch ((BiffRecordType)record.Type) {
+                case BiffRecordType.Blank:
+                    _kinds[ordinal] = ValueKind.Empty;
+                    break;
+                case BiffRecordType.LabelSst:
+                    if (record.Length < 10) throw TruncatedCell(record);
+                    _kinds[ordinal] = ValueKind.Text;
+                    _strings[ordinal] = GetSharedString(ReadUInt32(_bytes, payload + 6));
+                    break;
+                case BiffRecordType.Label:
+                    _kinds[ordinal] = ValueKind.Text;
+                    _strings[ordinal] = ReadLabel(record);
+                    break;
+                case BiffRecordType.Number:
+                    if (record.Length < 14) throw TruncatedCell(record);
+                    StoreNumber(ordinal, ReadDouble(_bytes, payload + 6), style);
+                    break;
+                case BiffRecordType.Rk:
+                    if (record.Length < 10) throw TruncatedCell(record);
+                    StoreNumber(ordinal, BiffRkNumberReader.ReadRkNumber(ReadUInt32(_bytes, payload + 6)), style);
+                    break;
+                case BiffRecordType.BoolErr:
+                    if (record.Length < 8) throw TruncatedCell(record);
+                    if (_bytes[payload + 7] != 0) {
+                        _kinds[ordinal] = ValueKind.Error;
+                        _strings[ordinal] = BiffErrorValue.ToText(_bytes[payload + 6]);
+                    } else {
+                        _kinds[ordinal] = ValueKind.Boolean;
+                        _booleans[ordinal] = _bytes[payload + 6] != 0;
+                    }
+                    break;
+                case BiffRecordType.Formula:
+                    StoreFormula(record, ordinal, style, ref pendingFormulaOrdinal, ref pendingFormulaStyle);
+                    break;
+            }
+        }
+
+        private void StoreMulRk(RecordSlice record) {
+            int payload = record.PayloadOffset;
+            int firstColumn = ReadUInt16(_bytes, payload + 2);
+            int lastColumn = ReadUInt16(_bytes, payload + record.Length - 2);
+            int count = checked(lastColumn - firstColumn + 1);
+            int expectedLength = checked(4 + count * 6 + 2);
+            if (record.Length != expectedLength) throw new InvalidDataException("A MULRK record has an invalid payload length.");
+            for (int index = 0; index < count; index++) {
+                int ordinal = firstColumn + index - _firstColumn;
+                int cellOffset = payload + 4 + index * 6;
+                StoreNumber(
+                    ordinal,
+                    BiffRkNumberReader.ReadRkNumber(ReadUInt32(_bytes, cellOffset + 2)),
+                    ReadUInt16(_bytes, cellOffset));
+            }
+        }
+
+        private void StoreFormula(
+            RecordSlice record,
+            int ordinal,
+            ushort style,
+            ref int pendingFormulaOrdinal,
+            ref ushort pendingFormulaStyle) {
+            if (record.Length < 20) throw TruncatedCell(record);
+            int result = record.PayloadOffset + 6;
+            if (ReadUInt16(_bytes, result + 6) != ushort.MaxValue) {
+                StoreNumber(ordinal, ReadDouble(_bytes, result), style);
+                return;
+            }
+            switch (_bytes[result]) {
+                case 0:
+                    pendingFormulaOrdinal = ordinal;
+                    pendingFormulaStyle = style;
+                    break;
+                case 1:
+                    _kinds[ordinal] = ValueKind.Boolean;
+                    _booleans[ordinal] = _bytes[result + 2] != 0;
+                    break;
+                case 2:
+                    _kinds[ordinal] = ValueKind.Error;
+                    _strings[ordinal] = BiffErrorValue.ToText(_bytes[result + 2]);
+                    break;
+                case 3:
+                    _kinds[ordinal] = ValueKind.Text;
+                    _strings[ordinal] = string.Empty;
+                    break;
+                default:
+                    throw new InvalidDataException("A Formula record contains an invalid cached-result marker.");
+            }
+        }
+
+        private void StoreFormulaString(
+            RecordSlice record,
+            int ordinal,
+            ushort style,
+            ref int nextRecordOffset) {
+            _ = style;
+            _kinds[ordinal] = ValueKind.Text;
+            _strings[ordinal] = ReadFormulaStringValue(record, ref nextRecordOffset);
+        }
+
+        private string ReadFormulaStringValue(RecordSlice record, ref int nextRecordOffset) {
+            var payloads = new List<byte[]> { CopyPayload(_bytes, record) };
+            int lookahead = nextRecordOffset;
+            while (TryReadRecord(_bytes, ref lookahead, out RecordSlice continuation)
+                   && continuation.Type == (ushort)BiffRecordType.Continue) {
+                payloads.Add(CopyPayload(_bytes, continuation));
+                nextRecordOffset = lookahead;
+            }
+            return BiffStringReader.ReadUnicodeString(payloads);
+        }
+
+        private bool FormulaExpectsString(RecordSlice record) {
+            if (record.Length < 20) throw TruncatedCell(record);
+            int result = record.PayloadOffset + 6;
+            return ReadUInt16(_bytes, result + 6) == ushort.MaxValue && _bytes[result] == 0;
+        }
+
+        private void StoreNumber(int ordinal, double number, ushort style) {
+            _kinds[ordinal] = _options.TreatDatesUsingNumberFormat
+                && style < _dateStyles.Length
+                && _dateStyles[style]
+                    ? ValueKind.Date
+                    : ValueKind.Number;
+            _numbers[ordinal] = number;
+        }
+
+        private string ReadLabel(RecordSlice record) {
+            if (record.Length < 8) throw TruncatedCell(record);
+            byte[] payload = CopyPayload(_bytes, record);
+            int offset = 6;
+            int original = offset;
+            try {
+                return BiffStringReader.ReadUnicodeString(payload, ref offset);
+            } catch (InvalidDataException) {
+                offset = original;
+                return BiffStringReader.ReadByteString(payload, ref offset);
+            }
+        }
+
+        private string GetSharedString(uint index) {
+            if (index >= _sharedStrings.Count) {
+                throw new InvalidDataException($"XLS shared-string index {index} is outside the loaded table.");
+            }
+            return _sharedStrings[checked((int)index)];
+        }
+
+        private string NumberToHeader(double value, ushort style) {
+            if (_options.TreatDatesUsingNumberFormat
+                && style < _dateStyles.Length
+                && _dateStyles[style]
+                && LegacyXlsDateSerialConverter.TryConvert(value, _uses1904DateSystem, out DateTime date)) {
+                return date.ToString(_options.Culture);
+            }
+            return value.ToString("R", _options.Culture);
+        }
+
+        private void CheckCancellation() {
+            if (!_cancellationToken.CanBeCanceled) return;
+            if ((++_recordsSinceCancellationCheck & 1023) == 0) {
+                _cancellationToken.ThrowIfCancellationRequested();
+            }
+        }
+
+        private static InvalidDataException TruncatedCell(RecordSlice record) =>
+            new($"BIFF cell record 0x{record.Type:X4} at offset {record.Offset} is truncated.");
+
+        private void ThrowIfClosed() {
+            if (_closed) throw new InvalidOperationException("The XLS table reader is closed.");
+        }
+
+        private void ValidateOrdinal(int ordinal) {
+            if (ordinal < 0 || ordinal >= FieldCount) {
+                throw new IndexOutOfRangeException($"Column ordinal {ordinal} is outside 0..{FieldCount - 1}.");
+            }
+        }
+
+        private void ValidateReadableOrdinal(int ordinal) {
+            ThrowIfClosed();
+            ValidateOrdinal(ordinal);
+            if (!_hasCurrentRow) throw new InvalidOperationException("Read must be called before accessing values.");
+        }
+
+        private enum ValueKind : byte {
+            Empty,
+            Text,
+            Number,
+            Boolean,
+            Date,
+            Error
+        }
+    }
+}

--- a/OfficeIMO.Excel/LegacyXls/Read/LegacyXlsTabularDataReader.cs
+++ b/OfficeIMO.Excel/LegacyXls/Read/LegacyXlsTabularDataReader.cs
@@ -109,18 +109,23 @@ namespace OfficeIMO.Excel.LegacyXls.Read {
 
             while (true) {
                 int recordOffset = _position;
-                if (!TryReadRecord(_bytes, ref _position, out RecordSlice record)) break;
+                if (!TryReadRecord(_bytes, ref _position, out RecordSlice record)) {
+                    if (pendingFormulaOrdinal >= 0) {
+                        throw MissingFormulaString();
+                    }
+                    break;
+                }
                 CheckCancellation();
-                if (record.Type == (ushort)BiffRecordType.Eof) break;
 
                 if (pendingFormulaOrdinal >= 0) {
                     if (record.Type != (ushort)BiffRecordType.String) {
-                        throw new InvalidDataException("An XLS string formula is not followed by its required String record.");
+                        throw MissingFormulaString();
                     }
                     StoreFormulaString(record, pendingFormulaOrdinal, pendingFormulaStyle, ref _position);
                     pendingFormulaOrdinal = -1;
                     continue;
                 }
+                if (record.Type == (ushort)BiffRecordType.Eof) break;
 
                 if (!TryGetCellBounds(record, out int row, out int firstColumn, out _)) continue;
                 if (row < currentRow) continue;
@@ -180,17 +185,17 @@ namespace OfficeIMO.Excel.LegacyXls.Read {
                     sawBof = true;
                     continue;
                 }
-                if (record.Type == (ushort)BiffRecordType.Eof) {
-                    sawEof = true;
-                    break;
-                }
                 if (pendingHeaderColumn >= 0) {
                     if (record.Type != (ushort)BiffRecordType.String) {
-                        throw new InvalidDataException("An XLS string formula is not followed by its required String record.");
+                        throw MissingFormulaString();
                     }
                     headerValues![pendingHeaderColumn] = ReadFormulaStringValue(record, ref offset);
                     pendingHeaderColumn = -1;
                     continue;
+                }
+                if (record.Type == (ushort)BiffRecordType.Eof) {
+                    sawEof = true;
+                    break;
                 }
                 if (!TryGetCellBounds(record, out int row, out int recordFirstColumn, out int recordLastColumn)) {
                     continue;
@@ -501,6 +506,9 @@ namespace OfficeIMO.Excel.LegacyXls.Read {
 
         private static InvalidDataException TruncatedCell(RecordSlice record) =>
             new($"BIFF cell record 0x{record.Type:X4} at offset {record.Offset} is truncated.");
+
+        private static InvalidDataException MissingFormulaString() =>
+            new("An XLS string formula is not followed by its required String record.");
 
         private void ThrowIfClosed() {
             if (_closed) throw new InvalidOperationException("The XLS table reader is closed.");

--- a/OfficeIMO.Excel/LegacyXls/Read/LegacyXlsTabularDataReader.cs
+++ b/OfficeIMO.Excel/LegacyXls/Read/LegacyXlsTabularDataReader.cs
@@ -258,6 +258,13 @@ namespace OfficeIMO.Excel.LegacyXls.Read {
                     firstColumn = ReadUInt16(_bytes, record.PayloadOffset + 2);
                     lastColumn = ReadUInt16(_bytes, record.PayloadOffset + record.Length - 2);
                     if (lastColumn < firstColumn) throw new InvalidDataException("A BIFF multiple-cell record has an invalid column range.");
+                    int cellCount = checked(lastColumn - firstColumn + 1);
+                    int bytesPerCell = record.Type == (ushort)BiffRecordType.MulBlank ? 2 : 6;
+                    int expectedLength = checked(4 + cellCount * bytesPerCell + 2);
+                    if (record.Length != expectedLength) {
+                        string recordName = record.Type == (ushort)BiffRecordType.MulBlank ? "MULBLANK" : "MULRK";
+                        throw new InvalidDataException($"A {recordName} record has an invalid payload length.");
+                    }
                     return true;
                 default:
                     return false;
@@ -273,7 +280,7 @@ namespace OfficeIMO.Excel.LegacyXls.Read {
                 for (int column = firstColumn; column <= lastColumn; column++) {
                     int cellOffset = record.PayloadOffset + 4 + (column - firstColumn) * 6;
                     double value = BiffRkNumberReader.ReadRkNumber(ReadUInt32(_bytes, cellOffset + 2));
-                    values[column] = value.ToString("R", _options.Culture);
+                    values[column] = NumberToHeader(value, ReadUInt16(_bytes, cellOffset));
                 }
                 return;
             }
@@ -459,11 +466,11 @@ namespace OfficeIMO.Excel.LegacyXls.Read {
         }
 
         private void StoreNumber(int ordinal, double number, ushort style) {
-            _kinds[ordinal] = _options.TreatDatesUsingNumberFormat
+            bool isDate = _options.TreatDatesUsingNumberFormat
                 && style < _dateStyles.Length
                 && _dateStyles[style]
-                    ? ValueKind.Date
-                    : ValueKind.Number;
+                && LegacyXlsDateSerialConverter.TryConvert(number, _uses1904DateSystem, out _);
+            _kinds[ordinal] = isDate ? ValueKind.Date : ValueKind.Number;
             _numbers[ordinal] = number;
         }
 

--- a/OfficeIMO.Excel/LegacyXls/Read/LegacyXlsTabularWorkbook.cs
+++ b/OfficeIMO.Excel/LegacyXls/Read/LegacyXlsTabularWorkbook.cs
@@ -156,10 +156,8 @@ namespace OfficeIMO.Excel.LegacyXls.Read {
         }
 
         private static bool IsWorkbookStreamName(string name) {
-            int separator = Math.Max(name.LastIndexOf('/'), name.LastIndexOf('\\'));
-            string leaf = separator >= 0 ? name.Substring(separator + 1) : name;
-            return string.Equals(leaf, "Workbook", StringComparison.OrdinalIgnoreCase)
-                || string.Equals(leaf, "Book", StringComparison.OrdinalIgnoreCase);
+            return string.Equals(name, "Workbook", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(name, "Book", StringComparison.OrdinalIgnoreCase);
         }
 
         private static void ParseGlobals(

--- a/OfficeIMO.Excel/LegacyXls/Read/LegacyXlsTabularWorkbook.cs
+++ b/OfficeIMO.Excel/LegacyXls/Read/LegacyXlsTabularWorkbook.cs
@@ -170,7 +170,7 @@ namespace OfficeIMO.Excel.LegacyXls.Read {
             out bool[] dateStyles,
             out bool uses1904DateSystem) {
             var parsedSheets = new List<SheetInfo>();
-            var xfNumberFormats = new List<ushort>();
+            var cellFormats = new List<XfInfo>();
             var customNumberFormats = new Dictionary<ushort, string>();
             var diagnostics = new List<LegacyXlsImportDiagnostic>();
             List<string>? parsedSharedStrings = null;
@@ -207,7 +207,15 @@ namespace OfficeIMO.Excel.LegacyXls.Read {
                         break;
                     case BiffRecordType.Xf:
                         if (record.Length < 6) throw Truncated(record, "XF");
-                        xfNumberFormats.Add(bytes.ReadUInt16(record.PayloadOffset + 2));
+                        ushort protection = bytes.ReadUInt16(record.PayloadOffset + 4);
+                        ushort attributes = record.Length >= 10
+                            ? bytes.ReadUInt16(record.PayloadOffset + 8)
+                            : (ushort)0;
+                        cellFormats.Add(new XfInfo(
+                            bytes.ReadUInt16(record.PayloadOffset + 2),
+                            isStyle: (protection & 0x0004) != 0,
+                            parentStyleIndex: (ushort)((protection >> 4) & 0x0fff),
+                            applyNumberFormat: (attributes & 0x0400) != 0));
                         break;
                     case BiffRecordType.Sst:
                         if (parsedSharedStrings != null) {
@@ -244,9 +252,9 @@ namespace OfficeIMO.Excel.LegacyXls.Read {
                 throw new InvalidDataException("The workbook contains no readable worksheets.");
             }
 
-            var styles = new bool[xfNumberFormats.Count];
+            var styles = new bool[cellFormats.Count];
             for (int index = 0; index < styles.Length; index++) {
-                ushort formatId = xfNumberFormats[index];
+                ushort formatId = ResolveEffectiveNumberFormat(cellFormats, index);
                 styles[index] = BiffBuiltInNumberFormat.IsDateLike(formatId)
                     || customNumberFormats.TryGetValue(formatId, out string? code)
                     && ExcelNumberFormatClassifier.LooksLikeDateFormat(code);
@@ -257,6 +265,18 @@ namespace OfficeIMO.Excel.LegacyXls.Read {
                 ? parsedSharedStrings
                 : Array.Empty<string>();
             dateStyles = styles;
+        }
+
+        private static ushort ResolveEffectiveNumberFormat(IReadOnlyList<XfInfo> cellFormats, int index) {
+            XfInfo format = cellFormats[index];
+            if (format.IsStyle
+                || format.ApplyNumberFormat
+                || format.ParentStyleIndex >= cellFormats.Count) {
+                return format.NumberFormatId;
+            }
+
+            XfInfo parent = cellFormats[format.ParentStyleIndex];
+            return parent.IsStyle ? parent.NumberFormatId : format.NumberFormatId;
         }
 
         private static List<string> ReadSharedStrings(
@@ -373,6 +393,27 @@ namespace OfficeIMO.Excel.LegacyXls.Read {
             internal int Offset { get; }
             internal int PayloadOffset { get; }
             internal int Length { get; }
+        }
+
+        private readonly struct XfInfo {
+            internal XfInfo(
+                ushort numberFormatId,
+                bool isStyle,
+                ushort parentStyleIndex,
+                bool applyNumberFormat) {
+                NumberFormatId = numberFormatId;
+                IsStyle = isStyle;
+                ParentStyleIndex = parentStyleIndex;
+                ApplyNumberFormat = applyNumberFormat;
+            }
+
+            internal ushort NumberFormatId { get; }
+
+            internal bool IsStyle { get; }
+
+            internal ushort ParentStyleIndex { get; }
+
+            internal bool ApplyNumberFormat { get; }
         }
 
         private readonly struct SheetInfo {

--- a/OfficeIMO.Excel/LegacyXls/Read/LegacyXlsTabularWorkbook.cs
+++ b/OfficeIMO.Excel/LegacyXls/Read/LegacyXlsTabularWorkbook.cs
@@ -1,0 +1,390 @@
+using OfficeIMO.Drawing.Internal;
+using OfficeIMO.Excel.LegacyXls.Biff;
+using OfficeIMO.Excel.LegacyXls.Diagnostics;
+using System.Data.Common;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace OfficeIMO.Excel.LegacyXls.Read {
+    /// <summary>
+    /// Read-only BIFF8 workbook metadata used by the tabular XLS fast path. The workbook
+    /// stream is extracted once and worksheet cells are decoded directly from record slices.
+    /// </summary>
+    internal sealed class LegacyXlsTabularWorkbook : IDisposable {
+        private const ushort Biff8Version = 0x0600;
+        private readonly LegacyBiffSource _workbookStream;
+        private readonly IReadOnlyList<SheetInfo> _sheets;
+        private readonly IReadOnlyList<string> _tableNames;
+        private readonly IReadOnlyList<string> _sharedStrings;
+        private readonly bool[] _dateStyles;
+        private readonly bool _uses1904DateSystem;
+        private bool _disposed;
+
+        private LegacyXlsTabularWorkbook(LegacyBiffSource workbookStream, ExcelReadOptions options) {
+            _workbookStream = workbookStream;
+            ParseGlobals(
+                workbookStream,
+                options,
+                out _sheets,
+                out _sharedStrings,
+                out _dateStyles,
+                out _uses1904DateSystem);
+            _tableNames = _sheets.Select(static sheet => sheet.Name).ToArray();
+        }
+
+        internal IReadOnlyList<string> TableNames => _tableNames;
+
+        internal static LegacyXlsTabularWorkbook Open(
+            string path,
+            ExcelReadOptions options,
+            CancellationToken cancellationToken = default) {
+            if (path == null) throw new ArgumentNullException(nameof(path));
+            if (options == null) throw new ArgumentNullException(nameof(options));
+            cancellationToken.ThrowIfCancellationRequested();
+            var stream = new FileStream(
+                path,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.Read,
+                1,
+                FileOptions.RandomAccess);
+            return Open(stream, options, cancellationToken);
+        }
+
+        internal static LegacyXlsTabularWorkbook Open(
+            byte[] bytes,
+            ExcelReadOptions options,
+            CancellationToken cancellationToken = default) {
+            if (bytes == null) throw new ArgumentNullException(nameof(bytes));
+            if (options == null) throw new ArgumentNullException(nameof(options));
+            cancellationToken.ThrowIfCancellationRequested();
+            var stream = new MemoryStream(bytes, writable: false);
+            return Open(stream, options, cancellationToken);
+        }
+
+        private static LegacyXlsTabularWorkbook Open(
+            Stream source,
+            ExcelReadOptions options,
+            CancellationToken cancellationToken) {
+            try {
+                cancellationToken.ThrowIfCancellationRequested();
+                Stream workbookStream = OpenWorkbookStream(source, options, cancellationToken);
+                cancellationToken.ThrowIfCancellationRequested();
+                var biffSource = new LegacyBiffSource(workbookStream, cancellationToken);
+                try {
+                    return new LegacyXlsTabularWorkbook(biffSource, options);
+                } catch {
+                    biffSource.Dispose();
+                    throw;
+                }
+            } catch {
+                source.Dispose();
+                throw;
+            }
+        }
+
+        internal DbDataReader OpenTable(
+            string tableName,
+            bool hasHeaderRow,
+            ExcelReadOptions options,
+            CancellationToken cancellationToken = default) {
+            ThrowIfDisposed();
+            int sheetIndex = -1;
+            for (int index = 0; index < _sheets.Count; index++) {
+                if (string.Equals(_sheets[index].Name, tableName, StringComparison.OrdinalIgnoreCase)) {
+                    sheetIndex = index;
+                    break;
+                }
+            }
+            if (sheetIndex < 0) {
+                throw new KeyNotFoundException($"Worksheet '{tableName}' was not found.");
+            }
+
+            SheetInfo sheet = _sheets[sheetIndex];
+            return new LegacyXlsTabularDataReader(
+                _workbookStream,
+                sheet.StreamOffset,
+                _sharedStrings,
+                _dateStyles,
+                _uses1904DateSystem,
+                hasHeaderRow,
+                options,
+                cancellationToken);
+        }
+
+        public void Dispose() {
+            if (_disposed) return;
+            _disposed = true;
+            _workbookStream.Dispose();
+        }
+
+        private void ThrowIfDisposed() {
+            if (_disposed) throw new ObjectDisposedException(nameof(LegacyXlsTabularWorkbook));
+        }
+
+        private static Stream OpenWorkbookStream(
+            Stream source,
+            ExcelReadOptions options,
+            CancellationToken cancellationToken) {
+            if (!source.CanRead || !source.CanSeek) {
+                throw new ArgumentException("The XLS fast path requires a readable seekable stream.", nameof(source));
+            }
+
+            long maximum = Math.Min(options.MaxInputBytes, int.MaxValue);
+            var compoundOptions = new OfficeCompoundReadOptions(
+                maxStreamBytes: maximum,
+                maxTotalStreamBytes: maximum);
+            bool read = OfficeCompoundFileReader.TryOpenStream(
+                source,
+                compoundOptions,
+                static (name, _) => IsWorkbookStreamName(name),
+                leaveOpen: false,
+                cancellationToken,
+                out Stream? workbookStream,
+                out string? error);
+            if (!read) {
+                throw new InvalidDataException(error ?? "The input is not a supported OLE compound XLS file.");
+            }
+            if (workbookStream == null) {
+                throw new InvalidDataException("The OLE compound file does not contain a Workbook or Book stream.");
+            }
+            return workbookStream;
+        }
+
+        private static bool IsWorkbookStreamName(string name) {
+            int separator = Math.Max(name.LastIndexOf('/'), name.LastIndexOf('\\'));
+            string leaf = separator >= 0 ? name.Substring(separator + 1) : name;
+            return string.Equals(leaf, "Workbook", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(leaf, "Book", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static void ParseGlobals(
+            LegacyBiffSource bytes,
+            ExcelReadOptions options,
+            out IReadOnlyList<SheetInfo> sheets,
+            out IReadOnlyList<string> sharedStrings,
+            out bool[] dateStyles,
+            out bool uses1904DateSystem) {
+            var parsedSheets = new List<SheetInfo>();
+            var xfNumberFormats = new List<ushort>();
+            var customNumberFormats = new Dictionary<ushort, string>();
+            var diagnostics = new List<LegacyXlsImportDiagnostic>();
+            List<string>? parsedSharedStrings = null;
+            int offset = 0;
+            bool sawBof = false;
+            bool sawEof = false;
+            uses1904DateSystem = false;
+
+            while (TryReadRecord(bytes, ref offset, out RecordSlice record)) {
+                options.CancellationToken.ThrowIfCancellationRequested();
+                if (!sawBof) {
+                    if (record.Type != (ushort)BiffRecordType.Bof || record.Length < 4) {
+                        throw new InvalidDataException("The XLS workbook stream is missing a valid workbook-globals BOF record.");
+                    }
+                    ushort version = bytes.ReadUInt16(record.PayloadOffset);
+                    ushort substreamType = bytes.ReadUInt16(record.PayloadOffset + 2);
+                    if (version != Biff8Version || substreamType != 0x0005) {
+                        throw new LegacyXlsFastPathNotSupportedException("The direct XLS reader supports BIFF8 workbook streams.");
+                    }
+                    sawBof = true;
+                    continue;
+                }
+
+                switch ((BiffRecordType)record.Type) {
+                    case BiffRecordType.BoundSheet8:
+                        parsedSheets.Add(ReadBoundSheet(bytes, record));
+                        break;
+                    case BiffRecordType.Date1904:
+                        if (record.Length < 2) throw Truncated(record, "Date1904");
+                        uses1904DateSystem = bytes.ReadUInt16(record.PayloadOffset) != 0;
+                        break;
+                    case BiffRecordType.Format:
+                        ReadNumberFormat(bytes, record, customNumberFormats);
+                        break;
+                    case BiffRecordType.Xf:
+                        if (record.Length < 6) throw Truncated(record, "XF");
+                        xfNumberFormats.Add(bytes.ReadUInt16(record.PayloadOffset + 2));
+                        break;
+                    case BiffRecordType.Sst:
+                        if (parsedSharedStrings != null) {
+                            throw new InvalidDataException("The XLS workbook contains more than one shared-string table.");
+                        }
+                        parsedSharedStrings = ReadSharedStrings(bytes, record, ref offset, options, diagnostics);
+                        break;
+                    case BiffRecordType.FilePass:
+                        throw new LegacyXlsFastPathNotSupportedException("Encrypted XLS workbooks use the full legacy import path.");
+                    case BiffRecordType.Eof:
+                        sawEof = true;
+                        offset = bytes.Length;
+                        break;
+                }
+            }
+
+            if (!sawBof || !sawEof) {
+                throw new InvalidDataException("The XLS workbook-globals substream is truncated before EOF.");
+            }
+
+            var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            SheetInfo[] worksheets = parsedSheets
+                .Where(static sheet => sheet.SheetType == 0)
+                .ToArray();
+            foreach (SheetInfo sheet in worksheets) {
+                if (sheet.StreamOffset < 0 || sheet.StreamOffset >= bytes.Length) {
+                    throw new InvalidDataException($"Worksheet '{sheet.Name}' has an invalid BIFF stream offset.");
+                }
+                if (!names.Add(sheet.Name)) {
+                    throw new InvalidDataException($"The workbook contains duplicate worksheet name '{sheet.Name}' under case-insensitive matching.");
+                }
+            }
+            if (worksheets.Length == 0) {
+                throw new InvalidDataException("The workbook contains no readable worksheets.");
+            }
+
+            var styles = new bool[xfNumberFormats.Count];
+            for (int index = 0; index < styles.Length; index++) {
+                ushort formatId = xfNumberFormats[index];
+                styles[index] = BiffBuiltInNumberFormat.IsDateLike(formatId)
+                    || customNumberFormats.TryGetValue(formatId, out string? code)
+                    && ExcelNumberFormatClassifier.LooksLikeDateFormat(code);
+            }
+
+            sheets = worksheets;
+            sharedStrings = parsedSharedStrings != null
+                ? parsedSharedStrings
+                : Array.Empty<string>();
+            dateStyles = styles;
+        }
+
+        private static List<string> ReadSharedStrings(
+            LegacyBiffSource bytes,
+            RecordSlice first,
+            ref int offset,
+            ExcelReadOptions options,
+            List<LegacyXlsImportDiagnostic> diagnostics) {
+            var payloads = new List<byte[]> { CopyPayload(bytes, first) };
+            int lookahead = offset;
+            while (TryReadRecord(bytes, ref lookahead, out RecordSlice continuation)
+                   && continuation.Type == (ushort)BiffRecordType.Continue) {
+                payloads.Add(CopyPayload(bytes, continuation));
+                offset = lookahead;
+            }
+
+            List<string> values = BiffStringReader.ReadSharedStringTexts(
+                payloads,
+                diagnostics,
+                first.Offset,
+                options.MaxSharedStringItems,
+                options.MaxSharedStringItemCharacters,
+                options.MaxSharedStringCharacters);
+            if (diagnostics.Count > 0) {
+                throw new InvalidDataException(diagnostics[diagnostics.Count - 1].Message);
+            }
+            if (values.Count > options.MaxSharedStringItems) {
+                throw new InvalidDataException(
+                    $"XLS shared-string count {values.Count} exceeds the configured limit of {options.MaxSharedStringItems}.");
+            }
+            long characters = 0;
+            foreach (string value in values) {
+                if (value.Length > options.MaxSharedStringItemCharacters) {
+                    throw new InvalidDataException(
+                        $"An XLS shared string contains {value.Length} characters, exceeding the configured limit of {options.MaxSharedStringItemCharacters}.");
+                }
+                characters = checked(characters + value.Length);
+                if (characters > options.MaxSharedStringCharacters) {
+                    throw new InvalidDataException(
+                        $"XLS shared strings contain more than the configured {options.MaxSharedStringCharacters} characters.");
+                }
+            }
+            return values;
+        }
+
+        private static SheetInfo ReadBoundSheet(LegacyBiffSource bytes, RecordSlice record) {
+            if (record.Length < 8) throw Truncated(record, "BoundSheet8");
+            byte[] payload = CopyPayload(bytes, record);
+            int nameOffset = 6;
+            string name = BiffStringReader.ReadShortUnicodeString(payload, ref nameOffset);
+            if (string.IsNullOrWhiteSpace(name)) {
+                throw new InvalidDataException("An XLS worksheet has an empty name.");
+            }
+            return new SheetInfo(
+                name,
+                checked((int)bytes.ReadUInt32(record.PayloadOffset)),
+                bytes.ReadByte(record.PayloadOffset + 5));
+        }
+
+        private static void ReadNumberFormat(
+            LegacyBiffSource bytes,
+            RecordSlice record,
+            IDictionary<ushort, string> formats) {
+            if (record.Length < 5) throw Truncated(record, "Format");
+            byte[] payload = CopyPayload(bytes, record);
+            ushort id = BiffRecordReader.ReadUInt16(payload, 0);
+            int valueOffset = 2;
+            formats[id] = BiffStringReader.ReadUnicodeString(payload, ref valueOffset);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool TryReadRecord(LegacyBiffSource bytes, ref int offset, out RecordSlice record) {
+            if (offset == bytes.Length) {
+                record = default;
+                return false;
+            }
+            if (offset < 0 || offset + 4 > bytes.Length) {
+                throw new InvalidDataException("The BIFF stream ended inside a record header.");
+            }
+            ushort type = bytes.ReadUInt16(offset);
+            ushort length = bytes.ReadUInt16(offset + 2);
+            int payloadOffset = checked(offset + 4);
+            int nextOffset = checked(payloadOffset + length);
+            if (nextOffset > bytes.Length) {
+                throw new InvalidDataException(
+                    $"BIFF record 0x{type:X4} at offset {offset} declares {length} payload bytes, but the stream ends early.");
+            }
+            record = new RecordSlice(type, offset, payloadOffset, length);
+            offset = nextOffset;
+            return true;
+        }
+
+        internal static ushort ReadUInt16(LegacyBiffSource bytes, int offset) => bytes.ReadUInt16(offset);
+
+        internal static uint ReadUInt32(LegacyBiffSource bytes, int offset) => bytes.ReadUInt32(offset);
+
+        internal static double ReadDouble(LegacyBiffSource bytes, int offset) => bytes.ReadDouble(offset);
+
+        internal static byte[] CopyPayload(LegacyBiffSource bytes, RecordSlice record) =>
+            bytes.Copy(record.PayloadOffset, record.Length);
+
+        private static InvalidDataException Truncated(RecordSlice record, string name) =>
+            new($"The {name} record at offset {record.Offset} is truncated.");
+
+        internal readonly struct RecordSlice {
+            internal RecordSlice(ushort type, int offset, int payloadOffset, int length) {
+                Type = type;
+                Offset = offset;
+                PayloadOffset = payloadOffset;
+                Length = length;
+            }
+
+            internal ushort Type { get; }
+            internal int Offset { get; }
+            internal int PayloadOffset { get; }
+            internal int Length { get; }
+        }
+
+        private readonly struct SheetInfo {
+            internal SheetInfo(string name, int streamOffset, byte sheetType) {
+                Name = name;
+                StreamOffset = streamOffset;
+                SheetType = sheetType;
+            }
+
+            internal string Name { get; }
+            internal int StreamOffset { get; }
+            internal byte SheetType { get; }
+        }
+    }
+
+    internal sealed class LegacyXlsFastPathNotSupportedException : NotSupportedException {
+        internal LegacyXlsFastPathNotSupportedException(string message) : base(message) { }
+    }
+}

--- a/OfficeIMO.Excel/LegacyXls/Read/LegacyXlsTabularWorkbook.cs
+++ b/OfficeIMO.Excel/LegacyXls/Read/LegacyXlsTabularWorkbook.cs
@@ -68,6 +68,10 @@ namespace OfficeIMO.Excel.LegacyXls.Read {
             CancellationToken cancellationToken) {
             try {
                 cancellationToken.ThrowIfCancellationRequested();
+                if (source.Length > options.MaxInputBytes) {
+                    throw new InvalidDataException(
+                        $"Workbook input contains {source.Length} bytes, exceeding the configured limit of {options.MaxInputBytes} bytes.");
+                }
                 Stream workbookStream = OpenWorkbookStream(source, options, cancellationToken);
                 cancellationToken.ThrowIfCancellationRequested();
                 var biffSource = new LegacyBiffSource(workbookStream, cancellationToken);

--- a/OfficeIMO.Excel/Read/ExcelDataReaderSchemaTable.cs
+++ b/OfficeIMO.Excel/Read/ExcelDataReaderSchemaTable.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
+
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Builds the canonical ADO.NET schema table shared by Excel data-reader implementations.
+    /// </summary>
+    internal static class ExcelDataReaderSchemaTable {
+        private const string IsReadOnlyColumn = "IsReadOnly";
+        private const string IsRowVersionColumn = "IsRowVersion";
+        private const string IsAutoIncrementColumn = "IsAutoIncrement";
+        private const string BaseCatalogNameColumn = "BaseCatalogName";
+
+        [UnconditionalSuppressMessage(
+            "Trimming",
+            "IL2111",
+            Justification = "The schema table stores Type values as data and does not reflect over Type members.")]
+        internal static DataTable Create(
+            int fieldCount,
+            Func<int, string> getName,
+            Func<int, Type> getFieldType) {
+            var schema = new DataTable("SchemaTable");
+            schema.Columns.Add(SchemaTableColumn.ColumnName, typeof(string));
+            schema.Columns.Add(SchemaTableColumn.ColumnOrdinal, typeof(int));
+            schema.Columns.Add(SchemaTableColumn.ColumnSize, typeof(int));
+            schema.Columns.Add(SchemaTableColumn.NumericPrecision, typeof(short));
+            schema.Columns.Add(SchemaTableColumn.NumericScale, typeof(short));
+            schema.Columns.Add(SchemaTableColumn.DataType, typeof(Type));
+            schema.Columns.Add(SchemaTableColumn.ProviderType, typeof(int));
+            schema.Columns.Add(SchemaTableColumn.IsLong, typeof(bool));
+            schema.Columns.Add(SchemaTableColumn.AllowDBNull, typeof(bool));
+            schema.Columns.Add(IsReadOnlyColumn, typeof(bool));
+            schema.Columns.Add(IsRowVersionColumn, typeof(bool));
+            schema.Columns.Add(SchemaTableColumn.IsUnique, typeof(bool));
+            schema.Columns.Add(SchemaTableColumn.IsKey, typeof(bool));
+            schema.Columns.Add(IsAutoIncrementColumn, typeof(bool));
+            schema.Columns.Add(SchemaTableColumn.BaseSchemaName, typeof(string));
+            schema.Columns.Add(BaseCatalogNameColumn, typeof(string));
+            schema.Columns.Add(SchemaTableColumn.BaseTableName, typeof(string));
+            schema.Columns.Add(SchemaTableColumn.BaseColumnName, typeof(string));
+
+            for (int ordinal = 0; ordinal < fieldCount; ordinal++) {
+                string name = getName(ordinal);
+                DataRow row = schema.NewRow();
+                row[SchemaTableColumn.ColumnName] = name;
+                row[SchemaTableColumn.ColumnOrdinal] = ordinal;
+                row[SchemaTableColumn.ColumnSize] = -1;
+                row[SchemaTableColumn.NumericPrecision] = DBNull.Value;
+                row[SchemaTableColumn.NumericScale] = DBNull.Value;
+                row[SchemaTableColumn.DataType] = getFieldType(ordinal);
+                row[SchemaTableColumn.ProviderType] = 0;
+                row[SchemaTableColumn.IsLong] = false;
+                row[SchemaTableColumn.AllowDBNull] = true;
+                row[IsReadOnlyColumn] = true;
+                row[IsRowVersionColumn] = false;
+                row[SchemaTableColumn.IsUnique] = false;
+                row[SchemaTableColumn.IsKey] = false;
+                row[IsAutoIncrementColumn] = false;
+                row[SchemaTableColumn.BaseSchemaName] = DBNull.Value;
+                row[BaseCatalogNameColumn] = DBNull.Value;
+                row[SchemaTableColumn.BaseTableName] = DBNull.Value;
+                row[SchemaTableColumn.BaseColumnName] = name;
+                schema.Rows.Add(row);
+            }
+
+            return schema;
+        }
+    }
+}

--- a/OfficeIMO.Excel/Read/ExcelDocumentReader.Sheets.cs
+++ b/OfficeIMO.Excel/Read/ExcelDocumentReader.Sheets.cs
@@ -12,7 +12,7 @@ namespace OfficeIMO.Excel {
         public ExcelSheetReader GetSheet(int index) {
             if (index < 1) throw new ArgumentOutOfRangeException(nameof(index));
             if (TryGetSheetByIndexXmlFast(index, out string fastSheetName, out WorksheetPart fastWorksheetPart)) {
-                return new ExcelSheetReader(fastSheetName, fastWorksheetPart, _sst, _styles, _opt, _dateSystem, _canStreamWorksheetParts);
+                return new ExcelSheetReader(fastSheetName, fastWorksheetPart, _sst, _styles, _opt, _dateSystem, _canStreamWorksheetParts, _partBufferReader);
             }
 
             var wb = WorkbookRoot;
@@ -35,7 +35,7 @@ namespace OfficeIMO.Excel {
                 throw new ArgumentOutOfRangeException(nameof(index));
             }
 
-            return new ExcelSheetReader(sheet.Name!, wsPart!, _sst, _styles, _opt, _dateSystem, _canStreamWorksheetParts);
+            return new ExcelSheetReader(sheet.Name!, wsPart!, _sst, _styles, _opt, _dateSystem, _canStreamWorksheetParts, _partBufferReader);
         }
 
         /// <summary>

--- a/OfficeIMO.Excel/Read/ExcelDocumentReader.cs
+++ b/OfficeIMO.Excel/Read/ExcelDocumentReader.cs
@@ -27,6 +27,7 @@ namespace OfficeIMO.Excel {
         private readonly StylesCacheProvider _styles;
         private readonly Package? _ownedPackage;
         private readonly Stream? _ownedStream;
+        private readonly IDisposable? _ownedResource;
         private readonly OpenXmlPackagePartBufferReader? _partBufferReader;
 
         private ExcelDocumentReader(
@@ -35,7 +36,8 @@ namespace OfficeIMO.Excel {
             bool owns,
             Package? ownedPackage = null,
             Stream? ownedStream = null,
-            OpenXmlPackagePartBufferReader? partBufferReader = null) {
+            OpenXmlPackagePartBufferReader? partBufferReader = null,
+            IDisposable? ownedResource = null) {
             _doc = doc;
             _owns = owns;
             _canStreamWorksheetParts = owns || doc.FileOpenAccess == FileAccess.Read;
@@ -43,6 +45,7 @@ namespace OfficeIMO.Excel {
             _opt.CancellationToken.ThrowIfCancellationRequested();
             _ownedPackage = ownedPackage;
             _ownedStream = ownedStream;
+            _ownedResource = ownedResource;
             _partBufferReader = partBufferReader;
             _dateSystem = GetWorkbookDateSystem(doc);
             _sst = SharedStringCache.Build(doc, _opt);
@@ -60,37 +63,52 @@ namespace OfficeIMO.Excel {
             }
 
             var effectiveOptions = options ?? new ExcelReadOptions();
-            long inputLength = new FileInfo(path).Length;
-            if (inputLength > effectiveOptions.MaxInputBytes) {
-                throw new InvalidDataException(
-                    $"Workbook input contains {inputLength} bytes, exceeding the configured limit of {effectiveOptions.MaxInputBytes} bytes.");
-            }
-
+            SharedReadOnlyFileSnapshot? snapshot = null;
+            Stream? documentStream = null;
             SpreadsheetDocument? document = null;
             OpenXmlPackagePartBufferReader? partBufferReader = null;
+            bool packageOpenAttempted = false;
             try {
-                document = SpreadsheetDocument.Open(path, isEditable: false);
-                partBufferReader = OpenXmlPackagePartBufferReader.TryOpen(path);
+                snapshot = SharedReadOnlyFileSnapshot.Open(path);
+                if (snapshot.Length > effectiveOptions.MaxInputBytes) {
+                    throw new InvalidDataException(
+                        $"Workbook input contains {snapshot.Length} bytes, exceeding the configured limit of {effectiveOptions.MaxInputBytes} bytes.");
+                }
+
+                documentStream = snapshot.CreateView();
+                packageOpenAttempted = true;
+                document = SpreadsheetDocument.Open(documentStream, isEditable: false);
+                partBufferReader = OpenXmlPackagePartBufferReader.TryOpen(snapshot.CreateView(bufferSize: 1));
                 ExcelDocumentReader reader = new ExcelDocumentReader(
                     document,
                     effectiveOptions,
                     owns: true,
-                    partBufferReader: partBufferReader);
+                    ownedStream: documentStream,
+                    partBufferReader: partBufferReader,
+                    ownedResource: snapshot);
+                snapshot = null;
+                documentStream = null;
                 partBufferReader = null;
                 return reader;
             } catch (Exception ex) {
                 partBufferReader?.Dispose();
                 document?.Dispose();
-                if (!IsRecoverableOpenException(ex)) {
+                documentStream?.Dispose();
+                if (!packageOpenAttempted || !IsRecoverableOpenException(ex)) {
+                    snapshot?.Dispose();
                     throw;
                 }
 
                 byte[] bytes;
-                using (var stream = File.OpenRead(path)) {
-                    bytes = OfficeStreamReader.ReadAllBytes(
-                        stream,
-                        effectiveOptions.CancellationToken,
-                        effectiveOptions.MaxInputBytes);
+                try {
+                    using (Stream stream = snapshot!.CreateView()) {
+                        bytes = OfficeStreamReader.ReadAllBytes(
+                            stream,
+                            effectiveOptions.CancellationToken,
+                            effectiveOptions.MaxInputBytes);
+                    }
+                } finally {
+                    snapshot?.Dispose();
                 }
 
                 return OpenFromBytes(
@@ -535,7 +553,11 @@ namespace OfficeIMO.Excel {
                         try {
                             _ownedStream?.Dispose();
                         } finally {
-                            _partBufferReader?.Dispose();
+                            try {
+                                _partBufferReader?.Dispose();
+                            } finally {
+                                _ownedResource?.Dispose();
+                            }
                         }
                     }
                 }

--- a/OfficeIMO.Excel/Read/ExcelDocumentReader.cs
+++ b/OfficeIMO.Excel/Read/ExcelDocumentReader.cs
@@ -27,8 +27,15 @@ namespace OfficeIMO.Excel {
         private readonly StylesCacheProvider _styles;
         private readonly Package? _ownedPackage;
         private readonly Stream? _ownedStream;
+        private readonly OpenXmlPackagePartBufferReader? _partBufferReader;
 
-        private ExcelDocumentReader(SpreadsheetDocument doc, ExcelReadOptions opt, bool owns, Package? ownedPackage = null, Stream? ownedStream = null) {
+        private ExcelDocumentReader(
+            SpreadsheetDocument doc,
+            ExcelReadOptions opt,
+            bool owns,
+            Package? ownedPackage = null,
+            Stream? ownedStream = null,
+            OpenXmlPackagePartBufferReader? partBufferReader = null) {
             _doc = doc;
             _owns = owns;
             _canStreamWorksheetParts = owns || doc.FileOpenAccess == FileAccess.Read;
@@ -36,6 +43,7 @@ namespace OfficeIMO.Excel {
             _opt.CancellationToken.ThrowIfCancellationRequested();
             _ownedPackage = ownedPackage;
             _ownedStream = ownedStream;
+            _partBufferReader = partBufferReader;
             _dateSystem = GetWorkbookDateSystem(doc);
             _sst = SharedStringCache.Build(doc, _opt);
             _styles = new StylesCacheProvider(doc);
@@ -59,10 +67,19 @@ namespace OfficeIMO.Excel {
             }
 
             SpreadsheetDocument? document = null;
+            OpenXmlPackagePartBufferReader? partBufferReader = null;
             try {
                 document = SpreadsheetDocument.Open(path, isEditable: false);
-                return new ExcelDocumentReader(document, effectiveOptions, owns: true);
+                partBufferReader = OpenXmlPackagePartBufferReader.TryOpen(path);
+                ExcelDocumentReader reader = new ExcelDocumentReader(
+                    document,
+                    effectiveOptions,
+                    owns: true,
+                    partBufferReader: partBufferReader);
+                partBufferReader = null;
+                return reader;
             } catch (Exception ex) {
+                partBufferReader?.Dispose();
                 document?.Dispose();
                 if (!IsRecoverableOpenException(ex)) {
                     throw;
@@ -157,7 +174,7 @@ namespace OfficeIMO.Excel {
         /// </summary>
         public ExcelSheetReader GetSheet(string name) {
             if (TryGetSheetByNameXmlFast(name, out string? fastSheetName, out WorksheetPart? fastWorksheetPart)) {
-                return new ExcelSheetReader(fastSheetName, fastWorksheetPart, _sst, _styles, _opt, _dateSystem, _canStreamWorksheetParts);
+                return new ExcelSheetReader(fastSheetName, fastWorksheetPart, _sst, _styles, _opt, _dateSystem, _canStreamWorksheetParts, _partBufferReader);
             }
 
             var wb = WorkbookRoot;
@@ -175,7 +192,7 @@ namespace OfficeIMO.Excel {
                 throw new KeyNotFoundException($"Sheet '{name}' is not a worksheet.");
             }
 
-            return new ExcelSheetReader(sheet.Name!, wsPart!, _sst, _styles, _opt, _dateSystem, _canStreamWorksheetParts);
+            return new ExcelSheetReader(sheet.Name!, wsPart!, _sst, _styles, _opt, _dateSystem, _canStreamWorksheetParts, _partBufferReader);
         }
 
         private bool TryGetWorksheetPart(Sheet sheet, out WorksheetPart? worksheetPart) {
@@ -509,9 +526,19 @@ namespace OfficeIMO.Excel {
         /// </summary>
         public void Dispose() {
             if (_owns) {
-                _doc.Dispose();
-                _ownedPackage?.Close();
-                _ownedStream?.Dispose();
+                try {
+                    _doc.Dispose();
+                } finally {
+                    try {
+                        _ownedPackage?.Close();
+                    } finally {
+                        try {
+                            _ownedStream?.Dispose();
+                        } finally {
+                            _partBufferReader?.Dispose();
+                        }
+                    }
+                }
             }
         }
 
@@ -525,6 +552,7 @@ namespace OfficeIMO.Excel {
             MemoryStream? packageStream = null;
             Package? package = null;
             SpreadsheetDocument? document = null;
+            OpenXmlPackagePartBufferReader? partBufferReader = null;
             try {
                 if (normalizeContentTypes) {
                     packageStream = new MemoryStream(bytes.Length + 4096);
@@ -540,18 +568,32 @@ namespace OfficeIMO.Excel {
                 package = Package.Open(packageStream, FileMode.Open, FileAccess.Read);
                 effectiveOptions.CancellationToken.ThrowIfCancellationRequested();
                 document = SpreadsheetDocument.Open(package);
-                return new ExcelDocumentReader(document, effectiveOptions, owns: true, package, packageStream);
+                partBufferReader = normalizeContentTypes
+                    ? null
+                    : OpenXmlPackagePartBufferReader.TryOpen(bytes);
+                ExcelDocumentReader reader = new ExcelDocumentReader(
+                    document,
+                    effectiveOptions,
+                    owns: true,
+                    package,
+                    packageStream,
+                    partBufferReader);
+                partBufferReader = null;
+                return reader;
             } catch (Exception ex) when (!normalizeContentTypes && IsRecoverableOpenException(ex)) {
+                partBufferReader?.Dispose();
                 document?.Dispose();
                 package?.Close();
                 packageStream?.Dispose();
                 return OpenFromBytes(bytes, effectiveOptions, normalizeContentTypes: true, contextMessage);
             } catch (Exception ex) when (IsRecoverableOpenException(ex)) {
+                partBufferReader?.Dispose();
                 document?.Dispose();
                 package?.Close();
                 packageStream?.Dispose();
                 throw new IOException($"{contextMessage} See inner exception for details.", ex);
             } catch {
+                partBufferReader?.Dispose();
                 document?.Dispose();
                 package?.Close();
                 packageStream?.Dispose();

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.Compact.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.Compact.cs
@@ -33,6 +33,7 @@ namespace OfficeIMO.Excel {
                 bool hasStyle = false;
                 bool isEmpty = false;
                 while (cursor < _length) {
+                    int whitespaceStart = cursor;
                     while (cursor < _length && IsAsciiWhitespace(_buffer[cursor])) {
                         cursor++;
                     }
@@ -44,14 +45,14 @@ namespace OfficeIMO.Excel {
                     }
                     if (_buffer[cursor] == (byte)'/') {
                         cursor++;
-                        while (cursor < _length && IsAsciiWhitespace(_buffer[cursor])) {
-                            cursor++;
-                        }
                         if (cursor >= _length || _buffer[cursor] != (byte)'>') {
                             return false;
                         }
                         isEmpty = true;
                         break;
+                    }
+                    if (cursor == whitespaceStart) {
+                        return false;
                     }
 
                     int attributeStart = cursor;

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.Compact.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.Compact.cs
@@ -1,0 +1,184 @@
+#nullable enable
+
+namespace OfficeIMO.Excel {
+    internal sealed partial class ExcelSheetReader {
+        private sealed partial class ExcelUtf8RangeRowSource {
+            private bool TryReadCompactCellStartTag(
+                ref int position,
+                ref int nextColumn,
+                out Utf8Tag tag,
+                out int columnIndex,
+                out Utf8CellKind kind,
+                out int styleIndex) {
+                tag = default;
+                columnIndex = 0;
+                kind = Utf8CellKind.Number;
+                styleIndex = -1;
+                int cursor = position;
+                if (cursor + 2 >= _length
+                    || _buffer![cursor] != (byte)'<'
+                    || _buffer[cursor + 1] != (byte)'c'
+                    || !IsTagNameTerminator(_buffer[cursor + 2])) {
+                    return false;
+                }
+
+                int start = cursor;
+                cursor += 2;
+                int referenceStart = 0;
+                int referenceLength = 0;
+                int typeStart = 0;
+                int typeLength = 0;
+                bool hasReference = false;
+                bool hasType = false;
+                bool hasStyle = false;
+                bool isEmpty = false;
+                while (cursor < _length) {
+                    while (cursor < _length && IsAsciiWhitespace(_buffer[cursor])) {
+                        cursor++;
+                    }
+                    if (cursor >= _length) {
+                        return false;
+                    }
+                    if (_buffer[cursor] == (byte)'>') {
+                        break;
+                    }
+                    if (_buffer[cursor] == (byte)'/') {
+                        cursor++;
+                        while (cursor < _length && IsAsciiWhitespace(_buffer[cursor])) {
+                            cursor++;
+                        }
+                        if (cursor >= _length || _buffer[cursor] != (byte)'>') {
+                            return false;
+                        }
+                        isEmpty = true;
+                        break;
+                    }
+
+                    int attributeStart = cursor;
+                    while (cursor < _length && !IsAttributeNameTerminator(_buffer[cursor])) {
+                        cursor++;
+                    }
+                    int attributeLength = cursor - attributeStart;
+                    if (attributeLength == 0) {
+                        return false;
+                    }
+                    while (cursor < _length && IsAsciiWhitespace(_buffer[cursor])) {
+                        cursor++;
+                    }
+                    if (cursor >= _length || _buffer[cursor++] != (byte)'=') {
+                        return false;
+                    }
+                    while (cursor < _length && IsAsciiWhitespace(_buffer[cursor])) {
+                        cursor++;
+                    }
+                    if (cursor >= _length || _buffer[cursor] is not ((byte)'\"') and not ((byte)'\'')) {
+                        return false;
+                    }
+                    byte quote = _buffer[cursor++];
+                    int valueStart = cursor;
+                    while (cursor < _length && _buffer[cursor] != quote) {
+                        if (_buffer[cursor] == (byte)'<') {
+                            return false;
+                        }
+                        cursor++;
+                    }
+                    if (cursor >= _length) {
+                        return false;
+                    }
+                    int valueLength = cursor - valueStart;
+                    cursor++;
+
+                    if (AsciiEquals(attributeStart, attributeLength, "r")) {
+                        if (hasReference) {
+                            return false;
+                        }
+                        hasReference = true;
+                        referenceStart = valueStart;
+                        referenceLength = valueLength;
+                    } else if (AsciiEquals(attributeStart, attributeLength, "t")) {
+                        if (hasType) {
+                            return false;
+                        }
+                        hasType = true;
+                        typeStart = valueStart;
+                        typeLength = valueLength;
+                    } else if (AsciiEquals(attributeStart, attributeLength, "s")) {
+                        if (hasStyle) {
+                            return false;
+                        }
+                        hasStyle = true;
+                        if (!TryParseNonNegativeInt(_buffer, valueStart, valueLength, out styleIndex)) {
+                            return false;
+                        }
+                    } else {
+                        return false;
+                    }
+                }
+
+                if (cursor >= _length || _buffer[cursor] != (byte)'>') {
+                    return false;
+                }
+                if (hasReference) {
+                    columnIndex = ParseColumnIndex(_buffer, referenceStart, referenceLength);
+                    if (columnIndex <= 0) {
+                        return false;
+                    }
+                } else {
+                    columnIndex = nextColumn;
+                }
+                if (hasType && !TryParseCellKind(typeStart, typeLength, out kind)) {
+                    return false;
+                }
+
+                tag = new Utf8Tag(start, cursor, start + 1, start + 2, start + 1, isEnd: false, isEmpty);
+                nextColumn = columnIndex + 1;
+                position = cursor + 1;
+                return true;
+            }
+
+            private bool TryIndexCompactValueCell(
+                ref int position,
+                int cellIndex,
+                out bool hasCachedValue,
+                out int valueStart,
+                out int valueLength) {
+                hasCachedValue = false;
+                valueStart = -1;
+                valueLength = -1;
+                int cursor = position;
+                if (MatchesAscii(cursor, "</c>")) {
+                    position = cursor + 4;
+                    return true;
+                }
+                if (!MatchesAscii(cursor, "<v>")) {
+                    return false;
+                }
+
+                int contentStart = cursor + 3;
+                int relativeEnd = _buffer!.AsSpan(contentStart, _length - contentStart).IndexOf((byte)'<');
+                if (relativeEnd < 0) {
+                    return false;
+                }
+                int valueEnd = contentStart + relativeEnd;
+                if (!MatchesAscii(valueEnd, "</v>") || !MatchesAscii(valueEnd + 4, "</c>")) {
+                    return false;
+                }
+
+                valueStart = contentStart;
+                valueLength = valueEnd - contentStart;
+                hasCachedValue = true;
+                if (cellIndex >= 0) {
+                    _valueStarts![cellIndex] = valueStart;
+                    _valueLengths![cellIndex] = valueLength;
+                }
+                position = valueEnd + 8;
+                return true;
+            }
+
+            private bool MatchesAscii(int start, string value) =>
+                start >= 0
+                && start <= _length - value.Length
+                && AsciiEquals(start, value.Length, value);
+        }
+    }
+}

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.FastValidation.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.FastValidation.cs
@@ -18,7 +18,7 @@ namespace OfficeIMO.Excel {
                 throwOnInvalidBytes: true);
 #if NET8_0_OR_GREATER
             private static readonly SearchValues<byte> CanonicalXmlSpecialBytes = SearchValues.Create(
-                new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 11, 12, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, (byte)'&', 0xef });
+                new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 11, 12, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, (byte)'&', (byte)']', 0xef });
 #endif
 
             /// <summary>
@@ -49,7 +49,11 @@ namespace OfficeIMO.Excel {
                         || value == 0xef
                             && index + 2 < _length
                             && _buffer[index + 1] == 0xbf
-                            && _buffer[index + 2] is 0xbe or 0xbf) {
+                            && _buffer[index + 2] is 0xbe or 0xbf
+                        || value == (byte)']'
+                            && index + 2 < _length
+                            && _buffer[index + 1] == (byte)']'
+                            && _buffer[index + 2] == (byte)'>') {
                         return false;
                     }
                 }
@@ -78,6 +82,8 @@ namespace OfficeIMO.Excel {
                 Span<int> nameLengths = stackalloc int[MaximumFastXmlDepth];
                 Span<int> namespacePrefixStarts = stackalloc int[MaximumFastXmlAttributes];
                 Span<int> namespacePrefixLengths = stackalloc int[MaximumFastXmlAttributes];
+                Span<int> namespaceUriStarts = stackalloc int[MaximumFastXmlAttributes];
+                Span<int> namespaceUriLengths = stackalloc int[MaximumFastXmlAttributes];
                 int depth = 0;
                 int namespacePrefixCount = 0;
                 int position = SkipUtf8PreambleAndWhitespace(0);
@@ -98,7 +104,8 @@ namespace OfficeIMO.Excel {
                         return rootClosed && ContainsOnlyAsciiWhitespace(position, _length);
                     }
                     int tagStart = position + relative;
-                    if (rootClosed && !ContainsOnlyAsciiWhitespace(position, tagStart)) {
+                    if ((rootClosed || !rootSeen)
+                        && !ContainsOnlyAsciiWhitespace(position, tagStart)) {
                         return false;
                     }
                     if (tagStart + 1 >= _length) {
@@ -131,6 +138,8 @@ namespace OfficeIMO.Excel {
                             isRootStartTag,
                             namespacePrefixStarts,
                             namespacePrefixLengths,
+                            namespaceUriStarts,
+                            namespaceUriLengths,
                             ref namespacePrefixCount)) {
                         return false;
                     }
@@ -189,7 +198,16 @@ namespace OfficeIMO.Excel {
                     }
 
                     if (document[index] != 0xef) {
-                        return true;
+                        if (document[index] != (byte)']') {
+                            return true;
+                        }
+                        if (index + 2 < document.Length
+                            && document[index + 1] == (byte)']'
+                            && document[index + 2] == (byte)'>') {
+                            return true;
+                        }
+                        document = document.Slice(index + 1);
+                        continue;
                     }
                     if (index + 2 < document.Length
                         && document[index + 1] == 0xbf
@@ -466,9 +484,14 @@ namespace OfficeIMO.Excel {
                 bool isRootStartTag,
                 Span<int> namespacePrefixStarts,
                 Span<int> namespacePrefixLengths,
+                Span<int> namespaceUriStarts,
+                Span<int> namespaceUriLengths,
                 ref int namespacePrefixCount) {
                 Span<int> usedPrefixStarts = stackalloc int[MaximumFastXmlAttributes];
                 Span<int> usedPrefixLengths = stackalloc int[MaximumFastXmlAttributes];
+                Span<int> usedLocalStarts = stackalloc int[MaximumFastXmlAttributes];
+                Span<int> usedLocalLengths = stackalloc int[MaximumFastXmlAttributes];
+                Span<int> usedNamespaceIndexes = stackalloc int[MaximumFastXmlAttributes];
                 int usedPrefixCount = 0;
                 int position = tag.NameEnd;
                 while (position < tag.End) {
@@ -534,6 +557,8 @@ namespace OfficeIMO.Excel {
                         }
                         namespacePrefixStarts[namespacePrefixCount] = localStart;
                         namespacePrefixLengths[namespacePrefixCount] = localLength;
+                        namespaceUriStarts[namespacePrefixCount] = valueStart;
+                        namespaceUriLengths[namespacePrefixCount] = valueLength;
                         namespacePrefixCount++;
                         continue;
                     }
@@ -546,24 +571,42 @@ namespace OfficeIMO.Excel {
                     }
                     usedPrefixStarts[usedPrefixCount] = nameStart;
                     usedPrefixLengths[usedPrefixCount] = prefixLength;
+                    usedLocalStarts[usedPrefixCount] = localStart;
+                    usedLocalLengths[usedPrefixCount] = localLength;
                     usedPrefixCount++;
                 }
 
                 for (int usedIndex = 0; usedIndex < usedPrefixCount; usedIndex++) {
-                    bool bound = false;
+                    int boundNamespaceIndex = -1;
                     for (int namespaceIndex = 0; namespaceIndex < namespacePrefixCount; namespaceIndex++) {
                         if (ByteRangesEqual(
                                 usedPrefixStarts[usedIndex],
                                 usedPrefixLengths[usedIndex],
                                 namespacePrefixStarts[namespaceIndex],
                                 namespacePrefixLengths[namespaceIndex])) {
-                            bound = true;
+                            boundNamespaceIndex = namespaceIndex;
                             break;
                         }
                     }
-                    if (!bound) {
+                    if (boundNamespaceIndex < 0) {
                         return false;
                     }
+                    for (int priorIndex = 0; priorIndex < usedIndex; priorIndex++) {
+                        int priorNamespaceIndex = usedNamespaceIndexes[priorIndex];
+                        if (ByteRangesEqual(
+                                usedLocalStarts[usedIndex],
+                                usedLocalLengths[usedIndex],
+                                usedLocalStarts[priorIndex],
+                                usedLocalLengths[priorIndex])
+                            && ByteRangesEqual(
+                                namespaceUriStarts[boundNamespaceIndex],
+                                namespaceUriLengths[boundNamespaceIndex],
+                                namespaceUriStarts[priorNamespaceIndex],
+                                namespaceUriLengths[priorNamespaceIndex])) {
+                            return false;
+                        }
+                    }
+                    usedNamespaceIndexes[usedIndex] = boundNamespaceIndex;
                 }
                 return true;
             }
@@ -585,9 +628,17 @@ namespace OfficeIMO.Excel {
                 if (start >= end || !IsAsciiXmlNameStart(_buffer![start])) {
                     return false;
                 }
+                bool sawColon = false;
                 for (int index = start + 1; index < end; index++) {
                     byte value = _buffer![index];
-                    if (value != (byte)':' && !IsAsciiXmlNameCharacter(value)) {
+                    if (value == (byte)':') {
+                        if (sawColon
+                            || index + 1 >= end
+                            || !IsAsciiXmlNameStart(_buffer[index + 1])) {
+                            return false;
+                        }
+                        sawColon = true;
+                    } else if (!IsAsciiXmlNameCharacter(value)) {
                         return false;
                     }
                 }

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.FastValidation.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.FastValidation.cs
@@ -1,0 +1,471 @@
+#nullable enable
+
+using System.Text;
+#if NET8_0_OR_GREATER
+using System.Buffers;
+using System.Text.Unicode;
+#endif
+
+namespace OfficeIMO.Excel {
+    internal sealed partial class ExcelSheetReader {
+        private sealed partial class ExcelUtf8RangeRowSource {
+            private const int MaximumFastXmlDepth = 64;
+            private const int MaximumFastXmlAttributes = 32;
+            private static readonly UTF8Encoding StrictUtf8 = new(
+                encoderShouldEmitUTF8Identifier: false,
+                throwOnInvalidBytes: true);
+#if NET8_0_OR_GREATER
+            private static readonly SearchValues<byte> InvalidXmlControlBytes = SearchValues.Create(
+                new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 11, 12, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31 });
+#endif
+
+            /// <summary>
+            /// Proves full well-formedness for the common, unprefixed SpreadsheetML shape.
+            /// Richer XML constructs fall back to XmlReader validation rather than weakening it.
+            /// </summary>
+            private bool IsCanonicalWorksheetXmlFullyValidated() {
+                if (!_sheetDataSupportsFastValidation) {
+                    return false;
+                }
+#if NET8_0_OR_GREATER
+                ReadOnlySpan<byte> document = _buffer!.AsSpan(0, _length);
+                if (!Utf8.IsValid(document)
+                    || document.IndexOf((byte)'&') >= 0
+                    || document.IndexOfAny(InvalidXmlControlBytes) >= 0) {
+                    return false;
+                }
+#else
+                try {
+                    _ = StrictUtf8.GetCharCount(_buffer!, 0, _length);
+                } catch (DecoderFallbackException) {
+                    return false;
+                }
+
+                for (int index = 0; index < _length; index++) {
+                    byte value = _buffer![index];
+                    if (value == (byte)'&'
+                        || value < 0x20 && value is not (byte)'\t' and not (byte)'\r' and not (byte)'\n') {
+                        return false;
+                    }
+                }
+#endif
+
+                if (_sheetDataContentStart >= 0
+                    && _sheetDataEndTagStart >= _sheetDataContentStart) {
+                    ReadOnlySpan<byte> sheetData = _buffer!.AsSpan(
+                        _sheetDataContentStart,
+                        _sheetDataEndTagStart - _sheetDataContentStart);
+#if NET8_0_OR_GREATER
+                    if (sheetData.IndexOf("<!"u8) >= 0 || sheetData.IndexOf("<?"u8) >= 0) {
+                        return false;
+                    }
+#else
+                    for (int index = 0; index + 1 < sheetData.Length; index++) {
+                        if (sheetData[index] == (byte)'<'
+                            && sheetData[index + 1] is (byte)'!' or (byte)'?') {
+                            return false;
+                        }
+                    }
+#endif
+                }
+
+                Span<int> nameStarts = stackalloc int[MaximumFastXmlDepth];
+                Span<int> nameLengths = stackalloc int[MaximumFastXmlDepth];
+                Span<int> namespacePrefixStarts = stackalloc int[MaximumFastXmlAttributes];
+                Span<int> namespacePrefixLengths = stackalloc int[MaximumFastXmlAttributes];
+                int depth = 0;
+                int namespacePrefixCount = 0;
+                int position = SkipUtf8PreambleAndWhitespace(0);
+                bool rootSeen = false;
+                bool rootClosed = false;
+                if (!HasOnlyRootDefaultNamespace()) {
+                    return false;
+                }
+
+                while (position < _length) {
+                    if (_sheetDataContentStart >= 0
+                        && position == _sheetDataContentStart
+                        && _sheetDataEndTagStart >= position) {
+                        position = _sheetDataEndTagStart;
+                    }
+                    int relative = _buffer!.AsSpan(position, _length - position).IndexOf((byte)'<');
+                    if (relative < 0) {
+                        return rootClosed && ContainsOnlyAsciiWhitespace(position, _length);
+                    }
+                    int tagStart = position + relative;
+                    if (rootClosed && !ContainsOnlyAsciiWhitespace(position, tagStart)) {
+                        return false;
+                    }
+                    if (tagStart + 1 >= _length) {
+                        return false;
+                    }
+
+                    byte marker = _buffer![tagStart + 1];
+                    if (marker == (byte)'?') {
+                        if (rootSeen) {
+                            return false;
+                        }
+                        int instructionEnd = IndexOfSequence(tagStart + 2, _length, (byte)'?', (byte)'>');
+                        if (instructionEnd < 0) {
+                            return false;
+                        }
+                        position = instructionEnd + 2;
+                        continue;
+                    }
+                    if (marker == (byte)'!'
+                        || !TryParseTag(tagStart, _length, out Utf8Tag tag)
+                        || !IsValidUnprefixedXmlName(tag.NameStart, tag.NameEnd)) {
+                        return false;
+                    }
+
+                    if (!ValidateCanonicalTagAttributes(
+                            tag,
+                            out bool declaresDefaultNamespace,
+                            out bool declaresSpreadsheetNamespace)) {
+                        return false;
+                    }
+                    bool isRootStartTag = !rootSeen && !tag.IsEnd;
+                    if (!ValidateCanonicalNamespaceUsage(
+                            tag,
+                            isRootStartTag,
+                            namespacePrefixStarts,
+                            namespacePrefixLengths,
+                            ref namespacePrefixCount)) {
+                        return false;
+                    }
+
+                    int nameLength = tag.NameEnd - tag.NameStart;
+                    if (tag.IsEnd) {
+                        if (tag.IsEmpty
+                            || declaresDefaultNamespace
+                            || depth == 0
+                            || !ByteRangesEqual(
+                                nameStarts[depth - 1],
+                                nameLengths[depth - 1],
+                                tag.NameStart,
+                                nameLength)) {
+                            return false;
+                        }
+                        depth--;
+                        if (depth == 0) {
+                            rootClosed = true;
+                        }
+                    } else {
+                        if (!rootSeen) {
+                            if (!AsciiEquals(tag.NameStart, nameLength, "worksheet")
+                                || !declaresSpreadsheetNamespace) {
+                                return false;
+                            }
+                            rootSeen = true;
+                        } else if (rootClosed || declaresDefaultNamespace) {
+                            return false;
+                        }
+
+                        if (!tag.IsEmpty) {
+                            if (depth == MaximumFastXmlDepth) {
+                                return false;
+                            }
+                            nameStarts[depth] = tag.NameStart;
+                            nameLengths[depth] = nameLength;
+                            depth++;
+                        } else if (depth == 0) {
+                            rootClosed = true;
+                        }
+                    }
+
+                    position = tag.End + 1;
+                }
+
+                return rootSeen && rootClosed && depth == 0;
+            }
+
+            private bool HasOnlyRootDefaultNamespace() {
+                int searchStart = 0;
+                int defaultNamespaceCount = 0;
+                while (searchStart < _length) {
+#if NET8_0_OR_GREATER
+                    int relative = _buffer!.AsSpan(searchStart, _length - searchStart).IndexOf("xmlns"u8);
+#else
+                    int relative = _buffer!.AsSpan(searchStart, _length - searchStart).IndexOf((byte)'x');
+#endif
+                    if (relative < 0) {
+                        return defaultNamespaceCount == 1;
+                    }
+                    int match = searchStart + relative;
+#if !NET8_0_OR_GREATER
+                    if (match + 5 > _length
+                        || _buffer![match + 1] != (byte)'m'
+                        || _buffer[match + 2] != (byte)'l'
+                        || _buffer[match + 3] != (byte)'n'
+                        || _buffer[match + 4] != (byte)'s') {
+                        searchStart = match + 1;
+                        continue;
+                    }
+#endif
+                    int position = match + 5;
+                    while (position < _length && IsAsciiWhitespace(_buffer![position])) {
+                        position++;
+                    }
+                    if (position < _length && _buffer![position] == (byte)'=') {
+                        defaultNamespaceCount++;
+                        if (defaultNamespaceCount > 1) {
+                            return false;
+                        }
+                    }
+                    searchStart = position + 1;
+                }
+                return defaultNamespaceCount == 1;
+            }
+
+            private int SkipUtf8PreambleAndWhitespace(int position) {
+                if (_length >= 3
+                    && _buffer![0] == 0xEF
+                    && _buffer[1] == 0xBB
+                    && _buffer[2] == 0xBF) {
+                    position = 3;
+                }
+                while (position < _length && IsAsciiWhitespace(_buffer![position])) {
+                    position++;
+                }
+                return position;
+            }
+
+            private bool ValidateCanonicalTagAttributes(
+                Utf8Tag tag,
+                out bool declaresDefaultNamespace,
+                out bool declaresSpreadsheetNamespace) {
+                declaresDefaultNamespace = false;
+                declaresSpreadsheetNamespace = false;
+                Span<int> starts = stackalloc int[MaximumFastXmlAttributes];
+                Span<int> lengths = stackalloc int[MaximumFastXmlAttributes];
+                int count = 0;
+                int position = tag.NameEnd;
+                while (position < tag.End) {
+                    while (position < tag.End && IsAsciiWhitespace(_buffer![position])) {
+                        position++;
+                    }
+                    if (position >= tag.End) {
+                        return true;
+                    }
+                    if (_buffer![position] == (byte)'/') {
+                        position++;
+                        while (position < tag.End && IsAsciiWhitespace(_buffer[position])) {
+                            position++;
+                        }
+                        return !tag.IsEnd && position == tag.End;
+                    }
+                    if (tag.IsEnd || count == MaximumFastXmlAttributes) {
+                        return false;
+                    }
+
+                    int nameStart = position;
+                    while (position < tag.End && !IsAttributeNameTerminator(_buffer[position])) {
+                        position++;
+                    }
+                    int nameLength = position - nameStart;
+                    if (!IsValidXmlAttributeName(nameStart, position)) {
+                        return false;
+                    }
+                    for (int index = 0; index < count; index++) {
+                        if (ByteRangesEqual(starts[index], lengths[index], nameStart, nameLength)) {
+                            return false;
+                        }
+                    }
+                    starts[count] = nameStart;
+                    lengths[count] = nameLength;
+                    count++;
+
+                    while (position < tag.End && IsAsciiWhitespace(_buffer[position])) {
+                        position++;
+                    }
+                    if (position >= tag.End || _buffer[position++] != (byte)'=') {
+                        return false;
+                    }
+                    while (position < tag.End && IsAsciiWhitespace(_buffer[position])) {
+                        position++;
+                    }
+                    if (position >= tag.End || _buffer[position] is not ((byte)'\"') and not ((byte)'\'')) {
+                        return false;
+                    }
+                    byte quote = _buffer[position++];
+                    int valueStart = position;
+                    while (position < tag.End && _buffer[position] != quote) {
+                        if (_buffer[position] == (byte)'<') {
+                            return false;
+                        }
+                        position++;
+                    }
+                    if (position >= tag.End) {
+                        return false;
+                    }
+                    int valueLength = position - valueStart;
+                    position++;
+
+                    if (AsciiEquals(nameStart, nameLength, "xmlns")) {
+                        declaresDefaultNamespace = true;
+                        declaresSpreadsheetNamespace =
+                            AsciiEquals(valueStart, valueLength, SpreadsheetNamespace)
+                            || AsciiEquals(valueStart, valueLength, StrictSpreadsheetNamespace);
+                    }
+                }
+                return true;
+            }
+
+            private bool ValidateCanonicalNamespaceUsage(
+                Utf8Tag tag,
+                bool isRootStartTag,
+                Span<int> namespacePrefixStarts,
+                Span<int> namespacePrefixLengths,
+                ref int namespacePrefixCount) {
+                Span<int> usedPrefixStarts = stackalloc int[MaximumFastXmlAttributes];
+                Span<int> usedPrefixLengths = stackalloc int[MaximumFastXmlAttributes];
+                int usedPrefixCount = 0;
+                int position = tag.NameEnd;
+                while (position < tag.End) {
+                    while (position < tag.End && IsAsciiWhitespace(_buffer![position])) {
+                        position++;
+                    }
+                    if (position >= tag.End || _buffer![position] == (byte)'/') {
+                        break;
+                    }
+
+                    int nameStart = position;
+                    int colon = -1;
+                    while (position < tag.End && !IsAttributeNameTerminator(_buffer[position])) {
+                        if (_buffer[position] == (byte)':') {
+                            if (colon >= 0) {
+                                return false;
+                            }
+                            colon = position;
+                        }
+                        position++;
+                    }
+                    int nameLength = position - nameStart;
+                    while (position < tag.End && IsAsciiWhitespace(_buffer[position])) {
+                        position++;
+                    }
+                    if (position >= tag.End || _buffer[position++] != (byte)'=') {
+                        return false;
+                    }
+                    while (position < tag.End && IsAsciiWhitespace(_buffer[position])) {
+                        position++;
+                    }
+                    if (position >= tag.End || _buffer[position] is not ((byte)'\"') and not ((byte)'\'')) {
+                        return false;
+                    }
+                    byte quote = _buffer[position++];
+                    int valueStart = position;
+                    while (position < tag.End && _buffer[position] != quote) {
+                        position++;
+                    }
+                    if (position >= tag.End) {
+                        return false;
+                    }
+                    int valueLength = position - valueStart;
+                    position++;
+
+                    if (colon < 0) {
+                        continue;
+                    }
+
+                    int prefixLength = colon - nameStart;
+                    int localStart = colon + 1;
+                    int localLength = nameStart + nameLength - localStart;
+                    if (AsciiEquals(nameStart, prefixLength, "xmlns")) {
+                        if (!isRootStartTag
+                            || localLength == 0
+                            || valueLength == 0
+                            || AsciiEquals(localStart, localLength, "xml")
+                            || AsciiEquals(localStart, localLength, "xmlns")
+                            || namespacePrefixCount == namespacePrefixStarts.Length) {
+                            return false;
+                        }
+                        namespacePrefixStarts[namespacePrefixCount] = localStart;
+                        namespacePrefixLengths[namespacePrefixCount] = localLength;
+                        namespacePrefixCount++;
+                        continue;
+                    }
+
+                    if (AsciiEquals(nameStart, prefixLength, "xml")) {
+                        continue;
+                    }
+                    if (usedPrefixCount == usedPrefixStarts.Length) {
+                        return false;
+                    }
+                    usedPrefixStarts[usedPrefixCount] = nameStart;
+                    usedPrefixLengths[usedPrefixCount] = prefixLength;
+                    usedPrefixCount++;
+                }
+
+                for (int usedIndex = 0; usedIndex < usedPrefixCount; usedIndex++) {
+                    bool bound = false;
+                    for (int namespaceIndex = 0; namespaceIndex < namespacePrefixCount; namespaceIndex++) {
+                        if (ByteRangesEqual(
+                                usedPrefixStarts[usedIndex],
+                                usedPrefixLengths[usedIndex],
+                                namespacePrefixStarts[namespaceIndex],
+                                namespacePrefixLengths[namespaceIndex])) {
+                            bound = true;
+                            break;
+                        }
+                    }
+                    if (!bound) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+
+            private bool IsValidUnprefixedXmlName(int start, int end) {
+                if (start >= end || !IsAsciiXmlNameStart(_buffer![start])) {
+                    return false;
+                }
+                for (int index = start + 1; index < end; index++) {
+                    byte value = _buffer![index];
+                    if (value == (byte)':' || !IsAsciiXmlNameCharacter(value)) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+
+            private bool IsValidXmlAttributeName(int start, int end) {
+                if (start >= end || !IsAsciiXmlNameStart(_buffer![start])) {
+                    return false;
+                }
+                for (int index = start + 1; index < end; index++) {
+                    byte value = _buffer![index];
+                    if (value != (byte)':' && !IsAsciiXmlNameCharacter(value)) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+
+            private static bool IsAsciiXmlNameStart(byte value) =>
+                value is >= (byte)'A' and <= (byte)'Z'
+                or >= (byte)'a' and <= (byte)'z'
+                or (byte)'_';
+
+            private static bool IsAsciiXmlNameCharacter(byte value) =>
+                IsAsciiXmlNameStart(value)
+                || value is >= (byte)'0' and <= (byte)'9'
+                or (byte)'.'
+                or (byte)'-';
+
+            private bool ByteRangesEqual(int firstStart, int firstLength, int secondStart, int secondLength) =>
+                firstLength == secondLength
+                && _buffer!.AsSpan(firstStart, firstLength).SequenceEqual(
+                    _buffer.AsSpan(secondStart, secondLength));
+
+            private bool ContainsOnlyAsciiWhitespace(int start, int end) {
+                for (int index = start; index < end; index++) {
+                    if (!IsAsciiWhitespace(_buffer![index])) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+        }
+    }
+}

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.FastValidation.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.FastValidation.cs
@@ -294,7 +294,8 @@ namespace OfficeIMO.Excel {
                                && !sawEncoding
                                && !sawStandalone
                                && AsciiEquals(nameStart, nameLength, "encoding")) {
-                        if (!IsValidXmlEncodingName(valueStart, valueLength)) {
+                        if (!AsciiEqualsIgnoreCase(valueStart, valueLength, "utf-8")
+                            && !AsciiEqualsIgnoreCase(valueStart, valueLength, "utf8")) {
                             return false;
                         }
                         sawEncoding = true;
@@ -317,27 +318,6 @@ namespace OfficeIMO.Excel {
                 nextPosition = instructionEnd + 2;
                 return true;
             }
-
-            private bool IsValidXmlEncodingName(int start, int length) {
-                if (length == 0 || !IsAsciiLetter(_buffer![start])) {
-                    return false;
-                }
-                for (int index = start + 1; index < start + length; index++) {
-                    byte value = _buffer![index];
-                    if (!IsAsciiLetter(value)
-                        && value is not (>= (byte)'0' and <= (byte)'9')
-                        and not (byte)'.'
-                        and not (byte)'_'
-                        and not (byte)'-') {
-                        return false;
-                    }
-                }
-                return true;
-            }
-
-            private static bool IsAsciiLetter(byte value) =>
-                value is >= (byte)'A' and <= (byte)'Z'
-                or >= (byte)'a' and <= (byte)'z';
 
             private bool HasOnlyRootDefaultNamespace() {
                 int searchStart = 0;

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.FastValidation.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.FastValidation.cs
@@ -116,7 +116,8 @@ namespace OfficeIMO.Excel {
                     if (!ValidateCanonicalTagAttributes(
                             tag,
                             out bool declaresDefaultNamespace,
-                            out bool declaresSpreadsheetNamespace)) {
+                            out bool declaresSpreadsheetNamespace,
+                            out _)) {
                         return false;
                     }
                     bool isRootStartTag = !rootSeen && !tag.IsEnd;
@@ -347,9 +348,11 @@ namespace OfficeIMO.Excel {
             private bool ValidateCanonicalTagAttributes(
                 Utf8Tag tag,
                 out bool declaresDefaultNamespace,
-                out bool declaresSpreadsheetNamespace) {
+                out bool declaresSpreadsheetNamespace,
+                out bool hasPrefixedAttributes) {
                 declaresDefaultNamespace = false;
                 declaresSpreadsheetNamespace = false;
+                hasPrefixedAttributes = false;
                 Span<int> starts = stackalloc int[MaximumFastXmlAttributes];
                 Span<int> lengths = stackalloc int[MaximumFastXmlAttributes];
                 int count = 0;
@@ -379,6 +382,12 @@ namespace OfficeIMO.Excel {
                     int nameLength = position - nameStart;
                     if (!IsValidXmlAttributeName(nameStart, position)) {
                         return false;
+                    }
+                    for (int index = nameStart; index < position; index++) {
+                        if (_buffer![index] == (byte)':') {
+                            hasPrefixedAttributes = true;
+                            break;
+                        }
                     }
                     for (int index = 0; index < count; index++) {
                         if (ByteRangesEqual(starts[index], lengths[index], nameStart, nameLength)) {

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.FastValidation.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.FastValidation.cs
@@ -11,12 +11,14 @@ namespace OfficeIMO.Excel {
         private sealed partial class ExcelUtf8RangeRowSource {
             private const int MaximumFastXmlDepth = 64;
             private const int MaximumFastXmlAttributes = 32;
+            private const string XmlNamespace = "http://www.w3.org/XML/1998/namespace";
+            private const string XmlnsNamespace = "http://www.w3.org/2000/xmlns/";
             private static readonly UTF8Encoding StrictUtf8 = new(
                 encoderShouldEmitUTF8Identifier: false,
                 throwOnInvalidBytes: true);
 #if NET8_0_OR_GREATER
-            private static readonly SearchValues<byte> InvalidXmlControlBytes = SearchValues.Create(
-                new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 11, 12, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31 });
+            private static readonly SearchValues<byte> CanonicalXmlSpecialBytes = SearchValues.Create(
+                new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 11, 12, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, (byte)'&', 0xef });
 #endif
 
             /// <summary>
@@ -30,8 +32,7 @@ namespace OfficeIMO.Excel {
 #if NET8_0_OR_GREATER
                 ReadOnlySpan<byte> document = _buffer!.AsSpan(0, _length);
                 if (!Utf8.IsValid(document)
-                    || document.IndexOf((byte)'&') >= 0
-                    || document.IndexOfAny(InvalidXmlControlBytes) >= 0) {
+                    || ContainsInvalidCanonicalXmlBytes(document)) {
                     return false;
                 }
 #else
@@ -44,7 +45,11 @@ namespace OfficeIMO.Excel {
                 for (int index = 0; index < _length; index++) {
                     byte value = _buffer![index];
                     if (value == (byte)'&'
-                        || value < 0x20 && value is not (byte)'\t' and not (byte)'\r' and not (byte)'\n') {
+                        || value < 0x20 && value is not (byte)'\t' and not (byte)'\r' and not (byte)'\n'
+                        || value == 0xef
+                            && index + 2 < _length
+                            && _buffer[index + 1] == 0xbf
+                            && _buffer[index + 2] is 0xbe or 0xbf) {
                         return false;
                     }
                 }
@@ -174,6 +179,28 @@ namespace OfficeIMO.Excel {
 
                 return rootSeen && rootClosed && depth == 0;
             }
+
+#if NET8_0_OR_GREATER
+            private static bool ContainsInvalidCanonicalXmlBytes(ReadOnlySpan<byte> document) {
+                while (!document.IsEmpty) {
+                    int index = document.IndexOfAny(CanonicalXmlSpecialBytes);
+                    if (index < 0) {
+                        return false;
+                    }
+
+                    if (document[index] != 0xef) {
+                        return true;
+                    }
+                    if (index + 2 < document.Length
+                        && document[index + 1] == 0xbf
+                        && document[index + 2] is 0xbe or 0xbf) {
+                        return true;
+                    }
+                    document = document.Slice(index + 1);
+                }
+                return false;
+            }
+#endif
 
             private bool TrySkipCanonicalXmlDeclaration(int start, out int nextPosition) {
                 nextPosition = start;
@@ -500,6 +527,8 @@ namespace OfficeIMO.Excel {
                             || valueLength == 0
                             || AsciiEquals(localStart, localLength, "xml")
                             || AsciiEquals(localStart, localLength, "xmlns")
+                            || AsciiEquals(valueStart, valueLength, XmlNamespace)
+                            || AsciiEquals(valueStart, valueLength, XmlnsNamespace)
                             || namespacePrefixCount == namespacePrefixStarts.Length) {
                             return false;
                         }

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.FastValidation.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.FastValidation.cs
@@ -102,14 +102,9 @@ namespace OfficeIMO.Excel {
 
                     byte marker = _buffer![tagStart + 1];
                     if (marker == (byte)'?') {
-                        if (rootSeen) {
+                        if (rootSeen || !TrySkipCanonicalXmlDeclaration(tagStart, out position)) {
                             return false;
                         }
-                        int instructionEnd = IndexOfSequence(tagStart + 2, _length, (byte)'?', (byte)'>');
-                        if (instructionEnd < 0) {
-                            return false;
-                        }
-                        position = instructionEnd + 2;
                         continue;
                     }
                     if (marker == (byte)'!'
@@ -179,6 +174,125 @@ namespace OfficeIMO.Excel {
                 return rootSeen && rootClosed && depth == 0;
             }
 
+            private bool TrySkipCanonicalXmlDeclaration(int start, out int nextPosition) {
+                nextPosition = start;
+                int preambleLength = _length >= 3
+                    && _buffer![0] == 0xEF
+                    && _buffer[1] == 0xBB
+                    && _buffer[2] == 0xBF
+                        ? 3
+                        : 0;
+                if (start != preambleLength
+                    || start + 5 >= _length
+                    || !AsciiEquals(start + 2, 3, "xml")
+                    || !IsAsciiWhitespace(_buffer![start + 5])) {
+                    return false;
+                }
+
+                int instructionEnd = IndexOfSequence(start + 5, _length, (byte)'?', (byte)'>');
+                if (instructionEnd < 0) {
+                    return false;
+                }
+
+                int position = start + 5;
+                bool sawVersion = false;
+                bool sawEncoding = false;
+                bool sawStandalone = false;
+                while (position < instructionEnd) {
+                    int whitespaceStart = position;
+                    while (position < instructionEnd && IsAsciiWhitespace(_buffer[position])) {
+                        position++;
+                    }
+                    if (position == instructionEnd) {
+                        break;
+                    }
+                    if (position == whitespaceStart) {
+                        return false;
+                    }
+
+                    int nameStart = position;
+                    while (position < instructionEnd && IsAsciiXmlNameCharacter(_buffer[position])) {
+                        position++;
+                    }
+                    int nameLength = position - nameStart;
+                    while (position < instructionEnd && IsAsciiWhitespace(_buffer[position])) {
+                        position++;
+                    }
+                    if (nameLength == 0 || position >= instructionEnd || _buffer[position++] != (byte)'=') {
+                        return false;
+                    }
+                    while (position < instructionEnd && IsAsciiWhitespace(_buffer[position])) {
+                        position++;
+                    }
+                    if (position >= instructionEnd || _buffer[position] is not ((byte)'\"') and not ((byte)'\'')) {
+                        return false;
+                    }
+
+                    byte quote = _buffer[position++];
+                    int valueStart = position;
+                    while (position < instructionEnd && _buffer[position] != quote) {
+                        position++;
+                    }
+                    if (position >= instructionEnd) {
+                        return false;
+                    }
+                    int valueLength = position - valueStart;
+                    position++;
+
+                    if (!sawVersion && AsciiEquals(nameStart, nameLength, "version")) {
+                        if (!AsciiEquals(valueStart, valueLength, "1.0")) {
+                            return false;
+                        }
+                        sawVersion = true;
+                    } else if (sawVersion
+                               && !sawEncoding
+                               && !sawStandalone
+                               && AsciiEquals(nameStart, nameLength, "encoding")) {
+                        if (!IsValidXmlEncodingName(valueStart, valueLength)) {
+                            return false;
+                        }
+                        sawEncoding = true;
+                    } else if (sawVersion
+                               && !sawStandalone
+                               && AsciiEquals(nameStart, nameLength, "standalone")) {
+                        if (!AsciiEquals(valueStart, valueLength, "yes")
+                            && !AsciiEquals(valueStart, valueLength, "no")) {
+                            return false;
+                        }
+                        sawStandalone = true;
+                    } else {
+                        return false;
+                    }
+                }
+
+                if (!sawVersion) {
+                    return false;
+                }
+                nextPosition = instructionEnd + 2;
+                return true;
+            }
+
+            private bool IsValidXmlEncodingName(int start, int length) {
+                if (length == 0 || !IsAsciiLetter(_buffer![start])) {
+                    return false;
+                }
+                for (int index = start + 1; index < start + length; index++) {
+                    byte value = _buffer![index];
+                    if (!IsAsciiLetter(value)
+                        && value is not (>= (byte)'0' and <= (byte)'9')
+                        and not (byte)'.'
+                        and not (byte)'_'
+                        and not (byte)'-') {
+                        return false;
+                    }
+                }
+                return true;
+            }
+
+            private static bool IsAsciiLetter(byte value) =>
+                value is >= (byte)'A' and <= (byte)'Z'
+                or >= (byte)'a' and <= (byte)'z';
+
             private bool HasOnlyRootDefaultNamespace() {
                 int searchStart = 0;
                 int defaultNamespaceCount = 0;
@@ -241,6 +355,7 @@ namespace OfficeIMO.Excel {
                 int count = 0;
                 int position = tag.NameEnd;
                 while (position < tag.End) {
+                    int whitespaceStart = position;
                     while (position < tag.End && IsAsciiWhitespace(_buffer![position])) {
                         position++;
                     }
@@ -249,12 +364,11 @@ namespace OfficeIMO.Excel {
                     }
                     if (_buffer![position] == (byte)'/') {
                         position++;
-                        while (position < tag.End && IsAsciiWhitespace(_buffer[position])) {
-                            position++;
-                        }
                         return !tag.IsEnd && position == tag.End;
                     }
-                    if (tag.IsEnd || count == MaximumFastXmlAttributes) {
+                    if (position == whitespaceStart
+                        || tag.IsEnd
+                        || count == MaximumFastXmlAttributes) {
                         return false;
                     }
 

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.Validation.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.Validation.cs
@@ -129,15 +129,15 @@ namespace OfficeIMO.Excel {
                 valueStart = -1;
                 valueLength = -1;
                 while (TryReadNextTag(ref position, _length, out Utf8Tag tag)) {
-                    if (tag.IsEnd && LocalNameEquals(tag, "c")) {
+                    if (tag.IsEnd && IsUnprefixedTag(tag) && LocalNameEquals(tag, "c")) {
                         return true;
                     }
 
-                    if (!tag.IsEnd && kind == Utf8CellKind.InlineString && LocalNameEquals(tag, "is")) {
+                    if (!tag.IsEnd && IsUnprefixedTag(tag) && kind == Utf8CellKind.InlineString && LocalNameEquals(tag, "is")) {
                         return TryIndexSimpleInlineStringCell(ref position, tag, cellIndex);
                     }
 
-                    if (tag.IsEnd || (!LocalNameEquals(tag, "v") && !LocalNameEquals(tag, "f"))) {
+                    if (tag.IsEnd || !IsUnprefixedTag(tag) || (!LocalNameEquals(tag, "v") && !LocalNameEquals(tag, "f"))) {
                         return false;
                     }
 
@@ -163,6 +163,7 @@ namespace OfficeIMO.Excel {
 
                     if (!TryReadNextTag(ref position, _length, out Utf8Tag endTag)
                         || !endTag.IsEnd
+                        || !IsUnprefixedTag(endTag)
                         || !LocalNamesEqual(tag, endTag)
                         || ContainsByte(tag.End + 1, endTag.Start, (byte)'<')) {
                         return false;

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.Xml.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.Xml.cs
@@ -31,13 +31,17 @@ namespace OfficeIMO.Excel {
             private bool TryReadNextTag(ref int position, int limit, out Utf8Tag tag) {
                 tag = default;
                 while (position < limit) {
-                    int relative = _buffer!.AsSpan(position, limit - position).IndexOf((byte)'<');
-                    if (relative < 0) {
-                        position = limit;
-                        return false;
+                    int start;
+                    if (_buffer![position] == (byte)'<') {
+                        start = position;
+                    } else {
+                        int relative = _buffer.AsSpan(position, limit - position).IndexOf((byte)'<');
+                        if (relative < 0) {
+                            position = limit;
+                            return false;
+                        }
+                        start = position + relative;
                     }
-
-                    int start = position + relative;
                     if (start + 1 >= limit) {
                         _parseFailed = true;
                         position = limit;

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.Xml.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.Xml.cs
@@ -92,7 +92,7 @@ namespace OfficeIMO.Excel {
                 int position = start + 1;
                 bool isEnd = position < limit && _buffer![position] == (byte)'/';
                 if (isEnd) position++;
-                while (position < limit && IsAsciiWhitespace(_buffer![position])) position++;
+                if (position >= limit || IsAsciiWhitespace(_buffer![position])) return false;
                 int nameStart = position;
                 while (position < limit && !IsTagNameTerminator(_buffer![position])) position++;
                 if (position == nameStart) return false;
@@ -109,6 +109,13 @@ namespace OfficeIMO.Excel {
                         int beforeEnd = position - 1;
                         while (beforeEnd >= nameEnd && IsAsciiWhitespace(_buffer[beforeEnd])) beforeEnd--;
                         bool isEmpty = !isEnd && beforeEnd >= nameEnd && _buffer[beforeEnd] == (byte)'/';
+                        if (isEnd) {
+                            for (int index = nameEnd; index < position; index++) {
+                                if (!IsAsciiWhitespace(_buffer[index])) return false;
+                            }
+                        } else if (isEmpty && beforeEnd != position - 1) {
+                            return false;
+                        }
                         int localNameStart = nameStart;
                         for (int i = nameStart; i < nameEnd; i++) {
                             if (_buffer[i] == (byte)':') localNameStart = i + 1;
@@ -130,8 +137,10 @@ namespace OfficeIMO.Excel {
                 valueLength = 0;
                 int position = tag.NameEnd;
                 while (position < tag.End) {
+                    int whitespaceStart = position;
                     while (position < tag.End && IsAsciiWhitespace(_buffer![position])) position++;
                     if (position >= tag.End || _buffer![position] == (byte)'/') return true;
+                    if (position == whitespaceStart) return false;
                     int attributeStart = position;
                     while (position < tag.End && !IsAttributeNameTerminator(_buffer![position])) position++;
                     int attributeEnd = position;
@@ -174,8 +183,10 @@ namespace OfficeIMO.Excel {
                 bool hasType = false;
                 int position = tag.NameEnd;
                 while (position < tag.End) {
+                    int whitespaceStart = position;
                     while (position < tag.End && IsAsciiWhitespace(_buffer![position])) position++;
                     if (position >= tag.End || _buffer![position] == (byte)'/') break;
+                    if (position == whitespaceStart) return false;
                     int attributeStart = position;
                     while (position < tag.End && !IsAttributeNameTerminator(_buffer![position])) position++;
                     int attributeEnd = position;

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.cs
@@ -37,6 +37,9 @@ namespace OfficeIMO.Excel {
             private int _maximumCellRow;
             private int _minimumCellColumn = int.MaxValue;
             private int _maximumCellColumn;
+            private int _sheetDataContentStart = -1;
+            private int _sheetDataEndTagStart = -1;
+            private bool _sheetDataSupportsFastValidation = true;
             private int _lastDateStyleIndex = -1;
             private bool _lastDateStyleResult;
             private bool _cellsFitWithinRange = true;
@@ -86,10 +89,17 @@ namespace OfficeIMO.Excel {
 
                 byte[]? buffer = null;
                 try {
-                    using var stream = owner._wsPart.GetStream(FileMode.Open, FileAccess.Read);
-                    RewindWorksheetStream(stream);
-                    if (!TryReadWorksheetBuffer(stream, ct, out buffer, out int length)) {
-                        return false;
+                    int length;
+                    if (!owner.TryReadWorksheetPartBuffer(
+                            MaximumBufferSize,
+                            ct,
+                            out buffer,
+                            out length)) {
+                        using var stream = owner._wsPart.GetStream(FileMode.Open, FileAccess.Read);
+                        RewindWorksheetStream(stream);
+                        if (!TryReadWorksheetBuffer(stream, ct, out buffer, out length)) {
+                            return false;
+                        }
                     }
 
                     var candidate = new ExcelUtf8RangeRowSource(
@@ -107,7 +117,9 @@ namespace OfficeIMO.Excel {
                             return false;
                         }
 
-                        candidate.ValidateBufferedWorksheetXml(ct);
+                        if (!candidate.IsCanonicalWorksheetXmlFullyValidated()) {
+                            candidate.ValidateBufferedWorksheetXml(ct);
+                        }
                     } catch {
                         candidate.Dispose();
                         throw;
@@ -309,7 +321,7 @@ namespace OfficeIMO.Excel {
                 Utf8Tag sheetData = default;
                 bool foundSheetData = false;
                 while (TryReadNextTag(ref position, _length, out Utf8Tag tag)) {
-                    if (!tag.IsEnd && LocalNameEquals(tag, "sheetData")) {
+                    if (!tag.IsEnd && IsUnprefixedTag(tag) && LocalNameEquals(tag, "sheetData")) {
                         sheetData = tag;
                         foundSheetData = true;
                         break;
@@ -323,16 +335,26 @@ namespace OfficeIMO.Excel {
                 if (sheetData.IsEmpty) {
                     return true;
                 }
+                _sheetDataContentStart = sheetData.End + 1;
 
                 int nextImplicitRow = 1;
                 int previousRow = 0;
                 while (TryReadNextTag(ref position, _length, out Utf8Tag tag)) {
-                    if (tag.IsEnd && LocalNameEquals(tag, "sheetData")) {
+                    if (tag.IsEnd && IsUnprefixedTag(tag) && LocalNameEquals(tag, "sheetData")) {
+                        _sheetDataEndTagStart = tag.Start;
                         return !_parseFailed;
                     }
 
-                    if (tag.IsEnd || !LocalNameEquals(tag, "row")) {
+                    if (tag.IsEnd || !IsUnprefixedTag(tag) || !LocalNameEquals(tag, "row")) {
                         return false;
+                    }
+
+                    if (!ValidateCanonicalTagAttributes(
+                            tag,
+                            out bool rowDeclaresDefaultNamespace,
+                            out _)
+                        || rowDeclaresDefaultNamespace) {
+                        _sheetDataSupportsFastValidation = false;
                     }
 
                     if (!TryGetAttribute(tag, "r", out bool hasRowReference, out int rowReferenceStart, out int rowReferenceLength)) {
@@ -377,17 +399,34 @@ namespace OfficeIMO.Excel {
                 bool rowWithinRange) {
                 int nextColumn = 1;
                 int previousColumn = 0;
-                while (TryReadNextTag(ref position, _length, out Utf8Tag tag)) {
-                    if (tag.IsEnd && LocalNameEquals(tag, "row")) {
-                        return true;
+                while (position < _length) {
+                    int originalPosition = position;
+                    int originalNextColumn = nextColumn;
+                    bool compactTag = TryReadCompactCellStartTag(
+                        ref position,
+                        ref nextColumn,
+                        out Utf8Tag tag,
+                        out int columnIndex,
+                        out Utf8CellKind kind,
+                        out int styleIndex);
+                    if (!compactTag) {
+                        position = originalPosition;
+                        nextColumn = originalNextColumn;
+                        if (!TryReadNextTag(ref position, _length, out tag)) {
+                            return false;
+                        }
+                        if (tag.IsEnd && IsUnprefixedTag(tag) && LocalNameEquals(tag, "row")) {
+                            return true;
+                        }
+                        _sheetDataSupportsFastValidation = false;
+                        if (tag.IsEnd
+                            || !IsUnprefixedTag(tag)
+                            || !LocalNameEquals(tag, "c")
+                            || !TryGetCellAttributes(tag, ref nextColumn, out columnIndex, out kind, out styleIndex)) {
+                            return false;
+                        }
                     }
-
-                    if (tag.IsEnd || !LocalNameEquals(tag, "c")) {
-                        return false;
-                    }
-
-                    if (!TryGetCellAttributes(tag, ref nextColumn, out int columnIndex, out Utf8CellKind kind, out int styleIndex)
-                        || columnIndex <= previousColumn) {
+                    if (columnIndex <= previousColumn) {
                         return false;
                     }
 
@@ -413,15 +452,27 @@ namespace OfficeIMO.Excel {
                     bool hasCachedValue = false;
                     int valueStart = -1;
                     int valueLength = -1;
-                    if (!tag.IsEmpty && !TryIndexCell(
-                            ref position,
-                            cellIndex,
-                            kind,
-                            out sharedFormulaFollower,
-                            out hasCachedValue,
-                            out valueStart,
-                            out valueLength)) {
-                        return false;
+                    if (!tag.IsEmpty) {
+                        int contentPosition = position;
+                        if (!TryIndexCompactValueCell(
+                                ref position,
+                                cellIndex,
+                                out hasCachedValue,
+                                out valueStart,
+                                out valueLength)) {
+                            _sheetDataSupportsFastValidation = false;
+                            position = contentPosition;
+                            if (!TryIndexCell(
+                                    ref position,
+                                    cellIndex,
+                                    kind,
+                                    out sharedFormulaFollower,
+                                    out hasCachedValue,
+                                    out valueStart,
+                                    out valueLength)) {
+                                return false;
+                            }
+                        }
                     }
 
                     ValidateIndexedCell(
@@ -452,6 +503,7 @@ namespace OfficeIMO.Excel {
                 if (!TryReadNextTag(ref position, _length, out Utf8Tag textTag)
                     || ContainsNonWhitespace(contentBoundary, textTag.Start)
                     || textTag.IsEnd
+                    || !IsUnprefixedTag(textTag)
                     || !LocalNameEquals(textTag, "t")) {
                     return false;
                 }
@@ -462,6 +514,7 @@ namespace OfficeIMO.Excel {
                 if (!textTag.IsEmpty) {
                     if (!TryReadNextTag(ref position, _length, out Utf8Tag textEndTag)
                         || !textEndTag.IsEnd
+                        || !IsUnprefixedTag(textEndTag)
                         || !LocalNamesEqual(textTag, textEndTag)
                         || ContainsByte(textTag.End + 1, textEndTag.Start, (byte)'<')) {
                         return false;
@@ -475,6 +528,7 @@ namespace OfficeIMO.Excel {
                 if (!TryReadNextTag(ref position, _length, out Utf8Tag inlineStringEndTag)
                     || ContainsNonWhitespace(nextBoundary, inlineStringEndTag.Start)
                     || !inlineStringEndTag.IsEnd
+                    || !IsUnprefixedTag(inlineStringEndTag)
                     || !LocalNamesEqual(inlineStringTag, inlineStringEndTag)) {
                     return false;
                 }
@@ -491,6 +545,7 @@ namespace OfficeIMO.Excel {
                 return TryReadNextTag(ref position, _length, out Utf8Tag cellEndTag)
                     && !ContainsNonWhitespace(contentBoundary, cellEndTag.Start)
                     && cellEndTag.IsEnd
+                    && IsUnprefixedTag(cellEndTag)
                     && LocalNameEquals(cellEndTag, "c");
             }
 
@@ -878,6 +933,9 @@ namespace OfficeIMO.Excel {
 
             private static bool IsAsciiWhitespace(byte value) =>
                 value == (byte)' ' || value == (byte)'\t' || value == (byte)'\r' || value == (byte)'\n';
+
+            private static bool IsUnprefixedTag(Utf8Tag tag) =>
+                tag.NameStart == tag.LocalNameStart;
 
             private static bool IsTagNameTerminator(byte value) =>
                 IsAsciiWhitespace(value) || value == (byte)'/' || value == (byte)'>';

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.cs
@@ -317,10 +317,24 @@ namespace OfficeIMO.Excel {
                     return false;
                 }
 
+                Span<int> namespacePrefixStarts = stackalloc int[MaximumFastXmlAttributes];
+                Span<int> namespacePrefixLengths = stackalloc int[MaximumFastXmlAttributes];
+                int namespacePrefixCount = 0;
+                bool hasCanonicalRootNamespaces = false;
                 int position = 0;
                 Utf8Tag sheetData = default;
                 bool foundSheetData = false;
                 while (TryReadNextTag(ref position, _length, out Utf8Tag tag)) {
+                    if (!tag.IsEnd
+                        && IsUnprefixedTag(tag)
+                        && LocalNameEquals(tag, "worksheet")) {
+                        hasCanonicalRootNamespaces = ValidateCanonicalNamespaceUsage(
+                            tag,
+                            isRootStartTag: true,
+                            namespacePrefixStarts,
+                            namespacePrefixLengths,
+                            ref namespacePrefixCount);
+                    }
                     if (!tag.IsEnd && IsUnprefixedTag(tag) && LocalNameEquals(tag, "sheetData")) {
                         sheetData = tag;
                         foundSheetData = true;
@@ -355,7 +369,14 @@ namespace OfficeIMO.Excel {
                             out _,
                             out bool rowHasPrefixedAttributes)
                         || rowDeclaresDefaultNamespace
-                        || rowHasPrefixedAttributes) {
+                        || rowHasPrefixedAttributes
+                            && (!hasCanonicalRootNamespaces
+                                || !ValidateCanonicalNamespaceUsage(
+                                    tag,
+                                    isRootStartTag: false,
+                                    namespacePrefixStarts,
+                                    namespacePrefixLengths,
+                                    ref namespacePrefixCount))) {
                         _sheetDataSupportsFastValidation = false;
                     }
 

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.cs
@@ -319,6 +319,8 @@ namespace OfficeIMO.Excel {
 
                 Span<int> namespacePrefixStarts = stackalloc int[MaximumFastXmlAttributes];
                 Span<int> namespacePrefixLengths = stackalloc int[MaximumFastXmlAttributes];
+                Span<int> namespaceUriStarts = stackalloc int[MaximumFastXmlAttributes];
+                Span<int> namespaceUriLengths = stackalloc int[MaximumFastXmlAttributes];
                 int namespacePrefixCount = 0;
                 bool hasCanonicalRootNamespaces = false;
                 int position = 0;
@@ -333,6 +335,8 @@ namespace OfficeIMO.Excel {
                             isRootStartTag: true,
                             namespacePrefixStarts,
                             namespacePrefixLengths,
+                            namespaceUriStarts,
+                            namespaceUriLengths,
                             ref namespacePrefixCount);
                     }
                     if (!tag.IsEnd && IsUnprefixedTag(tag) && LocalNameEquals(tag, "sheetData")) {
@@ -376,6 +380,8 @@ namespace OfficeIMO.Excel {
                                     isRootStartTag: false,
                                     namespacePrefixStarts,
                                     namespacePrefixLengths,
+                                    namespaceUriStarts,
+                                    namespaceUriLengths,
                                     ref namespacePrefixCount))) {
                         _sheetDataSupportsFastValidation = false;
                     }

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.cs
@@ -352,8 +352,10 @@ namespace OfficeIMO.Excel {
                     if (!ValidateCanonicalTagAttributes(
                             tag,
                             out bool rowDeclaresDefaultNamespace,
-                            out _)
-                        || rowDeclaresDefaultNamespace) {
+                            out _,
+                            out bool rowHasPrefixedAttributes)
+                        || rowDeclaresDefaultNamespace
+                        || rowHasPrefixedAttributes) {
                         _sheetDataSupportsFastValidation = false;
                     }
 

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Xml.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Xml.cs
@@ -15,11 +15,6 @@ namespace OfficeIMO.Excel {
     /// </summary>
     internal sealed partial class ExcelSheetReader {
         private sealed class ExcelXmlRangeDataReader : DbDataReader {
-            private const string IsReadOnlyColumn = "IsReadOnly";
-            private const string IsRowVersionColumn = "IsRowVersion";
-            private const string IsAutoIncrementColumn = "IsAutoIncrement";
-            private const string BaseCatalogNameColumn = "BaseCatalogName";
-
             private readonly ExcelSheetReader _owner;
             private readonly Stream _stream = Stream.Null;
             private readonly XmlReader _reader = null!;
@@ -315,52 +310,8 @@ namespace OfficeIMO.Excel {
 
             /// <inheritdoc />
             [UnconditionalSuppressMessage("Trimming", "IL2111", Justification = "The schema table stores Type values as data and does not reflect over Type.TypeInitializer or other Type members.")]
-            public override DataTable GetSchemaTable() {
-                var schema = new DataTable("SchemaTable");
-                schema.Columns.Add(SchemaTableColumn.ColumnName, typeof(string));
-                schema.Columns.Add(SchemaTableColumn.ColumnOrdinal, typeof(int));
-                schema.Columns.Add(SchemaTableColumn.ColumnSize, typeof(int));
-                schema.Columns.Add(SchemaTableColumn.NumericPrecision, typeof(short));
-                schema.Columns.Add(SchemaTableColumn.NumericScale, typeof(short));
-                schema.Columns.Add(SchemaTableColumn.DataType, typeof(Type));
-                schema.Columns.Add(SchemaTableColumn.ProviderType, typeof(int));
-                schema.Columns.Add(SchemaTableColumn.IsLong, typeof(bool));
-                schema.Columns.Add(SchemaTableColumn.AllowDBNull, typeof(bool));
-                schema.Columns.Add(IsReadOnlyColumn, typeof(bool));
-                schema.Columns.Add(IsRowVersionColumn, typeof(bool));
-                schema.Columns.Add(SchemaTableColumn.IsUnique, typeof(bool));
-                schema.Columns.Add(SchemaTableColumn.IsKey, typeof(bool));
-                schema.Columns.Add(IsAutoIncrementColumn, typeof(bool));
-                schema.Columns.Add(SchemaTableColumn.BaseSchemaName, typeof(string));
-                schema.Columns.Add(BaseCatalogNameColumn, typeof(string));
-                schema.Columns.Add(SchemaTableColumn.BaseTableName, typeof(string));
-                schema.Columns.Add(SchemaTableColumn.BaseColumnName, typeof(string));
-
-                for (int i = 0; i < _fieldCount; i++) {
-                    var row = schema.NewRow();
-                    row[SchemaTableColumn.ColumnName] = _columnNames[i];
-                    row[SchemaTableColumn.ColumnOrdinal] = i;
-                    row[SchemaTableColumn.ColumnSize] = -1;
-                    row[SchemaTableColumn.NumericPrecision] = DBNull.Value;
-                    row[SchemaTableColumn.NumericScale] = DBNull.Value;
-                    row[SchemaTableColumn.DataType] = _columnTypes[i];
-                    row[SchemaTableColumn.ProviderType] = 0;
-                    row[SchemaTableColumn.IsLong] = false;
-                    row[SchemaTableColumn.AllowDBNull] = true;
-                    row[IsReadOnlyColumn] = true;
-                    row[IsRowVersionColumn] = false;
-                    row[SchemaTableColumn.IsUnique] = false;
-                    row[SchemaTableColumn.IsKey] = false;
-                    row[IsAutoIncrementColumn] = false;
-                    row[SchemaTableColumn.BaseSchemaName] = DBNull.Value;
-                    row[BaseCatalogNameColumn] = DBNull.Value;
-                    row[SchemaTableColumn.BaseTableName] = DBNull.Value;
-                    row[SchemaTableColumn.BaseColumnName] = _columnNames[i];
-                    schema.Rows.Add(row);
-                }
-
-                return schema;
-            }
+            public override DataTable GetSchemaTable() =>
+                ExcelDataReaderSchemaTable.Create(_fieldCount, GetName, GetFieldType);
 
             /// <inheritdoc />
             public override IEnumerator GetEnumerator() {

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.cs
@@ -443,11 +443,6 @@ namespace OfficeIMO.Excel {
         }
 
         private sealed class ExcelRangeDataReader : DbDataReader {
-            private const string IsReadOnlyColumn = "IsReadOnly";
-            private const string IsRowVersionColumn = "IsRowVersion";
-            private const string IsAutoIncrementColumn = "IsAutoIncrement";
-            private const string BaseCatalogNameColumn = "BaseCatalogName";
-
             private readonly IEnumerator<RangeChunk> _chunks;
             private readonly int _lastRow;
             private readonly int _fieldCount;
@@ -686,52 +681,8 @@ namespace OfficeIMO.Excel {
 
             /// <inheritdoc />
             [UnconditionalSuppressMessage("Trimming", "IL2111", Justification = "The schema table stores Type values as data and does not reflect over Type.TypeInitializer or other Type members.")]
-            public override DataTable GetSchemaTable() {
-                var schema = new DataTable("SchemaTable");
-                schema.Columns.Add(SchemaTableColumn.ColumnName, typeof(string));
-                schema.Columns.Add(SchemaTableColumn.ColumnOrdinal, typeof(int));
-                schema.Columns.Add(SchemaTableColumn.ColumnSize, typeof(int));
-                schema.Columns.Add(SchemaTableColumn.NumericPrecision, typeof(short));
-                schema.Columns.Add(SchemaTableColumn.NumericScale, typeof(short));
-                schema.Columns.Add(SchemaTableColumn.DataType, typeof(Type));
-                schema.Columns.Add(SchemaTableColumn.ProviderType, typeof(int));
-                schema.Columns.Add(SchemaTableColumn.IsLong, typeof(bool));
-                schema.Columns.Add(SchemaTableColumn.AllowDBNull, typeof(bool));
-                schema.Columns.Add(IsReadOnlyColumn, typeof(bool));
-                schema.Columns.Add(IsRowVersionColumn, typeof(bool));
-                schema.Columns.Add(SchemaTableColumn.IsUnique, typeof(bool));
-                schema.Columns.Add(SchemaTableColumn.IsKey, typeof(bool));
-                schema.Columns.Add(IsAutoIncrementColumn, typeof(bool));
-                schema.Columns.Add(SchemaTableColumn.BaseSchemaName, typeof(string));
-                schema.Columns.Add(BaseCatalogNameColumn, typeof(string));
-                schema.Columns.Add(SchemaTableColumn.BaseTableName, typeof(string));
-                schema.Columns.Add(SchemaTableColumn.BaseColumnName, typeof(string));
-
-                for (int i = 0; i < _fieldCount; i++) {
-                    var row = schema.NewRow();
-                    row[SchemaTableColumn.ColumnName] = _columnNames[i];
-                    row[SchemaTableColumn.ColumnOrdinal] = i;
-                    row[SchemaTableColumn.ColumnSize] = -1;
-                    row[SchemaTableColumn.NumericPrecision] = DBNull.Value;
-                    row[SchemaTableColumn.NumericScale] = DBNull.Value;
-                    row[SchemaTableColumn.DataType] = _columnTypes[i];
-                    row[SchemaTableColumn.ProviderType] = 0;
-                    row[SchemaTableColumn.IsLong] = false;
-                    row[SchemaTableColumn.AllowDBNull] = true;
-                    row[IsReadOnlyColumn] = true;
-                    row[IsRowVersionColumn] = false;
-                    row[SchemaTableColumn.IsUnique] = false;
-                    row[SchemaTableColumn.IsKey] = false;
-                    row[IsAutoIncrementColumn] = false;
-                    row[SchemaTableColumn.BaseSchemaName] = DBNull.Value;
-                    row[BaseCatalogNameColumn] = DBNull.Value;
-                    row[SchemaTableColumn.BaseTableName] = DBNull.Value;
-                    row[SchemaTableColumn.BaseColumnName] = _columnNames[i];
-                    schema.Rows.Add(row);
-                }
-
-                return schema;
-            }
+            public override DataTable GetSchemaTable() =>
+                ExcelDataReaderSchemaTable.Create(_fieldCount, GetName, GetFieldType);
 
             /// <inheritdoc />
             public override IEnumerator GetEnumerator() {

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.cs
@@ -23,6 +23,7 @@ namespace OfficeIMO.Excel {
         private readonly ExcelReadOptions _opt;
         private readonly ExcelDateSystem _dateSystem;
         private readonly bool _canStreamWorksheetPart;
+        private readonly OpenXmlPackagePartBufferReader? _partBufferReader;
         private StylesCache? _stylesCache;
         private List<string>? _sharedStringItems;
         private bool? _hasWorksheetPartStreamContent;
@@ -34,7 +35,15 @@ namespace OfficeIMO.Excel {
         private static readonly object BoxedTrue = true;
         private static readonly object BoxedFalse = false;
 
-        internal ExcelSheetReader(string sheetName, WorksheetPart wsPart, SharedStringCache sst, StylesCacheProvider styles, ExcelReadOptions opt, ExcelDateSystem dateSystem, bool canStreamWorksheetPart) {
+        internal ExcelSheetReader(
+            string sheetName,
+            WorksheetPart wsPart,
+            SharedStringCache sst,
+            StylesCacheProvider styles,
+            ExcelReadOptions opt,
+            ExcelDateSystem dateSystem,
+            bool canStreamWorksheetPart,
+            OpenXmlPackagePartBufferReader? partBufferReader = null) {
             _sheetName = sheetName;
             _wsPart = wsPart;
             _sst = sst;
@@ -42,6 +51,23 @@ namespace OfficeIMO.Excel {
             _opt = opt;
             _dateSystem = dateSystem;
             _canStreamWorksheetPart = canStreamWorksheetPart;
+            _partBufferReader = partBufferReader;
+        }
+
+        private bool TryReadWorksheetPartBuffer(
+            int maximumBytes,
+            CancellationToken cancellationToken,
+            out byte[]? buffer,
+            out int length) {
+            buffer = null;
+            length = 0;
+            return _partBufferReader != null
+                && _partBufferReader.TryRead(
+                _wsPart.Uri,
+                maximumBytes,
+                cancellationToken,
+                out buffer,
+                out length);
         }
 
         private DateTime FromExcelSerialDate(double serial) => ExcelDateSystemConverter.FromSerial(serial, _dateSystem);

--- a/OfficeIMO.Excel/Read/ExcelWorkbookDataReader.cs
+++ b/OfficeIMO.Excel/Read/ExcelWorkbookDataReader.cs
@@ -11,11 +11,12 @@ using OfficeIMO.Drawing;
 using OfficeIMO.Excel.LegacyXls;
 using OfficeIMO.Excel.LegacyXls.Model;
 using OfficeIMO.Excel.LegacyXls.Projection;
+using OfficeIMO.Excel.LegacyXls.Read;
 using OfficeIMO.Excel.Xlsb.Read;
 
 namespace OfficeIMO.Excel {
     /// <summary>
-    /// Package-owned ADO.NET projection for XLSX, XLSM, and XLSB workbook worksheets.
+    /// Package-owned ADO.NET projection for XLSX, XLSM, XLSB, and BIFF8 XLS workbook worksheets.
     /// </summary>
     public sealed class ExcelWorkbookDataReader : DbDataReader {
         private readonly IReadOnlyList<SheetSelection> _sheets;
@@ -127,6 +128,16 @@ namespace OfficeIMO.Excel {
         }
 
         internal static ExcelWorkbookDataReader OpenLegacy(string path, ExcelReadOptions options) {
+            if (CanUseLegacyFastPath(options)) {
+                try {
+                    return CreateLegacy(
+                        LegacyXlsTabularWorkbook.Open(path, options, options.CancellationToken),
+                        options);
+                } catch (LegacyXlsFastPathNotSupportedException) {
+                    // Unsupported legacy variants retain the full import/projection path.
+                }
+            }
+
             options.CancellationToken.ThrowIfCancellationRequested();
             using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
             byte[] bytes = OfficeIMO.Drawing.Internal.OfficeStreamReader.ReadRemainingBytes(
@@ -137,8 +148,24 @@ namespace OfficeIMO.Excel {
         }
 
         internal static ExcelWorkbookDataReader OpenLegacy(byte[] bytes, ExcelReadOptions options) {
+            if (CanUseLegacyFastPath(options)) {
+                try {
+                    return CreateLegacy(
+                        LegacyXlsTabularWorkbook.Open(bytes, options, options.CancellationToken),
+                        options);
+                } catch (LegacyXlsFastPathNotSupportedException) {
+                    // Unsupported legacy variants retain the full import/projection path.
+                }
+            }
+
             return OpenLegacyCore(bytes, sourcePath: null, options);
         }
+
+        private static bool CanUseLegacyFastPath(ExcelReadOptions options) =>
+            string.IsNullOrWhiteSpace(options.A1Range)
+            && !options.InferSchema
+            && options.CellValueConverter == null
+            && options.UseCachedFormulaResult;
 
         private static ExcelWorkbookDataReader OpenLegacyCore(
             byte[] bytes,
@@ -264,6 +291,27 @@ namespace OfficeIMO.Excel {
 
         private static ExcelWorkbookDataReader CreateBinary(
             XlsbTabularWorkbook owner,
+            ExcelReadOptions options) {
+            try {
+                IReadOnlyList<SheetSelection> sheets = SelectSheets(owner.TableNames, options);
+                return new ExcelWorkbookDataReader(
+                    sheets,
+                    index => owner.OpenTable(
+                        sheets[index].Name,
+                        options.HasHeaderRow,
+                        options,
+                        options.CancellationToken),
+                    owner,
+                    options.Culture,
+                    options.CancellationToken);
+            } catch {
+                owner.Dispose();
+                throw;
+            }
+        }
+
+        private static ExcelWorkbookDataReader CreateLegacy(
+            LegacyXlsTabularWorkbook owner,
             ExcelReadOptions options) {
             try {
                 IReadOnlyList<SheetSelection> sheets = SelectSheets(owner.TableNames, options);

--- a/OfficeIMO.Excel/Read/OpenXmlPackagePartBufferReader.cs
+++ b/OfficeIMO.Excel/Read/OpenXmlPackagePartBufferReader.cs
@@ -19,30 +19,26 @@ namespace OfficeIMO.Excel {
             _archive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: true);
         }
 
-        internal static OpenXmlPackagePartBufferReader? TryOpen(string path) {
-            FileStream? stream = null;
+        /// <summary>
+        /// Opens a ZIP reader that takes ownership of the supplied stream, including when
+        /// the stream does not contain a readable ZIP archive.
+        /// </summary>
+        internal static OpenXmlPackagePartBufferReader? TryOpen(Stream stream) {
+            if (stream == null) throw new ArgumentNullException(nameof(stream));
             try {
-                stream = new FileStream(
-                    path,
-                    FileMode.Open,
-                    FileAccess.Read,
-                    FileShare.ReadWrite | FileShare.Delete,
-                    bufferSize: 1,
-                    FileOptions.RandomAccess);
                 var reader = new OpenXmlPackagePartBufferReader(stream);
-                stream = null;
                 return reader;
             } catch (InvalidDataException) {
-                stream?.Dispose();
+                stream.Dispose();
                 return null;
             } catch (IOException) {
-                stream?.Dispose();
+                stream.Dispose();
                 return null;
             } catch (UnauthorizedAccessException) {
-                stream?.Dispose();
+                stream.Dispose();
                 return null;
             } catch (NotSupportedException) {
-                stream?.Dispose();
+                stream.Dispose();
                 return null;
             }
         }

--- a/OfficeIMO.Excel/Read/OpenXmlPackagePartBufferReader.cs
+++ b/OfficeIMO.Excel/Read/OpenXmlPackagePartBufferReader.cs
@@ -1,0 +1,125 @@
+#nullable enable
+
+using System.Buffers;
+using System.IO.Compression;
+using System.Threading;
+
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Provides bounded, exact-size reads for package parts whose OPC streams do not expose
+    /// their declared uncompressed length. This avoids repeated growth copies on large sheets.
+    /// </summary>
+    internal sealed class OpenXmlPackagePartBufferReader : IDisposable {
+        private readonly Stream _stream;
+        private readonly ZipArchive _archive;
+        private bool _disposed;
+
+        private OpenXmlPackagePartBufferReader(Stream stream) {
+            _stream = stream;
+            _archive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: true);
+        }
+
+        internal static OpenXmlPackagePartBufferReader? TryOpen(string path) {
+            FileStream? stream = null;
+            try {
+                stream = new FileStream(
+                    path,
+                    FileMode.Open,
+                    FileAccess.Read,
+                    FileShare.ReadWrite | FileShare.Delete,
+                    bufferSize: 1,
+                    FileOptions.RandomAccess);
+                var reader = new OpenXmlPackagePartBufferReader(stream);
+                stream = null;
+                return reader;
+            } catch (InvalidDataException) {
+                stream?.Dispose();
+                return null;
+            } catch (IOException) {
+                stream?.Dispose();
+                return null;
+            } catch (UnauthorizedAccessException) {
+                stream?.Dispose();
+                return null;
+            } catch (NotSupportedException) {
+                stream?.Dispose();
+                return null;
+            }
+        }
+
+        internal static OpenXmlPackagePartBufferReader? TryOpen(byte[] bytes) {
+            MemoryStream? stream = null;
+            try {
+                stream = new MemoryStream(bytes, 0, bytes.Length, writable: false, publiclyVisible: false);
+                var reader = new OpenXmlPackagePartBufferReader(stream);
+                stream = null;
+                return reader;
+            } catch (InvalidDataException) {
+                stream?.Dispose();
+                return null;
+            }
+        }
+
+        internal bool TryRead(
+            Uri partUri,
+            int maximumBytes,
+            CancellationToken cancellationToken,
+            out byte[]? buffer,
+            out int length) {
+            if (_disposed) {
+                throw new ObjectDisposedException(nameof(OpenXmlPackagePartBufferReader));
+            }
+            cancellationToken.ThrowIfCancellationRequested();
+            buffer = null;
+            length = 0;
+            string partName = partUri.OriginalString.TrimStart('/').Replace('\\', '/');
+            ZipArchiveEntry? entry = null;
+            foreach (ZipArchiveEntry candidate in _archive.Entries) {
+                if (string.Equals(candidate.FullName, partName, StringComparison.OrdinalIgnoreCase)) {
+                    entry = candidate;
+                    break;
+                }
+            }
+            if (entry == null || entry.Length < 0 || entry.Length > maximumBytes || entry.Length > int.MaxValue) {
+                return false;
+            }
+
+            length = checked((int)entry.Length);
+            byte[] output = ArrayPool<byte>.Shared.Rent(Math.Max(1, length));
+            try {
+                using Stream input = entry.Open();
+                int offset = 0;
+                while (offset < length) {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    int read = input.Read(output, offset, length - offset);
+                    if (read == 0) {
+                        throw new EndOfStreamException(
+                            $"Package part '{partName}' ended after {offset} of {length} declared bytes.");
+                    }
+                    offset += read;
+                }
+                cancellationToken.ThrowIfCancellationRequested();
+                if (input.ReadByte() >= 0) {
+                    throw new InvalidDataException(
+                        $"Package part '{partName}' exceeds its declared decompressed length of {length} bytes.");
+                }
+                buffer = output;
+                return true;
+            } catch {
+                ArrayPool<byte>.Shared.Return(output);
+                buffer = null;
+                length = 0;
+                throw;
+            }
+        }
+
+        public void Dispose() {
+            if (_disposed) {
+                return;
+            }
+            _disposed = true;
+            _archive.Dispose();
+            _stream.Dispose();
+        }
+    }
+}

--- a/OfficeIMO.Excel/Read/SharedReadOnlyFileSnapshot.cs
+++ b/OfficeIMO.Excel/Read/SharedReadOnlyFileSnapshot.cs
@@ -1,0 +1,169 @@
+#nullable enable
+
+using System.IO;
+
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Owns one open file identity and creates independent-position read views over it.
+    /// This keeps package metadata and fast ZIP-part reads on the same snapshot even when
+    /// the path is atomically replaced while the workbook is open.
+    /// </summary>
+    internal sealed class SharedReadOnlyFileSnapshot : IDisposable {
+        private readonly object _gate = new object();
+        private readonly FileStream _stream;
+        private readonly long _length;
+        private bool _disposed;
+
+        private SharedReadOnlyFileSnapshot(FileStream stream) {
+            _stream = stream;
+            _length = stream.Length;
+        }
+
+        internal long Length => _length;
+
+        internal static SharedReadOnlyFileSnapshot Open(string path) {
+            var stream = new FileStream(
+                path,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.ReadWrite | FileShare.Delete,
+                bufferSize: 1,
+                FileOptions.RandomAccess);
+            try {
+                return new SharedReadOnlyFileSnapshot(stream);
+            } catch {
+                stream.Dispose();
+                throw;
+            }
+        }
+
+        internal Stream CreateView(int bufferSize = 4096) {
+            ThrowIfDisposed();
+            var view = new View(this);
+            return bufferSize > 1
+                ? new BufferedStream(view, bufferSize)
+                : view;
+        }
+
+        private int Read(long position, byte[] buffer, int offset, int count) {
+            ThrowIfDisposed();
+            if (position >= _length || count == 0) {
+                return 0;
+            }
+            count = checked((int)Math.Min(count, _length - position));
+#if NET8_0_OR_GREATER
+            return RandomAccess.Read(_stream.SafeFileHandle, buffer.AsSpan(offset, count), position);
+#else
+            lock (_gate) {
+                ThrowIfDisposed();
+                _stream.Position = position;
+                return _stream.Read(buffer, offset, count);
+            }
+#endif
+        }
+
+#if NET8_0_OR_GREATER
+        private int Read(long position, Span<byte> buffer) {
+            ThrowIfDisposed();
+            if (position >= _length || buffer.Length == 0) {
+                return 0;
+            }
+            int count = checked((int)Math.Min(buffer.Length, _length - position));
+            return RandomAccess.Read(_stream.SafeFileHandle, buffer.Slice(0, count), position);
+        }
+#endif
+
+        private void ThrowIfDisposed() {
+            if (_disposed) {
+                throw new ObjectDisposedException(nameof(SharedReadOnlyFileSnapshot));
+            }
+        }
+
+        public void Dispose() {
+            if (_disposed) {
+                return;
+            }
+            _disposed = true;
+            _stream.Dispose();
+        }
+
+        private sealed class View : Stream {
+            private readonly SharedReadOnlyFileSnapshot _snapshot;
+            private long _position;
+            private bool _disposed;
+
+            internal View(SharedReadOnlyFileSnapshot snapshot) {
+                _snapshot = snapshot;
+            }
+
+            public override bool CanRead => !_disposed;
+            public override bool CanSeek => !_disposed;
+            public override bool CanWrite => false;
+            public override long Length {
+                get {
+                    ThrowIfDisposed();
+                    return _snapshot._length;
+                }
+            }
+            public override long Position {
+                get {
+                    ThrowIfDisposed();
+                    return _position;
+                }
+                set {
+                    ThrowIfDisposed();
+                    if (value < 0) throw new ArgumentOutOfRangeException(nameof(value));
+                    _position = value;
+                }
+            }
+
+            public override int Read(byte[] buffer, int offset, int count) {
+                ThrowIfDisposed();
+                if (buffer == null) throw new ArgumentNullException(nameof(buffer));
+                if (offset < 0 || count < 0 || offset > buffer.Length - count) {
+                    throw new ArgumentOutOfRangeException();
+                }
+                int read = _snapshot.Read(_position, buffer, offset, count);
+                _position = checked(_position + read);
+                return read;
+            }
+
+#if NET8_0_OR_GREATER
+            public override int Read(Span<byte> buffer) {
+                ThrowIfDisposed();
+                int read = _snapshot.Read(_position, buffer);
+                _position = checked(_position + read);
+                return read;
+            }
+#endif
+
+            public override long Seek(long offset, SeekOrigin origin) {
+                ThrowIfDisposed();
+                long position = origin switch {
+                    SeekOrigin.Begin => offset,
+                    SeekOrigin.Current => checked(_position + offset),
+                    SeekOrigin.End => checked(_snapshot._length + offset),
+                    _ => throw new ArgumentOutOfRangeException(nameof(origin))
+                };
+                if (position < 0) throw new IOException("Attempted to seek before the file snapshot.");
+                _position = position;
+                return position;
+            }
+
+            public override void Flush() { }
+            public override void SetLength(long value) => throw new NotSupportedException();
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+            protected override void Dispose(bool disposing) {
+                _disposed = true;
+                base.Dispose(disposing);
+            }
+
+            private void ThrowIfDisposed() {
+                if (_disposed) {
+                    throw new ObjectDisposedException(nameof(View));
+                }
+            }
+        }
+    }
+}

--- a/OfficeIMO.Excel/Xlsb/Biff12/XlsbCellReadBudget.cs
+++ b/OfficeIMO.Excel/Xlsb/Biff12/XlsbCellReadBudget.cs
@@ -21,6 +21,13 @@ namespace OfficeIMO.Excel.Xlsb.Biff12 {
             _remaining--;
         }
 
+        internal void Consume(int count) {
+            if (count < 0 || count > _remaining) {
+                ThrowExceeded();
+            }
+            _remaining -= count;
+        }
+
         [MethodImpl(MethodImplOptions.NoInlining)]
         private void ThrowExceeded() =>
             throw new InvalidDataException(

--- a/OfficeIMO.Excel/Xlsb/Biff12/XlsbRecordReadBudget.cs
+++ b/OfficeIMO.Excel/Xlsb/Biff12/XlsbRecordReadBudget.cs
@@ -21,6 +21,13 @@ namespace OfficeIMO.Excel.Xlsb.Biff12 {
             _remaining--;
         }
 
+        internal void Consume(int count) {
+            if (count < 0 || count > _remaining) {
+                ThrowExceeded();
+            }
+            _remaining -= count;
+        }
+
         [MethodImpl(MethodImplOptions.NoInlining)]
         private void ThrowExceeded() =>
             throw new InvalidDataException(

--- a/OfficeIMO.Excel/Xlsb/Package/XlsbPackagePartReader.cs
+++ b/OfficeIMO.Excel/Xlsb/Package/XlsbPackagePartReader.cs
@@ -65,7 +65,7 @@ namespace OfficeIMO.Excel.Xlsb.Package {
             return output;
         }
 
-        internal Stream ReadSeekablePart(
+        internal XlsbPooledPartStream ReadSeekablePart(
             string partName,
             CancellationToken cancellationToken = default) {
             cancellationToken.ThrowIfCancellationRequested();

--- a/OfficeIMO.Excel/Xlsb/Package/XlsbPooledPartStream.cs
+++ b/OfficeIMO.Excel/Xlsb/Package/XlsbPooledPartStream.cs
@@ -9,12 +9,19 @@ namespace OfficeIMO.Excel.Xlsb.Package {
     internal sealed class XlsbPooledPartStream : MemoryStream {
         private byte[]? _buffer;
         private readonly int _length;
+        private IDisposable? _secondaryOwner;
 
-        internal XlsbPooledPartStream(byte[] buffer, int length)
+        internal XlsbPooledPartStream(byte[] buffer, int length, IDisposable? secondaryOwner = null)
             : base(buffer, 0, length, writable: false, publiclyVisible: false) {
             _buffer = buffer ?? throw new ArgumentNullException(nameof(buffer));
             _length = length;
+            _secondaryOwner = secondaryOwner;
         }
+
+        internal byte[] Buffer => _buffer
+            ?? throw new ObjectDisposedException(nameof(XlsbPooledPartStream));
+
+        internal int DataLength => _length;
 
         protected override void Dispose(bool disposing) {
             base.Dispose(disposing);
@@ -23,6 +30,7 @@ namespace OfficeIMO.Excel.Xlsb.Package {
                 Array.Clear(buffer, 0, _length);
                 ArrayPool<byte>.Shared.Return(buffer);
             }
+            Interlocked.Exchange(ref _secondaryOwner, null)?.Dispose();
         }
     }
 }

--- a/OfficeIMO.Excel/Xlsb/Read/XlsbRecordSliceReader.cs
+++ b/OfficeIMO.Excel/Xlsb/Read/XlsbRecordSliceReader.cs
@@ -12,12 +12,14 @@ namespace OfficeIMO.Excel.Xlsb.Read {
         private readonly int _length;
         private readonly int _maxRecordBytes;
         private readonly XlsbRecordReadBudget _budget;
+        private readonly bool _consumeRecordBudget;
 
         internal XlsbRecordSliceReader(
             byte[] bytes,
             int maxRecordBytes,
             XlsbRecordReadBudget budget,
-            int? length = null) {
+            int? length = null,
+            bool consumeRecordBudget = true) {
             _bytes = bytes ?? throw new ArgumentNullException(nameof(bytes));
             _length = length ?? bytes.Length;
             if (_length < 0 || _length > bytes.Length) {
@@ -25,10 +27,12 @@ namespace OfficeIMO.Excel.Xlsb.Read {
             }
             _maxRecordBytes = maxRecordBytes;
             _budget = budget ?? throw new ArgumentNullException(nameof(budget));
+            _consumeRecordBudget = consumeRecordBudget;
         }
 
         internal int Position { get; set; }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal bool TryRead(out XlsbRecordSlice record) {
             if (Position == _length) {
                 record = default;
@@ -63,11 +67,14 @@ namespace OfficeIMO.Excel.Xlsb.Read {
 
             int payloadOffset = Position;
             Position += size;
-            _budget.Consume();
+            if (_consumeRecordBudget) {
+                _budget.Consume();
+            }
             record = new XlsbRecordSlice(_bytes, recordOffset, type, payloadOffset, size);
             return true;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private int ReadVariableLengthValue() {
             int value = 0;
             for (int index = 0; index < 4; index++) {
@@ -81,6 +88,7 @@ namespace OfficeIMO.Excel.Xlsb.Read {
             throw new InvalidDataException("The BIFF12 record size header is invalid.");
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private int ReadRequiredByte(string fieldName) {
             if (Position >= _length) {
                 throw new EndOfStreamException($"The BIFF12 stream ended inside the {fieldName} header.");
@@ -324,6 +332,7 @@ namespace OfficeIMO.Excel.Xlsb.Read {
                 | (_bytes[offset + 3] << 24));
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal int ReadInt32() => unchecked((int)ReadUInt32());
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/OfficeIMO.Excel/Xlsb/Read/XlsbTabularDataReader.Discovery.cs
+++ b/OfficeIMO.Excel/Xlsb/Read/XlsbTabularDataReader.Discovery.cs
@@ -26,12 +26,9 @@ namespace OfficeIMO.Excel.Xlsb.Read {
             lastDataRow = -1;
             int currentRow = -1;
             int previousCellColumn = -1;
-            var scanner = new XlsbRecordSliceReader(
-                worksheetPart.Buffer,
-                limits.MaxRecordBytes,
-                recordBudget,
-                worksheetPart.DataLength,
-                consumeRecordBudget: false);
+            byte[] bytes = worksheetPart.Buffer;
+            int dataLength = worksheetPart.DataLength;
+            int position = 0;
             {
                 bool inSheetData = false;
                 bool sawBeginSheetData = false;
@@ -45,22 +42,77 @@ namespace OfficeIMO.Excel.Xlsb.Read {
                 var currentRowSpanBounds = new int[32];
                 int currentRowSpanCount = 0;
                 cancellationToken.ThrowIfCancellationRequested();
-                while (scanner.TryRead(out XlsbRecordSlice record)) {
+                // Discovery is the full-buffer validation pass. Fuse BIFF12 framing with the
+                // common fixed-cell checks so large worksheets are validated once without a
+                // method dispatch and record-object path for every cell.
+                while (position < dataLength) {
+                    int recordOffset = position;
+                    int firstTypeByte = bytes[position++];
+                    int recordType = firstTypeByte & 0x7F;
+                    if ((firstTypeByte & 0x80) != 0) {
+                        if (position == dataLength) {
+                            throw new EndOfStreamException(
+                                "The BIFF12 stream ended inside the record type header.");
+                        }
+                        int secondTypeByte = bytes[position++];
+                        recordType |= (secondTypeByte & 0x7F) << 7;
+                        if (recordType < 128) {
+                            throw new InvalidDataException(
+                                "The BIFF12 record type uses a non-canonical two-byte encoding.");
+                        }
+                    }
+
+                    if (position == dataLength) {
+                        throw new EndOfStreamException(
+                            "The BIFF12 stream ended inside the record size header.");
+                    }
+                    int sizeByte = bytes[position++];
+                    int recordSize = sizeByte & 0x7F;
+                    if ((sizeByte & 0x80) != 0) {
+                        bool complete = false;
+                        for (int sizeIndex = 1; sizeIndex < 4; sizeIndex++) {
+                            if (position == dataLength) {
+                                throw new EndOfStreamException(
+                                    "The BIFF12 stream ended inside the record size header.");
+                            }
+                            sizeByte = bytes[position++];
+                            recordSize |= (sizeByte & 0x7F) << (sizeIndex * 7);
+                            if ((sizeByte & 0x80) == 0) {
+                                complete = true;
+                                break;
+                            }
+                        }
+                        if (!complete) {
+                            throw new InvalidDataException(
+                                "The BIFF12 record size header is invalid.");
+                        }
+                    }
+                    if (recordSize > limits.MaxRecordBytes) {
+                        throw new InvalidDataException(
+                            $"The BIFF12 record at offset {recordOffset} declares {recordSize} payload bytes, exceeding the configured limit of {limits.MaxRecordBytes} bytes.");
+                    }
+                    if (recordSize > dataLength - position) {
+                        throw new EndOfStreamException(
+                            $"The BIFF12 record at offset {recordOffset} declares {recordSize} payload bytes but only {dataLength - position} remain.");
+                    }
+                    int payloadOffset = position;
+                    position += recordSize;
+
                     pendingRecordBudget++;
                     if (pendingRecordBudget == DiscoveryBudgetBatchSize) {
                         recordBudget.Consume(pendingRecordBudget);
                         pendingRecordBudget = 0;
                     }
                     if (firstRecordType < 0) {
-                        firstRecordType = record.Type;
+                        firstRecordType = recordType;
                     }
-                    lastRecordType = record.Type;
+                    lastRecordType = recordType;
                     recordsSinceCancellationCheck++;
                     if ((recordsSinceCancellationCheck & 1023) == 0) {
                         cancellationToken.ThrowIfCancellationRequested();
                     }
 
-                    if (record.Type == BrtWsDim) {
+                    if (recordType == BrtWsDim) {
                         if (sawDimension) {
                             throw new InvalidDataException(
                                 "The XLSB worksheet contains more than one BrtWsDim record.");
@@ -70,11 +122,19 @@ namespace OfficeIMO.Excel.Xlsb.Read {
                                 "The XLSB worksheet contains a misplaced BrtWsDim record.");
                         }
 
-                        ReadWorksheetDimension(record, out _, out _);
+                        ReadWorksheetDimension(
+                            new XlsbRecordSlice(
+                                bytes,
+                                recordOffset,
+                                recordType,
+                                payloadOffset,
+                                recordSize),
+                            out _,
+                            out _);
                         sawDimension = true;
                         continue;
                     }
-                    if (record.Type == BrtBeginSheetData) {
+                    if (recordType == BrtBeginSheetData) {
                         if (sawBeginSheetData) {
                             throw new InvalidDataException(
                                 "The XLSB worksheet contains duplicate or nested BrtBeginSheetData records.");
@@ -88,7 +148,7 @@ namespace OfficeIMO.Excel.Xlsb.Read {
                         inSheetData = true;
                         continue;
                     }
-                    if (record.Type == BrtEndSheetData) {
+                    if (recordType == BrtEndSheetData) {
                         if (!inSheetData) {
                             throw new InvalidDataException(
                                 "The XLSB worksheet contains BrtEndSheetData without a matching BrtBeginSheetData record.");
@@ -100,16 +160,21 @@ namespace OfficeIMO.Excel.Xlsb.Read {
                         continue;
                     }
                     if (!inSheetData) {
-                        if (record.Type == BrtRowHdr || IsCellRecord(record.Type)) {
+                        if (recordType == BrtRowHdr || IsCellRecord(recordType)) {
                             throw new InvalidDataException(
-                                $"The XLSB row or cell record at offset {record.RecordOffset} appears outside BrtBeginSheetData/BrtEndSheetData.");
+                                $"The XLSB row or cell record at offset {recordOffset} appears outside BrtBeginSheetData/BrtEndSheetData.");
                         }
 
                         continue;
                     }
-                    if (record.Type == BrtRowHdr) {
+                    if (recordType == BrtRowHdr) {
                         int nextRow = ValidateRowHeader(
-                            record,
+                            new XlsbRecordSlice(
+                                bytes,
+                                recordOffset,
+                                recordType,
+                                payloadOffset,
+                                recordSize),
                             currentRowSpanBounds,
                             out currentRowSpanCount);
                         if (currentRow >= 0 && nextRow <= currentRow) {
@@ -121,12 +186,12 @@ namespace OfficeIMO.Excel.Xlsb.Read {
                         previousCellColumn = -1;
                         continue;
                     }
-                    if (!IsCellRecord(record.Type)) {
+                    if (!IsCellRecord(recordType)) {
                         continue;
                     }
                     if (currentRow < 0) {
                         throw new InvalidDataException(
-                            $"The XLSB cell record at offset {record.RecordOffset} appears before a row header.");
+                            $"The XLSB cell record at offset {recordOffset} appears before a row header.");
                     }
 
                     pendingCellBudget++;
@@ -135,24 +200,74 @@ namespace OfficeIMO.Excel.Xlsb.Read {
                         pendingCellBudget = 0;
                     }
                     if (!useCachedFormulaResult) {
-                        EnsureFormulaModeSupported(record.Type, useCachedFormulaResult);
+                        EnsureFormulaModeSupported(recordType, useCachedFormulaResult);
                     }
                     if (firstDataRow < 0) {
                         firstDataRow = currentRow;
                     }
                     lastDataRow = currentRow;
-                    int column = ValidateCellPayloadStructure(
-                        record,
-                        styleCount,
-                        sharedStringCount,
-                        limits.MaxStringCharacters);
+                    int column;
+                    if (recordSize >= sizeof(int) + sizeof(uint)
+                        && recordType is >= BrtCellBlank and <= BrtCellIsst) {
+                        column = BinaryPrimitives.ReadInt32LittleEndian(
+                            bytes.AsSpan(payloadOffset, sizeof(int)));
+                        uint styleIndex = BinaryPrimitives.ReadUInt32LittleEndian(
+                            bytes.AsSpan(payloadOffset + sizeof(int), sizeof(uint))) & 0x00FFFFFFU;
+                        if (styleIndex >= styleCount) {
+                            throw new InvalidDataException(
+                                $"The XLSB cell record at offset {recordOffset} refers to missing cell format " +
+                                $"{styleIndex}; the styles part exposes {styleCount} format(s).");
+                        }
+
+                        int valueBytes = recordSize - sizeof(int) - sizeof(uint);
+                        bool validFixedPayload = recordType switch {
+                            BrtCellBlank => true,
+                            BrtCellRk => valueBytes >= sizeof(uint),
+                            BrtCellError or BrtCellBool => valueBytes >= sizeof(byte),
+                            BrtCellReal => valueBytes >= sizeof(double),
+                            BrtCellIsst => valueBytes >= sizeof(uint),
+                            _ => false
+                        };
+                        if (validFixedPayload && recordType == BrtCellIsst) {
+                            uint sharedStringIndex = BinaryPrimitives.ReadUInt32LittleEndian(
+                                bytes.AsSpan(payloadOffset + sizeof(int) + sizeof(uint), sizeof(uint)));
+                            if (sharedStringIndex >= sharedStringCount) {
+                                throw new InvalidDataException(
+                                    $"The XLSB cell record at offset {recordOffset} refers to missing shared string " +
+                                    $"{sharedStringIndex}; the shared-string part exposes {sharedStringCount} item(s).");
+                            }
+                        }
+                        if (!validFixedPayload) {
+                            column = ValidateCellPayloadStructure(
+                                new XlsbRecordSlice(
+                                    bytes,
+                                    recordOffset,
+                                    recordType,
+                                    payloadOffset,
+                                    recordSize),
+                                styleCount,
+                                sharedStringCount,
+                                limits.MaxStringCharacters);
+                        }
+                    } else {
+                        column = ValidateCellPayloadStructure(
+                            new XlsbRecordSlice(
+                                bytes,
+                                recordOffset,
+                                recordType,
+                                payloadOffset,
+                                recordSize),
+                            styleCount,
+                            sharedStringCount,
+                            limits.MaxStringCharacters);
+                    }
                     if (column < 0 || column >= A1.MaxColumns) {
                         throw new InvalidDataException(
-                            $"The XLSB cell record at offset {record.RecordOffset} contains invalid column index {column}.");
+                            $"The XLSB cell record at offset {recordOffset} contains invalid column index {column}.");
                     }
                     if (column <= previousCellColumn) {
                         throw new InvalidDataException(
-                            $"The XLSB cell record at offset {record.RecordOffset} is duplicated or out of order within its row.");
+                            $"The XLSB cell record at offset {recordOffset} is duplicated or out of order within its row.");
                     }
                     previousCellColumn = column;
                     bool covered = currentRowSpanCount == 1
@@ -160,11 +275,15 @@ namespace OfficeIMO.Excel.Xlsb.Read {
                         : IsCoveredByRowSpan(currentRowSpanBounds, currentRowSpanCount, column);
                     if (!covered) {
                         throw new InvalidDataException(
-                            $"The XLSB cell record at offset {record.RecordOffset} for column {column} is not covered by its BrtRowHdr column spans.");
+                            $"The XLSB cell record at offset {recordOffset} for column {column} is not covered by its BrtRowHdr column spans.");
                     }
 
-                    firstColumn = Math.Min(firstColumn, column);
-                    lastColumn = Math.Max(lastColumn, column);
+                    if (column < firstColumn) {
+                        firstColumn = column;
+                    }
+                    if (column > lastColumn) {
+                        lastColumn = column;
+                    }
                 }
 
                 cancellationToken.ThrowIfCancellationRequested();

--- a/OfficeIMO.Excel/Xlsb/Read/XlsbTabularDataReader.Discovery.cs
+++ b/OfficeIMO.Excel/Xlsb/Read/XlsbTabularDataReader.Discovery.cs
@@ -1,10 +1,14 @@
 using OfficeIMO.Excel.Xlsb.Biff12;
+using OfficeIMO.Excel.Xlsb.Package;
+using System.Buffers.Binary;
 using System.Threading;
 
 namespace OfficeIMO.Excel.Xlsb.Read {
     internal sealed partial class XlsbTabularDataReader {
+        private const int DiscoveryBudgetBatchSize = 1024;
+
         private static void DiscoverDataColumns(
-            Stream worksheetPart,
+            XlsbPooledPartStream worksheetPart,
             XlsbImportOptions limits,
             XlsbRecordReadBudget recordBudget,
             XlsbCellReadBudget cellBudget,
@@ -16,24 +20,19 @@ namespace OfficeIMO.Excel.Xlsb.Read {
             out int lastColumn,
             out int firstDataRow,
             out int lastDataRow) {
-            if (!worksheetPart.CanSeek) {
-                throw new InvalidOperationException(
-                    "XLSB reads require a seekable worksheet part for schema discovery.");
-            }
-
             firstColumn = int.MaxValue;
             lastColumn = -1;
             firstDataRow = -1;
             lastDataRow = -1;
             int currentRow = -1;
             int previousCellColumn = -1;
-            long startPosition = worksheetPart.Position;
-            try {
-                using var scanner = new XlsbStreamRecordSliceReader(
-                    worksheetPart,
-                    limits.MaxRecordBytes,
-                    recordBudget,
-                    leaveOpen: true);
+            var scanner = new XlsbRecordSliceReader(
+                worksheetPart.Buffer,
+                limits.MaxRecordBytes,
+                recordBudget,
+                worksheetPart.DataLength,
+                consumeRecordBudget: false);
+            {
                 bool inSheetData = false;
                 bool sawBeginSheetData = false;
                 bool sawEndSheetData = false;
@@ -41,10 +40,17 @@ namespace OfficeIMO.Excel.Xlsb.Read {
                 int firstRecordType = -1;
                 int lastRecordType = -1;
                 int recordsSinceCancellationCheck = 0;
+                int pendingRecordBudget = 0;
+                int pendingCellBudget = 0;
                 var currentRowSpanBounds = new int[32];
                 int currentRowSpanCount = 0;
                 cancellationToken.ThrowIfCancellationRequested();
                 while (scanner.TryRead(out XlsbRecordSlice record)) {
+                    pendingRecordBudget++;
+                    if (pendingRecordBudget == DiscoveryBudgetBatchSize) {
+                        recordBudget.Consume(pendingRecordBudget);
+                        pendingRecordBudget = 0;
+                    }
                     if (firstRecordType < 0) {
                         firstRecordType = record.Type;
                     }
@@ -123,10 +129,14 @@ namespace OfficeIMO.Excel.Xlsb.Read {
                             $"The XLSB cell record at offset {record.RecordOffset} appears before a row header.");
                     }
 
-                    cellBudget.Consume();
-                    EnsureFormulaModeSupported(
-                        record.Type,
-                        useCachedFormulaResult);
+                    pendingCellBudget++;
+                    if (pendingCellBudget == DiscoveryBudgetBatchSize) {
+                        cellBudget.Consume(pendingCellBudget);
+                        pendingCellBudget = 0;
+                    }
+                    if (!useCachedFormulaResult) {
+                        EnsureFormulaModeSupported(record.Type, useCachedFormulaResult);
+                    }
                     if (firstDataRow < 0) {
                         firstDataRow = currentRow;
                     }
@@ -145,15 +155,9 @@ namespace OfficeIMO.Excel.Xlsb.Read {
                             $"The XLSB cell record at offset {record.RecordOffset} is duplicated or out of order within its row.");
                     }
                     previousCellColumn = column;
-                    bool covered = false;
-                    for (int index = 0; index < currentRowSpanCount; index++) {
-                        int offset = index * 2;
-                        if (currentRowSpanBounds[offset] <= column
-                            && column <= currentRowSpanBounds[offset + 1]) {
-                            covered = true;
-                            break;
-                        }
-                    }
+                    bool covered = currentRowSpanCount == 1
+                        ? currentRowSpanBounds[0] <= column && column <= currentRowSpanBounds[1]
+                        : IsCoveredByRowSpan(currentRowSpanBounds, currentRowSpanCount, column);
                     if (!covered) {
                         throw new InvalidDataException(
                             $"The XLSB cell record at offset {record.RecordOffset} for column {column} is not covered by its BrtRowHdr column spans.");
@@ -164,6 +168,8 @@ namespace OfficeIMO.Excel.Xlsb.Read {
                 }
 
                 cancellationToken.ThrowIfCancellationRequested();
+                recordBudget.Consume(pendingRecordBudget);
+                cellBudget.Consume(pendingCellBudget);
                 if (firstRecordType != BrtBeginSheet
                     || lastRecordType != BrtEndSheet) {
                     throw new InvalidDataException(
@@ -181,9 +187,17 @@ namespace OfficeIMO.Excel.Xlsb.Read {
                     throw new InvalidDataException(
                         "The XLSB worksheet ended before the required BrtEndSheetData record.");
                 }
-            } finally {
-                worksheetPart.Position = startPosition;
             }
+        }
+
+        private static bool IsCoveredByRowSpan(int[] spanBounds, int spanCount, int column) {
+            for (int index = 0; index < spanCount; index++) {
+                int offset = index * 2;
+                if (spanBounds[offset] <= column && column <= spanBounds[offset + 1]) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         private static void ReadWorksheetDimension(
@@ -217,6 +231,53 @@ namespace OfficeIMO.Excel.Xlsb.Read {
             int styleCount,
             int sharedStringCount,
             int maxStringCharacters) {
+            if (record.Size >= sizeof(int) + sizeof(uint)) {
+                byte[] bytes = record.Bytes;
+                int position = record.PayloadOffset;
+                int column = BinaryPrimitives.ReadInt32LittleEndian(
+                    bytes.AsSpan(position, sizeof(int)));
+                uint styleIndex = BinaryPrimitives.ReadUInt32LittleEndian(
+                    bytes.AsSpan(position + sizeof(int), sizeof(uint))) & 0x00FFFFFFU;
+                if (styleIndex >= styleCount) {
+                    throw new InvalidDataException(
+                        $"The XLSB cell record at offset {record.RecordOffset} refers to missing cell format " +
+                        $"{styleIndex}; the styles part exposes {styleCount} format(s).");
+                }
+
+                int valuePosition = position + sizeof(int) + sizeof(uint);
+                int valueBytes = record.Size - sizeof(int) - sizeof(uint);
+                switch (record.Type) {
+                    case BrtCellBlank:
+                        return column;
+                    case BrtCellRk:
+                    case BrtCellIsst:
+                        if (valueBytes >= sizeof(uint)) {
+                            if (record.Type == BrtCellIsst) {
+                                uint sharedStringIndex = BinaryPrimitives.ReadUInt32LittleEndian(
+                                    bytes.AsSpan(valuePosition, sizeof(uint)));
+                                if (sharedStringIndex >= sharedStringCount) {
+                                    throw new InvalidDataException(
+                                        $"The XLSB cell record at offset {record.RecordOffset} refers to missing shared string " +
+                                        $"{sharedStringIndex}; the shared-string part exposes {sharedStringCount} item(s).");
+                                }
+                            }
+                            return column;
+                        }
+                        break;
+                    case BrtCellError:
+                    case BrtCellBool:
+                        if (valueBytes >= sizeof(byte)) {
+                            return column;
+                        }
+                        break;
+                    case BrtCellReal:
+                        if (valueBytes >= sizeof(double)) {
+                            return column;
+                        }
+                        break;
+                }
+            }
+
             try {
                 var cursor = record.CreateCursor();
                 int column = cursor.ReadInt32();

--- a/OfficeIMO.Excel/Xlsb/Read/XlsbTabularDataReader.FastCells.cs
+++ b/OfficeIMO.Excel/Xlsb/Read/XlsbTabularDataReader.FastCells.cs
@@ -1,11 +1,16 @@
 using OfficeIMO.Excel.LegacyXls.Biff;
+using System.Buffers.Binary;
+using System.Text;
 
 namespace OfficeIMO.Excel.Xlsb.Read {
     internal sealed partial class XlsbTabularDataReader {
         private void StoreCellFast(XlsbRecordSlice record) {
-            var cursor = record.CreateCursor();
-            int column = cursor.ReadInt32();
-            uint styleIndex = cursor.ReadUInt32() & 0x00FFFFFFU;
+            byte[] bytes = record.Bytes;
+            int position = record.PayloadOffset;
+            int column = BinaryPrimitives.ReadInt32LittleEndian(bytes.AsSpan(position, sizeof(int)));
+            uint styleIndex = BinaryPrimitives.ReadUInt32LittleEndian(bytes.AsSpan(position + sizeof(int), sizeof(uint)))
+                & 0x00FFFFFFU;
+            position += sizeof(int) + sizeof(uint);
 
             int ordinal = column - _firstColumn;
             if (ordinal < 0 || ordinal >= FieldCount) {
@@ -18,52 +23,73 @@ namespace OfficeIMO.Excel.Xlsb.Read {
                     _kinds[ordinal] = XlsbTabularValueKind.Empty;
                     break;
                 case BrtCellRk:
-                    StoreNumber(ordinal, BiffRkNumberReader.ReadRkNumber(cursor.ReadUInt32()), styleIndex);
+                    StoreNumber(
+                        ordinal,
+                        BiffRkNumberReader.ReadRkNumber(
+                            BinaryPrimitives.ReadUInt32LittleEndian(bytes.AsSpan(position, sizeof(uint)))),
+                        styleIndex);
                     break;
                 case BrtCellError:
                     _kinds[ordinal] = XlsbTabularValueKind.Error;
-                    _strings[ordinal] = BiffErrorValue.ToText(cursor.ReadByte());
+                    _strings[ordinal] = BiffErrorValue.ToText(bytes[position]);
                     break;
                 case BrtCellBool:
                     _kinds[ordinal] = XlsbTabularValueKind.Boolean;
-                    _booleans[ordinal] = cursor.ReadByte() != 0;
+                    _booleans[ordinal] = bytes[position] != 0;
                     break;
                 case BrtCellReal:
-                    StoreNumber(ordinal, cursor.ReadDouble(), styleIndex);
+                    StoreNumber(
+                        ordinal,
+                        BitConverter.Int64BitsToDouble(
+                            BinaryPrimitives.ReadInt64LittleEndian(bytes.AsSpan(position, sizeof(long)))),
+                        styleIndex);
                     break;
                 case BrtCellSt:
                     _kinds[ordinal] = XlsbTabularValueKind.Text;
-                    _strings[ordinal] = cursor.ReadWideString(_limits.MaxStringCharacters);
+                    _strings[ordinal] = ReadValidatedWideString(bytes, position);
                     break;
                 case BrtCellIsst: {
-                    uint sharedStringIndex = cursor.ReadUInt32();
+                    uint sharedStringIndex = BinaryPrimitives.ReadUInt32LittleEndian(
+                        bytes.AsSpan(position, sizeof(uint)));
                     _kinds[ordinal] = XlsbTabularValueKind.Text;
                     _strings[ordinal] = _sharedStrings[checked((int)sharedStringIndex)];
                     break;
                 }
                 case BrtCellRString:
-                    cursor.ReadByte();
                     _kinds[ordinal] = XlsbTabularValueKind.Text;
-                    _strings[ordinal] = cursor.ReadWideString(_limits.MaxStringCharacters);
+                    _strings[ordinal] = ReadValidatedWideString(bytes, position + 1);
                     break;
                 case BrtFmlaString:
                     _kinds[ordinal] = XlsbTabularValueKind.Text;
-                    _strings[ordinal] = cursor.ReadWideString(_limits.MaxStringCharacters);
+                    _strings[ordinal] = ReadValidatedWideString(bytes, position);
                     break;
                 case BrtFmlaNum:
-                    StoreNumber(ordinal, cursor.ReadDouble(), styleIndex);
+                    StoreNumber(
+                        ordinal,
+                        BitConverter.Int64BitsToDouble(
+                            BinaryPrimitives.ReadInt64LittleEndian(bytes.AsSpan(position, sizeof(long)))),
+                        styleIndex);
                     break;
                 case BrtFmlaBool:
                     _kinds[ordinal] = XlsbTabularValueKind.Boolean;
-                    _booleans[ordinal] = cursor.ReadByte() != 0;
+                    _booleans[ordinal] = bytes[position] != 0;
                     break;
                 case BrtFmlaError:
                     _kinds[ordinal] = XlsbTabularValueKind.Error;
-                    _strings[ordinal] = BiffErrorValue.ToText(cursor.ReadByte());
+                    _strings[ordinal] = BiffErrorValue.ToText(bytes[position]);
                     break;
                 default:
                     throw new InvalidOperationException($"Unsupported XLSB cell record type {record.Type}.");
             }
+        }
+
+        private static string ReadValidatedWideString(byte[] bytes, int position) {
+            int characterCount = checked((int)BinaryPrimitives.ReadUInt32LittleEndian(
+                bytes.AsSpan(position, sizeof(uint))));
+            return Encoding.Unicode.GetString(
+                bytes,
+                position + sizeof(uint),
+                checked(characterCount * sizeof(char)));
         }
 
         private void StoreNumber(int ordinal, double number, uint styleIndex) {

--- a/OfficeIMO.Excel/Xlsb/Read/XlsbTabularDataReader.PooledPart.cs
+++ b/OfficeIMO.Excel/Xlsb/Read/XlsbTabularDataReader.PooledPart.cs
@@ -1,0 +1,49 @@
+using OfficeIMO.Excel.Xlsb.Package;
+using System.Buffers;
+using System.Threading;
+
+namespace OfficeIMO.Excel.Xlsb.Read {
+    internal sealed partial class XlsbTabularDataReader {
+        private static XlsbPooledPartStream CreatePooledPart(
+            Stream worksheetPart,
+            XlsbImportOptions limits,
+            CancellationToken cancellationToken) {
+            if (worksheetPart == null) {
+                throw new ArgumentNullException(nameof(worksheetPart));
+            }
+            try {
+                if (!worksheetPart.CanRead || !worksheetPart.CanSeek) {
+                    throw new InvalidOperationException(
+                        "XLSB reads require a readable, seekable worksheet part.");
+                }
+                long remaining = worksheetPart.Length - worksheetPart.Position;
+                if (remaining < 0 || remaining > limits.MaxPartBytes || remaining > int.MaxValue) {
+                    throw new InvalidDataException(
+                        $"The XLSB worksheet part contains {remaining} bytes, exceeding the configured limit of {limits.MaxPartBytes} bytes.");
+                }
+                int length = checked((int)remaining);
+                byte[] buffer = ArrayPool<byte>.Shared.Rent(Math.Max(1, length));
+                try {
+                    int offset = 0;
+                    while (offset < length) {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        int read = worksheetPart.Read(buffer, offset, length - offset);
+                        if (read == 0) {
+                            throw new EndOfStreamException(
+                                $"The XLSB worksheet part ended after {offset} of {length} declared bytes.");
+                        }
+                        offset += read;
+                    }
+                    cancellationToken.ThrowIfCancellationRequested();
+                    return new XlsbPooledPartStream(buffer, length, worksheetPart);
+                } catch {
+                    ArrayPool<byte>.Shared.Return(buffer, clearArray: true);
+                    throw;
+                }
+            } catch {
+                worksheetPart.Dispose();
+                throw;
+            }
+        }
+    }
+}

--- a/OfficeIMO.Excel/Xlsb/Read/XlsbTabularDataReader.Rows.cs
+++ b/OfficeIMO.Excel/Xlsb/Read/XlsbTabularDataReader.Rows.cs
@@ -1,0 +1,49 @@
+namespace OfficeIMO.Excel.Xlsb.Read {
+    internal sealed partial class XlsbTabularDataReader {
+        private bool ReadCurrentRowRecordsFast() {
+            bool checkCancellation = _cancellationToken.CanBeCanceled;
+            while (_records.TryRead(out XlsbRecordSlice record)) {
+                if (checkCancellation) {
+                    CheckCancellation();
+                }
+                if (record.Type == BrtRowHdr) {
+                    if (TrySetPendingRow(record)) {
+                        return true;
+                    }
+                    continue;
+                }
+                if (record.Type == BrtEndSheetData) {
+                    _reachedEndSheetData = true;
+                    return true;
+                }
+                if (IsCellRecord(record.Type)) {
+                    StoreCellFast(record);
+                }
+            }
+            return false;
+        }
+
+        private bool ReadCurrentRowRecordsConverted() {
+            bool checkCancellation = _cancellationToken.CanBeCanceled;
+            while (_records.TryRead(out XlsbRecordSlice record)) {
+                if (checkCancellation) {
+                    CheckCancellation();
+                }
+                if (record.Type == BrtRowHdr) {
+                    if (TrySetPendingRow(record)) {
+                        return true;
+                    }
+                    continue;
+                }
+                if (record.Type == BrtEndSheetData) {
+                    _reachedEndSheetData = true;
+                    return true;
+                }
+                if (IsCellRecord(record.Type)) {
+                    StoreCell(record);
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/OfficeIMO.Excel/Xlsb/Read/XlsbTabularDataReader.Values.cs
+++ b/OfficeIMO.Excel/Xlsb/Read/XlsbTabularDataReader.Values.cs
@@ -184,20 +184,7 @@ namespace OfficeIMO.Excel.Xlsb.Read {
         public override IEnumerator GetEnumerator() => new DbEnumerator(this, closeReader: false);
 
         [UnconditionalSuppressMessage("Trimming", "IL2111", Justification = "The schema table stores Type values as data and does not reflect over Type.TypeInitializer or other Type members.")]
-        public override DataTable GetSchemaTable() {
-            var table = new DataTable("SchemaTable");
-            table.Columns.Add("ColumnName", typeof(string));
-            table.Columns.Add("ColumnOrdinal", typeof(int));
-            table.Columns.Add("DataType", typeof(Type));
-            for (int ordinal = 0; ordinal < FieldCount; ordinal++) {
-                DataRow row = table.NewRow();
-                row["ColumnName"] = GetName(ordinal);
-                row["ColumnOrdinal"] = ordinal;
-                row["DataType"] = GetFieldType(ordinal);
-                table.Rows.Add(row);
-            }
-
-            return table;
-        }
+        public override DataTable GetSchemaTable() =>
+            ExcelDataReaderSchemaTable.Create(FieldCount, GetName, GetFieldType);
     }
 }

--- a/OfficeIMO.Excel/Xlsb/Read/XlsbTabularDataReader.cs
+++ b/OfficeIMO.Excel/Xlsb/Read/XlsbTabularDataReader.cs
@@ -1,6 +1,7 @@
 using OfficeIMO.Excel.LegacyXls.Biff;
 using OfficeIMO.Excel.LegacyXls.Projection;
 using OfficeIMO.Excel.Xlsb.Biff12;
+using OfficeIMO.Excel.Xlsb.Package;
 using DocumentFormat.OpenXml.Spreadsheet;
 using System.Data.Common;
 using System.Globalization;
@@ -31,7 +32,8 @@ namespace OfficeIMO.Excel.Xlsb.Read {
         private const int BrtEndSheetData = 146;
         private const int BrtWsDim = 148;
 
-        private readonly XlsbStreamRecordSliceReader _records;
+        private readonly XlsbRecordSliceReader _records;
+        private readonly XlsbPooledPartStream _worksheetPart;
         private readonly IReadOnlyList<string> _sharedStrings;
         private readonly bool[] _dateStyles;
         private readonly bool _uses1904DateSystem;
@@ -58,6 +60,30 @@ namespace OfficeIMO.Excel.Xlsb.Read {
 
         internal XlsbTabularDataReader(
             Stream worksheetPart,
+            IReadOnlyList<string> sharedStrings,
+            bool[] dateStyles,
+            bool uses1904DateSystem,
+            bool hasHeaderRow,
+            ExcelReadOptions options,
+            XlsbImportOptions limits,
+            XlsbRecordReadBudget recordBudget,
+            XlsbCellReadBudget cellBudget,
+            CancellationToken cancellationToken)
+            : this(
+                CreatePooledPart(worksheetPart, limits, cancellationToken),
+                sharedStrings,
+                dateStyles,
+                uses1904DateSystem,
+                hasHeaderRow,
+                options,
+                limits,
+                recordBudget,
+                cellBudget,
+                cancellationToken) {
+        }
+
+        internal XlsbTabularDataReader(
+            XlsbPooledPartStream worksheetPart,
             IReadOnlyList<string> sharedStrings,
             bool[] dateStyles,
             bool uses1904DateSystem,
@@ -105,12 +131,14 @@ namespace OfficeIMO.Excel.Xlsb.Read {
 
             // Discovery validates the complete immutable worksheet before the reader is exposed.
             // The delivery pass can therefore decode it without repeating those same checks.
-            var records = new XlsbStreamRecordSliceReader(
-                worksheetPart ?? throw new ArgumentNullException(nameof(worksheetPart)),
+            var records = new XlsbRecordSliceReader(
+                worksheetPart.Buffer,
                 limits.MaxRecordBytes,
                 recordBudget ?? throw new ArgumentNullException(nameof(recordBudget)),
+                worksheetPart.DataLength,
                 consumeRecordBudget: false);
             _records = records;
+            _worksheetPart = worksheetPart;
             _lastDataRow = actualLastDataRow;
             try {
                 FindSheetData(
@@ -189,7 +217,7 @@ namespace OfficeIMO.Excel.Xlsb.Read {
                     ? BufferSchemaRows()
                     : null;
             } catch {
-                records.Dispose();
+                worksheetPart.Dispose();
                 throw;
             }
         }
@@ -242,51 +270,9 @@ namespace OfficeIMO.Excel.Xlsb.Read {
 
             int currentRowIndex = _pendingRowIndex;
             _hasPendingRow = false;
-            bool reachedRowBoundary = false;
-            if (_cancellationToken.CanBeCanceled) {
-                while (_records.TryRead(out XlsbRecordSlice record)) {
-                    CheckCancellation();
-                    if (record.Type == BrtRowHdr) {
-                        if (TrySetPendingRow(record)) {
-                            reachedRowBoundary = true;
-                            break;
-                        }
-
-                        continue;
-                    }
-
-                    if (record.Type == BrtEndSheetData) {
-                        _reachedEndSheetData = true;
-                        reachedRowBoundary = true;
-                        break;
-                    }
-
-                    if (IsCellRecord(record.Type)) {
-                        StoreCell(record);
-                    }
-                }
-            } else {
-                while (_records.TryRead(out XlsbRecordSlice record)) {
-                    if (record.Type == BrtRowHdr) {
-                        if (TrySetPendingRow(record)) {
-                            reachedRowBoundary = true;
-                            break;
-                        }
-
-                        continue;
-                    }
-
-                    if (record.Type == BrtEndSheetData) {
-                        _reachedEndSheetData = true;
-                        reachedRowBoundary = true;
-                        break;
-                    }
-
-                    if (IsCellRecord(record.Type)) {
-                        StoreCell(record);
-                    }
-                }
-            }
+            bool reachedRowBoundary = _options.CellValueConverter == null
+                ? ReadCurrentRowRecordsFast()
+                : ReadCurrentRowRecordsConverted();
 
             if (!reachedRowBoundary) {
                 throw new InvalidDataException(
@@ -311,7 +297,7 @@ namespace OfficeIMO.Excel.Xlsb.Read {
             }
 
             _closed = true;
-            _records.Dispose();
+            _worksheetPart.Dispose();
             _schemaRows?.Clear();
         }
 

--- a/OfficeIMO.Excel/Xlsb/Read/XlsbTabularWorkbook.cs
+++ b/OfficeIMO.Excel/Xlsb/Read/XlsbTabularWorkbook.cs
@@ -194,7 +194,7 @@ namespace OfficeIMO.Excel.Xlsb.Read {
                 throw new KeyNotFoundException($"Table '{tableName}' was not found.");
             }
 
-            Stream part = _parts.ReadSeekablePart(sheet.PartName, cancellationToken);
+            XlsbPooledPartStream part = _parts.ReadSeekablePart(sheet.PartName, cancellationToken);
             try {
                 return new XlsbTabularDataReader(
                     part,

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.OleObjects.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.OleObjects.cs
@@ -413,7 +413,7 @@ namespace OfficeIMO.Tests {
                 new MemoryStream(oversizedLogical, writable: false),
                 "Package"));
 
-            Assert.Contains("Compound stream bytes exceed",
+            Assert.Contains("exceeds physical bounds",
                 addException.Message, StringComparison.OrdinalIgnoreCase);
             Assert.Empty(slide.OleObjects);
             using var original = new MemoryStream(valid, writable: false);
@@ -422,7 +422,7 @@ namespace OfficeIMO.Tests {
             InvalidDataException updateException = Assert.Throws<
                 InvalidDataException>(() => ole.UpdateData(
                 new MemoryStream(oversizedLogical, writable: false)));
-            Assert.Contains("Compound stream bytes exceed",
+            Assert.Contains("exceeds physical bounds",
                 updateException.Message, StringComparison.OrdinalIgnoreCase);
             Assert.Equal(valid, ole.GetData());
         }

--- a/OfficeIMO.Shared.Tests/PackageDependencyGuardrails.cs
+++ b/OfficeIMO.Shared.Tests/PackageDependencyGuardrails.cs
@@ -547,6 +547,7 @@ public sealed class PackageDependencyGuardrailTests {
                 "OfficeIMO.SharedSource/Compound/OfficeCompoundFileReader.cs",
                 "OfficeIMO.SharedSource/Compound/OfficeCompoundFileReader.Inspection.cs",
                 "OfficeIMO.SharedSource/Compound/OfficeCompoundFileReader.Selective.cs",
+                "OfficeIMO.SharedSource/Compound/OfficeCompoundFileReader.Stream.cs",
                 "OfficeIMO.SharedSource/Compound/OfficeCompoundFileWriter.cs",
                 "OfficeIMO.SharedSource/Compound/OfficeCompoundWriterLayout.cs",
                 "OfficeIMO.SharedSource/OpenXml/OfficeOpenXmlPackagePayload.cs",

--- a/OfficeIMO.SharedSource/Compound/OfficeCompoundFileReader.Selective.cs
+++ b/OfficeIMO.SharedSource/Compound/OfficeCompoundFileReader.Selective.cs
@@ -70,9 +70,13 @@ namespace OfficeIMO.Drawing.Internal {
                 int miniFatSectorCount = checked((int)ReadUInt32(header, 64));
                 uint firstDifat = ReadUInt32(header, 68);
                 int difatSectorCount = checked((int)ReadUInt32(header, 72));
-                if (fatSectorCount > physicalSectorCount || difatSectorCount > physicalSectorCount) {
-                    throw new InvalidDataException("Compound allocation table counts exceed the file size.");
-                }
+                ValidateAllocationTableCounts(
+                    fatSectorCount,
+                    difatSectorCount,
+                    miniFatSectorCount,
+                    physicalSectorCount,
+                    sectorSize,
+                    options.MaxTotalStreamBytes);
 
                 List<uint> fatSectorIds = ReadFatSectorIds(stream, basePosition, header, sectorSize,
                     physicalSectorCount, firstDifat, difatSectorCount,

--- a/OfficeIMO.SharedSource/Compound/OfficeCompoundFileReader.Selective.cs
+++ b/OfficeIMO.SharedSource/Compound/OfficeCompoundFileReader.Selective.cs
@@ -144,7 +144,7 @@ namespace OfficeIMO.Drawing.Internal {
                             if (destination == null || !destination.CanWrite) {
                                 throw new InvalidDataException("The external compound destination is not writable.");
                             }
-                            CopyEntry(stream, destination, entry, miniCutoff, miniFat, rootChain, basePosition,
+                            CopyEntry(stream, destination, entry, miniCutoff, miniFat, rootChain, root.Size, basePosition,
                                 sectorSize, physicalSectorCount, fatSectorIds,
                                 fatCache, cancellationToken);
                         }
@@ -152,7 +152,7 @@ namespace OfficeIMO.Drawing.Internal {
                         streams[path] = Array.Empty<byte>();
                     } else {
                         using (var destination = new MemoryStream(checked((int)entry.Size))) {
-                            CopyEntry(stream, destination, entry, miniCutoff, miniFat, rootChain, basePosition,
+                            CopyEntry(stream, destination, entry, miniCutoff, miniFat, rootChain, root.Size, basePosition,
                                 sectorSize, physicalSectorCount, fatSectorIds,
                                 fatCache, cancellationToken);
                             streams[path] = destination.ToArray();
@@ -181,14 +181,14 @@ namespace OfficeIMO.Drawing.Internal {
         }
 
         private static void CopyEntry(Stream input, Stream output, DirectoryEntry entry, uint miniCutoff,
-            IReadOnlyList<uint> miniFat, IReadOnlyList<uint> rootChain, long basePosition, int sectorSize,
+            IReadOnlyList<uint> miniFat, IReadOnlyList<uint> rootChain, long rootSize, long basePosition, int sectorSize,
             int physicalSectorCount, IReadOnlyList<uint> fatSectorIds,
             IDictionary<uint, byte[]> fatCache,
             CancellationToken cancellationToken) {
             cancellationToken.ThrowIfCancellationRequested();
             if (entry.Size == 0) return;
             if (entry.Size < miniCutoff) {
-                CopyMiniChain(input, output, entry.StartSector, entry.Size, miniFat, rootChain,
+                CopyMiniChain(input, output, entry.StartSector, entry.Size, miniFat, rootChain, rootSize,
                     basePosition, sectorSize, cancellationToken);
                 return;
             }
@@ -254,7 +254,7 @@ namespace OfficeIMO.Drawing.Internal {
 
         private static void CopyMiniChain(Stream input, Stream output, uint startSector, long size,
             IReadOnlyList<uint> miniFat, IReadOnlyList<uint> rootChain,
-            long basePosition, int sectorSize,
+            long rootSize, long basePosition, int sectorSize,
             CancellationToken cancellationToken) {
             uint miniSector = startSector;
             long remaining = size;
@@ -265,6 +265,10 @@ namespace OfficeIMO.Drawing.Internal {
                     throw new InvalidDataException("Compound mini-sector chain is shorter than its declared size.");
                 }
                 long miniOffset = checked((long)miniSector * MiniSectorSize);
+                int write = checked((int)Math.Min(MiniSectorSize, remaining));
+                if (miniOffset > rootSize - write) {
+                    throw new InvalidDataException("Compound mini-sector points outside the declared root mini stream length.");
+                }
                 int rootSectorIndex = checked((int)(miniOffset / sectorSize));
                 int offsetWithinSector = checked((int)(miniOffset % sectorSize));
                 if (rootSectorIndex >= rootChain.Count || offsetWithinSector + MiniSectorSize > sectorSize) {
@@ -273,8 +277,7 @@ namespace OfficeIMO.Drawing.Internal {
                 long physicalOffset = checked(basePosition + ((long)rootChain[rootSectorIndex] + 1) * sectorSize +
                     offsetWithinSector);
                 byte[] bytes = ReadAt(input, physicalOffset,
-                    MiniSectorSize, cancellationToken);
-                int write = (int)Math.Min(bytes.Length, remaining);
+                    write, cancellationToken);
                 output.Write(bytes, 0, write);
                 remaining -= write;
                 miniSector = miniFat[(int)miniSector];

--- a/OfficeIMO.SharedSource/Compound/OfficeCompoundFileReader.Selective.cs
+++ b/OfficeIMO.SharedSource/Compound/OfficeCompoundFileReader.Selective.cs
@@ -63,6 +63,7 @@ namespace OfficeIMO.Drawing.Internal {
                 }
 
                 int physicalSectorCount = checked((int)((remainingBytes - sectorSize) / sectorSize));
+                long maximumPhysicalStreamBytes = checked((long)physicalSectorCount * sectorSize);
                 int fatSectorCount = checked((int)ReadUInt32(header, 44));
                 uint directoryStart = ReadUInt32(header, 48);
                 uint miniCutoff = ReadUInt32(header, 56);
@@ -88,7 +89,9 @@ namespace OfficeIMO.Drawing.Internal {
                     options.MaxDirectoryEntries, cancellationToken);
                 DirectoryEntry? root = entries.FirstOrDefault(entry => entry.ObjectType == 5);
                 if (root == null) throw new InvalidDataException("Compound file root directory entry is missing.");
-                if (root.Size < 0 || root.Size > options.MaxTotalStreamBytes || root.Size > remainingBytes) {
+                if (root.Size < 0
+                    || root.Size > options.MaxTotalStreamBytes
+                    || root.Size > maximumPhysicalStreamBytes) {
                     throw new InvalidDataException("Compound file mini stream exceeds configured or physical bounds.");
                 }
 
@@ -110,6 +113,7 @@ namespace OfficeIMO.Drawing.Internal {
                         (!isExternal && entry.Size > int.MaxValue)) {
                         throw new InvalidDataException($"Compound stream '{path}' has unsupported size {entry.Size}.");
                     }
+                    ValidateRegularStreamPhysicalBounds(path, entry.Size, miniCutoff, maximumPhysicalStreamBytes);
                     totalStreamBytes = checked(totalStreamBytes + entry.Size);
                     if (totalStreamBytes > options.MaxTotalStreamBytes) {
                         throw new InvalidDataException($"Compound stream bytes exceed {options.MaxTotalStreamBytes}.");

--- a/OfficeIMO.SharedSource/Compound/OfficeCompoundFileReader.Selective.cs
+++ b/OfficeIMO.SharedSource/Compound/OfficeCompoundFileReader.Selective.cs
@@ -229,13 +229,14 @@ namespace OfficeIMO.Drawing.Internal {
             CancellationToken cancellationToken) {
             int required = checked((int)((size + sectorSize - 1) / sectorSize));
             var result = new List<uint>(required);
-            var visited = new HashSet<uint>();
+            var visited = new bool[physicalSectorCount];
             uint sector = startSector;
             while (result.Count < required) {
                 if (sector == EndOfChain || sector == FreeSect || sector >= physicalSectorCount ||
-                    !visited.Add(sector)) {
+                    visited[sector]) {
                     throw new InvalidDataException("Compound mini stream chain is shorter than its declared size.");
                 }
+                visited[sector] = true;
                 result.Add(sector);
                 sector = ReadFatEntry(input, basePosition, sector, sectorSize, physicalSectorCount,
                     fatSectorIds, fatCache, cancellationToken);

--- a/OfficeIMO.SharedSource/Compound/OfficeCompoundFileReader.Stream.cs
+++ b/OfficeIMO.SharedSource/Compound/OfficeCompoundFileReader.Stream.cs
@@ -1,0 +1,394 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+
+namespace OfficeIMO.Drawing.Internal {
+    internal static partial class OfficeCompoundFileReader {
+        /// <summary>
+        /// Opens one compound payload as a bounded seekable view without materializing its bytes.
+        /// The returned stream owns <paramref name="source"/> unless <paramref name="leaveOpen"/> is true.
+        /// </summary>
+        internal static bool TryOpenStream(
+            Stream source,
+            OfficeCompoundReadOptions options,
+            Func<string, long, bool> selector,
+            bool leaveOpen,
+            CancellationToken cancellationToken,
+            out Stream? selectedStream,
+            out string? error) {
+            selectedStream = null;
+            error = null;
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (options == null) throw new ArgumentNullException(nameof(options));
+            if (selector == null) throw new ArgumentNullException(nameof(selector));
+            if (!source.CanRead || !source.CanSeek) {
+                error = "Compound stream views require a readable seekable source.";
+                return false;
+            }
+
+            long originalPosition = source.Position;
+            try {
+                cancellationToken.ThrowIfCancellationRequested();
+                long basePosition = originalPosition;
+                long remainingBytes = checked(source.Length - basePosition);
+                if (remainingBytes < HeaderSize) {
+                    source.Position = originalPosition;
+                    error = "The compound file is shorter than its header.";
+                    return false;
+                }
+                byte[] header = ReadAt(source, basePosition, HeaderSize, cancellationToken);
+                if (!HasSignature(header)) {
+                    source.Position = originalPosition;
+                    error = "The file does not start with the OLE compound document signature.";
+                    return false;
+                }
+
+                ushort majorVersion = ReadUInt16(header, 26);
+                ushort byteOrder = ReadUInt16(header, 28);
+                ushort sectorShift = ReadUInt16(header, 30);
+                ushort miniSectorShift = ReadUInt16(header, 32);
+                if ((sectorShift != 9 && sectorShift != 12) || miniSectorShift != 6) {
+                    throw new InvalidDataException("Unsupported compound file sector sizes.");
+                }
+                int sectorSize = 1 << sectorShift;
+                bool validVersion = (majorVersion == 3 && sectorSize == 512)
+                    || (majorVersion == 4 && sectorSize == 4096);
+                if (!validVersion || byteOrder != 0xfffe || remainingBytes < sectorSize) {
+                    throw new InvalidDataException("Unsupported compound file version or byte order.");
+                }
+
+                int physicalSectorCount = checked((int)((remainingBytes - sectorSize) / sectorSize));
+                int fatSectorCount = checked((int)ReadUInt32(header, 44));
+                uint directoryStart = ReadUInt32(header, 48);
+                uint miniCutoff = ReadUInt32(header, 56);
+                uint miniFatStart = ReadUInt32(header, 60);
+                int miniFatSectorCount = checked((int)ReadUInt32(header, 64));
+                uint firstDifat = ReadUInt32(header, 68);
+                int difatSectorCount = checked((int)ReadUInt32(header, 72));
+                if (fatSectorCount > physicalSectorCount || difatSectorCount > physicalSectorCount) {
+                    throw new InvalidDataException("Compound allocation table counts exceed the file size.");
+                }
+
+                List<uint> fatSectorIds = ReadFatSectorIds(
+                    source,
+                    basePosition,
+                    header,
+                    sectorSize,
+                    physicalSectorCount,
+                    firstDifat,
+                    difatSectorCount,
+                    fatSectorCount,
+                    cancellationToken);
+                byte[] directoryBytes = ReadDirectoryStream(
+                    source,
+                    basePosition,
+                    directoryStart,
+                    sectorSize,
+                    physicalSectorCount,
+                    fatSectorIds,
+                    options.MaxDirectoryEntries,
+                    cancellationToken);
+                List<DirectoryEntry> entries = ReadDirectoryEntries(
+                    directoryBytes,
+                    majorVersion,
+                    options.MaxDirectoryEntries,
+                    cancellationToken);
+                DirectoryEntry? root = entries.FirstOrDefault(static entry => entry.ObjectType == 5);
+                if (root == null) throw new InvalidDataException("Compound file root directory entry is missing.");
+
+                IReadOnlyDictionary<int, string> paths = BuildCompoundEntryPaths(entries, cancellationToken);
+                DirectoryEntry? selected = null;
+                foreach (DirectoryEntry entry in entries) {
+                    if (entry.ObjectType != 2) continue;
+                    cancellationToken.ThrowIfCancellationRequested();
+                    string path = paths.TryGetValue(entry.Index, out string? value) ? value : entry.Name;
+                    if (!selector(path, entry.Size)) continue;
+                    if (selected != null) {
+                        throw new InvalidDataException("More than one compound stream matched the requested selector.");
+                    }
+                    if (entry.Size < 0 || entry.Size > options.MaxStreamBytes) {
+                        throw new InvalidDataException($"Compound stream '{path}' has unsupported size {entry.Size}.");
+                    }
+                    options.StreamSizeValidator?.Invoke(path, entry.Size);
+                    selected = entry;
+                }
+                if (selected == null) {
+                    source.Position = originalPosition;
+                    error = "The requested compound stream was not found.";
+                    return false;
+                }
+
+                List<uint>? regularChain = null;
+                List<uint>? miniChain = null;
+                List<uint>? rootChain = null;
+                if (selected.Size >= miniCutoff) {
+                    regularChain = GetRegularSectorChainForView(
+                        source,
+                        basePosition,
+                        selected.StartSector,
+                        selected.Size,
+                        sectorSize,
+                        physicalSectorCount,
+                        fatSectorIds,
+                        cancellationToken);
+                } else if (selected.Size > 0) {
+                    var fatCache = new Dictionary<uint, byte[]>();
+                    uint[] miniFat = miniFatStart == EndOfChain || miniFatSectorCount == 0
+                        ? Array.Empty<uint>()
+                        : BytesToUInt32Array(ReadRegularChain(
+                            source,
+                            basePosition,
+                            miniFatStart,
+                            checked((long)miniFatSectorCount * sectorSize),
+                            sectorSize,
+                            physicalSectorCount,
+                            fatSectorIds,
+                            fatCache,
+                            cancellationToken), cancellationToken);
+                    rootChain = root.StartSector == EndOfChain || root.Size == 0
+                        ? new List<uint>()
+                        : GetRegularSectorChainForView(
+                            source,
+                            basePosition,
+                            root.StartSector,
+                            root.Size,
+                            sectorSize,
+                            physicalSectorCount,
+                            fatSectorIds,
+                            cancellationToken);
+                    miniChain = GetMiniSectorChain(selected.StartSector, selected.Size, miniFat);
+                }
+
+                selectedStream = new CompoundEntryStream(
+                    source,
+                    basePosition,
+                    sectorSize,
+                    selected.Size,
+                    regularChain,
+                    miniChain,
+                    rootChain,
+                    leaveOpen,
+                    cancellationToken);
+                return true;
+            } catch (Exception exception) when (exception is IOException
+                                                || exception is ArgumentException
+                                                || exception is InvalidDataException
+                                                || exception is OverflowException
+                                                || exception is IndexOutOfRangeException
+                                                || exception is NotSupportedException) {
+                source.Position = originalPosition;
+                error = $"The OLE compound stream could not be opened. {exception.Message}";
+                return false;
+            }
+        }
+
+        private static List<uint> GetMiniSectorChain(uint startSector, long size, IReadOnlyList<uint> miniFat) {
+            int required = checked((int)((size + MiniSectorSize - 1) / MiniSectorSize));
+            var chain = new List<uint>(required);
+            var visited = new bool[miniFat.Count];
+            uint sector = startSector;
+            while (chain.Count < required) {
+                if (sector == EndOfChain || sector == FreeSect || sector >= miniFat.Count || visited[sector]) {
+                    throw new InvalidDataException("Compound mini-sector chain is shorter than its declared stream size.");
+                }
+                visited[sector] = true;
+                chain.Add(sector);
+                sector = miniFat[checked((int)sector)];
+            }
+            return chain;
+        }
+
+        private static List<uint> GetRegularSectorChainForView(
+            Stream source,
+            long basePosition,
+            uint startSector,
+            long size,
+            int sectorSize,
+            int physicalSectorCount,
+            IReadOnlyList<uint> fatSectorIds,
+            CancellationToken cancellationToken) {
+            int required = checked((int)((size + sectorSize - 1) / sectorSize));
+            var chain = new List<uint>(required);
+            var visited = new uint[checked((physicalSectorCount + 31) / 32)];
+            byte[] fatSector = new byte[sectorSize];
+            int loadedFatIndex = -1;
+            int entriesPerSector = sectorSize / 4;
+            uint sector = startSector;
+            while (chain.Count < required) {
+                if (sector == EndOfChain || sector == FreeSect || sector >= physicalSectorCount) {
+                    throw new InvalidDataException("Compound sector chain is shorter than its declared stream size.");
+                }
+                int visitedIndex = checked((int)(sector / 32));
+                uint visitedMask = 1U << checked((int)(sector % 32));
+                if ((visited[visitedIndex] & visitedMask) != 0) {
+                    throw new InvalidDataException("Compound sector chain contains a cycle.");
+                }
+                visited[visitedIndex] |= visitedMask;
+                chain.Add(sector);
+
+                int fatIndex = checked((int)(sector / entriesPerSector));
+                if (fatIndex >= fatSectorIds.Count) {
+                    throw new InvalidDataException("The FAT does not contain the requested sector entry.");
+                }
+                if (fatIndex != loadedFatIndex) {
+                    long physical = checked(basePosition + ((long)fatSectorIds[fatIndex] + 1) * sectorSize);
+                    ReadExact(source, physical, fatSector, cancellationToken);
+                    loadedFatIndex = fatIndex;
+                }
+                sector = ReadUInt32(fatSector, checked((int)(sector % entriesPerSector)) * 4);
+            }
+            return chain;
+        }
+
+        private static void ReadExact(
+            Stream source,
+            long offset,
+            byte[] buffer,
+            CancellationToken cancellationToken) {
+            source.Position = offset;
+            int total = 0;
+            while (total < buffer.Length) {
+                cancellationToken.ThrowIfCancellationRequested();
+                int read = source.Read(buffer, total, buffer.Length - total);
+                if (read <= 0) throw new EndOfStreamException("The compound file ended inside a FAT sector.");
+                total += read;
+            }
+        }
+
+        private sealed class CompoundEntryStream : Stream {
+            private readonly Stream _source;
+            private readonly long _basePosition;
+            private readonly int _sectorSize;
+            private readonly long _length;
+            private readonly IReadOnlyList<uint>? _regularChain;
+            private readonly IReadOnlyList<uint>? _miniChain;
+            private readonly IReadOnlyList<uint>? _rootChain;
+            private readonly bool _leaveOpen;
+            private readonly CancellationToken _cancellationToken;
+            private long _position;
+            private bool _disposed;
+
+            internal CompoundEntryStream(
+                Stream source,
+                long basePosition,
+                int sectorSize,
+                long length,
+                IReadOnlyList<uint>? regularChain,
+                IReadOnlyList<uint>? miniChain,
+                IReadOnlyList<uint>? rootChain,
+                bool leaveOpen,
+                CancellationToken cancellationToken) {
+                _source = source;
+                _basePosition = basePosition;
+                _sectorSize = sectorSize;
+                _length = length;
+                _regularChain = regularChain;
+                _miniChain = miniChain;
+                _rootChain = rootChain;
+                _leaveOpen = leaveOpen;
+                _cancellationToken = cancellationToken;
+            }
+
+            public override bool CanRead => !_disposed;
+            public override bool CanSeek => !_disposed;
+            public override bool CanWrite => false;
+            public override long Length { get { ThrowIfDisposed(); return _length; } }
+            public override long Position {
+                get { ThrowIfDisposed(); return _position; }
+                set { Seek(value, SeekOrigin.Begin); }
+            }
+
+            public override int Read(byte[] buffer, int offset, int count) {
+                ThrowIfDisposed();
+                if (buffer == null) throw new ArgumentNullException(nameof(buffer));
+                if (offset < 0 || count < 0 || offset > buffer.Length - count) throw new ArgumentOutOfRangeException();
+                if (_position >= _length || count == 0) return 0;
+                _cancellationToken.ThrowIfCancellationRequested();
+                int total = 0;
+                int wanted = checked((int)Math.Min(count, _length - _position));
+                while (total < wanted) {
+                    int read = _regularChain != null
+                        ? ReadRegular(buffer, offset + total, wanted - total)
+                        : ReadMini(buffer, offset + total, wanted - total);
+                    if (read <= 0) throw new EndOfStreamException("The compound stream ended before its declared length.");
+                    total += read;
+                    _position += read;
+                }
+                return total;
+            }
+
+            private int ReadRegular(byte[] buffer, int offset, int count) {
+                int chainIndex = checked((int)(_position / _sectorSize));
+                int within = checked((int)(_position % _sectorSize));
+                int sectorCount = 1;
+                if (within == 0) {
+                    while (chainIndex + sectorCount < _regularChain!.Count
+                           && _regularChain[chainIndex + sectorCount] == _regularChain[chainIndex] + sectorCount
+                           && sectorCount * _sectorSize < count) {
+                        sectorCount++;
+                    }
+                }
+                int available = checked(sectorCount * _sectorSize - within);
+                int read = Math.Min(count, available);
+                long physical = checked(_basePosition + ((long)_regularChain![chainIndex] + 1) * _sectorSize + within);
+                ReadSource(physical, buffer, offset, read);
+                return read;
+            }
+
+            private int ReadMini(byte[] buffer, int offset, int count) {
+                int chainIndex = checked((int)(_position / MiniSectorSize));
+                int within = checked((int)(_position % MiniSectorSize));
+                uint miniSector = _miniChain![chainIndex];
+                long miniOffset = checked((long)miniSector * MiniSectorSize + within);
+                int rootIndex = checked((int)(miniOffset / _sectorSize));
+                int rootOffset = checked((int)(miniOffset % _sectorSize));
+                if (rootIndex >= _rootChain!.Count) throw new InvalidDataException("Compound mini-sector points outside the root mini stream.");
+                int read = Math.Min(count, MiniSectorSize - within);
+                long physical = checked(_basePosition + ((long)_rootChain[rootIndex] + 1) * _sectorSize + rootOffset);
+                ReadSource(physical, buffer, offset, read);
+                return read;
+            }
+
+            private void ReadSource(long physical, byte[] buffer, int offset, int count) {
+                _source.Position = physical;
+                int total = 0;
+                while (total < count) {
+                    _cancellationToken.ThrowIfCancellationRequested();
+                    int read = _source.Read(buffer, offset + total, count - total);
+                    if (read <= 0) throw new EndOfStreamException("The compound source ended while reading a sector chain.");
+                    total += read;
+                }
+            }
+
+            public override long Seek(long offset, SeekOrigin origin) {
+                ThrowIfDisposed();
+                long position = origin switch {
+                    SeekOrigin.Begin => offset,
+                    SeekOrigin.Current => checked(_position + offset),
+                    SeekOrigin.End => checked(_length + offset),
+                    _ => throw new ArgumentOutOfRangeException(nameof(origin))
+                };
+                if (position < 0 || position > _length) throw new IOException("Attempted to seek outside the compound stream.");
+                _position = position;
+                return position;
+            }
+
+            public override void Flush() { }
+            public override void SetLength(long value) => throw new NotSupportedException();
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+            protected override void Dispose(bool disposing) {
+                if (_disposed) return;
+                _disposed = true;
+                if (disposing && !_leaveOpen) _source.Dispose();
+                base.Dispose(disposing);
+            }
+
+            private void ThrowIfDisposed() {
+                if (_disposed) throw new ObjectDisposedException(nameof(CompoundEntryStream));
+            }
+        }
+    }
+}

--- a/OfficeIMO.SharedSource/Compound/OfficeCompoundFileReader.Stream.cs
+++ b/OfficeIMO.SharedSource/Compound/OfficeCompoundFileReader.Stream.cs
@@ -180,6 +180,7 @@ namespace OfficeIMO.Drawing.Internal {
                     regularChain,
                     miniChain,
                     rootChain,
+                    root.Size,
                     leaveOpen,
                     cancellationToken);
                 return true;
@@ -276,6 +277,7 @@ namespace OfficeIMO.Drawing.Internal {
             private readonly IReadOnlyList<uint>? _regularChain;
             private readonly IReadOnlyList<uint>? _miniChain;
             private readonly IReadOnlyList<uint>? _rootChain;
+            private readonly long _rootSize;
             private readonly bool _leaveOpen;
             private readonly CancellationToken _cancellationToken;
             private long _position;
@@ -289,6 +291,7 @@ namespace OfficeIMO.Drawing.Internal {
                 IReadOnlyList<uint>? regularChain,
                 IReadOnlyList<uint>? miniChain,
                 IReadOnlyList<uint>? rootChain,
+                long rootSize,
                 bool leaveOpen,
                 CancellationToken cancellationToken) {
                 _source = source;
@@ -298,6 +301,7 @@ namespace OfficeIMO.Drawing.Internal {
                 _regularChain = regularChain;
                 _miniChain = miniChain;
                 _rootChain = rootChain;
+                _rootSize = rootSize;
                 _leaveOpen = leaveOpen;
                 _cancellationToken = cancellationToken;
             }
@@ -353,10 +357,13 @@ namespace OfficeIMO.Drawing.Internal {
                 int within = checked((int)(_position % MiniSectorSize));
                 uint miniSector = _miniChain![chainIndex];
                 long miniOffset = checked((long)miniSector * MiniSectorSize + within);
+                int read = Math.Min(count, MiniSectorSize - within);
+                if (miniOffset > _rootSize - read) {
+                    throw new InvalidDataException("Compound mini-sector points outside the declared root mini stream length.");
+                }
                 int rootIndex = checked((int)(miniOffset / _sectorSize));
                 int rootOffset = checked((int)(miniOffset % _sectorSize));
                 if (rootIndex >= _rootChain!.Count) throw new InvalidDataException("Compound mini-sector points outside the root mini stream.");
-                int read = Math.Min(count, MiniSectorSize - within);
                 long physical = checked(_basePosition + ((long)_rootChain[rootIndex] + 1) * _sectorSize + rootOffset);
                 ReadSource(physical, buffer, offset, read);
                 return read;

--- a/OfficeIMO.SharedSource/Compound/OfficeCompoundFileReader.Stream.cs
+++ b/OfficeIMO.SharedSource/Compound/OfficeCompoundFileReader.Stream.cs
@@ -121,6 +121,7 @@ namespace OfficeIMO.Drawing.Internal {
                     if (entry.Size < 0 || entry.Size > options.MaxStreamBytes) {
                         throw new InvalidDataException($"Compound stream '{path}' has unsupported size {entry.Size}.");
                     }
+                    ValidateRegularStreamPhysicalBounds(path, entry.Size, miniCutoff, maximumPhysicalStreamBytes);
                     options.StreamSizeValidator?.Invoke(path, entry.Size);
                     selected = entry;
                 }

--- a/OfficeIMO.SharedSource/Compound/OfficeCompoundFileReader.Stream.cs
+++ b/OfficeIMO.SharedSource/Compound/OfficeCompoundFileReader.Stream.cs
@@ -97,6 +97,12 @@ namespace OfficeIMO.Drawing.Internal {
                     cancellationToken);
                 DirectoryEntry? root = entries.FirstOrDefault(static entry => entry.ObjectType == 5);
                 if (root == null) throw new InvalidDataException("Compound file root directory entry is missing.");
+                long maximumPhysicalStreamBytes = checked((long)physicalSectorCount * sectorSize);
+                if (root.Size < 0
+                    || root.Size > options.MaxTotalStreamBytes
+                    || root.Size > maximumPhysicalStreamBytes) {
+                    throw new InvalidDataException("Compound file mini stream exceeds configured or physical bounds.");
+                }
 
                 IReadOnlyDictionary<int, string> paths = BuildCompoundEntryPaths(entries, cancellationToken);
                 DirectoryEntry? selected = null;

--- a/OfficeIMO.SharedSource/Compound/OfficeCompoundFileReader.Stream.cs
+++ b/OfficeIMO.SharedSource/Compound/OfficeCompoundFileReader.Stream.cs
@@ -67,9 +67,13 @@ namespace OfficeIMO.Drawing.Internal {
                 int miniFatSectorCount = checked((int)ReadUInt32(header, 64));
                 uint firstDifat = ReadUInt32(header, 68);
                 int difatSectorCount = checked((int)ReadUInt32(header, 72));
-                if (fatSectorCount > physicalSectorCount || difatSectorCount > physicalSectorCount) {
-                    throw new InvalidDataException("Compound allocation table counts exceed the file size.");
-                }
+                ValidateAllocationTableCounts(
+                    fatSectorCount,
+                    difatSectorCount,
+                    miniFatSectorCount,
+                    physicalSectorCount,
+                    sectorSize,
+                    options.MaxTotalStreamBytes);
 
                 List<uint> fatSectorIds = ReadFatSectorIds(
                     source,

--- a/OfficeIMO.SharedSource/Compound/OfficeCompoundFileReader.cs
+++ b/OfficeIMO.SharedSource/Compound/OfficeCompoundFileReader.cs
@@ -97,10 +97,13 @@ namespace OfficeIMO.Drawing.Internal {
                 int difatSectorCount = checked((int)ReadUInt32(bytes, 72));
 
                 int physicalSectorCount = (bytes.Length - sectorSize) / sectorSize;
-                if (fatSectorCount < 0 || fatSectorCount > physicalSectorCount || difatSectorCount < 0 ||
-                    difatSectorCount > physicalSectorCount) {
-                    throw new InvalidDataException("Compound file allocation table counts exceed the file size.");
-                }
+                ValidateAllocationTableCounts(
+                    fatSectorCount,
+                    difatSectorCount,
+                    miniFatSectorCount,
+                    physicalSectorCount,
+                    sectorSize,
+                    options.MaxTotalStreamBytes);
 
                 List<uint> fatSectorIds = ReadDifat(bytes, sectorSize, firstDifat, difatSectorCount, fatSectorCount, cancellationToken);
                 uint[] fat = ReadFat(bytes, sectorSize, fatSectorIds, cancellationToken);
@@ -173,6 +176,26 @@ namespace OfficeIMO.Drawing.Internal {
                 compoundFile = null;
                 error = $"The OLE compound file could not be read. {ex.Message}";
                 return false;
+            }
+        }
+
+        /// <summary>
+        /// Rejects allocation-table declarations before any table-sized buffer is created.
+        /// </summary>
+        private static void ValidateAllocationTableCounts(
+            int fatSectorCount,
+            int difatSectorCount,
+            int miniFatSectorCount,
+            int physicalSectorCount,
+            int sectorSize,
+            long maximumTableBytes) {
+            long miniFatBytes = checked((long)miniFatSectorCount * sectorSize);
+            if (fatSectorCount > physicalSectorCount
+                || difatSectorCount > physicalSectorCount
+                || miniFatSectorCount > physicalSectorCount
+                || miniFatBytes > maximumTableBytes) {
+                throw new InvalidDataException(
+                    "Compound allocation table counts exceed configured or physical bounds.");
             }
         }
 

--- a/OfficeIMO.SharedSource/Compound/OfficeCompoundFileReader.cs
+++ b/OfficeIMO.SharedSource/Compound/OfficeCompoundFileReader.cs
@@ -97,6 +97,7 @@ namespace OfficeIMO.Drawing.Internal {
                 int difatSectorCount = checked((int)ReadUInt32(bytes, 72));
 
                 int physicalSectorCount = (bytes.Length - sectorSize) / sectorSize;
+                long maximumPhysicalStreamBytes = checked((long)physicalSectorCount * sectorSize);
                 ValidateAllocationTableCounts(
                     fatSectorCount,
                     difatSectorCount,
@@ -117,8 +118,11 @@ namespace OfficeIMO.Drawing.Internal {
                     cancellationToken);
                 DirectoryEntry? root = entries.FirstOrDefault(entry => entry.ObjectType == 5);
                 if (root == null) throw new InvalidDataException("Compound file root directory entry is missing.");
-                if (root.Size < 0 || root.Size > options.MaxTotalStreamBytes || root.Size > int.MaxValue) {
-                    throw new InvalidDataException("Compound file mini stream exceeds configured bounds.");
+                if (root.Size < 0
+                    || root.Size > options.MaxTotalStreamBytes
+                    || root.Size > maximumPhysicalStreamBytes
+                    || root.Size > int.MaxValue) {
+                    throw new InvalidDataException("Compound file mini stream exceeds configured or physical bounds.");
                 }
 
                 IReadOnlyDictionary<int, string> streamPaths = BuildCompoundEntryPaths(entries, cancellationToken);
@@ -135,6 +139,7 @@ namespace OfficeIMO.Drawing.Internal {
                     if (entry.Size < 0 || entry.Size > options.MaxStreamBytes || entry.Size > int.MaxValue) {
                         throw new InvalidDataException($"Compound stream '{entry.Name}' has unsupported size {entry.Size}.");
                     }
+                    ValidateRegularStreamPhysicalBounds(path, entry.Size, miniCutoff, maximumPhysicalStreamBytes);
                     totalStreamBytes = checked(totalStreamBytes + entry.Size);
                     if (totalStreamBytes > options.MaxTotalStreamBytes) {
                         throw new InvalidDataException($"Compound stream bytes exceed {options.MaxTotalStreamBytes}.");
@@ -196,6 +201,20 @@ namespace OfficeIMO.Drawing.Internal {
                 || miniFatBytes > maximumTableBytes) {
                 throw new InvalidDataException(
                     "Compound allocation table counts exceed configured or physical bounds.");
+            }
+        }
+
+        /// <summary>
+        /// Rejects regular-stream declarations that cannot fit in the compound file before chain-sized storage is allocated.
+        /// </summary>
+        private static void ValidateRegularStreamPhysicalBounds(
+            string path,
+            long size,
+            uint miniCutoff,
+            long maximumPhysicalStreamBytes) {
+            if (size >= miniCutoff && size > maximumPhysicalStreamBytes) {
+                throw new InvalidDataException(
+                    $"Compound stream '{path}' exceeds physical bounds.");
             }
         }
 

--- a/Website/scripts/Test-BenchmarkPage.ps1
+++ b/Website/scripts/Test-BenchmarkPage.ps1
@@ -211,6 +211,7 @@ if ($pageHtml -notmatch 'data-excel-benchmarks' -or $pageHtml -notmatch 'data-be
 if ($pageHtml -notmatch 'data-library-comparison-benchmarks' -or
     $pageHtml -notmatch 'data-comparison-id="markpflug-65k-csv-decoded-net10\.0"' -or
     $pageHtml -notmatch 'data-library-comparison-workload="csv-25k-datareader-write-net10\.0"' -or
+    $pageHtml -notmatch 'data-library-comparison-workload="markpflug-65k-xls-typed-net10\.0"' -or
     $pageHtml -notmatch 'data-library-comparison-workload="xlsx-25k-datareader-write-net10\.0"' -or
     $pageHtml -notmatch 'data-library-comparison-workload="markpflug-65k-xlsx-typed-net10\.0"' -or
     $pageHtml -notmatch 'data-library-comparison-workload="markpflug-65k-xlsb-typed-net10\.0"' -or

--- a/Website/static/js/benchmarks.js
+++ b/Website/static/js/benchmarks.js
@@ -370,6 +370,7 @@
     var names = {
       'markpflug-65k-csv-decoded-net10.0': 'CSV · decoded strings',
       'csv-25k-datareader-write-net10.0': 'CSV · IDataReader write',
+      'markpflug-65k-xls-typed-net10.0': 'XLS · typed values',
       'markpflug-65k-xlsx-typed-net10.0': 'XLSX · typed values',
       'xlsx-25k-datareader-write-net10.0': 'XLSX · IDataReader write',
       'markpflug-65k-xlsb-typed-net10.0': 'XLSB · typed values'

--- a/Website/themes/officeimo/partials/library-comparison-benchmarks.html
+++ b/Website/themes/officeimo/partials/library-comparison-benchmarks.html
@@ -20,6 +20,7 @@
       <div class="imo-library-comparison-buttons" data-library-comparison-workloads>
         <button type="button" data-library-comparison-workload="markpflug-65k-csv-decoded-net10.0">CSV decoded strings</button>
         <button type="button" data-library-comparison-workload="csv-25k-datareader-write-net10.0">CSV IDataReader write</button>
+        <button type="button" data-library-comparison-workload="markpflug-65k-xls-typed-net10.0">XLS typed</button>
         <button type="button" data-library-comparison-workload="markpflug-65k-xlsx-typed-net10.0">XLSX typed</button>
         <button type="button" data-library-comparison-workload="xlsx-25k-datareader-write-net10.0">XLSX IDataReader write</button>
         <button type="button" data-library-comparison-workload="markpflug-65k-xlsb-typed-net10.0">XLSB typed</button>


### PR DESCRIPTION
## What changed

This keeps the unified `OpenDataReader` / `CreateDataReader` API from #2208 while moving the common tabular paths much closer to the metal. No public API was added or changed.

- XLS reads supported BIFF8 worksheets directly from bounded OLE streams instead of projecting the workbook through Open XML. Unsupported or encrypted variants retain the existing fallback.
- XLSX reads exact worksheet entry lengths into pooled buffers and uses a compact UTF-8 path only after proving the XML shape and namespace bindings. Non-canonical or malformed XML falls back to `XmlReader` validation.
- XLSB uses pooled package parts, direct record slices, batched safety budgets, and a fused validation scan for common fixed-width cell records.
- CSV avoids repeated allocation for common one-character ASCII values while preserving the existing streaming reader contract.
- The benchmark harness includes an authentic 65,535-row XLS comparison alongside CSV, XLSB, and XLSX, and the benchmark page exposes the XLS lane in its workload selector.

The fast paths retain input, cell, string, record, cycle, and depth limits; cancellation checks; cached formula handling; date-style conversion; sparse-row behavior; and fail-closed malformed-input handling. All Excel data readers now share one canonical ADO.NET schema-table implementation, so XLS, XLSB, and XLSX expose the same metadata contract without expanding the public API.

Review-driven regressions cover XML namespace and reserved-URI binding, duplicate expanded attribute names, QName boundaries, UTF-8 declaration compatibility, forbidden XML scalars and raw CDATA terminators, character data outside the document root, root-level XLS workbook stream selection, BIFF MULRK/MULBLANK framing, inherited number formats, invalid date serials, compound-file allocation bounds, mini-sector bounds against the root's declared byte length, and one-snapshot XLSX path reads across atomic replacement. FAT, DIFAT, mini-FAT, mini-stream, and regular-stream declarations are bounded by configured and physical limits before chain-sized storage is allocated.

On the same XLS fixture, the previous projected public path took about 321 seconds and allocated roughly 1.1 TB per operation. The direct path below takes about 53 ms and allocates 16.15 MB. Interleaved 500-iteration CSV profiles against master were 4.6-6.8% faster with the same checksum.

## Full benchmark snapshot

Windows 11, AMD Ryzen 9 9950X3D, .NET SDK 10.0.302 / runtime 10.0.10. XLS and XLSX were rerun at final source `b2b718fb4`; CSV and XLSB retain the `95be1525e` results because the final remediation did not touch their timed read loops. Every case scans the same 65,535-row fixture, validates row and cell counts, and consumes typed values into a checksum.

| Format | Source | OfficeIMO | Closest specialist | Result |
|---|---|---:|---:|---|
| CSV | `95be1525e` | 20.67 ms / 34.96 MB | Sep: 18.29 ms / 34.22 MB | 13.0% slower than Sep; 1.6% faster and leaner than Sylvan |
| XLS | `b2b718fb4` | 53.48 ms / 16.15 MB | Sylvan: 45.60 ms / 16.19 MB | 17.3% slower, slightly leaner |
| XLSB | `95be1525e` | 80.28 ms / 16.11 MB | Sylvan: 65.73 ms / 16.34 MB | 22.1% slower, leaner |
| XLSX | `b2b718fb4` | 137.7 ms / 28.89 MB | Sylvan: 228.3 ms / 29.13 MB | 1.66x faster, leaner |

The table deliberately keeps the remaining losses visible: Sep wins CSV, while Sylvan wins XLS and XLSB. XLSB was the noisiest lane; two isolated final-head processes put OfficeIMO 11-22% behind Sylvan, while the steady allocation remained 16.11 MB. The previous 1.5x-class gaps are gone, allocations are competitive, and XLSX leads both time and memory.

Reproduce any lane with:

```powershell
./Build/Run-LibraryComparisonBenchmarks.ps1 -RunMode full -Framework net10.0 -Workload <csv|xls|xlsb|xlsx>
```

## Validation

- OfficeIMO.Excel builds netstandard2.0, net472, net8.0, and net10.0 with 0 warnings and 0 errors.
- Windows .NET 10 Excel suite: 3,094 passed, 5 expected environment skips, 0 failed.
- Windows .NET 10 Email and PowerPoint suites: 1,280 and 1,470 passed, with only expected environment skips.
- Windows OfficeIMO.Shared suite: 191/191 passed on net10.0 and net8.0; 190/190 passed on net472.
- The final XLS/XLSX snapshot and mini-stream regressions pass on net472, net8.0, and net10.0; the broader 142-test `OpenDataReader` slice passes on Windows and on an exact-head Ubuntu clone.
- Exact-head Ubuntu builds the supported Linux target matrix with 0 warnings and 0 errors; the Email and PowerPoint compound regressions pass on net8.0 and net10.0; and the shared-source ownership guardrail passes.
- The generated benchmark page was exercised at wide and compact viewports: the XLS selector updates the URL, exposes the honest missing-evidence state, and produces no console warnings.

Repository macOS CI remains the cross-platform gate for this exact head.
