### PR TITLE
Add factory projection for constructor-bound row models

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -409,13 +409,17 @@ rows lazily while the owning workbook remains open. Replace preview
 `RowsAsStream<T>()` calls with `RowsAs<T>()`; call `ToList()` or `ToArray()` when
 an eagerly materialized collection is required. Use the overload accepting
 `Action<RowMapper<T>>` for explicit, NativeAOT-friendly column assignments.
+That mapper still requires `T : new()`. For positional records and other
+constructor-bound models, use the `factory:` overload accepting
+`Func<IDataRecord, T>`; it does not require a public parameterless constructor.
 Named cancellation arguments on `RowsAs`, `EnumerateCells`, and `EnumerateRange`
 use `cancellationToken` instead of `ct`.
 
 Use `CsvDocument.Load(...).RowsAs<T>()` when a mutable/materialized CSV document
 is required. For a forward-only typed read, use
 `CsvDocument.OpenDataReader(...).RowsAs<T>()`; the same automatic and explicit
-mapping definitions are supported without exposing another CSV reader type.
+mapping definitions and the constructor factory are supported without exposing
+another CSV reader type.
 
 `ExcelDocument.Sheets` now exposes `IReadOnlyList<ExcelSheet>` instead of
 `List<ExcelSheet>`. Enumerate or index the property as before, use the workbook's

--- a/OfficeIMO.CSV.Tests/CsvMappingTests.cs
+++ b/OfficeIMO.CSV.Tests/CsvMappingTests.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Linq;
 using OfficeIMO.CSV;
+using OfficeIMO.Data;
 using Xunit;
 
 namespace OfficeIMO.CSV.Tests;
@@ -23,6 +25,8 @@ public class CsvMappingTests
     {
         public DateTime Created { get; init; }
     }
+
+    private sealed record PositionalPerson(int Id, string Name);
 
     [Fact]
     public void Maps_To_Typed_Record()
@@ -55,5 +59,27 @@ public class CsvMappingTests
             .FromColumn<DateTime>("Created", (item, value) => item with { Created = value })));
 
         Assert.Equal(new DateTime(2026, 7, 7), row.Created);
+    }
+
+    [Fact]
+    public void Factory_Maps_Positional_Record_From_Document_And_DataReader()
+    {
+        var doc = new CsvDocument()
+            .WithHeader("Id", "Name")
+            .AddRow(42, "Ada");
+
+        PositionalPerson fromDocument = Assert.Single(doc.RowsAs(factory: row =>
+            new PositionalPerson(
+                row.GetInt32(row.GetOrdinal("Id")),
+                row.GetString(row.GetOrdinal("Name")))));
+
+        using DbDataReader reader = doc.CreateDataReader();
+        PositionalPerson fromReader = Assert.Single(reader.RowsAs(factory: row =>
+            new PositionalPerson(
+                row.GetInt32(row.GetOrdinal("Id")),
+                row.GetString(row.GetOrdinal("Name")))));
+
+        Assert.Equal(new PositionalPerson(42, "Ada"), fromDocument);
+        Assert.Equal(fromDocument, fromReader);
     }
 }

--- a/OfficeIMO.CSV/CsvMappingExtensions.cs
+++ b/OfficeIMO.CSV/CsvMappingExtensions.cs
@@ -1,5 +1,7 @@
 #nullable enable
 
+using System.Data;
+using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
 using OfficeIMO.Data;
 
@@ -27,6 +29,20 @@ public static class CsvMappingExtensions {
         return EnumerateExplicit(document, configure);
     }
 
+    /// <summary>
+    /// Projects rows with a caller-supplied factory.
+    /// This overload supports constructor-bound and other models without a public parameterless constructor.
+    /// </summary>
+    /// <param name="document">Document whose rows are projected.</param>
+    /// <param name="factory">Creates one model instance from the current row.</param>
+    public static IEnumerable<T> RowsAs<T>(
+        this CsvDocument document,
+        Func<IDataRecord, T> factory) {
+        if (document is null) throw new ArgumentNullException(nameof(document));
+        if (factory is null) throw new ArgumentNullException(nameof(factory));
+        return EnumerateFactory(document, factory);
+    }
+
     private static IEnumerable<T> EnumerateAutomatic<
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(
         CsvDocument document) where T : new() {
@@ -49,6 +65,15 @@ public static class CsvMappingExtensions {
                 index => row[index],
                 document.Culture,
                 document.DateTimeFormats);
+        }
+    }
+
+    private static IEnumerable<T> EnumerateFactory<T>(
+        CsvDocument document,
+        Func<IDataRecord, T> factory) {
+        using DbDataReader reader = document.CreateDataReader();
+        foreach (T row in reader.RowsAs(factory)) {
+            yield return row;
         }
     }
 }

--- a/OfficeIMO.CSV/README.md
+++ b/OfficeIMO.CSV/README.md
@@ -188,6 +188,25 @@ public sealed record PersonRecord {
 }
 ```
 
+The mapper overload still requires a public parameterless constructor. For a
+positional record or another constructor-bound model, use the factory overload:
+
+```csharp
+using OfficeIMO.CSV;
+
+var people = CsvDocument.Load("people.csv")
+    .RowsAs(factory: row => new PersonRecord(
+        row.GetInt32(row.GetOrdinal("Id")),
+        row.GetString(row.GetOrdinal("Name"))))
+    .ToList();
+
+public sealed record PersonRecord(int Id, string Name);
+```
+
+The factory receives the current `IDataRecord`; its typed getters use the CSV
+reader's configured culture and schema conversions. The same overload is
+available on `DbDataReader` and does not require `T : new()`.
+
 ## Read once or edit
 
 Use `CsvDocument.OpenDataReader` when the caller only needs a forward-only

--- a/OfficeIMO.Core/Data/RowMapping.cs
+++ b/OfficeIMO.Core/Data/RowMapping.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -79,6 +80,21 @@ public static class DataReaderMappingExtensions {
         return EnumerateExplicit(reader, configure);
     }
 
+    /// <summary>
+    /// Projects the remaining unread rows with a caller-supplied factory.
+    /// This overload supports constructor-bound and other models without a public parameterless constructor.
+    /// The caller retains ownership of the reader.
+    /// </summary>
+    /// <param name="reader">Reader positioned before the first row to project.</param>
+    /// <param name="factory">Creates one model instance from the current row.</param>
+    public static IEnumerable<T> RowsAs<T>(
+        this DbDataReader reader,
+        Func<IDataRecord, T> factory) {
+        if (reader is null) throw new ArgumentNullException(nameof(reader));
+        if (factory is null) throw new ArgumentNullException(nameof(factory));
+        return EnumerateFactory(reader, factory);
+    }
+
     private static IEnumerable<T> EnumerateAutomatic<
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(
         DbDataReader reader) where T : new() {
@@ -120,6 +136,16 @@ public static class DataReaderMappingExtensions {
                 culture,
                 dateTimeFormats,
                 typeConverter);
+        }
+    }
+
+    private static IEnumerable<T> EnumerateFactory<T>(
+        DbDataReader reader,
+        Func<IDataRecord, T> factory) {
+        if (reader.FieldCount == 0) yield break;
+
+        while (reader.Read()) {
+            yield return factory(reader);
         }
     }
 

--- a/OfficeIMO.Excel.Tests/Excel.TypedRowsApi.cs
+++ b/OfficeIMO.Excel.Tests/Excel.TypedRowsApi.cs
@@ -51,6 +51,8 @@ public partial class Excel {
 
         Assert.Throws<OperationCanceledException>(() =>
             sheet.RowsAs<TypedSalesRow>(cancellationToken: cancellation.Token).ToArray());
+        Assert.Throws<OperationCanceledException>(() =>
+            sheet.RowsAs(factory: _ => new PositionalSalesRow(0, 0m), cancellationToken: cancellation.Token).ToArray());
 
         using var optionsCancellation = new CancellationTokenSource();
         optionsCancellation.Cancel();
@@ -125,6 +127,28 @@ public partial class Excel {
         Assert.Equal(usedRangeRow.Amount, specifiedRangeRow.Amount);
     }
 
+    [Fact]
+    public void RowsAs_FactorySupportsPositionalRecordsForUsedAndSpecifiedRanges() {
+        using ExcelDocument document = ExcelDocument.Create();
+        ExcelSheet sheet = document.AddWorksheet("Data");
+        sheet.CellValue(1, 1, "Order Number");
+        sheet.CellValue(1, 2, "Amount");
+        sheet.CellValue(2, 1, 42);
+        sheet.CellValue(2, 2, 12.5m);
+
+        PositionalSalesRow usedRangeRow = Assert.Single(sheet.RowsAs(factory: row =>
+            new PositionalSalesRow(
+                row.GetInt32(row.GetOrdinal("Order Number")),
+                row.GetDecimal(row.GetOrdinal("Amount")))));
+        PositionalSalesRow specifiedRangeRow = Assert.Single(sheet.RowsAs("A1:B2", factory: row =>
+            new PositionalSalesRow(
+                row.GetInt32(row.GetOrdinal("Order Number")),
+                row.GetDecimal(row.GetOrdinal("Amount")))));
+
+        Assert.Equal(new PositionalSalesRow(42, 12.5m), usedRangeRow);
+        Assert.Equal(usedRangeRow, specifiedRangeRow);
+    }
+
     private sealed class TypedSalesRow {
         public int OrderId { get; set; }
         public decimal Amount { get; set; }
@@ -135,4 +159,6 @@ public partial class Excel {
         public int OrderId { get; set; }
         public decimal Amount { get; set; }
     }
+
+    private sealed record PositionalSalesRow(int OrderId, decimal Amount);
 }

--- a/OfficeIMO.Excel/ExcelSheet.ReadBridge.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ReadBridge.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Data;
 using System.Threading;
 using OfficeIMO.Data;
 
@@ -50,6 +51,22 @@ namespace OfficeIMO.Excel {
         }
 
         /// <summary>
+        /// Streams the sheet's used range with a caller-supplied factory.
+        /// This overload supports constructor-bound and other models without a public parameterless constructor.
+        /// Enumerate the returned sequence while the owning <see cref="ExcelDocument"/> remains open.
+        /// </summary>
+        /// <param name="factory">Creates one model instance from the current row.</param>
+        /// <param name="options">Optional read options.</param>
+        /// <param name="cancellationToken">Cancellation token observed during enumeration.</param>
+        public IEnumerable<T> RowsAs<T>(
+            Func<IDataRecord, T> factory,
+            ExcelReadOptions? options = null,
+            CancellationToken cancellationToken = default) {
+            if (factory is null) throw new ArgumentNullException(nameof(factory));
+            return RowsAsUsedRangeIterator(factory, options, cancellationToken);
+        }
+
+        /// <summary>
         /// Streams the specified A1 range as instances of T using header-to-property mapping.
         /// Enumerate the returned sequence while the owning <see cref="ExcelDocument"/> remains open.
         /// </summary>
@@ -77,6 +94,25 @@ namespace OfficeIMO.Excel {
             if (string.IsNullOrWhiteSpace(a1Range)) throw new ArgumentNullException(nameof(a1Range));
             if (configure is null) throw new ArgumentNullException(nameof(configure));
             return RowsAsRangeIterator(a1Range, configure, options, cancellationToken);
+        }
+
+        /// <summary>
+        /// Streams the specified A1 range with a caller-supplied factory.
+        /// This overload supports constructor-bound and other models without a public parameterless constructor.
+        /// Enumerate the returned sequence while the owning <see cref="ExcelDocument"/> remains open.
+        /// </summary>
+        /// <param name="a1Range">Inclusive A1 range containing the header and data rows.</param>
+        /// <param name="factory">Creates one model instance from the current row.</param>
+        /// <param name="options">Optional read options.</param>
+        /// <param name="cancellationToken">Cancellation token observed during enumeration.</param>
+        public IEnumerable<T> RowsAs<T>(
+            string a1Range,
+            Func<IDataRecord, T> factory,
+            ExcelReadOptions? options = null,
+            CancellationToken cancellationToken = default) {
+            if (string.IsNullOrWhiteSpace(a1Range)) throw new ArgumentNullException(nameof(a1Range));
+            if (factory is null) throw new ArgumentNullException(nameof(factory));
+            return RowsAsRangeIterator(a1Range, factory, options, cancellationToken);
         }
 
         /// <summary>
@@ -139,6 +175,23 @@ namespace OfficeIMO.Excel {
             }
         }
 
+        private IEnumerable<T> RowsAsUsedRangeIterator<T>(
+            Func<IDataRecord, T> factory,
+            ExcelReadOptions? options,
+            CancellationToken cancellationToken) {
+            ExcelReadOptions effectiveOptions = options ?? new ExcelReadOptions();
+            using var linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+                cancellationToken,
+                effectiveOptions.CancellationToken);
+            CancellationToken token = linkedCancellation.Token;
+            using ExcelWorkbookDataReader reader = _excelDocument.CreateDataReader(
+                effectiveOptions.ForSheet(Name, a1Range: null, cancellationToken: token));
+            foreach (T row in reader.RowsAs(factory)) {
+                token.ThrowIfCancellationRequested();
+                yield return row;
+            }
+        }
+
         private IEnumerable<T> RowsAsRangeIterator<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(
             string a1Range,
             ExcelReadOptions? options,
@@ -169,6 +222,24 @@ namespace OfficeIMO.Excel {
             using ExcelWorkbookDataReader reader = _excelDocument.CreateDataReader(
                 effectiveOptions.ForSheet(Name, a1Range, token));
             foreach (T row in reader.RowsAs(configure)) {
+                token.ThrowIfCancellationRequested();
+                yield return row;
+            }
+        }
+
+        private IEnumerable<T> RowsAsRangeIterator<T>(
+            string a1Range,
+            Func<IDataRecord, T> factory,
+            ExcelReadOptions? options,
+            CancellationToken cancellationToken) {
+            ExcelReadOptions effectiveOptions = options ?? new ExcelReadOptions();
+            using var linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+                cancellationToken,
+                effectiveOptions.CancellationToken);
+            CancellationToken token = linkedCancellation.Token;
+            using ExcelWorkbookDataReader reader = _excelDocument.CreateDataReader(
+                effectiveOptions.ForSheet(Name, a1Range, token));
+            foreach (T row in reader.RowsAs(factory)) {
                 token.ThrowIfCancellationRequested();
                 yield return row;
             }

--- a/OfficeIMO.Excel/README.md
+++ b/OfficeIMO.Excel/README.md
@@ -276,10 +276,18 @@ List<RowModel> mappedRows = sheet.RowsAs<RowModel>(map => map
     .FromColumn<string>("Status", static (row, value) => { row.Status = value; return row; }))
     .ToList();
 
+// Constructor-bound models use an explicit factory and do not require T : new().
+List<ImmutableRow> immutableRows = sheet.RowsAs(factory: row => new ImmutableRow(
+    row.GetString(row.GetOrdinal("Name")),
+    row.GetString(row.GetOrdinal("Status"))))
+    .ToList();
+
 public sealed class RowModel {
     public string Name { get; set; } = "";
     public string Status { get; set; } = "";
 }
+
+public sealed record ImmutableRow(string Name, string Status);
 ```
 
 ### Charts and dashboard recipes


### PR DESCRIPTION
## Summary

- add a shared `RowsAs<T>(Func<IDataRecord, T>)` projection to `OfficeIMO.Core`
- expose the same factory path from `CsvDocument` and from Excel used-range and A1-range helpers
- document the exact boundary: automatic and mapper-based projection still require `T : new()`, while `factory:` supports positional records and other constructor-bound models

## Why

The 3.1 cleanup already supports immutable records with init-only properties through functional mapper assignments, but positional records still cannot satisfy `T : new()`. This adds an explicit construction path without automatic constructor guessing or another format-specific mapping engine.

Related to #2195.

## Validation

- full .NET 10 CSV suite: 343 passed
- full .NET 10 Excel suite: 3,480 passed, 5 environment-gated skips
- focused factory and existing typed-row contracts passed on .NET 8, .NET 10, and .NET Framework 4.7.2
- affected Core, CSV, and Excel projects build cleanly for `netstandard2.0`
- locally packed 3.1.0 Core, CSV, and Excel packages compiled and ran in an isolated consumer using positional records
- independent read-only public-API review reported no P0-P3 findings
