### PR TITLE
Handle duplicate SmartArt identifiers without crashing

### DIFF
--- a/OfficeIMO.Word.Tests/Word.SmartArt.StructuralEdits.cs
+++ b/OfficeIMO.Word.Tests/Word.SmartArt.StructuralEdits.cs
@@ -59,6 +59,10 @@ namespace OfficeIMO.Tests {
             Assert.Equal(3, smartArt.NodeCount);
             Assert.Equal(new[] { "A", "B", "C" },
                 Enumerable.Range(0, smartArt.NodeCount).Select(smartArt.GetNodeText));
+            Assert.Contains("non-empty and unique", Assert.Throws<InvalidOperationException>(() => smartArt.AddNode("D")).Message);
+            Assert.Contains("non-empty and unique", Assert.Throws<InvalidOperationException>(() => smartArt.InsertNodeAt(1, "D")).Message);
+            Assert.Contains("non-empty and unique", Assert.Throws<InvalidOperationException>(() => smartArt.RemoveNodeAt(1)).Message);
+            Assert.Contains("non-empty and unique", Assert.Throws<InvalidOperationException>(() => smartArt.MoveNode(0, 2)).Message);
         }
 
         [Fact]
@@ -80,6 +84,7 @@ namespace OfficeIMO.Tests {
                 .First(item => (string?)item.Attribute("srcId") == docId);
             XElement duplicate = new XElement(connection);
             duplicate.SetAttributeValue("modelId", "{" + Guid.NewGuid().ToString().ToUpperInvariant() + "}");
+            duplicate.SetAttributeValue("srcOrd", 99);
             connection.AddAfterSelf(duplicate);
             SaveDiagramData(dataPart, data);
 
@@ -96,6 +101,54 @@ namespace OfficeIMO.Tests {
                 item => Assert.Equal(2, (int)item.Attribute("srcOrd")!));
             Assert.Equal(new[] { "B", "C", "A" },
                 Enumerable.Range(0, smartArt.NodeCount).Select(smartArt.GetNodeText));
+        }
+
+        [Fact]
+        public void SmartArt_InsertAndRemove_ResequenceDuplicateDocumentChildConnections() {
+            string filePath = Path.Combine(_directoryWithFiles, "SmartArt.ResequenceDuplicateDocumentChildConnections.docx");
+            string docId;
+            string duplicateDestination;
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                WordSmartArt smartArt = document.AddSmartArt(SmartArtType.BasicProcess);
+                smartArt.SetNodeText(0, "A");
+                smartArt.AddNode("B");
+                smartArt.AddNode("C");
+
+                DiagramDataPart dataPart = document._wordprocessingDocument.MainDocumentPart!.DiagramDataParts.Single();
+                XDocument data = LoadDiagramData(dataPart);
+                XNamespace dgm = "http://schemas.openxmlformats.org/drawingml/2006/diagram";
+                docId = (string)data.Descendants(dgm + "pt")
+                    .Single(point => (string?)point.Attribute("type") == "doc")
+                    .Attribute("modelId")!;
+                XElement connection = data.Descendants(dgm + "cxn")
+                    .Single(item => (string?)item.Attribute("srcId") == docId && (int?)item.Attribute("srcOrd") == 1);
+                duplicateDestination = (string)connection.Attribute("destId")!;
+                XElement duplicate = new XElement(connection);
+                duplicate.SetAttributeValue("modelId", "{" + Guid.NewGuid().ToString().ToUpperInvariant() + "}");
+                duplicate.SetAttributeValue("srcOrd", 99);
+                connection.AddAfterSelf(duplicate);
+                SaveDiagramData(dataPart, data);
+
+                smartArt.InsertNodeAt(1, "X");
+                smartArt.RemoveNodeAt(0);
+
+                Assert.Equal(new[] { "X", "B", "C" },
+                    Enumerable.Range(0, smartArt.NodeCount).Select(smartArt.GetNodeText));
+                AssertDuplicateConnectionsShareOrder(LoadDiagramData(dataPart), dgm, docId, duplicateDestination, 1);
+                document.Save();
+            }
+
+            using WordDocument reloaded = WordDocument.Load(filePath);
+            WordSmartArt imported = Assert.Single(reloaded.SmartArts);
+            Assert.Equal(new[] { "X", "B", "C" },
+                Enumerable.Range(0, imported.NodeCount).Select(imported.GetNodeText));
+            DiagramDataPart reloadedDataPart = reloaded._wordprocessingDocument.MainDocumentPart!.DiagramDataParts.Single();
+            AssertDuplicateConnectionsShareOrder(
+                LoadDiagramData(reloadedDataPart),
+                "http://schemas.openxmlformats.org/drawingml/2006/diagram",
+                docId,
+                duplicateDestination,
+                1);
         }
 
         [Fact]
@@ -156,6 +209,20 @@ namespace OfficeIMO.Tests {
             data.Save(stream);
             stream.Position = 0;
             part.FeedData(stream);
+        }
+
+        private static void AssertDuplicateConnectionsShareOrder(
+            XDocument data,
+            XNamespace dgm,
+            string docId,
+            string destinationId,
+            int expectedOrder) {
+            var connections = data.Descendants(dgm + "cxn")
+                .Where(item => (string?)item.Attribute("srcId") == docId)
+                .Where(item => (string?)item.Attribute("destId") == destinationId)
+                .ToList();
+            Assert.Equal(2, connections.Count);
+            Assert.All(connections, item => Assert.Equal(expectedOrder, (int)item.Attribute("srcOrd")!));
         }
     }
 }

--- a/OfficeIMO.Word.Tests/Word.SmartArt.StructuralEdits.cs
+++ b/OfficeIMO.Word.Tests/Word.SmartArt.StructuralEdits.cs
@@ -34,6 +34,71 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void SmartArt_DuplicateNodeModelIds_FallBackToDocumentOrder() {
+            string filePath = Path.Combine(_directoryWithFiles, "SmartArt.DuplicateNodeModelIds.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                WordSmartArt createdSmartArt = document.AddSmartArt(SmartArtType.BasicProcess);
+                createdSmartArt.SetNodeText(0, "A");
+                createdSmartArt.AddNode("B");
+                createdSmartArt.AddNode("C");
+
+                DiagramDataPart dataPart = document._wordprocessingDocument.MainDocumentPart!.DiagramDataParts.Single();
+                XDocument data = LoadDiagramData(dataPart);
+                XNamespace dgm = "http://schemas.openxmlformats.org/drawingml/2006/diagram";
+                var nodes = data.Descendants(dgm + "pt")
+                    .Where(point => (string?)point.Attribute("type") is null or "node")
+                    .Where(point => point.Element(dgm + "t") != null)
+                    .ToList();
+                nodes[1].SetAttributeValue("modelId", (string)nodes[0].Attribute("modelId")!);
+                SaveDiagramData(dataPart, data);
+                document.Save();
+            }
+
+            using WordDocument reloaded = WordDocument.Load(filePath);
+            WordSmartArt smartArt = Assert.Single(reloaded.SmartArts);
+            Assert.Equal(3, smartArt.NodeCount);
+            Assert.Equal(new[] { "A", "B", "C" },
+                Enumerable.Range(0, smartArt.NodeCount).Select(smartArt.GetNodeText));
+        }
+
+        [Fact]
+        public void SmartArt_MoveNode_UpdatesDuplicateDocumentChildConnections() {
+            string filePath = Path.Combine(_directoryWithFiles, "SmartArt.DuplicateDocumentChildConnections.docx");
+            using WordDocument document = WordDocument.Create(filePath);
+            WordSmartArt smartArt = document.AddSmartArt(SmartArtType.BasicProcess);
+            smartArt.SetNodeText(0, "A");
+            smartArt.AddNode("B");
+            smartArt.AddNode("C");
+
+            DiagramDataPart dataPart = document._wordprocessingDocument.MainDocumentPart!.DiagramDataParts.Single();
+            XDocument data = LoadDiagramData(dataPart);
+            XNamespace dgm = "http://schemas.openxmlformats.org/drawingml/2006/diagram";
+            string docId = (string)data.Descendants(dgm + "pt")
+                .Single(point => (string?)point.Attribute("type") == "doc")
+                .Attribute("modelId")!;
+            XElement connection = data.Descendants(dgm + "cxn")
+                .First(item => (string?)item.Attribute("srcId") == docId);
+            XElement duplicate = new XElement(connection);
+            duplicate.SetAttributeValue("modelId", "{" + Guid.NewGuid().ToString().ToUpperInvariant() + "}");
+            connection.AddAfterSelf(duplicate);
+            SaveDiagramData(dataPart, data);
+
+            smartArt.MoveNode(0, 2);
+
+            XDocument updated = LoadDiagramData(dataPart);
+            string duplicateDestination = (string)duplicate.Attribute("destId")!;
+            var duplicateConnections = updated.Descendants(dgm + "cxn")
+                .Where(item => (string?)item.Attribute("srcId") == docId)
+                .Where(item => (string?)item.Attribute("destId") == duplicateDestination)
+                .ToList();
+            Assert.Equal(2, duplicateConnections.Count);
+            Assert.All(duplicateConnections,
+                item => Assert.Equal(2, (int)item.Attribute("srcOrd")!));
+            Assert.Equal(new[] { "B", "C", "A" },
+                Enumerable.Range(0, smartArt.NodeCount).Select(smartArt.GetNodeText));
+        }
+
+        [Fact]
         public void SmartArt_RemoveNode_RemovesIncomingAndOutgoingConnections() {
             string filePath = Path.Combine(_directoryWithFiles, "SmartArt.RemoveIncidentConnections.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {

--- a/OfficeIMO.Word/WordSmartArt.cs
+++ b/OfficeIMO.Word/WordSmartArt.cs
@@ -391,17 +391,20 @@ namespace OfficeIMO.Word {
                 .Attribute("modelId") ?? throw new InvalidOperationException("Cannot locate document point in SmartArt data model.");
             XElement connections = xdoc.Descendants(dgm + "cxnLst").FirstOrDefault()
                 ?? throw new InvalidOperationException("SmartArt data model missing cxnLst.");
-            Dictionary<string, XElement> byDestination = connections.Elements(dgm + "cxn")
+            Dictionary<string, List<XElement>> byDestination = connections.Elements(dgm + "cxn")
                 .Where(connection => (string?)connection.Attribute("srcId") == docId)
                 .Where(connection => connection.Attribute("destId") != null)
-                .ToDictionary(connection => (string)connection.Attribute("destId")!, StringComparer.Ordinal);
+                .GroupBy(connection => (string)connection.Attribute("destId")!, StringComparer.Ordinal)
+                .ToDictionary(group => group.Key, group => group.ToList(), StringComparer.Ordinal);
             for (int index = 0; index < nodes.Count; index++) {
                 string id = (string?)nodes[index].Attribute("modelId")
                     ?? throw new InvalidOperationException("SmartArt node is missing modelId.");
-                if (!byDestination.TryGetValue(id, out XElement? connection)) {
+                if (!byDestination.TryGetValue(id, out List<XElement>? matchingConnections)) {
                     throw new InvalidOperationException("SmartArt node does not have a document-child connection.");
                 }
-                connection.SetAttributeValue("srcOrd", index);
+                foreach (XElement connection in matchingConnections) {
+                    connection.SetAttributeValue("srcOrd", index);
+                }
             }
             SaveDiagramData(dataPart, xdoc);
         }
@@ -457,15 +460,21 @@ namespace OfficeIMO.Word {
                 .Attribute("modelId");
             if (string.IsNullOrEmpty(docId)) return nodes;
 
-            Dictionary<string, XElement> byId = nodes
-                .Where(node => node.Attribute("modelId") != null)
-                .ToDictionary(node => (string)node.Attribute("modelId")!, StringComparer.Ordinal);
+            var byId = new Dictionary<string, XElement>(StringComparer.Ordinal);
+            foreach (XElement node in nodes) {
+                string? nodeId = (string?)node.Attribute("modelId");
+                if (string.IsNullOrEmpty(nodeId) || !byId.TryAdd(nodeId, node)) {
+                    return nodes;
+                }
+            }
             List<XElement> ordered = xdoc.Descendants(dgm + "cxn")
                 .Where(connection => (string?)connection.Attribute("srcId") == docId)
                 .OrderBy(connection => (int?)connection.Attribute("srcOrd") ?? int.MaxValue)
                 .Select(connection => (string?)connection.Attribute("destId"))
-                .Where(id => id != null && byId.ContainsKey(id))
-                .Select(id => byId[id!])
+                .OfType<string>()
+                .Distinct(StringComparer.Ordinal)
+                .Where(byId.ContainsKey)
+                .Select(id => byId[id])
                 .ToList();
             return ordered.Count == nodes.Count ? ordered : nodes;
         }

--- a/OfficeIMO.Word/WordSmartArt.cs
+++ b/OfficeIMO.Word/WordSmartArt.cs
@@ -215,6 +215,7 @@ namespace OfficeIMO.Word {
             var docPt = xdoc.Descendants(dgm + "pt").FirstOrDefault(p => (string?)p.Attribute("type") == "doc");
             if (docPt == null) throw new InvalidOperationException("Cannot locate document point in SmartArt data model.");
             var docId = (string?)docPt.Attribute("modelId") ?? throw new InvalidOperationException("Document point missing modelId.");
+            EnsureEditableNodeIdsAreUnique(GetEditableNodePoints(xdoc, dgm));
 
             // Create node point
             string newId = "{" + Guid.NewGuid().ToString().ToUpper() + "}";
@@ -236,8 +237,9 @@ namespace OfficeIMO.Word {
             ptLst.Add(pt);
 
             // Determine next position
-            var existing = cxnLst.Elements(dgm + "cxn").Where(x => (string?)x.Attribute("srcId") == docId).ToList();
-            uint nextPos = existing.Any() ? (uint)(existing.Select(x => (int?)x.Attribute("srcOrd") ?? 0).DefaultIfEmpty(0).Max() + 1) : 0U;
+            List<List<XElement>> existing = GetDocumentChildConnectionGroups(cxnLst, dgm, docId);
+            ResequenceDocumentChildConnections(existing);
+            uint nextPos = (uint)existing.Count;
 
             // Create connection
             var cxn = new XElement(dgm + "cxn",
@@ -267,13 +269,16 @@ namespace OfficeIMO.Word {
             var docPt = xdoc.Descendants(dgm + "pt").FirstOrDefault(p => (string?)p.Attribute("type") == "doc");
             if (docPt == null) throw new InvalidOperationException("Cannot locate document point in SmartArt data model.");
             var docId = (string?)docPt.Attribute("modelId") ?? throw new InvalidOperationException("Document point missing modelId.");
+            EnsureEditableNodeIdsAreUnique(GetEditableNodePoints(xdoc, dgm));
 
             // Resequence existing srcOrd >= index
-            var conns = cxnLst.Elements(dgm + "cxn").Where(c => (string?)c.Attribute("srcId") == docId).OrderBy(c => (int?)c.Attribute("srcOrd") ?? 0).ToList();
-            if (index < 0 || index > conns.Count) throw new ArgumentOutOfRangeException(nameof(index));
-            foreach (var c in conns.Where((c, i) => i >= index)) {
-                var cur = (int?)c.Attribute("srcOrd") ?? 0;
-                c.SetAttributeValue("srcOrd", cur + 1);
+            List<List<XElement>> connectionGroups = GetDocumentChildConnectionGroups(cxnLst, dgm, docId);
+            if (index < 0 || index > connectionGroups.Count) throw new ArgumentOutOfRangeException(nameof(index));
+            for (int groupIndex = 0; groupIndex < connectionGroups.Count; groupIndex++) {
+                int order = groupIndex < index ? groupIndex : groupIndex + 1;
+                foreach (XElement connection in connectionGroups[groupIndex]) {
+                    connection.SetAttributeValue("srcOrd", order);
+                }
             }
 
             // Create new point
@@ -341,6 +346,7 @@ namespace OfficeIMO.Word {
             var dgm = ns.dgm;
 
             List<XElement> nodePts = GetOrderedEditableNodePoints(xdoc, dgm);
+            EnsureEditableNodeIdsAreUnique(nodePts);
             var targetPt = nodePts[index];
             var targetId = (string)targetPt.Attribute("modelId")!;
 
@@ -357,11 +363,7 @@ namespace OfficeIMO.Word {
                 XElement? docPt = xdoc.Descendants(dgm + "pt").FirstOrDefault(p => (string?)p.Attribute("type") == "doc");
                 var docId = (string?)docPt?.Attribute("modelId");
                 if (docId != null) {
-                    var conns = cxn.Elements(dgm + "cxn").Where(x => (string?)x.Attribute("srcId") == docId).ToList();
-                    uint ord = 0;
-                    foreach (var c in conns.OrderBy(c => (int?)c.Attribute("srcOrd") ?? 0)) {
-                        c.SetAttributeValue("srcOrd", ord++);
-                    }
+                    ResequenceDocumentChildConnections(GetDocumentChildConnectionGroups(cxn, dgm, docId));
                 }
             }
 
@@ -383,6 +385,7 @@ namespace OfficeIMO.Word {
 
             XNamespace dgm = ns.dgm;
             List<XElement> nodes = GetOrderedEditableNodePoints(xdoc, dgm);
+            EnsureEditableNodeIdsAreUnique(nodes);
             XElement moved = nodes[fromIndex];
             nodes.RemoveAt(fromIndex);
             nodes.Insert(toIndex, moved);
@@ -391,11 +394,8 @@ namespace OfficeIMO.Word {
                 .Attribute("modelId") ?? throw new InvalidOperationException("Cannot locate document point in SmartArt data model.");
             XElement connections = xdoc.Descendants(dgm + "cxnLst").FirstOrDefault()
                 ?? throw new InvalidOperationException("SmartArt data model missing cxnLst.");
-            Dictionary<string, List<XElement>> byDestination = connections.Elements(dgm + "cxn")
-                .Where(connection => (string?)connection.Attribute("srcId") == docId)
-                .Where(connection => connection.Attribute("destId") != null)
-                .GroupBy(connection => (string)connection.Attribute("destId")!, StringComparer.Ordinal)
-                .ToDictionary(group => group.Key, group => group.ToList(), StringComparer.Ordinal);
+            Dictionary<string, List<XElement>> byDestination = GetDocumentChildConnectionGroups(connections, dgm, docId)
+                .ToDictionary(group => (string)group[0].Attribute("destId")!, StringComparer.Ordinal);
             for (int index = 0; index < nodes.Count; index++) {
                 string id = (string?)nodes[index].Attribute("modelId")
                     ?? throw new InvalidOperationException("SmartArt node is missing modelId.");
@@ -452,6 +452,33 @@ namespace OfficeIMO.Word {
                        (point.Element(dgm + "t") != null || point.Element(dgm + "txBody") != null);
             })
             .ToList();
+
+        private static void EnsureEditableNodeIdsAreUnique(IEnumerable<XElement> nodes) {
+            var ids = new HashSet<string>(StringComparer.Ordinal);
+            foreach (XElement node in nodes) {
+                string? id = (string?)node.Attribute("modelId");
+                if (string.IsNullOrEmpty(id) || !ids.Add(id)) {
+                    throw new InvalidOperationException("SmartArt node modelId values must be non-empty and unique for structural edits.");
+                }
+            }
+        }
+
+        private static List<List<XElement>> GetDocumentChildConnectionGroups(XElement connections, XNamespace dgm, string docId) => connections
+            .Elements(dgm + "cxn")
+            .Where(connection => (string?)connection.Attribute("srcId") == docId)
+            .Where(connection => !string.IsNullOrEmpty((string?)connection.Attribute("destId")))
+            .GroupBy(connection => (string)connection.Attribute("destId")!, StringComparer.Ordinal)
+            .OrderBy(group => group.Min(connection => (int?)connection.Attribute("srcOrd") ?? int.MaxValue))
+            .Select(group => group.ToList())
+            .ToList();
+
+        private static void ResequenceDocumentChildConnections(IReadOnlyList<List<XElement>> connectionGroups) {
+            for (int index = 0; index < connectionGroups.Count; index++) {
+                foreach (XElement connection in connectionGroups[index]) {
+                    connection.SetAttributeValue("srcOrd", index);
+                }
+            }
+        }
 
         private static List<XElement> GetOrderedEditableNodePoints(XDocument xdoc, XNamespace dgm) {
             List<XElement> nodes = GetEditableNodePoints(xdoc, dgm);

--- a/OfficeIMO.Word/WordSmartArt.cs
+++ b/OfficeIMO.Word/WordSmartArt.cs
@@ -457,7 +457,7 @@ namespace OfficeIMO.Word {
             var ids = new HashSet<string>(StringComparer.Ordinal);
             foreach (XElement node in nodes) {
                 string? id = (string?)node.Attribute("modelId");
-                if (string.IsNullOrEmpty(id) || !ids.Add(id)) {
+                if (id == null || id.Length == 0 || !ids.Add(id)) {
                     throw new InvalidOperationException("SmartArt node modelId values must be non-empty and unique for structural edits.");
                 }
             }
@@ -490,9 +490,10 @@ namespace OfficeIMO.Word {
             var byId = new Dictionary<string, XElement>(StringComparer.Ordinal);
             foreach (XElement node in nodes) {
                 string? nodeId = (string?)node.Attribute("modelId");
-                if (string.IsNullOrEmpty(nodeId) || !byId.TryAdd(nodeId, node)) {
+                if (nodeId == null || nodeId.Length == 0 || byId.ContainsKey(nodeId)) {
                     return nodes;
                 }
+                byId.Add(nodeId, node);
             }
             List<XElement> ordered = xdoc.Descendants(dgm + "cxn")
                 .Where(connection => (string?)connection.Attribute("srcId") == docId)


### PR DESCRIPTION
## Summary

- fall back to document order when editable SmartArt nodes have duplicate or missing `modelId` values
- treat duplicate document-child connections as one logical destination across SmartArt ordering and structural edits
- reject ambiguous ID-based structural edits before mutating the package
- add malformed-package regression coverage for public accessors, move, insert, remove, and reload behavior

Addresses Codex Security finding `6582c2161a14819194c7651aef8c2cca`.

## Validation

- full `OfficeIMO.Word.Tests` suite on .NET 8 and .NET 10: 2,781 passed and 11 environment-gated skips per framework
- independent local review plus targeted confirmation: no remaining findings