### PR TITLE
Harden Office-to-PDF conversion resource limits

### DIFF
--- a/OfficeIMO.Drawing.Tests/Drawing.OfficePackageSecurity.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.OfficePackageSecurity.cs
@@ -119,6 +119,35 @@ public sealed class DrawingOfficePackageSecurityTests {
         Assert.Equal(0, report.ExternalRelationshipCount);
     }
 
+    [Theory]
+    [InlineData("[Content_Types].xml", OfficePackageSecurityRule.MalformedPackage)]
+    [InlineData("_rels/.rels", OfficePackageSecurityRule.MalformedRelationship)]
+    public void InspectorBoundsXmlPackageMetadataBeforeDocumentOpen(
+        string entryName,
+        OfficePackageSecurityRule expectedRule) {
+        string xml = entryName == "[Content_Types].xml"
+            ? "<Types><Default Extension=\"" + new string('a', 512) + "\" ContentType=\"application/xml\" /></Types>"
+            : "<Relationships><Relationship Id=\"rId1\" Type=\"urn:test\" Target=\"" + new string('a', 512) + "\" /></Relationships>";
+        byte[] package = CreateZip(archive => AddEntry(archive, entryName, xml));
+        var options = OfficePackageSecurityOptions.SecureDefaults;
+        options.MaxXmlCharactersInPart = 128;
+
+        OfficePackageSecurityReport report = OfficePackageSecurityInspector.Inspect(package, options);
+
+        OfficePackageSecurityFinding finding = Assert.Single(
+            report.Findings,
+            item => item.Rule == expectedRule);
+        Assert.Contains("parsed safely", finding.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void InspectorRejectsInvalidXmlPackageMetadataLimit() {
+        var options = OfficePackageSecurityOptions.SecureDefaults;
+        options.MaxXmlCharactersInPart = 0;
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => OfficePackageSecurityInspector.Inspect([], options));
+    }
+
     [Fact]
     public void InspectorCountsDirectoryEntriesBeforeMaterializingZipParts() {
         byte[] package = CreateZip(archive => {

--- a/OfficeIMO.Drawing/Documents/OfficePackageSecurity.cs
+++ b/OfficeIMO.Drawing/Documents/OfficePackageSecurity.cs
@@ -72,6 +72,9 @@ namespace OfficeIMO.Drawing {
         /// <summary>Maximum uncompressed size of one part. Defaults to 256 MiB.</summary>
         public long MaxPartUncompressedBytes { get; set; } = 256L * 1024L * 1024L;
 
+        /// <summary>Maximum XML characters parsed from one package metadata part. Defaults to 256 MiB.</summary>
+        public long MaxXmlCharactersInPart { get; set; } = 256L * 1024L * 1024L;
+
         /// <summary>Maximum aggregate uncompressed part size. Defaults to 1 GiB.</summary>
         public long MaxTotalUncompressedBytes { get; set; } = 1024L * 1024L * 1024L;
 

--- a/OfficeIMO.Drawing/Documents/OfficePackageSecurityInspector.ZipMetadata.cs
+++ b/OfficeIMO.Drawing/Documents/OfficePackageSecurityInspector.ZipMetadata.cs
@@ -23,11 +23,12 @@ namespace OfficeIMO.Drawing {
             ISet<string> macroParts,
             ISet<string> embeddedParts,
             ISet<string> activeXParts,
+            long maxXmlCharactersInPart,
             ICollection<OfficePackageSecurityFinding> findings) {
             var defaultContentTypes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             try {
                 using Stream stream = contentTypesPart.Entry.Open();
-                using XmlReader reader = XmlReader.Create(stream, CreateSecureXmlSettings(contentTypesPart.Entry.Length));
+                using XmlReader reader = XmlReader.Create(stream, CreateSecureXmlSettings(maxXmlCharactersInPart));
                 while (reader.Read()) {
                     if (reader.NodeType != XmlNodeType.Element) continue;
                     if (string.Equals(reader.LocalName, "Override", StringComparison.Ordinal)) {
@@ -63,12 +64,12 @@ namespace OfficeIMO.Drawing {
             }
         }
 
-        private static XmlReaderSettings CreateSecureXmlSettings(long entryLength) => new XmlReaderSettings {
+        private static XmlReaderSettings CreateSecureXmlSettings(long maxXmlCharactersInPart) => new XmlReaderSettings {
             DtdProcessing = DtdProcessing.Prohibit,
             XmlResolver = null,
             IgnoreComments = true,
             IgnoreWhitespace = true,
-            MaxCharactersInDocument = Math.Max(1024L, entryLength + 1L)
+            MaxCharactersInDocument = maxXmlCharactersInPart
         };
 
         private static void AddContentTypeClassification(

--- a/OfficeIMO.Drawing/Documents/OfficePackageSecurityInspector.cs
+++ b/OfficeIMO.Drawing/Documents/OfficePackageSecurityInspector.cs
@@ -225,7 +225,8 @@ namespace OfficeIMO.Drawing {
 
                 if (partCount <= options.MaxPartCount && totalBytes <= options.MaxTotalUncompressedBytes) {
                     if (contentTypesPart != null) {
-                        InspectContentTypes(contentTypesPart, partNames, macroParts, embeddedParts, activeXParts, findings);
+                        InspectContentTypes(contentTypesPart, partNames, macroParts, embeddedParts, activeXParts,
+                            options.MaxXmlCharactersInPart, findings);
                     }
                     foreach (ZipXmlPart relationshipPart in relationshipParts) {
                         externalCount += InspectRelationships(
@@ -234,6 +235,7 @@ namespace OfficeIMO.Drawing {
                             macroParts,
                             embeddedParts,
                             activeXParts,
+                            options.MaxXmlCharactersInPart,
                             findings);
                     }
                 }
@@ -349,11 +351,12 @@ namespace OfficeIMO.Drawing {
             ISet<string> macroParts,
             ISet<string> embeddedParts,
             ISet<string> activeXParts,
+            long maxXmlCharactersInPart,
             ICollection<OfficePackageSecurityFinding> findings) {
             int externalCount = 0;
             try {
                 using Stream stream = entry.Open();
-                using XmlReader reader = XmlReader.Create(stream, CreateSecureXmlSettings(entry.Length));
+                using XmlReader reader = XmlReader.Create(stream, CreateSecureXmlSettings(maxXmlCharactersInPart));
                 while (reader.Read()) {
                     if (reader.NodeType != XmlNodeType.Element
                         || !string.Equals(reader.LocalName, "Relationship", StringComparison.Ordinal)) continue;
@@ -382,6 +385,7 @@ namespace OfficeIMO.Drawing {
             if (options.MaxPackageBytes < 1) throw new ArgumentOutOfRangeException(nameof(options.MaxPackageBytes));
             if (options.MaxPartCount < 1) throw new ArgumentOutOfRangeException(nameof(options.MaxPartCount));
             if (options.MaxPartUncompressedBytes < 1) throw new ArgumentOutOfRangeException(nameof(options.MaxPartUncompressedBytes));
+            if (options.MaxXmlCharactersInPart < 1) throw new ArgumentOutOfRangeException(nameof(options.MaxXmlCharactersInPart));
             if (options.MaxTotalUncompressedBytes < 1) throw new ArgumentOutOfRangeException(nameof(options.MaxTotalUncompressedBytes));
             if (double.IsNaN(options.MaxCompressionRatio) || double.IsInfinity(options.MaxCompressionRatio)
                 || options.MaxCompressionRatio <= 0) {

--- a/OfficeIMO.Excel.Tests/Excel.LoadSecurityLimits.cs
+++ b/OfficeIMO.Excel.Tests/Excel.LoadSecurityLimits.cs
@@ -1,0 +1,54 @@
+using DocumentFormat.OpenXml.Packaging;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        public void LoadAppliesOpenXmlCharacterLimitBeforeContentTypeNormalization() {
+            byte[] package;
+            using (var output = new MemoryStream()) {
+                using (ExcelDocument document = ExcelDocument.Create()) {
+                    document.AddWorksheet("Data").CellValue(1, 1, "safe");
+                    document.Save(output);
+                }
+                package = output.ToArray();
+            }
+
+            using var input = new MemoryStream(package, writable: false);
+            var options = new ExcelLoadOptions {
+                AccessMode = DocumentAccessMode.ReadOnly,
+                OpenSettings = new OpenSettings { MaxCharactersInPart = 128 }
+            };
+
+            IOException exception = Assert.Throws<IOException>(() => ExcelDocument.Load(input, options));
+
+            InvalidDataException inner = Assert.IsType<InvalidDataException>(exception.InnerException);
+            Assert.Contains("content-types part", inner.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("128-character limit", inner.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void OpenFileBackedAppliesOpenXmlCharacterLimitBeforeContentTypeNormalization() {
+            string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".xlsx");
+            try {
+                using (ExcelDocument document = ExcelDocument.Create()) {
+                    document.AddWorksheet("Data").CellValue(1, 1, "safe");
+                    document.Save(path);
+                }
+                var options = new ExcelLoadOptions {
+                    AccessMode = DocumentAccessMode.ReadOnly,
+                    OpenSettings = new OpenSettings { MaxCharactersInPart = 128 }
+                };
+
+                InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+                    ExcelDocument.OpenFileBacked(path, options));
+
+                Assert.Contains("content-types part", exception.Message, StringComparison.OrdinalIgnoreCase);
+                Assert.Contains("128-character limit", exception.Message, StringComparison.Ordinal);
+            } finally {
+                if (File.Exists(path)) File.Delete(path);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelDocument.CreateLoad.cs
+++ b/OfficeIMO.Excel/ExcelDocument.CreateLoad.cs
@@ -279,7 +279,10 @@ namespace OfficeIMO.Excel {
                 normalizedStream.Write(bytes, 0, bytes.Length);
                 normalizedStream.Position = 0;
 
-                bool normalizedContentTypes = Utilities.ExcelPackageUtilities.NormalizeContentTypes(normalizedStream, leaveOpen: true);
+                bool normalizedContentTypes = Utilities.ExcelPackageUtilities.NormalizeContentTypes(
+                    normalizedStream,
+                    leaveOpen: true,
+                    maxCharactersInPart: effectiveOpenSettings.MaxCharactersInPart);
                 normalizedStream.Position = 0;
                 byte[] unchangedPackageBytes = normalizedContentTypes ? normalizedStream.ToArray() : bytes;
 

--- a/OfficeIMO.Excel/ExcelDocument.FileBackedEdit.cs
+++ b/OfficeIMO.Excel/ExcelDocument.FileBackedEdit.cs
@@ -63,11 +63,15 @@ namespace OfficeIMO.Excel {
                 }
 
                 packageStream.Position = 0;
-                bool normalized = ExcelPackageUtilities.NormalizeContentTypes(packageStream, leaveOpen: true);
+                OpenSettings effectiveOpenSettings = CreateOpenSettings(resolved.OpenSettings);
+                bool normalized = ExcelPackageUtilities.NormalizeContentTypes(
+                    packageStream,
+                    leaveOpen: true,
+                    maxCharactersInPart: effectiveOpenSettings.MaxCharactersInPart);
                 cancellationToken.ThrowIfCancellationRequested();
                 packageStream.Position = 0;
                 bool readOnly = resolved.AccessMode == DocumentAccessMode.ReadOnly;
-                package = SpreadsheetDocument.Open(packageStream, !readOnly, CreateOpenSettings(resolved.OpenSettings));
+                package = SpreadsheetDocument.Open(packageStream, !readOnly, effectiveOpenSettings);
                 cancellationToken.ThrowIfCancellationRequested();
                 ExcelDocument document = CreateDocument(
                     package,

--- a/OfficeIMO.Excel/Utilities/ExcelPackageUtilities.cs
+++ b/OfficeIMO.Excel/Utilities/ExcelPackageUtilities.cs
@@ -26,10 +26,13 @@ namespace OfficeIMO.Excel.Utilities {
             return NormalizeContentTypes(stream, leaveOpen: true);
         }
 
-        internal static bool NormalizeContentTypes(Stream packageStream, bool leaveOpen = false) {
+        internal static bool NormalizeContentTypes(
+            Stream packageStream,
+            bool leaveOpen = false,
+            long maxCharactersInPart = 0) {
             if (packageStream == null || !packageStream.CanRead || !packageStream.CanSeek) return false;
             long originalPosition = packageStream.Position;
-            if (!NeedsContentTypeNormalization(packageStream)) {
+            if (!NeedsContentTypeNormalization(packageStream, maxCharactersInPart)) {
                 packageStream.Position = originalPosition;
                 return false;
             }
@@ -41,7 +44,7 @@ namespace OfficeIMO.Excel.Utilities {
                 return false;
             }
 
-            string xml = ReadContentTypesXml(entry);
+            string xml = ReadContentTypesXml(entry, maxCharactersInPart);
 
             if (string.IsNullOrWhiteSpace(xml)) {
                 return false;
@@ -135,7 +138,7 @@ namespace OfficeIMO.Excel.Utilities {
             return true;
         }
 
-        internal static bool NeedsContentTypeNormalization(Stream packageStream) {
+        internal static bool NeedsContentTypeNormalization(Stream packageStream, long maxCharactersInPart = 0) {
             try {
                 using var archive = new ZipArchive(packageStream, ZipArchiveMode.Read, leaveOpen: true);
                 var entry = archive.GetEntry(ContentTypesEntry);
@@ -143,7 +146,7 @@ namespace OfficeIMO.Excel.Utilities {
                     return true;
                 }
 
-                string xml = ReadContentTypesXml(entry);
+                string xml = ReadContentTypesXml(entry, maxCharactersInPart);
 
                 if (string.IsNullOrWhiteSpace(xml)) {
                     return true;
@@ -203,13 +206,16 @@ namespace OfficeIMO.Excel.Utilities {
             }
         }
 
-        private static string ReadContentTypesXml(ZipArchiveEntry entry) {
+        private static string ReadContentTypesXml(ZipArchiveEntry entry, long maxCharactersInPart) {
             long declaredLength = entry.Length;
             if (declaredLength > MaximumContentTypesEntryBytes) {
                 throw new InvalidDataException(
                     $"The package content-types part exceeds the supported {MaximumContentTypesEntryBytes}-byte limit.");
             }
 
+            long characterLimit = maxCharactersInPart > 0
+                ? Math.Min(maxCharactersInPart, MaximumContentTypesEntryBytes)
+                : MaximumContentTypesEntryBytes;
             using Stream entryStream = entry.Open();
             using var reader = new StreamReader(
                 entryStream,
@@ -217,14 +223,14 @@ namespace OfficeIMO.Excel.Utilities {
                 detectEncodingFromByteOrderMarks: true,
                 bufferSize: 4096,
                 leaveOpen: false);
-            var text = new StringBuilder((int)Math.Min(declaredLength, 8192L));
-            var buffer = new char[4096];
+            var text = new StringBuilder((int)Math.Min(Math.Min(declaredLength, characterLimit), 8192L));
+            var buffer = new char[(int)Math.Min(4096L, characterLimit)];
             while (true) {
                 int read = reader.Read(buffer, 0, buffer.Length);
                 if (read == 0) return text.ToString();
-                if (text.Length > MaximumContentTypesEntryBytes - read) {
+                if (text.Length > characterLimit - read) {
                     throw new InvalidDataException(
-                        $"The package content-types part exceeds the supported {MaximumContentTypesEntryBytes}-byte limit.");
+                        $"The package content-types part exceeds the configured {characterLimit}-character limit.");
                 }
                 text.Append(buffer, 0, read);
             }

--- a/OfficeIMO.Tool.Tests/OfficePdfCommandTests.cs
+++ b/OfficeIMO.Tool.Tests/OfficePdfCommandTests.cs
@@ -2,6 +2,7 @@ using OfficeIMO.Excel;
 using OfficeIMO.PowerPoint;
 using OfficeIMO.Tool.Commands.Convert;
 using OfficeIMO.Word;
+using System.IO.Compression;
 using Xunit;
 
 namespace OfficeIMO.Tool.Tests;
@@ -90,6 +91,189 @@ public sealed class OfficePdfCommandTests {
     }
 
     [Fact]
+    public async Task ConvertRejectsPackageBombWithDefaultLimits() {
+        string directory = CreateTestDirectory();
+        string inputPath = Path.Combine(directory, "source.docx");
+        string outputPath = Path.Combine(directory, "result.pdf");
+        CreateCompressedDocxBomb(inputPath);
+        await using var output = new MemoryStream();
+        using var error = new StringWriter();
+
+        try {
+            int exitCode = await OfficeImoToolApp.RunAsync(
+                ["convert", inputPath, "--output", outputPath],
+                Stream.Null,
+                output,
+                error);
+
+            Assert.Equal((int)OfficeImoToolExitCode.UnsupportedInput, exitCode);
+            Assert.Contains("compression ratio", error.ToString(), StringComparison.OrdinalIgnoreCase);
+            Assert.False(File.Exists(outputPath));
+            Assert.Empty(Directory.EnumerateFiles(directory, ".officeimo-*.tmp"));
+        } finally {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ConvertAppliesConfiguredOpenXmlCharacterLimit() {
+        string directory = CreateTestDirectory();
+        string inputPath = Path.Combine(directory, "source.docx");
+        string outputPath = Path.Combine(directory, "result.pdf");
+        CreateSource(inputPath, ".docx");
+        ReplaceZipEntry(
+            inputPath,
+            "word/document.xml",
+            "<w:document xmlns:w=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\"><w:body>" +
+            "<w:p><w:r><w:t>" + new string('A', 4096) + "</w:t></w:r></w:p><w:sectPr/>" +
+            "</w:body></w:document>");
+        await using var output = new MemoryStream();
+        using var error = new StringWriter();
+
+        try {
+            int exitCode = await OfficeImoToolApp.RunAsync(
+                ["convert", inputPath, "--output", outputPath, "--max-characters-in-part", "2048"],
+                Stream.Null,
+                output,
+                error);
+
+            Assert.Equal((int)OfficeImoToolExitCode.OperationFailed, exitCode);
+            Assert.Contains("XmlException", error.ToString(), StringComparison.Ordinal);
+            Assert.False(File.Exists(outputPath));
+            Assert.Empty(Directory.EnumerateFiles(directory, ".officeimo-*.tmp"));
+        } finally {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData(".docx")]
+    [InlineData(".xlsx")]
+    [InlineData(".pptx")]
+    public async Task ConvertAppliesConfiguredCharacterLimitToPackageMetadata(string extension) {
+        string directory = CreateTestDirectory();
+        string inputPath = Path.Combine(directory, "source" + extension);
+        string outputPath = Path.Combine(directory, "result.pdf");
+        CreateSource(inputPath, extension);
+        ReplaceZipEntry(
+            inputPath,
+            "[Content_Types].xml",
+            "<Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\">" +
+            "<Default Extension=\"" + new string('a', 512) + "\" ContentType=\"application/xml\" />" +
+            "</Types>");
+        await using var output = new MemoryStream();
+        using var error = new StringWriter();
+
+        try {
+            int exitCode = await OfficeImoToolApp.RunAsync(
+                ["convert", inputPath, "--output", outputPath, "--max-characters-in-part", "128"],
+                Stream.Null,
+                output,
+                error);
+
+            Assert.Equal((int)OfficeImoToolExitCode.UnsupportedInput, exitCode);
+            Assert.Contains("content-types", error.ToString(), StringComparison.OrdinalIgnoreCase);
+            Assert.False(File.Exists(outputPath));
+            Assert.Empty(Directory.EnumerateFiles(directory, ".officeimo-*.tmp"));
+        } finally {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ConvertRejectsInputBeyondConfiguredLimit() {
+        string directory = CreateTestDirectory();
+        string inputPath = Path.Combine(directory, "source.docx");
+        string outputPath = Path.Combine(directory, "result.pdf");
+        CreateSource(inputPath, ".docx");
+        await using var output = new MemoryStream();
+        using var error = new StringWriter();
+
+        try {
+            int exitCode = await OfficeImoToolApp.RunAsync(
+                ["convert", inputPath, "--output", outputPath, "--max-input-bytes", "64"],
+                Stream.Null,
+                output,
+                error);
+
+            Assert.Equal((int)OfficeImoToolExitCode.UnsupportedInput, exitCode);
+            Assert.Contains("64", error.ToString(), StringComparison.Ordinal);
+            Assert.False(File.Exists(outputPath));
+            Assert.Empty(Directory.EnumerateFiles(directory, ".officeimo-*.tmp"));
+        } finally {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ConvertRejectsPdfBeyondConfiguredOutputLimit() {
+        string directory = CreateTestDirectory();
+        string inputPath = Path.Combine(directory, "source.docx");
+        string outputPath = Path.Combine(directory, "result.pdf");
+        CreateSource(inputPath, ".docx");
+        await using var output = new MemoryStream();
+        using var error = new StringWriter();
+
+        try {
+            int exitCode = await OfficeImoToolApp.RunAsync(
+                ["convert", inputPath, "--output", outputPath, "--max-output-bytes", "64"],
+                Stream.Null,
+                output,
+                error);
+
+            Assert.Equal((int)OfficeImoToolExitCode.OutputFailed, exitCode);
+            Assert.Contains("64", error.ToString(), StringComparison.Ordinal);
+            Assert.False(File.Exists(outputPath));
+            Assert.Empty(Directory.EnumerateFiles(directory, ".officeimo-*.tmp"));
+        } finally {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task OutputLimitPreservesExistingDestinationWhenForceIsEnabled() {
+        string directory = CreateTestDirectory();
+        string inputPath = Path.Combine(directory, "source.docx");
+        string outputPath = Path.Combine(directory, "result.pdf");
+        CreateSource(inputPath, ".docx");
+        await File.WriteAllTextAsync(outputPath, "keep");
+        await using var output = new MemoryStream();
+        using var error = new StringWriter();
+
+        try {
+            int exitCode = await OfficeImoToolApp.RunAsync(
+                ["convert", inputPath, "--output", outputPath, "--force", "--max-output-bytes", "64"],
+                Stream.Null,
+                output,
+                error);
+
+            Assert.Equal((int)OfficeImoToolExitCode.OutputFailed, exitCode);
+            Assert.Equal("keep", await File.ReadAllTextAsync(outputPath));
+            Assert.Empty(Directory.EnumerateFiles(directory, ".officeimo-*.tmp"));
+        } finally {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData("--max-input-bytes")]
+    [InlineData("--max-output-bytes")]
+    [InlineData("--max-characters-in-part")]
+    public async Task ConvertRejectsNonPositiveResourceLimits(string option) {
+        await using var output = new MemoryStream();
+        using var error = new StringWriter();
+
+        int exitCode = await OfficeImoToolApp.RunAsync(
+            ["convert", "source.docx", option, "0"],
+            Stream.Null,
+            output,
+            error);
+
+        Assert.Equal((int)OfficeImoToolExitCode.Usage, exitCode);
+        Assert.Contains("positive integer", error.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task OutputCommitFailsAtomicallyWhenDestinationAppearsWithoutForce() {
         string directory = Path.Combine(Path.GetTempPath(), "OfficeIMO.Tool.Tests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(directory);
@@ -97,8 +281,10 @@ public sealed class OfficePdfCommandTests {
         await File.WriteAllTextAsync(outputPath, "keep");
 
         try {
+            string temporaryPath = Path.Combine(directory, ".officeimo-test.tmp");
+            await File.WriteAllBytesAsync(temporaryPath, "%PDF-new"u8.ToArray());
             await Assert.ThrowsAsync<OfficePdfOutputExistsException>(() => OfficePdfCommand.CommitOutputAsync(
-                "%PDF-new"u8.ToArray(), outputPath, force: false, CancellationToken.None));
+                temporaryPath, outputPath, force: false, CancellationToken.None));
 
             Assert.Equal("keep", await File.ReadAllTextAsync(outputPath));
             Assert.Empty(Directory.EnumerateFiles(directory, "*.tmp"));
@@ -117,8 +303,10 @@ public sealed class OfficePdfCommandTests {
         cancellation.Cancel();
 
         try {
+            string temporaryPath = Path.Combine(directory, ".officeimo-test.tmp");
+            await File.WriteAllBytesAsync(temporaryPath, "%PDF-new"u8.ToArray());
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() => OfficePdfCommand.CommitOutputAsync(
-                "%PDF-new"u8.ToArray(), outputPath, force: true, cancellation.Token));
+                temporaryPath, outputPath, force: true, cancellation.Token));
 
             Assert.Equal("keep", await File.ReadAllTextAsync(outputPath));
             Assert.Empty(Directory.EnumerateFiles(directory, "*.tmp"));
@@ -151,5 +339,35 @@ public sealed class OfficePdfCommandTests {
             default:
                 throw new ArgumentOutOfRangeException(nameof(extension));
         }
+    }
+
+    private static string CreateTestDirectory() {
+        string directory = Path.Combine(Path.GetTempPath(), "OfficeIMO.Tool.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    private static void CreateCompressedDocxBomb(string path) {
+        CreateSource(path, ".docx");
+        using ZipArchive archive = ZipFile.Open(path, ZipArchiveMode.Update);
+        ZipArchiveEntry documentPart = archive.GetEntry("word/document.xml")
+            ?? throw new InvalidDataException("The generated DOCX has no document part.");
+        documentPart.Delete();
+        ZipArchiveEntry replacement = archive.CreateEntry("word/document.xml", CompressionLevel.SmallestSize);
+        using var writer = new StreamWriter(replacement.Open(), new UTF8Encoding(false));
+        writer.Write("<w:document xmlns:w=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\"><w:body><w:p><w:r><w:t>");
+        string compressibleBlock = new string('A', 1024 * 1024);
+        for (int index = 0; index < 32; index++) writer.Write(compressibleBlock);
+        writer.Write("</w:t></w:r></w:p><w:sectPr/></w:body></w:document>");
+    }
+
+    private static void ReplaceZipEntry(string path, string entryName, string content) {
+        using ZipArchive archive = ZipFile.Open(path, ZipArchiveMode.Update);
+        ZipArchiveEntry entry = archive.GetEntry(entryName)
+            ?? throw new InvalidDataException("The generated package has no " + entryName + " part.");
+        entry.Delete();
+        ZipArchiveEntry replacement = archive.CreateEntry(entryName, CompressionLevel.Optimal);
+        using var writer = new StreamWriter(replacement.Open(), new UTF8Encoding(false));
+        writer.Write(content);
     }
 }

--- a/OfficeIMO.Tool/Commands/Convert/OfficePdfArguments.cs
+++ b/OfficeIMO.Tool/Commands/Convert/OfficePdfArguments.cs
@@ -1,10 +1,19 @@
+using System.Globalization;
+
 namespace OfficeIMO.Tool.Commands.Convert;
 
 internal sealed class OfficePdfArguments {
+    internal const long DefaultMaxInputBytes = 64L * 1024L * 1024L;
+    internal const long DefaultMaxOutputBytes = 256L * 1024L * 1024L;
+    internal const long DefaultMaxCharactersInPart = 10_000_000L;
+
     internal bool Help { get; private set; }
     internal string? InputPath { get; private set; }
     internal string? OutputPath { get; private set; }
     internal bool Force { get; private set; }
+    internal long MaxInputBytes { get; private set; } = DefaultMaxInputBytes;
+    internal long MaxOutputBytes { get; private set; } = DefaultMaxOutputBytes;
+    internal long MaxCharactersInPart { get; private set; } = DefaultMaxCharactersInPart;
 
     internal static OfficePdfArguments Parse(string[] args) {
         ArgumentNullException.ThrowIfNull(args);
@@ -22,6 +31,15 @@ internal sealed class OfficePdfArguments {
                     break;
                 case "--force":
                     parsed.Force = true;
+                    break;
+                case "--max-input-bytes":
+                    parsed.MaxInputBytes = ParsePositiveLong(NextValue(args, ref index, token), token);
+                    break;
+                case "--max-output-bytes":
+                    parsed.MaxOutputBytes = ParsePositiveLong(NextValue(args, ref index, token), token);
+                    break;
+                case "--max-characters-in-part":
+                    parsed.MaxCharactersInPart = ParsePositiveLong(NextValue(args, ref index, token), token);
                     break;
                 default:
                     if (token.StartsWith("-", StringComparison.Ordinal)) {
@@ -63,6 +81,13 @@ internal sealed class OfficePdfArguments {
             throw new OfficePdfUsageException(option + " requires a value.");
         }
         return args[index];
+    }
+
+    private static long ParsePositiveLong(string value, string option) {
+        if (!long.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out long parsed) || parsed <= 0) {
+            throw new OfficePdfUsageException(option + " requires a positive integer.");
+        }
+        return parsed;
     }
 
     private static bool IsHelp(string value) => value is "help" or "--help" or "-h";

--- a/OfficeIMO.Tool/Commands/Convert/OfficePdfCommand.cs
+++ b/OfficeIMO.Tool/Commands/Convert/OfficePdfCommand.cs
@@ -1,3 +1,4 @@
+using DocumentFormat.OpenXml.Packaging;
 using OfficeIMO.Drawing;
 using OfficeIMO.Excel;
 using OfficeIMO.Excel.Pdf;
@@ -16,8 +17,11 @@ OfficeIMO.Tool - Office to PDF
 
 Usage:
   officeimo convert <input.docx|input.xlsx|input.pptx> [--output <file.pdf>] [--force]
+                    [--max-input-bytes <bytes>] [--max-output-bytes <bytes>]
+                    [--max-characters-in-part <characters>]
 
 The command uses the first-party OfficeIMO Word, Excel, or PowerPoint PDF adapter.
+Package structure, Open XML part size, and PDF output are bounded by default.
 Conversion diagnostics are written to standard error.
 """;
 
@@ -37,34 +41,52 @@ Conversion diagnostics are written to standard error.
             string inputPath = Path.GetFullPath(parsed.InputPath!);
             string outputPath = Path.GetFullPath(parsed.OutputPath!);
             if (!File.Exists(inputPath)) throw new FileNotFoundException("Input document was not found.", inputPath);
+            if (!parsed.Force && File.Exists(outputPath)) throw new OfficePdfOutputExistsException(outputPath);
 
-            using var pdf = new MemoryStream();
-            PdfSaveResult result = Convert(inputPath, pdf);
-            if (!result.Succeeded) {
-                foreach (string diagnostic in result.Diagnostics) {
-                    await standardError.WriteLineAsync(diagnostic).ConfigureAwait(false);
+            string temporaryPath = CreateTemporaryOutputPath(outputPath);
+            try {
+                PdfSaveResult result;
+                await using (var destination = new FileStream(
+                    temporaryPath,
+                    FileMode.CreateNew,
+                    FileAccess.Write,
+                    FileShare.None,
+                    bufferSize: 81920,
+                    options: FileOptions.Asynchronous | FileOptions.SequentialScan)) {
+                    using var boundedOutput = new OfficePdfOutputLimitStream(destination, parsed.MaxOutputBytes);
+                    result = Convert(inputPath, boundedOutput, parsed);
+                    await boundedOutput.FlushAsync(cancellationToken).ConfigureAwait(false);
                 }
-                return (int)OfficeImoToolExitCode.OutputFailed;
-            }
 
-            foreach (PdfConversionWarning warning in result.Warnings) {
-                await standardError.WriteLineAsync(
-                    warning.Severity + " " + warning.Code + " [" + warning.Source + "]: " + warning.Message).ConfigureAwait(false);
-            }
-            if (result.HasLoss && result.Warnings.Count == 0) {
-                await standardError.WriteLineAsync("Warning SourceContentLoss: the source conversion reported possible content loss.").ConfigureAwait(false);
-            }
-            if (result.Report.HasErrors) {
-                return (int)OfficeImoToolExitCode.OutputFailed;
-            }
+                if (!result.Succeeded) {
+                    foreach (string diagnostic in result.Diagnostics) {
+                        await standardError.WriteLineAsync(diagnostic).ConfigureAwait(false);
+                    }
+                    return (int)OfficeImoToolExitCode.OutputFailed;
+                }
 
-            cancellationToken.ThrowIfCancellationRequested();
-            await CommitOutputAsync(pdf.ToArray(), outputPath, parsed.Force, cancellationToken).ConfigureAwait(false);
-            await WriteUtf8Async(
-                standardOutput,
-                outputPath + Environment.NewLine,
-                CancellationToken.None).ConfigureAwait(false);
-            return (int)OfficeImoToolExitCode.Success;
+                foreach (PdfConversionWarning warning in result.Warnings) {
+                    await standardError.WriteLineAsync(
+                        warning.Severity + " " + warning.Code + " [" + warning.Source + "]: " + warning.Message).ConfigureAwait(false);
+                }
+                if (result.HasLoss && result.Warnings.Count == 0) {
+                    await standardError.WriteLineAsync("Warning SourceContentLoss: the source conversion reported possible content loss.").ConfigureAwait(false);
+                }
+                if (result.Report.HasErrors) {
+                    return (int)OfficeImoToolExitCode.OutputFailed;
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+                await CommitOutputAsync(temporaryPath, outputPath, parsed.Force, cancellationToken).ConfigureAwait(false);
+                temporaryPath = string.Empty;
+                await WriteUtf8Async(
+                    standardOutput,
+                    outputPath + Environment.NewLine,
+                    CancellationToken.None).ConfigureAwait(false);
+                return (int)OfficeImoToolExitCode.Success;
+            } finally {
+                if (temporaryPath.Length > 0 && File.Exists(temporaryPath)) File.Delete(temporaryPath);
+            }
         } catch (OfficePdfUsageException exception) {
             await standardError.WriteLineAsync(exception.Message).ConfigureAwait(false);
             await standardError.WriteLineAsync(Usage).ConfigureAwait(false);
@@ -76,6 +98,9 @@ Conversion diagnostics are written to standard error.
             await standardError.WriteLineAsync(exception.Message).ConfigureAwait(false);
             return (int)OfficeImoToolExitCode.InputNotFound;
         } catch (OfficePdfOutputExistsException exception) {
+            await standardError.WriteLineAsync(exception.Message).ConfigureAwait(false);
+            return (int)OfficeImoToolExitCode.OutputFailed;
+        } catch (OfficePdfOutputLimitException exception) {
             await standardError.WriteLineAsync(exception.Message).ConfigureAwait(false);
             return (int)OfficeImoToolExitCode.OutputFailed;
         } catch (IOException exception) {
@@ -90,18 +115,43 @@ Conversion diagnostics are written to standard error.
         }
     }
 
-    private static PdfSaveResult Convert(string inputPath, Stream output) {
+    private static PdfSaveResult Convert(
+        string inputPath,
+        Stream output,
+        OfficePdfArguments arguments) {
+        OfficePackageSecurityOptions packageSecurity = OfficePackageSecurityOptions.SecureDefaults;
+        packageSecurity.MaxPackageBytes = arguments.MaxInputBytes;
+        packageSecurity.MaxXmlCharactersInPart = arguments.MaxCharactersInPart;
+        var openSettings = new OpenSettings {
+            MaxCharactersInPart = arguments.MaxCharactersInPart
+        };
+
         switch (Path.GetExtension(inputPath).ToLowerInvariant()) {
             case ".docx":
-                using (WordDocument document = WordDocument.Load(inputPath, new WordLoadOptions { AccessMode = DocumentAccessMode.ReadOnly })) {
+                using (WordDocument document = WordDocument.Load(inputPath, new WordLoadOptions {
+                    AccessMode = DocumentAccessMode.ReadOnly,
+                    MaxInputBytes = arguments.MaxInputBytes,
+                    PackageSecurity = packageSecurity,
+                    OpenSettings = openSettings
+                })) {
                     return document.TrySaveAsPdf(output);
                 }
             case ".xlsx":
-                using (ExcelDocument document = ExcelDocument.Load(inputPath, new ExcelLoadOptions { AccessMode = DocumentAccessMode.ReadOnly })) {
+                using (ExcelDocument document = ExcelDocument.Load(inputPath, new ExcelLoadOptions {
+                    AccessMode = DocumentAccessMode.ReadOnly,
+                    MaxInputBytes = arguments.MaxInputBytes,
+                    PackageSecurity = packageSecurity,
+                    OpenSettings = openSettings
+                })) {
                     return document.TrySaveAsPdf(output);
                 }
             case ".pptx":
-                using (PowerPointPresentation presentation = PowerPointPresentation.Load(inputPath, new PowerPointLoadOptions { AccessMode = DocumentAccessMode.ReadOnly })) {
+                using (PowerPointPresentation presentation = PowerPointPresentation.Load(inputPath, new PowerPointLoadOptions {
+                    AccessMode = DocumentAccessMode.ReadOnly,
+                    MaxInputBytes = arguments.MaxInputBytes,
+                    PackageSecurity = packageSecurity,
+                    OpenSettings = openSettings
+                })) {
                     return presentation.TrySaveAsPdf(output);
                 }
             default:
@@ -109,29 +159,12 @@ Conversion diagnostics are written to standard error.
         }
     }
 
-    internal static async Task CommitOutputAsync(
-        byte[] content,
+    internal static Task CommitOutputAsync(
+        string temporaryPath,
         string outputPath,
         bool force,
         CancellationToken cancellationToken) {
-        string? directory = Path.GetDirectoryName(outputPath);
-        if (!string.IsNullOrEmpty(directory)) Directory.CreateDirectory(directory);
-
-        string temporaryPath = Path.Combine(
-            directory ?? Directory.GetCurrentDirectory(),
-            ".officeimo-" + Guid.NewGuid().ToString("N") + ".tmp");
         try {
-            await using (var stream = new FileStream(
-                temporaryPath,
-                FileMode.CreateNew,
-                FileAccess.Write,
-                FileShare.None,
-                bufferSize: 81920,
-                options: FileOptions.Asynchronous | FileOptions.SequentialScan)) {
-                await stream.WriteAsync(content.AsMemory(), cancellationToken).ConfigureAwait(false);
-                await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
-            }
-
             cancellationToken.ThrowIfCancellationRequested();
             try {
                 File.Move(temporaryPath, outputPath, overwrite: force);
@@ -142,6 +175,16 @@ Conversion diagnostics are written to standard error.
         } finally {
             if (temporaryPath.Length > 0 && File.Exists(temporaryPath)) File.Delete(temporaryPath);
         }
+
+        return Task.CompletedTask;
+    }
+
+    private static string CreateTemporaryOutputPath(string outputPath) {
+        string? directory = Path.GetDirectoryName(outputPath);
+        if (!string.IsNullOrEmpty(directory)) Directory.CreateDirectory(directory);
+        return Path.Combine(
+            directory ?? Directory.GetCurrentDirectory(),
+            ".officeimo-" + Guid.NewGuid().ToString("N") + ".tmp");
     }
 
     private static async Task WriteUtf8Async(Stream output, string value, CancellationToken cancellationToken) {

--- a/OfficeIMO.Tool/Commands/Convert/OfficePdfOutputLimitStream.cs
+++ b/OfficeIMO.Tool/Commands/Convert/OfficePdfOutputLimitStream.cs
@@ -1,0 +1,119 @@
+namespace OfficeIMO.Tool.Commands.Convert;
+
+/// <summary>Rejects PDF output before it exceeds the configured byte limit.</summary>
+internal sealed class OfficePdfOutputLimitStream : Stream {
+    private readonly Stream _destination;
+    private readonly long _maximumLength;
+
+    internal OfficePdfOutputLimitStream(Stream destination, long maximumLength) {
+        _destination = destination ?? throw new ArgumentNullException(nameof(destination));
+        if (!destination.CanWrite) throw new ArgumentException("The destination stream must be writable.", nameof(destination));
+        if (maximumLength <= 0) throw new ArgumentOutOfRangeException(nameof(maximumLength));
+        _maximumLength = maximumLength;
+    }
+
+    public override bool CanRead => false;
+    public override bool CanSeek => _destination.CanSeek;
+    public override bool CanWrite => true;
+    public override long Length => _destination.Length;
+
+    public override long Position {
+        get => _destination.Position;
+        set {
+            EnsureWithinLimit(value);
+            _destination.Position = value;
+        }
+    }
+
+    public override void Flush() => _destination.Flush();
+
+    public override Task FlushAsync(CancellationToken cancellationToken) =>
+        _destination.FlushAsync(cancellationToken);
+
+    public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    public override long Seek(long offset, SeekOrigin origin) {
+        if (!_destination.CanSeek) throw new NotSupportedException();
+        long originPosition = origin switch {
+            SeekOrigin.Begin => 0L,
+            SeekOrigin.Current => _destination.Position,
+            SeekOrigin.End => _destination.Length,
+            _ => throw new ArgumentOutOfRangeException(nameof(origin))
+        };
+        long target = checked(originPosition + offset);
+        EnsureWithinLimit(target);
+        return _destination.Seek(offset, origin);
+    }
+
+    public override void SetLength(long value) {
+        EnsureWithinLimit(value);
+        _destination.SetLength(value);
+    }
+
+    public override void Write(byte[] buffer, int offset, int count) {
+        ArgumentNullException.ThrowIfNull(buffer);
+        ValidateBufferRange(buffer, offset, count);
+        long end = checked(Position + count);
+        EnsureWithinLimit(end);
+        _destination.Write(buffer, offset, count);
+    }
+
+    public override void Write(ReadOnlySpan<byte> buffer) {
+        long end = checked(Position + buffer.Length);
+        EnsureWithinLimit(end);
+        _destination.Write(buffer);
+    }
+
+    public override void WriteByte(byte value) {
+        long end = checked(Position + 1L);
+        EnsureWithinLimit(end);
+        _destination.WriteByte(value);
+    }
+
+    public override Task WriteAsync(
+        byte[] buffer,
+        int offset,
+        int count,
+        CancellationToken cancellationToken) {
+        ArgumentNullException.ThrowIfNull(buffer);
+        ValidateBufferRange(buffer, offset, count);
+        long end = checked(Position + count);
+        EnsureWithinLimit(end);
+        return _destination.WriteAsync(buffer, offset, count, cancellationToken);
+    }
+
+    public override ValueTask WriteAsync(
+        ReadOnlyMemory<byte> buffer,
+        CancellationToken cancellationToken = default) {
+        long end = checked(Position + buffer.Length);
+        EnsureWithinLimit(end);
+        return _destination.WriteAsync(buffer, cancellationToken);
+    }
+
+    protected override void Dispose(bool disposing) {
+        // The command owns the destination stream.
+        base.Dispose(disposing);
+    }
+
+    private void EnsureWithinLimit(long length) {
+        if (length < 0 || length > _maximumLength) {
+            throw new OfficePdfOutputLimitException(length, _maximumLength);
+        }
+    }
+
+    private static void ValidateBufferRange(byte[] buffer, int offset, int count) {
+        if ((uint)offset > (uint)buffer.Length) throw new ArgumentOutOfRangeException(nameof(offset));
+        if ((uint)count > (uint)(buffer.Length - offset)) throw new ArgumentOutOfRangeException(nameof(count));
+    }
+}
+
+internal sealed class OfficePdfOutputLimitException : IOException {
+    internal OfficePdfOutputLimitException(long observedBytes, long maximumBytes)
+        : base("PDF output size " + observedBytes + " bytes exceeds the configured maximum of " + maximumBytes + " bytes.") {
+        ObservedBytes = observedBytes;
+        MaximumBytes = maximumBytes;
+    }
+
+    internal long ObservedBytes { get; }
+    internal long MaximumBytes { get; }
+}

--- a/OfficeIMO.Tool/README.md
+++ b/OfficeIMO.Tool/README.md
@@ -32,7 +32,9 @@ officeimo convert .\workbook.xlsx --output .\published\workbook.pdf
 officeimo convert .\deck.pptx --output .\deck.pdf --force
 ```
 
-The input extension selects `OfficeIMO.Word.Pdf`, `OfficeIMO.Excel.Pdf`, or `OfficeIMO.PowerPoint.Pdf`. The tool opens the source read-only, writes conversion diagnostics to standard error, and refuses to replace an existing PDF unless `--force` is supplied. The default output is the input path with a `.pdf` extension.
+The input extension selects `OfficeIMO.Word.Pdf`, `OfficeIMO.Excel.Pdf`, or `OfficeIMO.PowerPoint.Pdf`. The tool opens the source read-only, applies structural package-bomb checks, bounds Open XML part parsing, writes conversion diagnostics to standard error, and refuses to replace an existing PDF unless `--force` is supplied. The default output is the input path with a `.pdf` extension.
+
+Conversion defaults to a 64 MiB input limit, 10,000,000 characters per Open XML part, and a 256 MiB PDF output limit. Operators processing larger trusted documents can set `--max-input-bytes`, `--max-characters-in-part`, or `--max-output-bytes` explicitly. PDF bytes are streamed to an atomic staging file so a rejected or failed conversion does not replace the destination or require a second full in-memory copy.
 
 ## Compact agent workflow
 


### PR DESCRIPTION
## Summary

- apply secure package-size, part-count, compression, and XML metadata limits before Office documents are opened
- bound Open XML parsing and PDF output for DOCX, XLSX, and PPTX conversions, with explicit operator overrides
- stream PDF output through an atomic bounded staging file so failures preserve the destination and avoid a second full in-memory copy
- propagate Open XML character limits through Excel content-type normalization, including file-backed loads

## Validation

- OfficeIMO.Tool.Tests: 81 passed on .NET 8 and 81 passed on .NET 10
- OfficeIMO.Drawing.Tests: 1,129 passed on .NET 8, .NET 10, and .NET Framework 4.7.2
- OfficeIMO.Excel.Tests: 3,467 passed and 5 skipped on .NET 8 with the optional desktop-Excel COM case excluded; focused load-limit tests passed on all three target frameworks
- real CLI conversion produced a readable PDF and left no staging files