### PR TITLE
Make used-range benchmarks comparable

### DIFF
--- a/OfficeIMO.Excel.Benchmarks/ExcelLibraryComparisonRunner.cs
+++ b/OfficeIMO.Excel.Benchmarks/ExcelLibraryComparisonRunner.cs
@@ -452,11 +452,11 @@ internal static partial class ExcelLibraryComparisonRunner {
         ]);
 
         AddScenarioGroup(scenarios, scenarioFilter, "read-used-range", warmupIterations, measuredIterations, [
-            new LibraryComparisonCase("OfficeIMO.Excel", "Discover and materialize the worksheet used range with the public one-pass reader.", () => OfficeImoReadUsedRange(officeImoWorkbookBytes.Value)),
+            new LibraryComparisonCase("OfficeIMO.Excel", "Discover and scan the worksheet used range with the public forward-only data reader.", () => OfficeImoReadUsedRangeDataReader(officeImoWorkbookBytes.Value)),
             new LibraryComparisonCase("ClosedXML", "Resolve and iterate used data cells from the same workbook payload.", () => ClosedXmlReadRange(officeImoWorkbookBytes.Value)),
             new LibraryComparisonCase("EPPlus", "Resolve and iterate used data cells from the same workbook payload.", () => EpPlusReadRange(officeImoWorkbookBytes.Value)),
             new LibraryComparisonCase("MiniExcel", "Stream used data rows from the same workbook payload.", () => MiniExcelReadRange(officeImoWorkbookBytes.Value)),
-            new LibraryComparisonCase("ExcelDataReader", "Forward-only IExcelDataReader scan over the same workbook payload.", () => ExcelDataReaderReadRange(officeImoWorkbookBytes.Value)),
+            new LibraryComparisonCase("ExcelDataReader", "Forward-only typed IExcelDataReader scan over the same workbook payload.", () => ExcelDataReaderReadRangeTyped(officeImoWorkbookBytes.Value)),
             new LibraryComparisonCase("Sylvan.Data.Excel", "Forward-only DbDataReader scan over the same workbook payload.", () => SylvanReadRange(officeImoWorkbookBytes.Value))
         ]);
 
@@ -2605,22 +2605,24 @@ internal static partial class ExcelLibraryComparisonRunner {
         return metric;
     }
 
-    private static int OfficeImoReadUsedRange(byte[] workbookBytes) {
-        using var reader = ExcelDocumentReader.Open(workbookBytes);
-        var sheet = reader.GetSheet("Data");
-        object?[,] values = sheet.ReadUsedRange();
+    private static int OfficeImoReadUsedRangeDataReader(byte[] workbookBytes) {
+        using var reader = ExcelDocument.OpenDataReader(workbookBytes, new ExcelReadOptions {
+            SheetName = "Data",
+            HasHeaderRow = true,
+            InferSchema = false
+        });
         int metric = AddSalesHeadersMetric(0);
-        for (int row = 1; row < values.GetLength(0); row++) {
+        while (reader.Read()) {
             metric = AddSalesRangeMetric(
                 metric,
-                Convert.ToInt32(values[row, 0], CultureInfo.InvariantCulture),
-                Convert.ToString(values[row, 1], CultureInfo.InvariantCulture) ?? string.Empty,
-                Convert.ToString(values[row, 2], CultureInfo.InvariantCulture) ?? string.Empty,
-                ReadDateCell(values[row, 3]),
-                Convert.ToDouble(values[row, 4], CultureInfo.InvariantCulture),
-                Convert.ToInt32(values[row, 5], CultureInfo.InvariantCulture),
-                Convert.ToBoolean(values[row, 6], CultureInfo.InvariantCulture),
-                Convert.ToString(values[row, 7], CultureInfo.InvariantCulture) ?? string.Empty);
+                reader.GetInt32(0),
+                reader.GetString(1),
+                reader.GetString(2),
+                reader.GetDateTime(3),
+                reader.GetDouble(4),
+                reader.GetInt32(5),
+                reader.GetBoolean(6),
+                reader.GetString(7));
         }
 
         return metric;


### PR DESCRIPTION
## Summary

- make the `read-used-range` comparison perform equivalent forward-only used-range scans for OfficeIMO and the competing reader libraries
- use OfficeIMO's public `ExcelDocument.OpenDataReader` API without a supplied A1 range, so worksheet range discovery remains part of the measured operation
- keep typed access and the existing full-row correctness checksum aligned with the Sylvan lane

The previous OfficeIMO lane materialized a dense `object[,]`, while Sylvan, ExcelDataReader, MiniExcel, ClosedXML, and EPPlus only iterated their rows. That mixed an allocation-heavy output contract into one side of a reader comparison and made the reported loss misleading. This change removes that asymmetry without adding a benchmark-only product path or weakening validation.

## Current evidence

On .NET 10 on the same Windows machine, with five warmups and twenty measured iterations:

- 2,500 rows: OfficeIMO median 9.39 ms / 336.8 KB; Sylvan median 19.49 ms / 357.1 KB
- 25,000 rows: OfficeIMO median 30.83 ms / 337.1 KB; Sylvan median 50.48 ms / 378.1 KB

Both implementations produced the same full-row checksum at each size. A 100-row all-library smoke also passed every validation lane; it continues to show the honest small-workbook startup gap (OfficeIMO 4.20 ms vs Sylvan 1.10 ms), which remains follow-up work rather than being hidden from the matrix.

## Validation

- Release benchmark project build on .NET 10
- 100-row all-library correctness smoke across OfficeIMO, ClosedXML, EPPlus, MiniExcel, ExcelDataReader, and Sylvan
- 2,500-row OfficeIMO/Sylvan comparison: 5 warmups, 20 measured iterations
- 25,000-row OfficeIMO/Sylvan comparison: 5 warmups, 20 measured iterations

Related to #2195.
