### PR TITLE
Prevent stack exhaustion in Visio diagram relayout

### DIFF
--- a/OfficeIMO.Visio.Tests/Visio.PowerPointVisioRoadmap.cs
+++ b/OfficeIMO.Visio.Tests/Visio.PowerPointVisioRoadmap.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
@@ -216,6 +217,28 @@ namespace OfficeIMO.Tests {
                 $"Dense relayout took {timer.Elapsed}.");
             Assert.True(page.Shapes.Last().PinX > page.Shapes.First().PinX);
             Assert.Equal(1000, page.Shapes.Select(shape => shape.PinX).Distinct().Count());
+        }
+
+        [Fact]
+        public void WholeDiagramRelayoutTopologyLayeringHandlesDeepGraphWithoutRecursion() {
+            const int nodeCount = 100000;
+            var nodes = new List<VisioShape>(nodeCount);
+            var outgoing = new Dictionary<VisioShape, HashSet<VisioShape>>(nodeCount);
+            for (int index = 0; index < nodeCount; index++) {
+                var node = new VisioShape("n" + index, 0, 0, 1, 1,
+                    string.Empty);
+                nodes.Add(node);
+                outgoing[node] = new HashSet<VisioShape>();
+                if (index > 0) outgoing[nodes[index - 1]].Add(node);
+            }
+
+            Dictionary<VisioShape, int> layers =
+                VisioWholeDiagramRelayoutExtensions.BuildTopologyLayers(nodes,
+                    outgoing);
+
+            Assert.Equal(nodeCount, layers.Count);
+            Assert.Equal(0, layers[nodes[0]]);
+            Assert.Equal(nodeCount - 1, layers[nodes[nodeCount - 1]]);
         }
 
         [Fact]

--- a/OfficeIMO.Visio/Layout/VisioWholeDiagramRelayoutExtensions.cs
+++ b/OfficeIMO.Visio/Layout/VisioWholeDiagramRelayoutExtensions.cs
@@ -75,7 +75,11 @@ namespace OfficeIMO.Visio {
             return page;
         }
 
-        private static Dictionary<VisioShape, int> BuildTopologyLayers(
+        /// <summary>
+        /// Computes deterministic topology layers without consuming call-stack depth
+        /// proportional to the graph depth.
+        /// </summary>
+        internal static Dictionary<VisioShape, int> BuildTopologyLayers(
             IReadOnlyList<VisioShape> nodes,
             IReadOnlyDictionary<VisioShape, HashSet<VisioShape>> outgoing) {
             int nextIndex = 0;
@@ -84,37 +88,52 @@ namespace OfficeIMO.Visio {
             var stack = new Stack<VisioShape>();
             var onStack = new HashSet<VisioShape>();
             var components = new List<List<VisioShape>>();
+            var traversal = new Stack<TraversalFrame>();
 
-            void Visit(VisioShape node) {
+            void BeginVisit(VisioShape node) {
                 indices[node] = nextIndex;
                 lowLinks[node] = nextIndex++;
                 stack.Push(node);
                 onStack.Add(node);
-                foreach (VisioShape target in outgoing[node]
-                             .OrderBy(item => item.Id,
-                                 StringComparer.OrdinalIgnoreCase)) {
-                    if (!indices.ContainsKey(target)) {
-                        Visit(target);
-                        lowLinks[node] = Math.Min(lowLinks[node],
-                            lowLinks[target]);
-                    } else if (onStack.Contains(target)) {
-                        lowLinks[node] = Math.Min(lowLinks[node],
-                            indices[target]);
-                    }
-                }
-                if (lowLinks[node] != indices[node]) return;
-                var component = new List<VisioShape>();
-                VisioShape member;
-                do {
-                    member = stack.Pop();
-                    onStack.Remove(member);
-                    component.Add(member);
-                } while (!ReferenceEquals(member, node));
-                components.Add(component);
+                traversal.Push(new TraversalFrame(node, outgoing[node]
+                    .OrderBy(item => item.Id, StringComparer.OrdinalIgnoreCase)
+                    .ToArray()));
             }
 
             foreach (VisioShape node in nodes) {
-                if (!indices.ContainsKey(node)) Visit(node);
+                if (indices.ContainsKey(node)) continue;
+                BeginVisit(node);
+                while (traversal.Count > 0) {
+                    TraversalFrame frame = traversal.Peek();
+                    if (frame.NextTargetIndex < frame.Targets.Length) {
+                        VisioShape target = frame.Targets[frame.NextTargetIndex++];
+                        if (!indices.ContainsKey(target)) {
+                            BeginVisit(target);
+                        } else if (onStack.Contains(target)) {
+                            lowLinks[frame.Node] = Math.Min(lowLinks[frame.Node],
+                                indices[target]);
+                        }
+                        continue;
+                    }
+
+                    traversal.Pop();
+                    if (lowLinks[frame.Node] == indices[frame.Node]) {
+                        var component = new List<VisioShape>();
+                        VisioShape member;
+                        do {
+                            member = stack.Pop();
+                            onStack.Remove(member);
+                            component.Add(member);
+                        } while (!ReferenceEquals(member, frame.Node));
+                        components.Add(component);
+                    }
+
+                    if (traversal.Count > 0) {
+                        VisioShape parent = traversal.Peek().Node;
+                        lowLinks[parent] = Math.Min(lowLinks[parent],
+                            lowLinks[frame.Node]);
+                    }
+                }
             }
 
             var componentByNode = new Dictionary<VisioShape, int>();
@@ -162,6 +181,19 @@ namespace OfficeIMO.Visio {
             }
             return nodes.ToDictionary(node => node,
                 node => componentLayers[componentByNode[node]]);
+        }
+
+        private sealed class TraversalFrame {
+            internal TraversalFrame(VisioShape node, VisioShape[] targets) {
+                Node = node;
+                Targets = targets;
+            }
+
+            internal VisioShape Node { get; }
+
+            internal VisioShape[] Targets { get; }
+
+            internal int NextTargetIndex { get; set; }
         }
 
         private static void Validate(VisioWholeDiagramRelayoutOptions options) {


### PR DESCRIPTION
## Summary

- replace recursive Tarjan traversal with an explicit DFS stack so attacker-controlled connector depth cannot exhaust the process stack
- preserve deterministic strongly connected component grouping and topology layer ordering
- add a 100,000-node deep-chain regression while retaining public relayout and cycle coverage

## Validation

- `dotnet build OfficeIMO.Visio/OfficeIMO.Visio.csproj --configuration Release --no-restore`
- `dotnet test OfficeIMO.Visio.Tests/OfficeIMO.Visio.Tests.csproj --framework net8.0 --no-restore`
- `dotnet test OfficeIMO.Visio.Tests/OfficeIMO.Visio.Tests.csproj --framework net10.0 --filter FullyQualifiedName~WholeDiagramRelayout --no-restore`
- independent local review completed with no actionable findings