### PR TITLE
Bound MathML and chart mutation planning

### DIFF
--- a/OfficeIMO.Excel.Tests/Excel.Security.ChartCachePlanning.cs
+++ b/OfficeIMO.Excel.Tests/Excel.Security.ChartCachePlanning.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using OfficeIMO.Excel;
+using Xunit;
+using C = DocumentFormat.OpenXml.Drawing.Charts;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        public void Test_StructuralRows_ChartCachePlanningRemainsLinearForSharedFormulaParent() {
+            const int formulaCount = 32_000;
+            using var document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet data = document.AddWorksheet("Data");
+            ExcelSheet summary = CreateChartOwner(document, "Summary");
+            ChartPart chartPart = Assert.Single(summary.WorksheetPart.DrawingsPart!.ChartParts);
+            C.Formula template = chartPart.ChartSpace.Descendants<C.Formula>().First();
+            OpenXmlCompositeElement reference = Assert.IsAssignableFrom<OpenXmlCompositeElement>(template.Parent);
+            reference.RemoveAllChildren();
+            for (int index = 0; index < formulaCount; index++) {
+                reference.Append(new C.Formula("Summary!A1:A2"));
+            }
+            Assert.Equal(formulaCount, reference.Elements<C.Formula>().Count());
+
+            var stopwatch = Stopwatch.StartNew();
+            ExcelRowMutationPlan plan = data.PlanInsertRows(
+                5,
+                options: new ExcelMutationPlanOptions {
+                    MaximumScannedElements = formulaCount + 1_000
+                });
+            stopwatch.Stop();
+
+            Assert.True(
+                stopwatch.Elapsed < TimeSpan.FromSeconds(5),
+                $"Chart mutation planning exceeded the linear-time budget: {stopwatch.Elapsed}.");
+            Assert.True(plan.ScannedElements <= formulaCount + 1_000);
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelSheet.StructuralMutationPlan.Dependencies.cs
+++ b/OfficeIMO.Excel/ExcelSheet.StructuralMutationPlan.Dependencies.cs
@@ -260,17 +260,16 @@ namespace OfficeIMO.Excel {
                         .Any(condition => Changes(condition.Reference?.Value)));
         }
 
-        private static bool ChartFormulaCacheWillBeInvalidated(
-            OpenXmlLeafTextElement formula,
-            ILookup<OpenXmlElement?, OpenXmlElement> directChildren) {
-            OpenXmlElement? reference = formula.Parent;
-            return reference != null
-                && (directChildren[reference].Any(element =>
-                        element.LocalName.EndsWith("Cache", StringComparison.OrdinalIgnoreCase))
-                    || (string.Equals(reference.LocalName, "numDim", StringComparison.Ordinal)
-                        || string.Equals(reference.LocalName, "strDim", StringComparison.Ordinal))
-                    && directChildren[reference].Any(element =>
-                        string.Equals(element.LocalName, "lvl", StringComparison.Ordinal)));
+        private static bool ChartChildInvalidatesFormulaCache(OpenXmlElement element) {
+            if (element.LocalName.EndsWith("Cache", StringComparison.OrdinalIgnoreCase)) {
+                return true;
+            }
+
+            OpenXmlElement? parent = element.Parent;
+            return parent != null
+                && (string.Equals(parent.LocalName, "numDim", StringComparison.Ordinal)
+                    || string.Equals(parent.LocalName, "strDim", StringComparison.Ordinal))
+                && string.Equals(element.LocalName, "lvl", StringComparison.Ordinal);
         }
 
         private int CountNamedSheetViewPlanImpacts(

--- a/OfficeIMO.Excel/ExcelSheet.StructuralMutationPlan.cs
+++ b/OfficeIMO.Excel/ExcelSheet.StructuralMutationPlan.cs
@@ -889,12 +889,15 @@ namespace OfficeIMO.Excel {
 
                 budget.Consume();
                 var chartElements = new List<OpenXmlElement>();
+                var chartCacheInvalidationParents = new HashSet<OpenXmlElement>();
                 foreach (OpenXmlElement element in chartRoot.Descendants()) {
                     budget.Consume();
                     chartElements.Add(element);
+                    if (ChartChildInvalidatesFormulaCache(element)
+                        && element.Parent is OpenXmlElement reference) {
+                        chartCacheInvalidationParents.Add(reference);
+                    }
                 }
-                ILookup<OpenXmlElement?, OpenXmlElement> chartDirectChildren =
-                    chartElements.ToLookup(element => element.Parent);
                 bool chartChanges = false;
                 foreach (OpenXmlElement element in chartElements) {
                     if (element is OpenXmlLeafTextElement formula
@@ -909,9 +912,8 @@ namespace OfficeIMO.Excel {
                             formulas++;
                             chartChanges = true;
                         }
-                        if (ChartFormulaCacheWillBeInvalidated(
-                                formula,
-                                chartDirectChildren)) {
+                        if (formula.Parent is OpenXmlElement reference
+                            && chartCacheInvalidationParents.Contains(reference)) {
                             chartChanges = true;
                         }
                     }

--- a/OfficeIMO.Html.Tests/Html.WordToHtml.OutputBudget.Transformations.cs
+++ b/OfficeIMO.Html.Tests/Html.WordToHtml.OutputBudget.Transformations.cs
@@ -32,8 +32,14 @@ namespace OfficeIMO.Tests {
 
             Assert.True(bounded.Succeeded);
             Assert.Equal(expected, bounded.RequireValue());
+            string projectedMathMl = Assert.Single(document.Equations).ToMathMl();
+            Assert.DoesNotContain("&quot;", projectedMathMl, StringComparison.Ordinal);
+            Assert.DoesNotContain("&apos;", projectedMathMl, StringComparison.Ordinal);
             Assert.Equal("WordHtmlOutputLimitExceeded", exceeded.Code);
-            Assert.StartsWith("Equation", exceeded.LimitSource);
+            Assert.Equal("EquationMathMl", exceeded.LimitSource);
+            Assert.Equal(expected.Length - 1L, exceeded.Limit);
+            Assert.True(exceeded.Actual > exceeded.Limit);
+            Assert.Equal($"Actual={exceeded.Actual}; Limit={exceeded.Limit}", exceeded.Detail);
         }
 
         [Fact]

--- a/OfficeIMO.Html.Tests/Html.WordToHtml.OutputBudget.cs
+++ b/OfficeIMO.Html.Tests/Html.WordToHtml.OutputBudget.cs
@@ -591,7 +591,7 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
-        public void Test_WordToHtml_OutputBudgetBoundsMathMlBeforeFragmentParsing() {
+        public void Test_WordToHtml_OutputBudgetBoundsEquationLabelBeforeMaterialization() {
             using WordDocument document = WordDocument.Create();
             document.AddParagraph()._paragraph.Append(
                 new M.OfficeMath(new M.Run(new M.Text(new string('&', 4096)))));
@@ -603,8 +603,10 @@ namespace OfficeIMO.Tests {
                 }));
 
             Assert.Equal("WordHtmlOutputLimitExceeded", exception.Code);
-            Assert.Equal("EquationMathMl", exception.LimitSource);
+            Assert.Equal("EquationAriaLabel", exception.LimitSource);
+            Assert.Equal(4096, exception.Limit);
             Assert.True(exception.Actual > exception.Limit);
+            Assert.Equal($"Actual={exception.Actual}; Limit={exception.Limit}", exception.Detail);
         }
 
         [Fact]

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.Equations.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.Equations.cs
@@ -6,8 +6,6 @@ using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word.Html {
     internal partial class WordToHtmlConverter {
-        private const long MaxMathMlEntityEncodingExpansion = 6L;
-
         private static IElement? CreateEquationNode(
             IHtmlDocument htmlDocument,
             IElement context,
@@ -16,7 +14,19 @@ namespace OfficeIMO.Word.Html {
             string label;
             string mathMl;
             try {
-                label = equation.GetText(options.MaxEquationNestingDepth);
+                long labelRemaining = GetRemainingOutputCharacters(htmlDocument);
+                try {
+                    label = equation.GetText(labelRemaining, options.MaxEquationNestingDepth);
+                } catch (WordMathMlOutputLimitExceededException exception) {
+                    ThrowExportLimitExceeded(
+                        options,
+                        "WordHtmlOutputLimitExceeded",
+                        "Generated equation accessibility text exceeds the configured HTML output-character limit before materialization.",
+                        "EquationAriaLabel",
+                        GetCumulativeOutputCharacters(options, exception),
+                        options.MaxOutputCharacters);
+                    return null;
+                }
                 if (equation.Representation == WordEquationRepresentation.EquationField) {
                     // InspectExport charged the cached field result as ordinary Word text. The
                     // MathML projection replaces that source text, so release it before charging
@@ -25,22 +35,22 @@ namespace OfficeIMO.Word.Html {
                         htmlDocument,
                         GetHtmlEncodedLength(label, attributeValue: false));
                 }
+                ReserveOutputCharacters(
+                    htmlDocument,
+                    " aria-label=\"\"".Length + GetHtmlEncodedLength(label, attributeValue: true),
+                    "Generated equation accessibility metadata exceeds the configured HTML output-character limit before DOM construction.",
+                    "EquationAriaLabel");
                 long remaining = GetRemainingOutputCharacters(htmlDocument);
-                // XML entity encoding can make the bounded projection larger than the HTML
-                // serializer's final text (notably for quotes and apostrophes). Keep that
-                // intermediate allocation proportional while enforcing the exact output limit
-                // against the parsed node below.
-                long projectionLimit = remaining > long.MaxValue / MaxMathMlEntityEncodingExpansion
-                    ? long.MaxValue
-                    : remaining * MaxMathMlEntityEncodingExpansion;
-                mathMl = equation.ToMathMl(projectionLimit, options.MaxEquationNestingDepth);
-            } catch (WordMathMlOutputLimitExceededException) {
+                // MathML text projection uses XML text escaping only. Bound the complete parser
+                // input by the remaining HTML budget before AngleSharp allocates a fragment DOM.
+                mathMl = equation.ToMathMl(remaining, options.MaxEquationNestingDepth);
+            } catch (WordMathMlOutputLimitExceededException exception) {
                 ThrowExportLimitExceeded(
                     options,
                     "WordHtmlOutputLimitExceeded",
                     "Generated MathML exceeds the configured HTML output-character limit before DOM construction.",
                     "EquationMathMl",
-                    SaturatingAdd(options.MaxOutputCharacters, 1),
+                    GetCumulativeOutputCharacters(options, exception),
                     options.MaxOutputCharacters);
                 return null;
             } catch (InvalidDataException exception) {
@@ -65,14 +75,17 @@ namespace OfficeIMO.Word.Html {
                 countingWriter.CharacterCount,
                 "Generated MathML exceeds the configured HTML output-character limit before DOM construction.",
                 "EquationMathMl");
-            ReserveOutputCharacters(
-                htmlDocument,
-                " aria-label=\"\"".Length + GetHtmlEncodedLength(label, attributeValue: true),
-                "Generated equation accessibility metadata exceeds the configured HTML output-character limit before DOM construction.",
-                "EquationAriaLabel");
-            // The complete serialized aria-label attribute is reserved before DOM assignment.
+            // The complete serialized aria-label attribute was reserved before materializing
+            // either the MathML fragment DOM or the attribute value.
             mathNode.SetAttribute("aria-label", label);
             return mathNode;
+        }
+
+        private static long GetCumulativeOutputCharacters(
+            WordToHtmlOptions options,
+            WordMathMlOutputLimitExceededException exception) {
+            long consumedBeforeProjection = Math.Max(0, options.MaxOutputCharacters - exception.Limit);
+            return SaturatingAdd(consumedBeforeProjection, exception.Actual);
         }
 
         private INode CreateEquationAdjacentTextNode(

--- a/OfficeIMO.Word/WordEquation.cs
+++ b/OfficeIMO.Word/WordEquation.cs
@@ -85,6 +85,10 @@ namespace OfficeIMO.Word {
             ? WordMath.GetText(MathElement, maxDepth)
             : FieldParagraph?.Text ?? string.Empty;
 
+        internal string GetText(long maxCharacters, int maxDepth) => MathElement != null
+            ? WordMath.GetText(MathElement, maxCharacters, maxDepth)
+            : FieldParagraph?.Text ?? string.Empty;
+
         /// <summary>Gets raw OMML when the equation is backed by DOCX math markup; otherwise <c>null</c>.</summary>
         public string? Omml => MathElement?.OuterXml;
 
@@ -528,13 +532,6 @@ namespace OfficeIMO.Word {
         private WordParagraph? FieldParagraph => _simpleField != null
             ? new WordParagraph(_document, _paragraph, _simpleField)
             : _runs != null ? new WordParagraph(_document, _paragraph, _runs) : null;
-
-        private static string EscapeXml(string value) => value
-            .Replace("&", "&amp;")
-            .Replace("<", "&lt;")
-            .Replace(">", "&gt;")
-            .Replace("\"", "&quot;")
-            .Replace("'", "&apos;");
     }
 
     internal sealed class WordEquationOccurrence {

--- a/OfficeIMO.Word/WordMath.MathMl.cs
+++ b/OfficeIMO.Word/WordMath.MathMl.cs
@@ -67,7 +67,7 @@ namespace OfficeIMO.Word {
                     return;
                 case "rad":
                     OpenXmlElement? degree = FindFirstChild(element, "deg");
-                    if (degree == null || GetText(degree).Length == 0) {
+                    if (degree == null || !HasProjectedText(degree)) {
                         builder.Append("<msqrt>");
                         AppendMathMlChild(builder, element, "e");
                         builder.Append("</msqrt>");
@@ -84,7 +84,12 @@ namespace OfficeIMO.Word {
                     return;
                 case "func":
                     builder.Append("<mrow><mi>");
-                    AppendEscapedXml(builder, ReadChildText(element, "fName"));
+                    OpenXmlElement? functionName = FindFirstChild(element, "fName");
+                    if (functionName != null) {
+                        AppendEscapedXml(
+                            builder,
+                            GetTextValidated(functionName, builder.RemainingCharacters));
+                    }
                     builder.Append("</mi><mo>(</mo>");
                     AppendMathMlChild(builder, element, "e");
                     builder.Append("<mo>)</mo></mrow>");
@@ -187,7 +192,7 @@ namespace OfficeIMO.Word {
 
         private static void AppendMathMlChildOrNone(BoundedStringBuilder builder, OpenXmlElement element, string localName) {
             OpenXmlElement? child = FindFirstChild(element, localName);
-            if (child == null || GetText(child).Length == 0) builder.Append("<none/>");
+            if (child == null || !HasProjectedText(child)) builder.Append("<none/>");
             else AppendMathMl(builder, child);
         }
 
@@ -257,16 +262,18 @@ namespace OfficeIMO.Word {
                     case '>':
                         builder.Append("&gt;");
                         break;
-                    case '"':
-                        builder.Append("&quot;");
-                        break;
-                    case '\'':
-                        builder.Append("&apos;");
-                        break;
                     default:
                         builder.Append(character);
                         break;
                 }
+            }
+        }
+
+        private static bool HasProjectedText(OpenXmlElement element) {
+            try {
+                return GetTextValidated(element, 1).Length > 0;
+            } catch (WordMathMlOutputLimitExceededException) {
+                return true;
             }
         }
 
@@ -279,6 +286,10 @@ namespace OfficeIMO.Word {
                 _maxCharacters = maxCharacters;
             }
 
+            internal int Length => _builder.Length;
+
+            internal long RemainingCharacters => Math.Max(0, _maxCharacters - _builder.Length);
+
             internal BoundedStringBuilder Append(string? value) {
                 if (string.IsNullOrEmpty(value)) return this;
                 EnsureCapacity(value!.Length);
@@ -289,6 +300,13 @@ namespace OfficeIMO.Word {
             internal BoundedStringBuilder Append(char value) {
                 EnsureCapacity(1);
                 _builder.Append(value);
+                return this;
+            }
+
+            internal BoundedStringBuilder Insert(int index, string value) {
+                if (value == null) throw new ArgumentNullException(nameof(value));
+                EnsureCapacity(value.Length);
+                _builder.Insert(index, value);
                 return this;
             }
 

--- a/OfficeIMO.Word/WordMath.cs
+++ b/OfficeIMO.Word/WordMath.cs
@@ -1,5 +1,4 @@
 using DocumentFormat.OpenXml;
-using System.Text;
 using M = DocumentFormat.OpenXml.Math;
 
 namespace OfficeIMO.Word {
@@ -15,12 +14,16 @@ namespace OfficeIMO.Word {
             GetText(element, DefaultMaximumProjectionDepth);
 
         internal static string GetText(OpenXmlElement element, int maxDepth) {
-            EnsureMaximumProjectionDepth(element, maxDepth);
-            return GetTextValidated(element);
+            return GetText(element, long.MaxValue, maxDepth);
         }
 
-        private static string GetTextValidated(OpenXmlElement element) {
-            var builder = new StringBuilder();
+        internal static string GetText(OpenXmlElement element, long maxCharacters, int maxDepth) {
+            EnsureMaximumProjectionDepth(element, maxDepth);
+            return GetTextValidated(element, maxCharacters);
+        }
+
+        private static string GetTextValidated(OpenXmlElement element, long maxCharacters = long.MaxValue) {
+            var builder = new BoundedStringBuilder(maxCharacters);
             AppendText(builder, element);
             return builder.ToString();
         }
@@ -42,7 +45,7 @@ namespace OfficeIMO.Word {
             }
         }
 
-        private static void AppendText(StringBuilder builder, OpenXmlElement element) {
+        private static void AppendText(BoundedStringBuilder builder, OpenXmlElement element) {
             if (element is M.Text text) {
                 builder.Append(text.Text);
                 return;
@@ -54,27 +57,32 @@ namespace OfficeIMO.Word {
                     return;
                 case "sSup":
                     AppendChildText(builder, element, "e");
-                    AppendScriptText(builder, "^", ReadChildText(element, "sup"));
+                    AppendScriptText(builder, "^", element, "sup");
                     return;
                 case "sSub":
                     AppendChildText(builder, element, "e");
-                    AppendScriptText(builder, "_", ReadChildText(element, "sub"));
+                    AppendScriptText(builder, "_", element, "sub");
                     return;
                 case "sSubSup":
                     AppendChildText(builder, element, "e");
-                    AppendScriptText(builder, "_", ReadChildText(element, "sub"));
-                    AppendScriptText(builder, "^", ReadChildText(element, "sup"));
+                    AppendScriptText(builder, "_", element, "sub");
+                    AppendScriptText(builder, "^", element, "sup");
                     return;
                 case "sPre":
-                    AppendScriptText(builder, "^", ReadChildText(element, "sup"));
-                    AppendScriptText(builder, "_", ReadChildText(element, "sub"));
+                    AppendScriptText(builder, "^", element, "sup");
+                    AppendScriptText(builder, "_", element, "sub");
                     AppendChildText(builder, element, "e");
                     return;
                 case "rad":
-                    string degree = ReadChildText(element, "deg");
-                    string radicand = ReadChildText(element, "e");
-                    builder.Append(degree.Length == 0 ? "sqrt(" : "root(" + degree + ",");
-                    builder.Append(radicand);
+                    int degreeStart = builder.Length;
+                    AppendChildText(builder, element, "deg");
+                    if (builder.Length == degreeStart) {
+                        builder.Append("sqrt(");
+                    } else {
+                        builder.Insert(degreeStart, "root(");
+                        builder.Append(',');
+                    }
+                    AppendChildText(builder, element, "e");
                     builder.Append(')');
                     return;
                 case "nary":
@@ -82,19 +90,21 @@ namespace OfficeIMO.Word {
                     AppendNaryText(builder, element);
                     return;
                 case "func":
-                    string functionName = ReadChildText(element, "fName");
-                    string argument = ReadChildText(element, "e");
-                    if (functionName.Length > 0) {
-                        AppendFunctionText(builder, functionName, argument);
+                    int functionStart = builder.Length;
+                    AppendChildText(builder, element, "fName");
+                    if (builder.Length > functionStart) {
+                        builder.Append('(');
+                        AppendChildText(builder, element, "e");
+                        builder.Append(')');
                     } else {
-                        builder.Append(argument);
+                        AppendChildText(builder, element, "e");
                     }
                     return;
                 case "acc":
                     AppendAccentText(builder, element);
                     return;
                 case "bar":
-                    AppendFunctionText(builder, "bar", ReadChildText(element, "e"));
+                    AppendFunctionText(builder, "bar", element, "e");
                     return;
                 case "d":
                     AppendDelimiterText(builder, element);
@@ -112,11 +122,11 @@ namespace OfficeIMO.Word {
                     return;
                 case "limLow":
                     AppendChildText(builder, element, "e");
-                    AppendScriptText(builder, "_", ReadChildText(element, "lim"));
+                    AppendScriptText(builder, "_", element, "lim");
                     return;
                 case "limUpp":
                     AppendChildText(builder, element, "e");
-                    AppendScriptText(builder, "^", ReadChildText(element, "lim"));
+                    AppendScriptText(builder, "^", element, "lim");
                     return;
             }
 
@@ -125,27 +135,36 @@ namespace OfficeIMO.Word {
             }
         }
 
-        private static void AppendFractionText(StringBuilder builder, OpenXmlElement element) {
-            string numerator = ReadChildText(element, "num");
-            string denominator = ReadChildText(element, "den");
+        private static void AppendFractionText(BoundedStringBuilder builder, OpenXmlElement element) {
             switch (ReadFractionType(element)) {
                 case MathFractionType.Linear:
-                    builder.Append(numerator).Append('/').Append(denominator);
+                    AppendChildText(builder, element, "num");
+                    builder.Append('/');
+                    AppendChildText(builder, element, "den");
                     return;
                 case MathFractionType.NoBar:
-                    builder.Append("stack(").Append(numerator).Append(',').Append(denominator).Append(')');
+                    builder.Append("stack(");
+                    AppendChildText(builder, element, "num");
+                    builder.Append(',');
+                    AppendChildText(builder, element, "den");
+                    builder.Append(')');
                     return;
                 case MathFractionType.Skewed:
-                    builder.Append(numerator).Append('\u2044').Append(denominator);
+                    AppendChildText(builder, element, "num");
+                    builder.Append('\u2044');
+                    AppendChildText(builder, element, "den");
                     return;
                 default:
-                    builder.Append('(').Append(numerator).Append(")/(").Append(denominator).Append(')');
+                    builder.Append('(');
+                    AppendChildText(builder, element, "num");
+                    builder.Append(")/(");
+                    AppendChildText(builder, element, "den");
+                    builder.Append(')');
                     return;
             }
         }
 
-        private static void AppendAccentText(StringBuilder builder, OpenXmlElement element) {
-            string expression = ReadChildText(element, "e");
+        private static void AppendAccentText(BoundedStringBuilder builder, OpenXmlElement element) {
             string accent = ReadCharacterOrDefault(element, "chr", "\u0302");
             string functionName = accent switch {
                 "^" => "hat",
@@ -159,17 +178,17 @@ namespace OfficeIMO.Word {
                 _ => string.Empty
             };
             if (functionName.Length > 0) {
-                AppendFunctionText(builder, functionName, expression);
+                AppendFunctionText(builder, functionName, element, "e");
             } else {
                 builder.Append("accent(");
                 builder.Append(accent);
                 builder.Append(',');
-                builder.Append(expression);
+                AppendChildText(builder, element, "e");
                 builder.Append(')');
             }
         }
 
-        private static void AppendDelimiterText(StringBuilder builder, OpenXmlElement element) {
+        private static void AppendDelimiterText(BoundedStringBuilder builder, OpenXmlElement element) {
             MathCharacter begin = ReadCharacter(element, "begChr");
             MathCharacter end = ReadCharacter(element, "endChr");
             builder.Append(begin.Present ? begin.Value : "(");
@@ -177,7 +196,7 @@ namespace OfficeIMO.Word {
             builder.Append(end.Present ? end.Value : ")");
         }
 
-        private static void AppendGroupCharacterText(StringBuilder builder, OpenXmlElement element) {
+        private static void AppendGroupCharacterText(BoundedStringBuilder builder, OpenXmlElement element) {
             string character = ReadCharacterOrDefault(element, "chr", "\u23df");
             string functionName = character switch {
                 "\u23de" => "overbrace",
@@ -186,10 +205,10 @@ namespace OfficeIMO.Word {
                 "\u23b5" => "underbracket",
                 _ => "group"
             };
-            AppendFunctionText(builder, functionName, ReadChildText(element, "e"));
+            AppendFunctionText(builder, functionName, element, "e");
         }
 
-        private static void AppendMatrixText(StringBuilder builder, OpenXmlElement element) {
+        private static void AppendMatrixText(BoundedStringBuilder builder, OpenXmlElement element) {
             builder.Append("matrix(");
             bool firstRow = true;
             foreach (OpenXmlElement row in FindChildren(element, "mr")) {
@@ -205,26 +224,30 @@ namespace OfficeIMO.Word {
             builder.Append(')');
         }
 
-        private static void AppendFunctionText(StringBuilder builder, string functionName, string expression) {
+        private static void AppendFunctionText(
+            BoundedStringBuilder builder,
+            string functionName,
+            OpenXmlElement element,
+            string expressionLocalName) {
             builder.Append(functionName);
             builder.Append('(');
-            builder.Append(expression);
+            AppendChildText(builder, element, expressionLocalName);
             builder.Append(')');
         }
 
-        private static void AppendNaryText(StringBuilder builder, OpenXmlElement element) {
+        private static void AppendNaryText(BoundedStringBuilder builder, OpenXmlElement element) {
             builder.Append(ReadNaryOperatorText(element));
-            AppendScriptText(builder, "_", ReadChildText(element, "sub"));
-            AppendScriptText(builder, "^", ReadChildText(element, "sup"));
-            string expression = ReadChildText(element, "e");
-            if (expression.Length > 0) {
-                builder.Append('(');
-                builder.Append(expression);
+            AppendScriptText(builder, "_", element, "sub");
+            AppendScriptText(builder, "^", element, "sup");
+            int expressionStart = builder.Length;
+            AppendChildText(builder, element, "e");
+            if (builder.Length > expressionStart) {
+                builder.Insert(expressionStart, "(");
                 builder.Append(')');
             }
         }
 
-        private static void AppendJoinedChildText(StringBuilder builder, OpenXmlElement element, string localName, string separator) {
+        private static void AppendJoinedChildText(BoundedStringBuilder builder, OpenXmlElement element, string localName, string separator) {
             bool first = true;
             foreach (OpenXmlElement child in FindChildren(element, localName)) {
                 if (!first) builder.Append(separator);
@@ -233,15 +256,19 @@ namespace OfficeIMO.Word {
             }
         }
 
-        private static void AppendScriptText(StringBuilder builder, string marker, string value) {
-            if (value.Length == 0) return;
-            builder.Append(marker);
-            builder.Append('(');
-            builder.Append(value);
+        private static void AppendScriptText(
+            BoundedStringBuilder builder,
+            string marker,
+            OpenXmlElement element,
+            string valueLocalName) {
+            int valueStart = builder.Length;
+            AppendChildText(builder, element, valueLocalName);
+            if (builder.Length == valueStart) return;
+            builder.Insert(valueStart, marker + "(");
             builder.Append(')');
         }
 
-        private static void AppendChildText(StringBuilder builder, OpenXmlElement element, string localName) {
+        private static void AppendChildText(BoundedStringBuilder builder, OpenXmlElement element, string localName) {
             OpenXmlElement? child = FindFirstChild(element, localName);
             if (child != null) AppendText(builder, child);
         }


### PR DESCRIPTION
## Summary

- bound equation accessibility text and MathML projection before large string or fragment-DOM materialization
- preserve the configured HTML output limit in cumulative failure diagnostics
- remove unnecessary XML text escaping amplification for quotes and apostrophes
- pre-index chart cache-invalidation parents during the charged chart traversal so mutation planning remains linear
- add regression contracts for both adversarial cases

## Security findings

- dae294c231308191bc19b961971ad96b — MathML output limit permits large pre-check allocation
- 1d448f9a7094819183bc05d67ba7a75c — Chart mutation planning has quadratic cache scans

## Validation

- OfficeIMO.Word.Tests equation tests: 29 passed per target
- OfficeIMO.Html.Tests equation/output-budget tests: 39 passed per target
- OfficeIMO.Excel.Tests mutation-plan/chart tests: 72 passed per target
- targets: .NET Framework 4.7.2, .NET 8, and .NET 10