### PR TITLE
Enforce OfficeIMO architecture ownership contracts

### DIFF
--- a/.github/workflows/repository-architecture.yml
+++ b/.github/workflows/repository-architecture.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   architecture:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-repository-architecture.yml@59c6271c2f6f94bdf5158fc93f18376fb9e49b0a
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-repository-architecture.yml@8002b6fac21c367709092e0fb45f7f69c4eea257
     with:
-      powerforge_ref: 59c6271c2f6f94bdf5158fc93f18376fb9e49b0a
+      powerforge_ref: 8002b6fac21c367709092e0fb45f7f69c4eea257
       config_path: .powerforge/architecture.json

--- a/.github/workflows/repository-architecture.yml
+++ b/.github/workflows/repository-architecture.yml
@@ -1,0 +1,18 @@
+name: Repository Architecture
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  architecture:
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-repository-architecture.yml@59c6271c2f6f94bdf5158fc93f18376fb9e49b0a
+    with:
+      powerforge_ref: 59c6271c2f6f94bdf5158fc93f18376fb9e49b0a
+      config_path: .powerforge/architecture.json

--- a/.gitignore
+++ b/.gitignore
@@ -394,3 +394,4 @@ Website/static/data/benchmarks/*
 !Website/static/data/benchmarks/library-comparisons/*.json
 Website/static/data/benchmarks/library-comparisons/.index.json.*.lock
 Website/data/ecosystem/stats.json
+.powerforge/_reports/

--- a/.powerforge/architecture.json
+++ b/.powerforge/architecture.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/EvotecIT/PSPublishModule/59c6271c2f6f94bdf5158fc93f18376fb9e49b0a/Schemas/powerforge.repository-architecture.schema.json",
+  "$schema": "https://raw.githubusercontent.com/EvotecIT/PSPublishModule/8002b6fac21c367709092e0fb45f7f69c4eea257/Schemas/powerforge.repository-architecture.schema.json",
   "schemaVersion": 1,
   "repositoryRoot": "..",
   "workspaceValidationConfig": ".powerforge/workspace.validation.json",

--- a/.powerforge/architecture.json
+++ b/.powerforge/architecture.json
@@ -1,0 +1,376 @@
+{
+  "$schema": "https://raw.githubusercontent.com/EvotecIT/PSPublishModule/59c6271c2f6f94bdf5158fc93f18376fb9e49b0a/Schemas/powerforge.repository-architecture.schema.json",
+  "schemaVersion": 1,
+  "repositoryRoot": "..",
+  "workspaceValidationConfig": ".powerforge/workspace.validation.json",
+  "workspaceValidationProfile": "architecture",
+  "globalImpactPaths": [
+    "Directory.Build.*",
+    ".github/workflows/dotnet-tests.yml",
+    ".github/workflows/repository-architecture.yml"
+  ],
+  "projectRules": [
+    {
+      "id": "core-neutral-owner",
+      "project": "OfficeIMO.Core/OfficeIMO.Core.csproj",
+      "allowedProjectReferences": [],
+      "allowedPackageReferences": []
+    },
+    {
+      "id": "excel-tabular-consumer",
+      "project": "OfficeIMO.Excel/OfficeIMO.Excel.csproj",
+      "allowedProjectReferences": ["OfficeIMO.Core/OfficeIMO.Core.csproj"],
+      "requiredProjectReferences": ["OfficeIMO.Core/OfficeIMO.Core.csproj"],
+      "allowedPackageReferences": [
+        "DocumentFormat.OpenXml",
+        "Microsoft.Bcl.AsyncInterfaces",
+        "System.Text.Json"
+      ],
+      "requiredPackageReferences": [
+        "DocumentFormat.OpenXml",
+        "Microsoft.Bcl.AsyncInterfaces",
+        "System.Text.Json"
+      ]
+    },
+    {
+      "id": "powerpoint-tabular-consumer",
+      "project": "OfficeIMO.PowerPoint/OfficeIMO.PowerPoint.csproj",
+      "allowedProjectReferences": ["OfficeIMO.Core/OfficeIMO.Core.csproj"],
+      "requiredProjectReferences": ["OfficeIMO.Core/OfficeIMO.Core.csproj"],
+      "allowedPackageReferences": [
+        "DocumentFormat.OpenXml",
+        "Microsoft.Bcl.AsyncInterfaces",
+        "System.Text.Encoding.CodePages"
+      ],
+      "requiredPackageReferences": [
+        "DocumentFormat.OpenXml",
+        "Microsoft.Bcl.AsyncInterfaces",
+        "System.Text.Encoding.CodePages"
+      ]
+    },
+    {
+      "id": "html-owner",
+      "project": "OfficeIMO.Html/OfficeIMO.Html.csproj",
+      "allowedProjectReferences": ["OfficeIMO.Core/OfficeIMO.Core.csproj"],
+      "requiredProjectReferences": ["OfficeIMO.Core/OfficeIMO.Core.csproj"],
+      "allowedPackageReferences": ["AngleSharp", "AngleSharp.Css"],
+      "requiredPackageReferences": ["AngleSharp", "AngleSharp.Css"]
+    },
+    {
+      "id": "html-rtf-bridge",
+      "project": "OfficeIMO.Html.Rtf/OfficeIMO.Html.Rtf.csproj",
+      "allowedProjectReferences": [
+        "OfficeIMO.Core/OfficeIMO.Core.csproj",
+        "OfficeIMO.Html/OfficeIMO.Html.csproj",
+        "OfficeIMO.Rtf/OfficeIMO.Rtf.csproj"
+      ],
+      "requiredProjectReferences": [
+        "OfficeIMO.Core/OfficeIMO.Core.csproj",
+        "OfficeIMO.Html/OfficeIMO.Html.csproj",
+        "OfficeIMO.Rtf/OfficeIMO.Rtf.csproj"
+      ],
+      "allowedPackageReferences": []
+    },
+    {
+      "id": "html-pdf-bridge",
+      "project": "OfficeIMO.Html.Pdf/OfficeIMO.Html.Pdf.csproj",
+      "allowedProjectReferences": [
+        "OfficeIMO.Core/OfficeIMO.Core.csproj",
+        "OfficeIMO.Html/OfficeIMO.Html.csproj",
+        "OfficeIMO.Pdf/OfficeIMO.Pdf.csproj"
+      ],
+      "requiredProjectReferences": [
+        "OfficeIMO.Core/OfficeIMO.Core.csproj",
+        "OfficeIMO.Html/OfficeIMO.Html.csproj",
+        "OfficeIMO.Pdf/OfficeIMO.Pdf.csproj"
+      ],
+      "allowedPackageReferences": []
+    },
+    {
+      "id": "mhtml-owner",
+      "project": "OfficeIMO.Mhtml/OfficeIMO.Mhtml.csproj",
+      "allowedProjectReferences": [
+        "OfficeIMO.Core/OfficeIMO.Core.csproj",
+        "OfficeIMO.Email/OfficeIMO.Email.csproj",
+        "OfficeIMO.Html/OfficeIMO.Html.csproj"
+      ],
+      "requiredProjectReferences": [
+        "OfficeIMO.Core/OfficeIMO.Core.csproj",
+        "OfficeIMO.Email/OfficeIMO.Email.csproj",
+        "OfficeIMO.Html/OfficeIMO.Html.csproj"
+      ],
+      "allowedPackageReferences": []
+    },
+    {
+      "id": "mhtml-pdf-bridge",
+      "project": "OfficeIMO.Mhtml.Pdf/OfficeIMO.Mhtml.Pdf.csproj",
+      "allowedProjectReferences": [
+        "OfficeIMO.Core/OfficeIMO.Core.csproj",
+        "OfficeIMO.Html.Pdf/OfficeIMO.Html.Pdf.csproj",
+        "OfficeIMO.Mhtml/OfficeIMO.Mhtml.csproj",
+        "OfficeIMO.Pdf/OfficeIMO.Pdf.csproj"
+      ],
+      "requiredProjectReferences": [
+        "OfficeIMO.Core/OfficeIMO.Core.csproj",
+        "OfficeIMO.Html.Pdf/OfficeIMO.Html.Pdf.csproj",
+        "OfficeIMO.Mhtml/OfficeIMO.Mhtml.csproj",
+        "OfficeIMO.Pdf/OfficeIMO.Pdf.csproj"
+      ],
+      "allowedPackageReferences": []
+    },
+    {
+      "id": "email-format-owner",
+      "project": "OfficeIMO.Email/OfficeIMO.Email.csproj",
+      "allowedProjectReferences": [
+        "OfficeIMO.Core/OfficeIMO.Core.csproj",
+        "OfficeIMO.Rtf/OfficeIMO.Rtf.csproj"
+      ],
+      "requiredProjectReferences": [
+        "OfficeIMO.Core/OfficeIMO.Core.csproj",
+        "OfficeIMO.Rtf/OfficeIMO.Rtf.csproj"
+      ],
+      "allowedPackageReferences": ["System.Text.Encoding.CodePages"],
+      "requiredPackageReferences": ["System.Text.Encoding.CodePages"]
+    },
+    {
+      "id": "rtf-format-owner",
+      "project": "OfficeIMO.Rtf/OfficeIMO.Rtf.csproj",
+      "allowedProjectReferences": ["OfficeIMO.Core/OfficeIMO.Core.csproj"],
+      "requiredProjectReferences": ["OfficeIMO.Core/OfficeIMO.Core.csproj"],
+      "allowedPackageReferences": ["System.Text.Encoding.CodePages"],
+      "requiredPackageReferences": ["System.Text.Encoding.CodePages"]
+    },
+    {
+      "id": "email-image-bridge",
+      "project": "OfficeIMO.Email.Image/OfficeIMO.Email.Image.csproj",
+      "allowedProjectReferences": [
+        "OfficeIMO.Core/OfficeIMO.Core.csproj",
+        "OfficeIMO.Email/OfficeIMO.Email.csproj",
+        "OfficeIMO.Html/OfficeIMO.Html.csproj",
+        "OfficeIMO.Html.Rtf/OfficeIMO.Html.Rtf.csproj"
+      ],
+      "requiredProjectReferences": [
+        "OfficeIMO.Core/OfficeIMO.Core.csproj",
+        "OfficeIMO.Email/OfficeIMO.Email.csproj",
+        "OfficeIMO.Html/OfficeIMO.Html.csproj",
+        "OfficeIMO.Html.Rtf/OfficeIMO.Html.Rtf.csproj"
+      ],
+      "allowedPackageReferences": []
+    },
+    {
+      "id": "epub-format-owner",
+      "project": "OfficeIMO.Epub/OfficeIMO.Epub.csproj",
+      "allowedProjectReferences": ["OfficeIMO.Core/OfficeIMO.Core.csproj"],
+      "requiredProjectReferences": ["OfficeIMO.Core/OfficeIMO.Core.csproj"],
+      "allowedPackageReferences": []
+    },
+    {
+      "id": "epub-image-bridge",
+      "project": "OfficeIMO.Epub.Image/OfficeIMO.Epub.Image.csproj",
+      "allowedProjectReferences": [
+        "OfficeIMO.Core/OfficeIMO.Core.csproj",
+        "OfficeIMO.Epub/OfficeIMO.Epub.csproj",
+        "OfficeIMO.Html/OfficeIMO.Html.csproj"
+      ],
+      "requiredProjectReferences": [
+        "OfficeIMO.Core/OfficeIMO.Core.csproj",
+        "OfficeIMO.Epub/OfficeIMO.Epub.csproj",
+        "OfficeIMO.Html/OfficeIMO.Html.csproj"
+      ],
+      "allowedPackageReferences": []
+    },
+    {
+      "id": "pdf-neutral-projection-owner",
+      "project": "OfficeIMO.Pdf/OfficeIMO.Pdf.csproj",
+      "allowedProjectReferences": ["OfficeIMO.Core/OfficeIMO.Core.csproj"],
+      "requiredProjectReferences": ["OfficeIMO.Core/OfficeIMO.Core.csproj"],
+      "allowedPackageReferences": []
+    },
+    {
+      "id": "reader-pdf-neutral-consumer",
+      "project": "OfficeIMO.Reader.Pdf/OfficeIMO.Reader.Pdf.csproj",
+      "allowedProjectReferences": [
+        "OfficeIMO.Core/OfficeIMO.Core.csproj",
+        "OfficeIMO.Pdf/OfficeIMO.Pdf.csproj",
+        "OfficeIMO.Reader.Core/OfficeIMO.Reader.Core.csproj"
+      ],
+      "requiredProjectReferences": [
+        "OfficeIMO.Core/OfficeIMO.Core.csproj",
+        "OfficeIMO.Pdf/OfficeIMO.Pdf.csproj",
+        "OfficeIMO.Reader.Core/OfficeIMO.Reader.Core.csproj"
+      ],
+      "allowedPackageReferences": []
+    },
+    {
+      "id": "reader-core-contract",
+      "project": "OfficeIMO.Reader.Core/OfficeIMO.Reader.Core.csproj",
+      "allowedProjectReferences": [],
+      "allowedPackageReferences": ["System.Text.Json"],
+      "requiredPackageReferences": ["System.Text.Json"]
+    },
+    {
+      "id": "visio-format-owner",
+      "project": "OfficeIMO.Visio/OfficeIMO.Visio.csproj",
+      "allowedProjectReferences": ["OfficeIMO.Core/OfficeIMO.Core.csproj"],
+      "requiredProjectReferences": ["OfficeIMO.Core/OfficeIMO.Core.csproj"],
+      "allowedPackageReferences": ["Microsoft.Bcl.AsyncInterfaces", "System.IO.Packaging"],
+      "requiredPackageReferences": ["Microsoft.Bcl.AsyncInterfaces", "System.IO.Packaging"]
+    },
+    {
+      "id": "reader-visio-neutral-consumer",
+      "project": "OfficeIMO.Reader.Visio/OfficeIMO.Reader.Visio.csproj",
+      "allowedProjectReferences": [
+        "OfficeIMO.Core/OfficeIMO.Core.csproj",
+        "OfficeIMO.Reader.Core/OfficeIMO.Reader.Core.csproj",
+        "OfficeIMO.Visio/OfficeIMO.Visio.csproj"
+      ],
+      "requiredProjectReferences": [
+        "OfficeIMO.Core/OfficeIMO.Core.csproj",
+        "OfficeIMO.Reader.Core/OfficeIMO.Reader.Core.csproj",
+        "OfficeIMO.Visio/OfficeIMO.Visio.csproj"
+      ],
+      "allowedPackageReferences": []
+    },
+    {
+      "id": "visio-pdf-bridge",
+      "project": "OfficeIMO.Visio.Pdf/OfficeIMO.Visio.Pdf.csproj",
+      "allowedProjectReferences": [
+        "OfficeIMO.Core/OfficeIMO.Core.csproj",
+        "OfficeIMO.Pdf/OfficeIMO.Pdf.csproj",
+        "OfficeIMO.Visio/OfficeIMO.Visio.csproj"
+      ],
+      "requiredProjectReferences": [
+        "OfficeIMO.Core/OfficeIMO.Core.csproj",
+        "OfficeIMO.Pdf/OfficeIMO.Pdf.csproj",
+        "OfficeIMO.Visio/OfficeIMO.Visio.csproj"
+      ],
+      "allowedPackageReferences": []
+    }
+  ],
+  "capabilities": [
+    {
+      "id": "tabular-row-projection",
+      "description": "OfficeIMO.Core owns generic and dictionary row projection; Excel and PowerPoint are thin consumers.",
+      "ownerProjects": ["OfficeIMO.Core/OfficeIMO.Core.csproj"],
+      "ownerPaths": [
+        "OfficeIMO.Core/Data/ObjectFlattener.Rows.cs",
+        "OfficeIMO.Core/Data/ObjectDictionaryAdapter.cs"
+      ],
+      "consumerProjects": [
+        "OfficeIMO.Excel/OfficeIMO.Excel.csproj",
+        "OfficeIMO.PowerPoint/OfficeIMO.PowerPoint.csproj"
+      ],
+      "usagePatterns": ["FlattenRows("],
+      "requiredEvidenceKinds": ["contract", "nativeAot"],
+      "evidence": [
+        {
+          "id": "excel-dictionary-contracts",
+          "kind": "contract",
+          "stepId": "excel-dictionary-contracts",
+          "path": "OfficeIMO.Excel.Tests/Excel.SheetComposer.DictionaryRows.cs",
+          "coversProjects": [
+            "OfficeIMO.Core/OfficeIMO.Core.csproj",
+            "OfficeIMO.Excel/OfficeIMO.Excel.csproj"
+          ]
+        },
+        {
+          "id": "powerpoint-dictionary-contracts",
+          "kind": "contract",
+          "stepId": "powerpoint-dictionary-contracts",
+          "path": "OfficeIMO.PowerPoint.Tests/PowerPoint.DictionaryRows.cs",
+          "coversProjects": ["OfficeIMO.PowerPoint/OfficeIMO.PowerPoint.csproj"]
+        },
+        {
+          "id": "excel-native-aot",
+          "kind": "nativeAot",
+          "stepId": "native-aot",
+          "path": "OfficeIMO.Excel.AotSmoke/Program.cs",
+          "coversProjects": [
+            "OfficeIMO.Core/OfficeIMO.Core.csproj",
+            "OfficeIMO.Excel/OfficeIMO.Excel.csproj"
+          ]
+        },
+        {
+          "id": "powerpoint-native-aot",
+          "kind": "nativeAot",
+          "stepId": "native-aot",
+          "path": "OfficeIMO.PowerPoint.AotSmoke/Program.cs",
+          "coversProjects": ["OfficeIMO.PowerPoint/OfficeIMO.PowerPoint.csproj"]
+        },
+        {
+          "id": "native-aot-runner",
+          "kind": "nativeAot",
+          "stepId": "native-aot",
+          "path": "Build/Test-AotScenarios.ps1",
+          "coversProjects": [
+            "OfficeIMO.Core/OfficeIMO.Core.csproj",
+            "OfficeIMO.Excel/OfficeIMO.Excel.csproj",
+            "OfficeIMO.PowerPoint/OfficeIMO.PowerPoint.csproj"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "neutral-document-model",
+      "description": "OfficeIMO.Core owns the source-neutral model; format packages project into it and OfficeIMO.Pdf renders it.",
+      "ownerProjects": ["OfficeIMO.Core/OfficeIMO.Core.csproj"],
+      "ownerPaths": ["OfficeIMO.Core/Documents/OfficeDocumentModel*.cs"],
+      "consumerProjects": [
+        "OfficeIMO.Pdf/OfficeIMO.Pdf.csproj",
+        "OfficeIMO.Reader.Pdf/OfficeIMO.Reader.Pdf.csproj",
+        "OfficeIMO.Reader.Visio/OfficeIMO.Reader.Visio.csproj",
+        "OfficeIMO.Visio/OfficeIMO.Visio.csproj",
+        "OfficeIMO.Visio.Pdf/OfficeIMO.Visio.Pdf.csproj"
+      ],
+      "ignoredUsageProjects": ["OfficeIMO.Reader.Core/OfficeIMO.Reader.Core.csproj"],
+      "usagePatterns": ["OfficeDocumentModel"],
+      "requiredEvidenceKinds": ["contract", "runtime", "nativeAot"],
+      "evidence": [
+        {
+          "id": "pdf-neutral-model-contracts",
+          "kind": "contract",
+          "stepId": "neutral-pdf-contracts",
+          "path": "OfficeIMO.Pdf.Tests/Pdf/PdfEngineRoadmapFoundationTests.cs",
+          "coversProjects": [
+            "OfficeIMO.Core/OfficeIMO.Core.csproj",
+            "OfficeIMO.Pdf/OfficeIMO.Pdf.csproj"
+          ]
+        },
+        {
+          "id": "visio-neutral-model-contracts",
+          "kind": "contract",
+          "stepId": "neutral-visio-contracts",
+          "path": "OfficeIMO.Visio.Tests/Visio.Pdf.ApiConsistency.cs",
+          "coversProjects": [
+            "OfficeIMO.Visio/OfficeIMO.Visio.csproj",
+            "OfficeIMO.Visio.Pdf/OfficeIMO.Visio.Pdf.csproj"
+          ]
+        },
+        {
+          "id": "reader-neutral-model-runtime",
+          "kind": "runtime",
+          "stepId": "neutral-reader-contracts",
+          "path": "OfficeIMO.Reader.Tests/Reader.DirectPdfAdapters.cs",
+          "coversProjects": [
+            "OfficeIMO.Reader.Pdf/OfficeIMO.Reader.Pdf.csproj",
+            "OfficeIMO.Reader.Visio/OfficeIMO.Reader.Visio.csproj"
+          ]
+        },
+        {
+          "id": "neutral-model-native-aot",
+          "kind": "nativeAot",
+          "stepId": "native-aot",
+          "path": "Build/Test-AotScenarios.ps1",
+          "coversProjects": [
+            "OfficeIMO.Core/OfficeIMO.Core.csproj",
+            "OfficeIMO.Pdf/OfficeIMO.Pdf.csproj",
+            "OfficeIMO.Reader.Pdf/OfficeIMO.Reader.Pdf.csproj",
+            "OfficeIMO.Reader.Visio/OfficeIMO.Reader.Visio.csproj",
+            "OfficeIMO.Visio/OfficeIMO.Visio.csproj",
+            "OfficeIMO.Visio.Pdf/OfficeIMO.Visio.Pdf.csproj"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.powerforge/workspace.validation.json
+++ b/.powerforge/workspace.validation.json
@@ -1,0 +1,99 @@
+{
+  "schemaVersion": 1,
+  "projectRoot": "..",
+  "profiles": [
+    {
+      "name": "architecture",
+      "description": "Contracts and runtime evidence for shared OfficeIMO owners and their declared consumers."
+    }
+  ],
+  "steps": [
+    {
+      "id": "excel-dictionary-contracts",
+      "name": "Excel dictionary row contracts",
+      "kind": "DotNet",
+      "profiles": ["architecture"],
+      "arguments": [
+        "test",
+        "OfficeIMO.Excel.Tests/OfficeIMO.Excel.Tests.csproj",
+        "--configuration",
+        "{configuration}",
+        "--filter",
+        "FullyQualifiedName~ExcelSheetComposerDictionaryRowTests"
+      ]
+    },
+    {
+      "id": "powerpoint-dictionary-contracts",
+      "name": "PowerPoint dictionary row contracts",
+      "kind": "DotNet",
+      "profiles": ["architecture"],
+      "arguments": [
+        "test",
+        "OfficeIMO.PowerPoint.Tests/OfficeIMO.PowerPoint.Tests.csproj",
+        "--configuration",
+        "{configuration}",
+        "--filter",
+        "FullyQualifiedName~PowerPointDictionaryRowTests"
+      ]
+    },
+    {
+      "id": "neutral-pdf-contracts",
+      "name": "Neutral document model PDF contracts",
+      "kind": "DotNet",
+      "profiles": ["architecture"],
+      "arguments": [
+        "test",
+        "OfficeIMO.Pdf.Tests/OfficeIMO.Pdf.Tests.csproj",
+        "--configuration",
+        "{configuration}",
+        "--filter",
+        "FullyQualifiedName~PdfEngineRoadmapFoundationTests"
+      ]
+    },
+    {
+      "id": "neutral-visio-contracts",
+      "name": "Neutral document model Visio contracts",
+      "kind": "DotNet",
+      "profiles": ["architecture"],
+      "arguments": [
+        "test",
+        "OfficeIMO.Visio.Tests/OfficeIMO.Visio.Tests.csproj",
+        "--configuration",
+        "{configuration}",
+        "--filter",
+        "FullyQualifiedName~VisioPdfApiConsistencyTests"
+      ]
+    },
+    {
+      "id": "neutral-reader-contracts",
+      "name": "Neutral document model Reader runtime contracts",
+      "kind": "DotNet",
+      "profiles": ["architecture"],
+      "arguments": [
+        "test",
+        "OfficeIMO.Reader.Tests/OfficeIMO.Reader.Tests.csproj",
+        "--configuration",
+        "{configuration}",
+        "--filter",
+        "FullyQualifiedName~ReaderDirectPdfAdapterTests"
+      ]
+    },
+    {
+      "id": "native-aot",
+      "name": "OfficeIMO NativeAOT scenarios",
+      "kind": "Command",
+      "profiles": ["architecture"],
+      "executable": "pwsh",
+      "arguments": [
+        "-NoLogo",
+        "-NoProfile",
+        "-File",
+        "Build/Test-AotScenarios.ps1",
+        "-Configuration",
+        "{configuration}"
+      ],
+      "failureContext": "A shared OfficeIMO capability failed its NativeAOT publish or runtime evidence.",
+      "failureHint": "Fix the shared owner and every declared consumer instead of adding consumer-local reflection or compatibility branches."
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,12 @@
 - Exercise documentation examples through real compile, restore, or run consumers where practical.
 - When low-value prose-only, implementation-only, duplicate, or obsolete tests are encountered in a touched area, remove them instead of preserving or replacing them for test-count optics.
 
+## Architecture policy
+
+- `.powerforge/architecture.json` is the executable source of truth for registered package boundaries, shared capability owners, direct consumers, and required evidence. Run `powerforge architecture verify --config .powerforge/architecture.json --working-tree --run-evidence` before and after changing a registered owner or consumer.
+- Extend the shared PowerForge contract when a reusable architecture rule cannot be expressed. Do not add an OfficeIMO-local project graph scanner, source-usage analyzer, impact calculator, or evidence runner.
+- Keep consumer packages thin. When a new project consumes a registered capability, add it to the policy and evidence closure in the same change instead of adding another projection, conversion, parser, or compatibility brain.
+
 ## Benchmark boundaries
 
 - Third-party libraries used for comparisons stay isolated in benchmark projects and opt-in verification runners; do not add them to OfficeIMO runtime projects without an explicit product decision.

--- a/OfficeIMO.Reader.Visio/OfficeIMO.Reader.Visio.csproj
+++ b/OfficeIMO.Reader.Visio/OfficeIMO.Reader.Visio.csproj
@@ -25,6 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\OfficeIMO.Core\OfficeIMO.Core.csproj" />
     <ProjectReference Include="..\OfficeIMO.Reader.Core\OfficeIMO.Reader.Core.csproj" />
     <ProjectReference Include="..\OfficeIMO.Visio\OfficeIMO.Visio.csproj" />
   </ItemGroup>


### PR DESCRIPTION
## What this changes

OfficeIMO now declares its package boundaries and shared capability ownership through the reusable PowerForge architecture contract from EvotecIT/PSPublishModule#703.

- locks the direct dependency surfaces for Core, HTML/RTF/email/MHTML/EPUB/PDF/Visio bridges, tabular consumers, and Reader neutral-model adapters
- registers Core-owned tabular row projection and the neutral document model, including every known direct consumer
- maps changes in those owners and consumers to existing focused contract tests and the existing NativeAOT scenario runner
- makes Reader.Visio declare its direct Core dependency instead of relying on the Visio transitive edge
- adds one immutable reusable-workflow call; OfficeIMO does not gain a local graph scanner, source analyzer, impact calculator, or test runner

## Stack and ownership

This PR is based on #2254 because that PR adds the current generic/dictionary tabular surface being registered. The workflow and schema are pinned to the exact cross-platform PowerForge head in PR #703. Merge order is PowerForge #703, OfficeIMO #2254, then this PR after rebasing its base to master.

## Limits

The shared policy inspects literal repository-local project/package references and lexical source usage. It is an enforceable ownership and evidence-closure contract, not a semantic clone detector or evaluated MSBuild graph.

## Validation

- static policy verification passed across 164 projects and 19 exact dependency rules
- six required evidence steps passed
- all 11 existing NativeAOT scenarios passed
- Reader direct PDF adapter contracts passed on net472, net8, and net10 after adding the direct Core reference
- one independent consumer-policy review found two P2 declaration gaps; both were fixed and the targeted confirmation found no remaining P0-P3 issues