### PR TITLE
Add native XLSB hyperlink mutation

### DIFF
--- a/Docs/Compatibility/generated/excel-xlsb.json
+++ b/Docs/Compatibility/generated/excel-xlsb.json
@@ -102,7 +102,7 @@
       "representability":"Native",
       "legacyImport":"Native",
       "newLegacyWrite":"Native",
-      "legacyRoundTrip":"PreservedOpaque",
+      "legacyRoundTrip":"Native",
       "modernToLegacy":"Native",
       "legacyToModern":"Native",
       "affectedFidelity":"None",

--- a/Docs/Compatibility/generated/excel-xlsb.md
+++ b/Docs/Compatibility/generated/excel-xlsb.md
@@ -10,7 +10,7 @@ Schema version: 1
 | Formulas | Excel.Xlsb.Formulas.Tokens | Excel.Xlsb | Native | Native | Approximated | PreservedOpaque | Approximated | Native | Editability, Carrier | Existing unsupported formula payloads are retained during allowed cell-value rewrites; new generation supports a bounded token subset. |
 | Formatting | Excel.Xlsb.Formatting.Styles | Excel.Xlsb | Native | Native | Approximated | PreservedOpaque | Approximated | Native | Editability, Carrier | A useful style subset projects and can be generated. Complex gradients, extensions, differential styles, and custom style families remain guarded. |
 | Structure | Excel.Xlsb.Structure.Geometry | Excel.Xlsb | Native | Native | Native | PreservedOpaque | Native | Native | None |  |
-| Navigation | Excel.Xlsb.Navigation.Hyperlinks | Excel.Xlsb | Native | Native | Native | PreservedOpaque | Native | Native | None |  |
+| Navigation | Excel.Xlsb.Navigation.Hyperlinks | Excel.Xlsb | Native | Native | Native | Native | Native | Native | None |  |
 | Data | Excel.Xlsb.Data.AutoFilter | Excel.Xlsb | Native | Native | Approximated | PreservedOpaque | Approximated | Native | Editability, Carrier | Unsupported criteria remain preserved on import; native new-package generation supports the documented equality-list subset. |
 | Print | Excel.Xlsb.Print.PageSetup | Excel.Xlsb | Native | Native | Native | PreservedOpaque | Native | Native | None |  |
 | Security | Excel.Xlsb.Security.Protection | Excel.Xlsb | Native | Native | Native | PreservedOpaque | Native | Native | None |  |

--- a/OfficeIMO.Excel.Tests/Excel.Security.AllSeverityBatch19.cs
+++ b/OfficeIMO.Excel.Tests/Excel.Security.AllSeverityBatch19.cs
@@ -78,4 +78,34 @@ public partial class Excel {
                 maxPackageBytes: 128 * 1_024));
         Assert.Contains("configured rewrite limit", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
+
+    [Fact]
+    public void Batch19_XlsbRewriteRejectsUnsafeAddedPartName() {
+        byte[] source = CreateMinimalXlsbPackage();
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(
+            () => XlsbNativePackageWriter.RewritePackage(
+                source,
+                new Dictionary<string, byte[]> { ["../outside.rels"] = Array.Empty<byte>() },
+                maxPartBytes: 1_024,
+                maxPackageBytes: 128 * 1_024));
+
+        Assert.Contains("not safe", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Batch19_XlsbRewriteChargesAddedPartAgainstBudget() {
+        byte[] source = CreateMinimalXlsbPackage();
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(
+            () => XlsbNativePackageWriter.RewritePackage(
+                source,
+                new Dictionary<string, byte[]> {
+                    ["xl/worksheets/_rels/sheet1.bin.rels"] = new byte[2_048]
+                },
+                maxPartBytes: 1_024,
+                maxPackageBytes: 128 * 1_024));
+
+        Assert.Contains("configured rewrite limit", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/OfficeIMO.Excel.Tests/Excel.Xlsb.Foundation.cs
+++ b/OfficeIMO.Excel.Tests/Excel.Xlsb.Foundation.cs
@@ -555,22 +555,216 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
-        public void Xlsb_HyperlinkMutation_RejectsBeforeNativeWrite() {
-            using ExcelDocument document = ExcelDocument.Load(GetHyperlinkExcelGeneratedXlsbFixturePath());
+        public void Xlsb_HyperlinkMutation_RewritesInternalTargetAndPreservesOtherParts() {
+            byte[] original = File.ReadAllBytes(GetHyperlinkExcelGeneratedXlsbFixturePath());
+            using ExcelDocument document = ExcelDocument.Load(new MemoryStream(original, writable: false));
             document.Sheets[0].SetInternalLink(
                 2,
                 1,
                 "'Target Sheet'!C3",
                 display: "Internal link",
                 style: false,
-                tooltip: "Internal screen tip");
-            using var destination = new MemoryStream();
+                tooltip: "Updated internal screen tip");
+
+            byte[] rewritten = document.ToBytes(ExcelFileFormat.Xlsb);
+
+            using ExcelDocument reloaded = ExcelDocument.Load(new MemoryStream(rewritten, writable: false));
+            IReadOnlyDictionary<string, ExcelHyperlinkSnapshot> hyperlinks = reloaded.Sheets[0].GetHyperlinks();
+            Assert.Equal("https://example.org/officeimo?source=xlsb", hyperlinks["A1"].Target);
+            Assert.Equal("'Target Sheet'!C3", hyperlinks["A2"].Target);
+            Assert.Equal("Updated internal screen tip", hyperlinks["A2"].Tooltip);
+            AssertPackageEntriesEqualExcept(original, rewritten, "xl/worksheets/sheet1.bin");
+        }
+
+        [Fact]
+        public void Xlsb_HyperlinkMutation_RewritesExternalRelationship() {
+            byte[] original = File.ReadAllBytes(GetHyperlinkExcelGeneratedXlsbFixturePath());
+            using ExcelDocument document = ExcelDocument.Load(new MemoryStream(original, writable: false));
+            document.Sheets[0].SetHyperlink(
+                1,
+                1,
+                "https://example.org/updated?source=xlsb&mode=rewrite",
+                display: "Updated external link",
+                style: false,
+                tooltip: "Updated external screen tip");
+
+            byte[] rewritten = document.ToBytes(ExcelFileFormat.Xlsb);
+
+            using ExcelDocument reloaded = ExcelDocument.Load(new MemoryStream(rewritten, writable: false));
+            IReadOnlyDictionary<string, ExcelHyperlinkSnapshot> hyperlinks = reloaded.Sheets[0].GetHyperlinks();
+            Assert.Equal("https://example.org/updated?source=xlsb&mode=rewrite", hyperlinks["A1"].Target);
+            Assert.Equal("Updated external screen tip", hyperlinks["A1"].Tooltip);
+            Assert.Equal("'Target Sheet'!B2", hyperlinks["A2"].Target);
+            AssertPackageEntriesEqualExcept(
+                original,
+                rewritten,
+                "xl/worksheets/sheet1.bin",
+                "xl/worksheets/_rels/sheet1.bin.rels");
+        }
+
+        [Fact]
+        public void Xlsb_HyperlinkMutation_AddsExternalRelationshipPartToLoadedWorkbook() {
+            byte[] original = File.ReadAllBytes(GetExcelGeneratedXlsbFixturePath());
+            using ExcelDocument document = ExcelDocument.Load(new MemoryStream(original, writable: false));
+            document.Sheets[0].SetHyperlinkReference(
+                1,
+                1,
+                "../docs/zażółć-rewrite.pdf",
+                tooltip: "Added after load");
+
+            byte[] rewritten = document.ToBytes(ExcelFileFormat.Xlsb);
+
+            using (var archive = new ZipArchive(new MemoryStream(rewritten, writable: false), ZipArchiveMode.Read)) {
+                Assert.NotNull(archive.GetEntry("xl/worksheets/_rels/sheet1.bin.rels"));
+            }
+            AssertPackageEntriesEqualExcept(
+                original,
+                rewritten,
+                "xl/worksheets/sheet1.bin",
+                "xl/worksheets/_rels/sheet1.bin.rels",
+                "xl/styles.bin");
+            using ExcelDocument reloaded = ExcelDocument.Load(new MemoryStream(rewritten, writable: false));
+            ExcelHyperlinkSnapshot hyperlink = Assert.Single(reloaded.Sheets[0].GetHyperlinks()).Value;
+            Assert.True(hyperlink.IsExternal);
+            Assert.Equal("../docs/zażółć-rewrite.pdf", hyperlink.Target);
+            Assert.Equal("Added after load", hyperlink.Tooltip);
+            Cell styledCell = Assert.Single(
+                reloaded.Sheets[0].WorksheetPart.Worksheet.Descendants<Cell>(),
+                cell => cell.CellReference?.Value == "A1");
+            uint styleIndex = Assert.IsType<DocumentFormat.OpenXml.UInt32Value>(styledCell.StyleIndex).Value;
+            Stylesheet stylesheet = Assert.IsType<Stylesheet>(reloaded.WorkbookPartRoot.WorkbookStylesPart?.Stylesheet);
+            CellFormat hyperlinkFormat = stylesheet.CellFormats!.Elements<CellFormat>().ElementAt(checked((int)styleIndex));
+            DocumentFormat.OpenXml.Spreadsheet.Font hyperlinkFont = stylesheet.Fonts!.Elements<DocumentFormat.OpenXml.Spreadsheet.Font>()
+                .ElementAt(checked((int)(hyperlinkFormat.FontId?.Value ?? 0U)));
+            Assert.NotNull(hyperlinkFont.Underline);
+            Assert.Equal("FF0563C1", hyperlinkFont.Color?.Rgb?.Value, ignoreCase: true);
+        }
+
+        [Fact]
+        public void Xlsb_HyperlinkMutation_InsertsFirstRecordBeforeLateWorksheetMetadata() {
+            byte[] original = File.ReadAllBytes(GetExcelGeneratedXlsbFixturePath());
+            byte[] withoutPrintMetadata;
+            using (var archive = new ZipArchive(new MemoryStream(original, writable: false), ZipArchiveMode.Read)) {
+                using Stream worksheetStream = Assert.IsType<ZipArchiveEntry>(archive.GetEntry("xl/worksheets/sheet1.bin")).Open();
+                IReadOnlyList<XlsbRecord> records = XlsbRecordReader.ReadAll(worksheetStream);
+                using var rewrittenPart = new MemoryStream();
+                foreach (XlsbRecord record in records) {
+                    if (record.Type >= 476 && record.Type <= 480) continue;
+                    if (record.Type == 130) XlsbRecordWriter.Write(rewrittenPart, 550, Array.Empty<byte>());
+                    XlsbRecordWriter.Write(rewrittenPart, record.Type, record.Data);
+                }
+                withoutPrintMetadata = ReplaceZipEntry(original, "xl/worksheets/sheet1.bin", rewrittenPart.ToArray());
+            }
+
+            using ExcelDocument document = ExcelDocument.Load(new MemoryStream(withoutPrintMetadata, writable: false));
+            document.Sheets[0].SetInternalLink(1, 1, "A1", display: "Top", style: false);
+
+            byte[] rewritten = document.ToBytes(ExcelFileFormat.Xlsb);
+
+            using var rewrittenArchive = new ZipArchive(new MemoryStream(rewritten, writable: false), ZipArchiveMode.Read);
+            using Stream rewrittenWorksheet = Assert.IsType<ZipArchiveEntry>(rewrittenArchive.GetEntry("xl/worksheets/sheet1.bin")).Open();
+            IReadOnlyList<XlsbRecord> rewrittenRecords = XlsbRecordReader.ReadAll(rewrittenWorksheet);
+            Assert.True(
+                rewrittenRecords.ToList().FindIndex(record => record.Type == 494)
+                < rewrittenRecords.ToList().FindIndex(record => record.Type == 550));
+        }
+
+        [Fact]
+        public void Xlsb_HyperlinkMutation_RejectsLocationAtBiff12Limit() {
+            using ExcelDocument document = ExcelDocument.Load(GetExcelGeneratedXlsbFixturePath());
+            document.Sheets[0].SetInternalLink(
+                1,
+                1,
+                new string('L', 2_084),
+                display: "Oversized location",
+                style: false);
 
             NotSupportedException exception = Assert.Throws<NotSupportedException>(() =>
-                document.Save(destination, ExcelFileFormat.Xlsb));
+                document.ToBytes(ExcelFileFormat.Xlsb));
 
-            Assert.Contains("cannot modify hyperlinks", exception.Message, StringComparison.OrdinalIgnoreCase);
-            Assert.Equal(0, destination.Length);
+            Assert.Contains("locations shorter than 2,084", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Xlsb_HyperlinkMutation_RejectsTooltipAtBiff12Limit() {
+            using ExcelDocument document = ExcelDocument.Load(GetExcelGeneratedXlsbFixturePath());
+            document.Sheets[0].SetHyperlinkReference(
+                1,
+                1,
+                "https://example.org/tooltip-limit",
+                style: false,
+                tooltip: new string('T', 256));
+
+            NotSupportedException exception = Assert.Throws<NotSupportedException>(() =>
+                document.ToBytes(ExcelFileFormat.Xlsb));
+
+            Assert.Contains("tooltips shorter than 256", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Xlsb_HyperlinkMutation_PreservesUnrelatedRelationshipsAndRemapsCollidingIds() {
+            const string relationshipPartName = "xl/worksheets/_rels/sheet1.bin.rels";
+            byte[] original = File.ReadAllBytes(GetExcelGeneratedXlsbFixturePath());
+
+            using ExcelDocument document = ExcelDocument.Load(new MemoryStream(original, writable: false));
+            document.Sheets[0].SetHyperlink(
+                1,
+                1,
+                "https://example.org/collision-safe",
+                display: "Collision-safe hyperlink",
+                style: false,
+                tooltip: "Relationship collision");
+
+            byte[] rewritten = document.ToBytes(ExcelFileFormat.Xlsb);
+
+            using (var archive = new ZipArchive(new MemoryStream(rewritten, writable: false), ZipArchiveMode.Read)) {
+                ZipArchiveEntry relationshipPart = Assert.IsType<ZipArchiveEntry>(archive.GetEntry(relationshipPartName));
+                System.Xml.Linq.XElement[] relationships = System.Xml.Linq.XDocument.Load(relationshipPart.Open())
+                    .Descendants()
+                    .Where(element => element.Name.LocalName == "Relationship")
+                    .ToArray();
+                Assert.Contains(relationships, relationship =>
+                    (string?)relationship.Attribute("Id") == "rId1"
+                    && ((string?)relationship.Attribute("Type"))?.EndsWith("/xlBinaryIndex", StringComparison.Ordinal) == true
+                    && (string?)relationship.Attribute("Target") == "binaryIndex1.bin");
+                Assert.Contains(relationships, relationship =>
+                    (string?)relationship.Attribute("Id") != "rId1"
+                    && ((string?)relationship.Attribute("Type"))?.EndsWith("/hyperlink", StringComparison.Ordinal) == true
+                    && (string?)relationship.Attribute("Target") == "https://example.org/collision-safe");
+                ZipArchiveEntry binaryIndex = Assert.IsType<ZipArchiveEntry>(archive.GetEntry("xl/worksheets/binaryIndex1.bin"));
+                Assert.Equal(61, binaryIndex.Length);
+            }
+            using ExcelDocument reloaded = ExcelDocument.Load(new MemoryStream(rewritten, writable: false));
+            Assert.Equal("https://example.org/collision-safe", Assert.Single(reloaded.Sheets[0].GetHyperlinks()).Value.Target);
+
+            reloaded.Sheets[0].ClearRange("A1:A1", ExcelClearOptions.Hyperlinks);
+            byte[] cleared = reloaded.ToBytes(ExcelFileFormat.Xlsb);
+            using var clearedArchive = new ZipArchive(new MemoryStream(cleared, writable: false), ZipArchiveMode.Read);
+            ZipArchiveEntry clearedRelationshipPart = Assert.IsType<ZipArchiveEntry>(clearedArchive.GetEntry(relationshipPartName));
+            System.Xml.Linq.XElement relationship = Assert.Single(
+                System.Xml.Linq.XDocument.Load(clearedRelationshipPart.Open()).Descendants(),
+                element => element.Name.LocalName == "Relationship");
+            Assert.Equal("rId1", (string?)relationship.Attribute("Id"));
+            Assert.EndsWith("/xlBinaryIndex", (string?)relationship.Attribute("Type"), StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void Xlsb_HyperlinkMutation_RemovesRecordsAndPreservesUnrelatedRelationshipPart() {
+            using ExcelDocument document = ExcelDocument.Load(GetHyperlinkExcelGeneratedXlsbFixturePath());
+            document.Sheets[0].ClearRange("A1:A2", ExcelClearOptions.Hyperlinks);
+
+            byte[] rewritten = document.ToBytes(ExcelFileFormat.Xlsb);
+
+            using (var archive = new ZipArchive(new MemoryStream(rewritten, writable: false), ZipArchiveMode.Read)) {
+                ZipArchiveEntry relationshipPart = Assert.IsType<ZipArchiveEntry>(
+                    archive.GetEntry("xl/worksheets/_rels/sheet1.bin.rels"));
+                System.Xml.Linq.XElement relationship = Assert.Single(
+                    System.Xml.Linq.XDocument.Load(relationshipPart.Open()).Descendants(),
+                    element => element.Name.LocalName == "Relationship");
+                Assert.EndsWith("/xlBinaryIndex", (string?)relationship.Attribute("Type"), StringComparison.Ordinal);
+            }
+            using ExcelDocument reloaded = ExcelDocument.Load(new MemoryStream(rewritten, writable: false));
+            Assert.Empty(reloaded.Sheets[0].GetHyperlinks());
         }
 
         [Fact]
@@ -589,6 +783,44 @@ namespace OfficeIMO.Tests {
                 ExcelDocument.Load(new MemoryStream(malformed, writable: false)));
 
             Assert.Contains("missing or invalid hyperlink relationship", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Xlsb_HyperlinkImport_RejectsLocationAtBiff12Limit() {
+            byte[] package = File.ReadAllBytes(GetHyperlinkExcelGeneratedXlsbFixturePath());
+            byte[] worksheet = ReadZipEntry(package, "xl/worksheets/sheet1.bin");
+            using var input = new MemoryStream(worksheet, writable: false);
+            IReadOnlyList<XlsbRecord> records = XlsbRecordReader.ReadAll(input);
+            XlsbRecord hyperlink = records.First(record => record.Type == 494);
+            byte[] malformed = ReplaceWorksheetRecords(
+                package,
+                records,
+                hyperlink,
+                RewriteXlsbHyperlinkStrings(hyperlink.Data, location: new string('L', 2_084)));
+
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+                ExcelDocument.Load(new MemoryStream(malformed, writable: false)));
+
+            Assert.Contains("limit of 2083 characters", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Xlsb_HyperlinkImport_RejectsTooltipAtBiff12Limit() {
+            byte[] package = File.ReadAllBytes(GetHyperlinkExcelGeneratedXlsbFixturePath());
+            byte[] worksheet = ReadZipEntry(package, "xl/worksheets/sheet1.bin");
+            using var input = new MemoryStream(worksheet, writable: false);
+            IReadOnlyList<XlsbRecord> records = XlsbRecordReader.ReadAll(input);
+            XlsbRecord hyperlink = records.First(record => record.Type == 494);
+            byte[] malformed = ReplaceWorksheetRecords(
+                package,
+                records,
+                hyperlink,
+                RewriteXlsbHyperlinkStrings(hyperlink.Data, tooltip: new string('T', 256)));
+
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+                ExcelDocument.Load(new MemoryStream(malformed, writable: false)));
+
+            Assert.Contains("limit of 255 characters", exception.Message, StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact]
@@ -1728,6 +1960,34 @@ namespace OfficeIMO.Tests {
                 XlsbRecordWriter.Write(output, record.Type, ReferenceEquals(record, target) ? replacementData : record.Data);
             }
             return ReplaceZipEntry(package, "xl/worksheets/sheet1.bin", output.ToArray());
+        }
+
+        private static byte[] RewriteXlsbHyperlinkStrings(
+            byte[] data,
+            string? location = null,
+            string? tooltip = null) {
+            var cursor = new XlsbBinaryCursor(data);
+            byte[] range = cursor.ReadBytes(16);
+            string relationshipId = cursor.ReadWideString(1_000_000);
+            string sourceLocation = cursor.ReadWideString(1_000_000);
+            string sourceTooltip = cursor.ReadWideString(1_000_000);
+            string display = cursor.ReadWideString(1_000_000);
+
+            using var output = new MemoryStream();
+            output.Write(range, 0, range.Length);
+            WriteXlsbTestWideString(output, relationshipId);
+            WriteXlsbTestWideString(output, location ?? sourceLocation);
+            WriteXlsbTestWideString(output, tooltip ?? sourceTooltip);
+            WriteXlsbTestWideString(output, display);
+            return output.ToArray();
+        }
+
+        private static void WriteXlsbTestWideString(Stream output, string value) {
+            byte[] count = new byte[4];
+            WriteXlsbTestUInt32(count, 0, checked((uint)value.Length));
+            output.Write(count, 0, count.Length);
+            byte[] text = System.Text.Encoding.Unicode.GetBytes(value);
+            output.Write(text, 0, text.Length);
         }
 
         private static byte[] RemoveWorksheetRowsAndCells(byte[] package) {

--- a/OfficeIMO.Excel/ExcelCompatibilityCatalog.cs
+++ b/OfficeIMO.Excel/ExcelCompatibilityCatalog.cs
@@ -85,7 +85,7 @@ public static class ExcelCompatibilityCatalog {
             XlsbSubset("Formatting.Styles", "Formatting", "Fonts, number formats, fills, borders, alignment, protection, and cell formats.",
                 "A useful style subset projects and can be generated. Complex gradients, extensions, differential styles, and custom style families remain guarded."),
             XlsbNative("Structure.Geometry", "Structure", "Dimensions, rows, columns, merges, panes, views, selections, and outline metadata."),
-            XlsbNative("Navigation.Hyperlinks", "Navigation", "Internal and relationship-backed external hyperlinks."),
+            XlsbNative("Navigation.Hyperlinks", "Navigation", "Internal and relationship-backed external hyperlinks.", editableRoundTrip: true),
             XlsbSubset("Data.AutoFilter", "Data", "Worksheet AutoFilter ranges and equality-list criteria.",
                 "Unsupported criteria remain preserved on import; native new-package generation supports the documented equality-list subset."),
             XlsbNative("Print.PageSetup", "Print", "Print options, margins, page setup, and text headers and footers."),
@@ -144,10 +144,11 @@ public static class ExcelCompatibilityCatalog {
         OfficeCapabilityCoverageState.Dropped, impact,
         "Exact carrier retention is safe for unchanged or explicitly preservation-aware XLS flows; editable cross-format parity is not claimed.");
 
-    private static OfficeCapability XlsbNative(string id, string category, string description) => Capability(
+    private static OfficeCapability XlsbNative(string id, string category, string description, bool editableRoundTrip = false) => Capability(
         XlsbFormatId, "Excel.Xlsb." + id, category, description, OfficeCapabilityRepresentability.Native,
         OfficeCapabilityCoverageState.Native, OfficeCapabilityCoverageState.Native,
-        OfficeCapabilityCoverageState.PreservedOpaque, OfficeCapabilityCoverageState.Native,
+        editableRoundTrip ? OfficeCapabilityCoverageState.Native : OfficeCapabilityCoverageState.PreservedOpaque,
+        OfficeCapabilityCoverageState.Native,
         OfficeCapabilityCoverageState.Native);
 
     private static OfficeCapability XlsbSubset(string id, string category, string description, string note) => Capability(

--- a/OfficeIMO.Excel/Xlsb/Model/XlsbWorkbook.cs
+++ b/OfficeIMO.Excel/Xlsb/Model/XlsbWorkbook.cs
@@ -41,6 +41,8 @@ namespace OfficeIMO.Excel.Xlsb.Model {
 
         internal XlsbStylesheet? Stylesheet { get; set; }
 
+        internal string? StylesheetPartName { get; set; }
+
         internal void AddWorksheet(XlsbWorksheet worksheet) => _worksheets.Add(worksheet);
 
         internal void AddDefinedName(XlsbDefinedName definedName) => _definedNames.Add(definedName);

--- a/OfficeIMO.Excel/Xlsb/Model/XlsbWorksheet.cs
+++ b/OfficeIMO.Excel/Xlsb/Model/XlsbWorksheet.cs
@@ -1,3 +1,5 @@
+using OfficeIMO.Excel.Xlsb.Package;
+
 namespace OfficeIMO.Excel.Xlsb.Model {
     internal sealed class XlsbWorksheet {
         private readonly List<XlsbCell> _cells = new List<XlsbCell>();
@@ -32,6 +34,9 @@ namespace OfficeIMO.Excel.Xlsb.Model {
         internal IReadOnlyList<XlsbCellRange> MergedRanges => _mergedRanges;
 
         internal IReadOnlyList<XlsbHyperlink> Hyperlinks => _hyperlinks;
+
+        internal IReadOnlyDictionary<string, XlsbPackageRelationship> Relationships { get; set; } =
+            new Dictionary<string, XlsbPackageRelationship>(StringComparer.Ordinal);
 
         internal XlsbCellRange? UsedRange { get; set; }
 

--- a/OfficeIMO.Excel/Xlsb/Projection/XlsbWorksheetHyperlinkProjector.cs
+++ b/OfficeIMO.Excel/Xlsb/Projection/XlsbWorksheetHyperlinkProjector.cs
@@ -37,23 +37,27 @@ namespace OfficeIMO.Excel.Xlsb.Projection {
             worksheet.Save();
         }
 
-        internal static void ValidateUnchanged(ExcelSheet sheet, XlsbWorksheet sourceSheet) {
+        internal static bool Matches(ExcelSheet sheet, XlsbWorksheet sourceSheet) {
             Worksheet worksheet = sheet.WorksheetPart.Worksheet
                 ?? throw new InvalidDataException($"Worksheet '{sheet.Name}' has no worksheet root.");
             Hyperlinks[] containers = worksheet.Elements<Hyperlinks>().ToArray();
             if (sourceSheet.Hyperlinks.Count == 0) {
-                if (containers.Length != 0 || sheet.WorksheetPart.HyperlinkRelationships.Any()) {
-                    ThrowMutation(sheet);
-                }
-                return;
+                return containers.Length == 0 && !sheet.WorksheetPart.HyperlinkRelationships.Any();
             }
-            if (containers.Length != 1) ThrowMutation(sheet);
+            if (containers.Length != 1) return false;
 
-            Hyperlink[] actualLinks = containers[0].Elements<Hyperlink>().ToArray();
+            Hyperlinks container = containers[0];
+            if (container.GetAttributes().Any(attribute =>
+                    !string.Equals(attribute.NamespaceUri, "http://www.w3.org/2000/xmlns/", StringComparison.Ordinal))) {
+                return false;
+            }
+            Hyperlink[] actualLinks = container.Elements<Hyperlink>().ToArray();
             HyperlinkRelationship[] relationships = sheet.WorksheetPart.HyperlinkRelationships.ToArray();
             int expectedExternalCount = sourceSheet.Hyperlinks.Count(link => link.IsExternal);
-            if (actualLinks.Length != sourceSheet.Hyperlinks.Count || relationships.Length != expectedExternalCount) {
-                ThrowMutation(sheet);
+            if (actualLinks.Length != container.ChildElements.Count
+                || actualLinks.Length != sourceSheet.Hyperlinks.Count
+                || relationships.Length != expectedExternalCount) {
+                return false;
             }
             var relationshipsById = relationships.ToDictionary(relationship => relationship.Id, StringComparer.Ordinal);
             for (int index = 0; index < actualLinks.Length; index++) {
@@ -65,7 +69,7 @@ namespace OfficeIMO.Excel.Xlsb.Projection {
                     || !MatchesOptional(actual.Location?.Value, expected.Location)
                     || !MatchesOptional(actual.Tooltip?.Value, expected.Tooltip)
                     || !MatchesOptional(actual.Display?.Value, expected.Display)) {
-                    ThrowMutation(sheet);
+                    return false;
                 }
 
                 string? relationshipId = actual.Id?.Value;
@@ -73,12 +77,14 @@ namespace OfficeIMO.Excel.Xlsb.Projection {
                     if (string.IsNullOrWhiteSpace(relationshipId)
                         || !relationshipsById.TryGetValue(relationshipId!, out HyperlinkRelationship? relationship)
                         || !string.Equals(relationship.Uri.OriginalString, expected.ExternalTarget, StringComparison.Ordinal)) {
-                        ThrowMutation(sheet);
+                        return false;
                     }
                 } else if (!string.IsNullOrWhiteSpace(relationshipId)) {
-                    ThrowMutation(sheet);
+                    return false;
                 }
             }
+
+            return true;
         }
 
         private static bool IsSupportedAttribute(string localName) {
@@ -91,10 +97,6 @@ namespace OfficeIMO.Excel.Xlsb.Projection {
 
         private static bool MatchesOptional(string? actual, string expected) {
             return string.Equals(actual ?? string.Empty, expected, StringComparison.Ordinal);
-        }
-
-        private static void ThrowMutation(ExcelSheet sheet) {
-            throw new NotSupportedException($"Native XLSB rewriting preserves but cannot modify hyperlinks on worksheet '{sheet.Name}'. Save as .xlsx to retain that change.");
         }
     }
 }

--- a/OfficeIMO.Excel/Xlsb/Read/XlsbTabularWorkbook.cs
+++ b/OfficeIMO.Excel/Xlsb/Read/XlsbTabularWorkbook.cs
@@ -38,6 +38,8 @@ namespace OfficeIMO.Excel.Xlsb.Read {
         private const int BrtBeginCellStyleXfs = 626;
         private const int BrtEndCellStyleXfs = 627;
         private const int MaxStyleItems = 65_536;
+        private const int MaxFonts = 0xFFD3;
+        private const int MaxCellFormats = 0xFF96;
         private const string WorksheetRelationshipSuffix = "/worksheet";
         private const string ChartSheetRelationshipSuffix = "/chartsheet";
         private const string DialogSheetRelationshipSuffix = "/dialogsheet";
@@ -809,9 +811,14 @@ namespace OfficeIMO.Excel.Xlsb.Read {
             }
 
             uint declared = record.CreateCursor().ReadUInt32();
-            if (declared > MaxStyleItems) {
+            int maximum = collectionName == "font"
+                ? MaxFonts
+                : collectionName == "cell-format"
+                    ? MaxCellFormats
+                    : MaxStyleItems;
+            if (declared > maximum) {
                 throw new InvalidDataException(
-                    $"The XLSB {collectionName} collection declares {declared} items, exceeding the supported limit of {MaxStyleItems}.");
+                    $"The XLSB {collectionName} collection declares {declared} items, exceeding the supported limit of {maximum}.");
             }
 
             activeCollectionEnd = expectedEndRecord;

--- a/OfficeIMO.Excel/Xlsb/Styles/XlsbStylesheetReader.cs
+++ b/OfficeIMO.Excel/Xlsb/Styles/XlsbStylesheetReader.cs
@@ -24,6 +24,8 @@ namespace OfficeIMO.Excel.Xlsb.Styles {
         private const int BrtBorder = 46;
         private const int BrtXf = 47;
         private const int MaxStyleItems = 65_536;
+        private const int MaxFonts = 0xFFD3;
+        private const int MaxCellFormats = 0xFF96;
 
         internal static XlsbStylesheet Read(
             byte[] bytes,
@@ -166,8 +168,13 @@ namespace OfficeIMO.Excel.Xlsb.Styles {
 
             var cursor = new XlsbBinaryCursor(record.Data);
             uint declared = cursor.ReadUInt32();
-            if (declared > MaxStyleItems) {
-                throw new InvalidDataException($"The XLSB {kind} collection declares {declared} items, exceeding the supported limit of {MaxStyleItems}.");
+            int maximum = kind == CollectionKind.Fonts
+                ? MaxFonts
+                : kind == CollectionKind.CellFormats
+                    ? MaxCellFormats
+                    : MaxStyleItems;
+            if (declared > maximum) {
+                throw new InvalidDataException($"The XLSB {kind} collection declares {declared} items, exceeding the supported limit of {maximum}.");
             }
 
             active = kind;

--- a/OfficeIMO.Excel/Xlsb/Write/XlsbNativePackageWriter.cs
+++ b/OfficeIMO.Excel/Xlsb/Write/XlsbNativePackageWriter.cs
@@ -7,10 +7,13 @@ using System.IO.Compression;
 
 namespace OfficeIMO.Excel.Xlsb.Write {
     /// <summary>
-    /// Rewrites the supported cell-value subset of an existing XLSB package while copying every other part.
+    /// Rewrites supported worksheet cells and hyperlinks in an existing XLSB package while copying every other part.
     /// </summary>
     internal static class XlsbNativePackageWriter {
         private const int MaxWorksheetPartBytes = 128 * 1024 * 1024;
+        private const string HyperlinkRelationshipSuffix = "/hyperlink";
+        private static readonly DateTimeOffset ReproducibleEntryTime =
+            new DateTimeOffset(1980, 1, 1, 0, 0, 0, TimeSpan.Zero);
 
         internal static byte[] Rewrite(
             ExcelDocument document,
@@ -23,8 +26,23 @@ namespace OfficeIMO.Excel.Xlsb.Write {
             ThrowIfUnsupportedWorkbookMutation(document, sourceWorkbook, sourcePackageBytes);
             ExcelSheet[] sheets = document.Sheets.ToArray();
             var replacements = new Dictionary<string, byte[]>(StringComparer.OrdinalIgnoreCase);
+            var deletions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             using (var packageStream = new MemoryStream(sourcePackageBytes, writable: false))
             using (var archive = new ZipArchive(packageStream, ZipArchiveMode.Read, leaveOpen: false)) {
+                byte[]? sourceStylesPart = null;
+                if (!string.IsNullOrWhiteSpace(sourceWorkbook.StylesheetPartName)) {
+                    ZipArchiveEntry sourceStylesEntry = FindEntry(archive, sourceWorkbook.StylesheetPartName!)
+                        ?? throw new InvalidDataException($"The source XLSB styles part '{sourceWorkbook.StylesheetPartName}' is missing.");
+                    sourceStylesPart = ReadEntry(sourceStylesEntry, sourceWorkbook.MaxPartBytes);
+                }
+                XlsbStylesheetRewritePlan stylesheetPlan = XlsbStylesheetRewritePlan.Create(
+                    document,
+                    sourceWorkbook,
+                    sourceStylesPart);
+                if (stylesheetPlan.Replacement != null) {
+                    replacements.Add(stylesheetPlan.PartName!, stylesheetPlan.Replacement);
+                }
+
                 for (int index = 0; index < sheets.Length; index++) {
                     XlsbWorksheet sourceSheet = sourceWorkbook.Worksheets[index];
                     string partName = sourceSheet.PartName
@@ -32,20 +50,50 @@ namespace OfficeIMO.Excel.Xlsb.Write {
                     ZipArchiveEntry sourceEntry = FindEntry(archive, partName)
                         ?? throw new InvalidDataException($"The source XLSB worksheet part '{partName}' is missing.");
                     byte[] originalPart = ReadEntry(sourceEntry, MaxWorksheetPartBytes);
-                    IReadOnlyList<XlsbWriteCell> cells = XlsbWorksheetCellExtractor.Extract(document, sheets[index], sourceSheet);
-                    byte[] rewrittenPart = XlsbWorksheetPartWriter.Rewrite(originalPart, cells);
+                    IReadOnlyList<XlsbWriteCell> cells = XlsbWorksheetCellExtractor.Extract(
+                        document,
+                        sheets[index],
+                        sourceSheet,
+                        stylesheetPlan.CellFormatCount);
+                    bool rewriteHyperlinks = !XlsbWorksheetHyperlinkProjector.Matches(sheets[index], sourceSheet);
+                    string[] reservedRelationshipIds = sourceSheet.Relationships.Values
+                        .Where(relationship => !relationship.Type.EndsWith(HyperlinkRelationshipSuffix, StringComparison.Ordinal))
+                        .Select(relationship => relationship.Id)
+                        .ToArray();
+                    XlsbWorksheetHyperlinkPlan? hyperlinkPlan = rewriteHyperlinks
+                        ? XlsbWorksheetHyperlinkPlan.Create(
+                            sheets[index],
+                            pruneOrphanedRelationships: true,
+                            reservedRelationshipIds)
+                        : null;
+                    byte[] rewrittenPart = XlsbWorksheetPartWriter.Rewrite(
+                        originalPart,
+                        cells,
+                        hyperlinkPlan?.Records ?? Array.Empty<XlsbGeneratedRecord>(),
+                        rewriteHyperlinks);
                     if (!originalPart.SequenceEqual(rewrittenPart)) {
                         replacements.Add(partName, rewrittenPart);
+                    }
+                    if (hyperlinkPlan != null && !hyperlinkPlan.RelationshipsMatch(sourceSheet)) {
+                        string relationshipPartName = GetRelationshipPartName(partName);
+                        int preservedRelationshipCount = sourceSheet.Relationships.Values.Count(relationship =>
+                            !relationship.Type.EndsWith(HyperlinkRelationshipSuffix, StringComparison.Ordinal));
+                        if (hyperlinkPlan.Relationships.Count == 0 && preservedRelationshipCount == 0) {
+                            deletions.Add(relationshipPartName);
+                        } else {
+                            replacements[relationshipPartName] = hyperlinkPlan.CreateRelationshipPart(sourceSheet.Relationships);
+                        }
                     }
                 }
             }
 
-            if (replacements.Count == 0) return sourcePackageBytes;
+            if (replacements.Count == 0 && deletions.Count == 0) return sourcePackageBytes;
             byte[] rewritten = RewritePackage(
                 sourcePackageBytes,
                 replacements,
                 sourceWorkbook.MaxPartBytes,
-                sourceWorkbook.MaxPackageBytes);
+                sourceWorkbook.MaxPackageBytes,
+                deletions);
             if (!XlsbPackageDetector.TryFindWorkbookPart(rewritten, out _)) {
                 throw new InvalidDataException("The rewritten package no longer satisfies the XLSB package contract.");
             }
@@ -77,8 +125,6 @@ namespace OfficeIMO.Excel.Xlsb.Write {
             ValidateWorkbookProtection(document, sourceWorkbook);
             ValidateDefinedNames(document, sourceWorkbook);
             ValidateCalculationProperties(document, sourceWorkbook);
-            ValidateStylesheet(document, sourceWorkbook);
-
             ExcelSheet[] sheets = document.Sheets.ToArray();
             if (sheets.Length != sourceWorkbook.Worksheets.Count) {
                 throw new NotSupportedException("Native XLSB rewriting currently requires the original worksheet set and order. Save workbook structure changes as .xlsx.");
@@ -141,33 +187,64 @@ namespace OfficeIMO.Excel.Xlsb.Write {
             }
         }
 
-        private static void ValidateStylesheet(ExcelDocument document, XlsbWorkbook sourceWorkbook) {
-            if (sourceWorkbook.Stylesheet == null) return;
-
-            Stylesheet? current = document.WorkbookPartRoot.WorkbookStylesPart?.Stylesheet;
-            Stylesheet expected = XlsbStylesheetProjector.Create(sourceWorkbook.Stylesheet);
-            if (current == null || !string.Equals(current.OuterXml, expected.OuterXml, StringComparison.Ordinal)) {
-                throw new NotSupportedException("Native XLSB rewriting currently preserves but cannot modify the workbook style table. Save style changes as .xlsx.");
-            }
-        }
+        internal static byte[] RewritePackage(
+            byte[] sourcePackageBytes,
+            IReadOnlyDictionary<string, byte[]> replacements,
+            int maxPartBytes,
+            long maxPackageBytes) => RewritePackage(
+                sourcePackageBytes,
+                replacements,
+                maxPartBytes,
+                maxPackageBytes,
+                deletions: null);
 
         internal static byte[] RewritePackage(
             byte[] sourcePackageBytes,
             IReadOnlyDictionary<string, byte[]> replacements,
             int maxPartBytes,
-            long maxPackageBytes) {
+            long maxPackageBytes,
+            ISet<string>? deletions) {
+            if (sourcePackageBytes == null) throw new ArgumentNullException(nameof(sourcePackageBytes));
+            if (replacements == null) throw new ArgumentNullException(nameof(replacements));
+
+            var normalizedReplacements = new Dictionary<string, byte[]>(StringComparer.OrdinalIgnoreCase);
+            foreach (KeyValuePair<string, byte[]> replacement in replacements) {
+                string normalizedName = NormalizePartName(replacement.Key);
+                if (replacement.Value == null) {
+                    throw new ArgumentException($"Replacement package part '{normalizedName}' has no content.", nameof(replacements));
+                }
+                if (normalizedReplacements.ContainsKey(normalizedName)) {
+                    throw new ArgumentException($"Replacement package part '{normalizedName}' is duplicated.", nameof(replacements));
+                }
+                normalizedReplacements.Add(normalizedName, replacement.Value);
+            }
+            var normalizedDeletions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if (deletions != null) {
+                foreach (string deletion in deletions) {
+                    string normalizedName = NormalizePartName(deletion);
+                    if (normalizedReplacements.ContainsKey(normalizedName)) {
+                        throw new ArgumentException($"Package part '{normalizedName}' cannot be replaced and deleted in the same rewrite.", nameof(deletions));
+                    }
+                    normalizedDeletions.Add(normalizedName);
+                }
+            }
+
             using var sourceStream = new MemoryStream(sourcePackageBytes, writable: false);
             using var sourceArchive = new ZipArchive(sourceStream, ZipArchiveMode.Read, leaveOpen: false);
             using var destinationStream = new MemoryStream(sourcePackageBytes.Length + 4096);
             long decompressedBytes = 0;
             byte[] buffer = new byte[81920];
+            var writtenReplacements = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             using (var destinationArchive = new ZipArchive(destinationStream, ZipArchiveMode.Create, leaveOpen: true)) {
                 foreach (ZipArchiveEntry sourceEntry in sourceArchive.Entries) {
-                    string normalizedName = sourceEntry.FullName.Replace('\\', '/');
+                    if (string.IsNullOrEmpty(sourceEntry.Name)) continue;
+                    string normalizedName = NormalizePartName(sourceEntry.FullName);
+                    if (normalizedDeletions.Contains(normalizedName)) continue;
                     ZipArchiveEntry destinationEntry = destinationArchive.CreateEntry(normalizedName, CompressionLevel.Optimal);
                     try { destinationEntry.LastWriteTime = sourceEntry.LastWriteTime; } catch (ArgumentOutOfRangeException) { }
                     using Stream output = destinationEntry.Open();
-                    if (replacements.TryGetValue(normalizedName, out byte[]? replacement)) {
+                    if (normalizedReplacements.TryGetValue(normalizedName, out byte[]? replacement)) {
+                        writtenReplacements.Add(normalizedName);
                         ChargeRewriteBytes(
                             normalizedName,
                             replacement.Length,
@@ -196,9 +273,41 @@ namespace OfficeIMO.Excel.Xlsb.Write {
                         }
                     }
                 }
+
+                foreach (KeyValuePair<string, byte[]> replacement in normalizedReplacements) {
+                    if (writtenReplacements.Contains(replacement.Key)) continue;
+                    ZipArchiveEntry destinationEntry = destinationArchive.CreateEntry(replacement.Key, CompressionLevel.Optimal);
+                    destinationEntry.LastWriteTime = ReproducibleEntryTime;
+                    ChargeRewriteBytes(
+                        replacement.Key,
+                        replacement.Value.Length,
+                        maxPartBytes,
+                        maxPackageBytes,
+                        ref decompressedBytes);
+                    using Stream output = destinationEntry.Open();
+                    output.Write(replacement.Value, 0, replacement.Value.Length);
+                }
             }
 
             return destinationStream.ToArray();
+        }
+
+        private static string GetRelationshipPartName(string sourcePartName) {
+            string source = NormalizePartName(sourcePartName);
+            int separator = source.LastIndexOf('/');
+            string directory = separator < 0 ? string.Empty : source.Substring(0, separator + 1);
+            string fileName = separator < 0 ? source : source.Substring(separator + 1);
+            return directory + "_rels/" + fileName + ".rels";
+        }
+
+        private static string NormalizePartName(string partName) {
+            if (string.IsNullOrWhiteSpace(partName)) throw new ArgumentException("Package part name cannot be empty.", nameof(partName));
+            string normalized = partName.Replace('\\', '/').TrimStart('/');
+            if (normalized.EndsWith("/", StringComparison.Ordinal)
+                || normalized.Split('/').Any(segment => segment.Length == 0 || segment == "." || segment == "..")) {
+                throw new InvalidDataException($"The package part name '{partName}' is not safe.");
+            }
+            return normalized;
         }
 
         private static void ChargeRewriteBytes(

--- a/OfficeIMO.Excel/Xlsb/Write/XlsbNewPackageWriter.cs
+++ b/OfficeIMO.Excel/Xlsb/Write/XlsbNewPackageWriter.cs
@@ -62,7 +62,7 @@ namespace OfficeIMO.Excel.Xlsb.Write {
                         WriteEntry(
                             archive,
                             "xl/worksheets/_rels/sheet" + (index + 1).ToString(System.Globalization.CultureInfo.InvariantCulture) + ".bin.rels",
-                            CreateWorksheetRelationships(hyperlinkPlans[index].Relationships));
+                            hyperlinkPlans[index].CreateRelationshipPart());
                     }
                 }
                 if (stylesPart != null) WriteEntry(archive, "xl/styles.bin", stylesPart);
@@ -170,34 +170,6 @@ namespace OfficeIMO.Excel.Xlsb.Write {
             }
             builder.Append("</Relationships>");
             return builder.ToString();
-        }
-
-        private static string CreateWorksheetRelationships(IReadOnlyList<XlsbHyperlinkRelationship> relationships) {
-            var builder = new StringBuilder(160 + relationships.Count * 220);
-            builder.Append("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>");
-            builder.Append("<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">");
-            foreach (XlsbHyperlinkRelationship relationship in relationships) {
-                builder.Append("<Relationship Id=\"");
-                AppendXmlEscaped(builder, relationship.Id);
-                builder.Append("\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink\" Target=\"");
-                AppendXmlEscaped(builder, relationship.Target);
-                builder.Append("\" TargetMode=\"External\"/>");
-            }
-            builder.Append("</Relationships>");
-            return builder.ToString();
-        }
-
-        private static void AppendXmlEscaped(StringBuilder builder, string value) {
-            foreach (char character in value) {
-                switch (character) {
-                    case '&': builder.Append("&amp;"); break;
-                    case '<': builder.Append("&lt;"); break;
-                    case '>': builder.Append("&gt;"); break;
-                    case '"': builder.Append("&quot;"); break;
-                    case '\'': builder.Append("&apos;"); break;
-                    default: builder.Append(character); break;
-                }
-            }
         }
 
         private static void WriteEntry(ZipArchive archive, string name, string content) {

--- a/OfficeIMO.Excel/Xlsb/Write/XlsbStylesheetPartWriter.cs
+++ b/OfficeIMO.Excel/Xlsb/Write/XlsbStylesheetPartWriter.cs
@@ -6,6 +6,8 @@ namespace OfficeIMO.Excel.Xlsb.Write {
     /// <summary>Writes the core BIFF12 formatting collections referenced by normal worksheet cells.</summary>
     internal static class XlsbStylesheetPartWriter {
         private const int MaximumStyleNameLength = 255;
+        private const int MaximumFonts = 0xFFD3;
+        private const int MaximumCellFormats = 0xFF96;
         private const int BrtBeginStyleSheet = 278;
         private const int BrtEndStyleSheet = 279;
         private const int BrtBeginFills = 603;
@@ -39,11 +41,11 @@ namespace OfficeIMO.Excel.Xlsb.Write {
 
             NumberingFormat[] numberFormats = stylesheet.NumberingFormats?.Elements<NumberingFormat>().ToArray()
                 ?? Array.Empty<NumberingFormat>();
-            Font[] fonts = RequireItems(stylesheet.Fonts?.Elements<Font>(), "fonts");
+            Font[] fonts = RequireItems(stylesheet.Fonts?.Elements<Font>(), "fonts", MaximumFonts);
             Fill[] fills = RequireItems(stylesheet.Fills?.Elements<Fill>(), "fills");
             Border[] borders = RequireItems(stylesheet.Borders?.Elements<Border>(), "borders");
             CellFormat[] styleFormats = RequireItems(stylesheet.CellStyleFormats?.Elements<CellFormat>(), "cell style formats");
-            CellFormat[] cellFormats = RequireItems(stylesheet.CellFormats?.Elements<CellFormat>(), "cell formats");
+            CellFormat[] cellFormats = RequireItems(stylesheet.CellFormats?.Elements<CellFormat>(), "cell formats", MaximumCellFormats);
             cellFormatCount = cellFormats.Length;
 
             ValidateCellFormatReferences(styleFormats, fonts.Length, fills.Length, borders.Length, isStyleFormat: true);
@@ -87,13 +89,16 @@ namespace OfficeIMO.Excel.Xlsb.Write {
             }
         }
 
-        private static T[] RequireItems<T>(IEnumerable<T>? items, string collectionName) where T : OpenXmlElement {
+        private static T[] RequireItems<T>(
+            IEnumerable<T>? items,
+            string collectionName,
+            int maximumItems = 65_536) where T : OpenXmlElement {
             T[] values = items?.ToArray() ?? Array.Empty<T>();
             if (values.Length == 0) {
                 throw new NotSupportedException($"Native XLSB generation requires a non-empty {collectionName} collection.");
             }
-            if (values.Length > 65_536) {
-                throw new NotSupportedException($"Native XLSB generation supports at most 65,536 {collectionName}.");
+            if (values.Length > maximumItems) {
+                throw new NotSupportedException($"Native XLSB generation supports at most {maximumItems:N0} {collectionName}.");
             }
             return values;
         }
@@ -145,6 +150,12 @@ namespace OfficeIMO.Excel.Xlsb.Write {
         }
 
         private static void WriteFont(Stream output, Font font) {
+            XlsbGeneratedRecord record = CreateFontRecord(font);
+            XlsbRecordWriter.Write(output, record.Type, record.Payload);
+        }
+
+        internal static XlsbGeneratedRecord CreateFontRecord(Font font) {
+            if (font == null) throw new ArgumentNullException(nameof(font));
             string name = font.FontName?.Val?.Value ?? "Calibri";
             double size = font.FontSize?.Val?.Value ?? 11D;
             if (string.IsNullOrWhiteSpace(name) || name.Length > 31 || size <= 0D || size > 409.55D) {
@@ -165,14 +176,16 @@ namespace OfficeIMO.Excel.Xlsb.Write {
             WriteUInt16(payload, flags);
             WriteUInt16(payload, font.Bold != null ? (ushort)700 : (ushort)400);
             WriteUInt16(payload, ToScript(font.VerticalTextAlignment?.Val?.Value));
-            payload.WriteByte(ToUnderline(font.Underline?.Val?.Value));
+            payload.WriteByte(font.Underline == null
+                ? (byte)0
+                : ToUnderline(font.Underline.Val?.Value ?? UnderlineValues.Single));
             payload.WriteByte(checked((byte)(font.FontFamilyNumbering?.Val?.Value ?? 0)));
             payload.WriteByte(checked((byte)(font.GetFirstChild<FontCharSet>()?.Val?.Value ?? 1)));
             payload.WriteByte(0);
             WriteColor(payload, font.Color);
             payload.WriteByte(ToFontScheme(font.GetFirstChild<FontScheme>()?.Val?.Value));
             WriteWideString(payload, name);
-            XlsbRecordWriter.Write(output, BrtFont, payload.ToArray());
+            return new XlsbGeneratedRecord(BrtFont, payload.ToArray());
         }
 
         private static void WriteFill(Stream output, Fill fill) {
@@ -223,6 +236,12 @@ namespace OfficeIMO.Excel.Xlsb.Write {
         }
 
         private static void WriteCellFormat(Stream output, CellFormat format, bool isStyleFormat) {
+            XlsbGeneratedRecord record = CreateCellFormatRecord(format, isStyleFormat);
+            XlsbRecordWriter.Write(output, record.Type, record.Payload);
+        }
+
+        internal static XlsbGeneratedRecord CreateCellFormatRecord(CellFormat format, bool isStyleFormat = false) {
+            if (format == null) throw new ArgumentNullException(nameof(format));
             using var payload = new MemoryStream(16);
             WriteUInt16(payload, isStyleFormat ? ushort.MaxValue : ToUInt16(format.FormatId?.Value ?? 0U, "parent style"));
             ushort numberFormatId = ToUInt16(format.NumberFormatId?.Value ?? 0U, "number format");
@@ -262,7 +281,7 @@ namespace OfficeIMO.Excel.Xlsb.Write {
             if (ShouldApply(format.ApplyFill, fillId != 0)) applyFlags |= 1 << 4;
             if (ShouldApply(format.ApplyProtection, format.Protection != null)) applyFlags |= 1 << 5;
             WriteUInt16(payload, applyFlags);
-            XlsbRecordWriter.Write(output, BrtXf, payload.ToArray());
+            return new XlsbGeneratedRecord(BrtXf, payload.ToArray());
         }
 
         private static bool ShouldApply(BooleanValue? value, bool inferred) => value?.Value ?? inferred;

--- a/OfficeIMO.Excel/Xlsb/Write/XlsbStylesheetRewritePlan.cs
+++ b/OfficeIMO.Excel/Xlsb/Write/XlsbStylesheetRewritePlan.cs
@@ -1,0 +1,245 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Excel.Xlsb.Biff12;
+using OfficeIMO.Excel.Xlsb.Model;
+using OfficeIMO.Excel.Xlsb.Projection;
+
+namespace OfficeIMO.Excel.Xlsb.Write {
+    /// <summary>Builds a preservation-aware append-only rewrite for loaded XLSB style tables.</summary>
+    internal sealed class XlsbStylesheetRewritePlan {
+        private const int BrtBeginFonts = 611;
+        private const int BrtEndFonts = 612;
+        private const int BrtBeginCellXfs = 617;
+        private const int BrtEndCellXfs = 618;
+        private const int MaximumFonts = 0xFFD3;
+        private const int MaximumCellFormats = 0xFF96;
+
+        private XlsbStylesheetRewritePlan(string? partName, byte[]? replacement, int cellFormatCount) {
+            PartName = partName;
+            Replacement = replacement;
+            CellFormatCount = cellFormatCount;
+        }
+
+        internal string? PartName { get; }
+
+        internal byte[]? Replacement { get; }
+
+        internal int CellFormatCount { get; }
+
+        internal static XlsbStylesheetRewritePlan Create(
+            ExcelDocument document,
+            XlsbWorkbook sourceWorkbook,
+            byte[]? sourcePartBytes) {
+            if (document == null) throw new ArgumentNullException(nameof(document));
+            if (sourceWorkbook == null) throw new ArgumentNullException(nameof(sourceWorkbook));
+
+            Stylesheet? current = document.WorkbookPartRoot.WorkbookStylesPart?.Stylesheet;
+            if (sourceWorkbook.Stylesheet == null) {
+                if (current != null) {
+                    throw new NotSupportedException("Native XLSB rewriting cannot add a workbook style table to a source that did not contain one. Save style changes as .xlsx.");
+                }
+                return new XlsbStylesheetRewritePlan(partName: null, replacement: null, cellFormatCount: 1);
+            }
+            if (string.IsNullOrWhiteSpace(sourceWorkbook.StylesheetPartName) || sourcePartBytes == null) {
+                throw new InvalidDataException("The loaded XLSB style table has no source package part.");
+            }
+            if (current == null) {
+                throw new NotSupportedException("Native XLSB rewriting cannot remove the workbook style table. Save style changes as .xlsx.");
+            }
+
+            Stylesheet expected = XlsbStylesheetProjector.Create(sourceWorkbook.Stylesheet);
+            if (string.Equals(current.OuterXml, expected.OuterXml, StringComparison.Ordinal)) {
+                return new XlsbStylesheetRewritePlan(
+                    sourceWorkbook.StylesheetPartName,
+                    replacement: null,
+                    sourceWorkbook.Stylesheet.CellFormats.Count);
+            }
+
+            ValidateRootAndUnchangedCollections(current, expected);
+            Font[] addedFonts = GetAppendedItems<Font>(current.Fonts, expected.Fonts, "fonts");
+            CellFormat[] addedCellFormats = GetAppendedItems<CellFormat>(current.CellFormats, expected.CellFormats, "cell formats");
+            if (addedFonts.Length == 0 && addedCellFormats.Length == 0) {
+                throw new NotSupportedException("Native XLSB rewriting found an unsupported workbook style-table mutation. Save style changes as .xlsx.");
+            }
+
+            int fontCount = checked(sourceWorkbook.Stylesheet.Fonts.Count + addedFonts.Length);
+            int cellFormatCount = checked(sourceWorkbook.Stylesheet.CellFormats.Count + addedCellFormats.Length);
+            if (fontCount > MaximumFonts) {
+                throw new NotSupportedException($"Native XLSB rewriting supports at most {MaximumFonts:N0} fonts.");
+            }
+            if (cellFormatCount > MaximumCellFormats) {
+                throw new NotSupportedException($"Native XLSB rewriting supports at most {MaximumCellFormats:N0} cell formats.");
+            }
+            ValidateAddedCellFormats(
+                addedCellFormats,
+                fontCount,
+                sourceWorkbook.Stylesheet.Fills.Count,
+                sourceWorkbook.Stylesheet.Borders.Count,
+                sourceWorkbook.Stylesheet.CellStyleFormats.Count);
+
+            XlsbGeneratedRecord[] fontRecords = addedFonts
+                .Select(XlsbStylesheetPartWriter.CreateFontRecord)
+                .ToArray();
+            XlsbGeneratedRecord[] cellFormatRecords = addedCellFormats
+                .Select(format => XlsbStylesheetPartWriter.CreateCellFormatRecord(format))
+                .ToArray();
+            byte[] replacement = RewriteCollections(
+                sourcePartBytes,
+                sourceWorkbook.Stylesheet.Fonts.Count,
+                sourceWorkbook.Stylesheet.CellFormats.Count,
+                fontRecords,
+                cellFormatRecords);
+            return new XlsbStylesheetRewritePlan(sourceWorkbook.StylesheetPartName, replacement, cellFormatCount);
+        }
+
+        private static void ValidateRootAndUnchangedCollections(Stylesheet current, Stylesheet expected) {
+            if (!AttributesMatch(current, expected, ignoreCount: false)) ThrowUnsupportedMutation();
+            OpenXmlElement[] currentChildren = current.ChildElements.ToArray();
+            OpenXmlElement[] expectedChildren = expected.ChildElements.ToArray();
+            if (currentChildren.Length != expectedChildren.Length) ThrowUnsupportedMutation();
+
+            for (int index = 0; index < currentChildren.Length; index++) {
+                OpenXmlElement actual = currentChildren[index];
+                OpenXmlElement baseline = expectedChildren[index];
+                if (actual.GetType() != baseline.GetType()) ThrowUnsupportedMutation();
+                if (actual is Fonts || actual is CellFormats) {
+                    if (!AttributesMatch(actual, baseline, ignoreCount: true)) ThrowUnsupportedMutation();
+                    continue;
+                }
+                if (!string.Equals(actual.OuterXml, baseline.OuterXml, StringComparison.Ordinal)) ThrowUnsupportedMutation();
+            }
+        }
+
+        private static T[] GetAppendedItems<T>(
+            OpenXmlCompositeElement? current,
+            OpenXmlCompositeElement? expected,
+            string collectionName) where T : OpenXmlElement {
+            T[] actualItems = current?.Elements<T>().ToArray() ?? Array.Empty<T>();
+            T[] expectedItems = expected?.Elements<T>().ToArray() ?? Array.Empty<T>();
+            if ((current != null && current.ChildElements.Count != actualItems.Length)
+                || (expected != null && expected.ChildElements.Count != expectedItems.Length)) {
+                throw new NotSupportedException($"Native XLSB rewriting found unsupported child content in the {collectionName} collection.");
+            }
+            if (actualItems.Length < expectedItems.Length) ThrowUnsupportedMutation();
+            for (int index = 0; index < expectedItems.Length; index++) {
+                if (!string.Equals(actualItems[index].OuterXml, expectedItems[index].OuterXml, StringComparison.Ordinal)) {
+                    throw new NotSupportedException($"Native XLSB rewriting cannot modify or reorder existing {collectionName}. Save style changes as .xlsx.");
+                }
+            }
+            return actualItems.Skip(expectedItems.Length).ToArray();
+        }
+
+        private static bool AttributesMatch(OpenXmlElement current, OpenXmlElement expected, bool ignoreCount) {
+            OpenXmlAttribute[] actual = current.GetAttributes()
+                .Where(attribute => !ignoreCount || !string.Equals(attribute.LocalName, "count", StringComparison.Ordinal))
+                .OrderBy(attribute => attribute.NamespaceUri, StringComparer.Ordinal)
+                .ThenBy(attribute => attribute.LocalName, StringComparer.Ordinal)
+                .ToArray();
+            OpenXmlAttribute[] baseline = expected.GetAttributes()
+                .Where(attribute => !ignoreCount || !string.Equals(attribute.LocalName, "count", StringComparison.Ordinal))
+                .OrderBy(attribute => attribute.NamespaceUri, StringComparer.Ordinal)
+                .ThenBy(attribute => attribute.LocalName, StringComparer.Ordinal)
+                .ToArray();
+            return actual.Length == baseline.Length
+                && actual.Zip(baseline, (left, right) =>
+                    left.LocalName == right.LocalName
+                    && left.NamespaceUri == right.NamespaceUri
+                    && left.Value == right.Value).All(match => match);
+        }
+
+        private static void ValidateAddedCellFormats(
+            IEnumerable<CellFormat> formats,
+            int fontCount,
+            int fillCount,
+            int borderCount,
+            int styleFormatCount) {
+            foreach (CellFormat format in formats) {
+                uint fontId = format.FontId?.Value ?? 0U;
+                uint fillId = format.FillId?.Value ?? 0U;
+                uint borderId = format.BorderId?.Value ?? 0U;
+                uint parentId = format.FormatId?.Value ?? 0U;
+                if (fontId >= fontCount || fillId >= fillCount || borderId >= borderCount || parentId >= styleFormatCount) {
+                    throw new NotSupportedException("Native XLSB rewriting found an appended cell format with an out-of-range style reference.");
+                }
+            }
+        }
+
+        private static byte[] RewriteCollections(
+            byte[] sourcePartBytes,
+            int sourceFontCount,
+            int sourceCellFormatCount,
+            IReadOnlyList<XlsbGeneratedRecord> addedFonts,
+            IReadOnlyList<XlsbGeneratedRecord> addedCellFormats) {
+            IReadOnlyList<XlsbRecord> records;
+            using (var input = new MemoryStream(sourcePartBytes, writable: false)) {
+                records = XlsbRecordReader.ReadAll(input);
+            }
+            int beginFonts = FindSingleRecord(records, BrtBeginFonts, "BrtBeginFonts");
+            int endFonts = FindSingleRecord(records, BrtEndFonts, "BrtEndFonts");
+            int beginCellFormats = FindSingleRecord(records, BrtBeginCellXfs, "BrtBeginCellXFs");
+            int endCellFormats = FindSingleRecord(records, BrtEndCellXfs, "BrtEndCellXFs");
+            ValidateDeclaredCount(records[beginFonts], sourceFontCount, "font");
+            ValidateDeclaredCount(records[beginCellFormats], sourceCellFormatCount, "cell format");
+
+            using var output = new MemoryStream(sourcePartBytes.Length + (addedFonts.Count + addedCellFormats.Count) * 64);
+            for (int index = 0; index < records.Count; index++) {
+                XlsbRecord record = records[index];
+                if (index == beginFonts) {
+                    WriteCountRecord(output, record.Type, checked(sourceFontCount + addedFonts.Count));
+                    continue;
+                }
+                if (index == beginCellFormats) {
+                    WriteCountRecord(output, record.Type, checked(sourceCellFormatCount + addedCellFormats.Count));
+                    continue;
+                }
+                if (index == endFonts) WriteGeneratedRecords(output, addedFonts);
+                if (index == endCellFormats) WriteGeneratedRecords(output, addedCellFormats);
+                XlsbRecordWriter.Write(output, record.Type, record.Data);
+            }
+            return output.ToArray();
+        }
+
+        private static int FindSingleRecord(IReadOnlyList<XlsbRecord> records, int type, string name) {
+            int found = -1;
+            for (int index = 0; index < records.Count; index++) {
+                if (records[index].Type != type) continue;
+                if (found >= 0) throw new InvalidDataException($"The XLSB styles part contains more than one {name} record.");
+                found = index;
+            }
+            if (found < 0) throw new InvalidDataException($"The XLSB styles part is missing its {name} record.");
+            return found;
+        }
+
+        private static void ValidateDeclaredCount(XlsbRecord record, int expected, string description) {
+            if (record.Data.Length != 4) {
+                throw new InvalidDataException($"The XLSB {description} collection has an invalid count payload.");
+            }
+            uint declared = (uint)(record.Data[0]
+                | (record.Data[1] << 8)
+                | (record.Data[2] << 16)
+                | (record.Data[3] << 24));
+            if (declared != expected) {
+                throw new InvalidDataException($"The XLSB {description} collection declares {declared} items but the loaded model contains {expected}.");
+            }
+        }
+
+        private static void WriteCountRecord(Stream output, int type, int count) {
+            byte[] payload = {
+                (byte)count,
+                (byte)(count >> 8),
+                (byte)(count >> 16),
+                (byte)(count >> 24)
+            };
+            XlsbRecordWriter.Write(output, type, payload);
+        }
+
+        private static void WriteGeneratedRecords(Stream output, IEnumerable<XlsbGeneratedRecord> records) {
+            foreach (XlsbGeneratedRecord record in records) {
+                XlsbRecordWriter.Write(output, record.Type, record.Payload);
+            }
+        }
+
+        private static void ThrowUnsupportedMutation() =>
+            throw new NotSupportedException("Native XLSB rewriting supports only append-only font and cell-format additions to the workbook style table. Save other style changes as .xlsx.");
+    }
+}

--- a/OfficeIMO.Excel/Xlsb/Write/XlsbWorksheetCellExtractor.cs
+++ b/OfficeIMO.Excel/Xlsb/Write/XlsbWorksheetCellExtractor.cs
@@ -6,18 +6,19 @@ using OfficeIMO.Excel.Xlsb.Projection;
 using System.Globalization;
 
 namespace OfficeIMO.Excel.Xlsb.Write {
-    /// <summary>Creates the bounded cell-only mutation plan supported by the first XLSB rewriter.</summary>
+    /// <summary>Creates the bounded cell mutation plan used by the preservation-aware XLSB rewriter.</summary>
     internal static class XlsbWorksheetCellExtractor {
         internal static IReadOnlyList<XlsbWriteCell> Extract(
             ExcelDocument document,
             ExcelSheet sheet,
-            XlsbWorksheet sourceSheet) {
+            XlsbWorksheet sourceSheet,
+            int availableCellFormatCount) {
             if (document == null) throw new ArgumentNullException(nameof(document));
             if (sheet == null) throw new ArgumentNullException(nameof(sheet));
             if (sourceSheet == null) throw new ArgumentNullException(nameof(sourceSheet));
 
             ThrowIfUnsupportedWorksheetMutation(sheet, sourceSheet);
-            return ExtractCore(document, sheet, sourceSheet);
+            return ExtractCore(document, sheet, sourceSheet, availableCellFormatCount);
         }
 
         internal static IReadOnlyList<XlsbWriteCell> ExtractNew(
@@ -27,13 +28,14 @@ namespace OfficeIMO.Excel.Xlsb.Write {
             if (sheet == null) throw new ArgumentNullException(nameof(sheet));
 
             ThrowIfUnsupportedNewWorksheetContent(sheet);
-            return ExtractCore(document, sheet, sourceSheet: null);
+            return ExtractCore(document, sheet, sourceSheet: null, availableCellFormatCount: null);
         }
 
         private static IReadOnlyList<XlsbWriteCell> ExtractCore(
             ExcelDocument document,
             ExcelSheet sheet,
-            XlsbWorksheet? sourceSheet) {
+            XlsbWorksheet? sourceSheet,
+            int? availableCellFormatCount) {
             var sourceCells = sourceSheet?.Cells.ToDictionary(cell => (cell.Row, cell.Column))
                 ?? new Dictionary<(int Row, int Column), XlsbCell>();
             var visitedSourceCells = new HashSet<(int Row, int Column)>();
@@ -59,8 +61,11 @@ namespace OfficeIMO.Excel.Xlsb.Write {
                         sheet.Name,
                         cellRow,
                         cellColumn,
-                        allowNewStyles: sourceSheet == null);
-                    if (sourceCell != null && CellMatchesSource(sheet, cell, sourceCell, resolvedFormulaTexts)) {
+                        allowNewStyles: sourceSheet == null,
+                        availableCellFormatCount);
+                    if (sourceCell != null
+                        && styleIndex == sourceCell.StyleIndex
+                        && CellMatchesSource(sheet, cell, sourceCell, resolvedFormulaTexts)) {
                         result.Add(XlsbWriteCell.PreserveSource(sourceCell));
                         sequentialColumn = cellColumn + 1;
                         continue;
@@ -138,7 +143,6 @@ namespace OfficeIMO.Excel.Xlsb.Write {
                 sourceSheet.PageMargins,
                 sourceSheet.PageSetup,
                 sourceSheet.HeaderFooter);
-            XlsbWorksheetHyperlinkProjector.ValidateUnchanged(sheet, sourceSheet);
         }
 
         private static XlsbWriteCell? ConvertCell(
@@ -297,18 +301,22 @@ namespace OfficeIMO.Excel.Xlsb.Write {
             string sheetName,
             int row,
             int column,
-            bool allowNewStyles) {
+            bool allowNewStyles,
+            int? availableCellFormatCount) {
             uint current = cell.StyleIndex?.Value ?? 0U;
             if (sourceCell != null) {
-                if (current != sourceCell.StyleIndex) {
-                    throw new NotSupportedException($"Native XLSB rewriting currently accepts cell-value edits only. Cell {sheetName}!{ToAddress(row, column)} changed style index from {sourceCell.StyleIndex} to {current}.");
+                if (current != sourceCell.StyleIndex
+                    && (!availableCellFormatCount.HasValue || current >= availableCellFormatCount.Value)) {
+                    throw new NotSupportedException($"Native XLSB rewriting cannot apply unavailable style index {current} to cell {sheetName}!{ToAddress(row, column)}.");
                 }
 
                 return current;
             }
 
-            if (current != 0 && !allowNewStyles) {
-                throw new NotSupportedException($"Native XLSB rewriting currently cannot add a styled cell. Cell {sheetName}!{ToAddress(row, column)} uses style index {current}.");
+            if (current != 0
+                && !allowNewStyles
+                && (!availableCellFormatCount.HasValue || current >= availableCellFormatCount.Value)) {
+                throw new NotSupportedException($"Native XLSB rewriting cannot add cell {sheetName}!{ToAddress(row, column)} with unavailable style index {current}.");
             }
 
             return current;

--- a/OfficeIMO.Excel/Xlsb/Write/XlsbWorksheetHyperlinkPlan.cs
+++ b/OfficeIMO.Excel/Xlsb/Write/XlsbWorksheetHyperlinkPlan.cs
@@ -2,11 +2,15 @@ using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using OfficeIMO.Excel.Xlsb.Model;
+using OfficeIMO.Excel.Xlsb.Package;
 
 namespace OfficeIMO.Excel.Xlsb.Write {
     /// <summary>Validates worksheet hyperlinks and builds their BIFF12 records and package relationships.</summary>
     internal sealed class XlsbWorksheetHyperlinkPlan {
         private const int BrtHLink = 494;
+        private const string HyperlinkRelationshipSuffix = "/hyperlink";
+        private const int MaximumLocationLengthExclusive = 2_084;
+        private const int MaximumTooltipLengthExclusive = 256;
 
         private XlsbWorksheetHyperlinkPlan(
             IReadOnlyList<XlsbGeneratedRecord> records,
@@ -19,7 +23,54 @@ namespace OfficeIMO.Excel.Xlsb.Write {
 
         internal IReadOnlyList<XlsbHyperlinkRelationship> Relationships { get; }
 
-        internal static XlsbWorksheetHyperlinkPlan Create(ExcelSheet sheet) {
+        internal bool RelationshipsMatch(XlsbWorksheet sourceSheet) {
+            if (sourceSheet == null) throw new ArgumentNullException(nameof(sourceSheet));
+            XlsbHyperlink[] sourceRelationships = sourceSheet.Hyperlinks
+                .Where(hyperlink => hyperlink.IsExternal)
+                .ToArray();
+            if (sourceRelationships.Length != Relationships.Count) return false;
+            var actual = Relationships.ToDictionary(relationship => relationship.Id, StringComparer.Ordinal);
+            foreach (XlsbHyperlink source in sourceRelationships) {
+                if (!actual.TryGetValue(source.RelationshipId, out XlsbHyperlinkRelationship? relationship)
+                    || !string.Equals(relationship.Target, source.ExternalTarget, StringComparison.Ordinal)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        internal byte[] CreateRelationshipPart(
+            IReadOnlyDictionary<string, XlsbPackageRelationship>? sourceRelationships = null) {
+            XlsbPackageRelationship[] preserved = sourceRelationships?.Values
+                .Where(relationship => !IsHyperlinkRelationship(relationship))
+                .ToArray() ?? Array.Empty<XlsbPackageRelationship>();
+            var builder = new StringBuilder(160 + (Relationships.Count + preserved.Length) * 220);
+            builder.Append("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>");
+            builder.Append("<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">");
+            foreach (XlsbPackageRelationship relationship in preserved) {
+                AppendRelationship(
+                    builder,
+                    relationship.Id,
+                    relationship.Type,
+                    relationship.Target,
+                    relationship.IsExternal);
+            }
+            foreach (XlsbHyperlinkRelationship relationship in Relationships) {
+                AppendRelationship(
+                    builder,
+                    relationship.Id,
+                    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink",
+                    relationship.Target,
+                    isExternal: true);
+            }
+            builder.Append("</Relationships>");
+            return new UTF8Encoding(encoderShouldEmitUTF8Identifier: false).GetBytes(builder.ToString());
+        }
+
+        internal static XlsbWorksheetHyperlinkPlan Create(
+            ExcelSheet sheet,
+            bool pruneOrphanedRelationships = false,
+            IReadOnlyCollection<string>? reservedRelationshipIds = null) {
             if (sheet == null) throw new ArgumentNullException(nameof(sheet));
             Worksheet worksheet = sheet.WorksheetPart.Worksheet
                 ?? throw new InvalidDataException($"Worksheet '{sheet.Name}' has no worksheet root.");
@@ -40,7 +91,7 @@ namespace OfficeIMO.Excel.Xlsb.Write {
             }
 
             if (containers.Length == 0) {
-                if (packageRelationships.Length != 0) {
+                if (packageRelationships.Length != 0 && !pruneOrphanedRelationships) {
                     throw new NotSupportedException($"Native XLSB generation found orphaned hyperlink relationships on worksheet '{sheet.Name}'.");
                 }
                 return new XlsbWorksheetHyperlinkPlan(
@@ -54,29 +105,47 @@ namespace OfficeIMO.Excel.Xlsb.Write {
             if (hyperlinks.Length != container.ChildElements.Count) ThrowUnsupportedContent(container, sheet.Name);
 
             var usedRelationshipIds = new HashSet<string>(StringComparer.Ordinal);
+            var emittedRelationshipIds = new HashSet<string>(
+                reservedRelationshipIds ?? Array.Empty<string>(),
+                StringComparer.Ordinal);
+            var emittedIdBySourceId = new Dictionary<string, string>(StringComparer.Ordinal);
             var records = new List<XlsbGeneratedRecord>(hyperlinks.Length);
             foreach (Hyperlink hyperlink in hyperlinks) {
+                string sourceRelationshipId = hyperlink.Id?.Value ?? string.Empty;
+                string emittedRelationshipId = sourceRelationshipId;
+                if (sourceRelationshipId.Length != 0) {
+                    if (!relationshipsById.ContainsKey(sourceRelationshipId)) {
+                        throw new NotSupportedException($"Native XLSB generation found missing hyperlink relationship '{sourceRelationshipId}' on worksheet '{sheet.Name}'.");
+                    }
+                    usedRelationshipIds.Add(sourceRelationshipId);
+                    if (!emittedIdBySourceId.TryGetValue(sourceRelationshipId, out emittedRelationshipId!)) {
+                        emittedRelationshipId = emittedRelationshipIds.Add(sourceRelationshipId)
+                            ? sourceRelationshipId
+                            : AllocateRelationshipId(emittedRelationshipIds);
+                        emittedIdBySourceId.Add(sourceRelationshipId, emittedRelationshipId);
+                    }
+                }
                 records.Add(new XlsbGeneratedRecord(
                     BrtHLink,
-                    CreatePayload(hyperlink, relationshipsById, usedRelationshipIds, sheet.Name)));
+                    CreatePayload(hyperlink, emittedRelationshipId, sheet.Name)));
             }
 
-            if (usedRelationshipIds.Count != relationshipsById.Count) {
+            if (usedRelationshipIds.Count != relationshipsById.Count && !pruneOrphanedRelationships) {
                 throw new NotSupportedException($"Native XLSB generation found orphaned hyperlink relationships on worksheet '{sheet.Name}'.");
             }
 
-            XlsbHyperlinkRelationship[] relationships = relationshipsById
-                .Where(pair => usedRelationshipIds.Contains(pair.Key))
-                .OrderBy(pair => pair.Key, StringComparer.Ordinal)
-                .Select(pair => new XlsbHyperlinkRelationship(pair.Key, pair.Value.Uri.OriginalString))
+            XlsbHyperlinkRelationship[] relationships = emittedIdBySourceId
+                .OrderBy(pair => pair.Value, StringComparer.Ordinal)
+                .Select(pair => new XlsbHyperlinkRelationship(
+                    pair.Value,
+                    relationshipsById[pair.Key].Uri.OriginalString))
                 .ToArray();
             return new XlsbWorksheetHyperlinkPlan(records.AsReadOnly(), Array.AsReadOnly(relationships));
         }
 
         private static byte[] CreatePayload(
             Hyperlink hyperlink,
-            IReadOnlyDictionary<string, HyperlinkRelationship> relationshipsById,
-            ISet<string> usedRelationshipIds,
+            string relationshipId,
             string sheetName) {
             EnsureOnlyAttributes(hyperlink, sheetName, "ref", "id", "location", "tooltip", "display");
             if (hyperlink.HasChildren) ThrowUnsupportedContent(hyperlink, sheetName);
@@ -84,15 +153,16 @@ namespace OfficeIMO.Excel.Xlsb.Write {
                 throw new NotSupportedException($"Native XLSB generation cannot encode hyperlink range '{hyperlink.Reference?.Value}' on worksheet '{sheetName}'.");
             }
 
-            string relationshipId = hyperlink.Id?.Value ?? string.Empty;
             string location = hyperlink.Location?.Value ?? string.Empty;
-            if (relationshipId.Length != 0) {
-                if (!relationshipsById.ContainsKey(relationshipId)) {
-                    throw new NotSupportedException($"Native XLSB generation found missing hyperlink relationship '{relationshipId}' on worksheet '{sheetName}'.");
-                }
-                usedRelationshipIds.Add(relationshipId);
-            } else if (string.IsNullOrWhiteSpace(location)) {
+            if (relationshipId.Length == 0 && string.IsNullOrWhiteSpace(location)) {
                 throw new NotSupportedException($"Native XLSB generation found a hyperlink without an external target or internal location on worksheet '{sheetName}'.");
+            }
+            string tooltip = hyperlink.Tooltip?.Value ?? string.Empty;
+            if (location.Length >= MaximumLocationLengthExclusive) {
+                throw new NotSupportedException($"Native XLSB generation requires hyperlink locations shorter than 2,084 characters on worksheet '{sheetName}'.");
+            }
+            if (tooltip.Length >= MaximumTooltipLengthExclusive) {
+                throw new NotSupportedException($"Native XLSB generation requires hyperlink tooltips shorter than 256 characters on worksheet '{sheetName}'.");
             }
 
             using var payload = new MemoryStream(64);
@@ -102,9 +172,35 @@ namespace OfficeIMO.Excel.Xlsb.Write {
             WriteUInt32(payload, checked((uint)(range.LastColumn - 1)));
             WriteWideString(payload, relationshipId);
             WriteWideString(payload, location);
-            WriteWideString(payload, hyperlink.Tooltip?.Value ?? string.Empty);
+            WriteWideString(payload, tooltip);
             WriteWideString(payload, hyperlink.Display?.Value ?? string.Empty);
             return payload.ToArray();
+        }
+
+        private static bool IsHyperlinkRelationship(XlsbPackageRelationship relationship) =>
+            relationship.Type.EndsWith(HyperlinkRelationshipSuffix, StringComparison.Ordinal);
+
+        private static string AllocateRelationshipId(ISet<string> usedIds) {
+            for (int index = 1; ; index++) {
+                string candidate = "rId" + index.ToString(System.Globalization.CultureInfo.InvariantCulture);
+                if (usedIds.Add(candidate)) return candidate;
+            }
+        }
+
+        private static void AppendRelationship(
+            StringBuilder builder,
+            string id,
+            string type,
+            string target,
+            bool isExternal) {
+            builder.Append("<Relationship Id=\"");
+            AppendXmlEscaped(builder, id);
+            builder.Append("\" Type=\"");
+            AppendXmlEscaped(builder, type);
+            builder.Append("\" Target=\"");
+            AppendXmlEscaped(builder, target);
+            if (isExternal) builder.Append("\" TargetMode=\"External");
+            builder.Append("\"/>");
         }
 
         private static bool TryParseRange(string? reference, out XlsbCellRange? range) {
@@ -145,6 +241,19 @@ namespace OfficeIMO.Excel.Xlsb.Write {
             output.WriteByte((byte)(value >> 8));
             output.WriteByte((byte)(value >> 16));
             output.WriteByte((byte)(value >> 24));
+        }
+
+        private static void AppendXmlEscaped(StringBuilder builder, string value) {
+            foreach (char character in value) {
+                switch (character) {
+                    case '&': builder.Append("&amp;"); break;
+                    case '<': builder.Append("&lt;"); break;
+                    case '>': builder.Append("&gt;"); break;
+                    case '"': builder.Append("&quot;"); break;
+                    case '\'': builder.Append("&apos;"); break;
+                    default: builder.Append(character); break;
+                }
+            }
         }
     }
 

--- a/OfficeIMO.Excel/Xlsb/Write/XlsbWorksheetPartWriter.cs
+++ b/OfficeIMO.Excel/Xlsb/Write/XlsbWorksheetPartWriter.cs
@@ -20,6 +20,28 @@ namespace OfficeIMO.Excel.Xlsb.Write {
         private const int BrtBeginSheetData = 145;
         private const int BrtEndSheetData = 146;
         private const int BrtWsDim = 148;
+        private const int BrtEndSheet = 130;
+        private const int BrtMargins = 476;
+        private const int BrtPrintOptions = 477;
+        private const int BrtPageSetup = 478;
+        private const int BrtBeginHeaderFooter = 479;
+        private const int BrtEndHeaderFooter = 480;
+        private const int BrtHLink = 494;
+        private const int BrtBeginRowBreaks = 392;
+        private const int BrtBeginColumnBreaks = 394;
+        private const int BrtDrawing = 550;
+        private const int BrtLegacyDrawing = 551;
+        private const int BrtLegacyDrawingHeaderFooter = 552;
+        private const int BrtBeginWebPublishItems = 554;
+        private const int BrtBackgroundImage = 562;
+        private const int BrtBeginDataValidations = 573;
+        private const int BrtBeginSmartTags = 594;
+        private const int BrtBeginCellWatches = 605;
+        private const int BrtBigName = 625;
+        private const int BrtBeginOleObjects = 638;
+        private const int BrtBeginActiveXControls = 643;
+        private const int BrtBeginCellIgnoreErrors = 648;
+        private const int BrtBeginTableParts = 660;
 
         private static readonly byte[] DefaultRowProperties = {
             0x00, 0x00, 0x00, 0x00,
@@ -86,9 +108,17 @@ namespace OfficeIMO.Excel.Xlsb.Write {
             return output.ToArray();
         }
 
-        internal static byte[] Rewrite(byte[] originalPart, IReadOnlyList<XlsbWriteCell> cells) {
+        internal static byte[] Rewrite(byte[] originalPart, IReadOnlyList<XlsbWriteCell> cells) =>
+            Rewrite(originalPart, cells, Array.Empty<XlsbGeneratedRecord>(), rewriteHyperlinks: false);
+
+        internal static byte[] Rewrite(
+            byte[] originalPart,
+            IReadOnlyList<XlsbWriteCell> cells,
+            IReadOnlyList<XlsbGeneratedRecord> hyperlinkRecords,
+            bool rewriteHyperlinks) {
             if (originalPart == null) throw new ArgumentNullException(nameof(originalPart));
             if (cells == null) throw new ArgumentNullException(nameof(cells));
+            if (hyperlinkRecords == null) throw new ArgumentNullException(nameof(hyperlinkRecords));
 
             IReadOnlyList<XlsbRecord> records;
             using (var input = new MemoryStream(originalPart, writable: false)) {
@@ -107,6 +137,9 @@ namespace OfficeIMO.Excel.Xlsb.Write {
                 .ToDictionary(group => group.Key, group => (IReadOnlyList<XlsbWriteCell>)group.OrderBy(cell => cell.Column).ToArray());
             int[] rowIndexes = layout.Rows.Keys.Concat(cellsByRow.Keys).Distinct().OrderBy(row => row).ToArray();
             byte[]? dimensionPayload = CreateExpandedDimensionPayload(records, cells);
+            int hyperlinkInsertionIndex = rewriteHyperlinks
+                ? FindHyperlinkInsertionIndex(records, endIndex)
+                : -1;
 
             using var output = new MemoryStream(originalPart.Length + Math.Max(256, cells.Count * 24));
             for (int index = 0; index <= beginIndex; index++) {
@@ -135,11 +168,61 @@ namespace OfficeIMO.Excel.Xlsb.Write {
             }
 
             for (int index = endIndex; index < records.Count; index++) {
+                if (rewriteHyperlinks && index == hyperlinkInsertionIndex) {
+                    foreach (XlsbGeneratedRecord hyperlink in hyperlinkRecords) {
+                        XlsbRecordWriter.Write(output, hyperlink.Type, hyperlink.Payload);
+                    }
+                }
+                if (rewriteHyperlinks && records[index].Type == BrtHLink) continue;
                 WriteRecord(output, records[index]);
             }
 
             return output.ToArray();
         }
+
+        private static int FindHyperlinkInsertionIndex(IReadOnlyList<XlsbRecord> records, int endSheetDataIndex) {
+            int endSheetIndex = FindSingleRecord(records, BrtEndSheet, "BrtEndSheet");
+            int firstHyperlinkIndex = -1;
+            for (int index = 0; index < records.Count; index++) {
+                if (records[index].Type != BrtHLink) continue;
+                if (index <= endSheetDataIndex || index >= endSheetIndex) {
+                    throw new InvalidDataException("The XLSB worksheet contains a BrtHLink record outside the supported worksheet-metadata region.");
+                }
+                if (firstHyperlinkIndex < 0) firstHyperlinkIndex = index;
+            }
+            if (firstHyperlinkIndex >= 0) return firstHyperlinkIndex;
+
+            for (int index = endSheetDataIndex + 1; index < endSheetIndex; index++) {
+                int type = records[index].Type;
+                if (IsHyperlinkSuccessorRecord(type)) {
+                    return index;
+                }
+            }
+            return endSheetIndex;
+        }
+
+        private static bool IsHyperlinkSuccessorRecord(int type) =>
+            type == BrtPrintOptions
+            || type == BrtMargins
+            || type == BrtPageSetup
+            || type == BrtBeginHeaderFooter
+            || type == BrtEndHeaderFooter
+            || type == BrtBeginRowBreaks
+            || type == BrtBeginColumnBreaks
+            || type == BrtBigName
+            || type == BrtBeginCellWatches
+            || type == BrtBeginCellIgnoreErrors
+            || type == BrtBeginSmartTags
+            || type == BrtDrawing
+            || type == BrtLegacyDrawing
+            || type == BrtLegacyDrawingHeaderFooter
+            || type == BrtBackgroundImage
+            || type == BrtBeginOleObjects
+            || type == BrtBeginActiveXControls
+            || type == BrtBeginWebPublishItems
+            || type == BrtBeginTableParts
+            || type == BrtBeginDataValidations
+            || type == BrtEndSheet;
 
         private static byte[] CreateRowHeaderPayload(
             int zeroBasedRow,

--- a/OfficeIMO.Excel/Xlsb/XlsbWorkbookReader.cs
+++ b/OfficeIMO.Excel/Xlsb/XlsbWorkbookReader.cs
@@ -75,6 +75,8 @@ namespace OfficeIMO.Excel.Xlsb {
         private const string SharedStringsRelationshipSuffix = "/sharedStrings";
         private const string StylesRelationshipSuffix = "/styles";
         private const string HyperlinkRelationshipSuffix = "/hyperlink";
+        private const int MaximumHyperlinkLocationLengthExclusive = 2_084;
+        private const int MaximumHyperlinkTooltipLengthExclusive = 256;
 
         internal static XlsbWorkbook Load(byte[] packageBytes, XlsbImportOptions? options = null) {
             if (packageBytes == null) throw new ArgumentNullException(nameof(packageBytes));
@@ -126,6 +128,7 @@ namespace OfficeIMO.Excel.Xlsb {
                 string sheetPartName = XlsbPackagePartReader.ResolveTarget(workbookPartName!, relationship.Target);
                 worksheet.PartName = sheetPartName;
                 IReadOnlyDictionary<string, XlsbPackageRelationship> worksheetRelationships = parts.ReadRelationships(sheetPartName, cancellationToken);
+                worksheet.Relationships = worksheetRelationships;
                 ParseWorksheetPart(
                     parts.ReadPart(sheetPartName, cancellationToken),
                     sheetPartName,
@@ -390,6 +393,7 @@ namespace OfficeIMO.Excel.Xlsb {
             if (relationship == null) return null;
 
             string partName = XlsbPackagePartReader.ResolveTarget(workbookPartName, relationship.Target);
+            workbook.StylesheetPartName = partName;
             return XlsbStylesheetReader.Read(parts.ReadPart(partName, options.CancellationToken), partName, options, workbook,
                 recordBudget);
         }
@@ -809,8 +813,12 @@ namespace OfficeIMO.Excel.Xlsb {
             var rangeRecord = new XlsbRecord(record.Offset, record.HeaderSize, BrtHLink, rangePayload);
             XlsbCellRange range = ParseCellRange(rangeRecord, "BrtHLink");
             string relationshipId = cursor.ReadWideString(options.MaxStringCharacters);
-            string location = cursor.ReadWideString(options.MaxStringCharacters);
-            string tooltip = cursor.ReadWideString(options.MaxStringCharacters);
+            string location = cursor.ReadWideString(Math.Min(
+                options.MaxStringCharacters,
+                MaximumHyperlinkLocationLengthExclusive - 1));
+            string tooltip = cursor.ReadWideString(Math.Min(
+                options.MaxStringCharacters,
+                MaximumHyperlinkTooltipLengthExclusive - 1));
             string display = cursor.ReadWideString(options.MaxStringCharacters);
             if (cursor.Remaining != 0) {
                 throw new InvalidDataException($"The BrtHLink record at offset {record.Offset} contains trailing payload bytes.");


### PR DESCRIPTION
## Summary

- let callers add, update, and remove internal or external hyperlinks in a loaded XLSB through the existing worksheet APIs
- preserve unrelated worksheet relationships, binary indexes, records, package parts, and existing style records while rewriting the changed hyperlink state
- support the existing default hyperlink styling path by appending only the required XLSB font and cell-format records
- reject unsafe package additions and out-of-range BIFF12 hyperlink/style data before producing a file
- update the generated compatibility catalog so XLSB hyperlink round trips are reported as native

This closes another practical XLSB editing gap without adding a second API surface: the same `SetHyperlink`, `SetHyperlinkReference`, and `ClearRange(..., ExcelClearOptions.Hyperlinks)` entry points now work for loaded XLSB workbooks.

## Compatibility boundary

The rewrite remains preservation-first. XLSB style edits outside the append-only font/cell-format additions needed by the hyperlink style are still rejected, and unrelated unsupported worksheet mutations continue to fail closed rather than silently dropping workbook content.

## Validation

- XLSB suite passes on .NET 10 and .NET 8 (80 tests on each target)
- focused hyperlink coverage passes on .NET Framework 4.7.2 (15 tests)
- package path/budget safety coverage passes (3 tests)
- all 12 generated compatibility catalog artifacts verify
- a generated mutation was opened through desktop Excel as native XLSB (`FileFormat = 50`), with the target, tooltip, display text, color, and underline preserved

Related to #2195.
