### PR TITLE
Add validated XLS and XLSB profiling loops

### DIFF
--- a/OfficeIMO.Excel.Benchmarks/Program.cs
+++ b/OfficeIMO.Excel.Benchmarks/Program.cs
@@ -10,8 +10,12 @@ bool profileOfficeIMOXlsb = args.Length > 0 &&
     string.Equals(args[0], "--profile-markpflug65k-xlsb-officeimo", StringComparison.OrdinalIgnoreCase);
 bool profileSylvanXlsb = args.Length > 0 &&
     string.Equals(args[0], "--profile-markpflug65k-xlsb-sylvan", StringComparison.OrdinalIgnoreCase);
+bool profileOfficeIMOXls = args.Length > 0 &&
+    string.Equals(args[0], "--profile-markpflug65k-xls-officeimo", StringComparison.OrdinalIgnoreCase);
+bool profileSylvanXls = args.Length > 0 &&
+    string.Equals(args[0], "--profile-markpflug65k-xls-sylvan", StringComparison.OrdinalIgnoreCase);
 
-if (profileOfficeIMOXlsb || profileSylvanXlsb) {
+if (profileOfficeIMOXlsb || profileSylvanXlsb || profileOfficeIMOXls || profileSylvanXls) {
     int iterations = args.Length > 1 && int.TryParse(args[1], out int parsedIterations)
         ? parsedIterations
         : 100;
@@ -19,12 +23,20 @@ if (profileOfficeIMOXlsb || profileSylvanXlsb) {
         throw new ArgumentOutOfRangeException(nameof(iterations));
     }
 
-    MarkPflug65KFixture.EnsureAuthentic(MarkPflug65KFixture.XlsbFileName);
-    var benchmark = new MarkPflug65KXlsbBenchmarks();
-    Func<ExcelReadObservation> run = profileOfficeIMOXlsb
-        ? benchmark.OfficeIMO
-        : benchmark.Sylvan;
-    string implementation = profileOfficeIMOXlsb ? "OfficeIMO" : "Sylvan";
+    bool isXlsb = profileOfficeIMOXlsb || profileSylvanXlsb;
+    bool isOfficeIMO = profileOfficeIMOXlsb || profileOfficeIMOXls;
+    Func<ExcelReadObservation> run;
+    if (isXlsb) {
+        var benchmark = new MarkPflug65KXlsbBenchmarks();
+        benchmark.Setup();
+        run = isOfficeIMO ? benchmark.OfficeIMO : benchmark.Sylvan;
+    } else {
+        var benchmark = new MarkPflug65KXlsBenchmarks();
+        benchmark.Setup();
+        run = isOfficeIMO ? benchmark.OfficeIMO : benchmark.Sylvan;
+    }
+    string implementation = isOfficeIMO ? "OfficeIMO" : "Sylvan";
+    string format = isXlsb ? "XLSB" : "XLS";
     for (int index = 0; index < 3; index++) {
         run();
     }
@@ -37,7 +49,7 @@ if (profileOfficeIMOXlsb || profileSylvanXlsb) {
     stopwatch.Stop();
 
     Console.WriteLine(
-        $"Profiled {implementation} XLSB {iterations} times in {stopwatch.Elapsed.TotalMilliseconds:F2} ms " +
+        $"Profiled {implementation} {format} {iterations} times in {stopwatch.Elapsed.TotalMilliseconds:F2} ms " +
         $"({stopwatch.Elapsed.TotalMilliseconds / iterations:F3} ms/iteration): {observation}.");
     return;
 }

--- a/OfficeIMO.Excel.Benchmarks/README.md
+++ b/OfficeIMO.Excel.Benchmarks/README.md
@@ -46,9 +46,18 @@ dotnet run -c Release -f net10.0 --project .\OfficeIMO.Excel.Benchmarks\OfficeIM
 dotnet run -c Release -f net10.0 --project .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -- --filter "*MarkPflug65KXlsBenchmarks*"
 dotnet run -c Release -f net10.0 --project .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -- --filter "*MarkPflug65KXlsbBenchmarks*"
 dotnet run -c Release -f net10.0 --project .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -- --filter "*XlsbOfficeIMOPipelineBenchmarks*"
+dotnet run -c Release -f net10.0 --project .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -- --profile-markpflug65k-xls-officeimo 100
+dotnet run -c Release -f net10.0 --project .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -- --profile-markpflug65k-xls-sylvan 100
 dotnet run -c Release -f net10.0 --project .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -- --profile-markpflug65k-xlsb-officeimo 100
 dotnet run -c Release -f net10.0 --project .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -- --profile-markpflug65k-xlsb-sylvan 100
 ```
+
+The four `--profile-markpflug65k-*` commands are lightweight profiling loops,
+not publication-grade benchmark runs. Before timing begins, they authenticate
+the fixture and require OfficeIMO, Sylvan.Data.Excel, and ExcelDataReader to
+produce the same row count, cell count, and deterministic payload observation.
+Use the BenchmarkDotNet class filters above when statistical error and
+allocation measurements are required.
 
 The XLS lane includes OfficeIMO, Sylvan.Data.Excel, and ExcelDataReader. The
 XLSX lane includes OfficeIMO, Sylvan.Data.Excel, ExcelDataReader,


### PR DESCRIPTION
## Summary

- add lightweight OfficeIMO and Sylvan profiling loops for the hash-pinned 65K XLS fixture
- run the full benchmark setup before XLS and XLSB timing so fixture authentication and equivalent OfficeIMO/Sylvan/ExcelDataReader observations are mandatory
- document when to use the profiling loops versus BenchmarkDotNet

## Why

The legacy-format profiler is useful for traces and targeted diagnostics, but timings are only meaningful when every implementation performs the same typed read workload. XLS now has the same focused path as XLSB, and both formats fail before timing if their comparison readers disagree.