### PR TITLE
Improve large CSV data-reader throughput

### DIFF
--- a/OfficeIMO.CSV.Benchmarks/Program.cs
+++ b/OfficeIMO.CSV.Benchmarks/Program.cs
@@ -7,8 +7,14 @@ using BenchmarkDotNet.Running;
 using OfficeIMO.Benchmarks;
 using OfficeIMO.CSV.Benchmarks;
 
-if (args.Length > 0 &&
-    string.Equals(args[0], "--profile-markpflug65k-officeimo", StringComparison.OrdinalIgnoreCase)) {
+bool profileOfficeIMO = args.Length > 0 &&
+    string.Equals(args[0], "--profile-markpflug65k-officeimo", StringComparison.OrdinalIgnoreCase);
+bool profileSep = args.Length > 0 &&
+    string.Equals(args[0], "--profile-markpflug65k-sep", StringComparison.OrdinalIgnoreCase);
+bool profileSylvan = args.Length > 0 &&
+    string.Equals(args[0], "--profile-markpflug65k-sylvan", StringComparison.OrdinalIgnoreCase);
+
+if (profileOfficeIMO || profileSep || profileSylvan) {
     int iterations = args.Length > 1 && int.TryParse(args[1], out int parsedIterations)
         ? parsedIterations
         : 100;
@@ -16,21 +22,31 @@ if (args.Length > 0 &&
         throw new ArgumentOutOfRangeException(nameof(iterations));
     }
 
-    MarkPflug65KFixture.EnsureAuthentic(MarkPflug65KFixture.CsvFileName);
     var benchmark = new MarkPflug65KCsvBenchmarks();
+    benchmark.Setup();
+    Func<CsvReadObservation> run = profileOfficeIMO
+        ? benchmark.OfficeIMO
+        : profileSep
+            ? benchmark.Sep
+            : benchmark.Sylvan;
+    string implementation = profileOfficeIMO
+        ? "OfficeIMO"
+        : profileSep
+            ? "Sep"
+            : "Sylvan";
     for (int index = 0; index < 3; index++) {
-        benchmark.OfficeIMO();
+        run();
     }
 
     CsvReadObservation observation = default;
     var stopwatch = System.Diagnostics.Stopwatch.StartNew();
     for (int index = 0; index < iterations; index++) {
-        observation = benchmark.OfficeIMO();
+        observation = run();
     }
     stopwatch.Stop();
 
     Console.WriteLine(
-        $"Profiled OfficeIMO CSV {iterations} times in {stopwatch.Elapsed.TotalMilliseconds:F2} ms " +
+        $"Profiled {implementation} CSV {iterations} times in {stopwatch.Elapsed.TotalMilliseconds:F2} ms " +
         $"({stopwatch.Elapsed.TotalMilliseconds / iterations:F3} ms/iteration): {observation}.");
     return;
 }

--- a/OfficeIMO.CSV/CsvLineReader.cs
+++ b/OfficeIMO.CSV/CsvLineReader.cs
@@ -9,18 +9,41 @@ namespace OfficeIMO.CSV;
 internal sealed partial class CsvLineReader : IDisposable
 {
     private const int DefaultBufferSize = 32 * 1024;
+    private const int MaximumReadRequestSize = 256 * 1024;
 #if NET8_0_OR_GREATER
     private const int UnquotedDelimiterIndexCapacity = 64;
     private const int QuotedPrefixReuseMinimumDelimiterCount = 4;
 #endif
     private readonly TextReader _reader;
-    private readonly char[] _buffer;
+    private char[] _buffer;
     private readonly CancellationToken _cancellationToken;
     private int _position;
     private int _length;
     private bool _endOfReader;
 
     internal char[] Buffer => _buffer;
+
+    internal bool TryGrowFilledBuffer(int minimumCapacity)
+    {
+        if (minimumCapacity <= _buffer.Length || _length < _buffer.Length)
+        {
+            return false;
+        }
+
+        char[] replacement = ArrayPool<char>.Shared.Rent(minimumCapacity);
+        int remaining = _length - _position;
+        if (remaining > 0)
+        {
+            Array.Copy(_buffer, _position, replacement, 0, remaining);
+        }
+
+        char[] previous = _buffer;
+        _buffer = replacement;
+        _position = 0;
+        _length = remaining;
+        ArrayPool<char>.Shared.Return(previous);
+        return true;
+    }
 
     public CsvLineReader(TextReader reader, CancellationToken cancellationToken)
     {
@@ -827,7 +850,7 @@ internal sealed partial class CsvLineReader : IDisposable
             return false;
         }
 
-        _length = _reader.Read(_buffer, 0, _buffer.Length);
+        _length = _reader.Read(_buffer, 0, Math.Min(MaximumReadRequestSize, _buffer.Length));
         _cancellationToken.ThrowIfCancellationRequested();
         _position = 0;
         if (_length > 0)
@@ -856,7 +879,10 @@ internal sealed partial class CsvLineReader : IDisposable
 
         _position = 0;
         _length = remaining;
-        var read = _reader.Read(_buffer, remaining, _buffer.Length - remaining);
+        var read = _reader.Read(
+            _buffer,
+            remaining,
+            Math.Min(MaximumReadRequestSize, _buffer.Length - remaining));
         _cancellationToken.ThrowIfCancellationRequested();
         if (read == 0)
         {

--- a/OfficeIMO.CSV/CsvParser.DataReaderRows.Stream.cs
+++ b/OfficeIMO.CSV/CsvParser.DataReaderRows.Stream.cs
@@ -14,6 +14,7 @@ internal static partial class CsvParser
     /// </summary>
     internal sealed class CsvStreamDataReaderRowSource : ICsvDataReaderTextRowSource
     {
+        private const int LargeDataReaderBufferSize = 512 * 1024;
         private readonly TextReader _reader;
         private readonly CsvLineReader _lineReader;
         private readonly CsvLoadOptions _options;
@@ -42,8 +43,15 @@ internal static partial class CsvParser
 
         internal int FieldCount => _visitor.FieldCount;
 
-        internal void SetSourceColumnCount(int sourceColumnCount) =>
+        internal void SetSourceColumnCount(int sourceColumnCount)
+        {
+            if (_lineReader.TryGrowFilledBuffer(LargeDataReaderBufferSize))
+            {
+                _visitor.SetBuffer(_lineReader.Buffer);
+            }
+
             _visitor.SetSourceColumnCount(sourceColumnCount);
+        }
 
         public bool Read()
         {
@@ -221,7 +229,7 @@ internal static partial class CsvParser
 
     private struct CsvDataReaderStreamRowVisitor : ICsvFieldSpanVisitor
     {
-        private readonly char[] _buffer;
+        private char[] _buffer;
         private static readonly string[] SingleCharacterStrings = CreateSingleCharacterStrings();
         private int[] _starts;
         private int[] _lengths;
@@ -242,6 +250,11 @@ internal static partial class CsvParser
         internal int FieldCount { get; private set; }
 
         internal int SourceColumnCount { get; private set; }
+
+        internal void SetBuffer(char[] buffer)
+        {
+            _buffer = buffer ?? throw new ArgumentNullException(nameof(buffer));
+        }
 
         internal void SetSourceColumnCount(int sourceColumnCount)
         {


### PR DESCRIPTION
## What changed

- Large forward-only CSV data-reader scans now grow the pooled line buffer only after the initial buffer fills, reducing refill and copy churn while small inputs keep the existing 32 KiB working size.
- Individual reader calls remain capped at 256 KiB so cancellation is checked between bounded chunks.
- The existing Mark Pflug 65K benchmark can profile OfficeIMO, Sep, and Sylvan through the same validated observation contract before timing begins.

There are no public API changes.

## Validation

- CSV test suites passed on .NET Framework 4.7.2, .NET 8, and .NET 10.
- OfficeIMO.CSV builds for .NET Standard 2.0, .NET Framework 4.7.2, .NET 8, and .NET 10.
- All three profile modes produced the same rows, cells, character count, and checksum on the pinned fixture.