### PR TITLE
Add native XLSB AutoFilter criteria rewriting

### DIFF
--- a/Docs/Compatibility/generated/excel-xlsb.json
+++ b/Docs/Compatibility/generated/excel-xlsb.json
@@ -121,7 +121,7 @@
       "modernToLegacy":"Approximated",
       "legacyToModern":"Native",
       "affectedFidelity":"Editability, Carrier",
-      "note":"Unsupported criteria remain preserved on import; native new-package generation supports the documented equality-list subset."
+      "note":"Unsupported criteria remain preserved on import; native generation and loaded-package criteria rewrites support the documented equality-list subset when the filter range is unchanged."
     },
     {
       "id":"Excel.Xlsb.Print.PageSetup",

--- a/Docs/Compatibility/generated/excel-xlsb.md
+++ b/Docs/Compatibility/generated/excel-xlsb.md
@@ -11,7 +11,7 @@ Schema version: 1
 | Formatting | Excel.Xlsb.Formatting.Styles | Excel.Xlsb | Native | Native | Approximated | PreservedOpaque | Approximated | Native | Editability, Carrier | A useful style subset projects and can be generated. Complex gradients, extensions, differential styles, and custom style families remain guarded. |
 | Structure | Excel.Xlsb.Structure.Geometry | Excel.Xlsb | Native | Native | Native | PreservedOpaque | Native | Native | None |  |
 | Navigation | Excel.Xlsb.Navigation.Hyperlinks | Excel.Xlsb | Native | Native | Native | Native | Native | Native | None |  |
-| Data | Excel.Xlsb.Data.AutoFilter | Excel.Xlsb | Native | Native | Approximated | PreservedOpaque | Approximated | Native | Editability, Carrier | Unsupported criteria remain preserved on import; native new-package generation supports the documented equality-list subset. |
+| Data | Excel.Xlsb.Data.AutoFilter | Excel.Xlsb | Native | Native | Approximated | PreservedOpaque | Approximated | Native | Editability, Carrier | Unsupported criteria remain preserved on import; native generation and loaded-package criteria rewrites support the documented equality-list subset when the filter range is unchanged. |
 | Print | Excel.Xlsb.Print.PageSetup | Excel.Xlsb | Native | Native | Native | PreservedOpaque | Native | Native | None |  |
 | Security | Excel.Xlsb.Security.Protection | Excel.Xlsb | Native | Native | Native | PreservedOpaque | Native | Native | None |  |
 | Names | Excel.Xlsb.Names.DefinedNames | Excel.Xlsb | Native | Native | Native | PreservedOpaque | Native | Native | None |  |

--- a/OfficeIMO.Excel.Tests/Excel.Xlsb.AutoFilterRewrite.cs
+++ b/OfficeIMO.Excel.Tests/Excel.Xlsb.AutoFilterRewrite.cs
@@ -185,6 +185,44 @@ namespace OfficeIMO.Tests {
             Assert.Contains("attribute 'blank'", exception.Message, StringComparison.Ordinal);
         }
 
+        [Fact]
+        public void Xlsb_NewWorkbook_AllowsRelationshipQualifiedHyperlinkIdButRejectsUnqualifiedId() {
+            using ExcelDocument document = ExcelDocument.Create();
+            ExcelSheet sheet = document.AddWorksheet("Report");
+            sheet.CellValue(1, 1, "OfficeIMO");
+            sheet.SetHyperlink(
+                1,
+                1,
+                "https://evotec.xyz/",
+                display: "OfficeIMO",
+                style: false);
+
+            Assert.NotEmpty(document.ToBytes(ExcelFileFormat.Xlsb));
+            Hyperlink hyperlink = Assert.Single(
+                sheet.WorksheetPart.Worksheet.GetFirstChild<Hyperlinks>()!.Elements<Hyperlink>());
+            Assert.False(string.IsNullOrEmpty(hyperlink.Id?.Value));
+            hyperlink.SetAttribute(new OpenXmlAttribute(string.Empty, "id", string.Empty, "rIdShadow"));
+
+            NotSupportedException exception = Assert.Throws<NotSupportedException>(
+                () => document.ToBytes(ExcelFileFormat.Xlsb));
+            Assert.Contains("attribute 'id'", exception.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void Xlsb_NewWorkbook_RejectsUnqualifiedPageSetupId() {
+            using ExcelDocument document = ExcelDocument.Create();
+            ExcelSheet sheet = document.AddWorksheet("Report");
+            sheet.CellValue(1, 1, "Status");
+            sheet.SetPageSetup(fitToWidth: 1U, fitToHeight: 0U);
+            PageSetup pageSetup = Assert.IsType<PageSetup>(
+                sheet.WorksheetPart.Worksheet.GetFirstChild<PageSetup>());
+            pageSetup.SetAttribute(new OpenXmlAttribute(string.Empty, "id", string.Empty, "rIdShadow"));
+
+            NotSupportedException exception = Assert.Throws<NotSupportedException>(
+                () => document.ToBytes(ExcelFileFormat.Xlsb));
+            Assert.Contains("attribute 'id'", exception.Message, StringComparison.Ordinal);
+        }
+
         [Theory]
         [InlineData(true)]
         [InlineData(false)]

--- a/OfficeIMO.Excel.Tests/Excel.Xlsb.AutoFilterRewrite.cs
+++ b/OfficeIMO.Excel.Tests/Excel.Xlsb.AutoFilterRewrite.cs
@@ -1,0 +1,153 @@
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Excel;
+using OfficeIMO.Excel.Xlsb.Biff12;
+using System.IO.Compression;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        public void Xlsb_LoadedWorkbook_RewritesEqualityListAutoFilterCriteria() {
+            byte[] source;
+            using (ExcelDocument document = ExcelDocument.Create()) {
+                ExcelSheet sheet = document.AddWorksheet("Report");
+                sheet.CellValue(1, 1, "Status");
+                sheet.CellValue(1, 2, "Owner");
+                sheet.CellValue(2, 1, "Open");
+                sheet.CellValue(2, 2, "Ada");
+                sheet.CellValue(3, 1, "Closed");
+                sheet.CellValue(3, 2, "Grace");
+                sheet.AddAutoFilter("A1:B3", new Dictionary<uint, IEnumerable<string>> {
+                    [0U] = new[] { "Open" }
+                });
+                source = document.ToBytes(ExcelFileFormat.Xlsb);
+            }
+
+            using ExcelDocument loaded = ExcelDocument.Load(new MemoryStream(source, writable: false));
+            ExcelSheet loadedSheet = Assert.Single(loaded.Sheets);
+            loadedSheet.AddAutoFilter("A1:B3", new Dictionary<uint, IEnumerable<string>> {
+                [0U] = new[] { "Open", "Closed" },
+                [1U] = new[] { "Ada" }
+            });
+
+            byte[] rewritten = loaded.ToBytes(ExcelFileFormat.Xlsb);
+            Assert.Equal(
+                ReadPackageEntry(source, "xl/workbook.bin"),
+                ReadPackageEntry(rewritten, "xl/workbook.bin"));
+            using (var archive = new ZipArchive(new MemoryStream(rewritten, writable: false), ZipArchiveMode.Read)) {
+                using Stream worksheetStream = Assert.IsType<ZipArchiveEntry>(archive.GetEntry("xl/worksheets/sheet1.bin")).Open();
+                IReadOnlyList<XlsbRecord> records = XlsbRecordReader.ReadAll(worksheetStream);
+                Assert.Single(records, record => record.Type == 161);
+                Assert.Single(records, record => record.Type == 162);
+                Assert.Equal(2, records.Count(record => record.Type == 163));
+                Assert.Equal(3, records.Count(record => record.Type == 167));
+            }
+
+            using ExcelDocument reloaded = ExcelDocument.Load(new MemoryStream(rewritten, writable: false));
+            AutoFilter filter = Assert.IsType<AutoFilter>(
+                Assert.Single(reloaded.Sheets).WorksheetPart.Worksheet.GetFirstChild<AutoFilter>());
+            Assert.Equal("A1:B3", filter.Reference?.Value);
+            FilterColumn[] columns = filter.Elements<FilterColumn>().OrderBy(column => column.ColumnId?.Value).ToArray();
+            Assert.Equal(2, columns.Length);
+            Assert.Equal(new[] { "Open", "Closed" },
+                columns[0].GetFirstChild<Filters>()!.Elements<Filter>().Select(value => value.Val?.Value));
+            Assert.Equal(new[] { "Ada" },
+                columns[1].GetFirstChild<Filters>()!.Elements<Filter>().Select(value => value.Val?.Value));
+        }
+
+        [Fact]
+        public void Xlsb_LoadedWorkbook_ClearsEqualityListCriteriaWithoutRemovingFilterRange() {
+            byte[] source;
+            using (ExcelDocument document = ExcelDocument.Create()) {
+                ExcelSheet sheet = document.AddWorksheet("Report");
+                sheet.CellValue(1, 1, "Status");
+                sheet.CellValue(2, 1, "Open");
+                sheet.AddAutoFilter("A1:A2", new Dictionary<uint, IEnumerable<string>> {
+                    [0U] = new[] { "Open" }
+                });
+                source = document.ToBytes(ExcelFileFormat.Xlsb);
+            }
+
+            using ExcelDocument loaded = ExcelDocument.Load(new MemoryStream(source, writable: false));
+            Assert.True(Assert.Single(loaded.Sheets).ClearAutoFilterColumn(0U));
+
+            byte[] rewritten = loaded.ToBytes(ExcelFileFormat.Xlsb);
+            using ExcelDocument reloaded = ExcelDocument.Load(new MemoryStream(rewritten, writable: false));
+            AutoFilter filter = Assert.IsType<AutoFilter>(
+                Assert.Single(reloaded.Sheets).WorksheetPart.Worksheet.GetFirstChild<AutoFilter>());
+            Assert.Equal("A1:A2", filter.Reference?.Value);
+            Assert.Empty(filter.Elements<FilterColumn>());
+        }
+
+        [Fact]
+        public void Xlsb_LoadedWorkbook_RewrittenAutoFilterOpensInDesktopExcelWhenAvailable() {
+            if (!IsWindowsPlatform()) return;
+
+            string path = Path.Combine(
+                Path.GetTempPath(),
+                $"OfficeIMO.Xlsb.AutoFilter.{Guid.NewGuid():N}.xlsb");
+            try {
+                byte[] source;
+                using (ExcelDocument document = ExcelDocument.Create()) {
+                    ExcelSheet sheet = document.AddWorksheet("Report");
+                    sheet.CellValue(1, 1, "Status");
+                    sheet.CellValue(2, 1, "Open");
+                    sheet.CellValue(3, 1, "Closed");
+                    sheet.AddAutoFilter("A1:A3", new Dictionary<uint, IEnumerable<string>> {
+                        [0U] = new[] { "Open" }
+                    });
+                    source = document.ToBytes(ExcelFileFormat.Xlsb);
+                }
+
+                using (ExcelDocument loaded = ExcelDocument.Load(new MemoryStream(source, writable: false))) {
+                    Assert.Single(loaded.Sheets).AddAutoFilter(
+                        "A1:A3",
+                        new Dictionary<uint, IEnumerable<string>> {
+                            [0U] = new[] { "Open", "Closed" }
+                        });
+                    File.WriteAllBytes(path, loaded.ToBytes(ExcelFileFormat.Xlsb));
+                }
+
+                AssertWorkbookOpensViaExcelComWhenAvailable(
+                    path,
+                    "The rewritten XLSB AutoFilter workbook failed to open in desktop Excel.");
+            } finally {
+                if (File.Exists(path)) File.Delete(path);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Xlsb_LoadedWorkbook_FailsClosedWhenFilterDatabaseNameWouldNeedChanging(bool remove) {
+            byte[] source;
+            using (ExcelDocument document = ExcelDocument.Create()) {
+                ExcelSheet sheet = document.AddWorksheet("Report");
+                sheet.CellValue(1, 1, "Status");
+                sheet.CellValue(2, 1, "Open");
+                sheet.AddAutoFilter("A1:A2");
+                source = document.ToBytes(ExcelFileFormat.Xlsb);
+            }
+
+            using ExcelDocument loaded = ExcelDocument.Load(new MemoryStream(source, writable: false));
+            ExcelSheet loadedSheet = Assert.Single(loaded.Sheets);
+            if (remove) {
+                loadedSheet.AutoFilterClear();
+            } else {
+                loadedSheet.AutoFilterAdd("A1:B2");
+            }
+
+            NotSupportedException exception = Assert.Throws<NotSupportedException>(
+                () => loaded.ToBytes(ExcelFileFormat.Xlsb));
+            Assert.Contains("_FilterDatabase", exception.Message, StringComparison.Ordinal);
+        }
+
+        private static byte[] ReadPackageEntry(byte[] package, string entryName) {
+            using var archive = new ZipArchive(new MemoryStream(package, writable: false), ZipArchiveMode.Read);
+            using Stream stream = Assert.IsType<ZipArchiveEntry>(archive.GetEntry(entryName)).Open();
+            using var output = new MemoryStream();
+            stream.CopyTo(output);
+            return output.ToArray();
+        }
+    }
+}

--- a/OfficeIMO.Excel.Tests/Excel.Xlsb.AutoFilterRewrite.cs
+++ b/OfficeIMO.Excel.Tests/Excel.Xlsb.AutoFilterRewrite.cs
@@ -1,6 +1,8 @@
+using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Spreadsheet;
 using OfficeIMO.Excel;
 using OfficeIMO.Excel.Xlsb.Biff12;
+using OfficeIMO.Excel.Xlsb.Write;
 using System.IO.Compression;
 using Xunit;
 
@@ -116,6 +118,73 @@ namespace OfficeIMO.Tests {
             }
         }
 
+        [Fact]
+        public void Xlsb_LoadedWorkbook_PreservesRecognizedRecordsInsideUnsupportedAutoFilterAndBlocksMutation() {
+            byte[] source;
+            using (ExcelDocument document = ExcelDocument.Create()) {
+                ExcelSheet sheet = document.AddWorksheet("Report");
+                sheet.CellValue(1, 1, "Status");
+                sheet.CellValue(2, 1, "Open");
+                sheet.AddAutoFilter("A1:A2", new Dictionary<uint, IEnumerable<string>> {
+                    [0U] = new[] { "Open" }
+                });
+                source = document.ToBytes(ExcelFileFormat.Xlsb);
+            }
+
+            byte[] nonCanonical = InsertWorksheetRecordBeforeAutoFilterEnd(
+                source,
+                recordType: 477,
+                payload: new byte[] { 0x00, 0x00 });
+            using (ExcelDocument loaded = ExcelDocument.Load(new MemoryStream(nonCanonical, writable: false))) {
+                ExcelSheet sheet = Assert.Single(loaded.Sheets);
+                sheet.CellValue(2, 1, "Edited");
+                byte[] rewritten = loaded.ToBytes(ExcelFileFormat.Xlsb);
+                IReadOnlyList<XlsbRecord> records = ReadWorksheetRecords(rewritten);
+                int begin = records.ToList().FindIndex(record => record.Type == 161);
+                int end = records.ToList().FindIndex(record => record.Type == 162);
+                Assert.Contains(records.Skip(begin + 1).Take(end - begin - 1),
+                    record => record.Type == 477 && record.Data.SequenceEqual(new byte[] { 0x00, 0x00 }));
+            }
+
+            using ExcelDocument changed = ExcelDocument.Load(new MemoryStream(nonCanonical, writable: false));
+            Assert.Single(changed.Sheets).AddAutoFilter(
+                "A1:A2",
+                new Dictionary<uint, IEnumerable<string>> {
+                    [0U] = new[] { "Open", "Closed" }
+                });
+            NotSupportedException exception = Assert.Throws<NotSupportedException>(
+                () => changed.ToBytes(ExcelFileFormat.Xlsb));
+            Assert.Contains("outside the supported equality-list subset", exception.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void Xlsb_LoadedWorkbook_RejectsForeignNamespaceAutoFilterAttributes() {
+            byte[] source;
+            using (ExcelDocument document = ExcelDocument.Create()) {
+                ExcelSheet sheet = document.AddWorksheet("Report");
+                sheet.CellValue(1, 1, "Status");
+                sheet.CellValue(2, 1, "Open");
+                sheet.AddAutoFilter("A1:A2", new Dictionary<uint, IEnumerable<string>> {
+                    [0U] = new[] { "Open" }
+                });
+                source = document.ToBytes(ExcelFileFormat.Xlsb);
+            }
+
+            using ExcelDocument loaded = ExcelDocument.Load(new MemoryStream(source, writable: false));
+            ExcelSheet loadedSheet = Assert.Single(loaded.Sheets);
+            loadedSheet.AddAutoFilter("A1:A2", new Dictionary<uint, IEnumerable<string>> {
+                [0U] = new[] { "Open", "Closed" }
+            });
+            AutoFilter filter = Assert.IsType<AutoFilter>(
+                loadedSheet.WorksheetPart.Worksheet.GetFirstChild<AutoFilter>());
+            Filters values = Assert.IsType<Filters>(Assert.Single(filter.Elements<FilterColumn>()).GetFirstChild<Filters>());
+            values.SetAttribute(new OpenXmlAttribute("ext", "blank", "urn:officeimo:test", "1"));
+
+            NotSupportedException exception = Assert.Throws<NotSupportedException>(
+                () => loaded.ToBytes(ExcelFileFormat.Xlsb));
+            Assert.Contains("attribute 'blank'", exception.Message, StringComparison.Ordinal);
+        }
+
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
@@ -148,6 +217,36 @@ namespace OfficeIMO.Tests {
             using var output = new MemoryStream();
             stream.CopyTo(output);
             return output.ToArray();
+        }
+
+        private static IReadOnlyList<XlsbRecord> ReadWorksheetRecords(byte[] package) {
+            byte[] worksheet = ReadPackageEntry(package, "xl/worksheets/sheet1.bin");
+            using var stream = new MemoryStream(worksheet, writable: false);
+            return XlsbRecordReader.ReadAll(stream);
+        }
+
+        private static byte[] InsertWorksheetRecordBeforeAutoFilterEnd(
+            byte[] package,
+            int recordType,
+            byte[] payload) {
+            IReadOnlyList<XlsbRecord> records = ReadWorksheetRecords(package);
+            using var worksheet = new MemoryStream();
+            bool inserted = false;
+            foreach (XlsbRecord record in records) {
+                if (!inserted && record.Type == 162) {
+                    XlsbRecordWriter.Write(worksheet, recordType, payload);
+                    inserted = true;
+                }
+                XlsbRecordWriter.Write(worksheet, record.Type, record.Data);
+            }
+            Assert.True(inserted);
+            return XlsbNativePackageWriter.RewritePackage(
+                package,
+                new Dictionary<string, byte[]> {
+                    ["xl/worksheets/sheet1.bin"] = worksheet.ToArray()
+                },
+                maxPartBytes: 128 * 1024 * 1024,
+                maxPackageBytes: 512L * 1024 * 1024);
         }
     }
 }

--- a/OfficeIMO.Excel/ExcelCompatibilityCatalog.cs
+++ b/OfficeIMO.Excel/ExcelCompatibilityCatalog.cs
@@ -87,7 +87,7 @@ public static class ExcelCompatibilityCatalog {
             XlsbNative("Structure.Geometry", "Structure", "Dimensions, rows, columns, merges, panes, views, selections, and outline metadata."),
             XlsbNative("Navigation.Hyperlinks", "Navigation", "Internal and relationship-backed external hyperlinks.", editableRoundTrip: true),
             XlsbSubset("Data.AutoFilter", "Data", "Worksheet AutoFilter ranges and equality-list criteria.",
-                "Unsupported criteria remain preserved on import; native new-package generation supports the documented equality-list subset."),
+                "Unsupported criteria remain preserved on import; native generation and loaded-package criteria rewrites support the documented equality-list subset when the filter range is unchanged."),
             XlsbNative("Print.PageSetup", "Print", "Print options, margins, page setup, and text headers and footers."),
             XlsbNative("Security.Protection", "Security", "Workbook and worksheet classic protection metadata."),
             XlsbNative("Names.DefinedNames", "Names", "Supported workbook defined names and self-sheet references."),

--- a/OfficeIMO.Excel/Xlsb/Projection/XlsbWorksheetAutoFilterProjector.cs
+++ b/OfficeIMO.Excel/Xlsb/Projection/XlsbWorksheetAutoFilterProjector.cs
@@ -13,18 +13,16 @@ namespace OfficeIMO.Excel.Xlsb.Projection {
             worksheet.Append(Create(source));
         }
 
-        internal static void ValidateUnchanged(ExcelSheet sheet, XlsbAutoFilter? expected) {
+        internal static bool Matches(ExcelSheet sheet, XlsbAutoFilter? expected) {
             Worksheet worksheet = sheet.WorksheetPart.Worksheet
                 ?? throw new InvalidDataException($"Worksheet '{sheet.Name}' has no worksheet root.");
             AutoFilter[] actual = worksheet.Elements<AutoFilter>().ToArray();
             AutoFilter? expectedElement = expected == null ? null : Create(expected);
-            if (actual.Length > 1
-                || (expectedElement == null && actual.Length != 0)
-                || (expectedElement != null
-                    && (actual.Length != 1
-                        || !string.Equals(actual[0].OuterXml, expectedElement.OuterXml, StringComparison.Ordinal)))) {
-                throw new NotSupportedException($"Native XLSB rewriting preserves but cannot modify the worksheet AutoFilter on worksheet '{sheet.Name}'. Save as .xlsx to retain that change.");
-            }
+            return actual.Length <= 1
+                && (expectedElement == null
+                    ? actual.Length == 0
+                    : actual.Length == 1
+                        && string.Equals(actual[0].OuterXml, expectedElement.OuterXml, StringComparison.Ordinal));
         }
 
         private static AutoFilter Create(XlsbAutoFilter source) {

--- a/OfficeIMO.Excel/Xlsb/Write/XlsbCalculationPropertiesWriter.cs
+++ b/OfficeIMO.Excel/Xlsb/Write/XlsbCalculationPropertiesWriter.cs
@@ -76,12 +76,8 @@ namespace OfficeIMO.Excel.Xlsb.Write {
         }
 
         private static void EnsureOnlyAttributes(OpenXmlElement element, params string[] allowedNames) {
-            var allowed = new HashSet<string>(allowedNames, StringComparer.Ordinal);
-            OpenXmlAttribute? unsupported = element.GetAttributes()
-                .Cast<OpenXmlAttribute?>()
-                .FirstOrDefault(attribute => attribute.HasValue
-                    && !string.Equals(attribute.Value.NamespaceUri, "http://www.w3.org/2000/xmlns/", StringComparison.Ordinal)
-                    && !allowed.Contains(attribute.Value.LocalName));
+            OpenXmlAttribute? unsupported =
+                XlsbOpenXmlAttributeValidator.FindUnsupported(element, allowedNames);
             if (unsupported.HasValue) {
                 throw new NotSupportedException($"Native XLSB generation does not yet support calculation property '{unsupported.Value.LocalName}'.");
             }

--- a/OfficeIMO.Excel/Xlsb/Write/XlsbDefinedNameWriter.cs
+++ b/OfficeIMO.Excel/Xlsb/Write/XlsbDefinedNameWriter.cs
@@ -350,12 +350,8 @@ namespace OfficeIMO.Excel.Xlsb.Write {
         }
 
         private static void EnsureOnlyAttributes(OpenXmlElement element, params string[] allowedNames) {
-            var allowed = new HashSet<string>(allowedNames, StringComparer.Ordinal);
-            OpenXmlAttribute? unsupported = element.GetAttributes()
-                .Cast<OpenXmlAttribute?>()
-                .FirstOrDefault(attribute => attribute.HasValue
-                    && !string.Equals(attribute.Value.NamespaceUri, "http://www.w3.org/2000/xmlns/", StringComparison.Ordinal)
-                    && !allowed.Contains(attribute.Value.LocalName));
+            OpenXmlAttribute? unsupported =
+                XlsbOpenXmlAttributeValidator.FindUnsupported(element, allowedNames);
             if (unsupported.HasValue) {
                 throw new NotSupportedException($"Native XLSB generation does not yet support defined-name attribute '{unsupported.Value.LocalName}'.");
             }

--- a/OfficeIMO.Excel/Xlsb/Write/XlsbNativePackageWriter.cs
+++ b/OfficeIMO.Excel/Xlsb/Write/XlsbNativePackageWriter.cs
@@ -7,7 +7,7 @@ using System.IO.Compression;
 
 namespace OfficeIMO.Excel.Xlsb.Write {
     /// <summary>
-    /// Rewrites supported worksheet cells and hyperlinks in an existing XLSB package while copying every other part.
+    /// Rewrites supported worksheet cells, AutoFilters, and hyperlinks in an existing XLSB package while copying every other part.
     /// </summary>
     internal static class XlsbNativePackageWriter {
         private const int MaxWorksheetPartBytes = 128 * 1024 * 1024;
@@ -55,6 +55,8 @@ namespace OfficeIMO.Excel.Xlsb.Write {
                         sheets[index],
                         sourceSheet,
                         stylesheetPlan.CellFormatCount);
+                    XlsbWorksheetAutoFilterPlan autoFilterPlan =
+                        XlsbWorksheetAutoFilterPlan.Create(sheets[index], sourceSheet);
                     bool rewriteHyperlinks = !XlsbWorksheetHyperlinkProjector.Matches(sheets[index], sourceSheet);
                     string[] reservedRelationshipIds = sourceSheet.Relationships.Values
                         .Where(relationship => !relationship.Type.EndsWith(HyperlinkRelationshipSuffix, StringComparison.Ordinal))
@@ -69,6 +71,8 @@ namespace OfficeIMO.Excel.Xlsb.Write {
                     byte[] rewrittenPart = XlsbWorksheetPartWriter.Rewrite(
                         originalPart,
                         cells,
+                        autoFilterPlan.Records,
+                        autoFilterPlan.Rewrite,
                         hyperlinkPlan?.Records ?? Array.Empty<XlsbGeneratedRecord>(),
                         rewriteHyperlinks);
                     if (!originalPart.SequenceEqual(rewrittenPart)) {

--- a/OfficeIMO.Excel/Xlsb/Write/XlsbOpenXmlAttributeValidator.cs
+++ b/OfficeIMO.Excel/Xlsb/Write/XlsbOpenXmlAttributeValidator.cs
@@ -1,0 +1,28 @@
+using DocumentFormat.OpenXml;
+
+namespace OfficeIMO.Excel.Xlsb.Write {
+    /// <summary>Finds attributes that cannot be represented by a native XLSB writer.</summary>
+    internal static class XlsbOpenXmlAttributeValidator {
+        private const string XmlnsNamespace = "http://www.w3.org/2000/xmlns/";
+
+        internal static OpenXmlAttribute? FindUnsupported(
+            OpenXmlElement element,
+            IEnumerable<string> allowedUnqualifiedNames,
+            Func<OpenXmlAttribute, bool>? allowQualified = null) {
+            if (element == null) throw new ArgumentNullException(nameof(element));
+            if (allowedUnqualifiedNames == null) throw new ArgumentNullException(nameof(allowedUnqualifiedNames));
+
+            var allowed = new HashSet<string>(allowedUnqualifiedNames, StringComparer.Ordinal);
+            foreach (OpenXmlAttribute attribute in element.GetAttributes()) {
+                if (string.Equals(attribute.NamespaceUri, XmlnsNamespace, StringComparison.Ordinal)) continue;
+                if (string.Equals(attribute.NamespaceUri, string.Empty, StringComparison.Ordinal)
+                    && allowed.Contains(attribute.LocalName)) {
+                    continue;
+                }
+                if (allowQualified?.Invoke(attribute) == true) continue;
+                return attribute;
+            }
+            return null;
+        }
+    }
+}

--- a/OfficeIMO.Excel/Xlsb/Write/XlsbWorkbookProtectionWriter.cs
+++ b/OfficeIMO.Excel/Xlsb/Write/XlsbWorkbookProtectionWriter.cs
@@ -44,12 +44,8 @@ namespace OfficeIMO.Excel.Xlsb.Write {
         }
 
         private static void EnsureOnlyAttributes(OpenXmlElement element, params string[] allowedNames) {
-            var allowed = new HashSet<string>(allowedNames, StringComparer.Ordinal);
-            OpenXmlAttribute? unsupported = element.GetAttributes()
-                .Cast<OpenXmlAttribute?>()
-                .FirstOrDefault(attribute => attribute.HasValue
-                    && !string.Equals(attribute.Value.NamespaceUri, "http://www.w3.org/2000/xmlns/", StringComparison.Ordinal)
-                    && !allowed.Contains(attribute.Value.LocalName));
+            OpenXmlAttribute? unsupported =
+                XlsbOpenXmlAttributeValidator.FindUnsupported(element, allowedNames);
             if (unsupported.HasValue) {
                 throw new NotSupportedException($"Native XLSB generation does not yet support workbook protection attribute '{unsupported.Value.LocalName}'.");
             }

--- a/OfficeIMO.Excel/Xlsb/Write/XlsbWorkbookViewWriter.cs
+++ b/OfficeIMO.Excel/Xlsb/Write/XlsbWorkbookViewWriter.cs
@@ -76,12 +76,8 @@ namespace OfficeIMO.Excel.Xlsb.Write {
             index.HasValue && index.Value < sheetCount ? index.Value : fallback;
 
         private static void EnsureOnlyAttributes(OpenXmlElement element, params string[] allowedNames) {
-            var allowed = new HashSet<string>(allowedNames, StringComparer.Ordinal);
-            OpenXmlAttribute? unsupported = element.GetAttributes()
-                .Cast<OpenXmlAttribute?>()
-                .FirstOrDefault(attribute => attribute.HasValue
-                    && !string.Equals(attribute.Value.NamespaceUri, "http://www.w3.org/2000/xmlns/", StringComparison.Ordinal)
-                    && !allowed.Contains(attribute.Value.LocalName));
+            OpenXmlAttribute? unsupported =
+                XlsbOpenXmlAttributeValidator.FindUnsupported(element, allowedNames);
             if (unsupported.HasValue) {
                 throw new NotSupportedException($"Native XLSB generation does not yet support workbook-view attribute '{unsupported.Value.LocalName}'.");
             }

--- a/OfficeIMO.Excel/Xlsb/Write/XlsbWorksheetAutoFilterPlan.cs
+++ b/OfficeIMO.Excel/Xlsb/Write/XlsbWorksheetAutoFilterPlan.cs
@@ -1,0 +1,68 @@
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Excel.Xlsb.Model;
+using OfficeIMO.Excel.Xlsb.Projection;
+
+namespace OfficeIMO.Excel.Xlsb.Write {
+    /// <summary>
+    /// Validates a loaded worksheet AutoFilter edit and builds its replacement BIFF12 records.
+    /// </summary>
+    internal sealed class XlsbWorksheetAutoFilterPlan {
+        private XlsbWorksheetAutoFilterPlan(
+            bool rewrite,
+            IReadOnlyList<XlsbGeneratedRecord> records) {
+            Rewrite = rewrite;
+            Records = records;
+        }
+
+        internal bool Rewrite { get; }
+
+        internal IReadOnlyList<XlsbGeneratedRecord> Records { get; }
+
+        internal static XlsbWorksheetAutoFilterPlan Create(
+            ExcelSheet sheet,
+            XlsbWorksheet sourceSheet) {
+            if (sheet == null) throw new ArgumentNullException(nameof(sheet));
+            if (sourceSheet == null) throw new ArgumentNullException(nameof(sourceSheet));
+            if (XlsbWorksheetAutoFilterProjector.Matches(sheet, sourceSheet.AutoFilter)) {
+                return new XlsbWorksheetAutoFilterPlan(
+                    rewrite: false,
+                    Array.Empty<XlsbGeneratedRecord>());
+            }
+
+            XlsbAutoFilter? source = sourceSheet.AutoFilter;
+            if (source == null) {
+                throw new NotSupportedException(
+                    $"Native XLSB rewriting cannot add a worksheet AutoFilter on worksheet '{sheet.Name}' yet because its workbook-level _FilterDatabase name must also be created.");
+            }
+            if (source.HasUnsupportedContent || source.Columns.Any(column => column.HasUnsupportedContent)) {
+                throw new NotSupportedException(
+                    $"Native XLSB rewriting preserves but cannot modify the worksheet AutoFilter on worksheet '{sheet.Name}' because it contains criteria outside the supported equality-list subset.");
+            }
+
+            Worksheet worksheet = sheet.WorksheetPart.Worksheet
+                ?? throw new InvalidDataException($"Worksheet '{sheet.Name}' has no worksheet root.");
+            AutoFilter[] filters = worksheet.Elements<AutoFilter>().ToArray();
+            if (filters.Length != 1) {
+                throw new NotSupportedException(
+                    $"Native XLSB rewriting cannot remove the worksheet AutoFilter on worksheet '{sheet.Name}' yet because its workbook-level _FilterDatabase name must also be removed.");
+            }
+            AutoFilter filter = filters[0];
+            if (!XlsbWorksheetAutoFilterWriter.TryGetRange(filter, out XlsbCellRange? range)
+                || range == null
+                || !RangesMatch(range, source.Range)) {
+                throw new NotSupportedException(
+                    $"Native XLSB rewriting cannot resize the worksheet AutoFilter on worksheet '{sheet.Name}' yet because its workbook-level _FilterDatabase name must also be updated.");
+            }
+
+            return new XlsbWorksheetAutoFilterPlan(
+                rewrite: true,
+                XlsbWorksheetAutoFilterWriter.CreateRecords(filter, sheet.Name));
+        }
+
+        private static bool RangesMatch(XlsbCellRange left, XlsbCellRange right) =>
+            left.FirstRow == right.FirstRow
+            && left.LastRow == right.LastRow
+            && left.FirstColumn == right.FirstColumn
+            && left.LastColumn == right.LastColumn;
+    }
+}

--- a/OfficeIMO.Excel/Xlsb/Write/XlsbWorksheetAutoFilterWriter.cs
+++ b/OfficeIMO.Excel/Xlsb/Write/XlsbWorksheetAutoFilterWriter.cs
@@ -131,12 +131,8 @@ namespace OfficeIMO.Excel.Xlsb.Write {
         }
 
         private static void EnsureOnlyAttributes(OpenXmlElement element, string sheetName, params string[] allowedNames) {
-            var allowed = new HashSet<string>(allowedNames, StringComparer.Ordinal);
-            OpenXmlAttribute? unsupported = element.GetAttributes()
-                .Cast<OpenXmlAttribute?>()
-                .FirstOrDefault(attribute => attribute.HasValue
-                    && !string.Equals(attribute.Value.NamespaceUri, "http://www.w3.org/2000/xmlns/", StringComparison.Ordinal)
-                    && !allowed.Contains(attribute.Value.LocalName));
+            OpenXmlAttribute? unsupported =
+                XlsbOpenXmlAttributeValidator.FindUnsupported(element, allowedNames);
             if (unsupported.HasValue) {
                 throw new NotSupportedException($"Native XLSB generation does not yet support AutoFilter attribute '{unsupported.Value.LocalName}' on worksheet '{sheetName}'.");
             }

--- a/OfficeIMO.Excel/Xlsb/Write/XlsbWorksheetAutoFilterWriter.cs
+++ b/OfficeIMO.Excel/Xlsb/Write/XlsbWorksheetAutoFilterWriter.cs
@@ -33,7 +33,7 @@ namespace OfficeIMO.Excel.Xlsb.Write {
             return TryParseRange(reference, out range);
         }
 
-        private static IReadOnlyList<XlsbGeneratedRecord> CreateRecords(AutoFilter autoFilter, string sheetName) {
+        internal static IReadOnlyList<XlsbGeneratedRecord> CreateRecords(AutoFilter autoFilter, string sheetName) {
             if (autoFilter.HasChildren && autoFilter.ChildElements.Any(element => element is not FilterColumn)) {
                 throw new NotSupportedException($"Native XLSB generation supports filterColumn children only in the worksheet AutoFilter on worksheet '{sheetName}'.");
             }

--- a/OfficeIMO.Excel/Xlsb/Write/XlsbWorksheetCellExtractor.cs
+++ b/OfficeIMO.Excel/Xlsb/Write/XlsbWorksheetCellExtractor.cs
@@ -136,7 +136,6 @@ namespace OfficeIMO.Excel.Xlsb.Write {
             XlsbWorksheetGeometryProjector.ValidateUnchanged(sheet, sourceSheet);
             XlsbWorksheetPropertiesProjector.ValidateUnchanged(sheet, sourceSheet.Properties);
             XlsbWorksheetProtectionProjector.ValidateUnchanged(sheet, sourceSheet.Protection);
-            XlsbWorksheetAutoFilterProjector.ValidateUnchanged(sheet, sourceSheet.AutoFilter);
             XlsbWorksheetPrintSettingsProjector.ValidateUnchanged(
                 sheet,
                 sourceSheet.PrintOptions,

--- a/OfficeIMO.Excel/Xlsb/Write/XlsbWorksheetGeometryPlan.cs
+++ b/OfficeIMO.Excel/Xlsb/Write/XlsbWorksheetGeometryPlan.cs
@@ -467,12 +467,8 @@ namespace OfficeIMO.Excel.Xlsb.Write {
         }
 
         private static void EnsureOnlyAttributes(OpenXmlElement element, string sheetName, params string[] allowedNames) {
-            var allowed = new HashSet<string>(allowedNames, StringComparer.Ordinal);
-            OpenXmlAttribute? unsupported = element.GetAttributes()
-                .Cast<OpenXmlAttribute?>()
-                .FirstOrDefault(attribute => attribute.HasValue
-                    && !string.Equals(attribute.Value.NamespaceUri, "http://www.w3.org/2000/xmlns/", StringComparison.Ordinal)
-                    && !allowed.Contains(attribute.Value.LocalName));
+            OpenXmlAttribute? unsupported =
+                XlsbOpenXmlAttributeValidator.FindUnsupported(element, allowedNames);
             if (unsupported.HasValue) {
                 throw new NotSupportedException($"Native XLSB generation does not yet support attribute '{unsupported.Value.LocalName}' on worksheet element '{element.LocalName}' in worksheet '{sheetName}'.");
             }

--- a/OfficeIMO.Excel/Xlsb/Write/XlsbWorksheetHyperlinkPlan.cs
+++ b/OfficeIMO.Excel/Xlsb/Write/XlsbWorksheetHyperlinkPlan.cs
@@ -148,7 +148,14 @@ namespace OfficeIMO.Excel.Xlsb.Write {
             Hyperlink hyperlink,
             string relationshipId,
             string sheetName) {
-            EnsureOnlyAttributes(hyperlink, sheetName, "ref", "id", "location", "tooltip", "display");
+            EnsureOnlyAttributes(
+                hyperlink,
+                sheetName,
+                true,
+                "ref",
+                "location",
+                "tooltip",
+                "display");
             if (hyperlink.HasChildren) ThrowUnsupportedContent(hyperlink, sheetName);
             if (!TryParseRange(hyperlink.Reference?.Value, out XlsbCellRange? range)) {
                 throw new NotSupportedException($"Native XLSB generation cannot encode hyperlink range '{hyperlink.Reference?.Value}' on worksheet '{sheetName}'.");
@@ -217,10 +224,18 @@ namespace OfficeIMO.Excel.Xlsb.Write {
         }
 
         private static void EnsureOnlyAttributes(OpenXmlElement element, string sheetName, params string[] allowedNames) {
+            EnsureOnlyAttributes(element, sheetName, false, allowedNames);
+        }
+
+        private static void EnsureOnlyAttributes(
+            OpenXmlElement element,
+            string sheetName,
+            bool allowRelationshipId,
+            params string[] allowedNames) {
             OpenXmlAttribute? unsupported = XlsbOpenXmlAttributeValidator.FindUnsupported(
                 element,
                 allowedNames,
-                attribute => allowedNames.Contains("id", StringComparer.Ordinal)
+                attribute => allowRelationshipId
                     && string.Equals(attribute.LocalName, "id", StringComparison.Ordinal)
                     && string.Equals(attribute.NamespaceUri, RelationshipsNamespace, StringComparison.Ordinal));
             if (unsupported.HasValue) {

--- a/OfficeIMO.Excel/Xlsb/Write/XlsbWorksheetHyperlinkPlan.cs
+++ b/OfficeIMO.Excel/Xlsb/Write/XlsbWorksheetHyperlinkPlan.cs
@@ -9,6 +9,7 @@ namespace OfficeIMO.Excel.Xlsb.Write {
     internal sealed class XlsbWorksheetHyperlinkPlan {
         private const int BrtHLink = 494;
         private const string HyperlinkRelationshipSuffix = "/hyperlink";
+        private const string RelationshipsNamespace = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
         private const int MaximumLocationLengthExclusive = 2_084;
         private const int MaximumTooltipLengthExclusive = 256;
 
@@ -216,12 +217,12 @@ namespace OfficeIMO.Excel.Xlsb.Write {
         }
 
         private static void EnsureOnlyAttributes(OpenXmlElement element, string sheetName, params string[] allowedNames) {
-            var allowed = new HashSet<string>(allowedNames, StringComparer.Ordinal);
-            OpenXmlAttribute? unsupported = element.GetAttributes()
-                .Cast<OpenXmlAttribute?>()
-                .FirstOrDefault(attribute => attribute.HasValue
-                    && !string.Equals(attribute.Value.NamespaceUri, "http://www.w3.org/2000/xmlns/", StringComparison.Ordinal)
-                    && !allowed.Contains(attribute.Value.LocalName));
+            OpenXmlAttribute? unsupported = XlsbOpenXmlAttributeValidator.FindUnsupported(
+                element,
+                allowedNames,
+                attribute => allowedNames.Contains("id", StringComparer.Ordinal)
+                    && string.Equals(attribute.LocalName, "id", StringComparison.Ordinal)
+                    && string.Equals(attribute.NamespaceUri, RelationshipsNamespace, StringComparison.Ordinal));
             if (unsupported.HasValue) {
                 throw new NotSupportedException($"Native XLSB generation does not yet support attribute '{unsupported.Value.LocalName}' on worksheet element '{element.LocalName}' in worksheet '{sheetName}'.");
             }

--- a/OfficeIMO.Excel/Xlsb/Write/XlsbWorksheetPartWriter.cs
+++ b/OfficeIMO.Excel/Xlsb/Write/XlsbWorksheetPartWriter.cs
@@ -109,15 +109,24 @@ namespace OfficeIMO.Excel.Xlsb.Write {
         }
 
         internal static byte[] Rewrite(byte[] originalPart, IReadOnlyList<XlsbWriteCell> cells) =>
-            Rewrite(originalPart, cells, Array.Empty<XlsbGeneratedRecord>(), rewriteHyperlinks: false);
+            Rewrite(
+                originalPart,
+                cells,
+                Array.Empty<XlsbGeneratedRecord>(),
+                rewriteAutoFilter: false,
+                Array.Empty<XlsbGeneratedRecord>(),
+                rewriteHyperlinks: false);
 
         internal static byte[] Rewrite(
             byte[] originalPart,
             IReadOnlyList<XlsbWriteCell> cells,
+            IReadOnlyList<XlsbGeneratedRecord> autoFilterRecords,
+            bool rewriteAutoFilter,
             IReadOnlyList<XlsbGeneratedRecord> hyperlinkRecords,
             bool rewriteHyperlinks) {
             if (originalPart == null) throw new ArgumentNullException(nameof(originalPart));
             if (cells == null) throw new ArgumentNullException(nameof(cells));
+            if (autoFilterRecords == null) throw new ArgumentNullException(nameof(autoFilterRecords));
             if (hyperlinkRecords == null) throw new ArgumentNullException(nameof(hyperlinkRecords));
 
             IReadOnlyList<XlsbRecord> records;
@@ -140,6 +149,9 @@ namespace OfficeIMO.Excel.Xlsb.Write {
             int hyperlinkInsertionIndex = rewriteHyperlinks
                 ? FindHyperlinkInsertionIndex(records, endIndex)
                 : -1;
+            (int Begin, int End) autoFilterBounds = rewriteAutoFilter
+                ? FindAutoFilterBounds(records, endIndex)
+                : (-1, -1);
 
             using var output = new MemoryStream(originalPart.Length + Math.Max(256, cells.Count * 24));
             for (int index = 0; index <= beginIndex; index++) {
@@ -168,6 +180,16 @@ namespace OfficeIMO.Excel.Xlsb.Write {
             }
 
             for (int index = endIndex; index < records.Count; index++) {
+                if (rewriteAutoFilter && index == autoFilterBounds.Begin) {
+                    foreach (XlsbGeneratedRecord autoFilter in autoFilterRecords) {
+                        XlsbRecordWriter.Write(output, autoFilter.Type, autoFilter.Payload);
+                    }
+                }
+                if (rewriteAutoFilter
+                    && index >= autoFilterBounds.Begin
+                    && index <= autoFilterBounds.End) {
+                    continue;
+                }
                 if (rewriteHyperlinks && index == hyperlinkInsertionIndex) {
                     foreach (XlsbGeneratedRecord hyperlink in hyperlinkRecords) {
                         XlsbRecordWriter.Write(output, hyperlink.Type, hyperlink.Payload);
@@ -178,6 +200,20 @@ namespace OfficeIMO.Excel.Xlsb.Write {
             }
 
             return output.ToArray();
+        }
+
+        private static (int Begin, int End) FindAutoFilterBounds(
+            IReadOnlyList<XlsbRecord> records,
+            int endSheetDataIndex) {
+            const int BrtBeginAFilter = 161;
+            const int BrtEndAFilter = 162;
+            int begin = FindSingleRecord(records, BrtBeginAFilter, "BrtBeginAFilter");
+            int end = FindSingleRecord(records, BrtEndAFilter, "BrtEndAFilter");
+            int endSheet = FindSingleRecord(records, BrtEndSheet, "BrtEndSheet");
+            if (begin <= endSheetDataIndex || end < begin || end >= endSheet) {
+                throw new InvalidDataException("The XLSB worksheet has an invalid AutoFilter record boundary order.");
+            }
+            return (begin, end);
         }
 
         private static int FindHyperlinkInsertionIndex(IReadOnlyList<XlsbRecord> records, int endSheetDataIndex) {

--- a/OfficeIMO.Excel/Xlsb/Write/XlsbWorksheetPrintSettingsWriter.cs
+++ b/OfficeIMO.Excel/Xlsb/Write/XlsbWorksheetPrintSettingsWriter.cs
@@ -77,6 +77,9 @@ namespace OfficeIMO.Excel.Xlsb.Write {
             if (pageSetup.HasChildren) {
                 throw new NotSupportedException($"Native XLSB generation does not support child content in page setup on worksheet '{sheetName}'.");
             }
+            if (!string.IsNullOrEmpty(pageSetup.Id?.Value)) {
+                throw new NotSupportedException($"Native XLSB generation does not yet support printer-settings relationships on worksheet '{sheetName}'.");
+            }
             EnsureOnlyAttributes(
                 pageSetup,
                 sheetName,
@@ -95,12 +98,7 @@ namespace OfficeIMO.Excel.Xlsb.Write {
                 "errors",
                 "horizontalDpi",
                 "verticalDpi",
-                "copies",
-                "id");
-
-            if (!string.IsNullOrEmpty(pageSetup.Id?.Value)) {
-                throw new NotSupportedException($"Native XLSB generation does not yet support printer-settings relationships on worksheet '{sheetName}'.");
-            }
+                "copies");
 
             uint scale = pageSetup.Scale?.Value ?? 0U;
             uint copies = pageSetup.Copies?.Value ?? 0U;

--- a/OfficeIMO.Excel/Xlsb/Write/XlsbWorksheetPrintSettingsWriter.cs
+++ b/OfficeIMO.Excel/Xlsb/Write/XlsbWorksheetPrintSettingsWriter.cs
@@ -219,12 +219,8 @@ namespace OfficeIMO.Excel.Xlsb.Write {
         }
 
         private static void EnsureOnlyAttributes(OpenXmlElement element, string sheetName, params string[] allowedNames) {
-            var allowed = new HashSet<string>(allowedNames, StringComparer.Ordinal);
-            OpenXmlAttribute? unsupported = element.GetAttributes()
-                .Cast<OpenXmlAttribute?>()
-                .FirstOrDefault(attribute => attribute.HasValue
-                    && !string.Equals(attribute.Value.NamespaceUri, "http://www.w3.org/2000/xmlns/", StringComparison.Ordinal)
-                    && !allowed.Contains(attribute.Value.LocalName));
+            OpenXmlAttribute? unsupported =
+                XlsbOpenXmlAttributeValidator.FindUnsupported(element, allowedNames);
             if (unsupported.HasValue) {
                 throw new NotSupportedException($"Native XLSB generation does not yet support print-setting attribute '{unsupported.Value.LocalName}' on worksheet '{sheetName}'.");
             }

--- a/OfficeIMO.Excel/Xlsb/Write/XlsbWorksheetPropertiesWriter.cs
+++ b/OfficeIMO.Excel/Xlsb/Write/XlsbWorksheetPropertiesWriter.cs
@@ -177,12 +177,8 @@ namespace OfficeIMO.Excel.Xlsb.Write {
         }
 
         private static void EnsureOnlyAttributes(OpenXmlElement element, string sheetName, params string[] allowedNames) {
-            var allowed = new HashSet<string>(allowedNames, StringComparer.Ordinal);
-            OpenXmlAttribute? unsupported = element.GetAttributes()
-                .Cast<OpenXmlAttribute?>()
-                .FirstOrDefault(attribute => attribute.HasValue
-                    && !string.Equals(attribute.Value.NamespaceUri, "http://www.w3.org/2000/xmlns/", StringComparison.Ordinal)
-                    && !allowed.Contains(attribute.Value.LocalName));
+            OpenXmlAttribute? unsupported =
+                XlsbOpenXmlAttributeValidator.FindUnsupported(element, allowedNames);
             if (unsupported.HasValue) {
                 throw new NotSupportedException($"Native XLSB generation does not yet support worksheet-property attribute '{unsupported.Value.LocalName}' on worksheet '{sheetName}'.");
             }

--- a/OfficeIMO.Excel/Xlsb/Write/XlsbWorksheetProtectionWriter.cs
+++ b/OfficeIMO.Excel/Xlsb/Write/XlsbWorksheetProtectionWriter.cs
@@ -58,12 +58,8 @@ namespace OfficeIMO.Excel.Xlsb.Write {
             !(protectionFlag?.Value ?? lockedWhenOmitted);
 
         private static void EnsureOnlyAttributes(OpenXmlElement element, params string[] allowedNames) {
-            var allowed = new HashSet<string>(allowedNames, StringComparer.Ordinal);
-            OpenXmlAttribute? unsupported = element.GetAttributes()
-                .Cast<OpenXmlAttribute?>()
-                .FirstOrDefault(attribute => attribute.HasValue
-                    && !string.Equals(attribute.Value.NamespaceUri, "http://www.w3.org/2000/xmlns/", StringComparison.Ordinal)
-                    && !allowed.Contains(attribute.Value.LocalName));
+            OpenXmlAttribute? unsupported =
+                XlsbOpenXmlAttributeValidator.FindUnsupported(element, allowedNames);
             if (unsupported.HasValue) {
                 throw new NotSupportedException($"Native XLSB generation does not yet support worksheet protection attribute '{unsupported.Value.LocalName}'.");
             }

--- a/OfficeIMO.Excel/Xlsb/XlsbWorkbookReader.cs
+++ b/OfficeIMO.Excel/Xlsb/XlsbWorkbookReader.cs
@@ -497,6 +497,12 @@ namespace OfficeIMO.Excel.Xlsb {
             int actualMergeCount = 0;
             foreach (XlsbRecord record in records) {
                 options.CancellationToken.ThrowIfCancellationRequested();
+                if (currentAutoFilter != null && !IsSupportedAutoFilterRecord(record.Type)) {
+                    currentAutoFilter.HasUnsupportedContent = true;
+                    if (currentFilterColumn != null) currentFilterColumn.HasUnsupportedContent = true;
+                    PreserveRecord(options, workbook, partName, record);
+                    continue;
+                }
                 switch (record.Type) {
                     case BrtBeginSheet:
                     case BrtEndSheet:
@@ -750,10 +756,6 @@ namespace OfficeIMO.Excel.Xlsb {
                         worksheet.AddCell(cell);
                         break;
                     default:
-                        if (currentAutoFilter != null) {
-                            currentAutoFilter.HasUnsupportedContent = true;
-                            if (currentFilterColumn != null) currentFilterColumn.HasUnsupportedContent = true;
-                        }
                         PreserveRecord(options, workbook, partName, record);
                         break;
                 }
@@ -778,6 +780,9 @@ namespace OfficeIMO.Excel.Xlsb {
                 throw new InvalidDataException($"The XLSB worksheet part '{partName}' does not contain BrtBeginSheetData/BrtEndSheetData.");
             }
         }
+
+        private static bool IsSupportedAutoFilterRecord(int recordType) =>
+            recordType >= BrtBeginAFilter && recordType <= BrtFilter;
 
         private static XlsbCellRange ParseCellRange(XlsbRecord record, string recordName) {
             if (record.Data.Length != 16) {


### PR DESCRIPTION
## Summary

- allow loaded XLSB workbooks to add, replace, or clear equality-list AutoFilter criteria through the existing worksheet APIs when the filter range is unchanged
- rewrite only the bounded BIFF12 AutoFilter record span while preserving the workbook-level `_FilterDatabase` name and unrelated package content
- fail closed for filter add/remove/resize, unsupported source criteria, non-AutoFilter records inside the filter span, and attributes that cannot be represented safely
- keep the compatibility catalog explicit about the supported loaded-package subset

## Limits

Adding, removing, or resizing a loaded XLSB AutoFilter remains blocked because those operations also require a preservation-aware rewrite of the workbook-level `_FilterDatabase` defined name. Unsupported criteria continue to round-trip opaquely when left unchanged.

## Validation

- 89 XLSB-focused tests on .NET 8
- focused rewrite and namespace-boundary tests on .NET 10 and .NET Framework 4.7.2
- `OfficeIMO.Excel` Release build across `netstandard2.0`, `net8.0`, `net10.0`, and `net472`
- generated compatibility catalog verification
- rewritten XLSB opened successfully in desktop Excel through the local COM interoperability check
