### PR TITLE
Harden tabular mapping and CSV safety contracts

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -393,10 +393,24 @@ The generic `DbDataReader.RowsAs<T>()` extensions now live in the neutral
 conversion rules. Mapping failures from this shared path throw
 `DataMappingException`.
 
+On .NET 8 and later, explicit `DateOnly` and `TimeOnly` targets work through
+`RowsAs<T>`, `DbDataReader.GetFieldValue<T>`, and CSV schema columns. Default
+CSV and Excel schema inference remains `DateTime`; OfficeIMO does not remap
+inferred dates based on the target framework. Set
+`CsvLoadOptions.MappingErrorValuePolicy` or
+`ExcelReadOptions.MappingErrorValuePolicy` to `Redact` when typed mapping errors
+must omit source values and custom-converter details.
+
 The low-level `CsvFile` compression helper is no longer public. Use
 `CsvDocument.Load`, `OpenDataReader`, `Save`, `WriteDataReader`, or caller-owned
 `TextReader` / `TextWriter` streams so file and compression behavior stays with
 the operation being performed.
+
+CSV `LoadAsync` and `SaveAsync` use asynchronous source or destination I/O but
+still materialize the document or serialized output. Use `OpenDataReader` for a
+bounded forward-only cursor. That reader remains synchronous and can be cast to
+`ICsvDataReaderPositionMetadata` for logical record numbers and available
+physical start/end line numbers.
 
 `WriteRows` keeps typed cell dispatch without boxing when its typed `Write`
 overloads are used. Use `WriteRowsAsync` for an `IAsyncEnumerable<T>` source; it

--- a/OfficeIMO.CSV.AotSmoke/Program.cs
+++ b/OfficeIMO.CSV.AotSmoke/Program.cs
@@ -1,36 +1,44 @@
 using OfficeIMO.CSV;
 using OfficeIMO.Data;
 
-CsvDocument document = CsvDocument.Parse("Name,Score\nAlice,42\n");
-if (!document.Header.SequenceEqual(new[] { "Name", "Score" })) {
+CsvDocument document = CsvDocument.Parse("Name,Score,Date,Time\nAlice,42,2026-08-06,14:35:12\n");
+if (!document.Header.SequenceEqual(new[] { "Name", "Score", "Date", "Time" })) {
     throw new InvalidOperationException("The CSV parser did not preserve the header schema.");
 }
 
 CsvSmokeRow mapped = document.RowsAs<CsvSmokeRow>().Single();
-if (mapped.Name != "Alice" || mapped.Score != 42) {
+if (mapped.Name != "Alice" || mapped.Score != 42 ||
+    mapped.Date != new DateOnly(2026, 8, 6) || mapped.Time != new TimeOnly(14, 35, 12)) {
     throw new InvalidOperationException("The CSV typed-row mapper lost a value.");
 }
 
 CsvSmokeRow explicitlyMapped = document.RowsAs<CsvSmokeRow>(mapper => mapper
     .FromColumn<string>("Name", static (row, value) => { row.Name = value; return row; })
-    .FromColumn<int>("Score", static (row, value) => { row.Score = value; return row; }))
+    .FromColumn<int>("Score", static (row, value) => { row.Score = value; return row; })
+    .FromColumn<DateOnly>("Date", static (row, value) => { row.Date = value; return row; })
+    .FromColumn<TimeOnly>("Time", static (row, value) => { row.Time = value; return row; }))
     .Single();
-if (explicitlyMapped.Name != "Alice" || explicitlyMapped.Score != 42) {
+if (explicitlyMapped.Name != "Alice" || explicitlyMapped.Score != 42 ||
+    explicitlyMapped.Date != new DateOnly(2026, 8, 6) || explicitlyMapped.Time != new TimeOnly(14, 35, 12)) {
     throw new InvalidOperationException("The explicit CSV typed-row mapper lost a value.");
 }
 
-using var reader = CsvDocument.OpenTextDataReader("Name,Score\nAlice,42\n");
+using var reader = CsvDocument.OpenTextDataReader("Name,Score,Date,Time\nAlice,42,2026-08-06,14:35:12\n");
 CsvSmokeRow streamed = reader.RowsAs<CsvSmokeRow>().Single();
-if (streamed.Name != "Alice" || streamed.Score != 42) {
+if (streamed.Name != "Alice" || streamed.Score != 42 ||
+    streamed.Date != new DateOnly(2026, 8, 6) || streamed.Time != new TimeOnly(14, 35, 12)) {
     throw new InvalidOperationException("The forward-only CSV typed-row mapper lost a value.");
 }
 
-using var explicitReader = CsvDocument.OpenTextDataReader("Name,Score\nAlice,42\n");
+using var explicitReader = CsvDocument.OpenTextDataReader("Name,Score,Date,Time\nAlice,42,2026-08-06,14:35:12\n");
 CsvSmokeRow explicitlyStreamed = explicitReader.RowsAs<CsvSmokeRow>(mapper => mapper
     .FromColumn<string>("Name", static (row, value) => { row.Name = value; return row; })
-    .FromColumn<int>("Score", static (row, value) => { row.Score = value; return row; }))
+    .FromColumn<int>("Score", static (row, value) => { row.Score = value; return row; })
+    .FromColumn<DateOnly>("Date", static (row, value) => { row.Date = value; return row; })
+    .FromColumn<TimeOnly>("Time", static (row, value) => { row.Time = value; return row; }))
     .Single();
-if (explicitlyStreamed.Name != "Alice" || explicitlyStreamed.Score != 42) {
+if (explicitlyStreamed.Name != "Alice" || explicitlyStreamed.Score != 42 ||
+    explicitlyStreamed.Date != new DateOnly(2026, 8, 6) || explicitlyStreamed.Time != new TimeOnly(14, 35, 12)) {
     throw new InvalidOperationException("The explicit forward-only typed-row mapper lost a value.");
 }
 
@@ -39,4 +47,6 @@ Console.WriteLine("PASS | CSV parse, schema inspection, automatic mapping, and e
 internal sealed class CsvSmokeRow {
     public string Name { get; set; } = string.Empty;
     public int Score { get; set; }
+    public DateOnly Date { get; set; }
+    public TimeOnly Time { get; set; }
 }

--- a/OfficeIMO.CSV.Tests/CsvDataReaderApiTests.cs
+++ b/OfficeIMO.CSV.Tests/CsvDataReaderApiTests.cs
@@ -75,6 +75,94 @@ public sealed class CsvDataReaderApiTests {
         Assert.False(reader.Read());
     }
 
+    [Theory]
+    [InlineData("\n")]
+    [InlineData("\r\n")]
+    public void OpenDataReader_ReportsLogicalRecordsAndStreamingPhysicalLines(string newLine) {
+        string path = Path.Combine(Path.GetTempPath(), $"OfficeIMO.CSV.Position.{Guid.NewGuid():N}.csv");
+        try {
+            string csv = string.Join(newLine, new[] {
+                "Id,Value",
+                "1,one",
+                "2,\"line one",
+                "line two\"",
+                "# ignored",
+                "3,three"
+            });
+            File.WriteAllText(path, csv);
+            using DbDataReader reader = CsvDocument.OpenDataReader(
+                path,
+                new CsvLoadOptions { SkipCommentRows = true });
+            ICsvDataReaderPositionMetadata position =
+                Assert.IsAssignableFrom<ICsvDataReaderPositionMetadata>(reader);
+
+            Assert.Equal(0, position.RecordNumber);
+            Assert.Null(position.PhysicalLineNumber);
+
+            Assert.True(reader.Read());
+            Assert.Equal(1, position.RecordNumber);
+            Assert.Equal(2, position.PhysicalLineNumber);
+            Assert.Equal(2, position.PhysicalEndLineNumber);
+
+            Assert.True(reader.Read());
+            Assert.Equal(2, position.RecordNumber);
+            Assert.Equal(3, position.PhysicalLineNumber);
+            Assert.Equal(4, position.PhysicalEndLineNumber);
+
+            Assert.True(reader.Read());
+            Assert.Equal(3, position.RecordNumber);
+            Assert.Equal(6, position.PhysicalLineNumber);
+            Assert.Equal(6, position.PhysicalEndLineNumber);
+
+            Assert.False(reader.Read());
+            Assert.Equal(0, position.RecordNumber);
+            Assert.Null(position.PhysicalLineNumber);
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Theory]
+    [InlineData("\n")]
+    [InlineData("\r\n")]
+    public void OpenDataReader_ReportsMultilineEndPositionAtEndOfFile(string newLine) {
+        string path = Path.Combine(Path.GetTempPath(), $"OfficeIMO.CSV.PositionEof.{Guid.NewGuid():N}.csv");
+        try {
+            File.WriteAllText(path, $"Id,Value{newLine}1,\"first{newLine}second\"");
+            using DbDataReader reader = CsvDocument.OpenDataReader(path);
+            ICsvDataReaderPositionMetadata position =
+                Assert.IsAssignableFrom<ICsvDataReaderPositionMetadata>(reader);
+
+            Assert.True(reader.Read());
+            Assert.Equal(2, position.PhysicalLineNumber);
+            Assert.Equal(3, position.PhysicalEndLineNumber);
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Theory]
+    [InlineData("\n")]
+    [InlineData("\r\n")]
+    public void OpenDataReader_PreservesPhysicalLinesForReplayedCommentLookahead(string newLine) {
+        string path = Path.Combine(Path.GetTempPath(), $"OfficeIMO.CSV.PositionComment.{Guid.NewGuid():N}.csv");
+        try {
+            File.WriteAllText(path, $"Id,Value{newLine}# \"unterminated{newLine}1,one{newLine}");
+            using DbDataReader reader = CsvDocument.OpenDataReader(
+                path,
+                new CsvLoadOptions { SkipCommentRows = true });
+            ICsvDataReaderPositionMetadata position =
+                Assert.IsAssignableFrom<ICsvDataReaderPositionMetadata>(reader);
+
+            Assert.True(reader.Read());
+            Assert.Equal("1", reader.GetString(0));
+            Assert.Equal(3, position.PhysicalLineNumber);
+            Assert.Equal(3, position.PhysicalEndLineNumber);
+        } finally {
+            File.Delete(path);
+        }
+    }
+
     [Fact]
     public void OpenDataReader_StringColumnsSupportTypedGettersWithoutSchemaInference() {
         Guid identifier = Guid.NewGuid();
@@ -97,6 +185,18 @@ public sealed class CsvDataReaderApiTests {
         Assert.Equal(165258.24m, reader.GetDecimal(7));
         Assert.Equal(new DateTime(2026, 7, 29), reader.GetDateTime(8));
         Assert.Equal(identifier, reader.GetGuid(9));
+    }
+
+    [Fact]
+    public void OpenDataReader_ExplicitDateOnlyAndTimeOnlyGettersPreserveStringSchema() {
+        using DbDataReader reader = CsvDocument.OpenTextDataReader(
+            "Date,Time\n2026-08-06,14:35:12\n");
+
+        Assert.True(reader.Read());
+        Assert.Equal(typeof(string), reader.GetFieldType(0));
+        Assert.Equal(typeof(string), reader.GetFieldType(1));
+        Assert.Equal(new DateOnly(2026, 8, 6), reader.GetFieldValue<DateOnly>(0));
+        Assert.Equal(new TimeOnly(14, 35, 12), reader.GetFieldValue<TimeOnly>(1));
     }
 
     [Fact]

--- a/OfficeIMO.CSV.Tests/CsvDocumentBasicsTests.cs
+++ b/OfficeIMO.CSV.Tests/CsvDocumentBasicsTests.cs
@@ -887,7 +887,7 @@ public class CsvDocumentBasicsTests
     }
 
     [Fact]
-    public void Formula_Injection_Policy_Escapes_Span_Formatted_Row_Values()
+    public void Formula_Injection_Policy_Preserves_Typed_Negative_Numbers()
     {
         using var writer = new StringWriter();
         using (var csv = new CsvRowWriter(writer, new CsvSaveOptions {
@@ -895,10 +895,26 @@ public class CsvDocumentBasicsTests
             FormulaInjectionPolicy = CsvFormulaInjectionPolicy.Escape
         }))
         {
-            csv.WriteRow(new[] { "Value" }, new object?[] { -1 });
+            csv.WriteRow(new[] { "Integer", "Decimal", "Text" }, new object?[] { -1, -2.5m, "-cmd" });
         }
 
-        Assert.Equal("Value\n'-1\n", writer.ToString());
+        Assert.Equal("Integer,Decimal,Text\n-1,-2.5,'-cmd\n", writer.ToString());
+    }
+
+    [Fact]
+    public void Formula_Injection_Policy_Preserves_Typed_Numbers_With_Text_Delimiters()
+    {
+        var document = new CsvDocument()
+            .WithHeader("Number", "Text")
+            .AddRow(-1, "-cmd");
+
+        string text = document.ToString(new CsvSaveOptions {
+            DelimiterText = "||",
+            NewLine = "\n",
+            FormulaInjectionPolicy = CsvFormulaInjectionPolicy.Escape
+        });
+
+        Assert.Equal("Number||Text\n-1||'-cmd\n", text);
     }
 
     [Fact]

--- a/OfficeIMO.CSV.Tests/CsvSchemaTests.cs
+++ b/OfficeIMO.CSV.Tests/CsvSchemaTests.cs
@@ -98,6 +98,87 @@ public class CsvSchemaTests
     }
 
     [Fact]
+    public void ExplicitSchema_SupportsDateOnlyAndTimeOnlyWithoutChangingDefaults()
+    {
+        CsvSchema schema = new CsvSchemaBuilder()
+            .Column("Date").AsDateOnly().Required()
+            .Column("Time").AsTimeOnly().Required()
+            .Done()
+            .Build();
+        using var reader = CsvDocument.OpenTextDataReader(
+            "Date,Time\n2026-08-06,14:35:12\n",
+            readerOptions: new CsvDataReaderOptions { Schema = schema });
+
+        Assert.True(reader.Read());
+        Assert.Equal(typeof(DateOnly), reader.GetFieldType(0));
+        Assert.Equal(typeof(TimeOnly), reader.GetFieldType(1));
+        Assert.Equal(new DateOnly(2026, 8, 6), Assert.IsType<DateOnly>(reader.GetValue(0)));
+        Assert.Equal(new TimeOnly(14, 35, 12), Assert.IsType<TimeOnly>(reader.GetValue(1)));
+    }
+
+    [Fact]
+    public void SchemaConversion_RedactsValuesAndInnerExceptionsWhenRequested()
+    {
+        const string secret = "customer-secret-value";
+        CsvDocument document = CsvDocument.Parse(
+                $"Value\n{secret}\n",
+                new CsvLoadOptions { MappingErrorValuePolicy = DataMappingErrorValuePolicy.Redact })
+            .EnsureSchema(schema => schema
+                .Column("Value").AsInt32().ConvertUsing(_ =>
+                    throw new InvalidOperationException($"failed for {secret}")));
+        using var reader = document.CreateDataReader();
+
+        Assert.True(reader.Read());
+        CsvException exception = Assert.Throws<CsvException>(() => reader.GetValue(0));
+
+        Assert.DoesNotContain(secret, exception.ToString(), StringComparison.Ordinal);
+        Assert.Null(exception.InnerException);
+        Assert.Contains("redacted", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void SchemaConversion_PreservesConverterDetailsByDefault()
+    {
+        const string detail = "converter-detail";
+        CsvDocument document = CsvDocument.Parse("Value\ninvalid\n")
+            .EnsureSchema(schema => schema
+                .Column("Value").AsInt32().ConvertUsing(_ =>
+                    throw new InvalidOperationException(detail)));
+        using var reader = document.CreateDataReader();
+
+        Assert.True(reader.Read());
+        CsvException exception = Assert.Throws<CsvException>(() => reader.GetValue(0));
+
+        Assert.Contains(detail, exception.ToString(), StringComparison.Ordinal);
+        Assert.IsType<InvalidOperationException>(exception.InnerException);
+
+        document.Validate(out IReadOnlyList<CsvValidationError> validationErrors);
+        Assert.Contains(detail, Assert.Single(validationErrors).Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SchemaValidation_RedactsFrameworkValuesAndConverterDetails()
+    {
+        const string sourceValue = "customer-source-value";
+        const string converterDetail = "converter-secret-detail";
+        CsvDocument document = CsvDocument.Parse(
+                $"Number,Converted\n{sourceValue},input\n",
+                new CsvLoadOptions { MappingErrorValuePolicy = DataMappingErrorValuePolicy.Redact })
+            .EnsureSchema(schema => schema
+                .Column("Number").AsInt32()
+                .Column("Converted").AsInt32().ConvertUsing(_ =>
+                    throw new InvalidOperationException(converterDetail)));
+
+        document.Validate(out IReadOnlyList<CsvValidationError> errors);
+
+        Assert.Equal(2, errors.Count);
+        string details = string.Join(Environment.NewLine, errors.Select(error => error.Message));
+        Assert.DoesNotContain(sourceValue, details, StringComparison.Ordinal);
+        Assert.DoesNotContain(converterDetail, details, StringComparison.Ordinal);
+        Assert.Contains("redacted", details, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void InferSchema_ForTypedRows_IsNotOrderDependent()
     {
         var doc = new CsvDocument()

--- a/OfficeIMO.CSV.Tests/CsvTypedRowsApiTests.cs
+++ b/OfficeIMO.CSV.Tests/CsvTypedRowsApiTests.cs
@@ -145,6 +145,48 @@ public sealed class CsvTypedRowsApiTests {
         Assert.Equal(165258.24m, row.Amount);
     }
 
+    [Fact]
+    public void RowsAs_ConvertsExplicitDateOnlyAndTimeOnlyTargetsWithoutChangingInference() {
+        CsvDocument document = CsvDocument.Parse("Date,Time\n2026-08-06,14:35:12\n");
+
+        DateAndTimeRow row = Assert.Single(document.RowsAs<DateAndTimeRow>());
+        CsvSchema inferred = document.InferSchema();
+
+        Assert.Equal(new DateOnly(2026, 8, 6), row.Date);
+        Assert.Equal(new TimeOnly(14, 35, 12), row.Time);
+        Assert.Equal(typeof(DateTime), inferred.Columns[0].DataType);
+    }
+
+    [Fact]
+    public void RowsAs_RedactsSourceValuesWhenRequested() {
+        const string secret = "customer-secret-value";
+        CsvDocument document = CsvDocument.Parse(
+            $"Order Id\n{secret}\n",
+            new CsvLoadOptions { MappingErrorValuePolicy = DataMappingErrorValuePolicy.Redact });
+
+        DataMappingException exception = Assert.Throws<DataMappingException>(() =>
+            document.RowsAs<SalesRow>().ToArray());
+
+        Assert.DoesNotContain(secret, exception.ToString(), StringComparison.Ordinal);
+        Assert.Contains("cannot be converted", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void RowsAs_PreservesSourceValuesByDefault() {
+        const string sourceValue = "not-an-order-id";
+        CsvDocument document = CsvDocument.Parse($"Order Id\n{sourceValue}\n");
+
+        DataMappingException exception = Assert.Throws<DataMappingException>(() =>
+            document.RowsAs<SalesRow>().ToArray());
+
+        Assert.Contains(sourceValue, exception.ToString(), StringComparison.Ordinal);
+    }
+
+    private sealed class DateAndTimeRow {
+        public DateOnly Date { get; set; }
+        public TimeOnly Time { get; set; }
+    }
+
     private sealed class SalesRow {
         public int OrderId { get; set; }
         public string SalesChannel { get; set; } = string.Empty;

--- a/OfficeIMO.CSV/CsvDataProjection.TextSpan.cs
+++ b/OfficeIMO.CSV/CsvDataProjection.TextSpan.cs
@@ -37,7 +37,8 @@ internal static partial class CsvDataProjectionConverter
         CsvDataColumnProjection column,
         int rowIndex,
         CultureInfo culture,
-        IReadOnlyList<string>? dateTimeFormats)
+        IReadOnlyList<string>? dateTimeFormats,
+        DataMappingErrorValuePolicy errorValuePolicy = DataMappingErrorValuePolicy.Include)
     {
         if (text.Length == 0 &&
             (column.ConversionKind != CsvDataConversionKind.String || column.SchemaColumn?.IsRequired == true))
@@ -85,11 +86,11 @@ internal static partial class CsvDataProjectionConverter
             case CsvDataConversionKind.Guid when Guid.TryParse(text, out var guid):
                 return guid;
             default:
-                return ConvertValue(text.ToString(), column, rowIndex, culture, dateTimeFormats);
+                return ConvertValue(text.ToString(), column, rowIndex, culture, dateTimeFormats, errorValuePolicy);
         }
 
         var value = text.ToString();
-        throw new CsvException($"Column '{column.Name}' value on row {rowIndex + 1} cannot be converted to {column.DataType.Name}: Cannot parse '{value}' as {column.DataType.Name}.");
+        throw CreateConversionException(column, rowIndex, value, errorValuePolicy);
     }
 
     private static bool TryParseInt32(ReadOnlySpan<char> text, CultureInfo culture, out int value)

--- a/OfficeIMO.CSV/CsvDataProjection.cs
+++ b/OfficeIMO.CSV/CsvDataProjection.cs
@@ -115,7 +115,8 @@ internal static partial class CsvDataProjectionConverter
         CsvDataColumnProjection column,
         int rowIndex,
         CultureInfo culture,
-        IReadOnlyList<string>? dateTimeFormats)
+        IReadOnlyList<string>? dateTimeFormats,
+        DataMappingErrorValuePolicy errorValuePolicy = DataMappingErrorValuePolicy.Include)
     {
         if (IsMissingValue(value, column))
         {
@@ -134,14 +135,14 @@ internal static partial class CsvDataProjectionConverter
         }
 
         if (column.ConversionKind != CsvDataConversionKind.General &&
-            TryConvertFast(value, column, rowIndex, culture, dateTimeFormats, out var fastValue))
+            TryConvertFast(value, column, rowIndex, culture, dateTimeFormats, errorValuePolicy, out var fastValue))
         {
             return fastValue;
         }
 
         if (column.SchemaColumn?.Converter is { } converter)
         {
-            value = ConvertWithCustomConverter(value, converter, column.Name, rowIndex, culture);
+            value = ConvertWithCustomConverter(value, converter, column.Name, rowIndex, culture, errorValuePolicy);
             if (IsMissingValue(value, column))
             {
                 if (column.SchemaColumn.DefaultValue is not null)
@@ -164,7 +165,7 @@ internal static partial class CsvDataProjectionConverter
             return value!;
         }
 
-        if (!DataValueConverter.TryConvert(value, column.DataType, culture, dateTimeFormats, typeConverter: null, out var converted, out var error))
+        if (!DataValueConverter.TryConvert(value, column.DataType, culture, dateTimeFormats, typeConverter: null, errorValuePolicy, out var converted, out var error))
         {
             throw new CsvException($"Column '{column.Name}' value on row {rowIndex + 1} cannot be converted to {column.DataType.Name}: {error}");
         }
@@ -188,6 +189,7 @@ internal static partial class CsvDataProjectionConverter
         int rowIndex,
         CultureInfo culture,
         IReadOnlyList<string>? dateTimeFormats,
+        DataMappingErrorValuePolicy errorValuePolicy,
         out object converted)
     {
         converted = DBNull.Value;
@@ -289,7 +291,7 @@ internal static partial class CsvDataProjectionConverter
                 return true;
         }
 
-        throw new CsvException($"Column '{column.Name}' value on row {rowIndex + 1} cannot be converted to {column.DataType.Name}: Cannot parse '{text}' as {column.DataType.Name}.");
+        throw CreateConversionException(column, rowIndex, text, errorValuePolicy);
     }
 
     private static bool TryParseDateTime(string text, CultureInfo culture, IReadOnlyList<string>? dateTimeFormats, out DateTime dateTime)
@@ -517,16 +519,38 @@ internal static partial class CsvDataProjectionConverter
         Func<object?, CultureInfo, object?> converter,
         string columnName,
         int rowIndex,
-        CultureInfo culture)
+        CultureInfo culture,
+        DataMappingErrorValuePolicy errorValuePolicy)
     {
         try
         {
             return converter(value, culture);
         }
-        catch (Exception ex) when (ex is not CsvException)
+        catch (Exception ex)
         {
+            if (errorValuePolicy == DataMappingErrorValuePolicy.Redact)
+            {
+                throw new CsvException($"Column '{columnName}' custom converter failed on row {rowIndex + 1}; source details were redacted.");
+            }
+
+            if (ex is CsvException)
+            {
+                throw;
+            }
+
             throw new CsvException($"Column '{columnName}' custom converter failed on row {rowIndex + 1}: {ex.Message}", ex);
         }
+    }
+
+    internal static CsvException CreateConversionException(
+        CsvDataColumnProjection column,
+        int rowIndex,
+        string value,
+        DataMappingErrorValuePolicy errorValuePolicy)
+    {
+        return errorValuePolicy == DataMappingErrorValuePolicy.Redact
+            ? new CsvException($"Column '{column.Name}' value on row {rowIndex + 1} cannot be converted to {column.DataType.Name}; source details were redacted.")
+            : new CsvException($"Column '{column.Name}' value on row {rowIndex + 1} cannot be converted to {column.DataType.Name}: Cannot parse '{value}' as {column.DataType.Name}.");
     }
 
     private static bool IsMissingValue(object? value, CsvDataColumnProjection column) =>

--- a/OfficeIMO.CSV/CsvDataReader.cs
+++ b/OfficeIMO.CSV/CsvDataReader.cs
@@ -12,7 +12,7 @@ namespace OfficeIMO.CSV;
 /// <summary>
 /// Forward-only reader for CSV rows projected through an optional schema.
 /// </summary>
-internal sealed class CsvDataReader : DbDataReader, ICsvDataReaderMetadata, IDataReaderMappingMetadata
+internal sealed class CsvDataReader : DbDataReader, ICsvDataReaderMetadata, ICsvDataReaderPositionMetadata, IDataReaderMappingMetadata, IDataReaderMappingErrorMetadata
 {
     private const string IsReadOnlyColumn = "IsReadOnly";
     private const string IsRowVersionColumn = "IsRowVersion";
@@ -35,6 +35,7 @@ internal sealed class CsvDataReader : DbDataReader, ICsvDataReaderMetadata, IDat
     Func<object, Type, CultureInfo, (bool ok, object? value)>? IDataReaderMappingMetadata.MappingTypeConverter => null;
 
     bool IDataReaderMappingMetadata.RequireAllColumnsMapped => false;
+    DataMappingErrorValuePolicy IDataReaderMappingErrorMetadata.MappingErrorValuePolicy => _mappingErrorValuePolicy;
     private readonly IDisposable? _rowOwner;
     private readonly CsvLoadOptions? _stringRowOptions;
     private readonly object?[]? _staticColumnValues;
@@ -43,6 +44,7 @@ internal sealed class CsvDataReader : DbDataReader, ICsvDataReaderMetadata, IDat
     private readonly bool _useDirectTextSourceStrings;
     private readonly bool _useDirectValueConversion;
     private readonly bool _rawRowsAreParsedStringsOnly;
+    private readonly DataMappingErrorValuePolicy _mappingErrorValuePolicy;
     private readonly string? _stringNullValue;
     private Dictionary<string, int>? _ordinals;
     private object?[]? _currentRawRow;
@@ -63,6 +65,7 @@ internal sealed class CsvDataReader : DbDataReader, ICsvDataReaderMetadata, IDat
         CultureInfo culture,
         IReadOnlyList<string>? dateTimeFormats,
         char delimiter,
+        DataMappingErrorValuePolicy mappingErrorValuePolicy = DataMappingErrorValuePolicy.Include,
         bool rawRowsAreParsedStringsOnly = false,
         IDisposable? rowOwner = null)
     {
@@ -71,6 +74,7 @@ internal sealed class CsvDataReader : DbDataReader, ICsvDataReaderMetadata, IDat
         _culture = culture;
         _dateTimeFormats = dateTimeFormats;
         Delimiter = delimiter;
+        _mappingErrorValuePolicy = mappingErrorValuePolicy;
         _rowOwner = rowOwner;
         _useRawStringValues = CanUseRawStringValues(columns);
         _useDirectValueConversion = CanUseDirectValueConversion(columns);
@@ -94,6 +98,7 @@ internal sealed class CsvDataReader : DbDataReader, ICsvDataReaderMetadata, IDat
         _staticColumnValues = CaptureStaticColumnValues(_stringRowOptions.StaticColumns);
         _culture = culture;
         _dateTimeFormats = dateTimeFormats;
+        _mappingErrorValuePolicy = options.MappingErrorValuePolicy;
         Delimiter = CsvParser.GetDelimiterChar(options);
         _rowOwner = rowOwner;
         _useRawStringValues = CanUseRawStringValues(columns);
@@ -118,6 +123,7 @@ internal sealed class CsvDataReader : DbDataReader, ICsvDataReaderMetadata, IDat
         _stringNullValue = options.NullValue;
         _culture = culture;
         _dateTimeFormats = dateTimeFormats;
+        _mappingErrorValuePolicy = options.MappingErrorValuePolicy;
         Delimiter = CsvParser.GetDelimiterChar(options);
         _useRawStringValues = CanUseRawStringValues(columns);
         _useDirectTextSourceStrings = _useRawStringValues && _stringNullValue is null;
@@ -137,7 +143,23 @@ internal sealed class CsvDataReader : DbDataReader, ICsvDataReaderMetadata, IDat
     public char Delimiter { get; }
 
     /// <inheritdoc />
+    public long RecordNumber => IsPositionedOnRow ? _rowIndex + 1L : 0L;
+
+    /// <inheritdoc />
+    public int? PhysicalLineNumber => IsPositionedOnRow
+        ? (_textRowSource as ICsvDataReaderPositionSource)?.CurrentPhysicalLineNumber
+        : null;
+
+    /// <inheritdoc />
+    public int? PhysicalEndLineNumber => IsPositionedOnRow
+        ? (_textRowSource as ICsvDataReaderPositionSource)?.CurrentPhysicalEndLineNumber
+        : null;
+
+    /// <inheritdoc />
     public override int FieldCount => _columns.Length;
+
+    private bool IsPositionedOnRow => !_closed &&
+        (_currentRawRow is not null || _currentStringRow is not null || _hasCurrentTextRow);
 
     /// <inheritdoc />
     public override bool HasRows
@@ -326,6 +348,25 @@ internal sealed class CsvDataReader : DbDataReader, ICsvDataReaderMetadata, IDat
     [UnconditionalSuppressMessage("Trimming", "IL2073", Justification = "CSV column types are scalar conversion tokens returned through DbDataReader; OfficeIMO never activates or reflects over their public members.")]
     [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]
     public override Type GetFieldType(int ordinal) => _columns[ordinal].DataType;
+
+#if NET6_0_OR_GREATER
+    /// <inheritdoc />
+    public override T GetFieldValue<T>(int ordinal)
+    {
+        Type destinationType = Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T);
+        if (destinationType == typeof(DateOnly) || destinationType == typeof(TimeOnly))
+        {
+            object? sourceValue = IsDBNull(ordinal) ? null : GetValue(ordinal);
+            return DataValueConverter.ConvertTo<T>(
+                sourceValue,
+                _culture,
+                _dateTimeFormats,
+                errorValuePolicy: _mappingErrorValuePolicy)!;
+        }
+
+        return base.GetFieldValue<T>(ordinal);
+    }
+#endif
 
     /// <inheritdoc />
     public override float GetFloat(int ordinal)
@@ -526,7 +567,7 @@ internal sealed class CsvDataReader : DbDataReader, ICsvDataReaderMetadata, IDat
 #endif
         {
             var rawValue = GetRawValue(ordinal);
-            value = CsvDataProjectionConverter.ConvertValue(rawValue, _columns[ordinal], _rowIndex, _culture, _dateTimeFormats);
+            value = CsvDataProjectionConverter.ConvertValue(rawValue, _columns[ordinal], _rowIndex, _culture, _dateTimeFormats, _mappingErrorValuePolicy);
         }
 
         _currentConvertedRow[ordinal] = value;
@@ -565,7 +606,7 @@ internal sealed class CsvDataReader : DbDataReader, ICsvDataReaderMetadata, IDat
                     null => DBNull.Value,
                     DBNull => DBNull.Value,
                     string text => text,
-                    _ => CsvDataProjectionConverter.ConvertValue(rawValue, _columns[i], _rowIndex, _culture, _dateTimeFormats)
+                    _ => CsvDataProjectionConverter.ConvertValue(rawValue, _columns[i], _rowIndex, _culture, _dateTimeFormats, _mappingErrorValuePolicy)
                 };
             }
 
@@ -593,12 +634,12 @@ internal sealed class CsvDataReader : DbDataReader, ICsvDataReaderMetadata, IDat
             var rowValueCount = Math.Min(count, row.Length);
             for (var i = 0; i < rowValueCount; i++)
             {
-                values[i] = CsvDataProjectionConverter.ConvertValue(row[i], _columns[i], _rowIndex, _culture, _dateTimeFormats);
+                values[i] = CsvDataProjectionConverter.ConvertValue(row[i], _columns[i], _rowIndex, _culture, _dateTimeFormats, _mappingErrorValuePolicy);
             }
 
             for (var i = rowValueCount; i < count; i++)
             {
-                values[i] = CsvDataProjectionConverter.ConvertValue(null, _columns[i], _rowIndex, _culture, _dateTimeFormats);
+                values[i] = CsvDataProjectionConverter.ConvertValue(null, _columns[i], _rowIndex, _culture, _dateTimeFormats, _mappingErrorValuePolicy);
             }
 
             return count;
@@ -611,7 +652,7 @@ internal sealed class CsvDataReader : DbDataReader, ICsvDataReaderMetadata, IDat
             if (value is null)
             {
                 var rawValue = GetRawValue(i);
-                value = CsvDataProjectionConverter.ConvertValue(rawValue, _columns[i], _rowIndex, _culture, _dateTimeFormats);
+                value = CsvDataProjectionConverter.ConvertValue(rawValue, _columns[i], _rowIndex, _culture, _dateTimeFormats, _mappingErrorValuePolicy);
                 _currentConvertedRow[i] = value;
             }
 
@@ -962,7 +1003,7 @@ internal sealed class CsvDataReader : DbDataReader, ICsvDataReaderMetadata, IDat
                 null => DBNull.Value,
                 DBNull => DBNull.Value,
                 string staticText => staticText,
-                _ => CsvDataProjectionConverter.ConvertValue(staticValue, _columns[ordinal], _rowIndex, _culture, _dateTimeFormats)
+                _ => CsvDataProjectionConverter.ConvertValue(staticValue, _columns[ordinal], _rowIndex, _culture, _dateTimeFormats, _mappingErrorValuePolicy)
             };
         }
 
@@ -977,7 +1018,7 @@ internal sealed class CsvDataReader : DbDataReader, ICsvDataReaderMetadata, IDat
             return text;
         }
 
-        return CsvDataProjectionConverter.ConvertValue(rawValue, _columns[ordinal], _rowIndex, _culture, _dateTimeFormats);
+        return CsvDataProjectionConverter.ConvertValue(rawValue, _columns[ordinal], _rowIndex, _culture, _dateTimeFormats, _mappingErrorValuePolicy);
     }
 
     private object? GetRawValue(int ordinal)
@@ -1075,7 +1116,7 @@ internal sealed class CsvDataReader : DbDataReader, ICsvDataReaderMetadata, IDat
                 ? _staticColumnValues[staticIndex]
                 : null;
 
-            values[i] = CsvDataProjectionConverter.ConvertValue(staticValue, _columns[i], _rowIndex, _culture, _dateTimeFormats);
+            values[i] = CsvDataProjectionConverter.ConvertValue(staticValue, _columns[i], _rowIndex, _culture, _dateTimeFormats, _mappingErrorValuePolicy);
         }
 
         return count;
@@ -1143,7 +1184,8 @@ internal sealed class CsvDataReader : DbDataReader, ICsvDataReaderMetadata, IDat
             column,
             _rowIndex,
             _culture,
-            _dateTimeFormats);
+            _dateTimeFormats,
+            _mappingErrorValuePolicy);
     }
 #endif
 
@@ -1215,7 +1257,7 @@ internal sealed class CsvDataReader : DbDataReader, ICsvDataReaderMetadata, IDat
                 break;
         }
 
-        return CsvDataProjectionConverter.ConvertValue(text, column, _rowIndex, _culture, _dateTimeFormats);
+        return CsvDataProjectionConverter.ConvertValue(text, column, _rowIndex, _culture, _dateTimeFormats, _mappingErrorValuePolicy);
     }
 
     private static int GetParsedStringRawRowValues(object?[] row, object[] values, int count)

--- a/OfficeIMO.CSV/CsvDocument.DataReader.cs
+++ b/OfficeIMO.CSV/CsvDocument.DataReader.cs
@@ -357,7 +357,14 @@ public sealed partial class CsvDocument
         }
 
         var rows = EnumerateRawRows();
-        return new CsvDataReader(columns, rows, _culture, _dateTimeFormats, _delimiter, _rowsAreParsedStringsOnly);
+        return new CsvDataReader(
+            columns,
+            rows,
+            _culture,
+            _dateTimeFormats,
+            _delimiter,
+            _mappingErrorValuePolicy,
+            _rowsAreParsedStringsOnly);
     }
 
     private static bool CanUseSinglePassFileDataReader(CsvLoadOptions options, CsvDataReaderOptions readerOptions) =>
@@ -595,6 +602,7 @@ public sealed partial class CsvDocument
                 _culture,
                 _dateTimeFormats,
                 _streamingSource.Options.Delimiter,
+                _streamingSource.Options.MappingErrorValuePolicy,
                 rowOwner: rowOwner);
         }
         catch

--- a/OfficeIMO.CSV/CsvDocument.DataTable.cs
+++ b/OfficeIMO.CSV/CsvDocument.DataTable.cs
@@ -50,7 +50,7 @@ public sealed partial class CsvDocument
                 {
                     var column = columns[i];
                     var value = i < row.Length ? row[i] : null;
-                    values[i] = CsvDataProjectionConverter.ConvertValue(value, column, rowIndex, _culture, _dateTimeFormats);
+                    values[i] = CsvDataProjectionConverter.ConvertValue(value, column, rowIndex, _culture, _dateTimeFormats, _mappingErrorValuePolicy);
                 }
 
                 table.Rows.Add(values);

--- a/OfficeIMO.CSV/CsvDocument.Loading.cs
+++ b/OfficeIMO.CSV/CsvDocument.Loading.cs
@@ -371,7 +371,14 @@ public sealed partial class CsvDocument
     {
         options = ResolveLoadOptions(readerFactory, options);
         var initialRecordsToSkip = GetInitialRecordsToSkip(options);
-        var document = new CsvDocument(options.Mode, options.Delimiter, options.Culture, encoding, options.ColumnCountMismatchPolicy, options.DateTimeFormats);
+        var document = new CsvDocument(
+            options.Mode,
+            options.Delimiter,
+            options.Culture,
+            encoding,
+            options.ColumnCountMismatchPolicy,
+            options.DateTimeFormats,
+            options.MappingErrorValuePolicy);
 
         var explicitHeader = NormalizeExplicitHeader(options);
         if (explicitHeader is not null)

--- a/OfficeIMO.CSV/CsvDocument.cs
+++ b/OfficeIMO.CSV/CsvDocument.cs
@@ -26,6 +26,7 @@ public sealed partial class CsvDocument
     private Encoding _encoding;
     private CsvColumnCountMismatchPolicy _columnCountMismatchPolicy;
     private string[]? _dateTimeFormats;
+    private DataMappingErrorValuePolicy _mappingErrorValuePolicy;
     private CsvSchema? _schema;
     private bool _rowsAreParsedStringsOnly;
 
@@ -41,7 +42,14 @@ public sealed partial class CsvDocument
         _columnCountMismatchPolicy = CsvColumnCountMismatchPolicy.Strict;
     }
 
-    private CsvDocument(CsvLoadMode mode, char delimiter, CultureInfo culture, Encoding encoding, CsvColumnCountMismatchPolicy columnCountMismatchPolicy, string[]? dateTimeFormats = null)
+    private CsvDocument(
+        CsvLoadMode mode,
+        char delimiter,
+        CultureInfo culture,
+        Encoding encoding,
+        CsvColumnCountMismatchPolicy columnCountMismatchPolicy,
+        string[]? dateTimeFormats = null,
+        DataMappingErrorValuePolicy mappingErrorValuePolicy = DataMappingErrorValuePolicy.Include)
     {
         _mode = mode;
         _delimiter = delimiter;
@@ -49,6 +57,7 @@ public sealed partial class CsvDocument
         _encoding = encoding;
         _columnCountMismatchPolicy = columnCountMismatchPolicy;
         _dateTimeFormats = dateTimeFormats;
+        _mappingErrorValuePolicy = mappingErrorValuePolicy;
     }
 
     /// <summary>
@@ -345,6 +354,9 @@ public sealed partial class CsvDocument
     /// </summary>
     public IReadOnlyList<string>? DateTimeFormats => _dateTimeFormats;
 
+    /// <summary>Gets how source values are represented in schema and row-mapping failures.</summary>
+    public DataMappingErrorValuePolicy MappingErrorValuePolicy => _mappingErrorValuePolicy;
+
     /// <summary>
     /// Saves the document to the specified path.
     /// </summary>
@@ -618,6 +630,13 @@ public sealed partial class CsvDocument
         }
 
         _dateTimeFormats = formats.ToArray();
+        return this;
+    }
+
+    /// <summary>Sets whether schema and row-mapping failures may include source values.</summary>
+    public CsvDocument WithMappingErrorValuePolicy(DataMappingErrorValuePolicy policy)
+    {
+        _mappingErrorValuePolicy = policy;
         return this;
     }
 

--- a/OfficeIMO.CSV/CsvLineReader.FieldSpans.Quoted.cs
+++ b/OfficeIMO.CSV/CsvLineReader.FieldSpans.Quoted.cs
@@ -29,7 +29,15 @@ internal sealed partial class CsvLineReader
 
         var start = _position;
         Span<StandardCsvFieldSpan> fields = stackalloc StandardCsvFieldSpan[StandardQuotedFieldSpanCapacity];
-        if (!TryParseStandardQuotedFieldSpans(start, delimiter, trim, fields, out var fieldCountValue, out var firstFieldLength, out var recordEnd))
+        if (!TryParseStandardQuotedFieldSpans(
+                start,
+                delimiter,
+                trim,
+                fields,
+                out var fieldCountValue,
+                out var firstFieldLength,
+                out var recordEnd,
+                out var embeddedLineSeparatorCount))
         {
             return false;
         }
@@ -43,6 +51,7 @@ internal sealed partial class CsvLineReader
 
         isEmptyRecord = fieldCount == 1 && firstFieldLength == 0;
         _position = recordEnd;
+        PhysicalLineSeparatorsConsumed += embeddedLineSeparatorCount;
         ConsumeLineSeparator(_buffer[recordEnd], out separator);
         readResult = CsvLineReadResult.UnquotedRecord;
         return true;
@@ -99,7 +108,8 @@ internal sealed partial class CsvLineReader
         }
 
         var index = quoteIndex;
-        if (!TryParsePrefixedStandardQuotedField(ref index, out var quotedField) ||
+        var embeddedLineSeparatorCount = 0;
+        if (!TryParsePrefixedStandardQuotedField(ref index, ref embeddedLineSeparatorCount, out var quotedField) ||
             !TryAddStandardField(fields, ref fieldCount, quotedField, ref firstFieldLength))
         {
             return false;
@@ -111,6 +121,7 @@ internal sealed partial class CsvLineReader
                 fields,
                 ref fieldCount,
                 ref firstFieldLength,
+                ref embeddedLineSeparatorCount,
                 out var recordEnd))
         {
             return false;
@@ -124,6 +135,7 @@ internal sealed partial class CsvLineReader
 
         isEmptyRecord = fieldCount == 1 && firstFieldLength == 0;
         _position = recordEnd;
+        PhysicalLineSeparatorsConsumed += embeddedLineSeparatorCount;
         ConsumeLineSeparator(_buffer[recordEnd], out separator);
         readResult = CsvLineReadResult.UnquotedRecord;
         return true;
@@ -136,11 +148,13 @@ internal sealed partial class CsvLineReader
         Span<StandardCsvFieldSpan> fields,
         out int fieldCount,
         out int firstFieldLength,
-        out int recordEnd)
+        out int recordEnd,
+        out int embeddedLineSeparatorCount)
     {
         fieldCount = 0;
         firstFieldLength = 0;
         recordEnd = -1;
+        embeddedLineSeparatorCount = 0;
         var index = start;
         var pendingTrailingField = false;
 
@@ -173,7 +187,7 @@ internal sealed partial class CsvLineReader
             StandardCsvFieldSpan field;
             if (value == '"')
             {
-                if (!TryParseStandardQuotedField(ref index, delimiter, trim, out field))
+                if (!TryParseStandardQuotedField(ref index, delimiter, trim, ref embeddedLineSeparatorCount, out field))
                 {
                     return false;
                 }
@@ -217,7 +231,12 @@ internal sealed partial class CsvLineReader
         return false;
     }
 
-    private bool TryParseStandardQuotedField(ref int index, char delimiter, bool trim, out StandardCsvFieldSpan field)
+    private bool TryParseStandardQuotedField(
+        ref int index,
+        char delimiter,
+        bool trim,
+        ref int embeddedLineSeparatorCount,
+        out StandardCsvFieldSpan field)
     {
         index++;
         var valueStart = index;
@@ -226,6 +245,22 @@ internal sealed partial class CsvLineReader
 
         while (index < _length)
         {
+            if (_buffer[index] == '\r')
+            {
+                embeddedLineSeparatorCount++;
+                index++;
+                if (index < _length && _buffer[index] == '\n')
+                {
+                    index++;
+                }
+                continue;
+            }
+            if (_buffer[index] == '\n')
+            {
+                embeddedLineSeparatorCount++;
+                index++;
+                continue;
+            }
             if (_buffer[index] != '"')
             {
                 index++;
@@ -266,7 +301,10 @@ internal sealed partial class CsvLineReader
         return false;
     }
 
-    private bool TryParsePrefixedStandardQuotedField(ref int index, out StandardCsvFieldSpan field)
+    private bool TryParsePrefixedStandardQuotedField(
+        ref int index,
+        ref int embeddedLineSeparatorCount,
+        out StandardCsvFieldSpan field)
     {
         index++;
         var valueStart = index;
@@ -281,6 +319,8 @@ internal sealed partial class CsvLineReader
                 field = default;
                 return false;
             }
+
+            embeddedLineSeparatorCount += CountLineSeparators(_buffer.AsSpan(index, quoteOffset));
 
             index += quoteOffset;
             if (index + 1 < _length && _buffer[index + 1] == '"')
@@ -354,6 +394,7 @@ internal sealed partial class CsvLineReader
         Span<StandardCsvFieldSpan> fields,
         ref int fieldCount,
         ref int firstFieldLength,
+        ref int embeddedLineSeparatorCount,
         out int recordEnd)
     {
         recordEnd = -1;
@@ -388,7 +429,12 @@ internal sealed partial class CsvLineReader
             StandardCsvFieldSpan field;
             if (value == '"')
             {
-                if (!TryParseStandardQuotedField(ref index, delimiter, trim: false, out field))
+                if (!TryParseStandardQuotedField(
+                        ref index,
+                        delimiter,
+                        trim: false,
+                        ref embeddedLineSeparatorCount,
+                        out field))
                 {
                     return false;
                 }
@@ -410,6 +456,28 @@ internal sealed partial class CsvLineReader
         }
 
         return false;
+    }
+
+    private static int CountLineSeparators(ReadOnlySpan<char> value)
+    {
+        int count = 0;
+        for (int index = 0; index < value.Length; index++)
+        {
+            if (value[index] == '\r')
+            {
+                count++;
+                if (index + 1 < value.Length && value[index + 1] == '\n')
+                {
+                    index++;
+                }
+            }
+            else if (value[index] == '\n')
+            {
+                count++;
+            }
+        }
+
+        return count;
     }
 
     private void VisitStandardQuotedFieldSpans<TVisitor>(

--- a/OfficeIMO.CSV/CsvLineReader.cs
+++ b/OfficeIMO.CSV/CsvLineReader.cs
@@ -31,6 +31,8 @@ internal sealed partial class CsvLineReader : IDisposable
 
     internal char[] Buffer => _buffer;
 
+    internal int PhysicalLineSeparatorsConsumed { get; private set; }
+
     internal bool TryGrowFilledBuffer(int minimumCapacity)
     {
         if (minimumCapacity <= _buffer.Length || _length < _buffer.Length)
@@ -881,6 +883,7 @@ internal sealed partial class CsvLineReader : IDisposable
     private void ConsumeLineSeparator(char newline, out string separator)
     {
         _position++;
+        PhysicalLineSeparatorsConsumed++;
         if (newline == '\r')
         {
             separator = ConsumeLineFeedAfterCarriageReturn() ? "\r\n" : "\r";

--- a/OfficeIMO.CSV/CsvLoadOptions.cs
+++ b/OfficeIMO.CSV/CsvLoadOptions.cs
@@ -86,6 +86,12 @@ public sealed class CsvLoadOptions
     public string[]? DateTimeFormats { get; set; }
 
     /// <summary>
+    /// Gets or sets whether schema and row-mapping failures may include source values.
+    /// Defaults to <see cref="DataMappingErrorValuePolicy.Include"/> for compatibility.
+    /// </summary>
+    public DataMappingErrorValuePolicy MappingErrorValuePolicy { get; set; } = DataMappingErrorValuePolicy.Include;
+
+    /// <summary>
     /// Gets or sets how malformed quoted fields are handled. Default is <see cref="CsvQuoteParsingMode.Lenient"/>
     /// to preserve common PowerShell-style import behavior.
     /// </summary>

--- a/OfficeIMO.CSV/CsvMappingExtensions.cs
+++ b/OfficeIMO.CSV/CsvMappingExtensions.cs
@@ -51,7 +51,8 @@ public static class CsvMappingExtensions {
             yield return plan.MapRow(
                 index => row[index],
                 document.Culture,
-                document.DateTimeFormats);
+                document.DateTimeFormats,
+                errorValuePolicy: document.MappingErrorValuePolicy);
         }
     }
 
@@ -64,7 +65,8 @@ public static class CsvMappingExtensions {
             yield return plan.MapRow(
                 index => row[index],
                 document.Culture,
-                document.DateTimeFormats);
+                document.DateTimeFormats,
+                errorValuePolicy: document.MappingErrorValuePolicy);
         }
     }
 

--- a/OfficeIMO.CSV/CsvParser.DataReaderRows.Stream.cs
+++ b/OfficeIMO.CSV/CsvParser.DataReaderRows.Stream.cs
@@ -12,7 +12,7 @@ internal static partial class CsvParser
     /// Pull-based row source over the existing bounded streaming parser. Field spans point at
     /// the reusable line buffer and are materialized only when a caller requests a string.
     /// </summary>
-    internal sealed class CsvStreamDataReaderRowSource : ICsvDataReaderTextRowSource
+    internal sealed class CsvStreamDataReaderRowSource : ICsvDataReaderTextRowSource, ICsvDataReaderPositionSource
     {
         private const int LargeDataReaderBufferSize = 512 * 1024;
         private readonly TextReader _reader;
@@ -27,6 +27,8 @@ internal static partial class CsvParser
         private CsvDataReaderStreamRowVisitor _visitor;
         private int _lineNumber = 1;
         private int _emittedRecordCount;
+        private int? _currentPhysicalLineNumber;
+        private int? _currentPhysicalEndLineNumber;
         private bool _disposed;
 
         internal CsvStreamDataReaderRowSource(TextReader reader, CsvLoadOptions options)
@@ -43,6 +45,10 @@ internal static partial class CsvParser
 
         internal int FieldCount => _visitor.FieldCount;
 
+        int? ICsvDataReaderPositionSource.CurrentPhysicalLineNumber => _currentPhysicalLineNumber;
+
+        int? ICsvDataReaderPositionSource.CurrentPhysicalEndLineNumber => _currentPhysicalEndLineNumber;
+
         internal void SetSourceColumnCount(int sourceColumnCount)
         {
             if (_lineReader.TryGrowFilledBuffer(LargeDataReaderBufferSize))
@@ -57,9 +63,15 @@ internal static partial class CsvParser
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
             _visitor.Reset();
+            _currentPhysicalLineNumber = null;
+            _currentPhysicalEndLineNumber = null;
             while (true)
             {
                 ThrowIfCancellationRequested(_options);
+                bool recordStartedFromPendingLine = _pendingLines.Count > 0;
+                int recordStartLineNumber = recordStartedFromPendingLine
+                    ? _pendingLines.Peek().PhysicalLineNumber
+                    : _lineReader.PhysicalLineSeparatorsConsumed + 1;
                 string? fastLine = null;
                 string lineSeparator;
                 CsvLineReadResult readResult;
@@ -95,6 +107,10 @@ internal static partial class CsvParser
                         _emittedRecordCount++;
                         ReportProgress(_options, _emittedRecordCount, _lineNumber - 1);
                         _visitor.Complete(fieldCount, _options.ColumnCountMismatchPolicy);
+                        _currentPhysicalLineNumber = recordStartLineNumber;
+                        _currentPhysicalEndLineNumber = GetCurrentPhysicalEndLineNumber(
+                            recordStartLineNumber,
+                            recordStartedFromPendingLine);
                         return true;
                     }
                 }
@@ -140,6 +156,10 @@ internal static partial class CsvParser
                     _emittedRecordCount++;
                     ReportProgress(_options, _emittedRecordCount, _lineNumber - 1);
                     _visitor.Complete(fields.Length, _options.ColumnCountMismatchPolicy);
+                    _currentPhysicalLineNumber = recordStartLineNumber;
+                    _currentPhysicalEndLineNumber = GetCurrentPhysicalEndLineNumber(
+                        recordStartLineNumber,
+                        recordStartedFromPendingLine);
                     return true;
                 }
 
@@ -183,9 +203,21 @@ internal static partial class CsvParser
                 _emittedRecordCount++;
                 ReportProgress(_options, _emittedRecordCount, _lineNumber - 1);
                 _visitor.Complete(_quotedFields.Count, _options.ColumnCountMismatchPolicy);
+                _currentPhysicalLineNumber = recordStartLineNumber;
+                _currentPhysicalEndLineNumber = GetCurrentPhysicalEndLineNumber(
+                    recordStartLineNumber,
+                    recordStartedFromPendingLine);
                 return true;
             }
         }
+
+        private int GetCurrentPhysicalEndLineNumber(
+            int recordStartLineNumber,
+            bool recordStartedFromPendingLine) => Math.Max(
+                recordStartLineNumber,
+                recordStartedFromPendingLine
+                    ? _lineNumber - 1
+                    : Math.Max(_lineNumber - 1, _lineReader.PhysicalLineSeparatorsConsumed));
 
         public ReadOnlySpan<char> GetSpan(int ordinal) => _visitor.GetSpan(ordinal);
 

--- a/OfficeIMO.CSV/CsvParser.Quoted.cs
+++ b/OfficeIMO.CSV/CsvParser.Quoted.cs
@@ -610,7 +610,7 @@ internal static partial class CsvParser
                 return QuotedRecordParseResult.Incomplete;
             }
 
-            continuations.Add(new CsvLine(next, lineSeparator));
+            continuations.Add(new CsvLine(next, lineSeparator, lineNumber + 1));
             line = next;
             index = 0;
             start = 0;

--- a/OfficeIMO.CSV/CsvParser.cs
+++ b/OfficeIMO.CSV/CsvParser.cs
@@ -8,15 +8,18 @@ internal static partial class CsvParser
 {
     private readonly struct CsvLine
     {
-        public CsvLine(string text, string separator)
+        public CsvLine(string text, string separator, int physicalLineNumber)
         {
             Text = text;
             Separator = separator;
+            PhysicalLineNumber = physicalLineNumber;
         }
 
         public string Text { get; }
 
         public string Separator { get; }
+
+        public int PhysicalLineNumber { get; }
     }
 
     internal readonly struct CsvParsedRecord
@@ -893,7 +896,10 @@ internal static partial class CsvParser
                 return true;
             }
 
-            continuations.Add(new CsvLine(next, nextSeparator));
+            continuations.Add(new CsvLine(
+                next,
+                nextSeparator,
+                lineNumber + continuations.Count + 1));
             UpdateQuotedRecordState(next, delimiter, options.TrimWhitespace, ref state);
             if (!state.InQuotes)
             {

--- a/OfficeIMO.CSV/CsvSchema.cs
+++ b/OfficeIMO.CSV/CsvSchema.cs
@@ -187,6 +187,18 @@ public sealed class CsvColumnBuilder
     /// </summary>
     public CsvColumnBuilder AsDateTime() => AsType(typeof(DateTime));
 
+#if NET6_0_OR_GREATER
+    /// <summary>
+    /// Sets the expected data type to <see cref="DateOnly"/> without changing default date inference.
+    /// </summary>
+    public CsvColumnBuilder AsDateOnly() => AsType(typeof(DateOnly));
+
+    /// <summary>
+    /// Sets the expected data type to <see cref="TimeOnly"/> without changing default time inference.
+    /// </summary>
+    public CsvColumnBuilder AsTimeOnly() => AsType(typeof(TimeOnly));
+#endif
+
     /// <summary>
     /// Sets the expected data type to <see cref="bool"/>.
     /// </summary>

--- a/OfficeIMO.CSV/CsvValidator.cs
+++ b/OfficeIMO.CSV/CsvValidator.cs
@@ -44,7 +44,14 @@ internal static class CsvValidator
                     }
                 }
 
-                if (!TryConvertValue(value, column, document.Culture, document.DateTimeFormats, out var convertedValue, out var error))
+                if (!TryConvertValue(
+                        value,
+                        column,
+                        document.Culture,
+                        document.DateTimeFormats,
+                        document.MappingErrorValuePolicy,
+                        out var convertedValue,
+                        out var error))
                 {
                     errors.Add(new CsvValidationError(rowIndex, column.Name, error ?? "Invalid value."));
                     continue;
@@ -84,6 +91,7 @@ internal static class CsvValidator
         CsvSchemaColumn column,
         CultureInfo culture,
         IReadOnlyList<string>? dateTimeFormats,
+        DataMappingErrorValuePolicy errorValuePolicy,
         out object? convertedValue,
         out string? error)
     {
@@ -96,8 +104,19 @@ internal static class CsvValidator
             {
                 convertedValue = converter(value, culture);
             }
-            catch (Exception ex) when (ex is not CsvException)
+            catch (Exception ex)
             {
+                if (errorValuePolicy == DataMappingErrorValuePolicy.Redact)
+                {
+                    error = "Custom converter failed; source details were redacted.";
+                    return false;
+                }
+
+                if (ex is CsvException)
+                {
+                    throw;
+                }
+
                 error = $"Custom converter failed: {ex.Message}";
                 return false;
             }
@@ -108,7 +127,15 @@ internal static class CsvValidator
             return true;
         }
 
-        if (!DataValueConverter.TryConvert(convertedValue, column.DataType, culture, dateTimeFormats, typeConverter: null, out convertedValue, out error))
+        if (!DataValueConverter.TryConvert(
+                convertedValue,
+                column.DataType,
+                culture,
+                dateTimeFormats,
+                typeConverter: null,
+                errorValuePolicy,
+                out convertedValue,
+                out error))
         {
             return false;
         }

--- a/OfficeIMO.CSV/CsvWriter.cs
+++ b/OfficeIMO.CSV/CsvWriter.cs
@@ -108,7 +108,7 @@ internal static partial class CsvWriter
             }
 
             var text = FormatValue(value, culture, dateTimeFormat, useUtc, nullValue);
-            if (formulaInjectionPolicy == CsvFormulaInjectionPolicy.Escape)
+            if (ShouldEscapeFormulaValue(value, formulaInjectionPolicy))
             {
                 text = ApplyFormulaInjectionPolicy(text, formulaInjectionPolicy);
             }
@@ -141,8 +141,9 @@ internal static partial class CsvWriter
                 writer.Write(delimiter);
             }
 
-            var text = FormatValue(values[i], culture, dateTimeFormat, useUtc, nullValue);
-            if (formulaInjectionPolicy == CsvFormulaInjectionPolicy.Escape)
+            var value = values[i];
+            var text = FormatValue(value, culture, dateTimeFormat, useUtc, nullValue);
+            if (ShouldEscapeFormulaValue(value, formulaInjectionPolicy))
             {
                 text = ApplyFormulaInjectionPolicy(text, formulaInjectionPolicy);
             }
@@ -174,8 +175,9 @@ internal static partial class CsvWriter
                 writer.Write(delimiter);
             }
 
-            var text = FormatValue(values[i], culture, dateTimeFormat, useUtc, nullValue);
-            if (formulaInjectionPolicy == CsvFormulaInjectionPolicy.Escape)
+            var value = values[i];
+            var text = FormatValue(value, culture, dateTimeFormat, useUtc, nullValue);
+            if (ShouldEscapeFormulaValue(value, formulaInjectionPolicy))
             {
                 text = ApplyFormulaInjectionPolicy(text, formulaInjectionPolicy);
             }
@@ -624,8 +626,9 @@ internal static partial class CsvWriter
                 writer.Write(delimiter);
             }
 
-            var text = FormatValue(valueAccessor(state, i), culture, dateTimeFormat, useUtc, nullValue);
-            if (formulaInjectionPolicy == CsvFormulaInjectionPolicy.Escape)
+            var value = valueAccessor(state, i);
+            var text = FormatValue(value, culture, dateTimeFormat, useUtc, nullValue);
+            if (ShouldEscapeFormulaValue(value, formulaInjectionPolicy))
             {
                 text = ApplyFormulaInjectionPolicy(text, formulaInjectionPolicy);
             }
@@ -858,6 +861,32 @@ internal static partial class CsvWriter
             or ulong;
     }
 
+    private static bool ShouldEscapeFormulaValue(
+        object? value,
+        CsvFormulaInjectionPolicy formulaInjectionPolicy)
+    {
+        if (formulaInjectionPolicy != CsvFormulaInjectionPolicy.Escape)
+        {
+            return false;
+        }
+
+        return value is null || ReferenceEquals(value, DBNull.Value) || !IsFormulaSafeTypedValue(value);
+    }
+
+    private static bool IsFormulaSafeTypedValue(object value)
+    {
+        if (value is bool || IsKnownCsvSafeSpanFormattedValue(value))
+        {
+            return true;
+        }
+
+#if NET6_0_OR_GREATER
+        return value is DateOnly or TimeOnly;
+#else
+        return false;
+#endif
+    }
+
     private static void WriteBufferedRecordLine(TextWriter writer, StringBuilder buffer, string newLine)
     {
 #if NET6_0_OR_GREATER
@@ -915,7 +944,7 @@ internal static partial class CsvWriter
 
         if (value is string text)
         {
-            if (formulaInjectionPolicy == CsvFormulaInjectionPolicy.Escape)
+            if (ShouldEscapeFormulaValue(value, formulaInjectionPolicy))
             {
                 text = ApplyFormulaInjectionPolicy(text, formulaInjectionPolicy);
             }
@@ -928,7 +957,7 @@ internal static partial class CsvWriter
             (value is DateTime || value is DateTimeOffset))
         {
             var formattedDate = FormatValue(value, culture, dateTimeFormat, useUtc, nullValue);
-            if (formulaInjectionPolicy == CsvFormulaInjectionPolicy.Escape)
+            if (ShouldEscapeFormulaValue(value, formulaInjectionPolicy))
             {
                 formattedDate = ApplyFormulaInjectionPolicy(formattedDate, formulaInjectionPolicy);
             }
@@ -950,7 +979,7 @@ internal static partial class CsvWriter
             if (spanFormattable.TryFormat(destination, out var charsWritten, default, culture))
             {
                 var formattedSpan = destination[..charsWritten];
-                var prefixApostrophe = formulaInjectionPolicy == CsvFormulaInjectionPolicy.Escape && StartsWithFormulaTrigger(formattedSpan);
+                var prefixApostrophe = ShouldEscapeFormulaValue(value, formulaInjectionPolicy) && StartsWithFormulaTrigger(formattedSpan);
                 AppendEscapedSpan(buffer, formattedSpan, delimiter, prefixApostrophe, quoteMode, forceQuote);
                 return;
             }
@@ -958,7 +987,7 @@ internal static partial class CsvWriter
 #endif
 
         var formatted = FormatValue(value, culture);
-        if (formulaInjectionPolicy == CsvFormulaInjectionPolicy.Escape)
+        if (ShouldEscapeFormulaValue(value, formulaInjectionPolicy))
         {
             formatted = ApplyFormulaInjectionPolicy(formatted, formulaInjectionPolicy);
         }
@@ -979,7 +1008,7 @@ internal static partial class CsvWriter
         string? nullValue = null)
     {
         var text = FormatValue(value, culture, dateTimeFormat, useUtc, nullValue);
-        if (formulaInjectionPolicy == CsvFormulaInjectionPolicy.Escape)
+        if (ShouldEscapeFormulaValue(value, formulaInjectionPolicy))
         {
             text = ApplyFormulaInjectionPolicy(text, formulaInjectionPolicy);
         }

--- a/OfficeIMO.CSV/ICsvDataReaderPositionMetadata.cs
+++ b/OfficeIMO.CSV/ICsvDataReaderPositionMetadata.cs
@@ -1,0 +1,32 @@
+#nullable enable
+
+namespace OfficeIMO.CSV;
+
+/// <summary>Exposes the current logical record and optional physical source-line position.</summary>
+public interface ICsvDataReaderPositionMetadata
+{
+    /// <summary>
+    /// Gets the one-based data-record number after header, comment, blank, and skipped-record handling.
+    /// Returns zero when the reader is not positioned on a row.
+    /// </summary>
+    long RecordNumber { get; }
+
+    /// <summary>
+    /// Gets the one-based physical source line on which the current record starts, when retained by the reader path.
+    /// Returns <c>null</c> when unavailable or when the reader is not positioned on a row.
+    /// </summary>
+    int? PhysicalLineNumber { get; }
+
+    /// <summary>
+    /// Gets the one-based physical source line on which the current record ends, when retained by the reader path.
+    /// This differs from <see cref="PhysicalLineNumber"/> for multiline quoted records.
+    /// </summary>
+    int? PhysicalEndLineNumber { get; }
+}
+
+internal interface ICsvDataReaderPositionSource
+{
+    int? CurrentPhysicalLineNumber { get; }
+
+    int? CurrentPhysicalEndLineNumber { get; }
+}

--- a/OfficeIMO.CSV/README.md
+++ b/OfficeIMO.CSV/README.md
@@ -138,7 +138,9 @@ foreach (Person person in reader.RowsAs<Person>()) {
 The same automatic and explicit `RowsAs<T>` mappings work on both a materialized
 `CsvDocument` and a forward-only reader. The caller owns and disposes the reader.
 
-Use the explicit overload for immutable models and trimming or NativeAOT-sensitive applications:
+Use the explicit overload when assignments must be declared without reflection,
+including trimming- and NativeAOT-sensitive applications. This overload still
+requires `T : new()`:
 
 ```csharp
 using OfficeIMO.CSV;
@@ -171,7 +173,8 @@ public sealed class Person {
 }
 ```
 
-For immutable models, return a new instance from each assignment:
+For a non-positional record with a public parameterless constructor, an
+assignment can return a new value from each step:
 
 ```csharp
 using OfficeIMO.CSV;
@@ -206,6 +209,16 @@ public sealed record PersonRecord(int Id, string Name);
 The factory receives the current `IDataRecord`; its typed getters use the CSV
 reader's configured culture and schema conversions. The same overload is
 available on `DbDataReader` and does not require `T : new()`.
+
+On .NET 8 and later, explicit `DateOnly` and `TimeOnly` targets are supported by
+`RowsAs<T>`, `GetFieldValue<T>`, and `CsvColumnBuilder.AsDateOnly()` /
+`AsTimeOnly()`. Default schema inference remains `DateTime`, so moving between
+target frameworks does not silently change a column's inferred type.
+
+Set `CsvLoadOptions.MappingErrorValuePolicy` to
+`DataMappingErrorValuePolicy.Redact` when schema and row-mapping failures must
+not include source values or custom-converter exception details. The default is
+`Include` for compatibility.
 
 ## Read once or edit
 
@@ -260,6 +273,15 @@ table.Load(reader);
 
 `OpenDataReader` is the forward-only entry point. Use `CsvDocument.Load` when a
 materialized document is required; 3.1 no longer exposes a load-mode switch.
+`LoadAsync` and `SaveAsync` perform asynchronous source or destination I/O but
+still materialize the document or serialized output. They are not an async CSV
+cursor; `DbDataReader.Read()` remains the bounded forward-only read path.
+
+Streaming readers also implement `ICsvDataReaderPositionMetadata`. Its
+`RecordNumber` is the one-based data-record number, while
+`PhysicalLineNumber` and `PhysicalEndLineNumber` identify the source lines for
+the current record when the selected reader path retains that information.
+Physical line values are `null` for materialized paths rather than estimated.
 
 ## Real-world headers
 
@@ -347,7 +369,7 @@ Console.WriteLine($"Imported {rowsRead} rows");
 
 ## Export options
 
-CSV output supports null tokens, date/time formatting, UTC conversion, append, no-clobber checks, compression, quoting, encoding, and formula escaping:
+CSV output supports null tokens, date/time formatting, UTC conversion, append, no-clobber checks, compression, quoting, encoding, and formula escaping. Formula escaping applies to text and configured text tokens; typed negative numeric values remain numeric:
 
 ```csharp
 CsvDocument.Load("input.csv")

--- a/OfficeIMO.Core/Data/AutomaticRowMappingPlan.cs
+++ b/OfficeIMO.Core/Data/AutomaticRowMappingPlan.cs
@@ -62,10 +62,11 @@ internal sealed class AutomaticRowMappingPlan<
         Func<int, object?> getValue,
         CultureInfo culture,
         IReadOnlyList<string>? dateTimeFormats,
-        Func<object, Type, CultureInfo, (bool ok, object? value)>? typeConverter = null) {
+        Func<object, Type, CultureInfo, (bool ok, object? value)>? typeConverter = null,
+        DataMappingErrorValuePolicy errorValuePolicy = DataMappingErrorValuePolicy.Include) {
         T instance = new T();
         foreach (MappingBinding binding in _bindings) {
-            instance = binding.Apply(instance, getValue(binding.ColumnIndex), culture, dateTimeFormats, typeConverter);
+            instance = binding.Apply(instance, getValue(binding.ColumnIndex), culture, dateTimeFormats, typeConverter, errorValuePolicy);
         }
         return instance;
     }
@@ -120,8 +121,9 @@ internal sealed class AutomaticRowMappingPlan<
             object? rawValue,
             CultureInfo culture,
             IReadOnlyList<string>? dateTimeFormats,
-            Func<object, Type, CultureInfo, (bool ok, object? value)>? typeConverter) {
-            if (!DataValueConverter.TryConvert(rawValue, _property.ValueType, culture, dateTimeFormats, typeConverter, out object? converted, out string? error)) {
+            Func<object, Type, CultureInfo, (bool ok, object? value)>? typeConverter,
+            DataMappingErrorValuePolicy errorValuePolicy) {
+            if (!DataValueConverter.TryConvert(rawValue, _property.ValueType, culture, dateTimeFormats, typeConverter, errorValuePolicy, out object? converted, out string? error)) {
                 throw new DataMappingException(
                     $"Column value cannot be assigned to {typeof(T).Name}.{_property.Name}: {error}");
             }

--- a/OfficeIMO.Core/Data/ExplicitRowMappingPlan.cs
+++ b/OfficeIMO.Core/Data/ExplicitRowMappingPlan.cs
@@ -31,7 +31,8 @@ internal sealed class ExplicitRowMappingPlan<T> where T : new() {
         Func<int, object?> getValue,
         CultureInfo culture,
         IReadOnlyList<string>? dateTimeFormats,
-        Func<object, Type, CultureInfo, (bool ok, object? value)>? typeConverter = null) {
+        Func<object, Type, CultureInfo, (bool ok, object? value)>? typeConverter = null,
+        DataMappingErrorValuePolicy errorValuePolicy = DataMappingErrorValuePolicy.Include) {
         T instance = new T();
         foreach (MappingBinding binding in _bindings) {
             instance = binding.Entry.Apply(
@@ -39,7 +40,8 @@ internal sealed class ExplicitRowMappingPlan<T> where T : new() {
                 getValue(binding.ColumnIndex),
                 culture,
                 dateTimeFormats,
-                typeConverter);
+                typeConverter,
+                errorValuePolicy);
         }
         return instance;
     }

--- a/OfficeIMO.Core/Data/RowMapping.cs
+++ b/OfficeIMO.Core/Data/RowMapping.cs
@@ -25,6 +25,21 @@ public interface IDataReaderMappingMetadata {
     bool RequireAllColumnsMapped { get; }
 }
 
+/// <summary>Controls whether typed-mapping failures may include source values.</summary>
+public enum DataMappingErrorValuePolicy {
+    /// <summary>Preserve converter and framework error details, which may include the source value.</summary>
+    Include = 0,
+
+    /// <summary>Omit source values and converter exception details from mapping errors.</summary>
+    Redact = 1
+}
+
+/// <summary>Supplies error-detail policy for typed mapping without extending the base metadata contract.</summary>
+public interface IDataReaderMappingErrorMetadata {
+    /// <summary>Gets how source values are represented in typed-mapping failures.</summary>
+    DataMappingErrorValuePolicy MappingErrorValuePolicy { get; }
+}
+
 /// <summary>Supplies additional column aliases for a model property.</summary>
 public interface IDataColumnAliasProvider {
     /// <summary>Gets the column names that may bind to the decorated property.</summary>
@@ -105,14 +120,16 @@ public static class DataReaderMappingExtensions {
             out CultureInfo culture,
             out IReadOnlyList<string>? dateTimeFormats,
             out Func<object, Type, CultureInfo, (bool ok, object? value)>? typeConverter,
-            out bool requireAllColumnsMapped);
+            out bool requireAllColumnsMapped,
+            out DataMappingErrorValuePolicy errorValuePolicy);
         AutomaticRowMappingPlan<T> plan = AutomaticRowMappingPlan<T>.Create(GetHeaders(reader), requireAllColumnsMapped);
         while (reader.Read()) {
             yield return plan.MapRow(
                 index => NormalizeDatabaseNull(reader.GetValue(index)),
                 culture,
                 dateTimeFormats,
-                typeConverter);
+                typeConverter,
+                errorValuePolicy);
         }
     }
 
@@ -129,13 +146,15 @@ public static class DataReaderMappingExtensions {
             out CultureInfo culture,
             out IReadOnlyList<string>? dateTimeFormats,
             out Func<object, Type, CultureInfo, (bool ok, object? value)>? typeConverter,
-            out _);
+            out _,
+            out DataMappingErrorValuePolicy errorValuePolicy);
         while (reader.Read()) {
             yield return plan.MapRow(
                 index => NormalizeDatabaseNull(reader.GetValue(index)),
                 culture,
                 dateTimeFormats,
-                typeConverter);
+                typeConverter,
+                errorValuePolicy);
         }
     }
 
@@ -165,19 +184,23 @@ public static class DataReaderMappingExtensions {
         out CultureInfo culture,
         out IReadOnlyList<string>? dateTimeFormats,
         out Func<object, Type, CultureInfo, (bool ok, object? value)>? typeConverter,
-        out bool requireAllColumnsMapped) {
+        out bool requireAllColumnsMapped,
+        out DataMappingErrorValuePolicy errorValuePolicy) {
         if (reader is IDataReaderMappingMetadata metadata) {
             culture = metadata.MappingCulture;
             dateTimeFormats = metadata.MappingDateTimeFormats;
             typeConverter = metadata.MappingTypeConverter;
             requireAllColumnsMapped = metadata.RequireAllColumnsMapped;
-            return;
+        } else {
+            culture = CultureInfo.InvariantCulture;
+            dateTimeFormats = null;
+            typeConverter = null;
+            requireAllColumnsMapped = false;
         }
 
-        culture = CultureInfo.InvariantCulture;
-        dateTimeFormats = null;
-        typeConverter = null;
-        requireAllColumnsMapped = false;
+        errorValuePolicy = reader is IDataReaderMappingErrorMetadata errorMetadata
+            ? errorMetadata.MappingErrorValuePolicy
+            : DataMappingErrorValuePolicy.Include;
     }
 }
 
@@ -188,7 +211,8 @@ internal interface IRowMappingEntry<T> {
         object? rawValue,
         CultureInfo culture,
         IReadOnlyList<string>? dateTimeFormats,
-        Func<object, Type, CultureInfo, (bool ok, object? value)>? typeConverter);
+        Func<object, Type, CultureInfo, (bool ok, object? value)>? typeConverter,
+        DataMappingErrorValuePolicy errorValuePolicy);
 }
 
 internal sealed class RowMappingEntry<T, TValue> : IRowMappingEntry<T> {
@@ -206,8 +230,9 @@ internal sealed class RowMappingEntry<T, TValue> : IRowMappingEntry<T> {
         object? rawValue,
         CultureInfo culture,
         IReadOnlyList<string>? dateTimeFormats,
-        Func<object, Type, CultureInfo, (bool ok, object? value)>? typeConverter) {
-        TValue? value = DataValueConverter.ConvertTo<TValue>(rawValue, culture, dateTimeFormats, typeConverter);
+        Func<object, Type, CultureInfo, (bool ok, object? value)>? typeConverter,
+        DataMappingErrorValuePolicy errorValuePolicy) {
+        TValue? value = DataValueConverter.ConvertTo<TValue>(rawValue, culture, dateTimeFormats, typeConverter, errorValuePolicy);
         return _assign(instance, value!);
     }
 }
@@ -217,9 +242,12 @@ internal static class DataValueConverter {
         object? value,
         CultureInfo culture,
         IReadOnlyList<string>? dateTimeFormats = null,
-        Func<object, Type, CultureInfo, (bool ok, object? value)>? typeConverter = null) {
-        if (!TryConvert(value, typeof(T), culture, dateTimeFormats, typeConverter, out object? result, out string? error)) {
-            throw new DataMappingException(error ?? $"Value '{value}' cannot be converted to {typeof(T).Name}.");
+        Func<object, Type, CultureInfo, (bool ok, object? value)>? typeConverter = null,
+        DataMappingErrorValuePolicy errorValuePolicy = DataMappingErrorValuePolicy.Include) {
+        if (!TryConvert(value, typeof(T), culture, dateTimeFormats, typeConverter, errorValuePolicy, out object? result, out string? error)) {
+            throw new DataMappingException(error ?? (errorValuePolicy == DataMappingErrorValuePolicy.Redact
+                ? $"Value cannot be converted to {typeof(T).Name}."
+                : $"Value '{value}' cannot be converted to {typeof(T).Name}."));
         }
         return (T?)result;
     }
@@ -230,6 +258,25 @@ internal static class DataValueConverter {
         CultureInfo culture,
         IReadOnlyList<string>? dateTimeFormats,
         Func<object, Type, CultureInfo, (bool ok, object? value)>? typeConverter,
+        out object? result,
+        out string? error) =>
+        TryConvert(
+            value,
+            targetType,
+            culture,
+            dateTimeFormats,
+            typeConverter,
+            DataMappingErrorValuePolicy.Include,
+            out result,
+            out error);
+
+    internal static bool TryConvert(
+        object? value,
+        Type targetType,
+        CultureInfo culture,
+        IReadOnlyList<string>? dateTimeFormats,
+        Func<object, Type, CultureInfo, (bool ok, object? value)>? typeConverter,
+        DataMappingErrorValuePolicy errorValuePolicy,
         out object? result,
         out string? error) {
         error = null;
@@ -252,7 +299,9 @@ internal static class DataValueConverter {
                     return true;
                 }
             } catch (Exception ex) {
-                error = ex.Message;
+                error = errorValuePolicy == DataMappingErrorValuePolicy.Redact
+                    ? $"Custom converter failed for {effectiveType.Name}."
+                    : ex.Message;
                 return false;
             }
         }
@@ -261,13 +310,34 @@ internal static class DataValueConverter {
             return true;
         }
         if (value is string text) {
-            return TryConvertFromString(text, effectiveType, culture, dateTimeFormats, out result, out error);
+            return TryConvertFromString(text, effectiveType, culture, dateTimeFormats, errorValuePolicy, out result, out error);
         }
+#if NET6_0_OR_GREATER
+        if (effectiveType == typeof(DateOnly) && value is DateTime dateTime) {
+            result = DateOnly.FromDateTime(dateTime);
+            return true;
+        }
+        if (effectiveType == typeof(TimeOnly) && value is DateTime timeDateTime) {
+            result = TimeOnly.FromDateTime(timeDateTime);
+            return true;
+        }
+        if (effectiveType == typeof(TimeOnly) && value is TimeSpan timeSpan &&
+            timeSpan >= TimeSpan.Zero && timeSpan < TimeSpan.FromDays(1)) {
+            result = TimeOnly.FromTimeSpan(timeSpan);
+            return true;
+        }
+        if (effectiveType == typeof(DateTime) && value is DateOnly dateOnly) {
+            result = dateOnly.ToDateTime(TimeOnly.MinValue);
+            return true;
+        }
+#endif
         try {
             result = Convert.ChangeType(value, effectiveType, culture);
             return true;
         } catch (Exception ex) {
-            error = ex.Message;
+            error = errorValuePolicy == DataMappingErrorValuePolicy.Redact
+                ? $"Value cannot be converted to {effectiveType.Name}."
+                : ex.Message;
             return false;
         }
     }
@@ -277,6 +347,7 @@ internal static class DataValueConverter {
         Type targetType,
         CultureInfo culture,
         IReadOnlyList<string>? dateTimeFormats,
+        DataMappingErrorValuePolicy errorValuePolicy,
         out object? result,
         out string? error) {
         error = null;
@@ -296,12 +367,22 @@ internal static class DataValueConverter {
             else if (targetType == typeof(DateTime) && dateTimeFormats is { Count: > 0 } &&
                      DateTime.TryParseExact(text, dateTimeFormats as string[] ?? dateTimeFormats.ToArray(), culture, DateTimeStyles.None, out DateTime formattedDateTime)) result = formattedDateTime;
             else if (targetType == typeof(DateTime)) result = DateTime.Parse(text, culture, DateTimeStyles.None);
+#if NET6_0_OR_GREATER
+            else if (targetType == typeof(DateOnly) && dateTimeFormats is { Count: > 0 } &&
+                     DateOnly.TryParseExact(text, dateTimeFormats as string[] ?? dateTimeFormats.ToArray(), culture, DateTimeStyles.None, out DateOnly formattedDateOnly)) result = formattedDateOnly;
+            else if (targetType == typeof(DateOnly)) result = DateOnly.Parse(text, culture, DateTimeStyles.None);
+            else if (targetType == typeof(TimeOnly) && dateTimeFormats is { Count: > 0 } &&
+                     TimeOnly.TryParseExact(text, dateTimeFormats as string[] ?? dateTimeFormats.ToArray(), culture, DateTimeStyles.None, out TimeOnly formattedTimeOnly)) result = formattedTimeOnly;
+            else if (targetType == typeof(TimeOnly)) result = TimeOnly.Parse(text, culture, DateTimeStyles.None);
+#endif
             else if (targetType == typeof(Guid) && Guid.TryParse(text, out Guid guidValue)) result = guidValue;
             else if (targetType.IsEnum) result = Enum.Parse(targetType, text, ignoreCase: true);
             else result = Convert.ChangeType(text, targetType, culture);
             return true;
         } catch (Exception ex) {
-            error = ex.Message;
+            error = errorValuePolicy == DataMappingErrorValuePolicy.Redact
+                ? $"Value cannot be converted to {targetType.Name}."
+                : ex.Message;
             return false;
         }
     }

--- a/OfficeIMO.Excel.AotSmoke/Program.cs
+++ b/OfficeIMO.Excel.AotSmoke/Program.cs
@@ -19,12 +19,14 @@ try {
         var sales = new DataTable("Sales");
         sales.Columns.Add("Region", typeof(string));
         sales.Columns.Add("Revenue", typeof(decimal));
-        sales.Rows.Add("North", 1250000M);
-        sales.Rows.Add("South", 980000M);
+        sales.Columns.Add("Date", typeof(DateOnly));
+        sales.Columns.Add("Time", typeof(TimeOnly));
+        sales.Rows.Add("North", 1250000M, new DateOnly(2026, 8, 6), new TimeOnly(14, 35, 12));
+        sales.Rows.Add("South", 980000M, new DateOnly(2026, 8, 7), new TimeOnly(9, 15, 0));
 
         ExcelSheet sheet = document.AddWorksheet("NativeAOT data");
         string range = sheet.InsertDataTableAsTable(sales, tableName: "Sales");
-        if (range != "A1:B3") {
+        if (range != "A1:D3") {
             throw new InvalidOperationException($"The Excel table used the unexpected range '{range}'.");
         }
         document.Save();
@@ -39,9 +41,12 @@ try {
     }
     AotSalesRow mappedRow = reopened.Sheets[0].RowsAs<AotSalesRow>(map => map
         .FromColumn<string>("Region", static (row, value) => { row.Region = value; return row; })
-        .FromColumn<decimal>("Revenue", static (row, value) => { row.Revenue = value; return row; }))
+        .FromColumn<decimal>("Revenue", static (row, value) => { row.Revenue = value; return row; })
+        .FromColumn<DateOnly>("Date", static (row, value) => { row.Date = value; return row; })
+        .FromColumn<TimeOnly>("Time", static (row, value) => { row.Time = value; return row; }))
         .First();
-    if (mappedRow.Region != "North" || mappedRow.Revenue != 1250000M) {
+    if (mappedRow.Region != "North" || mappedRow.Revenue != 1250000M ||
+        mappedRow.Date != new DateOnly(2026, 8, 6) || mappedRow.Time != new TimeOnly(14, 35, 12)) {
         throw new InvalidOperationException("The AOT-safe typed-row mapping returned unexpected data.");
     }
 
@@ -61,4 +66,6 @@ internal readonly record struct SalesRow(string Region, decimal Revenue);
 internal sealed class AotSalesRow {
     public string Region { get; set; } = string.Empty;
     public decimal Revenue { get; set; }
+    public DateOnly Date { get; set; }
+    public TimeOnly Time { get; set; }
 }

--- a/OfficeIMO.Excel.Tests/Excel.DataReaderApi.cs
+++ b/OfficeIMO.Excel.Tests/Excel.DataReaderApi.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Data;
 using Xunit;
 
 namespace OfficeIMO.Excel.Tests;
@@ -132,6 +133,48 @@ public partial class Excel {
 
         Assert.True(reader.Read());
         Assert.Equal(42, reader.GetFieldValue<int?>(0));
+    }
+
+    [Fact]
+    public void OpenDataReader_GetFieldValueSupportsDateOnlyAndTimeOnlyWithoutChangingSchemaTypes() {
+        using var document = ExcelDocument.Create(new MemoryStream());
+        ExcelSheet sheet = document.AddWorksheet("Data");
+        sheet.CellValue(1, 1, "Date");
+        sheet.CellValue(1, 2, "Time");
+        sheet.CellValue(2, 1, new DateOnly(2026, 8, 6));
+        sheet.CellValue(2, 2, new TimeOnly(14, 35, 12));
+
+        using DbDataReader reader = ExcelDocument.OpenDataReader(
+            document.ToBytes(),
+            new ExcelReadOptions { InferSchema = true });
+
+        Assert.True(reader.Read());
+        Assert.Equal(typeof(DateTime), reader.GetFieldType(0));
+        Assert.Equal(typeof(DateTime), reader.GetFieldType(1));
+        Assert.Equal(new DateOnly(2026, 8, 6), reader.GetFieldValue<DateOnly>(0));
+        Assert.Equal(new TimeOnly(14, 35, 12), reader.GetFieldValue<TimeOnly>(1));
+    }
+
+    [Fact]
+    public void OpenDataReader_DateOnlyGetterRedactsSourceValuesWhenRequested() {
+        const string sourceValue = "customer-secret-date";
+        using var document = ExcelDocument.Create(new MemoryStream());
+        ExcelSheet sheet = document.AddWorksheet("Data");
+        sheet.CellValue(1, 1, "Date");
+        sheet.CellValue(2, 1, sourceValue);
+
+        using DbDataReader reader = ExcelDocument.OpenDataReader(
+            document.ToBytes(),
+            new ExcelReadOptions {
+                InferSchema = false,
+                MappingErrorValuePolicy = DataMappingErrorValuePolicy.Redact
+            });
+
+        Assert.True(reader.Read());
+        DataMappingException exception = Assert.Throws<DataMappingException>(() =>
+            reader.GetFieldValue<DateOnly>(0));
+
+        Assert.DoesNotContain(sourceValue, exception.ToString(), StringComparison.Ordinal);
     }
 
     [Fact]

--- a/OfficeIMO.Excel.Tests/Excel.TypedRowsApi.cs
+++ b/OfficeIMO.Excel.Tests/Excel.TypedRowsApi.cs
@@ -91,6 +91,40 @@ public partial class Excel {
     }
 
     [Fact]
+    public void RowsAs_MapsDateOnlyAndTimeOnlyFromExcelDateCells() {
+        using ExcelDocument document = ExcelDocument.Create();
+        ExcelSheet sheet = document.AddWorksheet("Data");
+        sheet.CellValue(1, 1, "Date");
+        sheet.CellValue(1, 2, "Time");
+        sheet.CellValue(2, 1, new DateOnly(2026, 8, 6));
+        sheet.CellValue(2, 2, new TimeOnly(14, 35, 12));
+
+        DateAndTimeRow row = Assert.Single(sheet.RowsAs<DateAndTimeRow>());
+
+        Assert.Equal(new DateOnly(2026, 8, 6), row.Date);
+        Assert.Equal(new TimeOnly(14, 35, 12), row.Time);
+    }
+
+    [Fact]
+    public void RowsAs_RedactsTypeConverterFailuresWhenRequested() {
+        const string secret = "customer-secret-value";
+        using ExcelDocument document = ExcelDocument.Create();
+        ExcelSheet sheet = document.AddWorksheet("Data");
+        sheet.CellValue(1, 1, "OrderId");
+        sheet.CellValue(2, 1, secret);
+        var options = new ExcelReadOptions {
+            MappingErrorValuePolicy = DataMappingErrorValuePolicy.Redact,
+            TypeConverter = (_, _, _) => throw new InvalidOperationException($"failed for {secret}")
+        };
+
+        DataMappingException exception = Assert.Throws<DataMappingException>(() =>
+            sheet.RowsAs<TypedSalesRow>(options).ToArray());
+
+        Assert.DoesNotContain(secret, exception.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Custom converter failed", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void RowsAs_StrictMappingRejectsUnmappedHeaders() {
         using ExcelDocument document = ExcelDocument.Create();
         ExcelSheet sheet = document.AddWorksheet("Data");
@@ -158,6 +192,11 @@ public partial class Excel {
         [ExcelColumn("Order Number")]
         public int OrderId { get; set; }
         public decimal Amount { get; set; }
+    }
+
+    private sealed class DateAndTimeRow {
+        public DateOnly Date { get; set; }
+        public TimeOnly Time { get; set; }
     }
 
     private sealed record PositionalSalesRow(int OrderId, decimal Amount);

--- a/OfficeIMO.Excel/README.md
+++ b/OfficeIMO.Excel/README.md
@@ -175,6 +175,14 @@ the package's existing first-party reader; use `ExcelDocument.Load` when the
 workbook must be inspected, edited, or saved again. CSV uses the parallel
 `CsvDocument.OpenDataReader` API from the separate `OfficeIMO.CSV` package.
 
+On .NET 8 and later, request `DateOnly` or `TimeOnly` explicitly through
+`GetFieldValue<T>` or `RowsAs<T>`. Inferred Excel date/time columns remain
+`DateTime`, so moving between target frameworks does not silently change the
+reader schema. Set `ExcelReadOptions.MappingErrorValuePolicy` to
+`DataMappingErrorValuePolicy.Redact` when typed mapping failures must omit
+source values and custom-converter exception details; the default is `Include`
+for compatibility.
+
 ### Append to an existing table
 
 ```csharp

--- a/OfficeIMO.Excel/Read/ExcelReadOptions.cs
+++ b/OfficeIMO.Excel/Read/ExcelReadOptions.cs
@@ -180,6 +180,12 @@ namespace OfficeIMO.Excel {
         public Func<object, Type, CultureInfo, (bool ok, object? value)>? TypeConverter { get; set; }
 
         /// <summary>
+        /// Gets or sets whether typed mapping failures may include source values.
+        /// Defaults to <see cref="DataMappingErrorValuePolicy.Include"/> for compatibility.
+        /// </summary>
+        public DataMappingErrorValuePolicy MappingErrorValuePolicy { get; set; } = DataMappingErrorValuePolicy.Include;
+
+        /// <summary>
         /// Maximum number of entries loaded from the workbook shared-string table.
         /// This protects readers from malformed workbooks that advertise or contain
         /// unbounded shared-string tables.

--- a/OfficeIMO.Excel/Read/ExcelWorkbookDataReader.cs
+++ b/OfficeIMO.Excel/Read/ExcelWorkbookDataReader.cs
@@ -18,7 +18,7 @@ namespace OfficeIMO.Excel {
     /// <summary>
     /// Package-owned ADO.NET projection for XLSX, XLSM, XLSB, and BIFF8 XLS workbook worksheets.
     /// </summary>
-    public sealed class ExcelWorkbookDataReader : DbDataReader, IDataReaderMappingMetadata {
+    public sealed class ExcelWorkbookDataReader : DbDataReader, IDataReaderMappingMetadata, IDataReaderMappingErrorMetadata {
         private readonly IReadOnlyList<SheetSelection> _sheets;
         private readonly IReadOnlyList<string> _sheetNames;
         private readonly Func<int, DbDataReader> _openSheet;
@@ -30,8 +30,10 @@ namespace OfficeIMO.Excel {
         IReadOnlyList<string>? IDataReaderMappingMetadata.MappingDateTimeFormats => null;
         Func<object, Type, CultureInfo, (bool ok, object? value)>? IDataReaderMappingMetadata.MappingTypeConverter => _typeConverter;
         bool IDataReaderMappingMetadata.RequireAllColumnsMapped => _requireAllColumnsMapped;
+        DataMappingErrorValuePolicy IDataReaderMappingErrorMetadata.MappingErrorValuePolicy => _mappingErrorValuePolicy;
         private readonly Func<object, Type, CultureInfo, (bool ok, object? value)>? _typeConverter;
         private readonly bool _requireAllColumnsMapped;
+        private readonly DataMappingErrorValuePolicy _mappingErrorValuePolicy;
         private readonly CancellationToken _cancellationToken;
         private DbDataReader _current;
         private int _resultIndex;
@@ -44,6 +46,7 @@ namespace OfficeIMO.Excel {
             CultureInfo culture,
             Func<object, Type, CultureInfo, (bool ok, object? value)>? typeConverter,
             bool requireAllColumnsMapped,
+            DataMappingErrorValuePolicy mappingErrorValuePolicy,
             CancellationToken cancellationToken) {
             if (sheets.Count == 0) {
                 owner.Dispose();
@@ -57,6 +60,7 @@ namespace OfficeIMO.Excel {
             _culture = culture;
             _typeConverter = typeConverter;
             _requireAllColumnsMapped = requireAllColumnsMapped;
+            _mappingErrorValuePolicy = mappingErrorValuePolicy;
             _cancellationToken = cancellationToken;
             _current = _openSheet(0);
         }
@@ -279,6 +283,7 @@ namespace OfficeIMO.Excel {
                     options.Culture,
                     options.TypeConverter,
                     options.StrictTypedMapping,
+                    options.MappingErrorValuePolicy,
                     options.CancellationToken);
             } catch {
                 lifetime.Dispose();
@@ -320,6 +325,7 @@ namespace OfficeIMO.Excel {
                     options.Culture,
                     options.TypeConverter,
                     options.StrictTypedMapping,
+                    options.MappingErrorValuePolicy,
                     options.CancellationToken);
             } catch {
                 owner.Dispose();
@@ -343,6 +349,7 @@ namespace OfficeIMO.Excel {
                     options.Culture,
                     options.TypeConverter,
                     options.StrictTypedMapping,
+                    options.MappingErrorValuePolicy,
                     options.CancellationToken);
             } catch {
                 owner.Dispose();
@@ -528,6 +535,15 @@ namespace OfficeIMO.Excel {
             if (destinationType == typeof(double)) return (T)(object)GetDouble(ordinal);
             if (destinationType == typeof(decimal)) return (T)(object)GetDecimal(ordinal);
             if (destinationType == typeof(DateTime)) return (T)(object)GetDateTime(ordinal);
+#if NET6_0_OR_GREATER
+            if (destinationType == typeof(DateOnly) || destinationType == typeof(TimeOnly)) {
+                object? sourceValue = IsDBNull(ordinal) ? null : GetValue(ordinal);
+                return DataValueConverter.ConvertTo<T>(
+                    sourceValue,
+                    _culture,
+                    errorValuePolicy: _mappingErrorValuePolicy)!;
+            }
+#endif
             if (destinationType == typeof(Guid)) return (T)(object)GetGuid(ordinal);
 
             object value = GetValue(ordinal);


### PR DESCRIPTION
## Summary
- adds explicit `DateOnly`/`TimeOnly` targets for CSV and Excel while keeping inferred date columns as `DateTime`
- adds opt-in mapping-error redaction with compatible `Include` defaults
- preserves typed negative numbers under CSV formula protection and exposes logical/physical reader position metadata
- updates NativeAOT coverage and documents the actual factory and async materialization boundaries

## Design boundaries
- constructor-bound records use `RowsAs(Func<IDataRecord, T>)`; mapper overloads still require `T : new()`
- `LoadAsync`/`SaveAsync` perform async I/O but still materialize
- no second async parser, parallel parsing layer, or runtime-type binder is added

## Validation
- Core, CSV, and Excel release builds: `net472`, `netstandard2.0`, `net8.0`, `net10.0`
- CSV tests: 358 passed
- Excel tests: 3483 passed, 5 environment-gated skipped; the desktop COM-only verifier was excluded after an unrelated Excel RPC shutdown failure
- CSV and Excel NativeAOT publish/run
- packed 3.1.0 local-package consumer
- 25k-row reader benchmark: no material throughput or allocation regression
- independent local review plus targeted confirmation: no remaining P0-P3 findings

Related to #2195.