### PR TITLE
Fix cross-target and release guardrails

### DIFF
--- a/.agents/plugins/officeimo-document-tools/.mcp.json
+++ b/.agents/plugins/officeimo-document-tools/.mcp.json
@@ -5,7 +5,7 @@
       "command": "dotnet",
       "args": [
         "dnx",
-        "OfficeIMO.Tool@3.1.0",
+        "OfficeIMO.Tool@3.1.1",
         "mcp",
         "serve",
         "--stdio"

--- a/OfficeIMO.CSV.Tests/CsvDataReaderApiTests.cs
+++ b/OfficeIMO.CSV.Tests/CsvDataReaderApiTests.cs
@@ -75,6 +75,7 @@ public sealed class CsvDataReaderApiTests {
         Assert.False(reader.Read());
     }
 
+#if NET8_0_OR_GREATER
     [Theory]
     [InlineData("\n")]
     [InlineData("\r\n")]
@@ -162,6 +163,7 @@ public sealed class CsvDataReaderApiTests {
             File.Delete(path);
         }
     }
+#endif
 
     [Fact]
     public void OpenDataReader_StringColumnsSupportTypedGettersWithoutSchemaInference() {
@@ -187,6 +189,7 @@ public sealed class CsvDataReaderApiTests {
         Assert.Equal(identifier, reader.GetGuid(9));
     }
 
+#if NET6_0_OR_GREATER
     [Fact]
     public void OpenDataReader_ExplicitDateOnlyAndTimeOnlyGettersPreserveStringSchema() {
         using DbDataReader reader = CsvDocument.OpenTextDataReader(
@@ -198,6 +201,7 @@ public sealed class CsvDataReaderApiTests {
         Assert.Equal(new DateOnly(2026, 8, 6), reader.GetFieldValue<DateOnly>(0));
         Assert.Equal(new TimeOnly(14, 35, 12), reader.GetFieldValue<TimeOnly>(1));
     }
+#endif
 
     [Fact]
     public void OpenDataReader_SeekableFallbackStartsAtCallerPosition() {

--- a/OfficeIMO.CSV.Tests/CsvSchemaTests.cs
+++ b/OfficeIMO.CSV.Tests/CsvSchemaTests.cs
@@ -97,6 +97,7 @@ public class CsvSchemaTests
         Assert.Equal(typeof(DateTime), Assert.Single(schema.Columns).DataType);
     }
 
+#if NET6_0_OR_GREATER
     [Fact]
     public void ExplicitSchema_SupportsDateOnlyAndTimeOnlyWithoutChangingDefaults()
     {
@@ -115,6 +116,7 @@ public class CsvSchemaTests
         Assert.Equal(new DateOnly(2026, 8, 6), Assert.IsType<DateOnly>(reader.GetValue(0)));
         Assert.Equal(new TimeOnly(14, 35, 12), Assert.IsType<TimeOnly>(reader.GetValue(1)));
     }
+#endif
 
     [Fact]
     public void SchemaConversion_RedactsValuesAndInnerExceptionsWhenRequested()

--- a/OfficeIMO.CSV.Tests/CsvTypedRowsApiTests.cs
+++ b/OfficeIMO.CSV.Tests/CsvTypedRowsApiTests.cs
@@ -145,6 +145,7 @@ public sealed class CsvTypedRowsApiTests {
         Assert.Equal(165258.24m, row.Amount);
     }
 
+#if NET6_0_OR_GREATER
     [Fact]
     public void RowsAs_ConvertsExplicitDateOnlyAndTimeOnlyTargetsWithoutChangingInference() {
         CsvDocument document = CsvDocument.Parse("Date,Time\n2026-08-06,14:35:12\n");
@@ -156,6 +157,7 @@ public sealed class CsvTypedRowsApiTests {
         Assert.Equal(new TimeOnly(14, 35, 12), row.Time);
         Assert.Equal(typeof(DateTime), inferred.Columns[0].DataType);
     }
+#endif
 
     [Fact]
     public void RowsAs_RedactsSourceValuesWhenRequested() {
@@ -182,10 +184,12 @@ public sealed class CsvTypedRowsApiTests {
         Assert.Contains(sourceValue, exception.ToString(), StringComparison.Ordinal);
     }
 
+#if NET6_0_OR_GREATER
     private sealed class DateAndTimeRow {
         public DateOnly Date { get; set; }
         public TimeOnly Time { get; set; }
     }
+#endif
 
     private sealed class SalesRow {
         public int OrderId { get; set; }

--- a/OfficeIMO.Core/Data/RowMapping.cs
+++ b/OfficeIMO.Core/Data/RowMapping.cs
@@ -382,7 +382,7 @@ internal static class DataValueConverter {
         } catch (Exception ex) {
             error = errorValuePolicy == DataMappingErrorValuePolicy.Redact
                 ? $"Value cannot be converted to {targetType.Name}."
-                : ex.Message;
+                : $"Value '{text}' cannot be converted to {targetType.Name}: {ex.Message}";
             return false;
         }
     }

--- a/OfficeIMO.Excel.Tests/Excel.DataReaderApi.cs
+++ b/OfficeIMO.Excel.Tests/Excel.DataReaderApi.cs
@@ -135,6 +135,7 @@ public partial class Excel {
         Assert.Equal(42, reader.GetFieldValue<int?>(0));
     }
 
+#if NET6_0_OR_GREATER
     [Fact]
     public void OpenDataReader_GetFieldValueSupportsDateOnlyAndTimeOnlyWithoutChangingSchemaTypes() {
         using var document = ExcelDocument.Create(new MemoryStream());
@@ -176,6 +177,7 @@ public partial class Excel {
 
         Assert.DoesNotContain(sourceValue, exception.ToString(), StringComparison.Ordinal);
     }
+#endif
 
     [Fact]
     public void OpenDataReader_RejectsCaseInsensitiveDuplicateOpenXmlWorksheetNames() {

--- a/OfficeIMO.Excel.Tests/Excel.TypedRowsApi.cs
+++ b/OfficeIMO.Excel.Tests/Excel.TypedRowsApi.cs
@@ -90,6 +90,7 @@ public partial class Excel {
         Assert.Equal(12.5m, row.Amount);
     }
 
+#if NET6_0_OR_GREATER
     [Fact]
     public void RowsAs_MapsDateOnlyAndTimeOnlyFromExcelDateCells() {
         using ExcelDocument document = ExcelDocument.Create();
@@ -104,6 +105,7 @@ public partial class Excel {
         Assert.Equal(new DateOnly(2026, 8, 6), row.Date);
         Assert.Equal(new TimeOnly(14, 35, 12), row.Time);
     }
+#endif
 
     [Fact]
     public void RowsAs_RedactsTypeConverterFailuresWhenRequested() {
@@ -194,10 +196,12 @@ public partial class Excel {
         public decimal Amount { get; set; }
     }
 
+#if NET6_0_OR_GREATER
     private sealed class DateAndTimeRow {
         public DateOnly Date { get; set; }
         public TimeOnly Time { get; set; }
     }
+#endif
 
     private sealed record PositionalSalesRow(int OrderId, decimal Amount);
 }

--- a/OfficeIMO.MarkdownRenderer.Wpf/packages.lock.json
+++ b/OfficeIMO.MarkdownRenderer.Wpf/packages.lock.json
@@ -120,8 +120,8 @@
       "officeimo.email": {
         "type": "Project",
         "dependencies": {
-          "OfficeIMO.Core": "[3.1.0, )",
-          "OfficeIMO.Rtf": "[3.1.0, )",
+          "OfficeIMO.Core": "[3.1.1, )",
+          "OfficeIMO.Rtf": "[3.1.1, )",
           "System.Text.Encoding.CodePages": "[8.0.0, )"
         }
       },
@@ -130,36 +130,36 @@
         "dependencies": {
           "AngleSharp": "[1.5.2, )",
           "AngleSharp.Css": "[1.0.0-beta.216, )",
-          "OfficeIMO.Core": "[3.1.0, )",
-          "OfficeIMO.Email": "[3.1.0, )",
-          "OfficeIMO.Rtf": "[3.1.0, )"
+          "OfficeIMO.Core": "[3.1.1, )",
+          "OfficeIMO.Email": "[3.1.1, )",
+          "OfficeIMO.Rtf": "[3.1.1, )"
         }
       },
       "officeimo.markdown": {
         "type": "Project",
         "dependencies": {
-          "OfficeIMO.Core": "[3.1.0, )"
+          "OfficeIMO.Core": "[3.1.1, )"
         }
       },
       "officeimo.markdown.html": {
         "type": "Project",
         "dependencies": {
-          "OfficeIMO.Html": "[3.1.0, )",
-          "OfficeIMO.Markdown": "[3.1.0, )"
+          "OfficeIMO.Html": "[3.1.1, )",
+          "OfficeIMO.Markdown": "[3.1.1, )"
         }
       },
       "officeimo.markdownrenderer": {
         "type": "Project",
         "dependencies": {
-          "OfficeIMO.Markdown": "[3.1.0, )",
-          "OfficeIMO.Markdown.Html": "[3.1.0, )",
+          "OfficeIMO.Markdown": "[3.1.1, )",
+          "OfficeIMO.Markdown.Html": "[3.1.1, )",
           "System.Text.Json": "[10.0.7, 11.0.0)"
         }
       },
       "officeimo.rtf": {
         "type": "Project",
         "dependencies": {
-          "OfficeIMO.Core": "[3.1.0, )",
+          "OfficeIMO.Core": "[3.1.1, )",
           "System.Text.Encoding.CodePages": "[8.0.0, )"
         }
       }
@@ -184,8 +184,8 @@
       "officeimo.email": {
         "type": "Project",
         "dependencies": {
-          "OfficeIMO.Core": "[3.1.0, )",
-          "OfficeIMO.Rtf": "[3.1.0, )"
+          "OfficeIMO.Core": "[3.1.1, )",
+          "OfficeIMO.Rtf": "[3.1.1, )"
         }
       },
       "officeimo.html": {
@@ -193,35 +193,35 @@
         "dependencies": {
           "AngleSharp": "[1.5.2, )",
           "AngleSharp.Css": "[1.0.0-beta.216, )",
-          "OfficeIMO.Core": "[3.1.0, )",
-          "OfficeIMO.Email": "[3.1.0, )",
-          "OfficeIMO.Rtf": "[3.1.0, )"
+          "OfficeIMO.Core": "[3.1.1, )",
+          "OfficeIMO.Email": "[3.1.1, )",
+          "OfficeIMO.Rtf": "[3.1.1, )"
         }
       },
       "officeimo.markdown": {
         "type": "Project",
         "dependencies": {
-          "OfficeIMO.Core": "[3.1.0, )"
+          "OfficeIMO.Core": "[3.1.1, )"
         }
       },
       "officeimo.markdown.html": {
         "type": "Project",
         "dependencies": {
-          "OfficeIMO.Html": "[3.1.0, )",
-          "OfficeIMO.Markdown": "[3.1.0, )"
+          "OfficeIMO.Html": "[3.1.1, )",
+          "OfficeIMO.Markdown": "[3.1.1, )"
         }
       },
       "officeimo.markdownrenderer": {
         "type": "Project",
         "dependencies": {
-          "OfficeIMO.Markdown": "[3.1.0, )",
-          "OfficeIMO.Markdown.Html": "[3.1.0, )"
+          "OfficeIMO.Markdown": "[3.1.1, )",
+          "OfficeIMO.Markdown.Html": "[3.1.1, )"
         }
       },
       "officeimo.rtf": {
         "type": "Project",
         "dependencies": {
-          "OfficeIMO.Core": "[3.1.0, )"
+          "OfficeIMO.Core": "[3.1.1, )"
         }
       }
     },
@@ -251,8 +251,8 @@
       "officeimo.email": {
         "type": "Project",
         "dependencies": {
-          "OfficeIMO.Core": "[3.1.0, )",
-          "OfficeIMO.Rtf": "[3.1.0, )"
+          "OfficeIMO.Core": "[3.1.1, )",
+          "OfficeIMO.Rtf": "[3.1.1, )"
         }
       },
       "officeimo.html": {
@@ -260,35 +260,35 @@
         "dependencies": {
           "AngleSharp": "[1.5.2, )",
           "AngleSharp.Css": "[1.0.0-beta.216, )",
-          "OfficeIMO.Core": "[3.1.0, )",
-          "OfficeIMO.Email": "[3.1.0, )",
-          "OfficeIMO.Rtf": "[3.1.0, )"
+          "OfficeIMO.Core": "[3.1.1, )",
+          "OfficeIMO.Email": "[3.1.1, )",
+          "OfficeIMO.Rtf": "[3.1.1, )"
         }
       },
       "officeimo.markdown": {
         "type": "Project",
         "dependencies": {
-          "OfficeIMO.Core": "[3.1.0, )"
+          "OfficeIMO.Core": "[3.1.1, )"
         }
       },
       "officeimo.markdown.html": {
         "type": "Project",
         "dependencies": {
-          "OfficeIMO.Html": "[3.1.0, )",
-          "OfficeIMO.Markdown": "[3.1.0, )"
+          "OfficeIMO.Html": "[3.1.1, )",
+          "OfficeIMO.Markdown": "[3.1.1, )"
         }
       },
       "officeimo.markdownrenderer": {
         "type": "Project",
         "dependencies": {
-          "OfficeIMO.Markdown": "[3.1.0, )",
-          "OfficeIMO.Markdown.Html": "[3.1.0, )"
+          "OfficeIMO.Markdown": "[3.1.1, )",
+          "OfficeIMO.Markdown.Html": "[3.1.1, )"
         }
       },
       "officeimo.rtf": {
         "type": "Project",
         "dependencies": {
-          "OfficeIMO.Core": "[3.1.0, )"
+          "OfficeIMO.Core": "[3.1.1, )"
         }
       }
     },
@@ -312,8 +312,8 @@
       "officeimo.email": {
         "type": "Project",
         "dependencies": {
-          "OfficeIMO.Core": "[3.1.0, )",
-          "OfficeIMO.Rtf": "[3.1.0, )"
+          "OfficeIMO.Core": "[3.1.1, )",
+          "OfficeIMO.Rtf": "[3.1.1, )"
         }
       },
       "officeimo.html": {
@@ -321,35 +321,35 @@
         "dependencies": {
           "AngleSharp": "[1.5.2, )",
           "AngleSharp.Css": "[1.0.0-beta.216, )",
-          "OfficeIMO.Core": "[3.1.0, )",
-          "OfficeIMO.Email": "[3.1.0, )",
-          "OfficeIMO.Rtf": "[3.1.0, )"
+          "OfficeIMO.Core": "[3.1.1, )",
+          "OfficeIMO.Email": "[3.1.1, )",
+          "OfficeIMO.Rtf": "[3.1.1, )"
         }
       },
       "officeimo.markdown": {
         "type": "Project",
         "dependencies": {
-          "OfficeIMO.Core": "[3.1.0, )"
+          "OfficeIMO.Core": "[3.1.1, )"
         }
       },
       "officeimo.markdown.html": {
         "type": "Project",
         "dependencies": {
-          "OfficeIMO.Html": "[3.1.0, )",
-          "OfficeIMO.Markdown": "[3.1.0, )"
+          "OfficeIMO.Html": "[3.1.1, )",
+          "OfficeIMO.Markdown": "[3.1.1, )"
         }
       },
       "officeimo.markdownrenderer": {
         "type": "Project",
         "dependencies": {
-          "OfficeIMO.Markdown": "[3.1.0, )",
-          "OfficeIMO.Markdown.Html": "[3.1.0, )"
+          "OfficeIMO.Markdown": "[3.1.1, )",
+          "OfficeIMO.Markdown.Html": "[3.1.1, )"
         }
       },
       "officeimo.rtf": {
         "type": "Project",
         "dependencies": {
-          "OfficeIMO.Core": "[3.1.0, )"
+          "OfficeIMO.Core": "[3.1.1, )"
         }
       }
     },
@@ -379,8 +379,8 @@
       "officeimo.email": {
         "type": "Project",
         "dependencies": {
-          "OfficeIMO.Core": "[3.1.0, )",
-          "OfficeIMO.Rtf": "[3.1.0, )"
+          "OfficeIMO.Core": "[3.1.1, )",
+          "OfficeIMO.Rtf": "[3.1.1, )"
         }
       },
       "officeimo.html": {
@@ -388,35 +388,35 @@
         "dependencies": {
           "AngleSharp": "[1.5.2, )",
           "AngleSharp.Css": "[1.0.0-beta.216, )",
-          "OfficeIMO.Core": "[3.1.0, )",
-          "OfficeIMO.Email": "[3.1.0, )",
-          "OfficeIMO.Rtf": "[3.1.0, )"
+          "OfficeIMO.Core": "[3.1.1, )",
+          "OfficeIMO.Email": "[3.1.1, )",
+          "OfficeIMO.Rtf": "[3.1.1, )"
         }
       },
       "officeimo.markdown": {
         "type": "Project",
         "dependencies": {
-          "OfficeIMO.Core": "[3.1.0, )"
+          "OfficeIMO.Core": "[3.1.1, )"
         }
       },
       "officeimo.markdown.html": {
         "type": "Project",
         "dependencies": {
-          "OfficeIMO.Html": "[3.1.0, )",
-          "OfficeIMO.Markdown": "[3.1.0, )"
+          "OfficeIMO.Html": "[3.1.1, )",
+          "OfficeIMO.Markdown": "[3.1.1, )"
         }
       },
       "officeimo.markdownrenderer": {
         "type": "Project",
         "dependencies": {
-          "OfficeIMO.Markdown": "[3.1.0, )",
-          "OfficeIMO.Markdown.Html": "[3.1.0, )"
+          "OfficeIMO.Markdown": "[3.1.1, )",
+          "OfficeIMO.Markdown.Html": "[3.1.1, )"
         }
       },
       "officeimo.rtf": {
         "type": "Project",
         "dependencies": {
-          "OfficeIMO.Core": "[3.1.0, )"
+          "OfficeIMO.Core": "[3.1.1, )"
         }
       }
     }


### PR DESCRIPTION
## Summary

- keep DateOnly/TimeOnly and streaming physical-line tests on the target frameworks that implement those contracts
- preserve source values in default mapping errors consistently on .NET Framework
- refresh the WPF package lock and plugin launcher to the coordinated 3.1.1 release

This restores the baseline checks that currently block the pending dependency security update.