### PR TITLE
Improve Windows tabular read and streaming write performance

### DIFF
--- a/OfficeIMO.CSV.Benchmarks/MarkPflug65KCsvBenchmarks.cs
+++ b/OfficeIMO.CSV.Benchmarks/MarkPflug65KCsvBenchmarks.cs
@@ -44,7 +44,7 @@ public class MarkPflug65KCsvBenchmarks {
         using DbDataReader reader = CsvDocument.OpenDataReader(
             MarkPflug65KFixture.CsvPath,
             new CsvLoadOptions { DetectDelimiter = false });
-        return Observe(reader.FieldCount, read: reader.Read, value: reader.GetString);
+        return Observe(reader);
     }
 
     [Benchmark]
@@ -71,7 +71,7 @@ public class MarkPflug65KCsvBenchmarks {
     public CsvReadObservation Sylvan() {
         using var text = new StreamReader(MarkPflug65KFixture.CsvPath);
         using SylvanCsvDataReader reader = SylvanCsvDataReader.Create(text);
-        return Observe(reader.FieldCount, read: reader.Read, value: reader.GetString);
+        return Observe(reader);
     }
 
     [Benchmark]
@@ -129,6 +129,25 @@ public class MarkPflug65KCsvBenchmarks {
             for (int column = 0; column < fieldCount; column++) {
                 cells++;
                 string decoded = value(column);
+                characters += decoded.Length;
+                AddValue(ref checksum, decoded);
+            }
+        }
+
+        return new CsvReadObservation(rows, cells, characters, checksum);
+    }
+
+    private static CsvReadObservation Observe(DbDataReader reader) {
+        int fieldCount = reader.FieldCount;
+        int rows = 0;
+        int cells = 0;
+        long characters = 0;
+        ulong checksum = ChecksumOffset;
+        while (reader.Read()) {
+            rows++;
+            for (int column = 0; column < fieldCount; column++) {
+                cells++;
+                string decoded = reader.GetString(column);
                 characters += decoded.Length;
                 AddValue(ref checksum, decoded);
             }

--- a/OfficeIMO.CSV.Benchmarks/Program.cs
+++ b/OfficeIMO.CSV.Benchmarks/Program.cs
@@ -6,6 +6,13 @@ using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Running;
 using OfficeIMO.Benchmarks;
 using OfficeIMO.CSV.Benchmarks;
+using System.Runtime.Intrinsics.X86;
+
+if (args.Length > 0
+    && string.Equals(args[0], "--print-intrinsics", StringComparison.OrdinalIgnoreCase)) {
+    Console.WriteLine($"AVX512BW={Avx512BW.IsSupported}; AVX2={Avx2.IsSupported}");
+    return;
+}
 
 bool profileOfficeIMO = args.Length > 0 &&
     string.Equals(args[0], "--profile-markpflug65k-officeimo", StringComparison.OrdinalIgnoreCase);
@@ -13,6 +20,76 @@ bool profileSep = args.Length > 0 &&
     string.Equals(args[0], "--profile-markpflug65k-sep", StringComparison.OrdinalIgnoreCase);
 bool profileSylvan = args.Length > 0 &&
     string.Equals(args[0], "--profile-markpflug65k-sylvan", StringComparison.OrdinalIgnoreCase);
+bool comparePaired = args.Length > 0 &&
+    string.Equals(args[0], "--compare-markpflug65k-paired", StringComparison.OrdinalIgnoreCase);
+
+if (comparePaired) {
+    int iterations = args.Length > 1 && int.TryParse(args[1], out int parsedIterations)
+        ? parsedIterations
+        : 100;
+    if (iterations <= 0) {
+        throw new ArgumentOutOfRangeException(nameof(iterations));
+    }
+    ApplyProcessAffinity(args, argumentIndex: 2);
+    const int warmupIterations = 10;
+    string affinity = args.Length > 2 ? args[2] : "unchanged";
+
+    var benchmark = new MarkPflug65KCsvBenchmarks();
+    benchmark.Setup();
+    for (int index = 0; index < warmupIterations; index++) {
+        benchmark.OfficeIMO();
+        benchmark.Sep();
+        benchmark.Sylvan();
+    }
+
+    var officeSamples = new double[iterations];
+    var sepSamples = new double[iterations];
+    var sylvanSamples = new double[iterations];
+    var officeSepRatios = new double[iterations];
+    var officeSylvanRatios = new double[iterations];
+    for (int index = 0; index < iterations; index++) {
+        CsvReadObservation officeObservation;
+        CsvReadObservation sepObservation;
+        CsvReadObservation sylvanObservation;
+        switch (index % 3) {
+            case 0:
+                officeSamples[index] = MeasureMilliseconds(benchmark.OfficeIMO, out officeObservation);
+                sepSamples[index] = MeasureMilliseconds(benchmark.Sep, out sepObservation);
+                sylvanSamples[index] = MeasureMilliseconds(benchmark.Sylvan, out sylvanObservation);
+                break;
+            case 1:
+                sepSamples[index] = MeasureMilliseconds(benchmark.Sep, out sepObservation);
+                sylvanSamples[index] = MeasureMilliseconds(benchmark.Sylvan, out sylvanObservation);
+                officeSamples[index] = MeasureMilliseconds(benchmark.OfficeIMO, out officeObservation);
+                break;
+            default:
+                sylvanSamples[index] = MeasureMilliseconds(benchmark.Sylvan, out sylvanObservation);
+                officeSamples[index] = MeasureMilliseconds(benchmark.OfficeIMO, out officeObservation);
+                sepSamples[index] = MeasureMilliseconds(benchmark.Sep, out sepObservation);
+                break;
+        }
+
+        if (officeObservation != sepObservation || officeObservation != sylvanObservation) {
+            throw new InvalidDataException(
+                $"Paired CSV sample {index} produced different observations: OfficeIMO={officeObservation}; Sep={sepObservation}; Sylvan={sylvanObservation}.");
+        }
+        officeSepRatios[index] = officeSamples[index] / sepSamples[index];
+        officeSylvanRatios[index] = officeSamples[index] / sylvanSamples[index];
+    }
+
+    double officeMedian = Median(officeSamples);
+    double sepMedian = Median(sepSamples);
+    double sylvanMedian = Median(sylvanSamples);
+    Console.WriteLine(
+        $"Paired CSV comparison ({warmupIterations} warmups, {iterations} rotating samples, affinity {affinity}, " +
+        $"AVX512BW={Avx512BW.IsSupported}, AVX2={Avx2.IsSupported}): " +
+        $"OfficeIMO {officeMedian:F3} ms, Sep {sepMedian:F3} ms, Sylvan {sylvanMedian:F3} ms; " +
+        $"OfficeIMO/Sep paired median {Median(officeSepRatios):F4} " +
+        $"(P25 {Percentile(officeSepRatios, 0.25d):F4}, P75 {Percentile(officeSepRatios, 0.75d):F4}); " +
+        $"OfficeIMO/Sylvan paired median {Median(officeSylvanRatios):F4} " +
+        $"(P25 {Percentile(officeSylvanRatios, 0.25d):F4}, P75 {Percentile(officeSylvanRatios, 0.75d):F4}).");
+    return;
+}
 
 if (profileOfficeIMO || profileSep || profileSylvan) {
     int iterations = args.Length > 1 && int.TryParse(args[1], out int parsedIterations)
@@ -21,6 +98,7 @@ if (profileOfficeIMO || profileSep || profileSylvan) {
     if (iterations <= 0) {
         throw new ArgumentOutOfRangeException(nameof(iterations));
     }
+    ApplyProcessAffinity(args, argumentIndex: 2);
 
     var benchmark = new MarkPflug65KCsvBenchmarks();
     benchmark.Setup();
@@ -59,3 +137,51 @@ var config = ManualConfig
     .AddColumn(StatisticColumn.OperationsPerSecond);
 
 BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, config);
+
+static double MeasureMilliseconds(
+    Func<CsvReadObservation> operation,
+    out CsvReadObservation observation) {
+    long started = System.Diagnostics.Stopwatch.GetTimestamp();
+    observation = operation();
+    return System.Diagnostics.Stopwatch.GetElapsedTime(started).TotalMilliseconds;
+}
+
+static void ApplyProcessAffinity(string[] arguments, int argumentIndex) {
+    if (arguments.Length <= argumentIndex
+        || !long.TryParse(arguments[argumentIndex], out long affinityMask)) {
+        return;
+    }
+    if (!OperatingSystem.IsWindows()) {
+        throw new PlatformNotSupportedException(
+            "Processor-affinity comparison is available only on Windows.");
+    }
+    if (affinityMask <= 0) {
+        throw new ArgumentOutOfRangeException(nameof(affinityMask));
+    }
+
+    System.Diagnostics.Process.GetCurrentProcess().ProcessorAffinity = checked((nint)affinityMask);
+}
+
+static double Median(double[] samples) {
+    Array.Sort(samples);
+    int middle = samples.Length / 2;
+    return (samples.Length & 1) == 0
+        ? (samples[middle - 1] + samples[middle]) / 2d
+        : samples[middle];
+}
+
+static double Percentile(double[] samples, double percentile) {
+    if (samples.Length == 0) {
+        throw new ArgumentException("At least one sample is required.", nameof(samples));
+    }
+    if (percentile < 0d || percentile > 1d) {
+        throw new ArgumentOutOfRangeException(nameof(percentile));
+    }
+
+    Array.Sort(samples);
+    double position = (samples.Length - 1) * percentile;
+    int lower = (int)position;
+    int upper = Math.Min(lower + 1, samples.Length - 1);
+    double fraction = position - lower;
+    return samples[lower] + (samples[upper] - samples[lower]) * fraction;
+}

--- a/OfficeIMO.CSV.Tests/CsvStreamingTests.cs
+++ b/OfficeIMO.CSV.Tests/CsvStreamingTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -285,6 +286,52 @@ public class CsvStreamingTests
         Assert.Equal(2, rows.Count);
         Assert.Equal(new[] { string.Empty, string.Empty }, rows[0]);
         Assert.Equal(new[] { "Alpha", "1" }, rows[1]);
+    }
+
+    [Fact]
+    public void ReadRowsReusable_DoesNotTreatCharactersAboveByteRangeAsByteMaxDelimiter()
+    {
+        var rows = new List<string[]>();
+        string value = new string('A', 16) + '\u0100' + new string('B', 16);
+        using var reader = new StringReader("Name\u00FFValue\n" + value + "\u00FF1\n");
+
+        CsvDocument.ReadRowsReusable(
+            reader,
+            (_, values) => rows.Add(values.ToArray()),
+            new CsvLoadOptions { Delimiter = '\u00FF' });
+
+        var row = Assert.Single(rows);
+        Assert.Equal(new[] { value, "1" }, row);
+    }
+
+    [Fact]
+    public void ReadRowsReusable_DoesNotTreatHighUnicodeAsNullDelimiter()
+    {
+        var rows = new List<string[]>();
+        string value = new string('A', 16) + '\u8000' + new string('B', 16);
+        using var reader = new StringReader("Name\0Value\n" + value + '\0' + "1\n");
+
+        CsvDocument.ReadRowsReusable(
+            reader,
+            (_, values) => rows.Add(values.ToArray()),
+            new CsvLoadOptions { Delimiter = '\0' });
+
+        var row = Assert.Single(rows);
+        Assert.Equal(new[] { value, "1" }, row);
+    }
+
+    [Fact]
+    public void OpenTextDataReader_DoesNotTreatCharactersAboveByteRangeAsByteMaxDelimiter()
+    {
+        string value = new string('A', 16) + '\u0100' + new string('B', 16);
+        using DbDataReader reader = CsvDocument.OpenTextDataReader(
+            "Name\u00FFValue\n" + value + "\u00FF1\n",
+            new CsvLoadOptions { Delimiter = '\u00FF' });
+
+        Assert.True(reader.Read());
+        Assert.Equal(value, reader.GetString(0));
+        Assert.Equal("1", reader.GetString(1));
+        Assert.False(reader.Read());
     }
 
     [Fact]

--- a/OfficeIMO.CSV/CsvDataReader.cs
+++ b/OfficeIMO.CSV/CsvDataReader.cs
@@ -22,6 +22,9 @@ internal sealed class CsvDataReader : DbDataReader
     private readonly IEnumerator<object?[]>? _rows;
     private readonly IEnumerator<IReadOnlyList<string>>? _stringRows;
     private readonly CsvDataReaderTextRowSource? _textRowSource;
+#if NET8_0_OR_GREATER
+    private readonly CsvParser.CsvStreamDataReaderRowSource? _streamTextRowSource;
+#endif
     private readonly CultureInfo _culture;
     private readonly IReadOnlyList<string>? _dateTimeFormats;
     private readonly IDisposable? _rowOwner;
@@ -96,6 +99,9 @@ internal sealed class CsvDataReader : DbDataReader
     {
         _columns = columns;
         _textRowSource = rows;
+#if NET8_0_OR_GREATER
+        _streamTextRowSource = rows as CsvParser.CsvStreamDataReaderRowSource;
+#endif
         _sourceColumnCount = sourceColumnCount;
         _stringRowOptions = options;
         _stringNullValue = options.NullValue;
@@ -431,6 +437,12 @@ internal sealed class CsvDataReader : DbDataReader
                 throw new InvalidOperationException("The reader is not positioned on a row.");
             }
 
+#if NET8_0_OR_GREATER
+            if (_streamTextRowSource is not null)
+            {
+                return _streamTextRowSource.GetString(ordinal);
+            }
+#endif
             return _textRowSource!.GetString(ordinal);
         }
 
@@ -637,7 +649,13 @@ internal sealed class CsvDataReader : DbDataReader
 
         if (_textRowSource is not null && !_hasBufferedRow)
         {
+#if NET8_0_OR_GREATER
+            _hasCurrentTextRow = _streamTextRowSource is not null
+                ? _streamTextRowSource.Read()
+                : _textRowSource.Read();
+#else
             _hasCurrentTextRow = _textRowSource.Read();
+#endif
             if (!_hasCurrentTextRow)
             {
                 _hasRows ??= false;

--- a/OfficeIMO.CSV/CsvDocument.Fields.cs
+++ b/OfficeIMO.CSV/CsvDocument.Fields.cs
@@ -355,6 +355,16 @@ public sealed partial class CsvDocument
             }
         }
 
+        public void VisitFieldRange(
+            int recordIndex,
+            int fieldIndex,
+            char[] buffer,
+            int start,
+            int length)
+        {
+            VisitField(recordIndex, fieldIndex, buffer.AsSpan(start, length));
+        }
+
         public void VisitFieldValue(int recordIndex, int fieldIndex, string value)
         {
             BeginOrAdvanceRecord(recordIndex);

--- a/OfficeIMO.CSV/CsvLineReader.Avx512.cs
+++ b/OfficeIMO.CSV/CsvLineReader.Avx512.cs
@@ -1,0 +1,127 @@
+#nullable enable
+
+#if NET8_0_OR_GREATER
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+
+namespace OfficeIMO.CSV;
+
+internal sealed partial class CsvLineReader
+{
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private bool TryReadUnquotedFieldSpansOrLineAvx512<TVisitor>(
+        char delimiter,
+        bool allowEmpty,
+        bool emitFields,
+        int recordIndex,
+        ICsvProjectedFieldSpanVisitor? projectedFieldVisitor,
+        ref TVisitor fieldVisitor,
+        out int fieldCount,
+        out bool isEmptyRecord,
+        out string separator,
+        out CsvLineReadResult readResult)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        fieldCount = 0;
+        isEmptyRecord = false;
+        separator = string.Empty;
+        readResult = CsvLineReadResult.Line;
+
+        int start = _position;
+        int end = _length - Vector512<ushort>.Count;
+        if (start > end)
+        {
+            return false;
+        }
+
+        Span<int> delimiterIndexes = stackalloc int[UnquotedDelimiterIndexCapacity];
+        int delimiterCount = 0;
+        int position = start;
+        Vector256<byte> delimiterVector = CreateDelimiterVector(delimiter);
+        ref ushort bufferStart = ref Unsafe.As<char, ushort>(
+            ref MemoryMarshal.GetArrayDataReference(_buffer));
+
+        while (position <= end)
+        {
+            Vector512<ushort> values = Vector512.LoadUnsafe(ref bufferStart, (nuint)position);
+            Vector256<byte> bytes = System.Runtime.Intrinsics.X86.Avx512BW
+                .ConvertToVector256ByteWithSaturation(values);
+            uint delimiterMask = (uint)System.Runtime.Intrinsics.X86.Avx512BW.MoveMask(
+                Vector256.Equals(bytes, delimiterVector));
+            uint quoteMask = (uint)System.Runtime.Intrinsics.X86.Avx512BW.MoveMask(
+                Vector256.Equals(bytes, CsvQuoteVector));
+            uint carriageReturnMask = (uint)System.Runtime.Intrinsics.X86.Avx512BW.MoveMask(
+                Vector256.Equals(bytes, CsvCarriageReturnVector));
+            uint lineFeedMask = (uint)System.Runtime.Intrinsics.X86.Avx512BW.MoveMask(
+                Vector256.Equals(bytes, CsvLineFeedVector));
+            uint terminalMask = quoteMask | carriageReturnMask | lineFeedMask;
+
+            if (terminalMask != 0)
+            {
+                int terminalOffset = BitOperations.TrailingZeroCount(terminalMask);
+                uint delimiterMaskBeforeTerminal = delimiterMask & ((1u << terminalOffset) - 1u);
+                if (!AddDelimiterIndexes(
+                        delimiterMaskBeforeTerminal,
+                        position,
+                        delimiterIndexes,
+                        ref delimiterCount))
+                {
+                    return false;
+                }
+
+                if (((quoteMask >> terminalOffset) & 1u) != 0)
+                {
+                    int quoteIndex = position + terminalOffset;
+                    if (delimiterCount >= QuotedPrefixReuseMinimumDelimiterCount &&
+                        TryReadStandardQuotedFieldSpansOrLineFromPrefix(
+                            delimiter,
+                            allowEmpty,
+                            emitFields,
+                            recordIndex,
+                            delimiterIndexes.Slice(0, delimiterCount),
+                            quoteIndex,
+                            projectedFieldVisitor,
+                            ref fieldVisitor,
+                            out fieldCount,
+                            out isEmptyRecord,
+                            out separator,
+                            out readResult))
+                    {
+                        return true;
+                    }
+
+                    return false;
+                }
+
+                int newlineIndex = position + terminalOffset;
+                int lineLength = newlineIndex - start;
+                fieldCount = VisitIndexedUntrimmedUnquotedFieldSpans(
+                    start,
+                    newlineIndex,
+                    delimiterIndexes.Slice(0, delimiterCount),
+                    (allowEmpty || lineLength != 0) && emitFields,
+                    recordIndex,
+                    projectedFieldVisitor,
+                    ref fieldVisitor,
+                    out int firstFieldLength);
+                isEmptyRecord = fieldCount == 1 && firstFieldLength == 0;
+                _position = newlineIndex;
+                ConsumeLineSeparator(_buffer[newlineIndex], out separator);
+                readResult = CsvLineReadResult.UnquotedRecord;
+                return true;
+            }
+
+            if (!AddDelimiterIndexes(delimiterMask, position, delimiterIndexes, ref delimiterCount))
+            {
+                return false;
+            }
+
+            position += Vector512<ushort>.Count;
+        }
+
+        return false;
+    }
+}
+#endif

--- a/OfficeIMO.CSV/CsvLineReader.cs
+++ b/OfficeIMO.CSV/CsvLineReader.cs
@@ -13,6 +13,14 @@ internal sealed partial class CsvLineReader : IDisposable
 #if NET8_0_OR_GREATER
     private const int UnquotedDelimiterIndexCapacity = 64;
     private const int QuotedPrefixReuseMinimumDelimiterCount = 4;
+    private static readonly System.Runtime.Intrinsics.Vector256<byte> CsvCommaVector =
+        System.Runtime.Intrinsics.Vector256.Create((byte)',');
+    private static readonly System.Runtime.Intrinsics.Vector256<byte> CsvQuoteVector =
+        System.Runtime.Intrinsics.Vector256.Create((byte)'"');
+    private static readonly System.Runtime.Intrinsics.Vector256<byte> CsvCarriageReturnVector =
+        System.Runtime.Intrinsics.Vector256.Create((byte)'\r');
+    private static readonly System.Runtime.Intrinsics.Vector256<byte> CsvLineFeedVector =
+        System.Runtime.Intrinsics.Vector256.Create((byte)'\n');
 #endif
     private readonly TextReader _reader;
     private char[] _buffer;
@@ -83,7 +91,7 @@ internal sealed partial class CsvLineReader : IDisposable
 
 #if NET8_0_OR_GREATER
         if (!trim &&
-            delimiter <= byte.MaxValue &&
+            CanUseAvx2PackedDelimiter(delimiter) &&
             System.Runtime.Intrinsics.X86.Avx2.IsSupported &&
             TryReadUnquotedRecordOrLineAvx2(delimiter, fields, out line, out separator, out var readResult))
         {
@@ -151,7 +159,25 @@ internal sealed partial class CsvLineReader : IDisposable
         }
 
         if (!trim &&
-            delimiter <= byte.MaxValue &&
+            delimiter < byte.MaxValue &&
+            System.Runtime.Intrinsics.X86.Avx512BW.IsSupported &&
+            TryReadUnquotedFieldSpansOrLineAvx512(
+                delimiter,
+                allowEmpty,
+                emitFields,
+                recordIndex,
+                projectedFieldVisitor,
+                ref fieldVisitor,
+                out fieldCount,
+                out isEmptyRecord,
+                out separator,
+                out var avx512ReadResult))
+        {
+            return avx512ReadResult;
+        }
+
+        if (!trim &&
+            CanUseAvx2PackedDelimiter(delimiter) &&
             System.Runtime.Intrinsics.X86.Avx2.IsSupported &&
             TryReadUnquotedFieldSpansOrLineAvx2(
                 delimiter,
@@ -340,10 +366,7 @@ internal sealed partial class CsvLineReader : IDisposable
         Span<int> delimiterIndexes = stackalloc int[UnquotedDelimiterIndexCapacity];
         var delimiterCount = 0;
         var pos = start;
-        var delimiterVector = System.Runtime.Intrinsics.Vector256.Create((byte)delimiter);
-        var quoteVector = System.Runtime.Intrinsics.Vector256.Create((byte)'"');
-        var carriageReturnVector = System.Runtime.Intrinsics.Vector256.Create((byte)'\r');
-        var lineFeedVector = System.Runtime.Intrinsics.Vector256.Create((byte)'\n');
+        var delimiterVector = CreateDelimiterVector(delimiter);
 
         while (pos <= end)
         {
@@ -357,11 +380,11 @@ internal sealed partial class CsvLineReader : IDisposable
             var delimiterMask = (uint)System.Runtime.Intrinsics.X86.Avx2.MoveMask(
                 System.Runtime.Intrinsics.X86.Avx2.CompareEqual(packedBytes, delimiterVector));
             var quoteMask = (uint)System.Runtime.Intrinsics.X86.Avx2.MoveMask(
-                System.Runtime.Intrinsics.X86.Avx2.CompareEqual(packedBytes, quoteVector));
+                System.Runtime.Intrinsics.X86.Avx2.CompareEqual(packedBytes, CsvQuoteVector));
             var carriageReturnMask = (uint)System.Runtime.Intrinsics.X86.Avx2.MoveMask(
-                System.Runtime.Intrinsics.X86.Avx2.CompareEqual(packedBytes, carriageReturnVector));
+                System.Runtime.Intrinsics.X86.Avx2.CompareEqual(packedBytes, CsvCarriageReturnVector));
             var lineFeedMask = (uint)System.Runtime.Intrinsics.X86.Avx2.MoveMask(
-                System.Runtime.Intrinsics.X86.Avx2.CompareEqual(packedBytes, lineFeedVector));
+                System.Runtime.Intrinsics.X86.Avx2.CompareEqual(packedBytes, CsvLineFeedVector));
             var terminalMask = quoteMask | carriageReturnMask | lineFeedMask;
 
             if (terminalMask != 0)
@@ -492,7 +515,7 @@ internal sealed partial class CsvLineReader : IDisposable
 
                 if (emit)
                 {
-                    fieldVisitor.VisitField(recordIndex, fieldIndex, _buffer.AsSpan(fieldStart, length));
+                    VisitFieldRange(ref fieldVisitor, recordIndex, fieldIndex, _buffer, fieldStart, length);
                 }
 
                 fieldIndex++;
@@ -507,7 +530,13 @@ internal sealed partial class CsvLineReader : IDisposable
 
             if (emit)
             {
-                fieldVisitor.VisitField(recordIndex, fieldIndex, _buffer.AsSpan(fieldStart, unprojectedFinalLength));
+                VisitFieldRange(
+                    ref fieldVisitor,
+                    recordIndex,
+                    fieldIndex,
+                    _buffer,
+                    fieldStart,
+                    unprojectedFinalLength);
             }
 
             return fieldIndex + 1;
@@ -528,7 +557,7 @@ internal sealed partial class CsvLineReader : IDisposable
 
             if (emit && CsvFieldSpanProjection.ShouldVisitField(projectedFieldVisitor, recordIndex, fieldIndex))
             {
-                fieldVisitor.VisitField(recordIndex, fieldIndex, _buffer.AsSpan(fieldStart, length));
+                VisitFieldRange(ref fieldVisitor, recordIndex, fieldIndex, _buffer, fieldStart, length);
             }
 
             fieldIndex++;
@@ -543,7 +572,7 @@ internal sealed partial class CsvLineReader : IDisposable
 
         if (emit && CsvFieldSpanProjection.ShouldVisitField(projectedFieldVisitor, recordIndex, fieldIndex))
         {
-            fieldVisitor.VisitField(recordIndex, fieldIndex, _buffer.AsSpan(fieldStart, finalLength));
+            VisitFieldRange(ref fieldVisitor, recordIndex, fieldIndex, _buffer, fieldStart, finalLength);
         }
 
         return fieldIndex + 1;
@@ -563,6 +592,20 @@ internal sealed partial class CsvLineReader : IDisposable
         var fieldIndex = 0;
         var fieldStart = start;
         firstFieldLength = 0;
+        if (emit
+            && projectedFieldVisitor is null
+            && typeof(TVisitor) == typeof(CsvParser.CsvDataReaderStreamRowVisitor))
+        {
+            ref CsvParser.CsvDataReaderStreamRowVisitor streamVisitor = ref
+                System.Runtime.CompilerServices.Unsafe.As<TVisitor, CsvParser.CsvDataReaderStreamRowVisitor>(
+                    ref fieldVisitor);
+            streamVisitor.VisitFieldRanges(_buffer, start, end, delimiterIndexes);
+            firstFieldLength = delimiterIndexes.Length == 0
+                ? end - start
+                : delimiterIndexes[0] - start;
+            return delimiterIndexes.Length + 1;
+        }
+
         if (projectedFieldVisitor is null)
         {
             foreach (var delimiterIndex in delimiterIndexes)
@@ -575,7 +618,7 @@ internal sealed partial class CsvLineReader : IDisposable
 
                 if (emit)
                 {
-                    fieldVisitor.VisitField(recordIndex, fieldIndex, _buffer.AsSpan(fieldStart, length));
+                    VisitFieldRange(ref fieldVisitor, recordIndex, fieldIndex, _buffer, fieldStart, length);
                 }
 
                 fieldIndex++;
@@ -590,7 +633,13 @@ internal sealed partial class CsvLineReader : IDisposable
 
             if (emit)
             {
-                fieldVisitor.VisitField(recordIndex, fieldIndex, _buffer.AsSpan(fieldStart, unprojectedFinalLength));
+                VisitFieldRange(
+                    ref fieldVisitor,
+                    recordIndex,
+                    fieldIndex,
+                    _buffer,
+                    fieldStart,
+                    unprojectedFinalLength);
             }
 
             return fieldIndex + 1;
@@ -606,7 +655,7 @@ internal sealed partial class CsvLineReader : IDisposable
 
             if (emit && CsvFieldSpanProjection.ShouldVisitField(projectedFieldVisitor, recordIndex, fieldIndex))
             {
-                fieldVisitor.VisitField(recordIndex, fieldIndex, _buffer.AsSpan(fieldStart, length));
+                VisitFieldRange(ref fieldVisitor, recordIndex, fieldIndex, _buffer, fieldStart, length);
             }
 
             fieldIndex++;
@@ -621,12 +670,35 @@ internal sealed partial class CsvLineReader : IDisposable
 
         if (emit && CsvFieldSpanProjection.ShouldVisitField(projectedFieldVisitor, recordIndex, fieldIndex))
         {
-            fieldVisitor.VisitField(recordIndex, fieldIndex, _buffer.AsSpan(fieldStart, finalLength));
+            VisitFieldRange(ref fieldVisitor, recordIndex, fieldIndex, _buffer, fieldStart, finalLength);
         }
 
         return fieldIndex + 1;
     }
 
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+    private static void VisitFieldRange<TVisitor>(
+        ref TVisitor fieldVisitor,
+        int recordIndex,
+        int fieldIndex,
+        char[] buffer,
+        int start,
+        int length)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        if (typeof(TVisitor) == typeof(CsvParser.CsvDataReaderStreamRowVisitor))
+        {
+            ref CsvParser.CsvDataReaderStreamRowVisitor streamVisitor = ref
+                System.Runtime.CompilerServices.Unsafe.As<TVisitor, CsvParser.CsvDataReaderStreamRowVisitor>(
+                    ref fieldVisitor);
+            streamVisitor.VisitFieldRange(recordIndex, fieldIndex, buffer, start, length);
+            return;
+        }
+
+        fieldVisitor.VisitField(recordIndex, fieldIndex, buffer.AsSpan(start, length));
+    }
+
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
     private bool TryReadUnquotedFieldSpansOrLineAvx2<TVisitor>(
         char delimiter,
         bool allowEmpty,
@@ -655,10 +727,7 @@ internal sealed partial class CsvLineReader : IDisposable
         Span<int> delimiterIndexes = stackalloc int[UnquotedDelimiterIndexCapacity];
         var delimiterCount = 0;
         var pos = start;
-        var delimiterVector = System.Runtime.Intrinsics.Vector256.Create((byte)delimiter);
-        var quoteVector = System.Runtime.Intrinsics.Vector256.Create((byte)'"');
-        var carriageReturnVector = System.Runtime.Intrinsics.Vector256.Create((byte)'\r');
-        var lineFeedVector = System.Runtime.Intrinsics.Vector256.Create((byte)'\n');
+        var delimiterVector = CreateDelimiterVector(delimiter);
 
         while (pos <= end)
         {
@@ -672,11 +741,11 @@ internal sealed partial class CsvLineReader : IDisposable
             var delimiterMask = (uint)System.Runtime.Intrinsics.X86.Avx2.MoveMask(
                 System.Runtime.Intrinsics.X86.Avx2.CompareEqual(packedBytes, delimiterVector));
             var quoteMask = (uint)System.Runtime.Intrinsics.X86.Avx2.MoveMask(
-                System.Runtime.Intrinsics.X86.Avx2.CompareEqual(packedBytes, quoteVector));
+                System.Runtime.Intrinsics.X86.Avx2.CompareEqual(packedBytes, CsvQuoteVector));
             var carriageReturnMask = (uint)System.Runtime.Intrinsics.X86.Avx2.MoveMask(
-                System.Runtime.Intrinsics.X86.Avx2.CompareEqual(packedBytes, carriageReturnVector));
+                System.Runtime.Intrinsics.X86.Avx2.CompareEqual(packedBytes, CsvCarriageReturnVector));
             var lineFeedMask = (uint)System.Runtime.Intrinsics.X86.Avx2.MoveMask(
-                System.Runtime.Intrinsics.X86.Avx2.CompareEqual(packedBytes, lineFeedVector));
+                System.Runtime.Intrinsics.X86.Avx2.CompareEqual(packedBytes, CsvLineFeedVector));
             var terminalMask = quoteMask | carriageReturnMask | lineFeedMask;
 
             if (terminalMask != 0)
@@ -741,6 +810,7 @@ internal sealed partial class CsvLineReader : IDisposable
         return false;
     }
 
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
     private static bool AddDelimiterIndexes(uint delimiterMask, int chunkStart, Span<int> delimiterIndexes, ref int delimiterCount)
     {
         while (delimiterMask != 0)
@@ -757,6 +827,16 @@ internal sealed partial class CsvLineReader : IDisposable
 
         return true;
     }
+
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+    private static bool CanUseAvx2PackedDelimiter(char delimiter) =>
+        delimiter > byte.MinValue && delimiter < byte.MaxValue;
+
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+    private static System.Runtime.Intrinsics.Vector256<byte> CreateDelimiterVector(char delimiter) =>
+        delimiter == ','
+            ? CsvCommaVector
+            : System.Runtime.Intrinsics.Vector256.Create((byte)delimiter);
 
     private void VisitFieldSpan<TVisitor>(
         int start,

--- a/OfficeIMO.CSV/CsvParser.DataReaderRows.Stream.cs
+++ b/OfficeIMO.CSV/CsvParser.DataReaderRows.Stream.cs
@@ -189,6 +189,7 @@ internal static partial class CsvParser
 
         public ReadOnlySpan<char> GetSpan(int ordinal) => _visitor.GetSpan(ordinal);
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string GetString(int ordinal) => _visitor.GetString(ordinal);
 
         public bool IsNull(int ordinal, string? nullValue) =>
@@ -227,7 +228,7 @@ internal static partial class CsvParser
         }
     }
 
-    private struct CsvDataReaderStreamRowVisitor : ICsvFieldSpanVisitor
+    internal struct CsvDataReaderStreamRowVisitor : ICsvFieldSpanVisitor
     {
         private char[] _buffer;
         private static readonly string[] SingleCharacterStrings = CreateSingleCharacterStrings();
@@ -275,8 +276,11 @@ internal static partial class CsvParser
 
         public void VisitField(int recordIndex, int fieldIndex, ReadOnlySpan<char> value)
         {
-            EnsureCapacity(fieldIndex + 1);
-            FieldCount = Math.Max(FieldCount, fieldIndex + 1);
+            if ((uint)fieldIndex >= (uint)_starts.Length)
+            {
+                EnsureCapacity(fieldIndex + 1);
+            }
+            FieldCount = fieldIndex + 1;
             _lengths[fieldIndex] = value.Length;
             if (_nextVisitIsUnescapedScratch)
             {
@@ -293,6 +297,50 @@ internal static partial class CsvParser
             _materialized[fieldIndex] = null;
         }
 
+        public void VisitFieldRange(
+            int recordIndex,
+            int fieldIndex,
+            char[] buffer,
+            int start,
+            int length)
+        {
+            if ((uint)fieldIndex >= (uint)_starts.Length)
+            {
+                EnsureCapacity(fieldIndex + 1);
+            }
+            FieldCount = fieldIndex + 1;
+            _starts[fieldIndex] = start;
+            _lengths[fieldIndex] = length;
+            _materialized[fieldIndex] = null;
+            _nextVisitIsUnescapedScratch = false;
+        }
+
+        internal void VisitFieldRanges(
+            char[] buffer,
+            int start,
+            int end,
+            ReadOnlySpan<int> delimiterIndexes)
+        {
+            int fieldCount = delimiterIndexes.Length + 1;
+            EnsureCapacity(fieldCount);
+            int fieldStart = start;
+            for (int fieldIndex = 0; fieldIndex < delimiterIndexes.Length; fieldIndex++)
+            {
+                int delimiterIndex = delimiterIndexes[fieldIndex];
+                _starts[fieldIndex] = fieldStart;
+                _lengths[fieldIndex] = delimiterIndex - fieldStart;
+                _materialized[fieldIndex] = null;
+                fieldStart = delimiterIndex + 1;
+            }
+
+            int finalFieldIndex = fieldCount - 1;
+            _starts[finalFieldIndex] = fieldStart;
+            _lengths[finalFieldIndex] = end - fieldStart;
+            _materialized[finalFieldIndex] = null;
+            _nextVisitIsUnescapedScratch = false;
+            FieldCount = fieldCount;
+        }
+
         public bool TryVisitEscapedField(
             int recordIndex,
             int fieldIndex,
@@ -305,8 +353,11 @@ internal static partial class CsvParser
 
         public void VisitFieldValue(int recordIndex, int fieldIndex, string value)
         {
-            EnsureCapacity(fieldIndex + 1);
-            FieldCount = Math.Max(FieldCount, fieldIndex + 1);
+            if ((uint)fieldIndex >= (uint)_starts.Length)
+            {
+                EnsureCapacity(fieldIndex + 1);
+            }
+            FieldCount = fieldIndex + 1;
             _starts[fieldIndex] = -1;
             _lengths[fieldIndex] = value.Length;
             _materialized[fieldIndex] = value;
@@ -348,6 +399,7 @@ internal static partial class CsvParser
                 : materialized.AsSpan();
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal string GetString(int ordinal)
         {
             ValidateOrdinal(ordinal);
@@ -394,6 +446,7 @@ internal static partial class CsvParser
             return _lengths[ordinal] < 0;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void ValidateOrdinal(int ordinal)
         {
             int maximum = SourceColumnCount > 0 ? SourceColumnCount : FieldCount;

--- a/OfficeIMO.CSV/CsvParser.DataReaderRows.Text.cs
+++ b/OfficeIMO.CSV/CsvParser.DataReaderRows.Text.cs
@@ -133,6 +133,19 @@ internal static partial class CsvParser
             _materialized[fieldIndex] = null;
         }
 
+        public void VisitFieldRange(
+            int recordIndex,
+            int fieldIndex,
+            char[] buffer,
+            int start,
+            int length)
+        {
+            VisitFieldValue(
+                recordIndex,
+                fieldIndex,
+                length == 0 ? string.Empty : new string(buffer, start, length));
+        }
+
         public bool TryVisitEscapedField(int recordIndex, int fieldIndex, ReadOnlySpan<char> escapedValue, int unescapedLength)
         {
             _nextVisitIsUnescapedScratch = true;
@@ -237,7 +250,7 @@ internal static partial class CsvParser
         var delimiter = GetDelimiterChar(options);
         var delimiterVector = System.Runtime.Intrinsics.Vector256<byte>.Zero;
         if (!options.TrimWhitespace &&
-            delimiter <= byte.MaxValue &&
+            CanUseAvx2PackedDelimiter(delimiter) &&
             System.Runtime.Intrinsics.X86.Avx2.IsSupported)
         {
             delimiterVector = System.Runtime.Intrinsics.Vector256.Create((byte)delimiter);

--- a/OfficeIMO.CSV/CsvParser.FieldSpans.Text.cs
+++ b/OfficeIMO.CSV/CsvParser.FieldSpans.Text.cs
@@ -66,7 +66,7 @@ internal static partial class CsvParser
         char[]? scratch = null;
         var delimiterVector = System.Runtime.Intrinsics.Vector256<byte>.Zero;
         if (!trim &&
-            delimiter <= byte.MaxValue &&
+            CanUseAvx2PackedDelimiter(delimiter) &&
             System.Runtime.Intrinsics.X86.Avx2.IsSupported)
         {
             delimiterVector = System.Runtime.Intrinsics.Vector256.Create((byte)delimiter);
@@ -261,7 +261,7 @@ internal static partial class CsvParser
 
         if (useAvx2UnquotedFastPath &&
             !trim &&
-            delimiter <= byte.MaxValue &&
+            CanUseAvx2PackedDelimiter(delimiter) &&
             System.Runtime.Intrinsics.X86.Avx2.IsSupported &&
             !textMayContainQuote &&
             TryReadTextQuoteFreeRecordFieldSpansAvx2(
@@ -282,7 +282,7 @@ internal static partial class CsvParser
 
         if (useAvx2UnquotedFastPath &&
             !trim &&
-            delimiter <= byte.MaxValue &&
+            CanUseAvx2PackedDelimiter(delimiter) &&
             System.Runtime.Intrinsics.X86.Avx2.IsSupported &&
             TryReadTextUnquotedRecordFieldSpansAvx2(
                 text,
@@ -351,6 +351,9 @@ internal static partial class CsvParser
 
         return true;
     }
+
+    private static bool CanUseAvx2PackedDelimiter(char delimiter) =>
+        delimiter > byte.MinValue && delimiter < byte.MaxValue;
 
     private static bool TryReadTextUnquotedRecordFieldSpansAvx2<TVisitor>(
         ReadOnlySpan<char> text,

--- a/OfficeIMO.CSV/ICsvFieldSpanVisitor.cs
+++ b/OfficeIMO.CSV/ICsvFieldSpanVisitor.cs
@@ -17,6 +17,21 @@ internal interface ICsvFieldSpanVisitor
     void VisitField(int recordIndex, int fieldIndex, ReadOnlySpan<char> value);
 
     /// <summary>
+    /// Visits a field that is already known to be an unchanged range of a parser buffer.
+    /// Visitors that retain ranges can override this to avoid reconstructing the source offset
+    /// from a span; other visitors use the normal transient-span callback.
+    /// </summary>
+    void VisitFieldRange(
+        int recordIndex,
+        int fieldIndex,
+        char[] buffer,
+        int start,
+        int length)
+    {
+        VisitField(recordIndex, fieldIndex, buffer.AsSpan(start, length));
+    }
+
+    /// <summary>
     /// Optionally visits an escaped quoted field without forcing the parser to compact doubled quotes into a scratch buffer.
     /// </summary>
     /// <param name="recordIndex">Zero-based emitted record index.</param>
@@ -75,6 +90,16 @@ internal readonly struct CsvFieldSpanActionVisitor : ICsvFieldSpanVisitor
     public void VisitField(int recordIndex, int fieldIndex, ReadOnlySpan<char> value)
     {
         _action(recordIndex, fieldIndex, value);
+    }
+
+    public void VisitFieldRange(
+        int recordIndex,
+        int fieldIndex,
+        char[] buffer,
+        int start,
+        int length)
+    {
+        _action(recordIndex, fieldIndex, buffer.AsSpan(start, length));
     }
 }
 #endif

--- a/OfficeIMO.Excel.Benchmarks/ExcelGeneratedRowStreamingBenchmarks.cs
+++ b/OfficeIMO.Excel.Benchmarks/ExcelGeneratedRowStreamingBenchmarks.cs
@@ -1,0 +1,46 @@
+using BenchmarkDotNet.Attributes;
+
+namespace OfficeIMO.Excel.Benchmarks;
+
+/// <summary>
+/// Guards the single-pass object-row contract with a generated source large enough to make
+/// accidental row buffering visible in both execution time and managed allocations.
+/// </summary>
+[MemoryDiagnoser]
+public class ExcelGeneratedRowStreamingBenchmarks {
+    private static readonly string[] Headers = ["Id", "Amount", "CreatedOn", "Active"];
+
+    [Params(1_000_000)]
+    public int RowCount { get; set; }
+
+    [Benchmark]
+    public int WriteRowsGenerated() {
+        ExcelDataSetImportResult result = ExcelDocument.WriteRows(
+            Stream.Null,
+            GenerateRows(RowCount),
+            Headers,
+            static (writer, row) => writer
+                .Write(row.Id)
+                .Write(row.Amount)
+                .Write(row.CreatedOn)
+                .Write(row.Active));
+        return result.RowCount;
+    }
+
+    private static IEnumerable<GeneratedRow> GenerateRows(int count) {
+        var start = new DateTime(2026, 1, 1);
+        for (int index = 0; index < count; index++) {
+            yield return new GeneratedRow(
+                index + 1,
+                index * 1.25m,
+                start.AddMinutes(index),
+                (index & 1) == 0);
+        }
+    }
+
+    private readonly record struct GeneratedRow(
+        int Id,
+        decimal Amount,
+        DateTime CreatedOn,
+        bool Active);
+}

--- a/OfficeIMO.Excel.Benchmarks/MarkPflug65KExcelBenchmarks.cs
+++ b/OfficeIMO.Excel.Benchmarks/MarkPflug65KExcelBenchmarks.cs
@@ -160,15 +160,26 @@ public class MarkPflug65KXlsxBenchmarks {
     internal static ExcelReadObservation Observe(DbDataReader reader) {
         var observation = new ExcelObservationAccumulator();
         while (reader.Read()) {
-            AddRow(
-                ref observation,
-                reader.GetString,
-                reader.GetDateTime,
-                reader.GetInt32,
-                reader.GetDecimal);
+            AddRow(ref observation, reader);
         }
 
         return observation.Build();
+    }
+
+    private static void AddRow(
+        ref ExcelObservationAccumulator observation,
+        DbDataReader reader) {
+        observation.BeginRow();
+        for (int ordinal = 0; ordinal <= 4; ordinal++) {
+            observation.Add(reader.GetString(ordinal));
+        }
+        observation.Add(reader.GetDateTime(5));
+        observation.Add(reader.GetInt32(6));
+        observation.Add(reader.GetDateTime(7));
+        observation.Add(reader.GetInt32(8));
+        for (int ordinal = 9; ordinal <= 13; ordinal++) {
+            observation.Add(reader.GetDecimal(ordinal));
+        }
     }
 
     internal static void AddRow(
@@ -362,8 +373,10 @@ internal struct ExcelObservationAccumulator {
 
     internal void Add(decimal value) {
         AddTag(4);
-        foreach (int part in decimal.GetBits(value)) {
-            AddUInt64(unchecked((uint)part));
+        Span<int> parts = stackalloc int[4];
+        decimal.GetBits(value, parts);
+        for (int index = 0; index < parts.Length; index++) {
+            AddUInt64(unchecked((uint)parts[index]));
         }
         _cells++;
     }

--- a/OfficeIMO.Excel.Benchmarks/Program.cs
+++ b/OfficeIMO.Excel.Benchmarks/Program.cs
@@ -14,6 +14,76 @@ bool profileOfficeIMOXls = args.Length > 0 &&
     string.Equals(args[0], "--profile-markpflug65k-xls-officeimo", StringComparison.OrdinalIgnoreCase);
 bool profileSylvanXls = args.Length > 0 &&
     string.Equals(args[0], "--profile-markpflug65k-xls-sylvan", StringComparison.OrdinalIgnoreCase);
+bool comparePairedXlsb = args.Length > 0 &&
+    string.Equals(args[0], "--compare-markpflug65k-xlsb-paired", StringComparison.OrdinalIgnoreCase);
+bool comparePairedXls = args.Length > 0 &&
+    string.Equals(args[0], "--compare-markpflug65k-xls-paired", StringComparison.OrdinalIgnoreCase);
+
+if (comparePairedXlsb || comparePairedXls) {
+    int iterations = args.Length > 1 && int.TryParse(args[1], out int parsedIterations)
+        ? parsedIterations
+        : 20;
+    if (iterations <= 0) {
+        throw new ArgumentOutOfRangeException(nameof(iterations));
+    }
+    ApplyProcessAffinity(args, argumentIndex: 2);
+    const int warmupIterations = 10;
+    string affinity = args.Length > 2 ? args[2] : "unchanged";
+
+    Func<ExcelReadObservation> runOfficeIMO;
+    Func<ExcelReadObservation> runSylvan;
+    string format;
+    if (comparePairedXlsb) {
+        var benchmark = new MarkPflug65KXlsbBenchmarks();
+        benchmark.Setup();
+        runOfficeIMO = benchmark.OfficeIMO;
+        runSylvan = benchmark.Sylvan;
+        format = "XLSB";
+    } else {
+        var benchmark = new MarkPflug65KXlsBenchmarks();
+        benchmark.Setup();
+        runOfficeIMO = benchmark.OfficeIMO;
+        runSylvan = benchmark.Sylvan;
+        format = "XLS";
+    }
+    for (int index = 0; index < warmupIterations; index++) {
+        runOfficeIMO();
+        runSylvan();
+    }
+
+    var officeSamples = new double[iterations];
+    var sylvanSamples = new double[iterations];
+    var pairedRatios = new double[iterations];
+    for (int index = 0; index < iterations; index++) {
+        ExcelReadObservation officeObservation;
+        ExcelReadObservation sylvanObservation;
+        if ((index & 1) == 0) {
+            officeSamples[index] = MeasureMilliseconds(runOfficeIMO, out officeObservation);
+            sylvanSamples[index] = MeasureMilliseconds(runSylvan, out sylvanObservation);
+        } else {
+            sylvanSamples[index] = MeasureMilliseconds(runSylvan, out sylvanObservation);
+            officeSamples[index] = MeasureMilliseconds(runOfficeIMO, out officeObservation);
+        }
+
+        if (officeObservation != sylvanObservation) {
+            throw new InvalidDataException(
+                $"Paired {format} sample {index} produced different observations: OfficeIMO={officeObservation}; Sylvan={sylvanObservation}.");
+        }
+        pairedRatios[index] = officeSamples[index] / sylvanSamples[index];
+    }
+
+    double officeMedian = Median(officeSamples);
+    double sylvanMedian = Median(sylvanSamples);
+    double pairedRatioMedian = Median(pairedRatios);
+    double pairedRatioP25 = Percentile(pairedRatios, 0.25d);
+    double pairedRatioP75 = Percentile(pairedRatios, 0.75d);
+    Console.WriteLine(
+        $"Paired {format} comparison ({warmupIterations} warmups, {iterations} alternating samples, affinity {affinity}): " +
+        $"OfficeIMO median {officeMedian:F3} ms, Sylvan median {sylvanMedian:F3} ms, " +
+        $"ratio of medians {officeMedian / sylvanMedian:F4}, paired ratio median {pairedRatioMedian:F4} " +
+        $"(P25 {pairedRatioP25:F4}, P75 {pairedRatioP75:F4}).");
+    return;
+}
 
 if (profileOfficeIMOXlsb || profileSylvanXlsb || profileOfficeIMOXls || profileSylvanXls) {
     int iterations = args.Length > 1 && int.TryParse(args[1], out int parsedIterations)
@@ -22,6 +92,7 @@ if (profileOfficeIMOXlsb || profileSylvanXlsb || profileOfficeIMOXls || profileS
     if (iterations <= 0) {
         throw new ArgumentOutOfRangeException(nameof(iterations));
     }
+    ApplyProcessAffinity(args, argumentIndex: 2);
 
     bool isXlsb = profileOfficeIMOXlsb || profileSylvanXlsb;
     bool isOfficeIMO = profileOfficeIMOXlsb || profileOfficeIMOXls;
@@ -648,6 +719,53 @@ static string[] GetAntiCheatScenarios()
         "realworld-report-extra-column",
         "realworld-report-post-mutation"
     ];
+
+static double MeasureMilliseconds(
+    Func<ExcelReadObservation> operation,
+    out ExcelReadObservation observation) {
+    long started = System.Diagnostics.Stopwatch.GetTimestamp();
+    observation = operation();
+    return System.Diagnostics.Stopwatch.GetElapsedTime(started).TotalMilliseconds;
+}
+
+static void ApplyProcessAffinity(string[] arguments, int argumentIndex) {
+    if (arguments.Length <= argumentIndex
+        || !long.TryParse(arguments[argumentIndex], out long affinityMask)) {
+        return;
+    }
+    if (!OperatingSystem.IsWindows()) {
+        throw new PlatformNotSupportedException("Processor-affinity comparison is available only on Windows.");
+    }
+    if (affinityMask <= 0) {
+        throw new ArgumentOutOfRangeException(nameof(affinityMask));
+    }
+
+    System.Diagnostics.Process.GetCurrentProcess().ProcessorAffinity = checked((nint)affinityMask);
+}
+
+static double Median(double[] samples) {
+    Array.Sort(samples);
+    int middle = samples.Length / 2;
+    return (samples.Length & 1) == 0
+        ? (samples[middle - 1] + samples[middle]) / 2d
+        : samples[middle];
+}
+
+static double Percentile(double[] samples, double percentile) {
+    if (samples.Length == 0) {
+        throw new ArgumentException("At least one sample is required.", nameof(samples));
+    }
+    if (percentile < 0d || percentile > 1d) {
+        throw new ArgumentOutOfRangeException(nameof(percentile));
+    }
+
+    Array.Sort(samples);
+    double position = (samples.Length - 1) * percentile;
+    int lower = (int)position;
+    int upper = Math.Min(lower + 1, samples.Length - 1);
+    double fraction = position - lower;
+    return samples[lower] + (samples[upper] - samples[lower]) * fraction;
+}
 
 internal sealed class ComparisonSuiteManifest {
     public DateTime GeneratedAtUtc { get; init; }

--- a/OfficeIMO.Excel.Tests/Excel.DataReaderApi.XlsFastPath.ReviewRegression.cs
+++ b/OfficeIMO.Excel.Tests/Excel.DataReaderApi.XlsFastPath.ReviewRegression.cs
@@ -47,6 +47,7 @@ namespace OfficeIMO.Tests {
             Assert.True(reader.Read());
             Assert.Equal(double.MaxValue, Assert.IsType<double>(reader.GetValue(0)));
             Assert.Equal(double.MaxValue, reader.GetDouble(0));
+            Assert.Throws<InvalidCastException>(() => reader.GetDecimal(0));
             Assert.False(reader.Read());
         }
 
@@ -61,6 +62,26 @@ namespace OfficeIMO.Tests {
                     new ExcelReadOptions { HasHeaderRow = false }));
 
             Assert.Contains("MULBLANK", exception.Message, StringComparison.Ordinal);
+        }
+
+        [Theory]
+        [InlineData((ushort)0x0006)]
+        [InlineData((ushort)0x00fd)]
+        [InlineData((ushort)0x0203)]
+        [InlineData((ushort)0x0204)]
+        [InlineData((ushort)0x0205)]
+        [InlineData((ushort)0x027e)]
+        public void OpenDataReader_XlsFastPathRejectsTruncatedNonHeaderScalarCells(ushort recordType) {
+            byte[] compound = LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFile(
+                LegacyXlsTestWorkbookBuilder.CreateTruncatedScalarCellWorkbookStream(recordType));
+
+            using DbDataReader reader = ExcelDocument.OpenDataReader(
+                compound,
+                new ExcelReadOptions { HasHeaderRow = false });
+            Assert.True(reader.Read());
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() => reader.Read());
+
+            Assert.Contains("truncated", exception.Message, StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact]
@@ -203,6 +224,19 @@ namespace OfficeIMO.Tests {
                         WriteUInt16(payload, 0);
                         WriteUInt16(payload, 2);
                         WriteRecord(worksheet, 0x00be, payload.ToArray());
+                    });
+
+            internal static byte[] CreateTruncatedScalarCellWorkbookStream(ushort recordType) =>
+                CreateFastPathRegressionWorkbookStream(
+                    "TruncatedCell",
+                    globals => { },
+                    worksheet => {
+                        WriteRecord(worksheet, 0x0203, BuildNumberPayload(0, 0, 1D));
+                        using var payload = new MemoryStream();
+                        WriteUInt16(payload, 1);
+                        WriteUInt16(payload, 0);
+                        WriteUInt16(payload, 0);
+                        WriteRecord(worksheet, recordType, payload.ToArray());
                     });
 
             private static byte[] CreateFastPathRegressionWorkbookStream(

--- a/OfficeIMO.Excel.Tests/Excel.TabularWrite.cs
+++ b/OfficeIMO.Excel.Tests/Excel.TabularWrite.cs
@@ -1,5 +1,6 @@
 using System.Data;
 using System.Globalization;
+using System.Threading;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using DocumentFormat.OpenXml.Validation;
@@ -211,6 +212,81 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void WriteObjects_InlineTupleSelectorsConsumeRowsSinglePass() {
+            using var output = new MemoryStream();
+            bool enumerationActive = false;
+
+            ExcelDataSetImportResult result = ExcelDocument.WriteObjects(
+                output,
+                StreamRows(),
+                new (string Header, Func<TabularWriteRow, object?> Selector)[] {
+                    ("Id", row => {
+                        Assert.True(enumerationActive);
+                        return row.Id;
+                    }),
+                    ("Name", row => row.Name)
+                },
+                new ExcelTabularWriteOptions { UseSharedStrings = false });
+
+            Assert.False(enumerationActive);
+            Assert.Equal(2, result.RowCount);
+            Assert.Equal("A1:B3", result.Range);
+            byte[] package = output.ToArray();
+            using (var spreadsheet = SpreadsheetDocument.Open(
+                       new MemoryStream(package, writable: false),
+                       false)) {
+                Assert.Null(spreadsheet.WorkbookPart!.WorksheetParts.Single().Worksheet.SheetDimension);
+                Assert.Empty(new OpenXmlValidator().Validate(spreadsheet));
+            }
+            using (var reader = ExcelDocumentReader.Open(new MemoryStream(package, writable: false))) {
+                object?[,] values = reader.GetSheet("Data").ReadRange("A1:B3");
+                Assert.Equal("Beta", values[2, 1]);
+            }
+
+            IEnumerable<TabularWriteRow> StreamRows() {
+                enumerationActive = true;
+                try {
+                    yield return new TabularWriteRow(1, "Alpha", new DateTime(2026, 7, 10), true);
+                    yield return new TabularWriteRow(2, "Beta", new DateTime(2026, 7, 11), false);
+                } finally {
+                    enumerationActive = false;
+                }
+            }
+        }
+
+        [Fact]
+        public void WriteObjects_InlineTypedColumnsConsumeRowsSinglePass() {
+            using var output = new MemoryStream();
+            bool enumerationActive = false;
+
+            ExcelDataSetImportResult result = ExcelDocument.WriteObjects(
+                output,
+                StreamRows(),
+                new ExcelTabularColumn<TabularWriteRow>[] {
+                    ExcelTabularColumn<TabularWriteRow>.Create("Id", row => {
+                        Assert.True(enumerationActive);
+                        return row.Id;
+                    }),
+                    ExcelTabularColumn<TabularWriteRow>.Create("Active", row => row.Active)
+                },
+                new ExcelTabularWriteOptions { UseSharedStrings = false });
+
+            Assert.False(enumerationActive);
+            Assert.Equal(2, result.RowCount);
+            Assert.Equal("A1:B3", result.Range);
+
+            IEnumerable<TabularWriteRow> StreamRows() {
+                enumerationActive = true;
+                try {
+                    yield return new TabularWriteRow(1, "Alpha", new DateTime(2026, 7, 10), true);
+                    yield return new TabularWriteRow(2, "Beta", new DateTime(2026, 7, 11), false);
+                } finally {
+                    enumerationActive = false;
+                }
+            }
+        }
+
+        [Fact]
         public void WriteObjects_RejectsDuplicateHeaders() {
             using var output = new MemoryStream();
             var rows = new[] { new TabularWriteRow(1, "Alpha", new DateTime(2026, 7, 10), true) };
@@ -248,6 +324,57 @@ namespace OfficeIMO.Tests {
             object?[,] values = reader.GetSheet("Data").ReadRange("A1:D3");
             Assert.Equal("Beta", values[2, 1]);
             Assert.Equal(false, values[2, 3]);
+        }
+
+        [Fact]
+        public void WriteRows_ConsumesGeneratorWhileWriting() {
+            using var output = new MemoryStream();
+            bool enumerationActive = false;
+
+            ExcelDataSetImportResult result = ExcelDocument.WriteRows(
+                output,
+                StreamRows(),
+                ["Id", "Name"],
+                (writer, row) => {
+                    Assert.True(enumerationActive);
+                    writer.Write(row.Id).Write(row.Name);
+                });
+
+            Assert.False(enumerationActive);
+            Assert.Equal(2, result.RowCount);
+            Assert.Equal("A1:B3", result.Range);
+
+            IEnumerable<TabularWriteRow> StreamRows() {
+                enumerationActive = true;
+                try {
+                    yield return new TabularWriteRow(1, "Alpha", new DateTime(2026, 7, 10), true);
+                    yield return new TabularWriteRow(2, "Beta", new DateTime(2026, 7, 11), false);
+                } finally {
+                    enumerationActive = false;
+                }
+            }
+        }
+
+        [Fact]
+        public void WriteRows_CancellationStopsBeforeAdvancingGenerator() {
+            using var output = new MemoryStream();
+            using var cts = new CancellationTokenSource();
+            bool enumerationStarted = false;
+            cts.Cancel();
+
+            Assert.Throws<OperationCanceledException>(() => ExcelDocument.WriteRows(
+                output,
+                StreamRows(),
+                ["Id"],
+                static (writer, row) => writer.Write(row.Id),
+                ct: cts.Token));
+
+            Assert.False(enumerationStarted);
+
+            IEnumerable<TabularWriteRow> StreamRows() {
+                enumerationStarted = true;
+                yield return new TabularWriteRow(1, "Alpha", new DateTime(2026, 7, 10), true);
+            }
         }
 
         [Fact]

--- a/OfficeIMO.Excel/ExcelDocument.DirectDataSet.TableModel.ObjectRows.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DirectDataSet.TableModel.ObjectRows.cs
@@ -5,9 +5,74 @@ namespace OfficeIMO.Excel {
         private interface IDirectObjectRows {
             int Count { get; }
 
+            bool HasKnownCount { get; }
+
             object? GetValue(int rowIndex, int columnIndex);
 
             void WriteRows(ExcelTabularRowWriter writer, CancellationToken ct);
+        }
+
+        private sealed class DirectStreamingObjectRows<T> : IDirectObjectRows {
+            private readonly IEnumerable<T> _rows;
+            private readonly Action<ExcelTabularRowWriter, T> _writeRow;
+            private readonly int _maximumRows;
+            private int _count;
+            private bool _written;
+            private readonly bool _hasKnownCount;
+
+            internal DirectStreamingObjectRows(
+                IEnumerable<T> rows,
+                Action<ExcelTabularRowWriter, T> writeRow,
+                int maximumRows) {
+                _rows = rows;
+                _writeRow = writeRow;
+                _maximumRows = maximumRows;
+                if (rows is ICollection<T> collection) {
+                    _count = collection.Count;
+                    _hasKnownCount = true;
+                } else if (rows is IReadOnlyCollection<T> readOnlyCollection) {
+                    _count = readOnlyCollection.Count;
+                    _hasKnownCount = true;
+                }
+            }
+
+            public int Count => _count;
+
+            public bool HasKnownCount => _hasKnownCount;
+
+            public object? GetValue(int rowIndex, int columnIndex) =>
+                throw new InvalidOperationException(
+                    "Single-pass object rows do not support random cell access.");
+
+            public void WriteRows(ExcelTabularRowWriter writer, CancellationToken ct) {
+                if (_written) {
+                    throw new InvalidOperationException(
+                        "Single-pass object rows cannot be written more than once.");
+                }
+                _written = true;
+
+                bool canCancel = ct.CanBeCanceled;
+                int writtenCount = 0;
+                using IEnumerator<T> enumerator = _rows.GetEnumerator();
+                while (true) {
+                    if (canCancel) {
+                        ct.ThrowIfCancellationRequested();
+                    }
+                    if (!enumerator.MoveNext()) {
+                        return;
+                    }
+                    if (writtenCount >= _maximumRows) {
+                        throw new InvalidOperationException(
+                            "Object-row export exceeds the maximum worksheet row count.");
+                    }
+
+                    writer.BeginRow();
+                    _writeRow(writer, enumerator.Current);
+                    writer.EndRow();
+                    writtenCount++;
+                    _count = writtenCount;
+                }
+            }
         }
 
         private sealed class DirectObjectRows<T> : IDirectObjectRows {
@@ -20,6 +85,8 @@ namespace OfficeIMO.Excel {
             }
 
             public int Count => _rows.Count;
+
+            public bool HasKnownCount => true;
 
             public object? GetValue(int rowIndex, int columnIndex)
                 => _selectors[columnIndex](_rows[rowIndex]);
@@ -49,6 +116,8 @@ namespace OfficeIMO.Excel {
 
             public int Count => _rows.Count;
 
+            public bool HasKnownCount => true;
+
             public object? GetValue(int rowIndex, int columnIndex)
                 => _columns[columnIndex].GetValue(_rows[rowIndex]);
 
@@ -76,6 +145,8 @@ namespace OfficeIMO.Excel {
             }
 
             public int Count => _rows.Count;
+
+            public bool HasKnownCount => true;
 
             public object? GetValue(int rowIndex, int columnIndex)
                 => throw new InvalidOperationException("Streaming callback rows do not support random cell access.");

--- a/OfficeIMO.Excel/ExcelDocument.DirectDataSet.TableModel.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DirectDataSet.TableModel.cs
@@ -166,6 +166,32 @@ namespace OfficeIMO.Excel {
                 return new DirectDataSetTableModel(columns, new DirectObjectRows<T>(rows, selectors));
             }
 
+            internal static DirectDataSetTableModel FromStreamingObjectRows<T>(
+                IReadOnlyList<string> columnNames,
+                IEnumerable<T> rows,
+                IReadOnlyList<Func<T, object?>> selectors,
+                int maximumRows) {
+                if (columnNames.Count != selectors.Count) {
+                    throw new ArgumentException("Column name and selector counts must match.", nameof(selectors));
+                }
+
+                var columns = new DirectDataSetColumnModel[columnNames.Count];
+                for (int i = 0; i < columns.Length; i++) {
+                    columns[i] = new DirectDataSetColumnModel(columnNames[i], typeof(object));
+                }
+
+                return new DirectDataSetTableModel(
+                    columns,
+                    new DirectStreamingObjectRows<T>(
+                        rows,
+                        (writer, row) => {
+                            for (int columnIndex = 0; columnIndex < selectors.Count; columnIndex++) {
+                                writer.Write(selectors[columnIndex](row));
+                            }
+                        },
+                        maximumRows));
+            }
+
             internal static DirectDataSetTableModel FromTypedObjectRows<T>(
                 IReadOnlyList<T> rows,
                 IReadOnlyList<ExcelTabularColumn<T>> tabularColumns) {
@@ -175,6 +201,27 @@ namespace OfficeIMO.Excel {
                 }
 
                 return new DirectDataSetTableModel(columns, new DirectTypedObjectRows<T>(rows, tabularColumns));
+            }
+
+            internal static DirectDataSetTableModel FromStreamingTypedObjectRows<T>(
+                IEnumerable<T> rows,
+                IReadOnlyList<ExcelTabularColumn<T>> tabularColumns,
+                int maximumRows) {
+                var columns = new DirectDataSetColumnModel[tabularColumns.Count];
+                for (int i = 0; i < columns.Length; i++) {
+                    columns[i] = new DirectDataSetColumnModel(tabularColumns[i].Header, tabularColumns[i].DataType);
+                }
+
+                return new DirectDataSetTableModel(
+                    columns,
+                    new DirectStreamingObjectRows<T>(
+                        rows,
+                        (writer, row) => {
+                            for (int columnIndex = 0; columnIndex < tabularColumns.Count; columnIndex++) {
+                                tabularColumns[columnIndex].WriteValue(writer, row);
+                            }
+                        },
+                        maximumRows));
             }
 
             internal static DirectDataSetTableModel FromCallbackRows<T>(
@@ -187,6 +234,21 @@ namespace OfficeIMO.Excel {
                 }
 
                 return new DirectDataSetTableModel(columns, new DirectCallbackRows<T>(rows, writeRow));
+            }
+
+            internal static DirectDataSetTableModel FromStreamingCallbackRows<T>(
+                IReadOnlyList<string> columnNames,
+                IEnumerable<T> rows,
+                Action<ExcelTabularRowWriter, T> writeRow,
+                int maximumRows) {
+                var columns = new DirectDataSetColumnModel[columnNames.Count];
+                for (int i = 0; i < columns.Length; i++) {
+                    columns[i] = new DirectDataSetColumnModel(columnNames[i], typeof(object));
+                }
+
+                return new DirectDataSetTableModel(
+                    columns,
+                    new DirectStreamingObjectRows<T>(rows, writeRow, maximumRows));
             }
 
             internal static DirectDataSetTableModel FromLegacyDictionaries(IReadOnlyList<string> columnNames, IReadOnlyList<Type> columnTypes, IReadOnlyList<System.Collections.IDictionary> rows) {
@@ -536,6 +598,8 @@ namespace OfficeIMO.Excel {
                 rows = null!;
                 return false;
             }
+
+            internal bool HasKnownRowCount => _objectRows?.HasKnownCount ?? true;
 
             internal object?[]? GetBufferedRow(int rowIndex) {
                 if (_arrayRows != null) {

--- a/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Writer.Worksheet.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Writer.Worksheet.cs
@@ -19,9 +19,11 @@ namespace OfficeIMO.Excel {
                     writer.Write(metadata!.SheetPropertiesXml);
                 }
 
-                writer.Write("<dimension ref=\"");
-                WriteEscaped(writer, GetWorksheetDimension(sheet));
-                writer.Write("\"/>");
+                if (sheet.Table.HasKnownRowCount) {
+                    writer.Write("<dimension ref=\"");
+                    WriteEscaped(writer, GetWorksheetDimension(sheet));
+                    writer.Write("\"/>");
+                }
                 if (!string.IsNullOrEmpty(metadata?.SheetViewsXml)) {
                     writer.Write(metadata!.SheetViewsXml);
                 }

--- a/OfficeIMO.Excel/ExcelDocument.TabularWrite.cs
+++ b/OfficeIMO.Excel/ExcelDocument.TabularWrite.cs
@@ -6,6 +6,8 @@ namespace OfficeIMO.Excel {
     public partial class ExcelDocument {
         /// <summary>
         /// Writes typed rows directly to an XLSX package without creating an editable workbook object.
+        /// Sources are consumed once while worksheet XML is written when shared strings, tables,
+        /// and automatic column sizing are disabled.
         /// </summary>
         public static ExcelDataSetImportResult WriteObjects<T>(
             Stream stream,
@@ -19,7 +21,6 @@ namespace OfficeIMO.Excel {
             if (columns == null) throw new ArgumentNullException(nameof(columns));
             if (columns.Count == 0) throw new ArgumentException("At least one column selector is required.", nameof(columns));
 
-            var rows = items as IReadOnlyList<T> ?? items.ToList();
             var headers = new string[columns.Count];
             var selectors = new Func<T, object?>[columns.Count];
             var usedHeaders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -37,12 +38,25 @@ namespace OfficeIMO.Excel {
                 selectors[columnIndex] = columns[columnIndex].Selector ?? throw new ArgumentException("Column selectors must not be null.", nameof(columns));
             }
 
-            var tableModel = DirectDataSetTableModel.FromObjectRows(headers, rows, selectors);
+            options ??= new ExcelTabularWriteOptions();
+            DirectDataSetTableModel tableModel;
+            if (CanWriteObjectRowsSinglePass(options)) {
+                tableModel = DirectDataSetTableModel.FromStreamingObjectRows(
+                    headers,
+                    items,
+                    selectors,
+                    GetMaximumDataRows(options));
+            } else {
+                var rows = items as IReadOnlyList<T> ?? items.ToList();
+                tableModel = DirectDataSetTableModel.FromObjectRows(headers, rows, selectors);
+            }
             return WriteTabularModel(stream, tableModel, options, ct);
         }
 
         /// <summary>
         /// Writes strongly typed rows directly into an XLSX package through a reusable row writer.
+        /// Sources are consumed once while worksheet XML is written unless table creation requires
+        /// the final row range before package output begins.
         /// </summary>
         public static ExcelDataSetImportResult WriteRows<T>(
             Stream stream,
@@ -74,8 +88,17 @@ namespace OfficeIMO.Excel {
                 }
             }
 
-            var rows = items as IReadOnlyList<T> ?? items.ToList();
-            var tableModel = DirectDataSetTableModel.FromCallbackRows(headers, rows, writeRow);
+            DirectDataSetTableModel tableModel;
+            if (CanWriteObjectRowsSinglePass(options)) {
+                tableModel = DirectDataSetTableModel.FromStreamingCallbackRows(
+                    headers,
+                    items,
+                    writeRow,
+                    GetMaximumDataRows(options));
+            } else {
+                var rows = items as IReadOnlyList<T> ?? items.ToList();
+                tableModel = DirectDataSetTableModel.FromCallbackRows(headers, rows, writeRow);
+            }
             return WriteTabularModel(stream, tableModel, options, ct);
         }
 
@@ -101,6 +124,8 @@ namespace OfficeIMO.Excel {
 
         /// <summary>
         /// Writes typed rows directly to an XLSX package using strongly typed column selectors.
+        /// Sources are consumed once while worksheet XML is written when shared strings, tables,
+        /// and automatic column sizing are disabled.
         /// </summary>
         public static ExcelDataSetImportResult WriteObjects<T>(
             Stream stream,
@@ -123,10 +148,27 @@ namespace OfficeIMO.Excel {
                 }
             }
 
-            var rows = items as IReadOnlyList<T> ?? items.ToList();
-            var tableModel = DirectDataSetTableModel.FromTypedObjectRows(rows, columns);
+            options ??= new ExcelTabularWriteOptions();
+            DirectDataSetTableModel tableModel;
+            if (CanWriteObjectRowsSinglePass(options)) {
+                tableModel = DirectDataSetTableModel.FromStreamingTypedObjectRows(
+                    items,
+                    columns,
+                    GetMaximumDataRows(options));
+            } else {
+                var rows = items as IReadOnlyList<T> ?? items.ToList();
+                tableModel = DirectDataSetTableModel.FromTypedObjectRows(rows, columns);
+            }
             return WriteTabularModel(stream, tableModel, options, ct);
         }
+
+        private static bool CanWriteObjectRowsSinglePass(ExcelTabularWriteOptions options) =>
+            !options.UseSharedStrings
+            && !options.CreateTable
+            && !options.AutoFit;
+
+        private static int GetMaximumDataRows(ExcelTabularWriteOptions options) =>
+            A1.MaxRows - (options.IncludeHeaders ? 1 : 0);
 
         /// <summary>
         /// Writes an open data reader directly to an XLSX package without creating an editable workbook object.
@@ -248,7 +290,22 @@ namespace OfficeIMO.Excel {
                 stream.Seek(0, SeekOrigin.Begin);
             }
 
-            return model.Results[0];
+            ExcelDataSetImportResult result = model.Results[0];
+            if (result.RowCount == tableModel.RowCount) {
+                return result;
+            }
+
+            string finalRange = ExcelSheet.BuildObjectExportRange(
+                1,
+                tableModel.ColumnCount,
+                tableModel.RowCount,
+                options.IncludeHeaders);
+            return new ExcelDataSetImportResult(
+                sheetName,
+                tableName: null,
+                finalRange,
+                tableModel.RowCount,
+                tableModel.ColumnCount);
         }
     }
 }

--- a/OfficeIMO.Excel/LegacyXls/Biff/BiffRkNumberReader.cs
+++ b/OfficeIMO.Excel/LegacyXls/Biff/BiffRkNumberReader.cs
@@ -1,17 +1,15 @@
+using System.Runtime.CompilerServices;
+
 namespace OfficeIMO.Excel.LegacyXls.Biff {
     internal static class BiffRkNumberReader {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static double ReadRkNumber(uint rawValue) {
             bool divideBy100 = (rawValue & 0x01) != 0;
             bool isInteger = (rawValue & 0x02) != 0;
             double value;
 
             if (isInteger) {
-                int integerValue = (int)(rawValue >> 2);
-                if ((integerValue & 0x20000000) != 0) {
-                    integerValue |= unchecked((int)0xc0000000);
-                }
-
-                value = integerValue;
+                value = unchecked((int)rawValue) >> 2;
             } else {
                 ulong doubleBits = ((ulong)(rawValue & 0xfffffffc)) << 32;
                 value = BitConverter.Int64BitsToDouble(unchecked((long)doubleBits));

--- a/OfficeIMO.Excel/LegacyXls/Read/LegacyBiffSource.cs
+++ b/OfficeIMO.Excel/LegacyXls/Read/LegacyBiffSource.cs
@@ -56,6 +56,12 @@ namespace OfficeIMO.Excel.LegacyXls.Read {
 
         internal int Length { get; }
 
+        /// <summary>
+        /// Gets the contiguous workbook buffer when the source was small enough to load eagerly.
+        /// Callers must treat the pooled buffer as immutable and observe <see cref="Length"/>.
+        /// </summary>
+        internal byte[]? ContiguousBuffer => _buffer;
+
         internal byte this[int offset] => ReadByte(offset);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/OfficeIMO.Excel/LegacyXls/Read/LegacyXlsTabularDataReader.cs
+++ b/OfficeIMO.Excel/LegacyXls/Read/LegacyXlsTabularDataReader.cs
@@ -1,7 +1,10 @@
 using OfficeIMO.Excel.LegacyXls.Biff;
 using OfficeIMO.Excel.LegacyXls.Projection;
+using System.Buffers;
+using System.Buffers.Binary;
 using System.Data.Common;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using static OfficeIMO.Excel.LegacyXls.Read.LegacyXlsTabularWorkbook;
 
@@ -12,6 +15,7 @@ namespace OfficeIMO.Excel.LegacyXls.Read {
     /// </summary>
     internal sealed partial class LegacyXlsTabularDataReader : DbDataReader {
         private readonly LegacyBiffSource _bytes;
+        private readonly byte[]? _bufferedBytes;
         private readonly IReadOnlyList<string> _sharedStrings;
         private readonly bool[] _dateStyles;
         private readonly bool _uses1904DateSystem;
@@ -26,6 +30,8 @@ namespace OfficeIMO.Excel.LegacyXls.Read {
         private readonly int _firstColumn;
         private readonly int _firstDataRow;
         private readonly int _lastDataRow;
+        private int[]? _bufferedRowOffsets;
+        private readonly int _bufferedWorksheetEndOffset;
         private int _position;
         private int _nextRow;
         private int _recordsSinceCancellationCheck;
@@ -42,49 +48,65 @@ namespace OfficeIMO.Excel.LegacyXls.Read {
             ExcelReadOptions options,
             CancellationToken cancellationToken) {
             _bytes = bytes ?? throw new ArgumentNullException(nameof(bytes));
+            _bufferedBytes = bytes.ContiguousBuffer;
             _sharedStrings = sharedStrings ?? throw new ArgumentNullException(nameof(sharedStrings));
             _dateStyles = dateStyles ?? throw new ArgumentNullException(nameof(dateStyles));
             _uses1904DateSystem = uses1904DateSystem;
             _options = options ?? throw new ArgumentNullException(nameof(options));
             _cancellationToken = cancellationToken;
 
-            Discover(
-                sheetOffset,
-                out int firstRow,
-                out int lastRow,
-                out int firstColumn,
-                out int lastColumn,
-                out Dictionary<int, string?>? headerValues);
-            _firstColumn = firstColumn;
-            _firstDataRow = hasHeaderRow && firstRow >= 0 ? checked(firstRow + 1) : firstRow;
-            _lastDataRow = lastRow;
-            _position = sheetOffset;
-            _nextRow = _firstDataRow;
+            int[]? bufferedRowOffsets = _bufferedBytes != null
+                ? ArrayPool<int>.Shared.Rent(ushort.MaxValue + 1)
+                : null;
+            int bufferedWorksheetEndOffset;
+            try {
+                Discover(
+                    sheetOffset,
+                    bufferedRowOffsets,
+                    out bufferedWorksheetEndOffset,
+                    out int firstRow,
+                    out int lastRow,
+                    out int firstColumn,
+                    out int lastColumn,
+                    out Dictionary<int, string?>? headerValues);
+                _bufferedRowOffsets = bufferedRowOffsets;
+                _bufferedWorksheetEndOffset = bufferedWorksheetEndOffset;
+                _firstColumn = firstColumn;
+                _firstDataRow = hasHeaderRow && firstRow >= 0 ? checked(firstRow + 1) : firstRow;
+                _lastDataRow = lastRow;
+                _position = sheetOffset;
+                _nextRow = _firstDataRow;
 
-            int fieldCount = lastColumn >= firstColumn
-                ? checked(lastColumn - firstColumn + 1)
-                : 0;
-            if (fieldCount > options.MaxDataReaderColumns) {
-                throw new InvalidDataException(
-                    $"XLS table column count {fieldCount} exceeds the configured limit of {options.MaxDataReaderColumns}.");
-            }
-            _headers = ExcelHeaderNameHelper.BuildUniqueHeaders(
-                fieldCount,
-                ordinal => hasHeaderRow
-                    && headerValues != null
-                    && headerValues.TryGetValue(ordinal + firstColumn, out string? value)
-                        ? value
-                        : null,
-                options.NormalizeHeaders);
-            _ordinals = new Dictionary<string, int>(_headers.Length, StringComparer.OrdinalIgnoreCase);
-            for (int index = 0; index < _headers.Length; index++) {
-                _ordinals[_headers[index]] = index;
-            }
+                int fieldCount = lastColumn >= firstColumn
+                    ? checked(lastColumn - firstColumn + 1)
+                    : 0;
+                if (fieldCount > options.MaxDataReaderColumns) {
+                    throw new InvalidDataException(
+                        $"XLS table column count {fieldCount} exceeds the configured limit of {options.MaxDataReaderColumns}.");
+                }
+                _headers = ExcelHeaderNameHelper.BuildUniqueHeaders(
+                    fieldCount,
+                    ordinal => hasHeaderRow
+                        && headerValues != null
+                        && headerValues.TryGetValue(ordinal + firstColumn, out string? value)
+                            ? value
+                            : null,
+                    options.NormalizeHeaders);
+                _ordinals = new Dictionary<string, int>(_headers.Length, StringComparer.OrdinalIgnoreCase);
+                for (int index = 0; index < _headers.Length; index++) {
+                    _ordinals[_headers[index]] = index;
+                }
 
-            _kinds = new ValueKind[fieldCount];
-            _numbers = new double[fieldCount];
-            _booleans = new bool[fieldCount];
-            _strings = new string?[fieldCount];
+                _kinds = new ValueKind[fieldCount];
+                _numbers = new double[fieldCount];
+                _booleans = new bool[fieldCount];
+                _strings = new string?[fieldCount];
+            } catch {
+                if (bufferedRowOffsets != null) {
+                    ArrayPool<int>.Shared.Return(bufferedRowOffsets);
+                }
+                throw;
+            }
         }
 
         public override object this[int ordinal] => GetValue(ordinal);
@@ -107,6 +129,39 @@ namespace OfficeIMO.Excel.LegacyXls.Read {
             int pendingFormulaOrdinal = -1;
             ushort pendingFormulaStyle = 0;
 
+            if (_bufferedBytes != null) {
+                int[] rowOffsets = _bufferedRowOffsets!;
+                int rowStartMarker = rowOffsets[currentRow];
+                if (rowStartMarker == 0) {
+                    _hasCurrentRow = true;
+                    return true;
+                }
+                int rowEnd = _bufferedWorksheetEndOffset;
+                for (int nextRow = currentRow + 1; nextRow <= _lastDataRow; nextRow++) {
+                    int nextMarker = rowOffsets[nextRow];
+                    if (nextMarker != 0) {
+                        rowEnd = nextMarker - 1;
+                        break;
+                    }
+                }
+                ReadBufferedCurrentRow(
+                    _bufferedBytes,
+                    rowStartMarker - 1,
+                    rowEnd,
+                    ref pendingFormulaOrdinal,
+                    ref pendingFormulaStyle);
+            } else {
+                ReadPagedCurrentRow(currentRow, ref pendingFormulaOrdinal, ref pendingFormulaStyle);
+            }
+
+            _hasCurrentRow = true;
+            return true;
+        }
+
+        private void ReadPagedCurrentRow(
+            int currentRow,
+            ref int pendingFormulaOrdinal,
+            ref ushort pendingFormulaStyle) {
             while (true) {
                 int recordOffset = _position;
                 if (!TryReadRecord(_bytes, ref _position, out RecordSlice record)) {
@@ -136,9 +191,53 @@ namespace OfficeIMO.Excel.LegacyXls.Read {
 
                 StoreCellRecord(record, ref pendingFormulaOrdinal, ref pendingFormulaStyle);
             }
+        }
 
-            _hasCurrentRow = true;
-            return true;
+        private void ReadBufferedCurrentRow(
+            byte[] bytes,
+            int rowStart,
+            int rowEnd,
+            ref int pendingFormulaOrdinal,
+            ref ushort pendingFormulaStyle) {
+            bool checkCancellation = _cancellationToken.CanBeCanceled;
+            _position = rowStart;
+            while (_position < rowEnd) {
+                int recordOffset = _position;
+                ushort type = (ushort)(bytes[recordOffset] | bytes[recordOffset + 1] << 8);
+                int length = bytes[recordOffset + 2] | bytes[recordOffset + 3] << 8;
+                int payloadOffset = recordOffset + 4;
+                _position = payloadOffset + length;
+                if (checkCancellation) {
+                    CheckCancellation();
+                }
+
+                if (pendingFormulaOrdinal >= 0) {
+                    if (type != (ushort)BiffRecordType.String) {
+                        throw MissingFormulaString();
+                    }
+                    StoreFormulaString(
+                        new RecordSlice(type, recordOffset, payloadOffset, length),
+                        pendingFormulaOrdinal,
+                        pendingFormulaStyle,
+                        ref _position);
+                    pendingFormulaOrdinal = -1;
+                    continue;
+                }
+                if (type == (ushort)BiffRecordType.Eof) break;
+
+                if (!IsCellRecordType(type)) continue;
+                StoreBufferedCellRecord(
+                    bytes,
+                    type,
+                    recordOffset,
+                    payloadOffset,
+                    length,
+                    ref pendingFormulaOrdinal,
+                    ref pendingFormulaStyle);
+            }
+            if (pendingFormulaOrdinal >= 0) {
+                throw MissingFormulaString();
+            }
         }
 
         public override bool NextResult() => false;
@@ -146,6 +245,10 @@ namespace OfficeIMO.Excel.LegacyXls.Read {
         public override void Close() {
             _closed = true;
             _hasCurrentRow = false;
+            int[]? rowOffsets = Interlocked.Exchange(ref _bufferedRowOffsets, null);
+            if (rowOffsets != null) {
+                ArrayPool<int>.Shared.Return(rowOffsets);
+            }
         }
 
         protected override void Dispose(bool disposing) {
@@ -155,6 +258,8 @@ namespace OfficeIMO.Excel.LegacyXls.Read {
 
         private void Discover(
             int sheetOffset,
+            int[]? bufferedRowOffsets,
+            out int bufferedWorksheetEndOffset,
             out int firstRow,
             out int lastRow,
             out int firstColumn,
@@ -169,10 +274,14 @@ namespace OfficeIMO.Excel.LegacyXls.Read {
             bool sawEof = false;
             int pendingHeaderColumn = -1;
             int previousCellRow = -1;
+            bool checkCancellation = _cancellationToken.CanBeCanceled;
+            bufferedWorksheetEndOffset = -1;
             headerValues = null;
 
-            while (TryReadRecord(_bytes, ref offset, out RecordSlice record)) {
-                CheckCancellation();
+            while (TryReadDiscoveryRecord(ref offset, out RecordSlice record)) {
+                if (checkCancellation) {
+                    CheckCancellation();
+                }
                 if (!sawBof) {
                     if (record.Type != (ushort)BiffRecordType.Bof || record.Length < 4) {
                         throw new InvalidDataException("The XLS worksheet stream is missing a valid BOF record.");
@@ -195,6 +304,7 @@ namespace OfficeIMO.Excel.LegacyXls.Read {
                 }
                 if (record.Type == (ushort)BiffRecordType.Eof) {
                     sawEof = true;
+                    bufferedWorksheetEndOffset = record.Offset;
                     break;
                 }
                 if (!TryGetCellBounds(record, out int row, out int recordFirstColumn, out int recordLastColumn)) {
@@ -203,6 +313,13 @@ namespace OfficeIMO.Excel.LegacyXls.Read {
                 if (row < previousCellRow) {
                     throw new InvalidDataException(
                         $"The XLS worksheet contains decreasing cell row index {row} after row {previousCellRow}.");
+                }
+                if (bufferedRowOffsets != null && row != previousCellRow) {
+                    int firstUninitializedRow = previousCellRow < 0 ? row : previousCellRow + 1;
+                    for (int missingRow = firstUninitializedRow; missingRow < row; missingRow++) {
+                        bufferedRowOffsets[missingRow] = 0;
+                    }
+                    bufferedRowOffsets[row] = record.Offset + 1;
                 }
                 previousCellRow = row;
 
@@ -216,7 +333,7 @@ namespace OfficeIMO.Excel.LegacyXls.Read {
                         pendingHeaderColumn = recordFirstColumn;
                     }
                 }
-                lastRow = Math.Max(lastRow, row);
+                lastRow = row;
                 firstColumn = Math.Min(firstColumn, recordFirstColumn);
                 lastColumn = Math.Max(lastColumn, recordLastColumn);
             }
@@ -247,16 +364,16 @@ namespace OfficeIMO.Excel.LegacyXls.Read {
                 case BiffRecordType.Number:
                 case BiffRecordType.Rk:
                     if (record.Length < 6) throw TruncatedCell(record);
-                    row = ReadUInt16(_bytes, record.PayloadOffset);
-                    firstColumn = ReadUInt16(_bytes, record.PayloadOffset + 2);
+                    row = ReadDiscoveryUInt16(record.PayloadOffset);
+                    firstColumn = ReadDiscoveryUInt16(record.PayloadOffset + 2);
                     lastColumn = firstColumn;
                     return true;
                 case BiffRecordType.MulBlank:
                 case BiffRecordType.MulRk:
                     if (record.Length < 6) throw TruncatedCell(record);
-                    row = ReadUInt16(_bytes, record.PayloadOffset);
-                    firstColumn = ReadUInt16(_bytes, record.PayloadOffset + 2);
-                    lastColumn = ReadUInt16(_bytes, record.PayloadOffset + record.Length - 2);
+                    row = ReadDiscoveryUInt16(record.PayloadOffset);
+                    firstColumn = ReadDiscoveryUInt16(record.PayloadOffset + 2);
+                    lastColumn = ReadDiscoveryUInt16(record.PayloadOffset + record.Length - 2);
                     if (lastColumn < firstColumn) throw new InvalidDataException("A BIFF multiple-cell record has an invalid column range.");
                     int cellCount = checked(lastColumn - firstColumn + 1);
                     int bytesPerCell = record.Type == (ushort)BiffRecordType.MulBlank ? 2 : 6;
@@ -270,6 +387,56 @@ namespace OfficeIMO.Excel.LegacyXls.Read {
                     return false;
             }
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool TryReadDiscoveryRecord(ref int offset, out RecordSlice record) {
+            byte[]? bytes = _bufferedBytes;
+            if (bytes == null) {
+                return TryReadRecord(_bytes, ref offset, out record);
+            }
+
+            int sourceLength = _bytes.Length;
+            if (offset == sourceLength) {
+                record = default;
+                return false;
+            }
+            if (offset < 0 || offset > sourceLength - 4) {
+                throw new InvalidDataException("The BIFF stream ended inside a record header.");
+            }
+
+            int recordOffset = offset;
+            ushort type = (ushort)(bytes[offset] | bytes[offset + 1] << 8);
+            int length = bytes[offset + 2] | bytes[offset + 3] << 8;
+            int payloadOffset = offset + 4;
+            if (length > sourceLength - payloadOffset) {
+                throw new InvalidDataException(
+                    $"BIFF record 0x{type:X4} at offset {recordOffset} declares {length} payload bytes, but the stream ends early.");
+            }
+
+            offset = payloadOffset + length;
+            record = new RecordSlice(type, recordOffset, payloadOffset, length);
+            return true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private ushort ReadDiscoveryUInt16(int offset) {
+            byte[]? bytes = _bufferedBytes;
+            return bytes != null
+                ? (ushort)(bytes[offset] | bytes[offset + 1] << 8)
+                : ReadUInt16(_bytes, offset);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsCellRecordType(ushort type) =>
+            type == (ushort)BiffRecordType.Blank
+            || type == (ushort)BiffRecordType.BoolErr
+            || type == (ushort)BiffRecordType.Formula
+            || type == (ushort)BiffRecordType.Label
+            || type == (ushort)BiffRecordType.LabelSst
+            || type == (ushort)BiffRecordType.Number
+            || type == (ushort)BiffRecordType.Rk
+            || type == (ushort)BiffRecordType.MulBlank
+            || type == (ushort)BiffRecordType.MulRk;
 
         private void ReadHeaderCells(RecordSlice record, IDictionary<int, string?> values) {
             if (record.Type == (ushort)BiffRecordType.MulRk) {
@@ -387,6 +554,76 @@ namespace OfficeIMO.Excel.LegacyXls.Read {
             }
         }
 
+        private void StoreBufferedCellRecord(
+            byte[] bytes,
+            ushort type,
+            int recordOffset,
+            int payloadOffset,
+            int length,
+            ref int pendingFormulaOrdinal,
+            ref ushort pendingFormulaStyle) {
+            if (type == (ushort)BiffRecordType.MulRk) {
+                StoreBufferedMulRk(bytes, payloadOffset, length);
+                return;
+            }
+            if (type == (ushort)BiffRecordType.MulBlank) return;
+
+            if (length < 6) {
+                throw TruncatedCell(new RecordSlice(type, recordOffset, payloadOffset, length));
+            }
+
+            int column = bytes[payloadOffset + 2] | bytes[payloadOffset + 3] << 8;
+            int ordinal = column - _firstColumn;
+            ushort style = (ushort)(bytes[payloadOffset + 4] | bytes[payloadOffset + 5] << 8);
+            switch ((BiffRecordType)type) {
+                case BiffRecordType.Blank:
+                    _kinds[ordinal] = ValueKind.Empty;
+                    break;
+                case BiffRecordType.LabelSst:
+                    if (length < 10) throw TruncatedCell(new RecordSlice(type, recordOffset, payloadOffset, length));
+                    _kinds[ordinal] = ValueKind.Text;
+                    _strings[ordinal] = GetSharedString(BinaryPrimitives.ReadUInt32LittleEndian(
+                        bytes.AsSpan(payloadOffset + 6, sizeof(uint))));
+                    break;
+                case BiffRecordType.Label: {
+                    var record = new RecordSlice(type, recordOffset, payloadOffset, length);
+                    _kinds[ordinal] = ValueKind.Text;
+                    _strings[ordinal] = ReadLabel(record);
+                    break;
+                }
+                case BiffRecordType.Number:
+                    if (length < 14) throw TruncatedCell(new RecordSlice(type, recordOffset, payloadOffset, length));
+                    StoreNumber(ordinal, ReadBufferedDouble(bytes, payloadOffset + 6), style);
+                    break;
+                case BiffRecordType.Rk:
+                    if (length < 10) throw TruncatedCell(new RecordSlice(type, recordOffset, payloadOffset, length));
+                    StoreNumber(
+                        ordinal,
+                        BiffRkNumberReader.ReadRkNumber(BinaryPrimitives.ReadUInt32LittleEndian(
+                            bytes.AsSpan(payloadOffset + 6, sizeof(uint)))),
+                        style);
+                    break;
+                case BiffRecordType.BoolErr:
+                    if (length < 8) throw TruncatedCell(new RecordSlice(type, recordOffset, payloadOffset, length));
+                    if (bytes[payloadOffset + 7] != 0) {
+                        _kinds[ordinal] = ValueKind.Error;
+                        _strings[ordinal] = BiffErrorValue.ToText(bytes[payloadOffset + 6]);
+                    } else {
+                        _kinds[ordinal] = ValueKind.Boolean;
+                        _booleans[ordinal] = bytes[payloadOffset + 6] != 0;
+                    }
+                    break;
+                case BiffRecordType.Formula:
+                    StoreFormula(
+                        new RecordSlice(type, recordOffset, payloadOffset, length),
+                        ordinal,
+                        style,
+                        ref pendingFormulaOrdinal,
+                        ref pendingFormulaStyle);
+                    break;
+            }
+        }
+
         private void StoreMulRk(RecordSlice record) {
             int payload = record.PayloadOffset;
             int firstColumn = ReadUInt16(_bytes, payload + 2);
@@ -403,6 +640,25 @@ namespace OfficeIMO.Excel.LegacyXls.Read {
                     ReadUInt16(_bytes, cellOffset));
             }
         }
+
+        private void StoreBufferedMulRk(byte[] bytes, int payloadOffset, int length) {
+            int firstColumn = bytes[payloadOffset + 2] | bytes[payloadOffset + 3] << 8;
+            int count = (length - 6) / 6;
+            int ordinal = firstColumn - _firstColumn;
+            int cellOffset = payloadOffset + 4;
+            for (int index = 0; index < count; index++, ordinal++, cellOffset += 6) {
+                StoreNumber(
+                    ordinal,
+                    BiffRkNumberReader.ReadRkNumber(BinaryPrimitives.ReadUInt32LittleEndian(
+                        bytes.AsSpan(cellOffset + 2, sizeof(uint)))),
+                    BinaryPrimitives.ReadUInt16LittleEndian(bytes.AsSpan(cellOffset, sizeof(ushort))));
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static double ReadBufferedDouble(byte[] bytes, int offset) =>
+            BitConverter.Int64BitsToDouble(BinaryPrimitives.ReadInt64LittleEndian(
+                bytes.AsSpan(offset, sizeof(long))));
 
         private void StoreFormula(
             RecordSlice record,
@@ -465,6 +721,7 @@ namespace OfficeIMO.Excel.LegacyXls.Read {
             return ReadUInt16(_bytes, result + 6) == ushort.MaxValue && _bytes[result] == 0;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void StoreNumber(int ordinal, double number, ushort style) {
             bool isDate = _options.TreatDatesUsingNumberFormat
                 && style < _dateStyles.Length

--- a/OfficeIMO.Excel/Xlsb/Read/XlsbRecordSliceReader.cs
+++ b/OfficeIMO.Excel/Xlsb/Read/XlsbRecordSliceReader.cs
@@ -32,6 +32,10 @@ namespace OfficeIMO.Excel.Xlsb.Read {
 
         internal int Position { get; set; }
 
+        internal byte[] Buffer => _bytes;
+
+        internal int Length => _length;
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal bool TryRead(out XlsbRecordSlice record) {
             if (Position == _length) {
@@ -71,6 +75,68 @@ namespace OfficeIMO.Excel.Xlsb.Read {
                 _budget.Consume();
             }
             record = new XlsbRecordSlice(_bytes, recordOffset, type, payloadOffset, size);
+            return true;
+        }
+
+        /// <summary>
+        /// Frames the next record after a complete validation pass over the same immutable
+        /// buffer. The validation pass has already proved canonical headers, payload bounds,
+        /// and record-size limits, so delivery only needs to decode the framing bytes.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal bool TryReadValidated(out XlsbRecordSlice record) {
+            if (!TryReadValidated(
+                    out int recordOffset,
+                    out int type,
+                    out int payloadOffset,
+                    out int size)) {
+                record = default;
+                return false;
+            }
+
+            record = new XlsbRecordSlice(_bytes, recordOffset, type, payloadOffset, size);
+            return true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal bool TryReadValidated(
+            out int recordOffset,
+            out int type,
+            out int payloadOffset,
+            out int size) {
+            int position = Position;
+            if (position == _length) {
+                recordOffset = 0;
+                type = 0;
+                payloadOffset = 0;
+                size = 0;
+                return false;
+            }
+
+            recordOffset = position;
+            int firstTypeByte = _bytes[position++];
+            type = firstTypeByte & 0x7F;
+            if ((firstTypeByte & 0x80) != 0) {
+                type |= (_bytes[position++] & 0x7F) << 7;
+            }
+
+            int current = _bytes[position++];
+            size = current & 0x7F;
+            if ((current & 0x80) != 0) {
+                current = _bytes[position++];
+                size |= (current & 0x7F) << 7;
+                if ((current & 0x80) != 0) {
+                    current = _bytes[position++];
+                    size |= (current & 0x7F) << 14;
+                    if ((current & 0x80) != 0) {
+                        current = _bytes[position++];
+                        size |= (current & 0x7F) << 21;
+                    }
+                }
+            }
+
+            payloadOffset = position;
+            Position = position + size;
             return true;
         }
 

--- a/OfficeIMO.Excel/Xlsb/Read/XlsbTabularDataReader.Discovery.cs
+++ b/OfficeIMO.Excel/Xlsb/Read/XlsbTabularDataReader.Discovery.cs
@@ -1,6 +1,7 @@
 using OfficeIMO.Excel.Xlsb.Biff12;
 using OfficeIMO.Excel.Xlsb.Package;
 using System.Buffers.Binary;
+using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace OfficeIMO.Excel.Xlsb.Read {
@@ -154,6 +155,9 @@ namespace OfficeIMO.Excel.Xlsb.Read {
                                 "The XLSB worksheet contains BrtEndSheetData without a matching BrtBeginSheetData record.");
                         }
 
+                        if (previousCellColumn > lastColumn) {
+                            lastColumn = previousCellColumn;
+                        }
                         sawEndSheetData = true;
                         inSheetData = false;
                         currentRow = -1;
@@ -168,6 +172,9 @@ namespace OfficeIMO.Excel.Xlsb.Read {
                         continue;
                     }
                     if (recordType == BrtRowHdr) {
+                        if (previousCellColumn > lastColumn) {
+                            lastColumn = previousCellColumn;
+                        }
                         int nextRow = ValidateRowHeader(
                             new XlsbRecordSlice(
                                 bytes,
@@ -202,17 +209,13 @@ namespace OfficeIMO.Excel.Xlsb.Read {
                     if (!useCachedFormulaResult) {
                         EnsureFormulaModeSupported(recordType, useCachedFormulaResult);
                     }
-                    if (firstDataRow < 0) {
-                        firstDataRow = currentRow;
-                    }
-                    lastDataRow = currentRow;
                     int column;
                     if (recordSize >= sizeof(int) + sizeof(uint)
                         && recordType is >= BrtCellBlank and <= BrtCellIsst) {
-                        column = BinaryPrimitives.ReadInt32LittleEndian(
-                            bytes.AsSpan(payloadOffset, sizeof(int)));
-                        uint styleIndex = BinaryPrimitives.ReadUInt32LittleEndian(
-                            bytes.AsSpan(payloadOffset + sizeof(int), sizeof(uint))) & 0x00FFFFFFU;
+                        ref byte payload = ref bytes[payloadOffset];
+                        column = Unsafe.ReadUnaligned<int>(ref payload);
+                        uint styleIndex = Unsafe.ReadUnaligned<uint>(
+                            ref Unsafe.Add(ref payload, sizeof(int))) & 0x00FFFFFFU;
                         if (styleIndex >= styleCount) {
                             throw new InvalidDataException(
                                 $"The XLSB cell record at offset {recordOffset} refers to missing cell format " +
@@ -229,8 +232,8 @@ namespace OfficeIMO.Excel.Xlsb.Read {
                             _ => false
                         };
                         if (validFixedPayload && recordType == BrtCellIsst) {
-                            uint sharedStringIndex = BinaryPrimitives.ReadUInt32LittleEndian(
-                                bytes.AsSpan(payloadOffset + sizeof(int) + sizeof(uint), sizeof(uint)));
+                            uint sharedStringIndex = Unsafe.ReadUnaligned<uint>(
+                                ref Unsafe.Add(ref payload, sizeof(int) + sizeof(uint)));
                             if (sharedStringIndex >= sharedStringCount) {
                                 throw new InvalidDataException(
                                     $"The XLSB cell record at offset {recordOffset} refers to missing shared string " +
@@ -265,7 +268,8 @@ namespace OfficeIMO.Excel.Xlsb.Read {
                         throw new InvalidDataException(
                             $"The XLSB cell record at offset {recordOffset} contains invalid column index {column}.");
                     }
-                    if (column <= previousCellColumn) {
+                    bool firstCellInRow = previousCellColumn < 0;
+                    if (!firstCellInRow && column <= previousCellColumn) {
                         throw new InvalidDataException(
                             $"The XLSB cell record at offset {recordOffset} is duplicated or out of order within its row.");
                     }
@@ -278,11 +282,14 @@ namespace OfficeIMO.Excel.Xlsb.Read {
                             $"The XLSB cell record at offset {recordOffset} for column {column} is not covered by its BrtRowHdr column spans.");
                     }
 
-                    if (column < firstColumn) {
-                        firstColumn = column;
-                    }
-                    if (column > lastColumn) {
-                        lastColumn = column;
+                    if (firstCellInRow) {
+                        if (firstDataRow < 0) {
+                            firstDataRow = currentRow;
+                        }
+                        lastDataRow = currentRow;
+                        if (column < firstColumn) {
+                            firstColumn = column;
+                        }
                     }
                 }
 

--- a/OfficeIMO.Excel/Xlsb/Read/XlsbTabularDataReader.FastCells.cs
+++ b/OfficeIMO.Excel/Xlsb/Read/XlsbTabularDataReader.FastCells.cs
@@ -1,12 +1,15 @@
 using OfficeIMO.Excel.LegacyXls.Biff;
 using System.Buffers.Binary;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace OfficeIMO.Excel.Xlsb.Read {
     internal sealed partial class XlsbTabularDataReader {
         private void StoreCellFast(XlsbRecordSlice record) {
-            byte[] bytes = record.Bytes;
-            int position = record.PayloadOffset;
+            StoreCellFast(record.Bytes, record.Type, record.PayloadOffset);
+        }
+
+        private void StoreCellFast(byte[] bytes, int recordType, int position) {
             int column = BinaryPrimitives.ReadInt32LittleEndian(bytes.AsSpan(position, sizeof(int)));
             uint styleIndex = BinaryPrimitives.ReadUInt32LittleEndian(bytes.AsSpan(position + sizeof(int), sizeof(uint)))
                 & 0x00FFFFFFU;
@@ -18,7 +21,7 @@ namespace OfficeIMO.Excel.Xlsb.Read {
                     $"The XLSB row contains column {column} outside the schema established by its header or worksheet dimension.");
             }
 
-            switch (record.Type) {
+            switch (recordType) {
                 case BrtCellBlank:
                     _kinds[ordinal] = XlsbTabularValueKind.Empty;
                     break;
@@ -79,8 +82,42 @@ namespace OfficeIMO.Excel.Xlsb.Read {
                     _strings[ordinal] = BiffErrorValue.ToText(bytes[position]);
                     break;
                 default:
-                    throw new InvalidOperationException($"Unsupported XLSB cell record type {record.Type}.");
+                    throw new InvalidOperationException($"Unsupported XLSB cell record type {recordType}.");
             }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void StoreValidatedRkCell(byte[] bytes, int position) {
+            ref byte payload = ref bytes[position];
+            int ordinal = Unsafe.ReadUnaligned<int>(ref payload) - _firstColumn;
+            uint styleIndex = Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref payload, sizeof(int)))
+                & 0x00FFFFFFU;
+            double number = BiffRkNumberReader.ReadRkNumber(
+                Unsafe.ReadUnaligned<uint>(
+                    ref Unsafe.Add(ref payload, sizeof(int) + sizeof(uint))));
+            StoreNumber(ordinal, number, styleIndex);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void StoreValidatedRealCell(byte[] bytes, int position) {
+            ref byte payload = ref bytes[position];
+            int ordinal = Unsafe.ReadUnaligned<int>(ref payload) - _firstColumn;
+            uint styleIndex = Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref payload, sizeof(int)))
+                & 0x00FFFFFFU;
+            double number = BitConverter.Int64BitsToDouble(
+                Unsafe.ReadUnaligned<long>(
+                    ref Unsafe.Add(ref payload, sizeof(int) + sizeof(uint))));
+            StoreNumber(ordinal, number, styleIndex);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void StoreValidatedSharedStringCell(byte[] bytes, int position) {
+            ref byte payload = ref bytes[position];
+            int ordinal = Unsafe.ReadUnaligned<int>(ref payload) - _firstColumn;
+            uint sharedStringIndex = Unsafe.ReadUnaligned<uint>(
+                ref Unsafe.Add(ref payload, sizeof(int) + sizeof(uint)));
+            _kinds[ordinal] = XlsbTabularValueKind.Text;
+            _strings[ordinal] = _sharedStrings[(int)sharedStringIndex];
         }
 
         private static string ReadValidatedWideString(byte[] bytes, int position) {
@@ -92,9 +129,9 @@ namespace OfficeIMO.Excel.Xlsb.Read {
                 checked(characterCount * sizeof(char)));
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void StoreNumber(int ordinal, double number, uint styleIndex) {
             bool isDate = _options.TreatDatesUsingNumberFormat
-                && styleIndex < _dateStyles.Length
                 && _dateStyles[styleIndex];
             _kinds[ordinal] = isDate ? XlsbTabularValueKind.Date : XlsbTabularValueKind.Number;
             _numbers[ordinal] = number;

--- a/OfficeIMO.Excel/Xlsb/Read/XlsbTabularDataReader.Rows.cs
+++ b/OfficeIMO.Excel/Xlsb/Read/XlsbTabularDataReader.Rows.cs
@@ -1,31 +1,79 @@
+using System.Runtime.CompilerServices;
+
 namespace OfficeIMO.Excel.Xlsb.Read {
     internal sealed partial class XlsbTabularDataReader {
         private bool ReadCurrentRowRecordsFast() {
             bool checkCancellation = _cancellationToken.CanBeCanceled;
-            while (_records.TryRead(out XlsbRecordSlice record)) {
+            byte[] bytes = _records.Buffer;
+            int position = _records.Position;
+            int length = _records.Length;
+            while (position < length) {
+                int firstTypeByte = bytes[position++];
+                int recordType = firstTypeByte & 0x7F;
+                if ((firstTypeByte & 0x80) != 0) {
+                    recordType |= (bytes[position++] & 0x7F) << 7;
+                }
+
+                int current = bytes[position++];
+                int recordSize = current & 0x7F;
+                if ((current & 0x80) != 0) {
+                    current = bytes[position++];
+                    recordSize |= (current & 0x7F) << 7;
+                    if ((current & 0x80) != 0) {
+                        current = bytes[position++];
+                        recordSize |= (current & 0x7F) << 14;
+                        if ((current & 0x80) != 0) {
+                            current = bytes[position++];
+                            recordSize |= (current & 0x7F) << 21;
+                        }
+                    }
+                }
+
+                int payloadOffset = position;
+                position += recordSize;
                 if (checkCancellation) {
                     CheckCancellation();
                 }
-                if (record.Type == BrtRowHdr) {
-                    if (TrySetPendingRow(record)) {
+                if (recordType == BrtRowHdr) {
+                    int rowIndex = Unsafe.ReadUnaligned<int>(ref bytes[payloadOffset]);
+                    if (rowIndex <= _lastDataRow) {
+                        _pendingRowIndex = rowIndex;
+                        _hasPendingRow = true;
+                        _records.Position = position;
                         return true;
                     }
                     continue;
                 }
-                if (record.Type == BrtEndSheetData) {
+                if (recordType == BrtEndSheetData) {
                     _reachedEndSheetData = true;
+                    _records.Position = position;
                     return true;
                 }
-                if (IsCellRecord(record.Type)) {
-                    StoreCellFast(record);
+                switch (recordType) {
+                    case BrtCellRk:
+                        StoreValidatedRkCell(bytes, payloadOffset);
+                        break;
+                    case BrtCellReal:
+                        StoreValidatedRealCell(bytes, payloadOffset);
+                        break;
+                    case BrtCellIsst:
+                        StoreValidatedSharedStringCell(bytes, payloadOffset);
+                        break;
+                    default:
+                        if (IsCellRecord(recordType)) {
+                            StoreCellFast(bytes, recordType, payloadOffset);
+                        }
+                        break;
                 }
             }
+
+            _records.Position = position;
             return false;
         }
 
         private bool ReadCurrentRowRecordsConverted() {
             bool checkCancellation = _cancellationToken.CanBeCanceled;
-            while (_records.TryRead(out XlsbRecordSlice record)) {
+            while (_records.TryReadValidated(out XlsbRecordSlice record)) {
                 if (checkCancellation) {
                     CheckCancellation();
                 }

--- a/OfficeIMO.Excel/Xlsb/Read/XlsbTabularDataReader.Values.cs
+++ b/OfficeIMO.Excel/Xlsb/Read/XlsbTabularDataReader.Values.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Data;
 using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 namespace OfficeIMO.Excel.Xlsb.Read {
     internal sealed partial class XlsbTabularDataReader {
@@ -135,9 +136,17 @@ namespace OfficeIMO.Excel.Xlsb.Read {
 
         public override decimal GetDecimal(int ordinal) {
             ValidateReadableOrdinal(ordinal);
-            return IsNumericValueKind(_kinds[ordinal])
-                ? ConvertExcelNumberToDecimal(_numbers[ordinal])
-                : Convert.ToDecimal(GetValue(ordinal), _options.Culture);
+            if (IsNumericValueKind(_kinds[ordinal])) {
+                try {
+                    return (decimal)_numbers[ordinal];
+                } catch (OverflowException exception) {
+                    throw new InvalidCastException(
+                        $"The XLSB numeric value '{_numbers[ordinal]}' cannot be represented as decimal.",
+                        exception);
+                }
+            }
+
+            return Convert.ToDecimal(GetValue(ordinal), _options.Culture);
         }
 
         public override DateTime GetDateTime(int ordinal) {
@@ -152,6 +161,7 @@ namespace OfficeIMO.Excel.Xlsb.Read {
             return value is Guid guid ? guid : Guid.Parse(Convert.ToString(value, _options.Culture)!);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool IsNumericValueKind(XlsbTabularValueKind kind) =>
             kind == XlsbTabularValueKind.Number
             || kind == XlsbTabularValueKind.Date;

--- a/OfficeIMO.Excel/Xlsb/Read/XlsbTabularDataReader.cs
+++ b/OfficeIMO.Excel/Xlsb/Read/XlsbTabularDataReader.cs
@@ -5,6 +5,7 @@ using OfficeIMO.Excel.Xlsb.Package;
 using DocumentFormat.OpenXml.Spreadsheet;
 using System.Data.Common;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace OfficeIMO.Excel.Xlsb.Read {
@@ -261,7 +262,9 @@ namespace OfficeIMO.Excel.Xlsb.Read {
 
             Array.Clear(_kinds, 0, _kinds.Length);
             Array.Clear(_strings, 0, _strings.Length);
-            Array.Clear(_customValues, 0, _customValues.Length);
+            if (_options.CellValueConverter != null) {
+                Array.Clear(_customValues, 0, _customValues.Length);
+            }
             if (_nextLogicalRowIndex < _pendingRowIndex) {
                 _nextLogicalRowIndex++;
                 _hasCurrentRow = true;
@@ -317,7 +320,7 @@ namespace OfficeIMO.Excel.Xlsb.Read {
             lastColumn = -1;
             bool inSheetData = false;
             bool sawDimension = false;
-            while (_records.TryRead(out XlsbRecordSlice record)) {
+            while (_records.TryReadValidated(out XlsbRecordSlice record)) {
                 CheckCancellation();
                 if (record.Type == BrtWsDim) {
                     if (sawDimension) {
@@ -362,7 +365,7 @@ namespace OfficeIMO.Excel.Xlsb.Read {
         private Dictionary<int, string?> ReadHeaderRow() {
             var values = new Dictionary<int, string?>();
             _hasPendingRow = false;
-            while (_records.TryRead(out XlsbRecordSlice record)) {
+            while (_records.TryReadValidated(out XlsbRecordSlice record)) {
                 CheckCancellation();
                 if (record.Type == BrtRowHdr) {
                     if (TrySetPendingRow(record)) {
@@ -563,15 +566,6 @@ namespace OfficeIMO.Excel.Xlsb.Read {
             throw new InvalidCastException($"The XLSB numeric value '{serial}' is not a valid Excel date.");
         }
 
-        private static decimal ConvertExcelNumberToDecimal(double number) {
-            if (TryConvertExcelNumberToDecimal(number, out decimal value)) {
-                return value;
-            }
-
-            throw new InvalidCastException(
-                $"The XLSB numeric value '{number}' cannot be represented as decimal.");
-        }
-
         private static bool TryConvertExcelNumberToDecimal(double number, out decimal value) {
             if (double.IsNaN(number) || double.IsInfinity(number)) {
                 value = default;
@@ -641,14 +635,12 @@ namespace OfficeIMO.Excel.Xlsb.Read {
                     nameof(spanBounds));
             }
 
-            var cursor = record.CreateCursor();
-            uint rowIndex = cursor.ReadUInt32();
-            cursor.ReadUInt32();
-            cursor.ReadUInt16();
-            byte extraFlags = cursor.ReadByte();
-            byte flags = cursor.ReadByte();
-            byte phoneticFlags = cursor.ReadByte();
-            uint declaredSpanCount = cursor.ReadUInt32();
+            ref byte payload = ref record.Bytes[record.PayloadOffset];
+            uint rowIndex = Unsafe.ReadUnaligned<uint>(ref payload);
+            byte extraFlags = Unsafe.Add(ref payload, 10);
+            byte flags = Unsafe.Add(ref payload, 11);
+            byte phoneticFlags = Unsafe.Add(ref payload, 12);
+            uint declaredSpanCount = Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref payload, 13));
             if (rowIndex >= A1.MaxRows
                 || (extraFlags & 0xFC) != 0
                 || (flags & 0x80) != 0
@@ -657,7 +649,7 @@ namespace OfficeIMO.Excel.Xlsb.Read {
                 throw new InvalidDataException(
                     $"The BrtRowHdr record at offset {record.RecordOffset} contains invalid row metadata.");
             }
-            if (cursor.Remaining != checked((int)declaredSpanCount * 8)) {
+            if (record.Size != 17 + checked((int)declaredSpanCount * 8)) {
                 throw new InvalidDataException(
                     $"The BrtRowHdr record at offset {record.RecordOffset} has an invalid column-span payload.");
             }
@@ -665,8 +657,9 @@ namespace OfficeIMO.Excel.Xlsb.Read {
             int previousLast = -1;
             spanCount = checked((int)declaredSpanCount);
             for (int index = 0; index < spanCount; index++) {
-                uint firstColumn = cursor.ReadUInt32();
-                uint lastColumn = cursor.ReadUInt32();
+                int spanOffset = 17 + index * 8;
+                uint firstColumn = Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref payload, spanOffset));
+                uint lastColumn = Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref payload, spanOffset + 4));
                 if (firstColumn > lastColumn
                     || lastColumn >= A1.MaxColumns
                     || firstColumn / 1024U != lastColumn / 1024U
@@ -703,19 +696,31 @@ namespace OfficeIMO.Excel.Xlsb.Read {
             return count;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void ValidateOrdinal(int ordinal) {
-            if (ordinal < 0 || ordinal >= FieldCount) {
-                throw new IndexOutOfRangeException($"Column ordinal {ordinal} is outside 0..{FieldCount - 1}.");
+            if ((uint)ordinal >= (uint)_headers.Length) {
+                ThrowOrdinalOutOfRange(ordinal);
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void ValidateReadableOrdinal(int ordinal) {
-            ThrowIfClosed();
-            ValidateOrdinal(ordinal);
-            if (!_hasCurrentRow) {
-                throw new InvalidOperationException("Read must be called before accessing values.");
+            if (_closed || (uint)ordinal >= (uint)_headers.Length || !_hasCurrentRow) {
+                ThrowInvalidReadableOrdinal(ordinal);
             }
         }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void ThrowInvalidReadableOrdinal(int ordinal) {
+            ThrowIfClosed();
+            ValidateOrdinal(ordinal);
+            throw new InvalidOperationException("Read must be called before accessing values.");
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void ThrowOrdinalOutOfRange(int ordinal) =>
+            throw new IndexOutOfRangeException(
+                $"Column ordinal {ordinal} is outside 0..{FieldCount - 1}.");
 
         private void ThrowIfClosed() {
             if (_closed) {


### PR DESCRIPTION
## What changed

- speeds up decoded CSV reads with wider vectorized scanning and lower-overhead streaming field delivery
- improves legacy XLS and XLSB forward-only readers while retaining complete workbook validation and malformed-input checks
- makes existing enumerable Excel write APIs truly single-pass when tables, shared strings, and auto-fit do not require buffering
- adds fair, correctness-checked comparison runners and regression coverage for streaming, cancellation, sparse rows, malformed records, and SIMD fallbacks

## Performance shape

On the Windows 9950X3D validation host, correctness-equivalent 65K-row scans now show:

- CSV: OfficeIMO leads Sep and Sylvan on lower and upper CCD affinity, including forced AVX2 runs without AVX-512
- XLS: OfficeIMO leads Sylvan by roughly 3-5% on median runtime on both affinity groups
- XLSX: OfficeIMO retains the established read lead, while the IDataReader write path remains ahead
- XLSB: the prior upper-CCD loss is removed; repeated runs range from slight OfficeIMO leadership to statistical parity, so this PR does not claim a universal XLSB win
- generated enumerable write: one million rows are written without materializing the source sequence

All comparison paths consume the same hash-pinned fixtures and verify identical row, cell, text, and checksum observations.

## API scope

This keeps the public surface focused. It does not introduce a separate mapping DSL or a family of async overloads. Reusable fluent mappings and async row enumeration need one coherent design shared by reading, writing, and templates rather than incremental API growth in a performance change.

## Validation

- OfficeIMO.CSV.Tests net10.0: 333 passed in default and forced-AVX2 modes
- focused XLS fast-path tests: 24 passed
- XLSB tests: 188 passed
- OfficeIMO.Excel.Tests net10.0: 3,456 passed, 5 skipped
- independent local review found two malformed-input/SIMD-boundary issues; both were fixed and the targeted confirmation found no remaining actionable issues