### PR TITLE
Add direct Excel chart image export APIs

### DIFF
--- a/OfficeIMO.Excel.Tests/Excel.ImageExport.ChartDirect.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ImageExport.ChartDirect.cs
@@ -114,5 +114,45 @@ namespace OfficeIMO.Tests {
 
             Assert.Contains("#0C2238", svg, System.StringComparison.OrdinalIgnoreCase);
         }
+
+        [Fact]
+        public void ExcelChart_DirectExportUsesAbsoluteAnchorDimensions() {
+            string filePath = Path.Combine(Path.GetTempPath(), System.Guid.NewGuid() + ".xlsx");
+            try {
+                using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                    ExcelSheet sheet = document.AddWorksheet("Summary");
+                    sheet.CellValue(1, 1, "Category");
+                    sheet.CellValue(1, 2, "Value");
+                    sheet.CellValue(2, 1, "Open");
+                    sheet.CellValue(2, 2, 12);
+                    sheet.AddChartFromRange(
+                        "A1:B2",
+                        row: 1,
+                        column: 4,
+                        widthPixels: 320,
+                        heightPixels: 180,
+                        title: "Absolute chart");
+                    document.Save();
+                }
+
+                MoveFirstChartToAbsoluteAnchor(
+                    filePath,
+                    xPixels: 40,
+                    yPixels: 30,
+                    widthPixels: 210,
+                    heightPixels: 110);
+
+                using ExcelDocument loaded = ExcelDocument.Load(filePath);
+                ExcelChart chart = Assert.Single(loaded.Sheets.Single().Charts);
+                OfficeImageExportResult result = chart.ExportImage(OfficeImageExportFormat.Png);
+
+                Assert.Equal(210, result.Width);
+                Assert.Equal(110, result.Height);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
     }
 }

--- a/OfficeIMO.Excel.Tests/Excel.ImageExport.ChartDirect.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ImageExport.ChartDirect.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Text;
 using OfficeIMO.Drawing;
 using OfficeIMO.Excel;
 using Xunit;
@@ -62,6 +63,56 @@ namespace OfficeIMO.Tests {
 
             Assert.Equal(OfficeImageExportFormat.Webp, result.Format);
             Assert.True(result.EncodedLength > 0);
+        }
+
+        [Theory]
+        [InlineData(OfficeImageExportFormat.Png)]
+        [InlineData(OfficeImageExportFormat.Svg)]
+        public void ExcelChart_PreservesSmallAnchoredDimensions(OfficeImageExportFormat format) {
+            using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet sheet = document.AddWorksheet("Summary");
+            sheet.CellValue(1, 1, "Category");
+            sheet.CellValue(1, 2, "Value");
+            sheet.CellValue(2, 1, "Open");
+            sheet.CellValue(2, 2, 12);
+            ExcelChart chart = sheet.AddChartFromRange(
+                "A1:B2",
+                row: 1,
+                column: 4,
+                widthPixels: 160,
+                heightPixels: 90,
+                title: "Small chart");
+
+            OfficeImageExportResult result = chart.ExportImage(format);
+
+            Assert.Equal(160, result.Width);
+            Assert.Equal(90, result.Height);
+        }
+
+        [Fact]
+        public void ExcelChart_SvgUsesRequestedExportBackgroundWhenChartHasNoFill() {
+            using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet sheet = document.AddWorksheet("Summary");
+            sheet.CellValue(1, 1, "Category");
+            sheet.CellValue(1, 2, "Value");
+            sheet.CellValue(2, 1, "Open");
+            sheet.CellValue(2, 2, 12);
+            ExcelChart chart = sheet.AddChartFromRange(
+                "A1:B2",
+                row: 1,
+                column: 4,
+                widthPixels: 320,
+                heightPixels: 180,
+                title: "Transparent chart");
+            chart.SetChartAreaStyle(noFill: true, noLine: true);
+
+            string svg = Encoding.UTF8.GetString(chart.ExportImage(
+                OfficeImageExportFormat.Svg,
+                new ExcelImageExportOptions {
+                    BackgroundColor = OfficeColor.FromRgb(12, 34, 56)
+                }).Bytes);
+
+            Assert.Contains("#0C2238", svg, System.StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/OfficeIMO.Excel.Tests/Excel.ImageExport.ChartDirect.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ImageExport.ChartDirect.cs
@@ -1,0 +1,67 @@
+using System.IO;
+using OfficeIMO.Drawing;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class ExcelImageExportTests {
+        [Theory]
+        [InlineData(OfficeImageExportFormat.Png)]
+        [InlineData(OfficeImageExportFormat.Svg)]
+        [InlineData(OfficeImageExportFormat.Jpeg)]
+        [InlineData(OfficeImageExportFormat.Tiff)]
+        [InlineData(OfficeImageExportFormat.Webp)]
+        public void ExcelChart_ExportsDirectlyThroughSharedImageContract(OfficeImageExportFormat format) {
+            using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet sheet = document.AddWorksheet("Summary");
+            sheet.CellValue(1, 1, "Category");
+            sheet.CellValue(1, 2, "Value");
+            sheet.CellValue(2, 1, "Open");
+            sheet.CellValue(2, 2, 12);
+            sheet.CellValue(3, 1, "Closed");
+            sheet.CellValue(3, 2, 30);
+            ExcelChart chart = sheet.AddChartFromRange(
+                "A1:B3",
+                row: 1,
+                column: 4,
+                widthPixels: 360,
+                heightPixels: 220,
+                title: "Ticket status");
+            chart.Name = "TicketStatus";
+
+            OfficeImageExportResult result = chart.ExportImage(format);
+
+            Assert.Equal(format, result.Format);
+            Assert.Equal("TicketStatus", result.Name);
+            Assert.Equal("Summary!TicketStatus", result.Source);
+            Assert.True(result.Width > 0);
+            Assert.True(result.Height > 0);
+            Assert.True(result.EncodedLength > 0);
+        }
+
+        [Fact]
+        public void ExcelChart_UsesTheSharedFluentImageBuilder() {
+            using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet sheet = document.AddWorksheet("Summary");
+            sheet.CellValue(1, 1, "Category");
+            sheet.CellValue(1, 2, "Value");
+            sheet.CellValue(2, 1, "Open");
+            sheet.CellValue(2, 2, 12);
+            ExcelChart chart = sheet.AddChartFromRange(
+                "A1:B2",
+                row: 1,
+                column: 4,
+                widthPixels: 360,
+                heightPixels: 220,
+                title: "Ticket status");
+
+            OfficeImageExportResult result = chart.ToImage()
+                .AsWebp()
+                .WithScale(1.25)
+                .Export();
+
+            Assert.Equal(OfficeImageExportFormat.Webp, result.Format);
+            Assert.True(result.EncodedLength > 0);
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelChart.cs
+++ b/OfficeIMO.Excel/ExcelChart.cs
@@ -437,6 +437,13 @@ namespace OfficeIMO.Excel {
                 return (hasWidth ? widthPixels : 480, hasHeight ? heightPixels : 320);
             }
 
+            Xdr.Extent? absoluteExtent = _frame.Ancestors<Xdr.AbsoluteAnchor>().FirstOrDefault()?.Extent;
+            if (absoluteExtent != null) {
+                return (
+                    EmuToPixels(absoluteExtent.Cx?.Value, 480),
+                    EmuToPixels(absoluteExtent.Cy?.Value, 320));
+            }
+
             Xdr.Extent? extent = _frame.Ancestors<Xdr.OneCellAnchor>().FirstOrDefault()?.Extent;
             return (EmuToPixels(extent?.Cx?.Value, 480), EmuToPixels(extent?.Cy?.Value, 320));
         }

--- a/OfficeIMO.Excel/Imaging/ExcelChart.Imaging.RasterFormats.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelChart.Imaging.RasterFormats.cs
@@ -1,0 +1,68 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using OfficeIMO.Drawing;
+
+namespace OfficeIMO.Excel {
+    public sealed partial class ExcelChart {
+        /// <summary>Renders this chart to dependency-free JPEG bytes.</summary>
+        public byte[] ToJpeg(ExcelImageExportOptions? options = null) =>
+            ExportImage(OfficeImageExportFormat.Jpeg, options).Bytes;
+
+        /// <summary>Renders this chart to dependency-free TIFF bytes.</summary>
+        public byte[] ToTiff(ExcelImageExportOptions? options = null) =>
+            ExportImage(OfficeImageExportFormat.Tiff, options).Bytes;
+
+        /// <summary>Renders this chart to dependency-free lossless WebP bytes.</summary>
+        public byte[] ToWebp(ExcelImageExportOptions? options = null) =>
+            ExportImage(OfficeImageExportFormat.Webp, options).Bytes;
+
+        /// <summary>Saves this chart as JPEG.</summary>
+        public OfficeImageExportResult SaveAsJpeg(string path, ExcelImageExportOptions? options = null) =>
+            new ExcelChartImageExportBuilder(this, options).AsJpeg().Save(path);
+
+        /// <summary>Saves this chart as TIFF.</summary>
+        public OfficeImageExportResult SaveAsTiff(string path, ExcelImageExportOptions? options = null) =>
+            new ExcelChartImageExportBuilder(this, options).AsTiff().Save(path);
+
+        /// <summary>Saves this chart as lossless WebP.</summary>
+        public OfficeImageExportResult SaveAsWebp(string path, ExcelImageExportOptions? options = null) =>
+            new ExcelChartImageExportBuilder(this, options).AsWebp().Save(path);
+
+        /// <summary>Writes this chart as JPEG.</summary>
+        public OfficeImageExportResult SaveAsJpeg(Stream stream, ExcelImageExportOptions? options = null) =>
+            new ExcelChartImageExportBuilder(this, options).AsJpeg().Save(stream);
+
+        /// <summary>Writes this chart as TIFF.</summary>
+        public OfficeImageExportResult SaveAsTiff(Stream stream, ExcelImageExportOptions? options = null) =>
+            new ExcelChartImageExportBuilder(this, options).AsTiff().Save(stream);
+
+        /// <summary>Writes this chart as lossless WebP.</summary>
+        public OfficeImageExportResult SaveAsWebp(Stream stream, ExcelImageExportOptions? options = null) =>
+            new ExcelChartImageExportBuilder(this, options).AsWebp().Save(stream);
+
+        /// <summary>Asynchronously saves this chart as JPEG.</summary>
+        public Task<OfficeImageExportResult> SaveAsJpegAsync(string path, ExcelImageExportOptions? options = null, CancellationToken cancellationToken = default) =>
+            new ExcelChartImageExportBuilder(this, options).AsJpeg().SaveAsync(path, cancellationToken);
+
+        /// <summary>Asynchronously saves this chart as TIFF.</summary>
+        public Task<OfficeImageExportResult> SaveAsTiffAsync(string path, ExcelImageExportOptions? options = null, CancellationToken cancellationToken = default) =>
+            new ExcelChartImageExportBuilder(this, options).AsTiff().SaveAsync(path, cancellationToken);
+
+        /// <summary>Asynchronously saves this chart as lossless WebP.</summary>
+        public Task<OfficeImageExportResult> SaveAsWebpAsync(string path, ExcelImageExportOptions? options = null, CancellationToken cancellationToken = default) =>
+            new ExcelChartImageExportBuilder(this, options).AsWebp().SaveAsync(path, cancellationToken);
+
+        /// <summary>Asynchronously writes this chart as JPEG.</summary>
+        public Task<OfficeImageExportResult> SaveAsJpegAsync(Stream stream, ExcelImageExportOptions? options = null, CancellationToken cancellationToken = default) =>
+            new ExcelChartImageExportBuilder(this, options).AsJpeg().SaveAsync(stream, cancellationToken);
+
+        /// <summary>Asynchronously writes this chart as TIFF.</summary>
+        public Task<OfficeImageExportResult> SaveAsTiffAsync(Stream stream, ExcelImageExportOptions? options = null, CancellationToken cancellationToken = default) =>
+            new ExcelChartImageExportBuilder(this, options).AsTiff().SaveAsync(stream, cancellationToken);
+
+        /// <summary>Asynchronously writes this chart as lossless WebP.</summary>
+        public Task<OfficeImageExportResult> SaveAsWebpAsync(Stream stream, ExcelImageExportOptions? options = null, CancellationToken cancellationToken = default) =>
+            new ExcelChartImageExportBuilder(this, options).AsWebp().SaveAsync(stream, cancellationToken);
+    }
+}

--- a/OfficeIMO.Excel/Imaging/ExcelChart.Imaging.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelChart.Imaging.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using OfficeIMO.Drawing;
+
+namespace OfficeIMO.Excel {
+    public sealed partial class ExcelChart {
+        /// <summary>
+        /// Exports this chart through the shared dependency-free chart renderer.
+        /// </summary>
+        /// <param name="format">Target image format.</param>
+        /// <param name="options">Shared Excel image-export settings.</param>
+        /// <param name="cancellationToken">Token used to cancel rendering.</param>
+        /// <returns>The encoded chart image and any fidelity diagnostics.</returns>
+        public OfficeImageExportResult ExportImage(
+            OfficeImageExportFormat format,
+            ExcelImageExportOptions? options = null,
+            CancellationToken cancellationToken = default) {
+            ExcelImageExportOptions resolved = options?.Clone() ?? new ExcelImageExportOptions();
+            resolved.ConditionalFormattingDate ??= DateTime.Today;
+            resolved.Validate();
+
+            return OfficeImageExportExecutionScope.Run(
+                resolved,
+                cancellationToken,
+                token => ExportImageCore(format, resolved, token));
+        }
+
+        /// <summary>Renders this chart to dependency-free PNG bytes.</summary>
+        public byte[] ToPng(ExcelImageExportOptions? options = null) =>
+            ExportImage(OfficeImageExportFormat.Png, options).Bytes;
+
+        /// <summary>Renders this chart to dependency-free SVG text.</summary>
+        public string ToSvg(ExcelImageExportOptions? options = null) =>
+            Encoding.UTF8.GetString(ExportImage(OfficeImageExportFormat.Svg, options).Bytes);
+
+        /// <summary>Saves this chart as a PNG file.</summary>
+        public OfficeImageExportResult SaveAsPng(string path, ExcelImageExportOptions? options = null) =>
+            new ExcelChartImageExportBuilder(this, options).AsPng().Save(path);
+
+        /// <summary>Saves this chart as an SVG file.</summary>
+        public OfficeImageExportResult SaveAsSvg(string path, ExcelImageExportOptions? options = null) =>
+            new ExcelChartImageExportBuilder(this, options).AsSvg().Save(path);
+
+        /// <summary>Writes this chart as PNG to a caller-owned stream.</summary>
+        public OfficeImageExportResult SaveAsPng(Stream stream, ExcelImageExportOptions? options = null) =>
+            new ExcelChartImageExportBuilder(this, options).AsPng().Save(stream);
+
+        /// <summary>Writes this chart as SVG to a caller-owned stream.</summary>
+        public OfficeImageExportResult SaveAsSvg(Stream stream, ExcelImageExportOptions? options = null) =>
+            new ExcelChartImageExportBuilder(this, options).AsSvg().Save(stream);
+
+        /// <summary>Asynchronously saves this chart as a PNG file.</summary>
+        public Task<OfficeImageExportResult> SaveAsPngAsync(
+            string path,
+            ExcelImageExportOptions? options = null,
+            CancellationToken cancellationToken = default) =>
+            new ExcelChartImageExportBuilder(this, options).AsPng().SaveAsync(path, cancellationToken);
+
+        /// <summary>Asynchronously saves this chart as an SVG file.</summary>
+        public Task<OfficeImageExportResult> SaveAsSvgAsync(
+            string path,
+            ExcelImageExportOptions? options = null,
+            CancellationToken cancellationToken = default) =>
+            new ExcelChartImageExportBuilder(this, options).AsSvg().SaveAsync(path, cancellationToken);
+
+        /// <summary>Asynchronously writes this chart as PNG to a stream.</summary>
+        public Task<OfficeImageExportResult> SaveAsPngAsync(
+            Stream stream,
+            ExcelImageExportOptions? options = null,
+            CancellationToken cancellationToken = default) =>
+            new ExcelChartImageExportBuilder(this, options).AsPng().SaveAsync(stream, cancellationToken);
+
+        /// <summary>Asynchronously writes this chart as SVG to a stream.</summary>
+        public Task<OfficeImageExportResult> SaveAsSvgAsync(
+            Stream stream,
+            ExcelImageExportOptions? options = null,
+            CancellationToken cancellationToken = default) =>
+            new ExcelChartImageExportBuilder(this, options).AsSvg().SaveAsync(stream, cancellationToken);
+
+        private OfficeImageExportResult ExportImageCore(
+            OfficeImageExportFormat format,
+            ExcelImageExportOptions options,
+            CancellationToken cancellationToken) {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!TryGetSnapshot(out ExcelChartSnapshot snapshot)) {
+                throw new InvalidOperationException(
+                    "The chart data could not be resolved into a renderable snapshot.");
+            }
+
+            var diagnostics = new List<OfficeImageExportDiagnostic>(snapshot.Diagnostics);
+            if (!ExcelRangeImageRenderer.TryCreateOfficeChartSnapshot(
+                snapshot,
+                snapshot.WidthPixels,
+                snapshot.HeightPixels,
+                diagnostics,
+                _sheetName,
+                out OfficeChartSnapshot? officeSnapshot) || officeSnapshot == null) {
+                throw new NotSupportedException(
+                    "The chart type cannot be rendered by the shared Office chart renderer.");
+            }
+
+            OfficeDrawing drawing = OfficeChartDrawingRenderer.Render(officeSnapshot);
+            drawing.Fonts.AddRange(options.Fonts);
+            string source = _sheetName + "!" + snapshot.Name;
+            drawing.AppendFontDiagnostics(diagnostics, source);
+
+            if (format == OfficeImageExportFormat.Svg) {
+                byte[] svgBytes = OfficeDrawingSvgExporter.ToSvgBytes(drawing, options.Scale);
+                if (!OfficeImageReader.TryIdentifyByContent(svgBytes, ".svg", out OfficeImageInfo svgInfo)) {
+                    throw new InvalidDataException("The rendered chart SVG dimensions could not be identified.");
+                }
+                cancellationToken.ThrowIfCancellationRequested();
+                return options.EnsureAccepted(new OfficeImageExportResult(
+                    format,
+                    svgInfo.Width,
+                    svgInfo.Height,
+                    svgBytes,
+                    snapshot.Name,
+                    source,
+                    diagnostics.AsReadOnly()));
+            }
+
+            if (!format.IsRaster()) {
+                throw new ArgumentOutOfRangeException(nameof(format), "The selected image format is not supported.");
+            }
+
+            OfficeRasterExportPlan plan = OfficeRasterExportPlanner.Resolve(
+                drawing.Width,
+                drawing.Height,
+                format,
+                options,
+                source);
+            if (plan.Diagnostic != null) {
+                diagnostics.Add(plan.Diagnostic);
+            }
+
+            OfficeRasterImage image = OfficeDrawingRasterRenderer.Render(
+                drawing,
+                new OfficeDrawingRasterRenderOptions {
+                    Scale = plan.Limit.Scale,
+                    Background = options.BackgroundColor,
+                    TextShapingProvider = options.TextShapingProvider,
+                    TextShapingLanguage = options.TextShapingLanguage,
+                    DiagnosticSink = diagnostics,
+                    DiagnosticSource = source,
+                    CancellationToken = cancellationToken
+                });
+            byte[] bytes = OfficeRasterImageEncoder.Encode(
+                image,
+                format,
+                plan.CreateEncodingOptions());
+            cancellationToken.ThrowIfCancellationRequested();
+            return options.EnsureAccepted(new OfficeImageExportResult(
+                format,
+                image.Width,
+                image.Height,
+                bytes,
+                snapshot.Name,
+                source,
+                diagnostics.AsReadOnly()));
+        }
+    }
+}

--- a/OfficeIMO.Excel/Imaging/ExcelChart.Imaging.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelChart.Imaging.cs
@@ -103,13 +103,24 @@ namespace OfficeIMO.Excel {
                     "The chart type cannot be rendered by the shared Office chart renderer.");
             }
 
-            OfficeDrawing drawing = OfficeChartDrawingRenderer.Render(officeSnapshot);
+            OfficeDrawing drawing = OfficeChartDrawingRenderer.Render(
+                officeSnapshot,
+                useMinimumCanvas: false);
             drawing.Fonts.AddRange(options.Fonts);
             string source = _sheetName + "!" + snapshot.Name;
             drawing.AppendFontDiagnostics(diagnostics, source);
 
             if (format == OfficeImageExportFormat.Svg) {
-                byte[] svgBytes = OfficeDrawingSvgExporter.ToSvgBytes(drawing, options.Scale);
+                OfficeDrawing svgDrawing = new OfficeDrawing(drawing.Width, drawing.Height);
+                OfficeShape background = OfficeShape.Rectangle(drawing.Width, drawing.Height);
+                background.FillColor = options.BackgroundColor;
+                background.StrokeWidth = 0D;
+                svgDrawing.AddShape(background, 0D, 0D);
+                svgDrawing.AddDrawing(drawing, 0D, 0D);
+                byte[] svgBytes = OfficeDrawingSvgExporter.ToSvgBytes(
+                    svgDrawing,
+                    options.Scale,
+                    OfficeSvgSizeUnit.Pixel);
                 if (!OfficeImageReader.TryIdentifyByContent(svgBytes, ".svg", out OfficeImageInfo svgInfo)) {
                     throw new InvalidDataException("The rendered chart SVG dimensions could not be identified.");
                 }

--- a/OfficeIMO.Excel/Imaging/ExcelChart.Imaging.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelChart.Imaging.cs
@@ -120,7 +120,10 @@ namespace OfficeIMO.Excel {
                 byte[] svgBytes = OfficeDrawingSvgExporter.ToSvgBytes(
                     svgDrawing,
                     options.Scale,
-                    OfficeSvgSizeUnit.Pixel);
+                    OfficeSvgSizeUnit.Pixel,
+                    imageCodec: null,
+                    resourceIdPrefix: null,
+                    cancellationToken);
                 if (!OfficeImageReader.TryIdentifyByContent(svgBytes, ".svg", out OfficeImageInfo svgInfo)) {
                     throw new InvalidDataException("The rendered chart SVG dimensions could not be identified.");
                 }

--- a/OfficeIMO.Excel/Imaging/ExcelImageExportBuilder.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelImageExportBuilder.cs
@@ -4,6 +4,17 @@ using OfficeIMO.Drawing;
 
 namespace OfficeIMO.Excel {
     /// <summary>
+    /// Fluent image-export builder for an Excel chart.
+    /// </summary>
+    public sealed class ExcelChartImageExportBuilder : OfficeImageExportBuilder<ExcelChartImageExportBuilder, ExcelImageExportOptions> {
+        internal ExcelChartImageExportBuilder(ExcelChart chart, ExcelImageExportOptions? options = null)
+            : base(
+                options?.Clone() ?? new ExcelImageExportOptions(),
+                (format, effective, cancellationToken) => chart.ExportImage(format, effective, cancellationToken)) {
+        }
+    }
+
+    /// <summary>
     /// Fluent image-export builder for an Excel range.
     /// </summary>
     public sealed class ExcelRangeImageExportBuilder : OfficeImageExportBuilder<ExcelRangeImageExportBuilder, ExcelImageExportOptions> {
@@ -214,6 +225,15 @@ namespace OfficeIMO.Excel {
         /// <summary>Starts a fluent image export using a cloned options snapshot.</summary>
         public ExcelRangeImageExportBuilder ToImage(ExcelImageExportOptions options) =>
             new ExcelRangeImageExportBuilder(this, options ?? throw new ArgumentNullException(nameof(options)));
+    }
+
+    public sealed partial class ExcelChart {
+        /// <summary>Starts a fluent image export for this chart.</summary>
+        public ExcelChartImageExportBuilder ToImage() => new ExcelChartImageExportBuilder(this);
+
+        /// <summary>Starts a fluent image export using a cloned options snapshot.</summary>
+        public ExcelChartImageExportBuilder ToImage(ExcelImageExportOptions options) =>
+            new ExcelChartImageExportBuilder(this, options ?? throw new ArgumentNullException(nameof(options)));
     }
 
     public partial class ExcelSheet {

--- a/OfficeIMO.Excel/Imaging/ExcelRangeImageRenderer.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelRangeImageRenderer.cs
@@ -335,7 +335,7 @@ namespace OfficeIMO.Excel {
                 OfficeSvgFormatting.ExtractSvgInner(chartSvg));
         }
 
-        private static bool TryCreateOfficeChartSnapshot(ExcelChartSnapshot snapshot, double width, double height, List<OfficeImageExportDiagnostic>? diagnostics, string sheetName, out OfficeChartSnapshot? officeSnapshot) {
+        internal static bool TryCreateOfficeChartSnapshot(ExcelChartSnapshot snapshot, double width, double height, List<OfficeImageExportDiagnostic>? diagnostics, string sheetName, out OfficeChartSnapshot? officeSnapshot) {
             officeSnapshot = null;
             if (!TryMapChartKind(snapshot.ChartType, out OfficeChartKind kind, out string? approximation)) {
                 diagnostics?.Add(ExcelImageExportDiagnosticClassifier.Create(

--- a/OfficeIMO.Excel/README.md
+++ b/OfficeIMO.Excel/README.md
@@ -698,6 +698,22 @@ document.ToImages()
 
 Excel layout, print-title, page-setup, and header/footer composition stays in `OfficeIMO.Excel`; final raster encoding is delegated once to `OfficeIMO.Drawing`.
 
+Charts use the same managed image contract and preserve their anchored dimensions:
+
+```csharp
+ExcelChart chart = sheet.ChartFromTable("RevenueTable")
+    .RevenueTrend("Revenue trend")
+    .Size(640, 320)
+    .At(row: 1, column: 5);
+
+chart.ToImage()
+    .WithBackground(OfficeColor.White)
+    .AsPng()
+    .Save("revenue-chart.png");
+
+chart.SaveAsSvg("revenue-chart.svg");
+```
+
 ## Adjacent packages
 
 | Package | Use it for |


### PR DESCRIPTION
## Summary

Adds direct and fluent image export APIs for Excel charts.

- exports charts to PNG, SVG, JPEG, TIFF, and WebP
- supports byte-array, stream, file, synchronous, and asynchronous workflows
- preserves one-cell, two-cell, and absolute-anchor chart dimensions
- honors the requested export background for SVG as well as raster formats
- reuses the shared chart-to-image renderer and format mapping
- documents the public workflow in the OfficeIMO.Excel package README

## Usage

```csharp
OfficeImageExportResult image = chart.ExportImage(OfficeImageExportFormat.Png);
byte[] png = chart.ToPng();

chart.ToImage()
    .WithBackground(OfficeColor.White)
    .AsPng()
    .WithScale(2)
    .Save("ticket-status.png");
```

## Validation

- complete OfficeIMO Excel test suite passed on .NET 8
- focused chart export and anchor tests passed on .NET 8 and .NET Framework 4.7.2
- package output includes the new public XML documentation
