### PR TITLE
Fix VS Code extension transitive npm vulnerabilities

### DIFF
--- a/OfficeIMO.Markup.VSCode/package-lock.json
+++ b/OfficeIMO.Markup.VSCode/package-lock.json
@@ -1753,16 +1753,16 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -3515,9 +3515,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/OfficeIMO.Markup.VSCode/package.json
+++ b/OfficeIMO.Markup.VSCode/package.json
@@ -399,6 +399,10 @@
   "dependencies": {
     "mermaid": "^11.14.0"
   },
+  "overrides": {
+    "brace-expansion": "5.0.9",
+    "js-yaml": "4.3.1"
+  },
   "devDependencies": {
     "@types/node": "^24.13.2",
     "@types/vscode": "1.107.0",


### PR DESCRIPTION
Pins js-yaml 4.3.1 to resolve Dependabot alert #56 and brace-expansion 5.0.9 to resolve adjacent high-severity audit findings in the same VS Code extension dev-tooling graph. The lockfile overrides keep @vscode/vsce as the dependency owner and add no unused direct dependencies.