### PR TITLE
Fix PDF and PowerPoint example regressions

### DIFF
--- a/OfficeIMO.Examples/Pdf/Pdf.ProfessionalReport.cs
+++ b/OfficeIMO.Examples/Pdf/Pdf.ProfessionalReport.cs
@@ -104,42 +104,11 @@ namespace OfficeIMO.Examples.Pdf {
         }
 
         private static byte[] CreateFallbackLogo() {
-            return new byte[] {
-                137, 80, 78, 71, 13, 10, 26, 10,
-                0, 0, 0, 13,
-                73, 72, 68, 82,
-                0, 0, 0, 1,
-                0, 0, 0, 1,
-                8, 2, 0, 0, 0,
-                0, 0, 0, 0,
-                0, 0, 0, 12,
-                73, 68, 65, 84,
-                0x78, 0x9C, 0x63, 0xF8, 0xCF, 0xC0, 0x00, 0x00, 0x03, 0x01, 0x01, 0x00,
-                0, 0, 0, 0,
-                0, 0, 0, 0,
-                73, 69, 78, 68,
-                0, 0, 0, 0
-            };
+            return OfficePngWriter.EncodeRgba(1, 1, new byte[] { 32, 76, 120, 255 });
         }
 
         private static byte[] CreateTransparentBadgePng() {
-            return new byte[] {
-                137, 80, 78, 71, 13, 10, 26, 10,
-                0, 0, 0, 13,
-                73, 72, 68, 82,
-                0, 0, 0, 1,
-                0, 0, 0, 1,
-                8, 6, 0, 0, 0,
-                0, 0, 0, 0,
-                0, 0, 0, 16,
-                73, 68, 65, 84,
-                0x78, 0x01, 0x01, 0x05, 0x00, 0xFA, 0xFF, 0x00,
-                0x2A, 0x84, 0x52, 0xA0, 0x03, 0x7D, 0x01, 0xA1,
-                0, 0, 0, 0,
-                0, 0, 0, 0,
-                73, 69, 78, 68,
-                0, 0, 0, 0
-            };
+            return OfficePngWriter.EncodeRgba(1, 1, new byte[] { 42, 132, 82, 160 });
         }
     }
 }

--- a/OfficeIMO.Examples/PowerPoint/EndToEndPowerPointProof.cs
+++ b/OfficeIMO.Examples/PowerPoint/EndToEndPowerPointProof.cs
@@ -115,22 +115,28 @@ namespace OfficeIMO.Examples.PowerPoint {
                 MinimumReadableFontSizePoints = 8,
                 DetectShapeCollisions = false
             };
-            PowerPointCompositionOptions composition = PowerPointCompositionOptions.FromBrief(brief);
-            composition.SelectBestAlternative = false;
-            composition.AlternativeIndex = 0;
+            PowerPointDeckDesign design = brief.CreateDesign(0);
+            design.Theme.SecondaryTextColor = "4F5963";
+            design.Theme.MutedTextColor = "59636D";
+            PowerPointCompositionOptions composition = PowerPointCompositionOptions.FromDesign(design);
             composition.Preflight = preflightOptions;
             PowerPointCompositionResult result = presentation.Compose(plan, composition);
             PowerPointDeckRhythmReport rhythm = result.Plan.InspectRhythm(result.Design);
             PowerPointDeckPreflightReport report = result.Preflight;
             report.SaveJson(reportPath);
             PowerPointAccessibilityReport accessibility = presentation.InspectAccessibility();
-            accessibility.EnsureCompliant().SaveJson(accessibilityPath);
+            accessibility.SaveJson(accessibilityPath);
+            accessibility.EnsureCompliant();
             presentation.Save();
 
             for (int slideIndex = 0; slideIndex < presentation.Slides.Count; slideIndex++) {
                 string stem = "Slide " + (slideIndex + 1).ToString("00");
-                presentation.Slides[slideIndex].SaveAsPng(Path.Combine(outputFolder, stem + ".png"));
-                presentation.Slides[slideIndex].SaveAsSvg(Path.Combine(outputFolder, stem + ".svg"));
+                presentation.Slides[slideIndex]
+                    .ExportImage(OfficeImageExportFormat.Png)
+                    .Save(Path.Combine(outputFolder, stem + ".png"), OfficeImageExportFileConflictPolicy.Replace);
+                presentation.Slides[slideIndex]
+                    .ExportImage(OfficeImageExportFormat.Svg)
+                    .Save(Path.Combine(outputFolder, stem + ".svg"), OfficeImageExportFileConflictPolicy.Replace);
             }
             var pdfOptions = new PowerPointPdfSaveOptions().UseProfile(PdfExportProfile.Faithful);
             PdfDocumentConversionResult pdfResult = presentation.ToPdfDocumentResult(pdfOptions);

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.Accessibility.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.Accessibility.cs
@@ -116,6 +116,13 @@ namespace OfficeIMO.Tests {
             using var stream = new MemoryStream();
             using PowerPointPresentation presentation = PowerPointPresentation.Create(stream, new PowerPointCreateOptions());
             presentation.AddDesignerSectionSlide("Delivery and evidence", "Accessible by default");
+            presentation.AddDesignerExecutiveSummarySlide("Executive summary", "Accessible metrics",
+                new PowerPointExecutiveSummaryContent(
+                    new[] { new PowerPointMetric("14", "proof slides"), new PowerPointMetric("0", "hidden rows") },
+                    Array.Empty<PowerPointCardContent>()),
+                options: new PowerPointExecutiveSummarySlideOptions {
+                    Variant = PowerPointExecutiveSummaryLayoutVariant.MetricLead
+                });
             presentation.AddDesignerProcessSlide("A controlled workflow", "Every step remains editable", new[] {
                 new PowerPointProcessStep("Inspect", "Read the source"),
                 new PowerPointProcessStep("Generate", "Create native content"),

--- a/OfficeIMO.PowerPoint/PowerPointDesignExecutiveExtensions.cs
+++ b/OfficeIMO.PowerPoint/PowerPointDesignExecutiveExtensions.cs
@@ -104,7 +104,7 @@ namespace OfficeIMO.PowerPoint {
             }
             PowerPointLayoutBox metrics = PowerPointLayoutBox.FromCentimeters(1.5, top, width - 3, 2.15);
             AddMetrics(slide, theme, content.Metrics.ToList(), metrics.LeftCm, metrics.TopCm,
-                metrics.WidthCm, metrics.HeightCm);
+                metrics.WidthCm, metrics.HeightCm, theme.PrimaryTextColor);
             double cardTop = content.Metrics.Count == 0 ? top : top + 2.6;
             PowerPointLayoutBox cards = PowerPointLayoutBox.FromCentimeters(1.5, cardTop, width - 3,
                 Math.Max(2.4, height - top - 4.1));

--- a/OfficeIMO.PowerPoint/PowerPointDesignExtensions.Visuals.cs
+++ b/OfficeIMO.PowerPoint/PowerPointDesignExtensions.Visuals.cs
@@ -8,7 +8,7 @@ using A = DocumentFormat.OpenXml.Drawing;
 namespace OfficeIMO.PowerPoint {
     internal static partial class PowerPointDesignExtensions {
         internal static void AddMetrics(PowerPointSlide slide, PowerPointDesignTheme theme, IReadOnlyList<PowerPointMetric> metrics,
-            double leftCm, double topCm, double widthCm, double heightCm) {
+            double leftCm, double topCm, double widthCm, double heightCm, string? textColor = null) {
             if (metrics.Count == 0) {
                 return;
             }
@@ -22,18 +22,19 @@ namespace OfficeIMO.PowerPoint {
             double labelHeight = Math.Max(0.32, heightCm - labelTopOffset);
             int valueFontSize = heightCm < 1.6 ? 24 : 29;
             int labelFontSize = heightCm < 1.6 ? 8 : 9;
+            string resolvedTextColor = textColor ?? theme.AccentContrastColor;
             for (int i = 0; i < count; i++) {
                 PowerPointMetric metric = metrics[i];
                 PowerPointLayoutBox box = boxes[i];
                 int resolvedValueFontSize = ResolveMetricValueFontSize(metric.Value, box.WidthCm, valueFontSize);
                 PowerPointTextBox value = AddText(slide, metric.Value, box.LeftCm, box.TopCm, box.WidthCm, valueHeight,
                     resolvedValueFontSize,
-                    theme.AccentContrastColor, theme.HeadingFontName, bold: true);
+                    resolvedTextColor, theme.HeadingFontName, bold: true);
                 CenterText(value);
                 int resolvedLabelFontSize = ResolveMetricLabelFontSize(metric.Label, box.WidthCm, labelFontSize);
                 PowerPointTextBox label = AddText(slide, metric.Label, box.LeftCm, box.TopCm + labelTopOffset,
                     box.WidthCm, labelHeight, resolvedLabelFontSize,
-                    theme.AccentContrastColor, theme.BodyFontName, bold: true);
+                    resolvedTextColor, theme.BodyFontName, bold: true);
                 CenterText(label);
             }
         }


### PR DESCRIPTION
## Summary

- generate valid fallback PNG assets through OfficeIMO instead of embedding malformed byte payloads
- keep PowerPoint metric-led executive summaries readable on light slide backgrounds
- make the end-to-end PowerPoint proof accessible and safe to rerun by replacing generated previews
- retain the accessibility report even when a future compliance gate fails

These corrections were found while checking the example catalog against the OfficeIMO 3.1 source and incoming pull requests. The section-break API/example cleanup remains isolated in #2228.