### PR TITLE
Preserve generic result types in conversion docs

### DIFF
--- a/Website/build.ps1
+++ b/Website/build.ps1
@@ -174,6 +174,20 @@ function Assert-SiteOutput {
     if (-not (Test-Path -LiteralPath $notFoundPage -PathType Leaf)) {
         throw "Build validation failed: expected '$notFoundPage' for GitHub Pages 404 handling."
     }
+
+    $conversionRoutesPage = Join-Path $SiteRoot 'docs/capabilities/conversions/index.html'
+    if (-not (Test-Path -LiteralPath $conversionRoutesPage -PathType Leaf)) {
+        throw "Build validation failed: expected '$conversionRoutesPage' for the conversion route catalog."
+    }
+
+    $conversionRoutesCatalog = Get-Content -LiteralPath (Join-Path $PSScriptRoot 'data/office_conversion_routes.json') -Raw | ConvertFrom-Json
+    $conversionRoutesHtml = Get-Content -LiteralPath $conversionRoutesPage -Raw
+    foreach ($resultContract in @($conversionRoutesCatalog.routes.resultContract | Where-Object { $_ -match '[<>]' } | Sort-Object -Unique)) {
+        $encodedContract = [System.Net.WebUtility]::HtmlEncode([string] $resultContract)
+        if (-not $conversionRoutesHtml.Contains("<code>$encodedContract</code>", [System.StringComparison]::Ordinal)) {
+            throw "Build validation failed: conversion result contract '$resultContract' is not preserved as encoded code text."
+        }
+    }
 }
 
 try {

--- a/Website/themes/officeimo/partials/shortcodes/conversion-routes.html
+++ b/Website/themes/officeimo/partials/shortcodes/conversion-routes.html
@@ -18,7 +18,7 @@
 <td><code>{{ route.packageId }}</code></td>
 <td>{{ if route.fidelity == "FixedLayout" }}Fixed layout{{ else if route.fidelity == "Editable" }}Editable document{{ else }}Semantic content{{ end }}</td>
 <td>{{ if route.browserAvailable }}Browser or .NET{{ else }}.NET application{{ end }}</td>
-<td><code>{{ route.resultContract }}</code></td>
+<td><code>{{ route.resultContract | html.escape }}</code></td>
 </tr>
 {{~ end ~}}
     </tbody>


### PR DESCRIPTION
## Summary

- HTML-encode conversion result contract values before inserting them into the generated table.
- Fail website builds when a generic result contract is not preserved as encoded code text.

## Why

Browsers interpreted generic .NET type arguments as HTML elements, so the conversion documentation dropped text such as the OdtDocument argument from OdfConversionResult<OdtDocument>.