### PR TITLE
Harden Office parsing resource limits

### DIFF
--- a/OfficeIMO.CSV/CsvDataReader.cs
+++ b/OfficeIMO.CSV/CsvDataReader.cs
@@ -90,7 +90,7 @@ internal sealed class CsvDataReader : DbDataReader, ICsvDataReaderMetadata
         _staticColumnValues = CaptureStaticColumnValues(_stringRowOptions.StaticColumns);
         _culture = culture;
         _dateTimeFormats = dateTimeFormats;
-        Delimiter = options.Delimiter;
+        Delimiter = CsvParser.GetDelimiterChar(options);
         _rowOwner = rowOwner;
         _useRawStringValues = CanUseRawStringValues(columns);
         _useDirectValueConversion = CanUseDirectValueConversion(columns);
@@ -114,7 +114,7 @@ internal sealed class CsvDataReader : DbDataReader, ICsvDataReaderMetadata
         _stringNullValue = options.NullValue;
         _culture = culture;
         _dateTimeFormats = dateTimeFormats;
-        Delimiter = options.Delimiter;
+        Delimiter = CsvParser.GetDelimiterChar(options);
         _useRawStringValues = CanUseRawStringValues(columns);
         _useDirectTextSourceStrings = _useRawStringValues && _stringNullValue is null;
         _useDirectValueConversion = CanUseDirectValueConversion(columns);

--- a/OfficeIMO.CSV/CsvParser.TextDelimiter.cs
+++ b/OfficeIMO.CSV/CsvParser.TextDelimiter.cs
@@ -9,7 +9,7 @@ internal static partial class CsvParser
     private static bool UsesTextDelimiter(CsvLoadOptions options) =>
         !string.IsNullOrEmpty(options.DelimiterText) && options.DelimiterText!.Length > 1;
 
-    private static char GetDelimiterChar(CsvLoadOptions options) =>
+    internal static char GetDelimiterChar(CsvLoadOptions options) =>
         string.IsNullOrEmpty(options.DelimiterText)
             ? options.Delimiter
             : options.DelimiterText![0];

--- a/OfficeIMO.Drawing.Tests/OfficeGeometryArcSecurityTests.cs
+++ b/OfficeIMO.Drawing.Tests/OfficeGeometryArcSecurityTests.cs
@@ -1,0 +1,33 @@
+using OfficeIMO.Drawing;
+using Xunit;
+
+namespace OfficeIMO.Drawing.Tests;
+
+public sealed class OfficeGeometryArcSecurityTests {
+    [Fact]
+    public void EllipticalArcRejectsSweepsThatRequireExcessiveSegments() {
+        double excessiveSweep = (4096D + 1D) * (Math.PI / 2D);
+
+        ArgumentOutOfRangeException exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
+            OfficeGeometry.CreateEllipticalArcCubicBezierCommands(
+                new OfficePoint(1D, 0D),
+                radiusX: 1D,
+                radiusY: 1D,
+                startRadians: 0D,
+                sweepRadians: excessiveSweep));
+
+        Assert.Equal("sweepRadians", exception.ParamName);
+    }
+
+    [Fact]
+    public void EllipticalArcStillProducesTheExpectedBoundedSegments() {
+        List<OfficePathCommand> commands = OfficeGeometry.CreateEllipticalArcCubicBezierCommands(
+            new OfficePoint(10D, 0D),
+            radiusX: 10D,
+            radiusY: 5D,
+            startRadians: 0D,
+            sweepRadians: Math.PI);
+
+        Assert.Equal(2, commands.Count);
+    }
+}

--- a/OfficeIMO.Drawing/OfficeGeometry.Arcs.cs
+++ b/OfficeIMO.Drawing/OfficeGeometry.Arcs.cs
@@ -5,6 +5,7 @@ namespace OfficeIMO.Drawing;
 
 public static partial class OfficeGeometry {
     private const double MaxCubicArcSegmentRadians = Math.PI / 2D;
+    private const int MaxCubicArcSegments = 4096;
 
     /// <summary>
     /// Converts an elliptical arc into cubic Bezier path commands, excluding the current move point.
@@ -36,7 +37,13 @@ public static partial class OfficeGeometry {
 
         double centerX = start.X - (Math.Cos(startRadians) * radiusX);
         double centerY = start.Y - (Math.Sin(startRadians) * radiusY);
-        int segments = Math.Max(1, (int)Math.Ceiling(Math.Abs(sweepRadians) / MaxCubicArcSegmentRadians));
+        double requestedSegments = Math.Ceiling(Math.Abs(sweepRadians) / MaxCubicArcSegmentRadians);
+        if (requestedSegments > MaxCubicArcSegments) {
+            throw new ArgumentOutOfRangeException(
+                nameof(sweepRadians),
+                $"Arc sweeps cannot require more than {MaxCubicArcSegments} cubic segments.");
+        }
+        int segments = Math.Max(1, (int)requestedSegments);
         double segmentSweep = sweepRadians / segments;
         double segmentStart = startRadians;
 

--- a/OfficeIMO.Drawing/Security/VbaSignatures/OfficeVbaProjectCanonicalizer.cs
+++ b/OfficeIMO.Drawing/Security/VbaSignatures/OfficeVbaProjectCanonicalizer.cs
@@ -156,10 +156,7 @@ internal static class OfficeVbaProjectCanonicalizer {
                 return false;
             }
             bool hashModuleName = false;
-            byte[][] lines = SplitLines(source).ToArray();
-            for (int lineIndex = 0; lineIndex < lines.Length; lineIndex++) {
-                byte[] line = lines[lineIndex];
-                if (lineIndex == lines.Length - 1 && line.Length == 0) continue;
+            foreach (byte[] line in SplitLinesWithoutTerminalEmptyLine(source)) {
                 bool attribute = StartsWithAsciiIgnoreCase(line, "attribute");
                 if (attribute && StartsWithAsciiIgnoreCase(line, "Attribute VB_Name = ")) continue;
                 if (attribute && V3DefaultAttributes.Any(defaultValue => BytesEqual(line, defaultValue))) continue;
@@ -184,6 +181,15 @@ internal static class OfficeVbaProjectCanonicalizer {
         output = buffer.ToArray();
         detail = string.Empty;
         return true;
+    }
+
+    private static IEnumerable<byte[]> SplitLinesWithoutTerminalEmptyLine(byte[] bytes) {
+        byte[]? pending = null;
+        foreach (byte[] line in SplitLines(bytes)) {
+            if (pending != null) yield return pending;
+            pending = line;
+        }
+        if (pending is { Length: > 0 }) yield return pending;
     }
 
     private static bool TryBuildFormsNormalizedData(OfficeCompoundFile compound, DirectoryModel model,

--- a/OfficeIMO.Drawing/Security/XmlDigitalSignatureReferenceWorkCalculator.cs
+++ b/OfficeIMO.Drawing/Security/XmlDigitalSignatureReferenceWorkCalculator.cs
@@ -1,0 +1,97 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml;
+
+namespace OfficeIMO.Security;
+
+internal static class XmlDigitalSignatureReferenceWorkCalculator {
+    private static readonly string[] LocalReferenceIdAttributeNames = { "Id", "ID", "id" };
+
+    internal static long Measure(
+        XmlDocument document,
+        XmlElement? signedInfo,
+        int certificateCandidateCount,
+        long maxDigestWorkBytes) {
+        if (certificateCandidateCount <= 0 || signedInfo == null) return 0L;
+
+        Dictionary<string, XmlElement?> targetsById = IndexLocalReferenceTargets(document);
+        var targetSizes = new Dictionary<string, long>(StringComparer.Ordinal);
+        long totalDigestWorkBytes = 0L;
+        foreach (XmlElement reference in signedInfo.ChildNodes
+                     .OfType<XmlElement>()
+                     .Where(element =>
+                         element.LocalName == "Reference" &&
+                         element.NamespaceURI == XmlDigitalSignatureAlgorithms.Namespace)) {
+            string uri = reference.GetAttribute("URI");
+            if (uri.Length > 0 && uri[0] != '#') continue;
+            if (!targetSizes.TryGetValue(uri, out long targetBytes)) {
+                XmlElement? target = ResolveLocalReferenceTarget(document, targetsById, uri);
+                targetBytes = target == null ? 0L : Encoding.UTF8.GetByteCount(target.OuterXml);
+                targetSizes.Add(uri, targetBytes);
+            }
+            long transformPasses = reference.ChildNodes
+                .OfType<XmlElement>()
+                .Where(element =>
+                    element.LocalName == "Transforms" &&
+                    element.NamespaceURI == XmlDigitalSignatureAlgorithms.Namespace)
+                .SelectMany(element => element.ChildNodes.OfType<XmlElement>())
+                .LongCount(element =>
+                    element.LocalName == "Transform" &&
+                    element.NamespaceURI == XmlDigitalSignatureAlgorithms.Namespace) + 1L;
+            long referenceWorkBytes = CheckedMultiply(targetBytes, transformPasses, maxDigestWorkBytes);
+            long candidateWorkBytes = CheckedMultiply(referenceWorkBytes, certificateCandidateCount, maxDigestWorkBytes);
+            if (candidateWorkBytes > maxDigestWorkBytes - totalDigestWorkBytes) {
+                throw CreateLimitException(maxDigestWorkBytes);
+            }
+            totalDigestWorkBytes += candidateWorkBytes;
+        }
+        return totalDigestWorkBytes;
+    }
+
+    private static long CheckedMultiply(long value, long multiplier, long limit) {
+        if (value > 0 && multiplier > long.MaxValue / value) throw CreateLimitException(limit);
+        return value * multiplier;
+    }
+
+    private static InvalidDataException CreateLimitException(long limit) =>
+        new("Local SignedInfo references exceed the " + limit +
+            " byte remaining aggregate digest-work limit across signature parts and certificate candidates.");
+
+    private static Dictionary<string, XmlElement?> IndexLocalReferenceTargets(XmlDocument document) {
+        var targets = new Dictionary<string, XmlElement?>(StringComparer.Ordinal);
+        if (document.DocumentElement == null) return targets;
+        foreach (XmlElement element in EnumerateElements(document.DocumentElement)) {
+            foreach (string attributeName in LocalReferenceIdAttributeNames) {
+                if (!element.HasAttribute(attributeName)) continue;
+                string id = element.GetAttribute(attributeName);
+                if (id.Length == 0) continue;
+                if (targets.TryGetValue(id, out XmlElement? existing)) {
+                    if (!ReferenceEquals(existing, element)) targets[id] = null;
+                } else {
+                    targets.Add(id, element);
+                }
+            }
+        }
+        return targets;
+    }
+
+    private static IEnumerable<XmlElement> EnumerateElements(XmlElement root) {
+        yield return root;
+        foreach (XmlElement descendant in root.GetElementsByTagName("*").OfType<XmlElement>()) {
+            yield return descendant;
+        }
+    }
+
+    private static XmlElement? ResolveLocalReferenceTarget(
+        XmlDocument document,
+        IReadOnlyDictionary<string, XmlElement?> targetsById,
+        string uri) {
+        if (uri.Length == 0) return document.DocumentElement;
+        if (uri.Length == 1) return null;
+        return targetsById.TryGetValue(uri.Substring(1), out XmlElement? target) ? target : null;
+    }
+}

--- a/OfficeIMO.Excel.Tests/Excel.Csv.cs
+++ b/OfficeIMO.Excel.Tests/Excel.Csv.cs
@@ -67,6 +67,23 @@ public class ExcelCsvExtensionsTests {
     }
 
     [Fact]
+    public void CsvTextImportReportsTheEffectiveDelimiterTextCharacter() {
+        var options = new ExcelCsvImportOptions {
+            SheetName = "Imported",
+            LoadOptions = new CsvLoadOptions { DelimiterText = "||" },
+            ReaderOptions = new CsvDataReaderOptions { InferSchema = false }
+        };
+        using var stream = new MemoryStream();
+        using var document = ExcelDocument.Create(stream);
+
+        ExcelCsvImportResult result = document.ImportCsvText("Name||Value\r\nAlpha||1", options);
+
+        Assert.Equal('|', result.Delimiter);
+        Assert.True(document["Imported"].TryGetCellText(2, 2, out string? value));
+        Assert.Equal("1", value);
+    }
+
+    [Fact]
     public void CsvTextImportEnforcesMaxInputBytesBeforeCreatingOrMutatingSheets() {
         var options = new ExcelCsvImportOptions {
             SheetName = "Rejected",

--- a/OfficeIMO.Excel.Tests/Excel.ReferenceSyntax.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ReferenceSyntax.cs
@@ -105,6 +105,20 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_FormulaSyntaxTree_RewritesDeepStructuredSelectorsWithoutRecursion() {
+            const int depth = 100_000;
+            string selector = new string('[', depth) + "Old" + new string(']', depth);
+
+            string rewritten = ExcelFormulaSyntaxTree.RewriteStructuredColumns(
+                selector,
+                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                    ["Old"] = "New"
+                });
+
+            Assert.Equal(new string('[', depth) + "New" + new string(']', depth), rewritten);
+        }
+
+        [Fact]
         public void Test_FormulaSyntaxTree_DoesNotTreatQualifiedDefinedNameAsTableName() {
             ExcelFormulaSyntaxTree tree = ExcelFormulaSyntaxTree.Parse("=Sales!TaxRate+Sales[Amount]");
 

--- a/OfficeIMO.Excel.Tests/Excel.Xlsb.TabularReader.cs
+++ b/OfficeIMO.Excel.Tests/Excel.Xlsb.TabularReader.cs
@@ -25,6 +25,7 @@ public partial class Excel {
                 new XlsbImportOptions(),
                 new XlsbRecordReadBudget(100),
                 new XlsbCellReadBudget(100),
+                new XlsbLogicalRowReadBudget(100),
                 CancellationToken.None));
 
         Assert.True(worksheetPart.WasDisposed);
@@ -46,6 +47,24 @@ public partial class Excel {
         Assert.True(reader.Read());
         Assert.Equal("Data", reader.GetString(0));
         Assert.False(reader.Read());
+    }
+
+    [Fact]
+    public void XlsbTabularReader_ChargesSparseRowsAgainstLogicalRowBudget() {
+        using var worksheetPart = CreateTabularWorksheet(
+            (0, 0U),
+            (100, 1U));
+        using var reader = CreateTabularReader(
+            worksheetPart,
+            new[] { "Value", "Data" },
+            hasHeaderRow: true,
+            new XlsbCellReadBudget(10),
+            logicalRowBudget: new XlsbLogicalRowReadBudget(4));
+
+        Assert.True(reader.Read());
+        Assert.True(reader.Read());
+        Assert.True(reader.Read());
+        Assert.Throws<InvalidDataException>(() => reader.Read());
     }
 
     [Fact]
@@ -729,7 +748,8 @@ public partial class Excel {
         XlsbCellReadBudget cellBudget,
         ExcelReadOptions? options = null,
         XlsbRecordReadBudget? recordBudget = null,
-        bool dateStyle = false) =>
+        bool dateStyle = false,
+        XlsbLogicalRowReadBudget? logicalRowBudget = null) =>
         new(
             worksheetPart,
             sharedStrings,
@@ -740,6 +760,7 @@ public partial class Excel {
             new XlsbImportOptions(),
             recordBudget ?? new XlsbRecordReadBudget(100),
             cellBudget,
+            logicalRowBudget ?? new XlsbLogicalRowReadBudget(100),
             CancellationToken.None);
 
     private static MemoryStream CreateTabularWorksheet(params (int RowIndex, uint SharedStringIndex)[] rows) {

--- a/OfficeIMO.Excel/ExcelFormulaSyntaxTree.cs
+++ b/OfficeIMO.Excel/ExcelFormulaSyntaxTree.cs
@@ -385,54 +385,62 @@ namespace OfficeIMO.Excel {
         }
 
         private static string RewriteStructuredSelector(string value, Func<string, string?> rewriteColumn) {
+            int[] matchingClosings = GetMatchedStructuredBrackets(value);
+            int[] nextOpenings = GetNextMatchedOpenings(matchingClosings);
             var builder = new StringBuilder(value.Length);
-            int cursor = 0;
-            while (cursor < value.Length) {
-                if (value[cursor] != '[' || IsEscapedStructuredCharacter(value, cursor)
-                    || !TryFindStructuredBracketEnd(value, cursor, out int end)) {
-                    builder.Append(value[cursor++]);
-                    continue;
-                }
-
-                string content = value.Substring(cursor + 1, end - cursor - 2);
-                if (ContainsUnescapedOpeningBracket(content)) {
-                    builder.Append('[').Append(RewriteStructuredSelector(content, rewriteColumn)).Append(']');
-                } else {
+            for (int cursor = 0; cursor < value.Length; cursor++) {
+                int closing = matchingClosings[cursor];
+                if (closing >= 0) {
+                    builder.Append('[');
+                    if (nextOpenings[cursor + 1] < closing) continue;
+                    string content = value.Substring(cursor + 1, closing - cursor - 1);
                     bool rowContext = content.Length > 0 && content[0] == '@';
                     string rawColumn = rowContext ? content.Substring(1) : content;
                     bool areaSpecifier = rawColumn.Length > 0 && rawColumn[0] == '#';
                     string? replacement = areaSpecifier ? null : rewriteColumn(rawColumn);
-                    builder.Append('[');
                     if (rowContext) builder.Append('@');
-                    builder.Append(replacement ?? rawColumn).Append(']');
+                    builder.Append(replacement ?? rawColumn);
+                    builder.Append(']');
+                    cursor = closing;
+                    continue;
                 }
-                cursor = end;
+                builder.Append(value[cursor]);
             }
             return builder.ToString();
         }
 
-        private static bool ContainsUnescapedOpeningBracket(string value) {
+        private static int[] GetMatchedStructuredBrackets(string value) {
+            int[] matchingClosings = Enumerable.Repeat(-1, value.Length).ToArray();
+            var pending = new Stack<int>();
+            int apostropheRun = 0;
             for (int index = 0; index < value.Length; index++) {
-                if (value[index] == '[' && !IsEscapedStructuredCharacter(value, index)) return true;
-            }
-            return false;
-        }
-
-        private static bool TryFindStructuredBracketEnd(string value, int start, out int end) {
-            int depth = 0;
-            for (int index = start; index < value.Length; index++) {
-                if (value[index] == '[' && !IsEscapedStructuredCharacter(value, index)) {
-                    depth++;
-                } else if (value[index] == ']' && !IsEscapedStructuredCharacter(value, index)) {
-                    depth--;
-                    if (depth == 0) {
-                        end = index + 1;
-                        return true;
-                    }
+                char current = value[index];
+                if (current == '\'') {
+                    apostropheRun++;
+                    continue;
+                }
+                bool escaped = (apostropheRun & 1) != 0;
+                apostropheRun = 0;
+                if (escaped) continue;
+                if (current == '[') {
+                    pending.Push(index);
+                } else if (current == ']' && pending.Count > 0) {
+                    int opening = pending.Pop();
+                    matchingClosings[opening] = index;
                 }
             }
-            end = start;
-            return false;
+            return matchingClosings;
+        }
+
+        private static int[] GetNextMatchedOpenings(int[] matchingClosings) {
+            var nextOpenings = new int[matchingClosings.Length + 1];
+            int next = matchingClosings.Length;
+            nextOpenings[matchingClosings.Length] = next;
+            for (int index = matchingClosings.Length - 1; index >= 0; index--) {
+                if (matchingClosings[index] >= 0) next = index;
+                nextOpenings[index] = next;
+            }
+            return nextOpenings;
         }
 
         internal static bool IsEscapedStructuredCharacter(string value, int position) {

--- a/OfficeIMO.Excel/Read/ExcelReadOptions.cs
+++ b/OfficeIMO.Excel/Read/ExcelReadOptions.cs
@@ -12,6 +12,7 @@ namespace OfficeIMO.Excel {
         private long _maxInputBytes = 512L * 1024L * 1024L;
         private int _schemaSampleRows = 1_024;
         private int _maxXlsbCells = 4_000_000;
+        private int _maxXlsbLogicalRows = 1_048_576;
 
         /// <summary>
         /// Gets or sets the worksheet exposed by <see cref="ExcelDocument.OpenDataReader(string, ExcelReadOptions?)"/>.
@@ -89,6 +90,21 @@ namespace OfficeIMO.Excel {
                 }
 
                 _maxXlsbCells = value;
+            }
+        }
+
+        /// <summary>
+        /// Maximum logical rows emitted across one XLSB workbook data-reader operation. Default: 1,048,576.
+        /// Sparse row gaps consume this aggregate budget just like populated rows.
+        /// </summary>
+        public int MaxXlsbLogicalRows {
+            get => _maxXlsbLogicalRows;
+            set {
+                if (value <= 0) {
+                    throw new ArgumentOutOfRangeException(nameof(value), "XLSB logical-row limit must be greater than zero.");
+                }
+
+                _maxXlsbLogicalRows = value;
             }
         }
 

--- a/OfficeIMO.Excel/Read/ExcelWorkbookDataReader.cs
+++ b/OfficeIMO.Excel/Read/ExcelWorkbookDataReader.cs
@@ -106,6 +106,7 @@ namespace OfficeIMO.Excel {
                 XlsbImportOptions = new OfficeIMO.Excel.Xlsb.XlsbImportOptions {
                     MaxPackageBytes = options.MaxInputBytes,
                     MaxCells = options.MaxXlsbCells,
+                    MaxLogicalRows = options.MaxXlsbLogicalRows,
                     MaxSharedStrings = options.MaxSharedStringItems,
                     MaxSharedStringItemCharacters = options.MaxSharedStringItemCharacters,
                     MaxSharedStringCharacters = options.MaxSharedStringCharacters,

--- a/OfficeIMO.Excel/Xlsb/Biff12/XlsbLogicalRowReadBudget.cs
+++ b/OfficeIMO.Excel/Xlsb/Biff12/XlsbLogicalRowReadBudget.cs
@@ -1,0 +1,26 @@
+using System.Runtime.CompilerServices;
+
+namespace OfficeIMO.Excel.Xlsb.Biff12 {
+    /// <summary>Tracks logical rows emitted across one XLSB workbook data-reader operation.</summary>
+    internal sealed class XlsbLogicalRowReadBudget {
+        private readonly int _maximum;
+        private int _remaining;
+
+        internal XlsbLogicalRowReadBudget(int maximum) {
+            if (maximum <= 0) throw new ArgumentOutOfRangeException(nameof(maximum));
+            _maximum = maximum;
+            _remaining = maximum;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void Consume() {
+            if (_remaining <= 0) ThrowExceeded();
+            _remaining--;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void ThrowExceeded() =>
+            throw new InvalidDataException(
+                $"The XLSB workbook exceeds the configured limit of {_maximum} logical data rows.");
+    }
+}

--- a/OfficeIMO.Excel/Xlsb/Read/XlsbTabularDataReader.cs
+++ b/OfficeIMO.Excel/Xlsb/Read/XlsbTabularDataReader.cs
@@ -50,6 +50,7 @@ namespace OfficeIMO.Excel.Xlsb.Read {
         private readonly int _firstColumn;
         private readonly int _lastDataRow;
         private readonly CancellationToken _cancellationToken;
+        private readonly XlsbLogicalRowReadBudget _logicalRowBudget;
         private bool _closed;
         private bool _hasPendingRow;
         private bool _hasCurrentRow;
@@ -69,6 +70,7 @@ namespace OfficeIMO.Excel.Xlsb.Read {
             XlsbImportOptions limits,
             XlsbRecordReadBudget recordBudget,
             XlsbCellReadBudget cellBudget,
+            XlsbLogicalRowReadBudget logicalRowBudget,
             CancellationToken cancellationToken)
             : this(
                 CreatePooledPart(worksheetPart, limits, cancellationToken),
@@ -80,6 +82,7 @@ namespace OfficeIMO.Excel.Xlsb.Read {
                 limits,
                 recordBudget,
                 cellBudget,
+                logicalRowBudget,
                 cancellationToken) {
         }
 
@@ -93,6 +96,7 @@ namespace OfficeIMO.Excel.Xlsb.Read {
             XlsbImportOptions limits,
             XlsbRecordReadBudget recordBudget,
             XlsbCellReadBudget cellBudget,
+            XlsbLogicalRowReadBudget logicalRowBudget,
             CancellationToken cancellationToken) {
             _sharedStrings = sharedStrings ?? throw new ArgumentNullException(nameof(sharedStrings));
             _dateStyles = dateStyles ?? throw new ArgumentNullException(nameof(dateStyles));
@@ -102,6 +106,7 @@ namespace OfficeIMO.Excel.Xlsb.Read {
             if (cellBudget == null) {
                 throw new ArgumentNullException(nameof(cellBudget));
             }
+            _logicalRowBudget = logicalRowBudget ?? throw new ArgumentNullException(nameof(logicalRowBudget));
             _cancellationToken = cancellationToken;
             if (worksheetPart == null) {
                 throw new ArgumentNullException(nameof(worksheetPart));
@@ -148,6 +153,7 @@ namespace OfficeIMO.Excel.Xlsb.Read {
                     out int dimensionLastColumn);
                 Dictionary<int, string?>? headerValues = null;
                 if (hasHeaderRow && _hasPendingRow) {
+                    _logicalRowBudget.Consume();
                     int headerRowIndex = _pendingRowIndex;
                     headerValues = ReadHeaderRow();
                     if (_hasPendingRow && _pendingRowIndex <= headerRowIndex) {
@@ -266,12 +272,14 @@ namespace OfficeIMO.Excel.Xlsb.Read {
                 Array.Clear(_customValues, 0, _customValues.Length);
             }
             if (_nextLogicalRowIndex < _pendingRowIndex) {
+                _logicalRowBudget.Consume();
                 _nextLogicalRowIndex++;
                 _hasCurrentRow = true;
                 return true;
             }
 
             int currentRowIndex = _pendingRowIndex;
+            _logicalRowBudget.Consume();
             _hasPendingRow = false;
             bool reachedRowBoundary = _options.CellValueConverter == null
                 ? ReadCurrentRowRecordsFast()

--- a/OfficeIMO.Excel/Xlsb/Read/XlsbTabularWorkbook.cs
+++ b/OfficeIMO.Excel/Xlsb/Read/XlsbTabularWorkbook.cs
@@ -53,6 +53,7 @@ namespace OfficeIMO.Excel.Xlsb.Read {
         private readonly XlsbImportOptions _limits;
         private readonly XlsbRecordReadBudget _recordBudget;
         private readonly XlsbCellReadBudget _cellBudget;
+        private readonly XlsbLogicalRowReadBudget _logicalRowBudget;
         private readonly IReadOnlyList<string> _sharedStrings;
         private readonly int _maxSharedStringItemCharacters;
         private readonly long _maxSharedStringCharacters;
@@ -78,12 +79,14 @@ namespace OfficeIMO.Excel.Xlsb.Read {
                 MaxPackageBytes = readOptions.MaxInputBytes,
                 MaxSharedStrings = readOptions.MaxSharedStringItems,
                 MaxCells = readOptions.MaxXlsbCells,
+                MaxLogicalRows = readOptions.MaxXlsbLogicalRows,
                 ReportPreservedRecords = false
             };
             _limits.Validate();
             _parts = new XlsbPackagePartReader(_archive, _limits);
             _recordBudget = new XlsbRecordReadBudget(_limits.MaxRecordCount);
             _cellBudget = new XlsbCellReadBudget(_limits.MaxCells);
+            _logicalRowBudget = new XlsbLogicalRowReadBudget(_limits.MaxLogicalRows);
 
             IReadOnlyDictionary<string, XlsbPackageRelationship> relationships =
                 _parts.ReadRelationships(workbookPartName, cancellationToken);
@@ -208,6 +211,7 @@ namespace OfficeIMO.Excel.Xlsb.Read {
                     _limits,
                     _recordBudget,
                     _cellBudget,
+                    _logicalRowBudget,
                     cancellationToken);
             } catch {
                 part.Dispose();

--- a/OfficeIMO.Excel/Xlsb/XlsbImportOptions.cs
+++ b/OfficeIMO.Excel/Xlsb/XlsbImportOptions.cs
@@ -21,6 +21,9 @@ namespace OfficeIMO.Excel.Xlsb {
         /// <summary>Gets or sets the maximum number of populated cells projected from one workbook.</summary>
         public int MaxCells { get; set; } = 4_000_000;
 
+        /// <summary>Gets or sets the maximum logical rows emitted across one workbook data-reader operation.</summary>
+        public int MaxLogicalRows { get; set; } = 1_048_576;
+
         /// <summary>Gets or sets the maximum number of row metadata definitions projected from one workbook.</summary>
         public int MaxRowDefinitions { get; set; } = 100_000;
 
@@ -56,6 +59,7 @@ namespace OfficeIMO.Excel.Xlsb {
             if (MaxRecordCount <= 0) throw new ArgumentOutOfRangeException(nameof(MaxRecordCount));
             if (MaxWorksheets <= 0) throw new ArgumentOutOfRangeException(nameof(MaxWorksheets));
             if (MaxCells <= 0) throw new ArgumentOutOfRangeException(nameof(MaxCells));
+            if (MaxLogicalRows <= 0) throw new ArgumentOutOfRangeException(nameof(MaxLogicalRows));
             if (MaxRowDefinitions <= 0) throw new ArgumentOutOfRangeException(nameof(MaxRowDefinitions));
             if (MaxSharedStrings <= 0) throw new ArgumentOutOfRangeException(nameof(MaxSharedStrings));
             if (MaxSharedStringItemCharacters <= 0) throw new ArgumentOutOfRangeException(nameof(MaxSharedStringItemCharacters));

--- a/OfficeIMO.Html.Tests/Html.Security.AllSeverityBatch16.cs
+++ b/OfficeIMO.Html.Tests/Html.Security.AllSeverityBatch16.cs
@@ -1,7 +1,9 @@
 using OfficeIMO.Word;
 using OfficeIMO.Word.Html;
 using DocumentFormat.OpenXml.Wordprocessing;
+using DocumentFormat.OpenXml;
 using Xunit;
+using M = DocumentFormat.OpenXml.Math;
 
 namespace OfficeIMO.Tests;
 
@@ -62,5 +64,52 @@ public sealed class HtmlAllSeverityBatch16SecurityTests {
         string html = document.ToHtml();
 
         Assert.Equal(2, System.Text.RegularExpressions.Regex.Matches(html, ">same-content</p>").Count);
+    }
+
+    [Fact]
+    public void WordToHtmlExpandsDeepTableCellWrappersWithoutRecursion() {
+        const int depth = 5_000;
+        using WordDocument document = WordDocument.Create();
+        WordTableCell cell = document.AddTable(1, 1).Rows[0].Cells[0];
+        cell._tableCell.RemoveAllChildren();
+        OpenXmlCompositeElement parent = cell._tableCell;
+        for (int index = 0; index < depth; index++) {
+            var content = new SdtContentBlock();
+            parent.Append(new SdtBlock(new SdtProperties(), content));
+            parent = content;
+        }
+        parent.Append(new Paragraph(new Run(new Text("deep-table-cell"))));
+
+        string html = document.ToHtml(new WordToHtmlOptions {
+            MaxDocumentElements = 100_000
+        });
+
+        Assert.Contains("deep-table-cell", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WordToHtmlRejectsDeepOmmlBeforeRecursiveProjection() {
+        const int depth = 5_000;
+        using WordDocument document = WordDocument.Create();
+        var equation = new M.OfficeMath();
+        OpenXmlCompositeElement parent = equation;
+        for (int index = 0; index < depth; index++) {
+            var numerator = new M.Numerator();
+            parent.Append(new M.Fraction(
+                numerator,
+                new M.Denominator(new M.Run(new M.Text("1")))));
+            parent = numerator;
+        }
+        parent.Append(new M.Run(new M.Text("x")));
+        document.AddParagraph()._paragraph.Append(equation);
+
+        HtmlConversionLimitException exception = Assert.Throws<HtmlConversionLimitException>(() =>
+            document.ToHtmlResult(new WordToHtmlOptions {
+                MaxDocumentElements = 100_000,
+                MaxEquationNestingDepth = 64
+            }));
+
+        Assert.Equal("WordEquationDepthLimitExceeded", exception.Code);
+        Assert.Equal("EquationOmml", exception.LimitSource);
     }
 }

--- a/OfficeIMO.Html.Tests/Html.WordToHtml.OutputBudget.Transformations.cs
+++ b/OfficeIMO.Html.Tests/Html.WordToHtml.OutputBudget.Transformations.cs
@@ -24,9 +24,16 @@ namespace OfficeIMO.Tests {
                 IncludeDefaultCss = false,
                 MaxOutputCharacters = expected.Length
             });
+            HtmlConversionLimitException exceeded = Assert.Throws<HtmlConversionLimitException>(() =>
+                document.ToHtmlResult(new WordToHtmlOptions {
+                    IncludeDefaultCss = false,
+                    MaxOutputCharacters = expected.Length - 1
+                }));
 
             Assert.True(bounded.Succeeded);
             Assert.Equal(expected, bounded.RequireValue());
+            Assert.Equal("WordHtmlOutputLimitExceeded", exceeded.Code);
+            Assert.StartsWith("Equation", exceeded.LimitSource);
         }
 
         [Fact]

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfPageImageRendererTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfPageImageRendererTests.cs
@@ -2617,6 +2617,57 @@ public class PdfPageImageRendererTests {
         Assert.Throws<ArgumentException>(() => PdfPageImageRenderer.RenderPage(new WriteOnlyStream()));
     }
 
+    [Fact]
+    public void IndexedPaletteLookupStopsAtTheExactPaletteByteBudget() {
+        var dictionary = new PdfDictionary();
+        dictionary.Items["Filter"] = new PdfName("FlateDecode");
+        var lookupStream = new PdfStream(dictionary, CompressWithDeflate(new byte[4_096]));
+
+        PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() =>
+            PdfIndexedImageNormalizer.TryReadIndexedLookupBytes(
+                lookupStream,
+                new Dictionary<int, PdfIndirectObject>(),
+                maxLookupBytes: 3,
+                out _));
+
+        Assert.Equal(PdfReadLimitKind.DecodedStreamBytes, exception.Kind);
+        Assert.Equal(3, exception.Limit);
+    }
+
+    [Fact]
+    public void RenderPageBoundsDeclaredColorSpaceResourceCount() {
+        byte[] pdf = BuildSingleStreamPdf(
+            "/Cs1 cs 0.5 sc 0 0 10 10 re f",
+            "<< /ColorSpace << /Cs1 /DeviceGray /Cs2 /DeviceRGB >> >>");
+        PdfReadDocument document = PdfReadDocument.Open(pdf, new PdfReadOptions {
+            Limits = new PdfReadLimits { MaxColorSpaceResourcesPerPage = 1 }
+        });
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+            document.Pages[0].ToDrawing());
+
+        Assert.Contains("color-space resources", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void CalculatorColorSpaceProgramUsesATinyDecodeBudget() {
+        string oversizedProgram = "{" + new string(' ', 300) + "}";
+        byte[] pdf = BuildSingleStreamPdf(
+            "/Cs1 cs 0.5 sc 0 0 10 10 re f",
+            "<< /ColorSpace << /Cs1 [/Separation /Spot /DeviceRGB 5 0 R] >> >>",
+            BuildStreamObject(
+                5,
+                "<< /FunctionType 4 /Domain [0 1] /Range [0 1 0 1 0 1]",
+                oversizedProgram));
+        PdfReadDocument document = PdfReadDocument.Open(pdf);
+
+        PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() =>
+            document.Pages[0].ToDrawing());
+
+        Assert.Equal(PdfReadLimitKind.DecodedStreamBytes, exception.Kind);
+        Assert.Equal(257, exception.Limit);
+    }
+
     private static void AssertPngSignature(byte[] bytes) {
         Assert.True(bytes.Length > 8);
         Assert.Equal(137, bytes[0]);

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfPublicApiContractTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfPublicApiContractTests.cs
@@ -129,7 +129,7 @@ public sealed class PdfPublicApiContractTests {
                 BindingFlags.DeclaredOnly).Length);
 
         Assert.InRange(exportedTypes.Length, 1, 503);
-        Assert.InRange(publicMemberCount, 1, 9965);
+        Assert.InRange(publicMemberCount, 1, 9968);
 
         string[] officeReferences = assembly.GetReferencedAssemblies()
             .Select(reference => reference.Name)

--- a/OfficeIMO.Pdf/Reading/Core/PdfIndexedImageNormalizer.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfIndexedImageNormalizer.cs
@@ -77,12 +77,16 @@ internal static class PdfIndexedImageNormalizer {
             return false;
         }
 
-        if (!TryReadIndexedLookupBytes(colorSpaceArray.Items[3], objects, out var lookupBytes)) {
+        int paletteEntryCount = highValue + 1;
+        int expectedLookupLength = paletteEntryCount * baseComponentCount;
+        if (!TryReadIndexedLookupBytes(
+                colorSpaceArray.Items[3],
+                objects,
+                expectedLookupLength,
+                out var lookupBytes)) {
             return false;
         }
 
-        int paletteEntryCount = highValue + 1;
-        int expectedLookupLength = paletteEntryCount * baseComponentCount;
         if (lookupBytes.Length < expectedLookupLength) {
             return false;
         }
@@ -117,10 +121,13 @@ internal static class PdfIndexedImageNormalizer {
     internal static bool TryReadIndexedLookupBytes(
         PdfObject? lookupObject,
         Dictionary<int, PdfIndirectObject> objects,
+        int maxLookupBytes,
         out byte[] lookupBytes) {
         lookupBytes = Array.Empty<byte>();
+        if (maxLookupBytes <= 0) return false;
         PdfObject? resolvedLookup = ResolveObject(lookupObject, objects);
         if (resolvedLookup is PdfStringObj lookupString) {
+            if (lookupString.RawBytes.Length > maxLookupBytes) return false;
             lookupBytes = lookupString.RawBytes;
             return true;
         }
@@ -130,7 +137,11 @@ internal static class PdfIndexedImageNormalizer {
                 return false;
             }
 
-            lookupBytes = Filters.StreamDecoder.Decode(lookupStream.Dictionary, lookupStream.Data, objects);
+            lookupBytes = Filters.StreamDecoder.Decode(
+                lookupStream.Dictionary,
+                lookupStream.Data,
+                objects,
+                maxLookupBytes);
             return lookupBytes.Length > 0;
         }
 

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadPage.ColorSpaces.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadPage.ColorSpaces.cs
@@ -71,13 +71,19 @@ public sealed partial class PdfReadPage {
             !TryReadExtendedColorSpaceResource(array.Items[1], depth + 1, out PdfPageColorSpace baseColorSpace) ||
             baseColorSpace.Kind is PdfPageColorSpaceKind.Pattern or PdfPageColorSpaceKind.Indexed ||
             TryReadInteger(array.Items[2]) is not int highValue ||
-            highValue < 0 || highValue > 255 ||
-            !PdfIndexedImageNormalizer.TryReadIndexedLookupBytes(array.Items[3], _objects, out byte[] lookupBytes)) {
+            highValue < 0 || highValue > 255) {
             return false;
         }
 
         int componentCount = baseColorSpace.ComponentCount;
         int paletteCount = highValue + 1;
+        int lookupLength = checked(paletteCount * componentCount);
+        int lookupLimit = Math.Min(lookupLength, _limits.MaxDecodedStreamBytes);
+        if (!PdfIndexedImageNormalizer.TryReadIndexedLookupBytes(
+                array.Items[3],
+                _objects,
+                lookupLimit,
+                out byte[] lookupBytes)) return false;
         if (lookupBytes.Length < paletteCount * componentCount) return false;
 
         var palette = new OfficeColor[paletteCount];
@@ -178,7 +184,12 @@ public sealed partial class PdfReadPage {
     private bool TryReadBoundedCalculatorProgram(PdfStream stream, int inputCount, int outputCount, out int duplicateCount) {
         duplicateCount = 0;
         if (Filters.StreamDecoder.GetUnsupportedFilters(stream.Dictionary, _objects).Count != 0) return false;
-        byte[] bytes = Filters.StreamDecoder.Decode(stream.Dictionary, stream.Data, _objects);
+        int decodeLimit = Math.Min(257, _limits.MaxDecodedStreamBytes);
+        byte[] bytes = Filters.StreamDecoder.Decode(
+            stream.Dictionary,
+            stream.Data,
+            _objects,
+            decodeLimit);
         if (bytes.Length > 256) return false;
         string program = Encoding.ASCII.GetString(bytes).Trim();
         if (program.Length < 2 || program[0] != '{' || program[program.Length - 1] != '}') return false;

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadPage.Visual.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadPage.Visual.cs
@@ -785,6 +785,10 @@ public sealed partial class PdfReadPage {
         if (colorSpaces == null) {
             return result;
         }
+        if (colorSpaces.Items.Count > _limits.MaxColorSpaceResourcesPerPage) {
+            throw new InvalidDataException(
+                $"The page declares more than {_limits.MaxColorSpaceResourcesPerPage} color-space resources.");
+        }
 
         foreach (KeyValuePair<string, PdfObject> entry in colorSpaces.Items) {
             if (TryReadColorSpaceResource(entry.Value, out PdfPageColorSpace colorSpace)) {
@@ -801,6 +805,10 @@ public sealed partial class PdfReadPage {
             !resources.Items.TryGetValue("ColorSpace", out PdfObject? colorSpacesObject) ||
             ResolveDictionary(colorSpacesObject) is not PdfDictionary colorSpaces) {
             return result;
+        }
+        if (colorSpaces.Items.Count > _limits.MaxColorSpaceResourcesPerPage) {
+            throw new InvalidDataException(
+                $"The page declares more than {_limits.MaxColorSpaceResourcesPerPage} color-space resources.");
         }
 
         foreach (KeyValuePair<string, PdfObject> entry in colorSpaces.Items) {

--- a/OfficeIMO.Pdf/Reading/Options/PdfReadLimits.cs
+++ b/OfficeIMO.Pdf/Reading/Options/PdfReadLimits.cs
@@ -86,6 +86,9 @@ public sealed class PdfReadLimits {
     /// <summary>Maximum annotations declared on one page. Default: 100,000.</summary>
     public int MaxAnnotationsPerPage { get; init; } = 100_000;
 
+    /// <summary>Maximum named color-space resources inspected on one page. Default: 4,096.</summary>
+    public int MaxColorSpaceResourcesPerPage { get; init; } = 4_096;
+
     /// <summary>Maximum operators parsed from one page or form content stream. Default: 1,000,000.</summary>
     public int MaxContentOperations { get; init; } = DefaultMaxContentOperations;
 
@@ -120,6 +123,7 @@ public sealed class PdfReadLimits {
             MaxTotalAttachmentBytes = MaxTotalAttachmentBytes,
             MaxFormFieldAppearanceStates = MaxFormFieldAppearanceStates,
             MaxAnnotationsPerPage = MaxAnnotationsPerPage,
+            MaxColorSpaceResourcesPerPage = MaxColorSpaceResourcesPerPage,
             MaxContentOperations = MaxContentOperations,
             MaxContentOperands = MaxContentOperands,
             MaxContentNestingDepth = MaxContentNestingDepth
@@ -177,6 +181,7 @@ public sealed class PdfReadLimits {
         }
         ValidatePositive(MaxFormFieldAppearanceStates, nameof(MaxFormFieldAppearanceStates), "Maximum form-field appearance states must be positive.");
         ValidatePositive(MaxAnnotationsPerPage, nameof(MaxAnnotationsPerPage), "Maximum annotations per page must be positive.");
+        ValidatePositive(MaxColorSpaceResourcesPerPage, nameof(MaxColorSpaceResourcesPerPage), "Maximum color-space resources per page must be positive.");
         ValidatePositive(MaxContentOperations, nameof(MaxContentOperations), "Maximum content operations must be positive.");
         ValidatePositive(MaxContentOperands, nameof(MaxContentOperands), "Maximum content operands must be positive.");
         ValidatePositive(MaxContentNestingDepth, nameof(MaxContentNestingDepth), "Maximum content nesting depth must be positive.");

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.ImageExport.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.ImageExport.cs
@@ -2125,6 +2125,90 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void PowerPointSlide_BoundsEmbeddedPictureReadsForVisualSnapshots() {
+            using var stream = new MemoryStream();
+            using PowerPointPresentation presentation = PowerPointPresentation.Create(stream);
+            PowerPointSlide slide = presentation.AddSlide();
+            byte[] png = OfficePngWriter.Encode(new OfficeRasterImage(2, 2, OfficeColor.CornflowerBlue));
+            slide.AddPicture(new MemoryStream(png), ImagePartType.Png,
+                PowerPointUnits.FromPoints(20), PowerPointUnits.FromPoints(20),
+                PowerPointUnits.FromPoints(20), PowerPointUnits.FromPoints(20));
+
+            PowerPointSlideVisualSnapshot snapshot = slide.CreateVisualSnapshot(new PowerPointImageExportOptions {
+                MaximumEmbeddedImageBytes = png.Length - 1,
+                MaximumTotalEmbeddedImageBytes = png.Length * 2L
+            });
+
+            Assert.Empty(snapshot.Drawing.Images);
+            Assert.Contains(snapshot.Diagnostics, diagnostic =>
+                diagnostic.Code == PowerPointImageExportDiagnosticCodes.UnsupportedShape &&
+                diagnostic.Message.Contains("embedded image bytes", StringComparison.OrdinalIgnoreCase));
+        }
+
+        [Fact]
+        public void PowerPointSlide_BoundsAggregateEmbeddedPictureReads() {
+            using var stream = new MemoryStream();
+            using PowerPointPresentation presentation = PowerPointPresentation.Create(stream);
+            PowerPointSlide slide = presentation.AddSlide();
+            byte[] png = OfficePngWriter.Encode(new OfficeRasterImage(2, 2, OfficeColor.CornflowerBlue));
+            slide.AddPicture(new MemoryStream(png), ImagePartType.Png,
+                PowerPointUnits.FromPoints(20), PowerPointUnits.FromPoints(20),
+                PowerPointUnits.FromPoints(20), PowerPointUnits.FromPoints(20));
+            slide.AddPicture(new MemoryStream(png), ImagePartType.Png,
+                PowerPointUnits.FromPoints(50), PowerPointUnits.FromPoints(20),
+                PowerPointUnits.FromPoints(20), PowerPointUnits.FromPoints(20));
+
+            PowerPointSlideVisualSnapshot snapshot = slide.CreateVisualSnapshot(new PowerPointImageExportOptions {
+                MaximumEmbeddedImageBytes = png.Length,
+                MaximumTotalEmbeddedImageBytes = png.Length
+            });
+
+            Assert.Single(snapshot.Drawing.Images);
+            Assert.Contains(snapshot.Diagnostics, diagnostic =>
+                diagnostic.Code == PowerPointImageExportDiagnosticCodes.UnsupportedShape);
+        }
+
+        [Fact]
+        public void PowerPointSlide_ChargesGroupedPicturesOnceAgainstAggregateBudget() {
+            using var stream = new MemoryStream();
+            using PowerPointPresentation presentation = PowerPointPresentation.Create(stream);
+            PowerPointSlide slide = presentation.AddSlide();
+            byte[] png = OfficePngWriter.Encode(new OfficeRasterImage(2, 2, OfficeColor.CornflowerBlue));
+            PowerPointPicture picture = slide.AddPicture(new MemoryStream(png), ImagePartType.Png,
+                PowerPointUnits.FromPoints(20), PowerPointUnits.FromPoints(20),
+                PowerPointUnits.FromPoints(20), PowerPointUnits.FromPoints(20));
+            PowerPointAutoShape anchor = slide.AddRectanglePoints(50, 20, 12, 12);
+            slide.GroupShapes(new PowerPointShape[] { picture, anchor }, "Bounded picture group");
+
+            PowerPointSlideVisualSnapshot snapshot = slide.CreateVisualSnapshot(new PowerPointImageExportOptions {
+                MaximumEmbeddedImageBytes = png.Length,
+                MaximumTotalEmbeddedImageBytes = png.Length
+            });
+
+            Assert.Single(snapshot.Drawing.Images);
+            Assert.DoesNotContain(snapshot.Diagnostics, diagnostic =>
+                diagnostic.Message.Contains("embedded image bytes", StringComparison.OrdinalIgnoreCase));
+        }
+
+        [Fact]
+        public void PowerPointSlide_BoundsEmbeddedBackgroundImageReads() {
+            using var stream = new MemoryStream();
+            using PowerPointPresentation presentation = PowerPointPresentation.Create(stream);
+            PowerPointSlide slide = presentation.AddSlide();
+            byte[] png = OfficePngWriter.Encode(new OfficeRasterImage(2, 2, OfficeColor.CornflowerBlue));
+            slide.SetBackgroundImage(new MemoryStream(png), ImagePartType.Png);
+
+            PowerPointSlideVisualSnapshot snapshot = slide.CreateVisualSnapshot(new PowerPointImageExportOptions {
+                MaximumEmbeddedImageBytes = png.Length - 1,
+                MaximumTotalEmbeddedImageBytes = png.Length * 2L
+            });
+
+            Assert.Empty(snapshot.Drawing.Images);
+            Assert.Contains(snapshot.Diagnostics, diagnostic =>
+                diagnostic.Code == PowerPointImageExportDiagnosticCodes.InvalidSlideBackgroundImage);
+        }
+
+        [Fact]
         public void PowerPointSlide_RasterizesExistingSvgPictureWithoutAPlaceholder() {
             using var stream = new MemoryStream();
             using PowerPointPresentation presentation = PowerPointPresentation.Create(stream);

--- a/OfficeIMO.PowerPoint/Imaging/PowerPointImageExportOptions.cs
+++ b/OfficeIMO.PowerPoint/Imaging/PowerPointImageExportOptions.cs
@@ -7,6 +7,12 @@ namespace OfficeIMO.PowerPoint {
     /// Options controlling dependency-free PowerPoint slide image export.
     /// </summary>
     public class PowerPointImageExportOptions : OfficeImageExportOptions {
+        /// <summary>Default maximum bytes read from one embedded image during export.</summary>
+        public const int DefaultMaximumEmbeddedImageBytes = 64 * 1024 * 1024;
+
+        /// <summary>Default aggregate embedded-image bytes retained by one slide export.</summary>
+        public const long DefaultMaximumTotalEmbeddedImageBytes = 256L * 1024 * 1024;
+
         /// <inheritdoc />
         public override double LogicalUnitsPerInch => 72D;
 
@@ -46,6 +52,12 @@ namespace OfficeIMO.PowerPoint {
         /// <summary>Maximum nested group-shape depth rendered into a shared visual snapshot. Zero skips group content; negative values disable the depth limit.</summary>
         public int MaxGroupShapeDepth { get; set; } = 32;
 
+        /// <summary>Maximum bytes read from one embedded image during export.</summary>
+        public int MaximumEmbeddedImageBytes { get; set; } = DefaultMaximumEmbeddedImageBytes;
+
+        /// <summary>Maximum aggregate embedded-image bytes retained by one slide export.</summary>
+        public long MaximumTotalEmbeddedImageBytes { get; set; } = DefaultMaximumTotalEmbeddedImageBytes;
+
         /// <summary>Creates an independent options snapshot.</summary>
         public PowerPointImageExportOptions Clone() =>
             CopyPowerPointOptionsTo(new PowerPointImageExportOptions());
@@ -62,11 +74,19 @@ namespace OfficeIMO.PowerPoint {
             target.IncludeCharts = IncludeCharts;
             target.IncludeHiddenShapes = IncludeHiddenShapes;
             target.MaxGroupShapeDepth = MaxGroupShapeDepth;
+            target.MaximumEmbeddedImageBytes = MaximumEmbeddedImageBytes;
+            target.MaximumTotalEmbeddedImageBytes = MaximumTotalEmbeddedImageBytes;
             return target;
         }
 
         internal void Validate() {
             ValidateImageExportOptions();
+            if (MaximumEmbeddedImageBytes <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(MaximumEmbeddedImageBytes));
+            }
+            if (MaximumTotalEmbeddedImageBytes <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(MaximumTotalEmbeddedImageBytes));
+            }
         }
     }
 

--- a/OfficeIMO.PowerPoint/Imaging/PowerPointSlideImageRenderer.cs
+++ b/OfficeIMO.PowerPoint/Imaging/PowerPointSlideImageRenderer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Text;
 using System.Threading;
 using OfficeIMO.Drawing;
@@ -77,6 +78,9 @@ namespace OfficeIMO.PowerPoint {
         }
 
         internal static PowerPointSlideVisualSnapshot CreateSnapshot(PowerPointSlide slide, PowerPointImageExportOptions options) {
+            if (slide == null) throw new ArgumentNullException(nameof(slide));
+            if (options == null) throw new ArgumentNullException(nameof(options));
+            options.Validate();
             List<OfficeImageExportDiagnostic> diagnostics = new List<OfficeImageExportDiagnostic>();
             OfficeDrawing drawing = CreateDrawing(slide, options, diagnostics);
             drawing.AppendFontDiagnostics(diagnostics, "PowerPoint slide");
@@ -86,18 +90,21 @@ namespace OfficeIMO.PowerPoint {
         private static OfficeDrawing CreateDrawing(PowerPointSlide slide, PowerPointImageExportOptions options, List<OfficeImageExportDiagnostic> diagnostics) {
             (double width, double height) = GetSlideSizePoints(slide);
             OfficeDrawing drawing = new OfficeDrawing(width, height).ApplyImageExportOptions(options);
+            var imageBudget = new PowerPointEmbeddedImageReadBudget(
+                options.MaximumEmbeddedImageBytes,
+                options.MaximumTotalEmbeddedImageBytes);
             AddBackgroundRectangle(drawing, options.BackgroundColor, fillGradient: null);
 
             if (options.IncludeSlideBackground) {
-                AddResolvedBackground(slide, drawing, diagnostics);
+                AddResolvedBackground(slide, drawing, diagnostics, imageBudget);
             }
 
             if (options.IncludeSlideContent) {
                 A.ColorScheme? colorScheme = GetSlideColorScheme(slide);
                 AddSlideContent(slide.GetInheritedShapesForExport(), drawing, diagnostics,
-                    PowerPointShapeBoundsMapping.Identity, colorScheme, options, 0);
+                    PowerPointShapeBoundsMapping.Identity, colorScheme, options, imageBudget, 0);
                 AddSlideContent(slide.Shapes, drawing, diagnostics,
-                    PowerPointShapeBoundsMapping.Identity, colorScheme, options, 0);
+                    PowerPointShapeBoundsMapping.Identity, colorScheme, options, imageBudget, 0);
             }
 
             return drawing;
@@ -105,7 +112,8 @@ namespace OfficeIMO.PowerPoint {
 
         private static void AddSlideContent(IEnumerable<PowerPointShape> shapes, OfficeDrawing drawing,
             List<OfficeImageExportDiagnostic> diagnostics, PowerPointShapeBoundsMapping mapping,
-            A.ColorScheme? colorScheme, PowerPointImageExportOptions options, int groupDepth) {
+            A.ColorScheme? colorScheme, PowerPointImageExportOptions options,
+            PowerPointEmbeddedImageReadBudget imageBudget, int groupDepth) {
             foreach (PowerPointShape shape in shapes) {
                 if (shape.Hidden && !options.IncludeHiddenShapes) {
                     continue;
@@ -115,9 +123,9 @@ namespace OfficeIMO.PowerPoint {
                 }
 
                 if (shape is PowerPointGroupShape groupShape) {
-                    AddGroupShape(drawing, groupShape, diagnostics, mapping, colorScheme, options, groupDepth);
+                    AddGroupShape(drawing, groupShape, diagnostics, mapping, colorScheme, options, imageBudget, groupDepth);
                 } else if (shape is PowerPointPicture picture) {
-                    AddPicture(drawing, picture, diagnostics, mapping);
+                    AddPicture(drawing, picture, diagnostics, mapping, imageBudget);
                 } else if (shape is PowerPointTable table) {
                     AddTable(drawing, table, diagnostics, mapping, colorScheme);
                 } else if (shape is PowerPointChart chart) {
@@ -158,7 +166,8 @@ namespace OfficeIMO.PowerPoint {
 
         private static void AddGroupShape(OfficeDrawing drawing, PowerPointGroupShape groupShape,
             List<OfficeImageExportDiagnostic> diagnostics, PowerPointShapeBoundsMapping mapping,
-            A.ColorScheme? colorScheme, PowerPointImageExportOptions options, int groupDepth) {
+            A.ColorScheme? colorScheme, PowerPointImageExportOptions options,
+            PowerPointEmbeddedImageReadBudget imageBudget, int groupDepth) {
             if (options.MaxGroupShapeDepth >= 0 && groupDepth >= options.MaxGroupShapeDepth) {
                 AddUnsupportedShapeDiagnostic(diagnostics, groupShape,
                     "Skipped nested PowerPoint group content because MaxGroupShapeDepth was reached.");
@@ -179,7 +188,7 @@ namespace OfficeIMO.PowerPoint {
                 groupDrawing.Fonts.AddRange(drawing.Fonts);
                 PowerPointShapeBoundsMapping localChildMapping = CreateGroupLocalChildMapping(groupShape, mapping);
                 AddSlideContent(groupShape.OwnerSlide.GetGroupChildren(groupShape), groupDrawing, diagnostics,
-                    localChildMapping, colorScheme, options, groupDepth + 1);
+                    localChildMapping, colorScheme, options, imageBudget, groupDepth + 1);
 
                 try {
                     OfficeImageFrameTransform groupFrameTransform = CreateGroupFrameTransform(groupShape, left, top, width, height);
@@ -195,21 +204,23 @@ namespace OfficeIMO.PowerPoint {
                 return;
             }
 
-            PowerPointShapeBoundsMapping childMapping = CreateGroupChildMapping(groupShape, mapping);
             if (TryGetBounds(groupShape, drawing, diagnostics, mapping, out double clipLeft, out double clipTop, out double clipWidth, out double clipHeight)) {
                 var groupDrawing = new OfficeDrawing(Math.Max(1D, drawing.Width - clipLeft), Math.Max(1D, drawing.Height - clipTop));
                 groupDrawing.Fonts.AddRange(drawing.Fonts);
                 PowerPointShapeBoundsMapping localChildMapping = CreateGroupLocalChildMapping(groupShape, mapping);
                 AddSlideContent(groupShape.OwnerSlide.GetGroupChildren(groupShape), groupDrawing, diagnostics,
-                    localChildMapping, colorScheme, options, groupDepth + 1);
+                    localChildMapping, colorScheme, options, imageBudget, groupDepth + 1);
                 if (RequiresGroupClip(groupDrawing, clipWidth, clipHeight)) {
                     drawing.AddClippedDrawing(groupDrawing, clipLeft, clipTop, OfficeClipPath.Rectangle(clipWidth, clipHeight));
-                    return;
+                } else {
+                    drawing.AddDrawing(groupDrawing, clipLeft, clipTop);
                 }
+                return;
             }
 
+            PowerPointShapeBoundsMapping childMapping = CreateGroupChildMapping(groupShape, mapping);
             AddSlideContent(groupShape.OwnerSlide.GetGroupChildren(groupShape), drawing, diagnostics,
-                childMapping, colorScheme, options, groupDepth + 1);
+                childMapping, colorScheme, options, imageBudget, groupDepth + 1);
         }
 
         private static bool RequiresGroupClip(OfficeDrawing groupDrawing, double width, double height) {
@@ -242,15 +253,19 @@ namespace OfficeIMO.PowerPoint {
             return false;
         }
 
-        private static void AddPicture(OfficeDrawing drawing, PowerPointPicture picture, List<OfficeImageExportDiagnostic> diagnostics, PowerPointShapeBoundsMapping mapping) {
+        private static void AddPicture(OfficeDrawing drawing, PowerPointPicture picture,
+            List<OfficeImageExportDiagnostic> diagnostics, PowerPointShapeBoundsMapping mapping,
+            PowerPointEmbeddedImageReadBudget imageBudget) {
             if (!TryGetBounds(picture, drawing, diagnostics, mapping, out double left, out double top, out double width, out double height)) {
                 return;
             }
 
             byte[] bytes;
             try {
-                bytes = picture.GetImageBytes();
-            } catch (InvalidOperationException) {
+                int readLimit = imageBudget.GetNextReadLimit();
+                bytes = picture.GetImageBytes(readLimit);
+                imageBudget.Consume(bytes.Length);
+            } catch (Exception exception) when (exception is InvalidOperationException or InvalidDataException) {
                 AddUnsupportedShapeDiagnostic(diagnostics, picture, "Skipped a PowerPoint picture because its embedded image bytes could not be read.");
                 return;
             }
@@ -1040,8 +1055,23 @@ namespace OfficeIMO.PowerPoint {
             }
         }
 
-        private static void AddResolvedBackground(PowerPointSlide slide, OfficeDrawing drawing, List<OfficeImageExportDiagnostic> diagnostics) {
-            PowerPointSlideBackground background = slide.GetBackground();
+        private static void AddResolvedBackground(PowerPointSlide slide, OfficeDrawing drawing,
+            List<OfficeImageExportDiagnostic> diagnostics, PowerPointEmbeddedImageReadBudget imageBudget) {
+            PowerPointSlideBackground background;
+            try {
+                int readLimit = imageBudget.GetNextReadLimit();
+                background = slide.GetBackground(readLimit);
+                if (background.Kind == PowerPointSlideBackgroundKind.Image) {
+                    imageBudget.Consume(background.ImageByteLength);
+                }
+            } catch (Exception exception) when (exception is InvalidOperationException or InvalidDataException) {
+                AddDiagnostic(
+                    diagnostics,
+                    PowerPointImageExportDiagnosticCodes.InvalidSlideBackgroundImage,
+                    "Used the configured fallback background because the PowerPoint slide background image exceeded the export limit.",
+                    OfficeImageExportLossKind.Omission);
+                return;
+            }
             switch (background.Kind) {
                 case PowerPointSlideBackgroundKind.None:
                     return;
@@ -1077,6 +1107,30 @@ namespace OfficeIMO.PowerPoint {
                         "Used the configured fallback background because " + (background.UnsupportedReason ?? "the PowerPoint slide background is not supported."),
                         OfficeImageExportLossKind.Omission);
                     return;
+            }
+        }
+
+        private sealed class PowerPointEmbeddedImageReadBudget {
+            private readonly int _maximumImageBytes;
+            private long _remainingBytes;
+
+            internal PowerPointEmbeddedImageReadBudget(int maximumImageBytes, long maximumTotalBytes) {
+                _maximumImageBytes = maximumImageBytes;
+                _remainingBytes = maximumTotalBytes;
+            }
+
+            internal int GetNextReadLimit() {
+                if (_remainingBytes <= 0) {
+                    throw new InvalidOperationException("The aggregate embedded-image byte limit was exceeded.");
+                }
+                return (int)Math.Min(_maximumImageBytes, Math.Min(int.MaxValue, _remainingBytes));
+            }
+
+            internal void Consume(int bytes) {
+                if (bytes < 0 || bytes > _remainingBytes) {
+                    throw new InvalidOperationException("The aggregate embedded-image byte limit was exceeded.");
+                }
+                _remainingBytes -= bytes;
             }
         }
 

--- a/OfficeIMO.PowerPoint/PowerPointDesktopReferenceRenderer.cs
+++ b/OfficeIMO.PowerPoint/PowerPointDesktopReferenceRenderer.cs
@@ -83,11 +83,14 @@ namespace OfficeIMO.PowerPoint {
             try {
                 using PowerPointPresentation source = PowerPointPresentation.Load(
                     fullPath, new PowerPointLoadOptions {
-                        AccessMode = DocumentAccessMode.ReadOnly
+                        AccessMode = DocumentAccessMode.ReadOnly,
+                        PackageSecurity = OfficePackageSecurityOptions.UntrustedDefaults
                     });
                 expectedSlideCount = source.Slides.Count;
                 slidesWithVisibleContent = source.Slides
-                    .Select(HasExpectedVisibleContent)
+                    .Select(slide => HasExpectedVisibleContent(
+                        slide,
+                        new PowerPointImageExportOptions()))
                     .ToArray();
             } catch (Exception ex) {
                 return new PowerPointReferenceRenderResult(
@@ -211,14 +214,22 @@ namespace OfficeIMO.PowerPoint {
         }
 
         internal static bool HasExpectedVisibleContent(PowerPointSlide slide) {
+            return HasExpectedVisibleContent(slide, new PowerPointImageExportOptions());
+        }
+
+        internal static bool HasExpectedVisibleContent(
+            PowerPointSlide slide,
+            PowerPointImageExportOptions options) {
             if (slide == null) throw new ArgumentNullException(nameof(slide));
+            if (options == null) throw new ArgumentNullException(nameof(options));
             if (slide.SmartArts.Any(smartArt => !smartArt.Hidden
                     && IsPotentiallyVisibleOnSlide(slide, smartArt)
                     && !smartArt.TryGetOfficeDiagramSnapshot(out _))) {
                 return true;
             }
             OfficeImageExportResult rendered = slide.ExportImage(
-                OfficeImageExportFormat.Png);
+                OfficeImageExportFormat.Png,
+                options);
             if (HasVisibleOmittedContent(slide, rendered.Diagnostics)) {
                 return true;
             }

--- a/OfficeIMO.PowerPoint/PowerPointSlide.BackgroundSnapshot.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSlide.BackgroundSnapshot.cs
@@ -13,6 +13,16 @@ namespace OfficeIMO.PowerPoint {
         /// Returns a detached snapshot of the slide background fill that exporters can consume without Open XML coupling.
         /// </summary>
         public PowerPointSlideBackground GetBackground() {
+            return GetBackgroundCore(maximumImageBytes: null);
+        }
+
+        /// <summary>Returns a detached slide-background snapshot with a bound on embedded image bytes.</summary>
+        public PowerPointSlideBackground GetBackground(int maximumImageBytes) {
+            if (maximumImageBytes <= 0) throw new ArgumentOutOfRangeException(nameof(maximumImageBytes));
+            return GetBackgroundCore(maximumImageBytes);
+        }
+
+        private PowerPointSlideBackground GetBackgroundCore(int? maximumImageBytes) {
             (BackgroundProperties? properties, OpenXmlPart? ownerPart) = GetResolvedBackgroundProperties();
             if (properties == null || !properties.HasChildren) {
                 (BackgroundStyleReference? styleReference, OpenXmlPart? styleOwnerPart) = GetResolvedBackgroundStyleReference();
@@ -35,7 +45,7 @@ namespace OfficeIMO.PowerPoint {
 
             A.BlipFill? blipFill = properties.GetFirstChild<A.BlipFill>();
             if (blipFill != null) {
-                return GetBackgroundImage(blipFill, ownerPart ?? _slidePart);
+                return GetBackgroundImage(blipFill, ownerPart ?? _slidePart, maximumImageBytes);
             }
 
             A.GradientFill? gradientFill = properties.GetFirstChild<A.GradientFill>();
@@ -148,7 +158,10 @@ namespace OfficeIMO.PowerPoint {
             return null;
         }
 
-        private static PowerPointSlideBackground GetBackgroundImage(A.BlipFill blipFill, OpenXmlPart ownerPart) {
+        private static PowerPointSlideBackground GetBackgroundImage(
+            A.BlipFill blipFill,
+            OpenXmlPart ownerPart,
+            int? maximumImageBytes) {
             string? relationshipId = blipFill.Blip?.Embed?.Value;
             if (string.IsNullOrWhiteSpace(relationshipId)) {
                 return PowerPointSlideBackground.Unsupported("The slide background image is missing its relationship id.");
@@ -166,14 +179,15 @@ namespace OfficeIMO.PowerPoint {
             }
 
             using Stream source = imagePart.GetStream(FileMode.Open, FileAccess.Read);
-            using var copy = new MemoryStream();
-            source.CopyTo(copy);
+            byte[] imageBytes = maximumImageBytes.HasValue
+                ? OfficeIMO.Drawing.Internal.OfficeStreamReader.ReadAllBytes(source, maximumImageBytes.Value)
+                : OfficeIMO.Drawing.Internal.OfficeStreamReader.ReadAllBytes(source);
             PowerPointPictureCrop crop = ReadSourceCrop(blipFill.SourceRectangle);
             if (blipFill.GetFirstChild<A.Tile>() != null) {
                 return PowerPointSlideBackground.Unsupported("The slide background image uses tiled placement, which is not currently supported by OfficeIMO exporters.");
             }
 
-            return PowerPointSlideBackground.Image(copy.ToArray(), imagePart.ContentType, crop);
+            return PowerPointSlideBackground.Image(imageBytes, imagePart.ContentType, crop);
         }
 
         private static PowerPointPictureCrop ReadSourceCrop(A.SourceRectangle? rect) {

--- a/OfficeIMO.PowerPoint/PowerPointSlideBackground.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSlideBackground.cs
@@ -58,6 +58,8 @@ namespace OfficeIMO.PowerPoint {
         /// <summary>Embedded background image bytes when <see cref="Kind"/> is <see cref="PowerPointSlideBackgroundKind.Image"/>.</summary>
         public byte[]? ImageBytes => _imageBytes == null ? null : (byte[])_imageBytes.Clone();
 
+        internal int ImageByteLength => _imageBytes?.Length ?? 0;
+
         /// <summary>Embedded image content type when <see cref="Kind"/> is <see cref="PowerPointSlideBackgroundKind.Image"/>.</summary>
         public string? ImageContentType { get; }
 

--- a/OfficeIMO.Security.Tests/OfficeVbaSignatureCrossHostTests.cs
+++ b/OfficeIMO.Security.Tests/OfficeVbaSignatureCrossHostTests.cs
@@ -102,6 +102,22 @@ public sealed class OfficeVbaSignatureCrossHostTests {
     }
 
     [Fact]
+    public void ManagedCanonicalizerProcessesManySourceLinesWithoutRetainingASplitArray() {
+        string sourceLines = string.Join("\r\n", Enumerable.Repeat("' bounded source line", 20_000));
+        byte[] project = CreateVbaProject("ManyLines()\r\n" + sourceLines + "\r\nSub Tail");
+
+        bool created = OfficeVbaProjectCanonicalizer.TryCreate(
+            project,
+            1024 * 1024,
+            out OfficeVbaProjectCanonicalizer.Result? canonical,
+            out string detail);
+
+        Assert.True(created, detail);
+        Assert.NotNull(canonical);
+        Assert.NotEmpty(canonical!.ComputeV3Hash());
+    }
+
+    [Fact]
     public void ManagedCanonicalizerPreservesDesignerStorageTraversalOrder() {
         byte[] project = CreateVbaProject("Test", "UserForm1", 0, new[] {
             new OfficeCompoundStream("UserForm1/AA", new byte[] { 0xAA }),
@@ -401,16 +417,22 @@ public sealed class OfficeVbaSignatureCrossHostTests {
     }
 
     private static byte[] CompressLiteral(byte[] uncompressed) {
-        var payload = new List<byte>();
-        for (int offset = 0; offset < uncompressed.Length; offset += 8) {
-            payload.Add(0);
-            int count = Math.Min(8, uncompressed.Length - offset);
-            for (int index = 0; index < count; index++) payload.Add(uncompressed[offset + index]);
+        const int maximumLiteralBytesPerChunk = 3_640;
+        var result = new List<byte> { 0x01 };
+        for (int chunkOffset = 0; chunkOffset < uncompressed.Length; chunkOffset += maximumLiteralBytesPerChunk) {
+            int chunkInputLength = Math.Min(maximumLiteralBytesPerChunk, uncompressed.Length - chunkOffset);
+            var payload = new List<byte>(chunkInputLength + ((chunkInputLength + 7) / 8));
+            for (int offset = 0; offset < chunkInputLength; offset += 8) {
+                payload.Add(0);
+                int count = Math.Min(8, chunkInputLength - offset);
+                for (int index = 0; index < count; index++) payload.Add(uncompressed[chunkOffset + offset + index]);
+            }
+            int chunkSize = payload.Count + 2;
+            ushort header = checked((ushort)(0xB000 | (chunkSize - 3)));
+            result.Add((byte)header);
+            result.Add((byte)(header >> 8));
+            result.AddRange(payload);
         }
-        int chunkSize = payload.Count + 2;
-        ushort header = checked((ushort)(0xB000 | (chunkSize - 3)));
-        var result = new List<byte> { 0x01, (byte)header, (byte)(header >> 8) };
-        result.AddRange(payload);
         return result.ToArray();
     }
 

--- a/OfficeIMO.Security/XmlDigitalSignatureService.cs
+++ b/OfficeIMO.Security/XmlDigitalSignatureService.cs
@@ -12,8 +12,6 @@ namespace OfficeIMO.Security;
 
 /// <summary>Bounded XML Digital Signature primitives used by format-owned signing workflows.</summary>
 internal static class XmlDigitalSignatureService {
-    private static readonly string[] LocalReferenceIdAttributeNames = { "Id", "ID", "id" };
-
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The provider selects a closed XML DSig algorithm set and does not resolve caller-supplied transform implementations.")]
     [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "The provider rejects XSLT and limits XML DSig to statically referenced canonicalization and enveloped-signature transforms.")]
     internal static byte[] Create(XmlDigitalSignatureCreationRequest request) {
@@ -190,9 +188,9 @@ internal static class XmlDigitalSignatureService {
             return Result(SecurityValidationStatus.Indeterminate, Array.Empty<X509Certificate2>(), findings);
         }
 
-        EnsureLocalReferenceWorkWithinLimit(
+        _ = XmlDigitalSignatureReferenceWorkCalculator.Measure(
             document,
-            signedXml,
+            signedInfoElement,
             request.CertificateCandidates.Count,
             request.MaxTotalDigestWorkBytes);
 
@@ -371,73 +369,6 @@ internal static class XmlDigitalSignatureService {
 #endif
         return publicKey;
     }
-
-    private static void EnsureLocalReferenceWorkWithinLimit(
-        XmlDocument document,
-        SignedXml signedXml,
-        int certificateCandidateCount,
-        long maxTotalDigestBytes) {
-        if (certificateCandidateCount <= 0 || signedXml.SignedInfo == null) return;
-        long totalDigestWorkBytes = 0;
-        var targetSizes = new Dictionary<string, long>(StringComparer.Ordinal);
-        IReadOnlyDictionary<string, XmlElement?> targetsById = IndexLocalReferenceTargets(document);
-        foreach (object item in signedXml.SignedInfo.References) {
-            if (item is not Reference reference) continue;
-            string uri = reference.Uri ?? string.Empty;
-            if (uri.Length > 0 && uri[0] != '#') continue;
-            if (!targetSizes.TryGetValue(uri, out long targetBytes)) {
-                XmlElement? target = ResolveLocalReferenceTarget(document, targetsById, uri);
-                targetBytes = target == null ? 0L : Encoding.UTF8.GetByteCount(target.OuterXml);
-                targetSizes.Add(uri, targetBytes);
-            }
-            int transformPasses = (reference.TransformChain?.Count ?? 0) + 1;
-            long referenceWorkBytes = SaturatingMultiply(targetBytes, transformPasses);
-            long candidateWorkBytes = SaturatingMultiply(referenceWorkBytes, certificateCandidateCount);
-            if (candidateWorkBytes > maxTotalDigestBytes - totalDigestWorkBytes) {
-                throw new InvalidDataException(
-                    "Local SignedInfo references exceed the " + maxTotalDigestBytes +
-                    " byte aggregate digest-work limit across certificate candidates.");
-            }
-            totalDigestWorkBytes += candidateWorkBytes;
-        }
-    }
-
-    private static XmlElement? ResolveLocalReferenceTarget(
-        XmlDocument document,
-        IReadOnlyDictionary<string, XmlElement?> targetsById,
-        string uri) {
-        if (uri.Length == 0) return document.DocumentElement;
-        if (uri.Length == 1) return null;
-        return targetsById.TryGetValue(uri.Substring(1), out XmlElement? target) ? target : null;
-    }
-
-    private static Dictionary<string, XmlElement?> IndexLocalReferenceTargets(XmlDocument document) {
-        var targetsById = new Dictionary<string, XmlElement?>(StringComparer.Ordinal);
-        if (document.DocumentElement == null) return targetsById;
-        foreach (XmlElement element in EnumerateElements(document.DocumentElement)) {
-            foreach (string attributeName in LocalReferenceIdAttributeNames) {
-                if (!element.HasAttribute(attributeName)) continue;
-                string id = element.GetAttribute(attributeName);
-                if (id.Length == 0) continue;
-                if (targetsById.TryGetValue(id, out XmlElement? existing)) {
-                    if (!ReferenceEquals(existing, element)) targetsById[id] = null;
-                } else {
-                    targetsById.Add(id, element);
-                }
-            }
-        }
-        return targetsById;
-    }
-
-    private static IEnumerable<XmlElement> EnumerateElements(XmlElement root) {
-        yield return root;
-        foreach (XmlElement descendant in root.GetElementsByTagName("*").OfType<XmlElement>()) {
-            yield return descendant;
-        }
-    }
-
-    private static long SaturatingMultiply(long value, int multiplier) =>
-        multiplier <= 0 || value > long.MaxValue / multiplier ? long.MaxValue : value * multiplier;
 
     private static void CopyBounded(Stream source, Stream destination, long maxBytes) {
         var buffer = new byte[81920];

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.Diagnostics.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.Diagnostics.cs
@@ -12,6 +12,13 @@ namespace OfficeIMO.Word.Html {
             if (options.MaxEmbeddedImageBytes <= 0) throw new ArgumentOutOfRangeException(nameof(options.MaxEmbeddedImageBytes));
             if (options.MaxTotalEmbeddedImageBytes <= 0) throw new ArgumentOutOfRangeException(nameof(options.MaxTotalEmbeddedImageBytes));
             if (options.MaxOutputCharacters <= 0) throw new ArgumentOutOfRangeException(nameof(options.MaxOutputCharacters));
+            if (options.MaxEquationNestingDepth <= 0) throw new ArgumentOutOfRangeException(nameof(options.MaxEquationNestingDepth));
+            if (options.MaxEquationNestingDepth > WordMath.DefaultMaximumProjectionDepth) {
+                throw new ArgumentOutOfRangeException(
+                    nameof(options.MaxEquationNestingDepth),
+                    "MaxEquationNestingDepth cannot exceed the supported OMML projection depth of " +
+                    WordMath.DefaultMaximumProjectionDepth + ".");
+            }
 
             long elements = 0;
             bool hasFields = false;

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.Equations.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.Equations.cs
@@ -11,19 +11,20 @@ namespace OfficeIMO.Word.Html {
             IElement context,
             WordEquation equation,
             WordToHtmlOptions options) {
-            string label = equation.Text;
-            if (equation.Representation == WordEquationRepresentation.EquationField) {
-                // InspectExport charged the cached field result as ordinary Word text. The
-                // MathML projection replaces that source text, so release it before charging
-                // the generated mtext and accessibility label that actually reach the output.
-                ReleaseOutputCharacters(
-                    htmlDocument,
-                    GetHtmlEncodedLength(label, attributeValue: false));
-            }
-            long remaining = GetRemainingOutputCharacters(htmlDocument);
+            string label;
             string mathMl;
             try {
-                mathMl = equation.ToMathMl(GetMathMlParserInputLimit(remaining));
+                label = equation.GetText(options.MaxEquationNestingDepth);
+                if (equation.Representation == WordEquationRepresentation.EquationField) {
+                    // InspectExport charged the cached field result as ordinary Word text. The
+                    // MathML projection replaces that source text, so release it before charging
+                    // the generated mtext and accessibility label that actually reach the output.
+                    ReleaseOutputCharacters(
+                        htmlDocument,
+                        GetHtmlEncodedLength(label, attributeValue: false));
+                }
+                long remaining = GetRemainingOutputCharacters(htmlDocument);
+                mathMl = equation.ToMathMl(remaining, options.MaxEquationNestingDepth);
             } catch (WordMathMlOutputLimitExceededException) {
                 ThrowExportLimitExceeded(
                     options,
@@ -32,6 +33,15 @@ namespace OfficeIMO.Word.Html {
                     "EquationMathMl",
                     SaturatingAdd(options.MaxOutputCharacters, 1),
                     options.MaxOutputCharacters);
+                return null;
+            } catch (InvalidDataException exception) {
+                ThrowExportLimitExceeded(
+                    options,
+                    "WordEquationDepthLimitExceeded",
+                    exception.Message,
+                    "EquationOmml",
+                    SaturatingAdd(options.MaxEquationNestingDepth, 1),
+                    options.MaxEquationNestingDepth);
                 return null;
             }
             IElement? mathNode = new HtmlParser()
@@ -55,11 +65,6 @@ namespace OfficeIMO.Word.Html {
             mathNode.SetAttribute("aria-label", label);
             return mathNode;
         }
-
-        private static long GetMathMlParserInputLimit(long remainingOutputCharacters) =>
-            remainingOutputCharacters > long.MaxValue / 6L
-                ? long.MaxValue
-                : remainingOutputCharacters * 6L;
 
         private INode CreateEquationAdjacentTextNode(
             IHtmlDocument htmlDocument,

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.Equations.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.Equations.cs
@@ -6,6 +6,8 @@ using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word.Html {
     internal partial class WordToHtmlConverter {
+        private const long MaxMathMlEntityEncodingExpansion = 6L;
+
         private static IElement? CreateEquationNode(
             IHtmlDocument htmlDocument,
             IElement context,
@@ -24,7 +26,14 @@ namespace OfficeIMO.Word.Html {
                         GetHtmlEncodedLength(label, attributeValue: false));
                 }
                 long remaining = GetRemainingOutputCharacters(htmlDocument);
-                mathMl = equation.ToMathMl(remaining, options.MaxEquationNestingDepth);
+                // XML entity encoding can make the bounded projection larger than the HTML
+                // serializer's final text (notably for quotes and apostrophes). Keep that
+                // intermediate allocation proportional while enforcing the exact output limit
+                // against the parsed node below.
+                long projectionLimit = remaining > long.MaxValue / MaxMathMlEntityEncodingExpansion
+                    ? long.MaxValue
+                    : remaining * MaxMathMlEntityEncodingExpansion;
+                mathMl = equation.ToMathMl(projectionLimit, options.MaxEquationNestingDepth);
             } catch (WordMathMlOutputLimitExceededException) {
                 ThrowExportLimitExceeded(
                     options,

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.TableCss.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.TableCss.cs
@@ -2,16 +2,33 @@ using AngleSharp.Dom;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Wordprocessing;
 using System.Globalization;
+using System.Threading;
 
 namespace OfficeIMO.Word.Html {
     internal partial class WordToHtmlConverter {
         private static IEnumerable<WordElement> ExpandTableCellBlockContent(WordTableCell cell) =>
-            ExpandTableCellBlockContent(cell.Document, cell._tableCell);
+            ExpandTableCellBlockContent(
+                cell.Document,
+                cell._tableCell,
+                int.MaxValue,
+                CancellationToken.None);
 
         private static IEnumerable<WordElement> ExpandTableCellBlockContent(
             WordDocument document,
-            OpenXmlCompositeElement container) {
-            foreach (OpenXmlElement child in container.ChildElements) {
+            OpenXmlCompositeElement container,
+            long maxElements,
+            CancellationToken cancellationToken) {
+            if (maxElements <= 0) throw new ArgumentOutOfRangeException(nameof(maxElements));
+            var pending = new Stack<OpenXmlElement>();
+            PushChildrenInDocumentOrder(container, pending);
+            long visited = 0;
+            while (pending.Count > 0) {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (++visited > maxElements) {
+                    throw new InvalidDataException(
+                        $"The Word table-cell content exceeds the {maxElements}-element HTML conversion limit.");
+                }
+                OpenXmlElement child = pending.Pop();
                 if (child is Paragraph paragraph) {
                     foreach (WordParagraph converted in WordSection.ConvertParagraphToWordParagraphs(document, paragraph)) {
                         yield return converted;
@@ -19,10 +36,16 @@ namespace OfficeIMO.Word.Html {
                 } else if (child is Table table) {
                     yield return new WordTable(document, table);
                 } else if (child is OpenXmlCompositeElement blockWrapper && child is not TableCellProperties) {
-                    foreach (WordElement nested in ExpandTableCellBlockContent(document, blockWrapper)) {
-                        yield return nested;
-                    }
+                    PushChildrenInDocumentOrder(blockWrapper, pending);
                 }
+            }
+        }
+
+        private static void PushChildrenInDocumentOrder(
+            OpenXmlCompositeElement container,
+            Stack<OpenXmlElement> pending) {
+            for (int index = container.ChildElements.Count - 1; index >= 0; index--) {
+                pending.Push(container.ChildElements[index]);
             }
         }
 

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
@@ -960,7 +960,11 @@ namespace OfficeIMO.Word.Html {
 
                         IElement? cellDefinitionList = null;
                         var cellElements = new List<WordElement>();
-                        IEnumerable<WordElement> projectedCellElements = ExpandTableCellBlockContent(cell);
+                        IEnumerable<WordElement> projectedCellElements = ExpandTableCellBlockContent(
+                            cell.Document,
+                            cell._tableCell,
+                            options.MaxDocumentElements,
+                            cancellationToken);
                         foreach (WordElement wordElement in projectedCellElements) {
                             if (wordElement is WordParagraph candidate &&
                                 cellElements.Count > 0 &&

--- a/OfficeIMO.Word.Html/Options/WordToHtmlOptions.cs
+++ b/OfficeIMO.Word.Html/Options/WordToHtmlOptions.cs
@@ -25,6 +25,9 @@ namespace OfficeIMO.Word.Html {
         /// </summary>
         public int MaxListNestingDepth { get; set; } = 128;
 
+        /// <summary>Maximum OMML equation nesting depth projected to text or MathML. Defaults to and cannot exceed 256.</summary>
+        public int MaxEquationNestingDepth { get; set; } = 256;
+
         /// <summary>
         /// Optional font family applied to created runs during conversion.
         /// </summary>
@@ -153,6 +156,7 @@ namespace OfficeIMO.Word.Html {
                 MaxOutputCharacters = MaxOutputCharacters,
                 MaxTableNestingDepth = MaxTableNestingDepth,
                 MaxListNestingDepth = MaxListNestingDepth,
+                MaxEquationNestingDepth = MaxEquationNestingDepth,
                 FontFamily = FontFamily,
                 IncludeFontStyles = IncludeFontStyles,
                 IncludeListStyles = IncludeListStyles,

--- a/OfficeIMO.Word.Tests/Word.CompareDocuments.StructuredSecurity.cs
+++ b/OfficeIMO.Word.Tests/Word.CompareDocuments.StructuredSecurity.cs
@@ -329,9 +329,9 @@ namespace OfficeIMO.Tests {
         [Fact]
         public void NumberingStyleInheritanceConsumesDisclosureWorkBudget() {
             string path = Path.Combine(_directoryWithFiles, "compare_structure_numbering_style_inheritance_budget.docx");
+            const int inheritanceDepth = 5_000;
             int styleCount;
             using (WordDocument document = WordDocument.Create(path)) {
-                const int inheritanceDepth = 32;
                 Styles styles = document._wordprocessingDocument.MainDocumentPart!.StyleDefinitionsPart!.Styles!;
                 styles.Append(new Style(
                     new StyleParagraphProperties(new NumberingProperties(
@@ -382,7 +382,7 @@ namespace OfficeIMO.Tests {
 
             object completedCache = Activator.CreateInstance(cacheType, nonPublic: true)
                 ?? throw new InvalidOperationException("Numbering style catalog cache could not be recreated.");
-            object completeBudget = CreateComparisonWorkBudget(styleCount + 128L);
+            object completeBudget = CreateComparisonWorkBudget(styleCount + inheritanceDepth + 128L);
             object completeResult = containsNumberingFormatting.Invoke(
                 null,
                 new[] {

--- a/OfficeIMO.Word.Tests/Word.DigitalSignature.ResourceLimits.cs
+++ b/OfficeIMO.Word.Tests/Word.DigitalSignature.ResourceLimits.cs
@@ -203,7 +203,78 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
-        public void Test_DigitalSignature_BoundsPackageDigestWorkPerSignaturePart() {
+        public void Test_DigitalSignature_BoundsLocalReferenceDigestWorkAcrossSignatureParts() {
+            string filePath = Path.Combine(_directoryWithFiles, "WordDigitalSignatureLocalReferenceMultiPartBudget.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Local SignedInfo reference work across signatures");
+                document.Save();
+            }
+            using X509Certificate2 certificate = CreateSelfSignedSigningCertificate();
+            string encodedCertificate = Convert.ToBase64String(certificate.Export(X509ContentType.Cert));
+            string digest = "<DigestMethod Algorithm=\"http://www.w3.org/2001/04/xmlenc#sha256\" /><DigestValue>T2ZmaWNlSU1P</DigestValue>";
+            byte[] signatureBytes = Encoding.UTF8.GetBytes(
+                "<Signature xmlns=\"http://www.w3.org/2000/09/xmldsig#\">" +
+                "<SignedInfo><CanonicalizationMethod Algorithm=\"http://www.w3.org/TR/2001/REC-xml-c14n-20010315\" />" +
+                "<SignatureMethod Algorithm=\"http://www.w3.org/2001/04/xmldsig-more#rsa-sha256\" />" +
+                "<Reference URI=\"#payload\">" + digest + "</Reference></SignedInfo>" +
+                "<SignatureValue>AA==</SignatureValue>" +
+                "<KeyInfo><X509Data><X509Certificate>" + encodedCertificate + "</X509Certificate></X509Data></KeyInfo>" +
+                "<Object Id=\"payload\">" + new string('x', 512) + "</Object></Signature>");
+            AddDigitalSignatureMetadata(filePath, signatureBytes, signatureCount: 2);
+
+            using WordDocument loaded = WordDocument.Load(filePath);
+            WordSignatureValidationReport bounded = loaded.ValidateSignatures(SecurityProvider, new WordSignatureValidationOptions {
+                MaxTotalDigestBytes = 768
+            });
+            WordSignatureValidationReport allowed = loaded.ValidateSignatures(SecurityProvider, new WordSignatureValidationOptions {
+                MaxTotalDigestBytes = 4096
+            });
+
+            Assert.Contains(bounded.Diagnostics, finding => finding.Code == "SignatureResourceLimitExceeded");
+            Assert.DoesNotContain(allowed.Diagnostics, finding => finding.Code == "SignatureResourceLimitExceeded");
+        }
+
+        [Fact]
+        public void Test_DigitalSignature_SharesDigestWorkAcrossInspectionAndCryptographicValidation() {
+            string filePath = Path.Combine(_directoryWithFiles, "WordDigitalSignatureSharedInspectionValidationBudget.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph(new string('x', 4096));
+                document.Save();
+            }
+
+            string documentDigest = ComputePackagePartSha256Digest(filePath, "/word/document.xml");
+            byte[] packageReferenceSignature = CreateSignatureXml(digestValue: documentDigest);
+            using X509Certificate2 certificate = CreateSelfSignedSigningCertificate();
+            string encodedCertificate = Convert.ToBase64String(certificate.Export(X509ContentType.Cert));
+            string digest = "<DigestMethod Algorithm=\"http://www.w3.org/2001/04/xmlenc#sha256\" /><DigestValue>T2ZmaWNlSU1P</DigestValue>";
+            byte[] localReferenceSignature = Encoding.UTF8.GetBytes(
+                "<Signature xmlns=\"http://www.w3.org/2000/09/xmldsig#\">" +
+                "<SignedInfo><CanonicalizationMethod Algorithm=\"http://www.w3.org/TR/2001/REC-xml-c14n-20010315\" />" +
+                "<SignatureMethod Algorithm=\"http://www.w3.org/2001/04/xmldsig-more#rsa-sha256\" />" +
+                "<Reference URI=\"#payload\">" + digest + "</Reference></SignedInfo>" +
+                "<SignatureValue>AA==</SignatureValue>" +
+                "<KeyInfo><X509Data><X509Certificate>" + encodedCertificate + "</X509Certificate></X509Data></KeyInfo>" +
+                "<Object Id=\"payload\">" + new string('x', 512) + "</Object></Signature>");
+            AddDigitalSignatureMetadata(filePath, packageReferenceSignature, localReferenceSignature);
+
+            long documentPartLength;
+            using (var archive = ZipFile.OpenRead(filePath)) {
+                documentPartLength = archive.GetEntry("word/document.xml")!.Length;
+            }
+            using WordDocument loaded = WordDocument.Load(filePath);
+            WordSignatureValidationReport bounded = loaded.ValidateSignatures(SecurityProvider, new WordSignatureValidationOptions {
+                MaxTotalDigestBytes = checked(documentPartLength + 256L)
+            });
+            WordSignatureValidationReport allowed = loaded.ValidateSignatures(SecurityProvider, new WordSignatureValidationOptions {
+                MaxTotalDigestBytes = checked(documentPartLength + 4096L)
+            });
+
+            Assert.Contains(bounded.Diagnostics, finding => finding.Code == "SignatureResourceLimitExceeded");
+            Assert.DoesNotContain(allowed.Diagnostics, finding => finding.Code == "SignatureResourceLimitExceeded");
+        }
+
+        [Fact]
+        public void Test_DigitalSignature_BoundsPackageDigestWorkAcrossSignatureParts() {
             string filePath = Path.Combine(_directoryWithFiles, "WordDigitalSignaturePackageDigestBudget.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddParagraph(new string('x', 4096));
@@ -227,21 +298,21 @@ namespace OfficeIMO.Tests {
                 package.DigitalSignatureOriginPart,
                 hasApplicationSignatureMetadata: true,
                 packageBytes,
-                maxTotalDigestBytes: documentPartLength - 1);
+                maxTotalDigestBytes: documentPartLength);
             OfficePackageSignatureInfo allowed = OfficePackageSignatureInspector.Inspect(
                 package,
                 package.DigitalSignatureOriginPart,
                 hasApplicationSignatureMetadata: true,
                 packageBytes,
-                maxTotalDigestBytes: documentPartLength);
+                maxTotalDigestBytes: checked(documentPartLength * 2L));
 
             Assert.Equal(2, bounded.SignatureParts.Count);
-            Assert.All(bounded.SignatureParts, part => Assert.Contains(
-                "aggregate digest-work limit",
-                part.ParseError,
-                StringComparison.OrdinalIgnoreCase));
+            Assert.True(bounded.InspectionResourceLimitExceeded);
             Assert.Contains(bounded.UnsupportedDetails, detail =>
                 detail.Contains("aggregate digest-work limit", StringComparison.OrdinalIgnoreCase));
+            Assert.Single(bounded.SignatureParts, part => part.ParseError == null);
+            Assert.Single(bounded.SignatureParts, part => part.ParseError != null &&
+                part.ParseError.Contains("aggregate digest-work limit", StringComparison.OrdinalIgnoreCase));
             Assert.All(allowed.SignatureParts, part => {
                 Assert.Null(part.ParseError);
                 Assert.Single(part.SignedReferences);
@@ -441,6 +512,36 @@ namespace OfficeIMO.Tests {
                 finding.Code == "SignatureResourceLimitExceeded" &&
                 finding.Message.Contains("pending package part", StringComparison.OrdinalIgnoreCase));
         }
+
+#if NETFRAMEWORK
+        [Fact]
+        public void Test_DigitalSignature_LegacyRuntimeBoundsLivePackageSerialization() {
+            string filePath = Path.Combine(_directoryWithFiles, "WordDigitalSignatureLegacyLivePackageLimit.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Signed content");
+                document.Save();
+            }
+            using X509Certificate2 certificate = CreateSelfSignedSigningCertificate();
+            Assert.True(WordDocument.SignPackage(filePath, SecurityProvider, certificate).Succeeded);
+            long originalPackageBytes = new FileInfo(filePath).Length;
+
+            using WordDocument loaded = WordDocument.Load(filePath);
+            byte[] randomBytes = new byte[256 * 1024];
+            new Random(17).NextBytes(randomBytes);
+            loaded.AddParagraph(Convert.ToBase64String(randomBytes));
+            WordSignatureValidationReport validation = loaded.ValidateSignatures(
+                SecurityProvider,
+                new WordSignatureValidationOptions {
+                    MaxPartBytes = 2L * 1024 * 1024,
+                    MaxPackageBytes = originalPackageBytes + 1024L,
+                    MaxTotalDigestBytes = 2L * 1024 * 1024
+                });
+
+            Assert.Contains(validation.Diagnostics, finding =>
+                finding.Code == "SignatureResourceLimitExceeded" &&
+                finding.Message.Contains("validation-snapshot limit", StringComparison.OrdinalIgnoreCase));
+        }
+#endif
 
         private static void AddRelatedSignatureCertificates(string filePath, params byte[][] certificates) {
             using WordprocessingDocument package = WordprocessingDocument.Open(filePath, true);

--- a/OfficeIMO.Word.Tests/Word.DigitalSignature.cs
+++ b/OfficeIMO.Word.Tests/Word.DigitalSignature.cs
@@ -2085,6 +2085,21 @@ namespace OfficeIMO.Tests {
             appPart.Properties.Save();
         }
 
+        private static void AddDigitalSignatureMetadata(string filePath, params byte[][] signatureParts) {
+            using WordprocessingDocument package = WordprocessingDocument.Open(filePath, true);
+            package.AddDigitalSignatureOriginPart();
+            foreach (byte[] signatureBytes in signatureParts) {
+                XmlSignaturePart signaturePart = package.DigitalSignatureOriginPart!.AddNewPart<XmlSignaturePart>();
+                using var stream = new MemoryStream(signatureBytes);
+                signaturePart.FeedData(stream);
+            }
+
+            ExtendedFilePropertiesPart appPart = package.ExtendedFilePropertiesPart ?? package.AddExtendedFilePropertiesPart();
+            appPart.Properties ??= new DocumentFormat.OpenXml.ExtendedProperties.Properties();
+            appPart.Properties.DigitalSignature = new DigitalSignature();
+            appPart.Properties.Save();
+        }
+
         private static X509Certificate2 CreateSelfSignedSigningCertificate(string subjectName = "CN=OfficeIMO Package Signing Test") {
             using RSA rsa = RSA.Create(2048);
             return CreateSelfSignedSigningCertificate(rsa, subjectName);

--- a/OfficeIMO.Word.Tests/Word.StreamOwnership.cs
+++ b/OfficeIMO.Word.Tests/Word.StreamOwnership.cs
@@ -52,7 +52,7 @@ namespace OfficeIMO.Tests {
             FieldInfo ownedStreamField = typeof(WordDocument).GetField(
                 "_ownedPackageStream",
                 BindingFlags.Instance | BindingFlags.NonPublic)!;
-            MemoryStream ownedPackageStream = Assert.IsType<MemoryStream>(ownedStreamField.GetValue(loaded));
+            MemoryStream ownedPackageStream = Assert.IsAssignableFrom<MemoryStream>(ownedStreamField.GetValue(loaded));
             Assert.Single(loaded.Paragraphs).SetText("After");
 
             using var output = new MemoryStream();

--- a/OfficeIMO.Word/Internal/PackageSignatures/OfficePackageSignatureInfo.cs
+++ b/OfficeIMO.Word/Internal/PackageSignatures/OfficePackageSignatureInfo.cs
@@ -29,7 +29,8 @@ namespace OfficeIMO.Word {
             IReadOnlyList<OfficePackageSignaturePartInfo> signatureParts,
             IReadOnlyList<string> unsupportedDetails,
             IReadOnlyList<string> details,
-            bool inspectionResourceLimitExceeded = false) {
+            bool inspectionResourceLimitExceeded = false,
+            long inspectionDigestWorkBytes = 0L) {
             HasDigitalSignatureOriginPart = hasDigitalSignatureOriginPart;
             OriginPartUri = originPartUri;
             OriginRelationshipId = originRelationshipId;
@@ -38,6 +39,7 @@ namespace OfficeIMO.Word {
             UnsupportedDetails = unsupportedDetails;
             Details = details;
             InspectionResourceLimitExceeded = inspectionResourceLimitExceeded;
+            InspectionDigestWorkBytes = inspectionDigestWorkBytes;
         }
 
         /// <summary>Gets whether any package signature metadata was found.</summary>
@@ -66,6 +68,9 @@ namespace OfficeIMO.Word {
 
         /// <summary>Gets whether inspection stopped before package-part traversal at a caller-owned resource limit.</summary>
         internal bool InspectionResourceLimitExceeded { get; }
+
+        /// <summary>Gets package-reference digest work reserved during structural inspection.</summary>
+        internal long InspectionDigestWorkBytes { get; }
     }
 
     /// <summary>
@@ -270,6 +275,8 @@ namespace OfficeIMO.Word {
                 }
             }
 
+            bool digestWorkLimitExceeded = false;
+            long digestInspectionWorkBytes = 0L;
             try {
                 if (originPart != null) {
                     originRelationshipId = FindRelationshipId(package.Parts, originPart);
@@ -283,8 +290,8 @@ namespace OfficeIMO.Word {
                     Dictionary<string, OpenXmlPart> packageParts = GetPackageParts(package);
                     HashSet<string> packagePartUris = GetPackagePartUris(packageParts);
                     if (signatureArchive != null) packagePartUris.UnionWith(signatureArchive.PartUris);
+                    var digestWorkBudget = new OfficePackageDigestWorkBudget(maxTotalDigestBytes);
                     foreach (XmlSignaturePart signaturePart in originPart.XmlSignatureParts) {
-                        var digestWorkBudget = new OfficePackageDigestWorkBudget(maxTotalDigestBytes);
                         OfficePackageSignaturePartInfo partInfo = InspectSignaturePart(
                             originPart,
                             signaturePart,
@@ -308,7 +315,12 @@ namespace OfficeIMO.Word {
                         AddTimestampDetails(details, partInfo.Timestamps);
                         AddParseDetails(details, "X509 subjects", partInfo.X509SubjectNames);
                         unsupportedDetails.AddRange(partInfo.UnsupportedDetails);
+                        if (digestWorkBudget.IsExceeded) {
+                            digestWorkLimitExceeded = true;
+                            break;
+                        }
                     }
+                    digestInspectionWorkBytes = digestWorkBudget.ConsumedBytes;
                 }
 
                 if (hasApplicationSignatureMetadata) {
@@ -326,7 +338,9 @@ namespace OfficeIMO.Word {
                     hasApplicationSignatureMetadata,
                     signatureParts,
                     unsupportedDetails.Distinct(StringComparer.OrdinalIgnoreCase).ToArray(),
-                    details.Distinct(StringComparer.OrdinalIgnoreCase).ToArray());
+                    details.Distinct(StringComparer.OrdinalIgnoreCase).ToArray(),
+                    inspectionResourceLimitExceeded: digestWorkLimitExceeded,
+                    inspectionDigestWorkBytes: digestInspectionWorkBytes);
             } finally {
                 signatureArchive?.Dispose();
             }

--- a/OfficeIMO.Word/Internal/PackageSignatures/OfficePackageSignatureInspector.ResourceLimits.cs
+++ b/OfficeIMO.Word/Internal/PackageSignatures/OfficePackageSignatureInspector.ResourceLimits.cs
@@ -13,8 +13,15 @@ namespace OfficeIMO.Word {
 
         internal long MaxBytes { get; }
 
+        internal long RemainingBytes => _remainingBytes;
+
+        internal long ConsumedBytes => MaxBytes - _remainingBytes;
+
+        internal bool IsExceeded { get; private set; }
+
         internal void Reserve(long bytes) {
             if (bytes > _remainingBytes) {
+                IsExceeded = true;
                 throw new InvalidDataException("Authenticated package references exceed the " + MaxBytes + " byte aggregate digest-work limit.");
             }
             _remainingBytes -= bytes;

--- a/OfficeIMO.Word/Internal/PackageSignatures/OfficePackageSignatureValidator.cs
+++ b/OfficeIMO.Word/Internal/PackageSignatures/OfficePackageSignatureValidator.cs
@@ -54,6 +54,8 @@ namespace OfficeIMO.Word {
             var timestampBudget = new OfficePackageTimestampValidationBudget(
                 options.MaxTimestampTokens,
                 options.MaxTimestampBytes);
+            var digestWorkBudget = new OfficePackageDigestWorkBudget(options.MaxTotalDigestBytes);
+            digestWorkBudget.Reserve(signatureInfo.InspectionDigestWorkBytes);
             Dictionary<string, XmlSignaturePart> packageParts = originPart.XmlSignatureParts
                 .ToDictionary(part => OfficePackageSignatureArchive.NormalizePartUri(part.Uri.ToString()), StringComparer.OrdinalIgnoreCase);
             var results = new List<WordSignaturePartValidationResult>(signatureInfo.SignatureParts.Count);
@@ -71,7 +73,8 @@ namespace OfficeIMO.Word {
                     securityProvider,
                     options,
                     certificateByteBudget,
-                    timestampBudget));
+                    timestampBudget,
+                    digestWorkBudget));
             }
             return results;
         }
@@ -83,7 +86,8 @@ namespace OfficeIMO.Word {
             IOfficeSecurityProvider securityProvider,
             WordSignatureValidationOptions options,
             OfficePackageCertificateByteBudget certificateByteBudget,
-            OfficePackageTimestampValidationBudget timestampBudget) {
+            OfficePackageTimestampValidationBudget timestampBudget,
+            OfficePackageDigestWorkBudget digestWorkBudget) {
             var findings = new List<WordSignatureValidationFinding>();
             var timestampResults = new List<Rfc3161TimestampVerificationResult>();
             var certificates = new List<X509Certificate2>();
@@ -130,12 +134,28 @@ namespace OfficeIMO.Word {
                                findings)) {
                     cryptographicStatus = WordSignatureValidationState.Unsupported;
                 } else {
+                    long availableDigestWorkBytes = digestWorkBudget.RemainingBytes;
+                    if (availableDigestWorkBytes <= 0) {
+                        throw new InvalidDataException(
+                            "Local SignedInfo references exceed the " + digestWorkBudget.MaxBytes +
+                            " byte aggregate digest-work limit across signature parts.");
+                    }
+                    long localDigestWorkBytes = XmlDigitalSignatureReferenceWorkCalculator.Measure(
+                        document,
+                        signatureElement.ChildNodes
+                            .OfType<XmlElement>()
+                            .FirstOrDefault(element =>
+                                element.LocalName == "SignedInfo" &&
+                                element.NamespaceURI == XmlDigitalSignatureAlgorithms.Namespace),
+                        certificates.Count,
+                        availableDigestWorkBytes);
+                    digestWorkBudget.Reserve(localDigestWorkBytes);
                     var verificationRequest = new XmlDigitalSignatureVerificationRequest(
                         signatureBytes,
                         certificates) {
                         MaxSignatureBytes = options.MaxSignatureBytes,
                         MaxReferences = options.MaxSignedReferences,
-                        MaxTotalDigestWorkBytes = options.MaxTotalDigestBytes,
+                        MaxTotalDigestWorkBytes = availableDigestWorkBytes,
                         AllowedCanonicalizationMethods = SupportedSignedInfoCanonicalizationMethods,
                         AllowedReferenceTransforms = SupportedSignedInfoReferenceTransforms
                     };
@@ -543,6 +563,7 @@ namespace OfficeIMO.Word {
                     element.LocalName == "Reference" &&
                     element.NamespaceURI == XmlDigitalSignatureAlgorithms.Namespace)
                 .ToArray();
+
 
         private static WordSignatureValidationFinding Finding(
             string code,

--- a/OfficeIMO.Word/WordDocument.CreateLoad.cs
+++ b/OfficeIMO.Word/WordDocument.CreateLoad.cs
@@ -365,9 +365,10 @@ namespace OfficeIMO.Word {
                     return LoadLegacyDocFromNormalFlow(sourceBytes, filePath, saveOnDispose, readOnly);
                 }
 
-                var memoryStream = new MemoryStream(sourceBytes.Length);
-                memoryStream.Write(sourceBytes, 0, sourceBytes.Length);
-                memoryStream.Position = 0;
+                MemoryStream memoryStream = CreateLegacyValidationPackageStream(
+                    sourceBytes,
+                    readOnly,
+                    resolved.PackageSecurity?.MaxPackageBytes ?? int.MaxValue);
 
                 var wordDocument = WordprocessingDocument.Open(memoryStream, !readOnly, effectiveOpenSettings);
 
@@ -482,9 +483,10 @@ namespace OfficeIMO.Word {
                 return LoadLegacyDocFromNormalFlow(sourceBytes, filePath, saveOnDispose, readOnly);
             }
 
-            var memoryStream = new MemoryStream(sourceBytes.Length);
-            memoryStream.Write(sourceBytes, 0, sourceBytes.Length);
-            memoryStream.Position = 0;
+            MemoryStream memoryStream = CreateLegacyValidationPackageStream(
+                sourceBytes,
+                readOnly,
+                resolved.PackageSecurity?.MaxPackageBytes ?? int.MaxValue);
 
             var wordDocument = WordprocessingDocument.Open(memoryStream, !readOnly, effectiveOpenSettings);
 
@@ -572,9 +574,10 @@ namespace OfficeIMO.Word {
                 return LoadLegacyDocFromNormalFlow(sourceBytes, sourcePath: null, saveOnDispose, readOnly);
             }
 
-            var packageStream = new MemoryStream(sourceBytes.Length);
-            packageStream.Write(sourceBytes, 0, sourceBytes.Length);
-            packageStream.Position = 0;
+            MemoryStream packageStream = CreateLegacyValidationPackageStream(
+                sourceBytes,
+                readOnly,
+                resolved.PackageSecurity?.MaxPackageBytes ?? int.MaxValue);
             try {
                 var document = new WordDocument() {
                     OriginalStream = OfficeDocumentLifecycle.ResolveAssociatedDestination(stream, resolved.AccessMode)!,

--- a/OfficeIMO.Word/WordDocument.SignatureValidationSnapshot.LegacyRuntime.cs
+++ b/OfficeIMO.Word/WordDocument.SignatureValidationSnapshot.LegacyRuntime.cs
@@ -15,6 +15,18 @@ namespace OfficeIMO.Word {
                 ? (byte[])sourceBytes.Clone()
                 : null;
 
+        private static MemoryStream CreateLegacyValidationPackageStream(
+            byte[] sourceBytes,
+            bool readOnly,
+            long maximumPackageBytes) {
+            MemoryStream stream = !readOnly && RequiresLegacyRuntimeSignatureSnapshot()
+                ? new LegacyValidationPackageMemoryStream(maximumPackageBytes)
+                : new MemoryStream(sourceBytes.Length);
+            stream.Write(sourceBytes, 0, sourceBytes.Length);
+            stream.Position = 0;
+            return stream;
+        }
+
         // System.IO.Packaging on .NET Framework invalidates ProgressiveCrcCalculatingStream after
         // in-memory package edits. Flush the live package once, retain that stream for the document,
         // and keep the original encoded bytes in the validation baseline instead of rereading stale
@@ -47,9 +59,21 @@ namespace OfficeIMO.Word {
                     " byte validation-snapshot limit.");
             }
             MemoryStream livePackageStream = DetachLegacyValidationLivePackageStream(encodedPackage);
-            _wordprocessingDocument.Save();
-            sourcePackage.Save();
-            livePackageStream.Flush();
+            LegacyValidationPackageMemoryStream? boundedLivePackage =
+                livePackageStream as LegacyValidationPackageMemoryStream;
+            if (boundedLivePackage == null) {
+                throw new SignatureValidationSnapshotResourceException(
+                    "The legacy runtime package stream cannot be serialized within a validation byte limit.");
+            }
+            long previousMaximum = boundedLivePackage.MaximumBytes;
+            boundedLivePackage.SetMaximumBytes(Math.Min(previousMaximum, options.MaxPackageBytes));
+            try {
+                _wordprocessingDocument.Save();
+                sourcePackage.Save();
+                livePackageStream.Flush();
+            } finally {
+                boundedLivePackage.SetMaximumBytes(previousMaximum);
+            }
             if (livePackageStream.Length > options.MaxPackageBytes) {
                 throw new SignatureValidationSnapshotResourceException(
                     "The current OPC package exceeds the " + options.MaxPackageBytes +
@@ -80,6 +104,47 @@ namespace OfficeIMO.Word {
             _ownedPackageStream = new MemoryStream(encodedPackage, writable: false);
             _legacyValidationEncodedPackageBytes = null;
             return livePackageStream;
+        }
+
+        private sealed class LegacyValidationPackageMemoryStream : MemoryStream {
+            internal LegacyValidationPackageMemoryStream(long maximumBytes) {
+                SetMaximumBytes(maximumBytes);
+            }
+
+            internal long MaximumBytes { get; private set; }
+
+            internal void SetMaximumBytes(long maximumBytes) {
+                if (maximumBytes <= 0) throw new ArgumentOutOfRangeException(nameof(maximumBytes));
+                if (Length > maximumBytes) {
+                    throw new SignatureValidationSnapshotResourceException(
+                        "The current OPC package exceeds the " + maximumBytes +
+                        " byte validation-snapshot limit.");
+                }
+                MaximumBytes = maximumBytes;
+            }
+
+            public override void Write(byte[] buffer, int offset, int count) {
+                EnsureWithinLimit(Math.Max(Length, checked(Position + count)));
+                base.Write(buffer, offset, count);
+            }
+
+            public override void WriteByte(byte value) {
+                EnsureWithinLimit(Math.Max(Length, checked(Position + 1)));
+                base.WriteByte(value);
+            }
+
+            public override void SetLength(long value) {
+                EnsureWithinLimit(value);
+                base.SetLength(value);
+            }
+
+            private void EnsureWithinLimit(long value) {
+                if (value > MaximumBytes) {
+                    throw new SignatureValidationSnapshotResourceException(
+                        "The current OPC package exceeds the " + MaximumBytes +
+                        " byte validation-snapshot limit.");
+                }
+            }
         }
 
         private Dictionary<Uri, byte[]> CaptureLegacyPendingRootPayloads(WordSignatureValidationOptions options) {

--- a/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.NumberingStyles.cs
+++ b/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.NumberingStyles.cs
@@ -95,47 +95,92 @@ namespace OfficeIMO.Word {
                     numbering = cached;
                     return true;
                 }
-                if (!visiting.Add(styleId)) {
-                    numbering = null;
-                    return true;
-                }
-                if (comparisonWorkBudget != null && !comparisonWorkBudget.TryConsume(1)) {
-                    visiting.Remove(styleId);
+                var frames = new List<StyleNumberingResolutionFrame>();
+                if (!TryPushStyleResolutionFrame(
+                        styleId,
+                        comparisonWorkBudget,
+                        visiting,
+                        frames)) {
                     numbering = null;
                     return false;
                 }
 
-                foreach (Style style in StylesById[styleId]) {
+                while (frames.Count > 0) {
+                    StyleNumberingResolutionFrame frame = frames[frames.Count - 1];
+                    if (frame.NextStyleIndex >= frame.Styles.Count) {
+                        CompleteStyleResolution(frames, visiting, frame.StyleId, null);
+                        continue;
+                    }
+
+                    Style style = frame.Styles[frame.NextStyleIndex++];
                     NumberingProperties? direct = style.StyleParagraphProperties?.NumberingProperties;
                     if (direct != null) {
-                        visiting.Remove(styleId);
-                        _resolvedNumbering[styleId] = direct;
-                        numbering = direct;
-                        return true;
+                        CompleteStyleResolution(frames, visiting, frame.StyleId, direct);
+                        continue;
                     }
+
                     string? baseStyleId = style.BasedOn?.Val?.Value;
-                    if (string.IsNullOrWhiteSpace(baseStyleId)) continue;
-                    if (!TryResolveStyleNumbering(
+                    if (string.IsNullOrWhiteSpace(baseStyleId) || visiting.Contains(baseStyleId!)) continue;
+                    if (_resolvedNumbering.TryGetValue(baseStyleId!, out NumberingProperties? inherited)) {
+                        if (inherited != null) {
+                            CompleteStyleResolution(frames, visiting, frame.StyleId, inherited);
+                        }
+                        continue;
+                    }
+                    if (!TryPushStyleResolutionFrame(
                             baseStyleId!,
                             comparisonWorkBudget,
                             visiting,
-                            out NumberingProperties? inherited)) {
-                        visiting.Remove(styleId);
+                            frames)) {
+                        foreach (StyleNumberingResolutionFrame pending in frames) visiting.Remove(pending.StyleId);
                         numbering = null;
                         return false;
                     }
-                    if (inherited != null) {
-                        visiting.Remove(styleId);
-                        _resolvedNumbering[styleId] = inherited;
-                        numbering = inherited;
-                        return true;
-                    }
                 }
 
-                visiting.Remove(styleId);
-                _resolvedNumbering[styleId] = null;
-                numbering = null;
+                numbering = _resolvedNumbering[styleId];
                 return true;
+            }
+
+            private bool TryPushStyleResolutionFrame(
+                string styleId,
+                ComparisonWorkBudget? comparisonWorkBudget,
+                ISet<string> visiting,
+                ICollection<StyleNumberingResolutionFrame> frames) {
+                if (!visiting.Add(styleId)) return true;
+                if (comparisonWorkBudget != null && !comparisonWorkBudget.TryConsume(1)) {
+                    visiting.Remove(styleId);
+                    return false;
+                }
+                frames.Add(new StyleNumberingResolutionFrame(styleId, StylesById[styleId].ToArray()));
+                return true;
+            }
+
+            private void CompleteStyleResolution(
+                IList<StyleNumberingResolutionFrame> frames,
+                ISet<string> visiting,
+                string styleId,
+                NumberingProperties? numbering) {
+                _resolvedNumbering[styleId] = numbering;
+                visiting.Remove(styleId);
+                frames.RemoveAt(frames.Count - 1);
+                while (numbering != null && frames.Count > 0) {
+                    StyleNumberingResolutionFrame parent = frames[frames.Count - 1];
+                    _resolvedNumbering[parent.StyleId] = numbering;
+                    visiting.Remove(parent.StyleId);
+                    frames.RemoveAt(frames.Count - 1);
+                }
+            }
+
+            private sealed class StyleNumberingResolutionFrame {
+                internal StyleNumberingResolutionFrame(string styleId, IReadOnlyList<Style> styles) {
+                    StyleId = styleId;
+                    Styles = styles;
+                }
+
+                internal string StyleId { get; }
+                internal IReadOnlyList<Style> Styles { get; }
+                internal int NextStyleIndex { get; set; }
             }
 
             internal static ParagraphNumberingStyleCatalog? Create(

--- a/OfficeIMO.Word/WordEquation.cs
+++ b/OfficeIMO.Word/WordEquation.cs
@@ -81,6 +81,10 @@ namespace OfficeIMO.Word {
             }
         }
 
+        internal string GetText(int maxDepth) => MathElement != null
+            ? WordMath.GetText(MathElement, maxDepth)
+            : FieldParagraph?.Text ?? string.Empty;
+
         /// <summary>Gets raw OMML when the equation is backed by DOCX math markup; otherwise <c>null</c>.</summary>
         public string? Omml => MathElement?.OuterXml;
 
@@ -95,6 +99,10 @@ namespace OfficeIMO.Word {
 
         internal string ToMathMl(long maxCharacters) => MathElement != null
             ? WordMath.ToMathMl(MathElement, maxCharacters)
+            : WordMath.ToMathMlText(Text, maxCharacters);
+
+        internal string ToMathMl(long maxCharacters, int maxDepth) => MathElement != null
+            ? WordMath.ToMathMl(MathElement, maxCharacters, maxDepth)
             : WordMath.ToMathMlText(Text, maxCharacters);
 
         /// <summary>Projects this equation into the reusable OfficeIMO math expression tree.</summary>

--- a/OfficeIMO.Word/WordMath.MathMl.cs
+++ b/OfficeIMO.Word/WordMath.MathMl.cs
@@ -17,7 +17,11 @@ namespace OfficeIMO.Word {
     internal static partial class WordMath {
         internal static string ToMathMl(OpenXmlElement element) => ToMathMl(element, long.MaxValue);
 
-        internal static string ToMathMl(OpenXmlElement element, long maxCharacters) {
+        internal static string ToMathMl(OpenXmlElement element, long maxCharacters) =>
+            ToMathMl(element, maxCharacters, DefaultMaximumProjectionDepth);
+
+        internal static string ToMathMl(OpenXmlElement element, long maxCharacters, int maxDepth) {
+            EnsureMaximumProjectionDepth(element, maxDepth);
             var builder = new BoundedStringBuilder(maxCharacters);
             builder.Append("<math xmlns=\"http://www.w3.org/1998/Math/MathML\">");
             AppendMathMl(builder, element);

--- a/OfficeIMO.Word/WordMath.cs
+++ b/OfficeIMO.Word/WordMath.cs
@@ -9,8 +9,17 @@ namespace OfficeIMO.Word {
     /// </summary>
     internal static partial class WordMath {
         internal const string MathNamespace = "http://schemas.openxmlformats.org/officeDocument/2006/math";
+        internal const int DefaultMaximumProjectionDepth = 256;
 
-        internal static string GetText(OpenXmlElement element) {
+        internal static string GetText(OpenXmlElement element) =>
+            GetText(element, DefaultMaximumProjectionDepth);
+
+        internal static string GetText(OpenXmlElement element, int maxDepth) {
+            EnsureMaximumProjectionDepth(element, maxDepth);
+            return GetTextValidated(element);
+        }
+
+        private static string GetTextValidated(OpenXmlElement element) {
             var builder = new StringBuilder();
             AppendText(builder, element);
             return builder.ToString();
@@ -239,7 +248,23 @@ namespace OfficeIMO.Word {
 
         private static string ReadChildText(OpenXmlElement element, string localName) {
             OpenXmlElement? child = FindFirstChild(element, localName);
-            return child == null ? string.Empty : GetText(child);
+            return child == null ? string.Empty : GetTextValidated(child);
+        }
+
+        private static void EnsureMaximumProjectionDepth(OpenXmlElement element, int maxDepth) {
+            if (maxDepth <= 0) throw new ArgumentOutOfRangeException(nameof(maxDepth));
+            var pending = new Stack<(OpenXmlElement Element, int Depth)>();
+            pending.Push((element, 1));
+            while (pending.Count > 0) {
+                (OpenXmlElement current, int depth) = pending.Pop();
+                if (depth > maxDepth) {
+                    throw new InvalidDataException(
+                        "OMML equation nesting exceeds the configured " + maxDepth + "-level projection limit.");
+                }
+                for (int index = current.ChildElements.Count - 1; index >= 0; index--) {
+                    pending.Push((current.ChildElements[index], depth + 1));
+                }
+            }
         }
 
         private static string ReadNaryOperatorText(OpenXmlElement element) {

--- a/OfficeIMO.Word/WordSignatureInfo.cs
+++ b/OfficeIMO.Word/WordSignatureInfo.cs
@@ -15,7 +15,8 @@ namespace OfficeIMO.Word {
             IReadOnlyList<WordSignaturePartInfo> signatureParts,
             IReadOnlyList<string> unsupportedDetails,
             IReadOnlyList<string> details,
-            bool inspectionResourceLimitExceeded = false) {
+            bool inspectionResourceLimitExceeded = false,
+            long inspectionDigestWorkBytes = 0L) {
             HasDigitalSignatureOriginPart = hasDigitalSignatureOriginPart;
             OriginPartUri = originPartUri;
             OriginRelationshipId = originRelationshipId;
@@ -24,6 +25,7 @@ namespace OfficeIMO.Word {
             UnsupportedDetails = unsupportedDetails;
             Details = details;
             InspectionResourceLimitExceeded = inspectionResourceLimitExceeded;
+            InspectionDigestWorkBytes = inspectionDigestWorkBytes;
         }
 
         /// <summary>
@@ -69,6 +71,9 @@ namespace OfficeIMO.Word {
         /// <summary>Gets whether bounded inspection stopped before package-part traversal at a caller-owned resource limit.</summary>
         internal bool InspectionResourceLimitExceeded { get; }
 
+        /// <summary>Gets package-reference digest work reserved during structural inspection.</summary>
+        internal long InspectionDigestWorkBytes { get; }
+
         /// <summary>
         /// Gets a count suitable for feature-report findings.
         /// </summary>
@@ -86,7 +91,8 @@ namespace OfficeIMO.Word {
                 packageInfo.SignatureParts.Select(WordSignaturePartInfo.FromPackagePart).ToArray(),
                 packageInfo.UnsupportedDetails,
                 packageInfo.Details,
-                packageInfo.InspectionResourceLimitExceeded);
+                packageInfo.InspectionResourceLimitExceeded,
+                packageInfo.InspectionDigestWorkBytes);
         }
     }
 

--- a/OfficeIMO.Word/WordSignatureValidationOptions.cs
+++ b/OfficeIMO.Word/WordSignatureValidationOptions.cs
@@ -32,7 +32,7 @@ namespace OfficeIMO.Word {
         public int MaxSignedReferences { get; set; } = 4096;
 
         /// <summary>
-        /// Gets or sets the maximum aggregate bytes processed by each package-part or local SignedInfo digest-work phase per signature part.
+        /// Gets or sets the maximum aggregate bytes processed by package-part and local SignedInfo digest-work phases across the validation operation.
         /// Local-reference work includes every certificate candidate that may trigger cryptographic verification. Defaults to 512 MiB.
         /// </summary>
         public long MaxTotalDigestBytes { get; set; } = 512L * 1024 * 1024;


### PR DESCRIPTION
## Summary

- bound attacker-controlled work across PDF color resources, Office package signatures, PowerPoint images, XLSB logical rows, VBA source canonicalization, custom geometry, and generated HTML/MathML
- replace recursive or quadratic traversal in Word wrappers and numbering, OMML projection, and Excel structured selectors with bounded or iterative owners
- apply untrusted package defaults to desktop PowerPoint rendering and report the effective CSV text delimiter correctly
- add focused cross-target contracts for the complete current OfficeIMO security-finding queue

## Security finding coverage

The live OfficeIMO all-severity dashboard contains 17 findings. This branch fixes 12 high-severity findings plus the informational CSV delimiter finding. The medium Office PDF CLI package-limit finding was fixed by merged PR #2239, whose merge commit is the base of this branch. The other three high-severity findings—SmartArt ordering, in-cell image copy amplification, and chart cache rescans—are already fixed on `master` with bounded or iterative implementations and regression coverage.

## Compatibility

Existing APIs retain their defaults and gain explicit resource-limit options where callers need tighter policy. OMML projection now rejects nesting deeper than 256 levels with a controlled resource-limit failure, and legacy .NET Framework signature snapshots are bounded before package serialization.