### PR TITLE
Reuse one worksheet buffer for used-range readers

### DIFF
--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.FastValidation.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.FastValidation.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System.Text;
+using System.Threading;
 #if NET8_0_OR_GREATER
 using System.Buffers;
 using System.Text.Unicode;
@@ -25,7 +26,8 @@ namespace OfficeIMO.Excel {
             /// Proves full well-formedness for the common, unprefixed SpreadsheetML shape.
             /// Richer XML constructs fall back to XmlReader validation rather than weakening it.
             /// </summary>
-            private bool IsCanonicalWorksheetXmlFullyValidated() {
+            private bool IsCanonicalWorksheetXmlFullyValidated(CancellationToken ct) {
+                ct.ThrowIfCancellationRequested();
                 if (!_sheetDataSupportsFastValidation) {
                     return false;
                 }
@@ -35,6 +37,7 @@ namespace OfficeIMO.Excel {
                     || ContainsInvalidCanonicalXmlBytes(document)) {
                     return false;
                 }
+                ct.ThrowIfCancellationRequested();
 #else
                 try {
                     _ = StrictUtf8.GetCharCount(_buffer!, 0, _length);
@@ -43,6 +46,9 @@ namespace OfficeIMO.Excel {
                 }
 
                 for (int index = 0; index < _length; index++) {
+                    if ((index & 0xFFFF) == 0) {
+                        ct.ThrowIfCancellationRequested();
+                    }
                     byte value = _buffer![index];
                     if (value == (byte)'&'
                         || value < 0x20 && value is not (byte)'\t' and not (byte)'\r' and not (byte)'\n'
@@ -61,6 +67,7 @@ namespace OfficeIMO.Excel {
 
                 if (_sheetDataContentStart >= 0
                     && _sheetDataEndTagStart >= _sheetDataContentStart) {
+                    ct.ThrowIfCancellationRequested();
                     ReadOnlySpan<byte> sheetData = _buffer!.AsSpan(
                         _sheetDataContentStart,
                         _sheetDataEndTagStart - _sheetDataContentStart);
@@ -76,6 +83,7 @@ namespace OfficeIMO.Excel {
                         }
                     }
 #endif
+                    ct.ThrowIfCancellationRequested();
                 }
 
                 Span<int> nameStarts = stackalloc int[MaximumFastXmlDepth];
@@ -89,11 +97,14 @@ namespace OfficeIMO.Excel {
                 int position = SkipUtf8PreambleAndWhitespace(0);
                 bool rootSeen = false;
                 bool rootClosed = false;
+                ct.ThrowIfCancellationRequested();
                 if (!HasOnlyRootDefaultNamespace()) {
                     return false;
                 }
+                ct.ThrowIfCancellationRequested();
 
                 while (position < _length) {
+                    ct.ThrowIfCancellationRequested();
                     if (_sheetDataContentStart >= 0
                         && position == _sheetDataContentStart
                         && _sheetDataEndTagStart >= position) {

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.Xml.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.Xml.cs
@@ -1,8 +1,50 @@
 #nullable enable
 
+using System.Text;
+using System.Threading;
+
 namespace OfficeIMO.Excel {
     internal sealed partial class ExcelSheetReader {
         private sealed partial class ExcelUtf8RangeRowSource {
+            private bool TryGetDeclaredRange(
+                CancellationToken ct,
+                out int firstRow,
+                out int firstColumn,
+                out int lastRow,
+                out int lastColumn) {
+                firstRow = 0;
+                firstColumn = 0;
+                lastRow = 0;
+                lastColumn = 0;
+                if (!HasSupportedUtf8Encoding()) {
+                    return false;
+                }
+
+                int position = 0;
+                while (TryReadNextTag(ref position, _length, out Utf8Tag tag)) {
+                    ct.ThrowIfCancellationRequested();
+                    if (tag.IsEnd) {
+                        continue;
+                    }
+
+                    if (LocalNameEquals(tag, "sheetData")) {
+                        return false;
+                    }
+
+                    if (!LocalNameEquals(tag, "dimension")
+                        || !TryGetAttribute(tag, "ref", out bool found, out int valueStart, out int valueLength)
+                        || !found) {
+                        continue;
+                    }
+
+                    string reference = Encoding.UTF8.GetString(_buffer!, valueStart, valueLength);
+                    return ExcelSheetReader.TryNormalizeWorksheetDimensionReference(reference, out string normalized)
+                        && A1.TryParseRange(normalized, out firstRow, out firstColumn, out lastRow, out lastColumn);
+                }
+
+                return false;
+            }
+
             private bool HasSupportedUtf8Encoding() {
                 int probeLength = Math.Min(_length, 256);
                 for (int i = 0; i < probeLength; i++) {

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.cs
@@ -18,8 +18,8 @@ namespace OfficeIMO.Excel {
 
             private readonly ExcelSheetReader _owner;
             private readonly ExcelReadOptions _options;
-            private readonly int _firstColumn;
-            private readonly int _fieldCount;
+            private int _firstColumn;
+            private int _fieldCount;
             private readonly Utf8StringCacheEntry[] _stringCache;
             private byte[]? _buffer;
             private int[]? _rowIndexes;
@@ -49,15 +49,31 @@ namespace OfficeIMO.Excel {
             private ExcelUtf8RangeRowSource(
                 ExcelSheetReader owner,
                 byte[] buffer,
-                int length,
-                int firstRow,
-                int lastRow,
-                int firstColumn,
-                int fieldCount) {
+                int length) {
                 _owner = owner;
                 _options = owner._opt;
                 _buffer = buffer;
                 _length = length;
+                _stringCache = new Utf8StringCacheEntry[StringCacheSize];
+            }
+
+            private ExcelUtf8RangeRowSource(
+                ExcelSheetReader owner,
+                byte[] buffer,
+                int length,
+                int firstRow,
+                int lastRow,
+                int firstColumn,
+                int fieldCount)
+                : this(owner, buffer, length) {
+                InitializeRange(firstRow, lastRow, firstColumn, fieldCount);
+            }
+
+            private void InitializeRange(
+                int firstRow,
+                int lastRow,
+                int firstColumn,
+                int fieldCount) {
                 _firstColumn = firstColumn;
                 _fieldCount = fieldCount;
 
@@ -70,7 +86,72 @@ namespace OfficeIMO.Excel {
                 _formulaLengths = ArrayPool<int>.Shared.Rent(cellCapacity);
                 _styleIndexes = ArrayPool<int>.Shared.Rent(cellCapacity);
                 _cellKinds = ArrayPool<byte>.Shared.Rent(cellCapacity);
-                _stringCache = new Utf8StringCacheEntry[StringCacheSize];
+            }
+
+            internal static bool TryCreateForUsedRange(
+                ExcelSheetReader owner,
+                CancellationToken ct,
+                out ExcelUtf8RangeRowSource? source,
+                out int declaredFirstColumn) {
+                source = null;
+                declaredFirstColumn = 0;
+                if (owner._opt.CellValueConverter != null) {
+                    return false;
+                }
+
+                byte[]? buffer = null;
+                try {
+                    if (!TryRentWorksheetBuffer(owner, ct, out buffer, out int length)) {
+                        return false;
+                    }
+
+                    var candidate = new ExcelUtf8RangeRowSource(owner, buffer!, length);
+                    buffer = null;
+                    try {
+                        if (!candidate.TryGetDeclaredRange(
+                                ct,
+                                out int firstRow,
+                                out int firstColumn,
+                                out int lastRow,
+                                out int lastColumn)) {
+                            candidate.Dispose();
+                            return false;
+                        }
+
+                        int fieldCount = lastColumn - firstColumn + 1;
+                        long rowCount = (long)lastRow - firstRow + 1L;
+                        long cellCount = rowCount * fieldCount;
+                        if (fieldCount <= 0
+                            || fieldCount > owner._opt.MaxDataReaderColumns
+                            || cellCount > owner._opt.MaxDataReaderBufferedCells
+                            || cellCount > MaximumIndexedCells) {
+                            candidate.Dispose();
+                            return false;
+                        }
+
+                        candidate.InitializeRange(firstRow, lastRow, firstColumn, fieldCount);
+                        if (!candidate.TryIndexRows(firstRow, lastRow, ct)) {
+                            candidate.Dispose();
+                            return false;
+                        }
+
+                        if (!candidate.IsCanonicalWorksheetXmlFullyValidated(ct)) {
+                            candidate.ValidateBufferedWorksheetXml(ct);
+                        }
+
+                        ct.ThrowIfCancellationRequested();
+                        declaredFirstColumn = firstColumn;
+                        source = candidate;
+                        return true;
+                    } catch {
+                        candidate.Dispose();
+                        throw;
+                    }
+                } finally {
+                    if (buffer != null) {
+                        ArrayPool<byte>.Shared.Return(buffer);
+                    }
+                }
             }
 
             internal static bool TryCreate(
@@ -89,17 +170,8 @@ namespace OfficeIMO.Excel {
 
                 byte[]? buffer = null;
                 try {
-                    int length;
-                    if (!owner.TryReadWorksheetPartBuffer(
-                            MaximumBufferSize,
-                            ct,
-                            out buffer,
-                            out length)) {
-                        using var stream = owner._wsPart.GetStream(FileMode.Open, FileAccess.Read);
-                        RewindWorksheetStream(stream);
-                        if (!TryReadWorksheetBuffer(stream, ct, out buffer, out length)) {
-                            return false;
-                        }
+                    if (!TryRentWorksheetBuffer(owner, ct, out buffer, out int length)) {
+                        return false;
                     }
 
                     var candidate = new ExcelUtf8RangeRowSource(
@@ -112,12 +184,12 @@ namespace OfficeIMO.Excel {
                         fieldCount);
                     buffer = null;
                     try {
-                        if (!candidate.TryIndexRows(firstRow, lastRow)) {
+                        if (!candidate.TryIndexRows(firstRow, lastRow, ct)) {
                             candidate.Dispose();
                             return false;
                         }
 
-                        if (!candidate.IsCanonicalWorksheetXmlFullyValidated()) {
+                        if (!candidate.IsCanonicalWorksheetXmlFullyValidated(ct)) {
                             candidate.ValidateBufferedWorksheetXml(ct);
                         }
                     } catch {
@@ -125,6 +197,7 @@ namespace OfficeIMO.Excel {
                         throw;
                     }
 
+                    ct.ThrowIfCancellationRequested();
                     source = candidate;
                     return true;
                 } finally {
@@ -132,6 +205,24 @@ namespace OfficeIMO.Excel {
                         ArrayPool<byte>.Shared.Return(buffer);
                     }
                 }
+            }
+
+            private static bool TryRentWorksheetBuffer(
+                ExcelSheetReader owner,
+                CancellationToken ct,
+                out byte[]? buffer,
+                out int length) {
+                if (owner.TryReadWorksheetPartBuffer(
+                        MaximumBufferSize,
+                        ct,
+                        out buffer,
+                        out length)) {
+                    return true;
+                }
+
+                using var stream = owner._wsPart.GetStream(FileMode.Open, FileAccess.Read);
+                RewindWorksheetStream(stream);
+                return TryReadWorksheetBuffer(stream, ct, out buffer, out length);
             }
 
             internal bool SelectRow(int rowIndex) {
@@ -312,7 +403,8 @@ namespace OfficeIMO.Excel {
                 }
             }
 
-            private bool TryIndexRows(int firstRow, int lastRow) {
+            private bool TryIndexRows(int firstRow, int lastRow, CancellationToken ct) {
+                ct.ThrowIfCancellationRequested();
                 if (!HasSupportedUtf8Encoding()) {
                     return false;
                 }
@@ -327,6 +419,7 @@ namespace OfficeIMO.Excel {
                 Utf8Tag sheetData = default;
                 bool foundSheetData = false;
                 while (TryReadNextTag(ref position, _length, out Utf8Tag tag)) {
+                    ct.ThrowIfCancellationRequested();
                     if (!tag.IsEnd
                         && IsUnprefixedTag(tag)
                         && LocalNameEquals(tag, "worksheet")) {
@@ -358,6 +451,7 @@ namespace OfficeIMO.Excel {
                 int nextImplicitRow = 1;
                 int previousRow = 0;
                 while (TryReadNextTag(ref position, _length, out Utf8Tag tag)) {
+                    ct.ThrowIfCancellationRequested();
                     if (tag.IsEnd && IsUnprefixedTag(tag) && LocalNameEquals(tag, "sheetData")) {
                         _sheetDataEndTagStart = tag.Start;
                         return !_parseFailed;
@@ -407,7 +501,7 @@ namespace OfficeIMO.Excel {
                         InitializeMetadataRow(rowOffset);
                     }
 
-                    if (!tag.IsEmpty && !TryIndexRow(ref position, rowIndex, rowOffset, includeRow)) {
+                    if (!tag.IsEmpty && !TryIndexRow(ref position, rowIndex, rowOffset, includeRow, ct)) {
                         return false;
                     }
 
@@ -425,10 +519,12 @@ namespace OfficeIMO.Excel {
                 ref int position,
                 int rowIndex,
                 int rowOffset,
-                bool rowWithinRange) {
+                bool rowWithinRange,
+                CancellationToken ct) {
                 int nextColumn = 1;
                 int previousColumn = 0;
                 while (position < _length) {
+                    ct.ThrowIfCancellationRequested();
                     int originalPosition = position;
                     int originalNextColumn = nextColumn;
                     bool compactTag = TryReadCompactCellStartTag(

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.cs
@@ -17,6 +17,11 @@ namespace OfficeIMO.Excel {
             bool headersInFirstRow = true,
             int schemaSampleRows = 0,
             CancellationToken ct = default) {
+            if (schemaSampleRows == 0
+                && TryCreateIndexedUsedRangeDataReader(headersInFirstRow, ct, out IDataReader? indexedReader)) {
+                return indexedReader!;
+            }
+
             if (TryGetWorksheetCellPresence(out bool hasCells, ct) && !hasCells) {
                 return new ExcelRangeDataReader(
                     Array.Empty<RangeChunk>(),
@@ -27,11 +32,6 @@ namespace OfficeIMO.Excel {
                     schemaSampleRows,
                     _opt,
                     ct);
-            }
-
-            if (schemaSampleRows == 0
-                && TryCreateIndexedUsedRangeDataReader(headersInFirstRow, ct, out IDataReader? indexedReader)) {
-                return indexedReader!;
             }
 
             ValidateDataReaderProjection(ct);
@@ -50,33 +50,11 @@ namespace OfficeIMO.Excel {
             out IDataReader? dataReader) {
             dataReader = null;
             if (!CanUseRangeStreamXmlReader()
-                || !TryGetWorksheetDimensionReferenceFromXml(out string declaredRange, ct)
-                || !A1.TryParseRange(
-                    declaredRange,
-                    out int declaredFirstRow,
-                    out int declaredFirstColumn,
-                    out int declaredLastRow,
-                    out int declaredLastColumn)) {
-                return false;
-            }
-
-            int declaredFieldCount = declaredLastColumn - declaredFirstColumn + 1;
-            long declaredRowCount = (long)declaredLastRow - declaredFirstRow + 1L;
-            long declaredCellCount = declaredRowCount * declaredFieldCount;
-            if (declaredFieldCount <= 0
-                || declaredFieldCount > _opt.MaxDataReaderColumns
-                || declaredCellCount > _opt.MaxDataReaderBufferedCells) {
-                return false;
-            }
-
-            if (!ExcelUtf8RangeRowSource.TryCreate(
+                || !ExcelUtf8RangeRowSource.TryCreateForUsedRange(
                     this,
-                    declaredFirstRow,
-                    declaredLastRow,
-                    declaredFirstColumn,
-                    declaredFieldCount,
                     ct,
-                    out ExcelUtf8RangeRowSource? source)) {
+                    out ExcelUtf8RangeRowSource? source,
+                    out int declaredFirstColumn)) {
                 return false;
             }
 


### PR DESCRIPTION
## Summary

- reuse the indexed worksheet buffer to discover the declared range and build the forward-only used-range reader
- avoid separate worksheet-presence and dimension stream passes on the normal UTF-8 XLSX path
- preserve stale-dimension fallback, configured resource ceilings, pooled-buffer cleanup, and cancellation during parsing/indexing

This improves the existing `ExcelDocument.OpenDataReader` path without adding another public API or a competitor-specific shortcut.

## Measured effect

Using the fair forward-only `read-used-range` comparison from #2231 (20 warmups, 31 measured iterations), steady OfficeIMO allocations dropped:

- 100 rows: about 314 KB to 281 KB
- 2,500 rows: about 324 KB to 292 KB
- 25,000 rows: about 324 KB to 292 KB

Wall-clock results were noisy on the shared workstation, so this PR deliberately makes no latency-win claim. OfficeIMO continued to validate the same checksum and remained ahead of Sylvan at the medium and large sizes in the measured runs.

## Validation

- 187 data-reader tests pass on each of net10.0, net8.0, and net472
- full net8.0 Excel suite: 3,434 passed, 5 skipped; one unrelated transactional-table concurrency test failed once and passed immediately in isolation
- independent reader/parser review found one cancellation issue; it was fixed and the targeted confirmation passed

Related to #2195.