### PR TITLE
Fix PDF decoder, OCR, and annotation correctness

### DIFF
--- a/.github/workflows/pdf-compliance-proof.yml
+++ b/.github/workflows/pdf-compliance-proof.yml
@@ -90,7 +90,7 @@ env:
     10.0.103
   BUILD_CONFIGURATION: Release
   PROOF_PATH: artifacts/pdf-compliance-proof
-  VERAPDF_CLI_IMAGE: ghcr.io/verapdf/cli:v1.31.119@sha256:be3c64c9e924247cd91df3f7723d131f144ef3614cbfd6c881b09e9fbb2afcbe
+  VERAPDF_CLI_IMAGE: ghcr.io/verapdf/cli:v1.31.133@sha256:dc2572cf0850b6078cefe0f4edd03d7d92e6bb44c2c58890198dd753434a81c0
   MUSTANG_VERSION: 2.24.0
   MUSTANG_CLI_URL: https://github.com/ZUGFeRD/mustangproject/releases/download/core-2.24.0/Mustang-CLI-2.24.0.jar
   MUSTANG_CLI_SHA256: e4904ffa0afdce3f5836dceb927c440a05ed5d60386fdd37e17a4b2f7652edbf

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -53,6 +53,20 @@ keep their existing capability-object shape. The former static implementation
 engines remain internal; applications should not replace the removed root
 methods with calls to those engines.
 
+### PDF OCR provider coordinates
+
+`PdfOcrRequest.PageWidth` and `PageHeight` now describe the rendered visual page
+after applying the crop box and page rotation. In earlier versions they exposed
+the unrotated logical dimensions even though `Png`, `PixelWidth`, and
+`PixelHeight` represented the rendered page. For pages rotated 90 or 270
+degrees, the point dimensions are therefore swapped.
+
+Existing `IPdfOcrProvider` implementations should map their pixel-space
+`PdfOcrWord` results against these visual dimensions. Providers that cached or
+recomputed unrotated media-box dimensions should instead use the request's
+`PageWidth`, `PageHeight`, and `Scale`, which now describe the same visual
+coordinate space as the supplied PNG.
+
 ## OfficeIMO 3.2: neutral conversion model
 
 Direct format conversion no longer uses Reader as its intermediate ownership

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfAnnotationCreationTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfAnnotationCreationTests.cs
@@ -53,6 +53,34 @@ public class PdfAnnotationCreationTests {
     }
 
     [Fact]
+    public void AddAnnotation_PreservesPageAndReplyTargetGenerations() {
+        byte[] source = BuildNonZeroGenerationAnnotationPdf();
+        PdfExternalSignaturePreparation preparation = PdfIncrementalUpdater.PrepareExternalSignature(source, new PdfExternalSignatureOptions {
+            Profile = PdfSignatureProfile.Certification,
+            CertificationPermission = PdfCertificationPermissionLevel.FormFillingAnnotationsAndSignatures,
+            FieldName = "GenerationCertification",
+            ReservedSignatureContentsBytes = 512
+        });
+        byte[] signed = PdfIncrementalUpdater.ApplyExternalSignature(preparation, new byte[] { 0x30, 0x01, 0x00 });
+
+        PdfAnnotationEditResult result = PdfAnnotationEditor.AddAnnotation(signed, new PdfAnnotationCreateOptions {
+            Subtype = "Text",
+            Rectangle = new[] { 70D, 70D, 90D, 90D },
+            Contents = "Generation-aware reply",
+            InReplyToObjectNumber = 6,
+            CreatePopup = true
+        });
+
+        string raw = Encoding.ASCII.GetString(result.Bytes);
+        PdfDocumentInfo info = PdfInspector.Inspect(result.Bytes);
+        Assert.Equal(PdfMutationExecutionMode.AppendOnly, result.MutationPlan.ExecutionMode);
+        Assert.Equal(2, info.GetAnnotationsBySubtype("Text").Count);
+        Assert.Single(info.GetAnnotationsBySubtype("Popup"));
+        Assert.Contains("/P 3 1 R", raw, StringComparison.Ordinal);
+        Assert.Contains("/IRT 6 2 R", raw, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void AddAnnotation_UsesAppendOnlyRevisionWhenCertificationAllowsAnnotations() {
         byte[] source = PdfDocument.Create().Paragraph(p => p.Text("Certified page")).ToBytes();
         PdfExternalSignaturePreparation preparation = PdfIncrementalUpdater.PrepareExternalSignature(source, new PdfExternalSignatureOptions {
@@ -185,5 +213,40 @@ public class PdfAnnotationCreationTests {
         Assert.Empty(info.GetAnnotationsBySubtype("FreeText"));
         Assert.Single(info.GetAnnotationsBySubtype("Highlight"));
         Assert.NotNull(result.RewritePreservationReport);
+    }
+
+    private static byte[] BuildNonZeroGenerationAnnotationPdf() {
+        var objects = new[] {
+            (Number: 1, Generation: 0, Body: "<< /Type /Catalog /Pages 2 0 R >>"),
+            (Number: 2, Generation: 0, Body: "<< /Type /Pages /Count 1 /Kids [3 1 R] >>"),
+            (Number: 3, Generation: 1, Body: "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R /Annots [6 2 R] >>"),
+            (Number: 4, Generation: 0, Body: "<< /Length 0 >>\nstream\n\nendstream"),
+            (Number: 6, Generation: 2, Body: "<< /Type /Annot /Subtype /Text /Rect [20 20 40 40] /Contents (Parent) >>")
+        };
+        var builder = new StringBuilder("%PDF-1.7\n");
+        var offsets = new Dictionary<int, (int Offset, int Generation)>();
+        foreach ((int number, int generation, string body) in objects) {
+            offsets[number] = (Encoding.ASCII.GetByteCount(builder.ToString()), generation);
+            builder.Append(number).Append(' ').Append(generation).Append(" obj\n")
+                .Append(body).Append("\nendobj\n");
+        }
+
+        int xrefOffset = Encoding.ASCII.GetByteCount(builder.ToString());
+        builder.Append("xref\n0 7\n0000000000 65535 f \n");
+        for (int number = 1; number < 7; number++) {
+            if (offsets.TryGetValue(number, out (int Offset, int Generation) entry)) {
+                builder.Append(entry.Offset.ToString("D10", System.Globalization.CultureInfo.InvariantCulture))
+                    .Append(' ')
+                    .Append(entry.Generation.ToString("D5", System.Globalization.CultureInfo.InvariantCulture))
+                    .Append(" n \n");
+            } else {
+                builder.Append("0000000000 00000 f \n");
+            }
+        }
+
+        builder.Append("trailer\n<< /Root 1 0 R /Size 7 >>\nstartxref\n")
+            .Append(xrefOffset)
+            .Append("\n%%EOF\n");
+        return Encoding.ASCII.GetBytes(builder.ToString());
     }
 }

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfOcrTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfOcrTests.cs
@@ -96,6 +96,37 @@ public class PdfOcrTests {
         Assert.Equal(1, exception.Limit);
     }
 
+    [Theory]
+    [InlineData(90)]
+    [InlineData(270)]
+    public async Task RecognizeAndMergeAsync_UsesVisualCoordinatesForRotatedCroppedPages(int rotation) {
+        byte[] pdf = PdfDocument.Create()
+            .Paragraph(paragraph => paragraph.Text("Native rotation"))
+            .ToBytes();
+        pdf = PdfPageEditor.SetCropBox(pdf, 0, 200, 595, 842);
+        pdf = PdfPageEditor.RotatePages(pdf, rotation);
+        PdfPageInteractionMap map = PdfPageInteractionMap.Create(pdf, 1);
+        Assert.NotEmpty(map.TextRegions);
+        PdfSelectionQuad nativeGlyph = map.TextRegions[0].Quad;
+        var provider = new StubOcrProvider(request => new PdfOcrResponse(new[] {
+            new PdfOcrWord(
+                "duplicate",
+                nativeGlyph.Left * request.Scale,
+                nativeGlyph.Top * request.Scale,
+                nativeGlyph.Width * request.Scale,
+                nativeGlyph.Height * request.Scale,
+                0.99)
+        }));
+
+        PdfOcrMergeResult result = await PdfDocument.Open(pdf).Read.OcrAsync(provider);
+        PdfOcrPageMergeResult page = Assert.Single(result.Pages);
+
+        Assert.Equal(map.Width, provider.LastRequest!.PageWidth, 3);
+        Assert.Equal(map.Height, provider.LastRequest.PageHeight, 3);
+        Assert.Empty(page.Words);
+        Assert.Equal(1, page.RejectedNativeOverlapCount);
+    }
+
     [Fact]
     public void PdfReadLimitKind_PreservesExistingInteractionRegionsValue() {
         Assert.Equal(20, (int)PdfReadLimitKind.InteractionRegions);

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfPageImageRendererTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfPageImageRendererTests.cs
@@ -2649,6 +2649,40 @@ public class PdfPageImageRendererTests {
     }
 
     [Fact]
+    public void ImageStreamDecoderPreservesDecodedSizeLimitFailures() {
+        var dictionary = new PdfDictionary();
+        dictionary.Items["Filter"] = new PdfName("FlateDecode");
+        var stream = new PdfStream(dictionary, CompressWithDeflate(new byte[8]));
+
+        PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() =>
+            PdfImageStreamDecoder.TryDecode(
+                stream,
+                new Dictionary<int, PdfIndirectObject>(),
+                out _,
+                maxDecodedBytes: 4));
+
+        Assert.Equal(PdfReadLimitKind.DecodedStreamBytes, exception.Kind);
+        Assert.Equal(4, exception.Limit);
+    }
+
+    [Fact]
+    public void ImageStreamDecoderReturnsFalseForMalformedStreamData() {
+        var dictionary = new PdfDictionary();
+        dictionary.Items["Filter"] = new PdfName("FlateDecode");
+        var decodeParameters = new PdfDictionary();
+        decodeParameters.Items["Predictor"] = new PdfNumber(12);
+        decodeParameters.Items["Columns"] = new PdfNumber(4);
+        dictionary.Items["DecodeParms"] = decodeParameters;
+        var stream = new PdfStream(dictionary, CompressWithDeflate(new byte[] { 1, 2, 3, 4 }));
+
+        Assert.False(PdfImageStreamDecoder.TryDecode(
+            stream,
+            new Dictionary<int, PdfIndirectObject>(),
+            out _,
+            maxDecodedBytes: 4));
+    }
+
+    [Fact]
     public void PackedImageNormalizersRejectMalformedPredictorFallbackBytes() {
         byte[] malformedPredictedPixels = Enumerable.Range(0, 64).Select(value => (byte)value).ToArray();
         byte[] encoded = CompressWithDeflate(malformedPredictedPixels);

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfPageImageRendererTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfPageImageRendererTests.cs
@@ -727,6 +727,20 @@ public class PdfPageImageRendererTests {
     }
 
     [Fact]
+    public void RenderPage_DoesNotTreatMalformedPredictorBytesAsImagePixels() {
+        byte[] malformedPredictedPixels = Enumerable.Range(0, 64).Select(value => (byte)value).ToArray();
+        byte[] pdf = BuildSingleStreamPdfWithBinaryImageXObject(
+            CompressWithDeflate(malformedPredictedPixels),
+            colorSpace: "/DeviceRGB",
+            imageWidth: 2,
+            extraImageEntries: " /DecodeParms << /Predictor 12 /Colors 1 /BitsPerComponent 8 /Columns 6 >>");
+
+        OfficeDrawing drawing = PdfPageImageRenderer.RenderPage(pdf);
+
+        Assert.Empty(drawing.Images);
+    }
+
+    [Fact]
     public void RenderPage_AppliesDeviceRgbImageXObjectColorKeyMaskAsPngAlpha() {
         byte[] pdf = BuildSingleStreamPdfWithBinaryImageXObject(
             CompressWithDeflate(new byte[] { 255, 0, 0, 0, 255, 0 }),
@@ -2632,6 +2646,35 @@ public class PdfPageImageRendererTests {
 
         Assert.Equal(PdfReadLimitKind.DecodedStreamBytes, exception.Kind);
         Assert.Equal(3, exception.Limit);
+    }
+
+    [Fact]
+    public void PackedImageNormalizersRejectMalformedPredictorFallbackBytes() {
+        byte[] malformedPredictedPixels = Enumerable.Range(0, 64).Select(value => (byte)value).ToArray();
+        byte[] encoded = CompressWithDeflate(malformedPredictedPixels);
+        var decodeParameters = new PdfDictionary();
+        decodeParameters.Items["Predictor"] = new PdfNumber(12);
+        decodeParameters.Items["Columns"] = new PdfNumber(8);
+
+        var maskDictionary = new PdfDictionary();
+        maskDictionary.Items["ImageMask"] = new PdfBoolean(true);
+        maskDictionary.Items["Filter"] = new PdfName("FlateDecode");
+        maskDictionary.Items["DecodeParms"] = decodeParameters;
+        var maskStream = new PdfStream(maskDictionary, encoded);
+
+        var indexedDictionary = new PdfDictionary();
+        indexedDictionary.Items["Filter"] = new PdfName("FlateDecode");
+        indexedDictionary.Items["DecodeParms"] = decodeParameters;
+        var indexedStream = new PdfStream(indexedDictionary, encoded);
+        var indexedColorSpace = new PdfArray();
+        indexedColorSpace.Items.Add(new PdfName("Indexed"));
+        indexedColorSpace.Items.Add(new PdfName("DeviceRGB"));
+        indexedColorSpace.Items.Add(new PdfNumber(1));
+        indexedColorSpace.Items.Add(new PdfStringObj(new byte[] { 0, 0, 0, 255, 255, 255 }));
+        var objects = new Dictionary<int, PdfIndirectObject>();
+
+        Assert.False(PdfImageMaskNormalizer.TryBuildPngFile(8, 1, maskStream, objects, out _));
+        Assert.False(PdfIndexedImageNormalizer.TryBuildPngFile(indexedColorSpace, 8, 1, 1, indexedStream, objects, out _));
     }
 
     [Fact]

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfReadLimitTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfReadLimitTests.cs
@@ -533,6 +533,69 @@ public class PdfReadLimitTests {
     }
 
     [Fact]
+    public void TryDecodeBudgetsPngPredictorSelectorsSeparatelyFromFinalOutput() {
+        var flateDictionary = new PdfDictionary();
+        flateDictionary.Items["Filter"] = new PdfName("FlateDecode");
+        var flateParameters = new PdfDictionary();
+        flateParameters.Items["Predictor"] = new PdfNumber(12);
+        flateParameters.Items["Columns"] = new PdfNumber(4);
+        flateDictionary.Items["DecodeParms"] = flateParameters;
+        byte[] predicted = { 0, 65, 66, 67, 68 };
+
+        bool flateDecoded = StreamDecoder.TryDecode(
+            flateDictionary,
+            CompressForDecoderTest(predicted),
+            4,
+            out byte[] flateOutput);
+
+        var lzwDictionary = new PdfDictionary();
+        lzwDictionary.Items["Filter"] = new PdfName("LZWDecode");
+        var lzwParameters = new PdfDictionary();
+        lzwParameters.Items["Predictor"] = new PdfNumber(12);
+        lzwParameters.Items["Columns"] = new PdfNumber(4);
+        lzwDictionary.Items["DecodeParms"] = lzwParameters;
+        bool lzwDecoded = StreamDecoder.TryDecode(
+            lzwDictionary,
+            PackNineBitCodes(new[] { 256, 0, 65, 66, 67, 68, 257 }),
+            4,
+            out byte[] lzwOutput);
+
+        Assert.True(flateDecoded);
+        Assert.True(lzwDecoded);
+        Assert.Equal(new byte[] { 65, 66, 67, 68 }, flateOutput);
+        Assert.Equal(flateOutput, lzwOutput);
+    }
+
+    [Theory]
+    [InlineData("ASCIIHexDecode", 12)]
+    [InlineData("ASCII85Decode", 0)]
+    [InlineData("RunLengthDecode", -1)]
+    public void TryDecodeRejectsDecodeParametersForFiltersWithoutParameters(string filterName, int predictor) {
+        var dictionary = new PdfDictionary();
+        dictionary.Items["Filter"] = new PdfName(filterName);
+        var decodeParameters = new PdfDictionary();
+        decodeParameters.Items["Predictor"] = new PdfNumber(predictor);
+        dictionary.Items["DecodeParms"] = decodeParameters;
+
+        Assert.False(StreamDecoder.TryDecode(dictionary, Array.Empty<byte>(), 1024, out _));
+    }
+
+    [Fact]
+    public void TryDecodeRejectsFilterSpecificDecodeParametersOnTheWrongFilter() {
+        var dictionary = new PdfDictionary();
+        dictionary.Items["Filter"] = new PdfName("FlateDecode");
+        var decodeParameters = new PdfDictionary();
+        decodeParameters.Items["EarlyChange"] = new PdfNumber(0);
+        dictionary.Items["DecodeParms"] = decodeParameters;
+
+        Assert.False(StreamDecoder.TryDecode(
+            dictionary,
+            CompressForDecoderTest(new byte[] { 65 }),
+            1024,
+            out _));
+    }
+
+    [Fact]
     public void TryDecodeResolvesIndirectPredictorParameters() {
         var dictionary = new PdfDictionary();
         dictionary.Items["Filter"] = new PdfName("FlateDecode");

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfReadLimitTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfReadLimitTests.cs
@@ -517,7 +517,7 @@ public class PdfReadLimitTests {
     }
 
     [Fact]
-    public void TryDecodeAppliesFlatePredictorWithinTheOutputBudget() {
+    public void TryDecodeAppliesPngPredictorWithinTheOutputBudget() {
         var dictionary = new PdfDictionary();
         dictionary.Items["Filter"] = new PdfName("FlateDecode");
         var decodeParameters = new PdfDictionary();
@@ -588,6 +588,12 @@ public class PdfReadLimitTests {
         Assert.True(decoded);
         Assert.Equal(original, output);
         Assert.Empty(StreamDecoder.GetUnsupportedFilters(dictionary));
+
+        Assert.False(StreamDecoder.TryDecode(dictionary, original, 3, out _));
+        PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(
+            () => StreamDecoder.DecodeRequired(dictionary, original, maxOutputBytes: 3));
+        Assert.Equal(PdfReadLimitKind.DecodedStreamBytes, exception.Kind);
+        Assert.Equal(3, exception.Limit);
     }
 
     [Theory]

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfReadLimitTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfReadLimitTests.cs
@@ -517,6 +517,83 @@ public class PdfReadLimitTests {
     }
 
     [Fact]
+    public void TryDecodeAppliesFlatePredictorWithinTheOutputBudget() {
+        var dictionary = new PdfDictionary();
+        dictionary.Items["Filter"] = new PdfName("FlateDecode");
+        var decodeParameters = new PdfDictionary();
+        decodeParameters.Items["Predictor"] = new PdfNumber(12);
+        decodeParameters.Items["Columns"] = new PdfNumber(4);
+        dictionary.Items["DecodeParms"] = decodeParameters;
+        byte[] encoded = CompressForDecoderTest(new byte[] { 0, 65, 66, 67, 68 });
+
+        bool decoded = StreamDecoder.TryDecode(dictionary, encoded, 1024, out byte[] output);
+
+        Assert.True(decoded);
+        Assert.Equal(new byte[] { 65, 66, 67, 68 }, output);
+    }
+
+    [Fact]
+    public void TryDecodeAppliesTiffPredictorAcrossSupportedBitDepths() {
+        AssertTiffPredictorDecode(1, 8, new byte[] { 0x5D }, new byte[] { 0x69 });
+        AssertTiffPredictorDecode(2, 4, new byte[] { 0x1B }, new byte[] { 0x1E });
+        AssertTiffPredictorDecode(4, 4, new byte[] { 0x12, 0x34 }, new byte[] { 0x13, 0x6A });
+        AssertTiffPredictorDecode(4, 2, new byte[] { 0x12, 0x33, 0x46 }, new byte[] { 0x12, 0x34, 0x69 }, colors: 3);
+        AssertTiffPredictorDecode(16, 3, new byte[] { 0x00, 0x01, 0x01, 0x01, 0xFE, 0xFD }, new byte[] { 0x00, 0x01, 0x01, 0x02, 0xFF, 0xFF });
+    }
+
+    [Fact]
+    public void TryDecodeRejectsInvalidLzwEarlyChange() {
+        var dictionary = new PdfDictionary();
+        dictionary.Items["Filter"] = new PdfName("LZWDecode");
+        var decodeParameters = new PdfDictionary();
+        decodeParameters.Items["EarlyChange"] = new PdfNumber(2);
+        dictionary.Items["DecodeParms"] = decodeParameters;
+        byte[] encoded = PackNineBitCodes(new[] { 256, 65, 257 });
+
+        Assert.False(StreamDecoder.TryDecode(dictionary, encoded, 1024, out _));
+    }
+
+    [Fact]
+    public void TryDecodeRejectsMalformedFilterAndDecodeParameterArrays() {
+        byte[] encoded = CompressForDecoderTest(new byte[] { 65, 66, 67, 68 });
+        var malformedFilter = new PdfDictionary();
+        var filters = new PdfArray();
+        filters.Items.Add(new PdfNumber(42));
+        filters.Items.Add(new PdfName("FlateDecode"));
+        malformedFilter.Items["Filter"] = filters;
+
+        var mismatchedParameters = new PdfDictionary();
+        var validFilters = new PdfArray();
+        validFilters.Items.Add(new PdfName("ASCII85Decode"));
+        validFilters.Items.Add(new PdfName("FlateDecode"));
+        mismatchedParameters.Items["Filter"] = validFilters;
+        var decodeParameters = new PdfArray();
+        decodeParameters.Items.Add(PdfNull.Instance);
+        mismatchedParameters.Items["DecodeParms"] = decodeParameters;
+
+        Assert.False(StreamDecoder.TryDecode(malformedFilter, encoded, 1024, out _));
+        Assert.Contains("MalformedFilterDeclaration", StreamDecoder.GetUnsupportedFilters(malformedFilter));
+        Assert.False(StreamDecoder.TryDecode(mismatchedParameters, encoded, 1024, out _));
+    }
+
+    [Theory]
+    [InlineData(3, 8, 1)]
+    [InlineData(2, 3, 1)]
+    [InlineData(2, 4, 3)]
+    public void TryDecodeRejectsUnsupportedOrIncompletePredictorDeclarations(int predictor, int bitsPerComponent, int encodedByteCount) {
+        var dictionary = new PdfDictionary();
+        dictionary.Items["Filter"] = new PdfName("FlateDecode");
+        var decodeParameters = new PdfDictionary();
+        decodeParameters.Items["Predictor"] = new PdfNumber(predictor);
+        decodeParameters.Items["Columns"] = new PdfNumber(3);
+        decodeParameters.Items["BitsPerComponent"] = new PdfNumber(bitsPerComponent);
+        dictionary.Items["DecodeParms"] = decodeParameters;
+        byte[] encoded = CompressForDecoderTest(new byte[encodedByteCount]);
+
+        Assert.False(StreamDecoder.TryDecode(dictionary, encoded, 1024, out _));
+    }
+
+    [Fact]
     public void AsciiDecodersStopBeforeMaterializingOutputBeyondBudget() {
         var hexDictionary = new PdfDictionary();
         hexDictionary.Items["Filter"] = new PdfName("ASCIIHexDecode");
@@ -576,6 +653,40 @@ public class PdfReadLimitTests {
 
         Assert.Equal(PdfReadLimitKind.InputBytes, exception.Kind);
         Assert.Equal(pdf.Length - 1, exception.Limit);
+    }
+
+    [Fact]
+    public void MalformedSupportedPageStreamBlocksPreflightAndRedaction() {
+        byte[] pdf = BuildMalformedFlatePageContentPdf();
+        var area = new PdfRedactionArea(1, 0, 0, 200, 200, "fail-closed");
+
+        PdfDocumentPreflight preflight = PdfInspector.Preflight(pdf);
+        PdfRedactionPlan plan = PdfRedactionPlanner.Plan(pdf, new[] { area });
+        PdfMutationBlockedException exception = Assert.Throws<PdfMutationBlockedException>(() =>
+            PdfRedactionApplier.Apply(pdf, new[] { area }));
+
+        Assert.False(preflight.CanReadLogicalObjects);
+        Assert.Contains(preflight.ReadBlockers, blocker => blocker.Kind == PdfReadBlockerKind.ParserUnsupported);
+        Assert.False(plan.Preflight.CanReadLogicalObjects);
+        Assert.Contains(plan.Findings, finding => finding.Code == "RedactionPlanBlocked");
+        Assert.Contains("Read.ParserUnsupported", exception.Plan.BlockerCodes);
+    }
+
+    [Fact]
+    public void MalformedFilterArrayBlocksPreflightAndRedaction() {
+        byte[] pdf = BuildMalformedFlatePageContentPdf("[42 /FlateDecode]");
+        var area = new PdfRedactionArea(1, 0, 0, 200, 200, "malformed-filter");
+
+        PdfDocumentPreflight preflight = PdfInspector.Preflight(pdf);
+        PdfRedactionPlan plan = PdfRedactionPlanner.Plan(pdf, new[] { area });
+        PdfMutationBlockedException exception = Assert.Throws<PdfMutationBlockedException>(() =>
+            PdfRedactionApplier.Apply(pdf, new[] { area }));
+
+        Assert.False(preflight.CanReadLogicalObjects);
+        Assert.Contains(preflight.ReadBlockers, blocker => blocker.Kind == PdfReadBlockerKind.UnsupportedContentStreamFilter);
+        Assert.False(plan.Preflight.CanReadLogicalObjects);
+        Assert.Contains(plan.Findings, finding => finding.Code == "RedactionPlanBlocked");
+        Assert.Contains("Read.UnsupportedContentStreamFilter", exception.Plan.BlockerCodes);
     }
 
     [Fact]
@@ -1019,6 +1130,44 @@ public class PdfReadLimitTests {
             .Append(bodies.Length + 1)
             .Append(" >>\nstartxref\n0\n%%EOF\n");
         return System.Text.Encoding.ASCII.GetBytes(builder.ToString());
+    }
+
+    private static byte[] BuildMalformedFlatePageContentPdf(string filterDeclaration = "/FlateDecode") {
+        const string content = "BT /F1 12 Tf 20 100 Td (SECRET) Tj ET";
+        return System.Text.Encoding.ASCII.GetBytes(string.Join("\n", new[] {
+            "%PDF-1.7",
+            "1 0 obj", "<< /Type /Catalog /Pages 2 0 R >>", "endobj",
+            "2 0 obj", "<< /Type /Pages /Count 1 /Kids [3 0 R] >>", "endobj",
+            "3 0 obj", "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>", "endobj",
+            "4 0 obj", "<< /Length " + content.Length.ToString(System.Globalization.CultureInfo.InvariantCulture) + " /Filter " + filterDeclaration + " >>", "stream", content, "endstream", "endobj",
+            "5 0 obj", "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>", "endobj",
+            "trailer", "<< /Root 1 0 R /Size 6 >>", "%%EOF"
+        }));
+    }
+
+    private static void AssertTiffPredictorDecode(int bitsPerComponent, int columns, byte[] predicted, byte[] expected, int colors = 1) {
+        var dictionary = new PdfDictionary();
+        dictionary.Items["Filter"] = new PdfName("FlateDecode");
+        var decodeParameters = new PdfDictionary();
+        decodeParameters.Items["Predictor"] = new PdfNumber(2);
+        decodeParameters.Items["Columns"] = new PdfNumber(columns);
+        decodeParameters.Items["Colors"] = new PdfNumber(colors);
+        decodeParameters.Items["BitsPerComponent"] = new PdfNumber(bitsPerComponent);
+        dictionary.Items["DecodeParms"] = decodeParameters;
+
+        bool decoded = StreamDecoder.TryDecode(dictionary, CompressForDecoderTest(predicted), 1024, out byte[] output);
+
+        Assert.True(decoded);
+        Assert.Equal(expected, output);
+    }
+
+    private static byte[] CompressForDecoderTest(byte[] bytes) {
+        using var buffer = new MemoryStream();
+        using (var compressor = new DeflateStream(buffer, CompressionLevel.Optimal, leaveOpen: true)) {
+            compressor.Write(bytes, 0, bytes.Length);
+        }
+
+        return buffer.ToArray();
     }
 
     private static byte[] PackNineBitCodes(IEnumerable<int> codes) {

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfReadLimitTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfReadLimitTests.cs
@@ -596,6 +596,63 @@ public class PdfReadLimitTests {
     }
 
     [Fact]
+    public void TryDecodeTreatsNullNumericDecodeParametersAsAbsent() {
+        var flateDictionary = new PdfDictionary();
+        flateDictionary.Items["Filter"] = new PdfName("FlateDecode");
+        var flateParameters = new PdfDictionary();
+        flateParameters.Items["Predictor"] = PdfNull.Instance;
+        flateParameters.Items["Columns"] = PdfNull.Instance;
+        flateParameters.Items["Colors"] = PdfNull.Instance;
+        flateParameters.Items["BitsPerComponent"] = PdfNull.Instance;
+        flateParameters.Items["EarlyChange"] = PdfNull.Instance;
+        flateDictionary.Items["DecodeParms"] = flateParameters;
+
+        bool flateDecoded = StreamDecoder.TryDecode(
+            flateDictionary,
+            CompressForDecoderTest(new byte[] { 65, 66, 67, 68 }),
+            4,
+            out byte[] flateOutput);
+
+        var lzwDictionary = new PdfDictionary();
+        lzwDictionary.Items["Filter"] = new PdfName("LZWDecode");
+        var lzwParameters = new PdfDictionary();
+        lzwParameters.Items["EarlyChange"] = new PdfReference(1, 0);
+        lzwDictionary.Items["DecodeParms"] = lzwParameters;
+        var objects = new Dictionary<int, PdfIndirectObject> {
+            [1] = new PdfIndirectObject(1, 0, PdfNull.Instance)
+        };
+        bool lzwDecoded = StreamDecoder.TryDecode(
+            lzwDictionary,
+            PackNineBitCodes(new[] { 256, 65, 257 }),
+            1,
+            out byte[] lzwOutput,
+            objects);
+
+        Assert.True(flateDecoded);
+        Assert.True(lzwDecoded);
+        Assert.Equal(new byte[] { 65, 66, 67, 68 }, flateOutput);
+        Assert.Equal(new byte[] { 65 }, lzwOutput);
+    }
+
+    [Fact]
+    public void TryDecodeAllowsOnlyNullParametersOnFiltersWithoutParameters() {
+        var dictionary = new PdfDictionary();
+        dictionary.Items["Filter"] = new PdfName("RunLengthDecode");
+        var decodeParameters = new PdfDictionary();
+        decodeParameters.Items["Predictor"] = PdfNull.Instance;
+        dictionary.Items["DecodeParms"] = decodeParameters;
+
+        bool decoded = StreamDecoder.TryDecode(
+            dictionary,
+            new byte[] { 0, 65, 128 },
+            1,
+            out byte[] output);
+
+        Assert.True(decoded);
+        Assert.Equal(new byte[] { 65 }, output);
+    }
+
+    [Fact]
     public void TryDecodeResolvesIndirectPredictorParameters() {
         var dictionary = new PdfDictionary();
         dictionary.Items["Filter"] = new PdfName("FlateDecode");

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfReadLimitTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfReadLimitTests.cs
@@ -533,6 +533,69 @@ public class PdfReadLimitTests {
     }
 
     [Fact]
+    public void TryDecodeResolvesIndirectPredictorParameters() {
+        var dictionary = new PdfDictionary();
+        dictionary.Items["Filter"] = new PdfName("FlateDecode");
+        var decodeParameters = new PdfDictionary();
+        decodeParameters.Items["Predictor"] = new PdfReference(1, 0);
+        decodeParameters.Items["Columns"] = new PdfReference(2, 0);
+        decodeParameters.Items["Colors"] = new PdfReference(3, 0);
+        decodeParameters.Items["BitsPerComponent"] = new PdfReference(4, 0);
+        dictionary.Items["DecodeParms"] = decodeParameters;
+        var objects = new Dictionary<int, PdfIndirectObject> {
+            [1] = new PdfIndirectObject(1, 0, new PdfNumber(12)),
+            [2] = new PdfIndirectObject(2, 0, new PdfReference(5, 0)),
+            [3] = new PdfIndirectObject(3, 0, new PdfNumber(1)),
+            [4] = new PdfIndirectObject(4, 0, new PdfNumber(8)),
+            [5] = new PdfIndirectObject(5, 0, new PdfNumber(4))
+        };
+        byte[] encoded = CompressForDecoderTest(new byte[] { 0, 65, 66, 67, 68 });
+
+        bool decoded = StreamDecoder.TryDecode(dictionary, encoded, 1024, out byte[] output, objects);
+
+        Assert.True(decoded);
+        Assert.Equal(new byte[] { 65, 66, 67, 68 }, output);
+    }
+
+    [Fact]
+    public void TryDecodeResolvesIndirectLzwEarlyChange() {
+        var dictionary = new PdfDictionary();
+        dictionary.Items["Filter"] = new PdfName("LZWDecode");
+        var decodeParameters = new PdfDictionary();
+        decodeParameters.Items["EarlyChange"] = new PdfReference(1, 0);
+        dictionary.Items["DecodeParms"] = decodeParameters;
+        var objects = new Dictionary<int, PdfIndirectObject> {
+            [1] = new PdfIndirectObject(1, 0, new PdfNumber(0))
+        };
+        byte[] encoded = PackNineBitCodes(new[] { 256, 65, 257 });
+
+        bool decoded = StreamDecoder.TryDecode(dictionary, encoded, 1024, out byte[] output, objects);
+
+        Assert.True(decoded);
+        Assert.Equal(new byte[] { 65 }, output);
+    }
+
+    [Fact]
+    public void TryDecodeRejectsCyclicIndirectDecodeParameters() {
+        var dictionary = new PdfDictionary();
+        dictionary.Items["Filter"] = new PdfName("FlateDecode");
+        var decodeParameters = new PdfDictionary();
+        decodeParameters.Items["Predictor"] = new PdfReference(1, 0);
+        dictionary.Items["DecodeParms"] = decodeParameters;
+        var objects = new Dictionary<int, PdfIndirectObject> {
+            [1] = new PdfIndirectObject(1, 0, new PdfReference(2, 0)),
+            [2] = new PdfIndirectObject(2, 0, new PdfReference(1, 0))
+        };
+
+        Assert.False(StreamDecoder.TryDecode(
+            dictionary,
+            CompressForDecoderTest(new byte[] { 65 }),
+            1024,
+            out _,
+            objects));
+    }
+
+    [Fact]
     public void TryDecodeAppliesTiffPredictorAcrossSupportedBitDepths() {
         AssertTiffPredictorDecode(1, 8, new byte[] { 0x5D }, new byte[] { 0x69 });
         AssertTiffPredictorDecode(2, 4, new byte[] { 0x1B }, new byte[] { 0x1E });

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfReadLimitTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfReadLimitTests.cs
@@ -576,6 +576,20 @@ public class PdfReadLimitTests {
         Assert.False(StreamDecoder.TryDecode(mismatchedParameters, encoded, 1024, out _));
     }
 
+    [Fact]
+    public void TryDecodeTreatsNullFilterAsAbsent() {
+        byte[] original = { 65, 66, 67, 68 };
+        var dictionary = new PdfDictionary();
+        dictionary.Items["Filter"] = PdfNull.Instance;
+        dictionary.Items["DecodeParms"] = new PdfNumber(42);
+
+        bool decoded = StreamDecoder.TryDecode(dictionary, original, 1024, out byte[] output);
+
+        Assert.True(decoded);
+        Assert.Equal(original, output);
+        Assert.Empty(StreamDecoder.GetUnsupportedFilters(dictionary));
+    }
+
     [Theory]
     [InlineData(3, 8, 1)]
     [InlineData(2, 3, 1)]

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfReaderAndFooterStreamDecodeTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfReaderAndFooterStreamDecodeTests.cs
@@ -23,6 +23,17 @@ public partial class PdfReaderAndFooterRegressionTests {
     }
 
     [Fact]
+    public void PdfTextExtractor_ExtractAllText_TreatsNullFilterAsAbsent() {
+        byte[] bytes = BuildSingleStreamPdf(
+            Encoding.ASCII.GetBytes("BT\n/F1 12 Tf\n72 720 Td\n(Hello null filter) Tj\nET"),
+            "/Filter null /DecodeParms 42");
+
+        string text = PdfTextExtractor.ExtractAllText(bytes);
+
+        Assert.Contains("Hello null filter", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void PdfTextExtractor_ExtractAllText_ReadsAsciiHexEncodedContentStreams() {
         byte[] bytes = BuildPdfWithAsciiHexEncodedStream("BT\n/F1 12 Tf\n72 720 Td\n(Hello hex) Tj\nET\n");
 

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfRedactionImageCoverageTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfRedactionImageCoverageTests.cs
@@ -62,6 +62,48 @@ public class PdfRedactionImageCoverageTests {
     }
 
     [Fact]
+    public void Apply_RoutesMalformedImagePredictorThroughUnsupportedImagePolicy() {
+        byte[] malformedPredictorRows = Enumerable.Range(1, 26).Select(value => (byte)value).ToArray();
+        malformedPredictorRows[0] = 9;
+        byte[] encoded = Compress(malformedPredictorRows);
+        Assert.True(encoded.Length >= CreateRgbPixels().Length);
+        byte[] source = BuildImagePdf(
+            "q\n40 0 0 20 20 30 cm\n/ImTarget Do\nQ\n",
+            "/ColorSpace /DeviceRGB /BitsPerComponent 8 /Filter /FlateDecode /DecodeParms << /Predictor 12 /Columns 12 >>",
+            encoded);
+        PdfRedactionArea area = LeftHalfArea(source);
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+            PdfRedactionApplier.Apply(source, new[] { area }));
+        byte[] removed = PdfRedactionApplier.Apply(
+            source,
+            new[] { area },
+            new PdfRedactionApplyOptions {
+                UnsupportedImagePolicy = PdfRedactionUnsupportedImagePolicy.RemoveWholePlacement
+            });
+
+        Assert.Contains("intersects image placement", exception.Message, StringComparison.Ordinal);
+        Assert.Empty(PdfImageExtractor.ExtractImages(removed));
+    }
+
+    [Fact]
+    public void Apply_RoutesMalformedSoftMaskPredictorThroughUnsupportedImagePolicy() {
+        byte[] malformedPredictorRows = Enumerable.Range(1, 10).Select(value => (byte)value).ToArray();
+        malformedPredictorRows[0] = 9;
+        byte[] source = BuildImagePdf(
+            "q\n40 0 0 20 20 30 cm\n/ImTarget Do\nQ\n",
+            "/ColorSpace /DeviceRGB /BitsPerComponent 8 /Filter /FlateDecode /SMask 6 0 R",
+            Compress(CreateRgbPixels()),
+            "/ColorSpace /DeviceGray /BitsPerComponent 8 /Filter /FlateDecode /DecodeParms << /Predictor 12 /Columns 4 >>",
+            Compress(malformedPredictorRows));
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+            PdfRedactionApplier.Apply(source, new[] { LeftHalfArea(source) }));
+
+        Assert.Contains("intersects image placement", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Apply_NormalizesIndexedAndColorKeyImagesBeforePartialRewrite() {
         byte[] indexed = BuildImagePdf(
             "q\n40 0 0 20 20 30 cm\n/ImTarget Do\nQ\n",

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfRedactionVerificationTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfRedactionVerificationTests.cs
@@ -171,10 +171,11 @@ public class PdfRedactionVerificationTests {
         Assert.Equal(placement.ResourceName, match.ResourceName);
         Assert.Equal(placement.ObjectNumber, match.ObjectNumber);
         Assert.Null(match.Text);
-        Assert.Contains(plan.Findings, finding =>
+        PdfDiagnosticFinding finding = Assert.Single(plan.Findings, finding =>
             finding.Code == "RedactionPlanImageIntersection" &&
             finding.Severity == PdfDiagnosticSeverity.Warning &&
             finding.PageNumber == image.PageNumber);
+        Assert.Contains("rewrites supported image pixels", finding.Message, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/OfficeIMO.Pdf/Manipulation/PdfAnnotationEditor.Create.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfAnnotationEditor.Create.cs
@@ -12,15 +12,15 @@ internal static partial class PdfAnnotationEditor {
         if (catalog == 0) throw new ArgumentException("PDF does not contain a readable catalog.", nameof(pdf));
         List<int> pages = GetPageObjectNumbersInDocumentOrder(objects);
         if (options.PageNumber > pages.Count) throw new ArgumentOutOfRangeException(nameof(options), "Annotation page number exceeds the PDF page count.");
-        int pageObjectNumber = pages[options.PageNumber - 1]; PdfDictionary page = (PdfDictionary)objects[pageObjectNumber].Value;
+        int pageObjectNumber = pages[options.PageNumber - 1]; PdfIndirectObject pageIndirect = objects[pageObjectNumber]; PdfDictionary page = (PdfDictionary)pageIndirect.Value;
         int annotationObjectNumber = NextAnnotationObjectNumber(objects);
-        var annotation = new PdfDictionary(); annotation.Items["Type"] = new PdfName("Annot"); annotation.Items["Subtype"] = new PdfName(options.Subtype); annotation.Items["P"] = new PdfReference(pageObjectNumber, 0);
+        var annotation = new PdfDictionary(); annotation.Items["Type"] = new PdfName("Annot"); annotation.Items["Subtype"] = new PdfName(options.Subtype); annotation.Items["P"] = new PdfReference(pageObjectNumber, pageIndirect.Generation);
         objects[annotationObjectNumber] = new PdfIndirectObject(annotationObjectNumber, 0, annotation);
 
         int? popupObjectNumber = null;
         if (options.CreatePopup) {
             popupObjectNumber = annotationObjectNumber + 1;
-            var popup = new PdfDictionary(); popup.Items["Type"] = new PdfName("Annot"); popup.Items["Subtype"] = new PdfName("Popup"); popup.Items["Parent"] = new PdfReference(annotationObjectNumber, 0); popup.Items["P"] = new PdfReference(pageObjectNumber, 0);
+            var popup = new PdfDictionary(); popup.Items["Type"] = new PdfName("Annot"); popup.Items["Subtype"] = new PdfName("Popup"); popup.Items["Parent"] = new PdfReference(annotationObjectNumber, 0); popup.Items["P"] = new PdfReference(pageObjectNumber, pageIndirect.Generation);
             popup.Items["Rect"] = CreateNumberArray(options.PopupRectangle ?? DefaultPopupRectangle(options.Rectangle)); popup.Items["Open"] = new PdfBoolean(options.PopupOpen);
             objects[popupObjectNumber.Value] = new PdfIndirectObject(popupObjectNumber.Value, 0, popup); annotation.Items["Popup"] = new PdfReference(popupObjectNumber.Value, 0);
         }

--- a/OfficeIMO.Pdf/Manipulation/PdfAnnotationEditor.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfAnnotationEditor.cs
@@ -301,7 +301,7 @@ internal static partial class PdfAnnotationEditor {
         if (options.InReplyToObjectNumber.HasValue) {
             int replyTarget = options.InReplyToObjectNumber.Value;
             if (!objects.TryGetValue(replyTarget, out PdfIndirectObject? target) || target.Value is not PdfDictionary targetDictionary || !IsAnnotation(targetDictionary)) throw new ArgumentException("Reply target annotation object was not found.", nameof(options));
-            annotation.Items["IRT"] = new PdfReference(replyTarget, 0);
+            annotation.Items["IRT"] = new PdfReference(replyTarget, target.Generation);
         }
         if (options.ReplyType is not null) annotation.Items["RT"] = new PdfName(options.ReplyType);
         if (options.PopupOpen.HasValue || options.PopupRectangle is not null) {

--- a/OfficeIMO.Pdf/Manipulation/PdfRedactionApplier.Images.PixelRewrite.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfRedactionApplier.Images.PixelRewrite.cs
@@ -37,7 +37,7 @@ internal static partial class PdfRedactionApplier {
                 continue;
             }
 
-            string content = PdfEncoding.Latin1GetString(StreamDecoder.Decode(stream.Dictionary, stream.Data, objects));
+            string content = PdfEncoding.Latin1GetString(StreamDecoder.DecodeRequired(stream.Dictionary, stream.Data, objects));
             ImagePixelRewriteContentResult result = RewriteImagePixelsInContent(objects, resources, xObjects, content, targets, options, Matrix2D.Identity, referenceCounts, new HashSet<int>(), removedMatches, ref nextObjectNumber);
             if (!string.Equals(result.Content, content, StringComparison.Ordinal)) {
                 PdfReference targetReference = reference;
@@ -163,7 +163,7 @@ internal static partial class PdfRedactionApplier {
         PdfDictionary formResources = EnsureFormResources(objects, formStream);
         PdfDictionary formXObjects = EnsureResourceXObjects(objects, formResources);
         Matrix2D formTransform = ApplyFormMatrix(invocationTransform, formStream.Dictionary);
-        string formContent = PdfEncoding.Latin1GetString(StreamDecoder.Decode(formStream.Dictionary, formStream.Data, objects));
+        string formContent = PdfEncoding.Latin1GetString(StreamDecoder.DecodeRequired(formStream.Dictionary, formStream.Data, objects));
         ImagePixelRewriteContentResult result = RewriteImagePixelsInContent(objects, formResources, formXObjects, formContent, targets, options, formTransform, referenceCounts, activeForms, removedMatches, ref nextObjectNumber);
         if (!string.Equals(result.Content, formContent, StringComparison.Ordinal)) {
             objects[formReference.ObjectNumber] = new PdfIndirectObject(formReference.ObjectNumber, formReference.Generation, new PdfStream(CleanStreamDictionary(formStream.Dictionary), PdfEncoding.Latin1GetBytes(result.Content)));
@@ -352,7 +352,15 @@ internal static partial class PdfRedactionApplier {
             return false;
         }
 
-        byte[] pixels = StreamDecoder.Decode(imageStream.Dictionary, imageStream.Data, objects, options.MaximumDecodedImageBytes);
+        if (!StreamDecoder.TryDecode(
+            imageStream.Dictionary,
+            imageStream.Data,
+            options.MaximumDecodedImageBytes,
+            out byte[] pixels,
+            objects)) {
+            return false;
+        }
+
         if (pixels.Length < expectedLengthLong) return false;
 
         if (!TryGetRedactionPixelBounds(target.Match.Area, transform, width, height, out int x0, out int y0, out int x1, out int y1)) {
@@ -626,10 +634,18 @@ internal static partial class PdfRedactionApplier {
             return false;
         }
 
-        byte[] maskPixels = StreamDecoder.Decode(softMaskStream.Dictionary, softMaskStream.Data, objects, maximumDecodedImageBytes);
+        if (!StreamDecoder.TryDecode(
+            softMaskStream.Dictionary,
+            softMaskStream.Data,
+            maximumDecodedImageBytes,
+            out byte[] maskPixels,
+            objects)) {
+            return false;
+        }
+
         if (maskPixels.Length < expectedLengthLong) return false;
 
-        softMask = new ImageSoftMaskRewriteTarget(softMaskReference, softMaskStream, width, height, maskEncoder);
+        softMask = new ImageSoftMaskRewriteTarget(softMaskReference, softMaskStream, width, height, maskEncoder, maskPixels);
         return true;
     }
 
@@ -653,10 +669,9 @@ internal static partial class PdfRedactionApplier {
             return false;
         }
 
-        byte[] pixels = StreamDecoder.Decode(softMask.Stream.Dictionary, softMask.Stream.Data, objects, maximumDecodedImageBytes);
-        if (pixels.Length < expectedLengthLong) return false;
+        if (softMask.Pixels.Length < expectedLengthLong) return false;
 
-        byte[] rewritten = (byte[])pixels.Clone();
+        byte[] rewritten = (byte[])softMask.Pixels.Clone();
         for (int row = y0; row < y1; row++) {
             int rowOffset = row * softMask.Width;
             for (int column = x0; column < x1; column++) {
@@ -933,12 +948,19 @@ internal static partial class PdfRedactionApplier {
     }
 
     private readonly struct ImageSoftMaskRewriteTarget {
-        public ImageSoftMaskRewriteTarget(PdfReference reference, PdfStream stream, int width, int height, ImageSampleRewriteEncoder encoder) {
+        public ImageSoftMaskRewriteTarget(
+            PdfReference reference,
+            PdfStream stream,
+            int width,
+            int height,
+            ImageSampleRewriteEncoder encoder,
+            byte[] pixels) {
             Reference = reference;
             Stream = stream;
             Width = width;
             Height = height;
             Encoder = encoder;
+            Pixels = pixels;
             HasMask = true;
         }
 
@@ -953,5 +975,7 @@ internal static partial class PdfRedactionApplier {
         public int Height { get; }
 
         public ImageSampleRewriteEncoder Encoder { get; }
+
+        public byte[] Pixels { get; }
     }
 }

--- a/OfficeIMO.Pdf/Manipulation/PdfRedactionApplier.Images.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfRedactionApplier.Images.cs
@@ -36,7 +36,7 @@ internal static partial class PdfRedactionApplier {
                     continue;
                 }
 
-                byte[] contentBytes = StreamDecoder.Decode(stream.Dictionary, stream.Data, objects);
+                byte[] contentBytes = StreamDecoder.DecodeRequired(stream.Dictionary, stream.Data, objects);
                 string content = PdfEncoding.Latin1GetString(contentBytes);
                 string scrubbed = RemoveImageInvocations(content, wholeImageTargets, out IReadOnlyList<ImageRedactionTarget> removedTargets);
                 if (string.Equals(content, scrubbed, StringComparison.Ordinal)) {
@@ -127,7 +127,7 @@ internal static partial class PdfRedactionApplier {
                 continue;
             }
 
-            string content = PdfEncoding.Latin1GetString(StreamDecoder.Decode(stream.Dictionary, stream.Data, objects));
+            string content = PdfEncoding.Latin1GetString(StreamDecoder.DecodeRequired(stream.Dictionary, stream.Data, objects));
             ImagePixelRewriteContentResult result = ScrubImageFormInvocations(objects, resources, xObjects, content, targets, Matrix2D.Identity, referenceCounts, new HashSet<int>(), removedMatches, ref nextObjectNumber);
             if (!string.Equals(result.Content, content, StringComparison.Ordinal)) {
                 PdfReference targetReference = reference;
@@ -233,7 +233,7 @@ internal static partial class PdfRedactionApplier {
         PdfDictionary formResources = ResolveDictionary(objects, formStream.Dictionary.Items.TryGetValue("Resources", out PdfObject? resourcesObject) ? resourcesObject : null) ?? inheritedResources;
         PdfDictionary formXObjects = EnsureResourceXObjects(objects, formResources);
         Matrix2D formTransform = ApplyFormMatrix(invocationTransform, formStream.Dictionary);
-        string formContent = PdfEncoding.Latin1GetString(StreamDecoder.Decode(formStream.Dictionary, formStream.Data, objects));
+        string formContent = PdfEncoding.Latin1GetString(StreamDecoder.DecodeRequired(formStream.Dictionary, formStream.Data, objects));
         string scrubbed = RemoveImageInvocations(formContent, targets, formTransform, out IReadOnlyList<ImageRedactionTarget> removedTargets);
         bool changed = false;
 
@@ -466,7 +466,7 @@ internal static partial class PdfRedactionApplier {
             if (PdfObjectLookup.TryGet(objects, reference, out PdfIndirectObject? indirect) &&
                 indirect.Value is PdfStream stream &&
                 !stream.DecodingFailed) {
-                builder.Append(PdfEncoding.Latin1GetString(StreamDecoder.Decode(stream.Dictionary, stream.Data, objects)));
+                builder.Append(PdfEncoding.Latin1GetString(StreamDecoder.DecodeRequired(stream.Dictionary, stream.Data, objects)));
                 builder.Append('\n');
             }
         }
@@ -499,7 +499,7 @@ internal static partial class PdfRedactionApplier {
         var invokedNames = new HashSet<string>(StringComparer.Ordinal);
         foreach (PdfIndirectObject indirect in objects.Values) {
             if (indirect.Value is not PdfStream stream || string.Equals(stream.Dictionary.Get<PdfName>("Subtype")?.Name, "Image", StringComparison.Ordinal) || stream.DecodingFailed || StreamDecoder.GetUnsupportedFilters(stream.Dictionary, objects).Count != 0) continue;
-            string content = PdfEncoding.Latin1GetString(StreamDecoder.Decode(stream.Dictionary, stream.Data, objects));
+            string content = PdfEncoding.Latin1GetString(StreamDecoder.DecodeRequired(stream.Dictionary, stream.Data, objects));
             foreach (TextContentParser.FormInvocation invocation in TextContentParser.ExtractFormInvocations(content)) invokedNames.Add(invocation.Name);
         }
         bool changed = false;

--- a/OfficeIMO.Pdf/Manipulation/PdfRedactionApplier.Paths.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfRedactionApplier.Paths.cs
@@ -8,7 +8,7 @@ internal static partial class PdfRedactionApplier {
         Dictionary<int, int> referenceCounts = CountIndirectReferenceUsage(objects); PdfObject currentContents = contentsObject; bool changed = false;
         foreach (PdfReference reference in EnumerateContentReferences(objects, contentsObject).ToArray()) {
             if (!PdfObjectLookup.TryGet(objects, reference, out PdfIndirectObject? indirect) || indirect.Value is not PdfStream stream || stream.DecodingFailed) continue;
-            string content = PdfEncoding.Latin1GetString(StreamDecoder.Decode(stream.Dictionary, stream.Data, objects, maximumDecodedStreamBytes)); string scrubbed = ScrubIntersectingPaths(content, areas);
+            string content = PdfEncoding.Latin1GetString(StreamDecoder.DecodeRequired(stream.Dictionary, stream.Data, objects, maximumDecodedStreamBytes)); string scrubbed = ScrubIntersectingPaths(content, areas);
             if (string.Equals(content, scrubbed, StringComparison.Ordinal)) continue;
             PdfReference target = reference;
             if (IsSharedReference(referenceCounts, reference)) { target = CloneIndirectObject(objects, reference, indirect, ref nextObjectNumber); ReplacePageContentReference(objects, page, currentContents, reference, target); currentContents = page.Items.TryGetValue("Contents", out PdfObject? updated) ? updated : currentContents; }

--- a/OfficeIMO.Pdf/Manipulation/PdfRedactionApplier.TextFormScrubbing.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfRedactionApplier.TextFormScrubbing.cs
@@ -95,7 +95,7 @@ internal static partial class PdfRedactionApplier {
         Matrix2D[] effectiveTransforms = parentTransforms
             .Select(parent => ApplyFormMatrix(Matrix2D.Multiply(parent, invocationTransform), formStream.Dictionary))
             .ToArray();
-        string formContent = PdfEncoding.Latin1GetString(StreamDecoder.Decode(formStream.Dictionary, formStream.Data, objects));
+        string formContent = PdfEncoding.Latin1GetString(StreamDecoder.DecodeRequired(formStream.Dictionary, formStream.Data, objects));
         string scrubbed = ScrubTextObjects(formContent, textTargets, formDecoders, effectiveTransforms);
         bool changed = !string.Equals(formContent, scrubbed, StringComparison.Ordinal);
         TextFormScrubContentResult nestedResult = ScrubFormInvocations(

--- a/OfficeIMO.Pdf/Manipulation/PdfRedactionApplier.TextScrubbing.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfRedactionApplier.TextScrubbing.cs
@@ -34,7 +34,7 @@ internal static partial class PdfRedactionApplier {
                 break;
             }
 
-            byte[] contentBytes = StreamDecoder.Decode(stream.Dictionary, stream.Data, objects);
+            byte[] contentBytes = StreamDecoder.DecodeRequired(stream.Dictionary, stream.Data, objects);
             contentSegments.Add(PdfEncoding.Latin1GetString(contentBytes));
         }
 
@@ -73,7 +73,7 @@ internal static partial class PdfRedactionApplier {
                     continue;
                 }
 
-                string content = PdfEncoding.Latin1GetString(StreamDecoder.Decode(stream.Dictionary, stream.Data, objects));
+                string content = PdfEncoding.Latin1GetString(StreamDecoder.DecodeRequired(stream.Dictionary, stream.Data, objects));
                 string scrubbed = ScrubTextObjects(content, textTargets, fontDecoders, new[] { Matrix2D.Identity }, graphicsState);
                 changed = ReplacePageContentStreamIfChanged(
                     objects,
@@ -172,7 +172,7 @@ internal static partial class PdfRedactionApplier {
                 continue;
             }
 
-            contentSegments[index] = PdfEncoding.Latin1GetString(StreamDecoder.Decode(stream.Dictionary, stream.Data, objects));
+            contentSegments[index] = PdfEncoding.Latin1GetString(StreamDecoder.DecodeRequired(stream.Dictionary, stream.Data, objects));
         }
 
         bool changed = false;

--- a/OfficeIMO.Pdf/Manipulation/PdfRedactionPlanner.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfRedactionPlanner.cs
@@ -148,7 +148,7 @@ internal static partial class PdfRedactionPlanner {
                 findings.Add(new PdfDiagnosticFinding(
                     PdfDiagnosticSeverity.Warning,
                     "RedactionPlanImageIntersection",
-                    "Redaction area intersects an image placement. The current redaction applier can paint the rectangle, but image pixel/resource rewriting must be handled by a safe image-redaction flow before treating the image content as removed.",
+                    "Redaction area intersects an image placement. Applying the plan rewrites supported image pixels and otherwise follows the configured fail-closed, whole-placement removal, or explicit visual-overlay policy.",
                     placement.ObjectNumber == 0 ? null : placement.ObjectNumber,
                     placement.PageNumber));
             }

--- a/OfficeIMO.Pdf/Reading/Core/PdfImageMaskNormalizer.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfImageMaskNormalizer.cs
@@ -79,7 +79,14 @@ internal static class PdfImageMaskNormalizer {
                 return false;
             }
 
-            bytes = Filters.StreamDecoder.Decode(stream.Dictionary, stream.Data, objects);
+            if (!Filters.StreamDecoder.TryDecode(
+                    stream.Dictionary,
+                    stream.Data,
+                    PdfReadLimits.DefaultMaxDecodedStreamBytes,
+                    out bytes,
+                    objects)) {
+                return false;
+            }
         } else {
             bytes = stream.Data;
         }

--- a/OfficeIMO.Pdf/Reading/Core/PdfImageMaskNormalizer.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfImageMaskNormalizer.cs
@@ -73,25 +73,7 @@ internal static class PdfImageMaskNormalizer {
         PdfStream stream,
         Dictionary<int, PdfIndirectObject> objects,
         out byte[] bytes) {
-        bytes = Array.Empty<byte>();
-        if (stream.Dictionary.Items.TryGetValue("Filter", out _)) {
-            if (Filters.StreamDecoder.GetUnsupportedFilters(stream.Dictionary, objects).Count != 0) {
-                return false;
-            }
-
-            if (!Filters.StreamDecoder.TryDecode(
-                    stream.Dictionary,
-                    stream.Data,
-                    PdfReadLimits.DefaultMaxDecodedStreamBytes,
-                    out bytes,
-                    objects)) {
-                return false;
-            }
-        } else {
-            bytes = stream.Data;
-        }
-
-        return bytes.Length > 0;
+        return PdfImageStreamDecoder.TryDecode(stream, objects, out bytes) && bytes.Length > 0;
     }
 
     private static int ReadMaskSample(byte[] maskPixels, int rowOffset, int pixelIndex) {

--- a/OfficeIMO.Pdf/Reading/Core/PdfImageStreamDecoder.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfImageStreamDecoder.cs
@@ -1,0 +1,21 @@
+namespace OfficeIMO.Pdf;
+
+internal static class PdfImageStreamDecoder {
+    internal static bool TryDecode(
+        PdfStream stream,
+        Dictionary<int, PdfIndirectObject> objects,
+        out byte[] decoded,
+        int maxDecodedBytes = PdfReadLimits.DefaultMaxDecodedStreamBytes) {
+        try {
+            decoded = Filters.StreamDecoder.DecodeRequired(
+                stream.Dictionary,
+                stream.Data,
+                objects,
+                maxDecodedBytes);
+            return true;
+        } catch (InvalidDataException) {
+            decoded = Array.Empty<byte>();
+            return false;
+        }
+    }
+}

--- a/OfficeIMO.Pdf/Reading/Core/PdfIndexedImageNormalizer.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfIndexedImageNormalizer.cs
@@ -158,25 +158,7 @@ internal static class PdfIndexedImageNormalizer {
         PdfStream stream,
         Dictionary<int, PdfIndirectObject> objects,
         out byte[] bytes) {
-        bytes = Array.Empty<byte>();
-        if (stream.Dictionary.Items.TryGetValue("Filter", out _)) {
-            if (Filters.StreamDecoder.GetUnsupportedFilters(stream.Dictionary, objects).Count != 0) {
-                return false;
-            }
-
-            if (!Filters.StreamDecoder.TryDecode(
-                    stream.Dictionary,
-                    stream.Data,
-                    PdfReadLimits.DefaultMaxDecodedStreamBytes,
-                    out bytes,
-                    objects)) {
-                return false;
-            }
-        } else {
-            bytes = stream.Data;
-        }
-
-        return bytes.Length > 0;
+        return PdfImageStreamDecoder.TryDecode(stream, objects, out bytes) && bytes.Length > 0;
     }
 
     private static bool TryBuildPngFileFromIndexedPixels(

--- a/OfficeIMO.Pdf/Reading/Core/PdfIndexedImageNormalizer.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfIndexedImageNormalizer.cs
@@ -137,12 +137,18 @@ internal static class PdfIndexedImageNormalizer {
                 return false;
             }
 
-            lookupBytes = Filters.StreamDecoder.Decode(
-                lookupStream.Dictionary,
-                lookupStream.Data,
-                objects,
-                maxLookupBytes);
-            return lookupBytes.Length > 0;
+            try {
+                lookupBytes = Filters.StreamDecoder.DecodeRequired(
+                    lookupStream.Dictionary,
+                    lookupStream.Data,
+                    objects,
+                    maxLookupBytes);
+                return lookupBytes.Length > 0;
+            } catch (PdfReadLimitException) {
+                throw;
+            } catch (InvalidDataException) {
+                return false;
+            }
         }
 
         return false;
@@ -158,7 +164,14 @@ internal static class PdfIndexedImageNormalizer {
                 return false;
             }
 
-            bytes = Filters.StreamDecoder.Decode(stream.Dictionary, stream.Data, objects);
+            if (!Filters.StreamDecoder.TryDecode(
+                    stream.Dictionary,
+                    stream.Data,
+                    PdfReadLimits.DefaultMaxDecodedStreamBytes,
+                    out bytes,
+                    objects)) {
+                return false;
+            }
         } else {
             bytes = stream.Data;
         }

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadPage.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadPage.cs
@@ -1,4 +1,5 @@
 using OfficeIMO.Drawing;
+using System.IO;
 
 namespace OfficeIMO.Pdf;
 
@@ -1438,7 +1439,13 @@ public sealed partial class PdfReadPage {
     }
 
     private byte[] DecodeIfNeeded(PdfStream s, int maxDecodedBytes) {
-        return Filters.StreamDecoder.Decode(s.Dictionary, s.Data, _objects, maxDecodedBytes);
+        if (s.DecodingFailed) {
+            throw new InvalidDataException(
+                "PDF page content stream could not be decoded safely" +
+                (string.IsNullOrWhiteSpace(s.DecodingError) ? "." : ": " + s.DecodingError));
+        }
+
+        return Filters.StreamDecoder.DecodeRequired(s.Dictionary, s.Data, _objects, maxDecodedBytes);
     }
 
     private sealed class PageContentBudget {

--- a/OfficeIMO.Pdf/Reading/Core/ResourceResolver.Images.cs
+++ b/OfficeIMO.Pdf/Reading/Core/ResourceResolver.Images.cs
@@ -337,12 +337,7 @@ internal static partial class ResourceResolver {
         PdfStream stream,
         Dictionary<int, PdfIndirectObject> objects,
         out byte[] decoded) =>
-        Filters.StreamDecoder.TryDecode(
-            stream.Dictionary,
-            stream.Data,
-            PdfReadLimits.DefaultMaxDecodedStreamBytes,
-            out decoded,
-            objects);
+        PdfImageStreamDecoder.TryDecode(stream, objects, out decoded);
 
     private static bool TryReadIndexedSample(byte[] pixels, int width, int sampleIndex, int bitsPerComponent, out int sample) {
         sample = 0;

--- a/OfficeIMO.Pdf/Reading/Core/ResourceResolver.Images.cs
+++ b/OfficeIMO.Pdf/Reading/Core/ResourceResolver.Images.cs
@@ -61,7 +61,9 @@ internal static partial class ResourceResolver {
             return false;
         }
 
-        byte[] maskPixels = Filters.StreamDecoder.Decode(stream.Dictionary, stream.Data, objects);
+        if (!TryDecodeImageStream(stream, objects, out byte[] maskPixels)) {
+            return false;
+        }
         byte[] scanlines = new byte[scanlineBytes];
         for (int sampleIndex = 0; sampleIndex < pixelCount; sampleIndex++) {
             if (!TryReadIndexedSample(maskPixels, width, sampleIndex, 1, out int sample)) {
@@ -118,7 +120,9 @@ internal static partial class ResourceResolver {
             return false;
         }
 
-        byte[] basePixels = Filters.StreamDecoder.Decode(stream.Dictionary, stream.Data, objects);
+        if (!TryDecodeImageStream(stream, objects, out byte[] basePixels)) {
+            return false;
+        }
         int expectedBaseLength = width * height * baseColors;
         if (basePixels.Length < expectedBaseLength) {
             return false;
@@ -179,7 +183,9 @@ internal static partial class ResourceResolver {
             return false;
         }
 
-        byte[] indexedPixels = Filters.StreamDecoder.Decode(stream.Dictionary, stream.Data, objects);
+        if (!TryDecodeImageStream(stream, objects, out byte[] indexedPixels)) {
+            return false;
+        }
         int expectedSampleCount = width * height;
         bool hasSoftMask = stream.Dictionary.Items.ContainsKey("SMask");
         byte[]? alphaPixels = null;
@@ -321,12 +327,22 @@ internal static partial class ResourceResolver {
                 lookupBytes = lookupString.RawBytes;
                 return lookupBytes.Length > 0;
             case PdfStream lookupStream:
-                lookupBytes = Filters.StreamDecoder.Decode(lookupStream.Dictionary, lookupStream.Data, objects);
-                return lookupBytes.Length > 0;
+                return TryDecodeImageStream(lookupStream, objects, out lookupBytes) && lookupBytes.Length > 0;
             default:
                 return false;
         }
     }
+
+    private static bool TryDecodeImageStream(
+        PdfStream stream,
+        Dictionary<int, PdfIndirectObject> objects,
+        out byte[] decoded) =>
+        Filters.StreamDecoder.TryDecode(
+            stream.Dictionary,
+            stream.Data,
+            PdfReadLimits.DefaultMaxDecodedStreamBytes,
+            out decoded,
+            objects);
 
     private static bool TryReadIndexedSample(byte[] pixels, int width, int sampleIndex, int bitsPerComponent, out int sample) {
         sample = 0;

--- a/OfficeIMO.Pdf/Reading/Core/ResourceResolver.cs
+++ b/OfficeIMO.Pdf/Reading/Core/ResourceResolver.cs
@@ -1098,13 +1098,9 @@ internal static partial class ResourceResolver {
         var colorDecodeTransform = PdfImageDecodeTransform.CreateColor(stream.Dictionary, colorNormalization.SourceColorCount, objects);
         var colorKeyMask = PdfImageColorKeyMask.Create(stream.Dictionary, colorNormalization.SourceColorCount, objects);
         if (colorKeyMask is not null) {
-            if (Filters.StreamDecoder.GetUnsupportedFilters(stream.Dictionary, objects).Count != 0) {
+            if (!TryDecodeImageStream(stream, objects, out byte[] pixels)) {
                 return false;
             }
-
-            byte[] pixels = string.IsNullOrEmpty(filter)
-                ? stream.Data
-                : Filters.StreamDecoder.Decode(stream.Dictionary, stream.Data, objects);
             return TryBuildPngFileFromDecodedPixelsWithColorKeyMask(
                 width,
                 height,
@@ -1132,7 +1128,9 @@ internal static partial class ResourceResolver {
 
         int predictor = (int)(decodeParms?.Get<PdfNumber>("Predictor")?.Value ?? 1);
         if (predictor <= 1 || predictor == 2) {
-            byte[] pixels = Filters.StreamDecoder.Decode(stream.Dictionary, stream.Data, objects);
+            if (!TryDecodeImageStream(stream, objects, out byte[] pixels)) {
+                return false;
+            }
             return TryBuildPngFileFromDecodedPixels(width, height, bitsPerComponent, colorNormalization.SourceColorCount, colorNormalization.PngColorType, colorDecodeTransform, pixels, out pngBytes);
         }
 
@@ -1143,8 +1141,14 @@ internal static partial class ResourceResolver {
         if ((colorNormalization.SourceColorCount != 1 && colorNormalization.SourceColorCount != 3) ||
             colorDecodeTransform is not null ||
             !CanWrapPngPredictorScanlines(decodeParms, width, bitsPerComponent, colorNormalization.SourceColorCount)) {
-            byte[] pixels = Filters.StreamDecoder.Decode(stream.Dictionary, stream.Data, objects);
+            if (!TryDecodeImageStream(stream, objects, out byte[] pixels)) {
+                return false;
+            }
             return TryBuildPngFileFromDecodedPixels(width, height, bitsPerComponent, colorNormalization.SourceColorCount, colorNormalization.PngColorType, colorDecodeTransform, pixels, out pngBytes);
+        }
+
+        if (!TryDecodeImageStream(stream, objects, out _)) {
+            return false;
         }
 
         pngBytes = OfficePngWriter.CreateFromCompressedScanlines(width, height, bitsPerComponent, colorNormalization.PngColorType, stream.Data);
@@ -1175,11 +1179,9 @@ internal static partial class ResourceResolver {
         Dictionary<int, PdfIndirectObject> objects,
         out byte[] pngBytes) {
         pngBytes = Array.Empty<byte>();
-        if (Filters.StreamDecoder.GetUnsupportedFilters(stream.Dictionary, objects).Count != 0) {
+        if (!TryDecodeImageStream(stream, objects, out byte[] pixels)) {
             return false;
         }
-
-        byte[] pixels = Filters.StreamDecoder.Decode(stream.Dictionary, stream.Data, objects);
         return TryBuildPngFileFromDecodedPixels(width, height, bitsPerComponent, sourceColorCount, pngColorType, decodeTransform, pixels, out pngBytes);
     }
 
@@ -1408,8 +1410,10 @@ internal static partial class ResourceResolver {
             return false;
         }
 
-        byte[] basePixels = Filters.StreamDecoder.Decode(stream.Dictionary, stream.Data, objects);
-        byte[] alphaPixels = Filters.StreamDecoder.Decode(softMask.Dictionary, softMask.Data, objects);
+        if (!TryDecodeImageStream(stream, objects, out byte[] basePixels) ||
+            !TryDecodeImageStream(softMask, objects, out byte[] alphaPixels)) {
+            return false;
+        }
         long baseRowLengthLong = (long)width * sourceColorCount;
         long alphaRowLengthLong = width;
         long expectedBaseLengthLong = baseRowLengthLong * height;
@@ -1494,7 +1498,9 @@ internal static partial class ResourceResolver {
             return false;
         }
 
-        alphaPixels = Filters.StreamDecoder.Decode(softMask.Dictionary, softMask.Data, objects);
+        if (!TryDecodeImageStream(softMask, objects, out alphaPixels)) {
+            return false;
+        }
         ApplySoftMaskDecode(softMask.Dictionary, alphaPixels, objects);
         return true;
     }

--- a/OfficeIMO.Pdf/Reading/Filters/FlateDecoder.cs
+++ b/OfficeIMO.Pdf/Reading/Filters/FlateDecoder.cs
@@ -72,11 +72,6 @@ internal static class FlateDecoder {
             }
         }
 
-        if (data.Length <= maxOutputBytes) {
-            output = data;
-            return true;
-        }
-
         output = Array.Empty<byte>();
         return false;
     }
@@ -136,4 +131,3 @@ internal static class FlateDecoder {
         return deflate && mod;
     }
 }
-

--- a/OfficeIMO.Pdf/Reading/Filters/StreamDecoder.cs
+++ b/OfficeIMO.Pdf/Reading/Filters/StreamDecoder.cs
@@ -140,6 +140,15 @@ internal static class StreamDecoder {
             return false;
         }
 
+        if (filterNames.Count == 0) {
+            if (!TryUseOriginal(data, maxOutputBytes, out decoded)) {
+                limitException = CreateDecodedLimitException(maxOutputBytes, data.LongLength);
+                return false;
+            }
+
+            return true;
+        }
+
         byte[] current = data;
         for (int filterIndex = 0; filterIndex < filterNames.Count; filterIndex++) {
             string filterName = filterNames[filterIndex];

--- a/OfficeIMO.Pdf/Reading/Filters/StreamDecoder.cs
+++ b/OfficeIMO.Pdf/Reading/Filters/StreamDecoder.cs
@@ -477,7 +477,7 @@ internal static class StreamDecoder {
 
                 DecodeFilterKind filterKind = GetFilterKind(filterNames[filterIndex]);
                 if (filterKind != DecodeFilterKind.Flate && filterKind != DecodeFilterKind.Lzw) {
-                    if (decodeParms.Items.Count != 0) {
+                    if (HasResolvedNonNullEntry(decodeParms, objects)) {
                         return false;
                     }
 
@@ -497,7 +497,7 @@ internal static class StreamDecoder {
                 }
 
                 if (filterKind == DecodeFilterKind.Flate) {
-                    if (decodeParms.Items.ContainsKey("EarlyChange")) {
+                    if (HasResolvedNonNullParameter(decodeParms, "EarlyChange", objects)) {
                         return false;
                     }
 
@@ -514,6 +514,26 @@ internal static class StreamDecoder {
         } catch {
             return false;
         }
+    }
+
+    private static bool HasResolvedNonNullEntry(
+        PdfDictionary dictionary,
+        Dictionary<int, PdfIndirectObject>? objects) {
+        foreach (PdfObject value in dictionary.Items.Values) {
+            if (ResolveObject(value, objects) is not PdfNull) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasResolvedNonNullParameter(
+        PdfDictionary dictionary,
+        string name,
+        Dictionary<int, PdfIndirectObject>? objects) {
+        return dictionary.Items.TryGetValue(name, out PdfObject? value) &&
+            ResolveObject(value, objects) is not PdfNull;
     }
 
     private static bool TryGetFilterNames(
@@ -569,7 +589,12 @@ internal static class StreamDecoder {
             return defaultValue;
         }
 
-        if (ResolveObject(parameter, objects) is not PdfNumber number ||
+        PdfObject? resolvedParameter = ResolveObject(parameter, objects);
+        if (resolvedParameter is PdfNull) {
+            return defaultValue;
+        }
+
+        if (resolvedParameter is not PdfNumber number ||
             double.IsNaN(number.Value) ||
             double.IsInfinity(number.Value) ||
             number.Value != Math.Truncate(number.Value) ||

--- a/OfficeIMO.Pdf/Reading/Filters/StreamDecoder.cs
+++ b/OfficeIMO.Pdf/Reading/Filters/StreamDecoder.cs
@@ -1,4 +1,5 @@
 using OfficeIMO.Pdf;
+using System.IO;
 
 namespace OfficeIMO.Pdf.Filters;
 
@@ -21,16 +22,20 @@ internal static class StreamDecoder {
             throw new ArgumentOutOfRangeException(nameof(maxOutputBytes), maxOutputBytes, "Maximum decoded stream bytes must be positive.");
         }
 
-        if (data == null || data.Length == 0 || !dict.Items.TryGetValue("Filter", out var filterObj)) {
+        if (data == null || !dict.Items.TryGetValue("Filter", out var filterObj)) {
             byte[] originalData = data ?? Array.Empty<byte>();
             ThrowIfDecodedLimitExceeded(originalData.LongLength, maxOutputBytes);
             return originalData;
         }
 
+        if (!TryGetFilterNames(filterObj, objects, out List<string> filterNames)) {
+            return ReturnWithinDecodedLimit(data, maxOutputBytes);
+        }
+
         byte[] original = data;
         byte[] current = data;
-        int filterIndex = 0;
-        foreach (string filterName in EnumerateFilters(filterObj, objects)) {
+        for (int filterIndex = 0; filterIndex < filterNames.Count; filterIndex++) {
+            string filterName = filterNames[filterIndex];
             try {
                 switch (GetFilterKind(filterName)) {
                     case DecodeFilterKind.Flate:
@@ -78,37 +83,78 @@ internal static class StreamDecoder {
             } catch {
                 return ReturnWithinDecodedLimit(original, maxOutputBytes);
             }
-
-            filterIndex++;
         }
 
         return ReturnWithinDecodedLimit(current, maxOutputBytes);
     }
 
     public static bool TryDecode(PdfDictionary dict, byte[] data, int maxOutputBytes, out byte[] decoded, Dictionary<int, PdfIndirectObject>? objects = null) {
+        return TryDecodeCore(dict, data, maxOutputBytes, out decoded, out _, objects);
+    }
+
+    internal static byte[] DecodeRequired(
+        PdfDictionary dict,
+        byte[] data,
+        Dictionary<int, PdfIndirectObject>? objects = null,
+        int maxOutputBytes = PdfReadLimits.DefaultMaxDecodedStreamBytes) {
+        if (maxOutputBytes <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(maxOutputBytes), maxOutputBytes, "Maximum decoded stream bytes must be positive.");
+        }
+
+        if (TryDecodeCore(dict, data, maxOutputBytes, out byte[] decoded, out PdfReadLimitException? limitException, objects)) {
+            return decoded;
+        }
+
+        if (limitException is not null) {
+            throw limitException;
+        }
+
+        throw new InvalidDataException("PDF stream could not be decoded using its declared filters.");
+    }
+
+    private static bool TryDecodeCore(
+        PdfDictionary dict,
+        byte[] data,
+        int maxOutputBytes,
+        out byte[] decoded,
+        out PdfReadLimitException? limitException,
+        Dictionary<int, PdfIndirectObject>? objects) {
         decoded = Array.Empty<byte>();
+        limitException = null;
         if (maxOutputBytes < 0) {
             return false;
         }
 
-        if (data == null || data.Length == 0 || !dict.Items.TryGetValue("Filter", out var filterObj)) {
-            return TryUseOriginal(data ?? Array.Empty<byte>(), maxOutputBytes, out decoded);
+        if (data == null || !dict.Items.TryGetValue("Filter", out var filterObj)) {
+            byte[] original = data ?? Array.Empty<byte>();
+            if (!TryUseOriginal(original, maxOutputBytes, out decoded)) {
+                limitException = CreateDecodedLimitException(maxOutputBytes, original.LongLength);
+                return false;
+            }
+
+            return true;
+        }
+
+        if (!TryGetFilterNames(filterObj, objects, out List<string> filterNames) ||
+            !HasValidDecodeParmsDeclaration(dict, filterNames.Count, objects)) {
+            return false;
         }
 
         byte[] current = data;
-        int filterIndex = 0;
-        foreach (string filterName in EnumerateFilters(filterObj, objects)) {
+        for (int filterIndex = 0; filterIndex < filterNames.Count; filterIndex++) {
+            string filterName = filterNames[filterIndex];
             try {
                 switch (GetFilterKind(filterName)) {
                     case DecodeFilterKind.Flate:
-                        if (HasActiveDecodeParms(dict, filterIndex, objects)) {
+                        if (!FlateDecoder.TryDecode(current, maxOutputBytes, out current, out bool flateLimitExceeded)) {
+                            if (flateLimitExceeded) {
+                                limitException = CreateDecodedLimitException(maxOutputBytes, (long)maxOutputBytes + 1L);
+                            }
+
                             return false;
                         }
 
-                        if (!FlateDecoder.TryDecode(current, maxOutputBytes, out current)) {
-                            return false;
-                        }
-
+                        current = ApplyDecodeParms(dict, filterIndex, current, objects, maxOutputBytes);
                         break;
                     case DecodeFilterKind.AsciiHex:
                         if (HasActiveDecodeParms(dict, filterIndex, objects)) {
@@ -116,6 +162,7 @@ internal static class StreamDecoder {
                         }
 
                         if (!AsciiHexDecoder.TryDecode(current, maxOutputBytes, out current)) {
+                            limitException = CreateDecodedLimitException(maxOutputBytes, (long)maxOutputBytes + 1L);
                             return false;
                         }
 
@@ -126,18 +173,21 @@ internal static class StreamDecoder {
                         }
 
                         if (!Ascii85Decoder.TryDecode(current, maxOutputBytes, out current)) {
+                            limitException = CreateDecodedLimitException(maxOutputBytes, (long)maxOutputBytes + 1L);
                             return false;
                         }
 
                         break;
                     case DecodeFilterKind.RunLength:
                         if (!RunLengthDecoder.TryDecode(current, maxOutputBytes, out current)) {
+                            limitException = CreateDecodedLimitException(maxOutputBytes, (long)maxOutputBytes + 1L);
                             return false;
                         }
 
                         break;
                     case DecodeFilterKind.Lzw:
                         if (!LzwDecoder.TryDecode(current, maxOutputBytes, out current, GetEarlyChange(dict, filterIndex, objects))) {
+                            limitException = CreateDecodedLimitException(maxOutputBytes, (long)maxOutputBytes + 1L);
                             return false;
                         }
 
@@ -147,11 +197,17 @@ internal static class StreamDecoder {
                     default:
                         return false;
                 }
+            } catch (PdfReadLimitException ex) {
+                limitException = ex;
+                return false;
             } catch {
                 return false;
             }
 
-            filterIndex++;
+            if (current.LongLength > maxOutputBytes) {
+                limitException = CreateDecodedLimitException(maxOutputBytes, current.LongLength);
+                return false;
+            }
         }
 
         decoded = current;
@@ -163,8 +219,12 @@ internal static class StreamDecoder {
             return new List<string>(0);
         }
 
+        if (!TryGetFilterNames(filterObj, objects, out List<string> filterNames)) {
+            return new List<string> { "MalformedFilterDeclaration" };
+        }
+
         var unsupported = new List<string>();
-        foreach (string filterName in EnumerateFilters(filterObj, objects)) {
+        foreach (string filterName in filterNames) {
             if (!IsSupportedFilter(filterName) && !ContainsFilter(unsupported, filterName)) {
                 unsupported.Add(filterName);
             }
@@ -243,7 +303,7 @@ internal static class StreamDecoder {
             return false;
         }
 
-        int predictor = (int)(decodeParms.Get<PdfNumber>("Predictor")?.Value ?? 1);
+        int predictor = ReadIntegerParameter(decodeParms, "Predictor", 1);
         return predictor > 1;
     }
 
@@ -258,20 +318,24 @@ internal static class StreamDecoder {
             return data;
         }
 
-        int predictor = (int)(decodeParms.Get<PdfNumber>("Predictor")?.Value ?? 1);
-        if (predictor <= 1) {
+        int predictor = ReadIntegerParameter(decodeParms, "Predictor", 1);
+        if (predictor == 1) {
             return data;
         }
 
-        int columns = (int)(decodeParms.Get<PdfNumber>("Columns")?.Value ?? 1);
-        int colors = (int)(decodeParms.Get<PdfNumber>("Colors")?.Value ?? 1);
-        int bitsPerComponent = (int)(decodeParms.Get<PdfNumber>("BitsPerComponent")?.Value ?? 8);
+        if (predictor != 2 && (predictor < 10 || predictor > 15)) {
+            throw new FormatException($"Unsupported PDF predictor value '{predictor}'.");
+        }
+
+        int columns = ReadPositiveIntegerParameter(decodeParms, "Columns", 1);
+        int colors = ReadPositiveIntegerParameter(decodeParms, "Colors", 1);
+        int bitsPerComponent = ReadIntegerParameter(decodeParms, "BitsPerComponent", 8);
+        if (bitsPerComponent != 1 && bitsPerComponent != 2 && bitsPerComponent != 4 && bitsPerComponent != 8 && bitsPerComponent != 16) {
+            throw new FormatException($"Unsupported PDF predictor bit depth '{bitsPerComponent}'.");
+        }
+
         if (predictor == 2) {
             return TiffPredictorDecoder.Decode(data, columns, colors, bitsPerComponent, maxOutputBytes);
-        }
-
-        if (predictor < 10) {
-            return data;
         }
 
         return PngPredictorDecoder.Decode(data, columns, colors, bitsPerComponent, maxOutputBytes);
@@ -283,7 +347,12 @@ internal static class StreamDecoder {
             return 1;
         }
 
-        return (int)(decodeParms.Get<PdfNumber>("EarlyChange")?.Value ?? 1);
+        int earlyChange = ReadIntegerParameter(decodeParms, "EarlyChange", 1);
+        if (earlyChange != 0 && earlyChange != 1) {
+            throw new FormatException($"Unsupported LZW EarlyChange value '{earlyChange}'.");
+        }
+
+        return earlyChange;
     }
 
     private static PdfDictionary? GetDecodeParms(PdfDictionary dict, int filterIndex, Dictionary<int, PdfIndirectObject>? objects) {
@@ -326,18 +395,86 @@ internal static class StreamDecoder {
         return obj;
     }
 
-    private static IEnumerable<string> EnumerateFilters(PdfObject filterObj, Dictionary<int, PdfIndirectObject>? objects) {
-        if (ResolveObject(filterObj, objects) is PdfName filterName) {
-            yield return filterName.Name;
-            yield break;
+    private static bool HasValidDecodeParmsDeclaration(
+        PdfDictionary dict,
+        int filterCount,
+        Dictionary<int, PdfIndirectObject>? objects) {
+        if (!dict.Items.TryGetValue("DecodeParms", out PdfObject? decodeParmsObject)) {
+            return true;
         }
 
-        if (ResolveObject(filterObj, objects) is PdfArray filterArray) {
-            foreach (var item in filterArray.Items) {
-                if (ResolveObject(item, objects) is PdfName arrayFilterName) {
-                    yield return arrayFilterName.Name;
-                }
+        PdfObject? resolved = ResolveObject(decodeParmsObject, objects);
+        if (resolved is PdfNull) {
+            return true;
+        }
+        if (resolved is PdfDictionary) {
+            return filterCount == 1;
+        }
+
+        if (resolved is not PdfArray decodeParmsArray || decodeParmsArray.Items.Count != filterCount) {
+            return false;
+        }
+
+        foreach (PdfObject item in decodeParmsArray.Items) {
+            PdfObject? entry = ResolveObject(item, objects);
+            if (entry is not PdfNull && entry is not PdfDictionary) {
+                return false;
             }
         }
+
+        return true;
+    }
+
+    private static bool TryGetFilterNames(
+        PdfObject filterObject,
+        Dictionary<int, PdfIndirectObject>? objects,
+        out List<string> filterNames) {
+        filterNames = new List<string>();
+        PdfObject? resolved = ResolveObject(filterObject, objects);
+        if (resolved is PdfName filterName) {
+            filterNames.Add(filterName.Name);
+            return true;
+        }
+
+        if (resolved is not PdfArray filterArray || filterArray.Items.Count == 0) {
+            return false;
+        }
+
+        foreach (PdfObject item in filterArray.Items) {
+            if (ResolveObject(item, objects) is not PdfName arrayFilterName) {
+                filterNames.Clear();
+                return false;
+            }
+
+            filterNames.Add(arrayFilterName.Name);
+        }
+
+        return true;
+    }
+
+    private static int ReadPositiveIntegerParameter(PdfDictionary dictionary, string name, int defaultValue) {
+        int value = ReadIntegerParameter(dictionary, name, defaultValue);
+        if (value <= 0) {
+            throw new FormatException($"PDF decode parameter '{name}' must be positive.");
+        }
+
+        return value;
+    }
+
+    private static int ReadIntegerParameter(PdfDictionary dictionary, string name, int defaultValue) {
+        if (!dictionary.Items.TryGetValue(name, out PdfObject? parameter)) {
+            return defaultValue;
+        }
+
+        if (parameter is not PdfNumber number ||
+            double.IsNaN(number.Value) ||
+            double.IsInfinity(number.Value) ||
+            number.Value != Math.Truncate(number.Value) ||
+            number.Value < int.MinValue ||
+            number.Value > int.MaxValue) {
+            throw new FormatException($"PDF decode parameter '{name}' must be an integer.");
+        }
+
+        return (int)number.Value;
     }
 }

--- a/OfficeIMO.Pdf/Reading/Filters/StreamDecoder.cs
+++ b/OfficeIMO.Pdf/Reading/Filters/StreamDecoder.cs
@@ -312,7 +312,7 @@ internal static class StreamDecoder {
             return false;
         }
 
-        int predictor = ReadIntegerParameter(decodeParms, "Predictor", 1);
+        int predictor = ReadIntegerParameter(decodeParms, "Predictor", 1, objects);
         return predictor > 1;
     }
 
@@ -327,7 +327,7 @@ internal static class StreamDecoder {
             return data;
         }
 
-        int predictor = ReadIntegerParameter(decodeParms, "Predictor", 1);
+        int predictor = ReadIntegerParameter(decodeParms, "Predictor", 1, objects);
         if (predictor == 1) {
             return data;
         }
@@ -336,9 +336,9 @@ internal static class StreamDecoder {
             throw new FormatException($"Unsupported PDF predictor value '{predictor}'.");
         }
 
-        int columns = ReadPositiveIntegerParameter(decodeParms, "Columns", 1);
-        int colors = ReadPositiveIntegerParameter(decodeParms, "Colors", 1);
-        int bitsPerComponent = ReadIntegerParameter(decodeParms, "BitsPerComponent", 8);
+        int columns = ReadPositiveIntegerParameter(decodeParms, "Columns", 1, objects);
+        int colors = ReadPositiveIntegerParameter(decodeParms, "Colors", 1, objects);
+        int bitsPerComponent = ReadIntegerParameter(decodeParms, "BitsPerComponent", 8, objects);
         if (bitsPerComponent != 1 && bitsPerComponent != 2 && bitsPerComponent != 4 && bitsPerComponent != 8 && bitsPerComponent != 16) {
             throw new FormatException($"Unsupported PDF predictor bit depth '{bitsPerComponent}'.");
         }
@@ -356,7 +356,7 @@ internal static class StreamDecoder {
             return 1;
         }
 
-        int earlyChange = ReadIntegerParameter(decodeParms, "EarlyChange", 1);
+        int earlyChange = ReadIntegerParameter(decodeParms, "EarlyChange", 1, objects);
         if (earlyChange != 0 && earlyChange != 1) {
             throw new FormatException($"Unsupported LZW EarlyChange value '{earlyChange}'.");
         }
@@ -394,11 +394,19 @@ internal static class StreamDecoder {
     }
 
     private static PdfObject? ResolveObject(PdfObject? obj, Dictionary<int, PdfIndirectObject>? objects) {
-        if (obj is PdfReference reference &&
-            objects is not null &&
-            PdfObjectLookup.TryGet(objects, reference, out var indirect) &&
-            indirect.Value is PdfObject resolvedObject) {
-            return resolvedObject;
+        if (objects is null) {
+            return obj;
+        }
+
+        HashSet<(int ObjectNumber, int Generation)>? visited = null;
+        while (obj is PdfReference reference) {
+            visited ??= new HashSet<(int ObjectNumber, int Generation)>();
+            if (!visited.Add((reference.ObjectNumber, reference.Generation)) ||
+                !PdfObjectLookup.TryGet(objects, reference, out PdfIndirectObject? indirect)) {
+                return obj;
+            }
+
+            obj = indirect.Value;
         }
 
         return obj;
@@ -469,8 +477,12 @@ internal static class StreamDecoder {
         return true;
     }
 
-    private static int ReadPositiveIntegerParameter(PdfDictionary dictionary, string name, int defaultValue) {
-        int value = ReadIntegerParameter(dictionary, name, defaultValue);
+    private static int ReadPositiveIntegerParameter(
+        PdfDictionary dictionary,
+        string name,
+        int defaultValue,
+        Dictionary<int, PdfIndirectObject>? objects) {
+        int value = ReadIntegerParameter(dictionary, name, defaultValue, objects);
         if (value <= 0) {
             throw new FormatException($"PDF decode parameter '{name}' must be positive.");
         }
@@ -478,12 +490,16 @@ internal static class StreamDecoder {
         return value;
     }
 
-    private static int ReadIntegerParameter(PdfDictionary dictionary, string name, int defaultValue) {
+    private static int ReadIntegerParameter(
+        PdfDictionary dictionary,
+        string name,
+        int defaultValue,
+        Dictionary<int, PdfIndirectObject>? objects) {
         if (!dictionary.Items.TryGetValue(name, out PdfObject? parameter)) {
             return defaultValue;
         }
 
-        if (parameter is not PdfNumber number ||
+        if (ResolveObject(parameter, objects) is not PdfNumber number ||
             double.IsNaN(number.Value) ||
             double.IsInfinity(number.Value) ||
             number.Value != Math.Truncate(number.Value) ||

--- a/OfficeIMO.Pdf/Reading/Filters/StreamDecoder.cs
+++ b/OfficeIMO.Pdf/Reading/Filters/StreamDecoder.cs
@@ -399,6 +399,10 @@ internal static class StreamDecoder {
         PdfDictionary dict,
         int filterCount,
         Dictionary<int, PdfIndirectObject>? objects) {
+        if (filterCount == 0) {
+            return true;
+        }
+
         if (!dict.Items.TryGetValue("DecodeParms", out PdfObject? decodeParmsObject)) {
             return true;
         }
@@ -431,6 +435,10 @@ internal static class StreamDecoder {
         out List<string> filterNames) {
         filterNames = new List<string>();
         PdfObject? resolved = ResolveObject(filterObject, objects);
+        if (resolved is PdfNull) {
+            return true;
+        }
+
         if (resolved is PdfName filterName) {
             filterNames.Add(filterName.Name);
             return true;

--- a/OfficeIMO.Pdf/Reading/Filters/StreamDecoder.cs
+++ b/OfficeIMO.Pdf/Reading/Filters/StreamDecoder.cs
@@ -28,7 +28,9 @@ internal static class StreamDecoder {
             return originalData;
         }
 
-        if (!TryGetFilterNames(filterObj, objects, out List<string> filterNames)) {
+        if (!TryGetFilterNames(filterObj, objects, out List<string> filterNames) ||
+            !HasValidDecodeParmsDeclaration(dict, filterNames.Count, objects) ||
+            !HasValidDecodeParmsForFilters(dict, filterNames, objects)) {
             return ReturnWithinDecodedLimit(data, maxOutputBytes);
         }
 
@@ -39,7 +41,8 @@ internal static class StreamDecoder {
             try {
                 switch (GetFilterKind(filterName)) {
                     case DecodeFilterKind.Flate:
-                        if (!FlateDecoder.TryDecode(current, maxOutputBytes, out current, out bool flateLimitExceeded)) {
+                        int flateOutputLimit = GetFilterOutputLimit(dict, filterIndex, objects, maxOutputBytes);
+                        if (!FlateDecoder.TryDecode(current, flateOutputLimit, out current, out bool flateLimitExceeded)) {
                             if (flateLimitExceeded) {
                                 throw CreateDecodedLimitException(maxOutputBytes, (long)maxOutputBytes + 1L);
                             }
@@ -68,7 +71,8 @@ internal static class StreamDecoder {
 
                         break;
                     case DecodeFilterKind.Lzw:
-                        if (!LzwDecoder.TryDecode(current, maxOutputBytes, out current, GetEarlyChange(dict, filterIndex, objects))) {
+                        int lzwOutputLimit = GetFilterOutputLimit(dict, filterIndex, objects, maxOutputBytes);
+                        if (!LzwDecoder.TryDecode(current, lzwOutputLimit, out current, GetEarlyChange(dict, filterIndex, objects))) {
                             throw CreateDecodedLimitException(maxOutputBytes, (long)maxOutputBytes + 1L);
                         }
 
@@ -136,7 +140,8 @@ internal static class StreamDecoder {
         }
 
         if (!TryGetFilterNames(filterObj, objects, out List<string> filterNames) ||
-            !HasValidDecodeParmsDeclaration(dict, filterNames.Count, objects)) {
+            !HasValidDecodeParmsDeclaration(dict, filterNames.Count, objects) ||
+            !HasValidDecodeParmsForFilters(dict, filterNames, objects)) {
             return false;
         }
 
@@ -155,7 +160,8 @@ internal static class StreamDecoder {
             try {
                 switch (GetFilterKind(filterName)) {
                     case DecodeFilterKind.Flate:
-                        if (!FlateDecoder.TryDecode(current, maxOutputBytes, out current, out bool flateLimitExceeded)) {
+                        int flateOutputLimit = GetFilterOutputLimit(dict, filterIndex, objects, maxOutputBytes);
+                        if (!FlateDecoder.TryDecode(current, flateOutputLimit, out current, out bool flateLimitExceeded)) {
                             if (flateLimitExceeded) {
                                 limitException = CreateDecodedLimitException(maxOutputBytes, (long)maxOutputBytes + 1L);
                             }
@@ -166,10 +172,6 @@ internal static class StreamDecoder {
                         current = ApplyDecodeParms(dict, filterIndex, current, objects, maxOutputBytes);
                         break;
                     case DecodeFilterKind.AsciiHex:
-                        if (HasActiveDecodeParms(dict, filterIndex, objects)) {
-                            return false;
-                        }
-
                         if (!AsciiHexDecoder.TryDecode(current, maxOutputBytes, out current)) {
                             limitException = CreateDecodedLimitException(maxOutputBytes, (long)maxOutputBytes + 1L);
                             return false;
@@ -177,10 +179,6 @@ internal static class StreamDecoder {
 
                         break;
                     case DecodeFilterKind.Ascii85:
-                        if (HasActiveDecodeParms(dict, filterIndex, objects)) {
-                            return false;
-                        }
-
                         if (!Ascii85Decoder.TryDecode(current, maxOutputBytes, out current)) {
                             limitException = CreateDecodedLimitException(maxOutputBytes, (long)maxOutputBytes + 1L);
                             return false;
@@ -195,7 +193,8 @@ internal static class StreamDecoder {
 
                         break;
                     case DecodeFilterKind.Lzw:
-                        if (!LzwDecoder.TryDecode(current, maxOutputBytes, out current, GetEarlyChange(dict, filterIndex, objects))) {
+                        int lzwOutputLimit = GetFilterOutputLimit(dict, filterIndex, objects, maxOutputBytes);
+                        if (!LzwDecoder.TryDecode(current, lzwOutputLimit, out current, GetEarlyChange(dict, filterIndex, objects))) {
                             limitException = CreateDecodedLimitException(maxOutputBytes, (long)maxOutputBytes + 1L);
                             return false;
                         }
@@ -306,16 +305,6 @@ internal static class StreamDecoder {
         return data;
     }
 
-    private static bool HasActiveDecodeParms(PdfDictionary dict, int filterIndex, Dictionary<int, PdfIndirectObject>? objects) {
-        var decodeParms = GetDecodeParms(dict, filterIndex, objects);
-        if (decodeParms is null) {
-            return false;
-        }
-
-        int predictor = ReadIntegerParameter(decodeParms, "Predictor", 1, objects);
-        return predictor > 1;
-    }
-
     private static byte[] ApplyDecodeParms(
         PdfDictionary dict,
         int filterIndex,
@@ -348,6 +337,35 @@ internal static class StreamDecoder {
         }
 
         return PngPredictorDecoder.Decode(data, columns, colors, bitsPerComponent, maxOutputBytes);
+    }
+
+    private static int GetFilterOutputLimit(
+        PdfDictionary dict,
+        int filterIndex,
+        Dictionary<int, PdfIndirectObject>? objects,
+        int maxOutputBytes) {
+        PdfDictionary? decodeParms = GetDecodeParms(dict, filterIndex, objects);
+        if (decodeParms is null) {
+            return maxOutputBytes;
+        }
+
+        int predictor = ReadIntegerParameter(decodeParms, "Predictor", 1, objects);
+        if (predictor < 10 || predictor > 15) {
+            return maxOutputBytes;
+        }
+
+        int columns = ReadPositiveIntegerParameter(decodeParms, "Columns", 1, objects);
+        int colors = ReadPositiveIntegerParameter(decodeParms, "Colors", 1, objects);
+        int bitsPerComponent = ReadIntegerParameter(decodeParms, "BitsPerComponent", 8, objects);
+        long rowBits = checked((long)columns * colors * bitsPerComponent);
+        long rowBytes = (rowBits + 7L) / 8L;
+        if (rowBytes <= 0L) {
+            return maxOutputBytes;
+        }
+
+        long rowCount = maxOutputBytes / rowBytes;
+        long predictorInputLimit = checked(rowCount * (rowBytes + 1L));
+        return predictorInputLimit >= int.MaxValue ? int.MaxValue : (int)predictorInputLimit;
     }
 
     private static int GetEarlyChange(PdfDictionary dict, int filterIndex, Dictionary<int, PdfIndirectObject>? objects) {
@@ -444,6 +462,58 @@ internal static class StreamDecoder {
         }
 
         return true;
+    }
+
+    private static bool HasValidDecodeParmsForFilters(
+        PdfDictionary dict,
+        List<string> filterNames,
+        Dictionary<int, PdfIndirectObject>? objects) {
+        try {
+            for (int filterIndex = 0; filterIndex < filterNames.Count; filterIndex++) {
+                PdfDictionary? decodeParms = GetDecodeParms(dict, filterIndex, objects);
+                if (decodeParms is null) {
+                    continue;
+                }
+
+                DecodeFilterKind filterKind = GetFilterKind(filterNames[filterIndex]);
+                if (filterKind != DecodeFilterKind.Flate && filterKind != DecodeFilterKind.Lzw) {
+                    if (decodeParms.Items.Count != 0) {
+                        return false;
+                    }
+
+                    continue;
+                }
+
+                int predictor = ReadIntegerParameter(decodeParms, "Predictor", 1, objects);
+                if (predictor != 1 && predictor != 2 && (predictor < 10 || predictor > 15)) {
+                    return false;
+                }
+
+                _ = ReadPositiveIntegerParameter(decodeParms, "Columns", 1, objects);
+                _ = ReadPositiveIntegerParameter(decodeParms, "Colors", 1, objects);
+                int bitsPerComponent = ReadIntegerParameter(decodeParms, "BitsPerComponent", 8, objects);
+                if (bitsPerComponent != 1 && bitsPerComponent != 2 && bitsPerComponent != 4 && bitsPerComponent != 8 && bitsPerComponent != 16) {
+                    return false;
+                }
+
+                if (filterKind == DecodeFilterKind.Flate) {
+                    if (decodeParms.Items.ContainsKey("EarlyChange")) {
+                        return false;
+                    }
+
+                    continue;
+                }
+
+                int earlyChange = ReadIntegerParameter(decodeParms, "EarlyChange", 1, objects);
+                if (earlyChange != 0 && earlyChange != 1) {
+                    return false;
+                }
+            }
+
+            return true;
+        } catch {
+            return false;
+        }
     }
 
     private static bool TryGetFilterNames(

--- a/OfficeIMO.Pdf/Reading/Filters/TiffPredictorDecoder.cs
+++ b/OfficeIMO.Pdf/Reading/Filters/TiffPredictorDecoder.cs
@@ -13,33 +13,104 @@ internal static class TiffPredictorDecoder {
             throw CreateDecodedLimitException(maxOutputBytes, data.LongLength);
         }
 
-        colors = Math.Max(1, colors);
-        columns = Math.Max(1, columns);
-        bitsPerComponent = Math.Max(1, bitsPerComponent);
-
-        if (bitsPerComponent != 8) {
-            return data;
+        if (colors <= 0 || columns <= 0) {
+            throw new FormatException("TIFF predictor colors and columns must be positive.");
+        }
+        if (bitsPerComponent != 1 && bitsPerComponent != 2 && bitsPerComponent != 4 && bitsPerComponent != 8 && bitsPerComponent != 16) {
+            throw new FormatException($"Unsupported TIFF predictor bit depth '{bitsPerComponent}'.");
         }
 
-        long rowLengthValue = (long)columns * colors;
+        long samplesPerRow;
+        long rowBits;
+        try {
+            samplesPerRow = checked((long)columns * colors);
+            rowBits = checked(samplesPerRow * bitsPerComponent);
+        } catch (OverflowException) {
+            throw CreateDecodedLimitException(maxOutputBytes, (long)maxOutputBytes + 1L);
+        }
+
+        long rowLengthValue = (rowBits + 7L) / 8L;
         if (rowLengthValue <= 0L || rowLengthValue > maxOutputBytes) {
+            throw CreateDecodedLimitException(maxOutputBytes, Math.Max(rowLengthValue, (long)maxOutputBytes + 1L));
+        }
+        if (samplesPerRow > int.MaxValue) {
             throw CreateDecodedLimitException(maxOutputBytes, Math.Max(rowLengthValue, (long)maxOutputBytes + 1L));
         }
 
         int rowLength = (int)rowLengthValue;
         if (data.Length % rowLength != 0) {
-            return data;
+            throw new FormatException("TIFF predictor data contains an incomplete row.");
         }
 
-        var output = new byte[data.Length];
+        var output = (byte[])data.Clone();
+        int sampleCount = checked((int)samplesPerRow);
+        int sampleMask = bitsPerComponent == 16 ? ushort.MaxValue : (1 << bitsPerComponent) - 1;
         for (int rowOffset = 0; rowOffset < data.Length; rowOffset += rowLength) {
-            for (int i = 0; i < rowLength; i++) {
-                int left = i >= colors ? output[rowOffset + i - colors] : 0;
-                output[rowOffset + i] = unchecked((byte)(data[rowOffset + i] + left));
+            if (bitsPerComponent == 8) {
+                DecodeEightBitRow(data, output, rowOffset, rowLength, colors);
+                continue;
+            }
+            if (bitsPerComponent == 16) {
+                DecodeSixteenBitRow(data, output, rowOffset, sampleCount, colors);
+                continue;
+            }
+
+            for (int sampleIndex = 0; sampleIndex < sampleCount; sampleIndex++) {
+                int encoded = ReadSample(data, rowOffset, sampleIndex, bitsPerComponent);
+                int left = sampleIndex >= colors
+                    ? ReadSample(output, rowOffset, sampleIndex - colors, bitsPerComponent)
+                    : 0;
+                WriteSample(output, rowOffset, sampleIndex, bitsPerComponent, (encoded + left) & sampleMask);
             }
         }
 
         return output;
+    }
+
+    private static void DecodeEightBitRow(byte[] input, byte[] output, int rowOffset, int rowLength, int colors) {
+        for (int index = 0; index < rowLength; index++) {
+            int left = index >= colors ? output[rowOffset + index - colors] : 0;
+            output[rowOffset + index] = unchecked((byte)(input[rowOffset + index] + left));
+        }
+    }
+
+    private static void DecodeSixteenBitRow(byte[] input, byte[] output, int rowOffset, int sampleCount, int colors) {
+        for (int sampleIndex = 0; sampleIndex < sampleCount; sampleIndex++) {
+            int byteOffset = rowOffset + (sampleIndex * 2);
+            int encoded = (input[byteOffset] << 8) | input[byteOffset + 1];
+            int left = 0;
+            if (sampleIndex >= colors) {
+                int leftOffset = rowOffset + ((sampleIndex - colors) * 2);
+                left = (output[leftOffset] << 8) | output[leftOffset + 1];
+            }
+
+            int decoded = (encoded + left) & ushort.MaxValue;
+            output[byteOffset] = (byte)(decoded >> 8);
+            output[byteOffset + 1] = (byte)decoded;
+        }
+    }
+
+    private static int ReadSample(byte[] data, int rowOffset, int sampleIndex, int bitsPerComponent) {
+        long bitOffset = (long)sampleIndex * bitsPerComponent;
+        int value = 0;
+        for (int bit = 0; bit < bitsPerComponent; bit++) {
+            long absoluteBit = bitOffset + bit;
+            int source = data[rowOffset + (int)(absoluteBit / 8L)];
+            value = (value << 1) | ((source >> (7 - (int)(absoluteBit % 8L))) & 1);
+        }
+
+        return value;
+    }
+
+    private static void WriteSample(byte[] data, int rowOffset, int sampleIndex, int bitsPerComponent, int value) {
+        long bitOffset = (long)sampleIndex * bitsPerComponent;
+        for (int bit = 0; bit < bitsPerComponent; bit++) {
+            long absoluteBit = bitOffset + bit;
+            int byteIndex = rowOffset + (int)(absoluteBit / 8L);
+            int mask = 1 << (7 - (int)(absoluteBit % 8L));
+            int sourceMask = 1 << (bitsPerComponent - bit - 1);
+            data[byteIndex] = (byte)((data[byteIndex] & ~mask) | ((value & sourceMask) != 0 ? mask : 0));
+        }
     }
 
     private static PdfReadLimitException CreateDecodedLimitException(int maximum, long actual) =>

--- a/OfficeIMO.Pdf/Reading/Ocr/PdfOcr.cs
+++ b/OfficeIMO.Pdf/Reading/Ocr/PdfOcr.cs
@@ -37,17 +37,19 @@ internal static class PdfOcr {
             cancellationToken.ThrowIfCancellationRequested();
             PdfPageRenderResult render = rendered[i];
             PdfLogicalPage nativePage = logical.Pages.First(page => page.PageNumber == render.PageNumber);
+            PdfReadPage readPage = readDocument.Pages[render.PageNumber - 1];
+            (double visualWidth, double visualHeight) = readPage.GetInteractionPageSize();
             double scale = effectiveOptions.Dpi / 72D;
-            var request = new PdfOcrRequest(render.PageNumber, render.Bytes!, render.Width, render.Height, nativePage.Width, nativePage.Height, scale);
+            var request = new PdfOcrRequest(render.PageNumber, render.Bytes!, render.Width, render.Height, visualWidth, visualHeight, scale);
             PdfOcrResponse response = await provider.RecognizeAsync(request, cancellationToken).ConfigureAwait(false)
                 ?? throw new InvalidOperationException("OCR provider returned a null response.");
-            pages.Add(MergePage(nativePage, response, request, effectiveOptions, cancellationToken));
+            pages.Add(MergePage(nativePage, readPage, response, request, effectiveOptions, cancellationToken));
         }
 
         return new PdfOcrMergeResult(logical, pages.AsReadOnly());
     }
 
-    private static PdfOcrPageMergeResult MergePage(PdfLogicalPage nativePage, PdfOcrResponse response, PdfOcrRequest request, PdfOcrMergeOptions options, CancellationToken cancellationToken) {
+    private static PdfOcrPageMergeResult MergePage(PdfLogicalPage nativePage, PdfReadPage readPage, PdfOcrResponse response, PdfOcrRequest request, PdfOcrMergeOptions options, CancellationToken cancellationToken) {
         ValidateProviderResponse(nativePage, response, options);
         var diagnostics = new List<string>(response.Diagnostics);
         var accepted = new List<PdfRecognizedWord>();
@@ -71,7 +73,7 @@ internal static class PdfOcr {
             if (OverlapsNativeText(
                     normalized,
                     nativePage.TextBlocks,
-                    nativePage.Height,
+                    readPage,
                     options.NativeTextOverlapThreshold,
                     options.MaxNativeTextOverlapComparisonsPerPage,
                     ref overlapComparisons,
@@ -87,7 +89,7 @@ internal static class PdfOcr {
             int y = left.Y.CompareTo(right.Y);
             return y != 0 ? y : left.X.CompareTo(right.X);
         });
-        string text = BuildMergedText(nativePage, accepted, options.MaxMergedTextCharactersPerPage);
+        string text = BuildMergedText(nativePage, readPage, accepted, options.MaxMergedTextCharactersPerPage);
         return new PdfOcrPageMergeResult(nativePage.PageNumber, accepted.AsReadOnly(), lowConfidence, nativeOverlap, diagnostics.AsReadOnly(), text);
     }
 
@@ -99,7 +101,7 @@ internal static class PdfOcr {
     private static bool OverlapsNativeText(
         PdfRecognizedWord word,
         IReadOnlyList<PdfLogicalTextBlock> blocks,
-        double pageHeight,
+        PdfReadPage readPage,
         double threshold,
         long maximumComparisons,
         ref long comparisons,
@@ -113,20 +115,30 @@ internal static class PdfOcr {
             if ((i & 255) == 0) cancellationToken.ThrowIfCancellationRequested();
             PdfLogicalTextBlock block = blocks[i];
             double blockHeight = Math.Max(block.FontSize * 1.2D, 1D);
-            double blockTop = pageHeight - block.BaselineY - blockHeight;
-            double overlapWidth = Math.Max(0D, Math.Min(word.X + word.Width, block.XEnd) - Math.Max(word.X, block.XStart));
-            double overlapHeight = Math.Max(0D, Math.Min(word.Y + word.Height, blockTop + blockHeight) - Math.Max(word.Y, blockTop));
+            PdfVisualBounds bounds = readPage.TransformBoundsToVisual(
+                Math.Min(block.XStart, block.XEnd),
+                block.BaselineY,
+                Math.Max(block.XStart, block.XEnd),
+                block.BaselineY + blockHeight);
+            double overlapWidth = Math.Max(0D, Math.Min(word.X + word.Width, bounds.Right) - Math.Max(word.X, bounds.Left));
+            double overlapHeight = Math.Max(0D, Math.Min(word.Y + word.Height, bounds.Bottom) - Math.Max(word.Y, bounds.Top));
             if ((overlapWidth * overlapHeight) / wordArea >= threshold) return true;
         }
 
         return false;
     }
 
-    private static string BuildMergedText(PdfLogicalPage page, List<PdfRecognizedWord> words, int maximumCharacters) {
+    private static string BuildMergedText(PdfLogicalPage page, PdfReadPage readPage, List<PdfRecognizedWord> words, int maximumCharacters) {
         var items = new List<(double Y, double X, string Text)>(page.TextBlocks.Count + words.Count);
         for (int i = 0; i < page.TextBlocks.Count; i++) {
             PdfLogicalTextBlock block = page.TextBlocks[i];
-            items.Add((page.Height - block.BaselineY - block.FontSize, block.XStart, block.Text));
+            double blockHeight = Math.Max(block.FontSize, 1D);
+            PdfVisualBounds bounds = readPage.TransformBoundsToVisual(
+                Math.Min(block.XStart, block.XEnd),
+                block.BaselineY,
+                Math.Max(block.XStart, block.XEnd),
+                block.BaselineY + blockHeight);
+            items.Add((bounds.Top, bounds.Left, block.Text));
         }
 
         for (int i = 0; i < words.Count; i++) items.Add((words[i].Y, words[i].X, words[i].Text));

--- a/OfficeIMO.Pdf/Reading/Ocr/PdfOcrContracts.cs
+++ b/OfficeIMO.Pdf/Reading/Ocr/PdfOcrContracts.cs
@@ -25,9 +25,9 @@ public sealed class PdfOcrRequest {
     public int PixelWidth { get; }
     /// <summary>Rendered pixel height.</summary>
     public int PixelHeight { get; }
-    /// <summary>Page width in PDF points.</summary>
+    /// <summary>Rendered visual page width in PDF points after crop and page rotation.</summary>
     public double PageWidth { get; }
-    /// <summary>Page height in PDF points.</summary>
+    /// <summary>Rendered visual page height in PDF points after crop and page rotation.</summary>
     public double PageHeight { get; }
     /// <summary>Pixels per PDF point.</summary>
     public double Scale { get; }

--- a/OfficeIMO.Pdf/Reading/Ocr/PdfOcrMergeResult.cs
+++ b/OfficeIMO.Pdf/Reading/Ocr/PdfOcrMergeResult.cs
@@ -33,16 +33,16 @@ public sealed class PdfOcrPageMergeResult {
     public string Text { get; }
 }
 
-/// <summary>OCR word normalized to top-left PDF-point coordinates.</summary>
+/// <summary>OCR word normalized to top-left visual PDF-point coordinates after crop and page rotation.</summary>
 public sealed class PdfRecognizedWord {
     internal PdfRecognizedWord(string text, double x, double y, double width, double height, double confidence) {
         Text = text; X = x; Y = y; Width = width; Height = height; Confidence = confidence;
     }
     /// <summary>Recognized text.</summary>
     public string Text { get; }
-    /// <summary>Left coordinate in PDF points.</summary>
+    /// <summary>Left coordinate in visual PDF points.</summary>
     public double X { get; }
-    /// <summary>Top coordinate in PDF points.</summary>
+    /// <summary>Top coordinate in visual PDF points.</summary>
     public double Y { get; }
     /// <summary>Width in PDF points.</summary>
     public double Width { get; }


### PR DESCRIPTION
## What changed

- makes declared page-content decoding fail closed when filters, filter arrays, decode parameters, or predictor data are malformed
- validates decode parameters against their selected filter and budgets PNG predictor selector bytes separately from final decoded output
- treats explicit null numeric decode parameters as omitted optional values, including indirect references, without relaxing filter-specific validation
- supports standards-compliant Flate and LZW predictors, including TIFF Predictor 2 for 1-, 2-, 4-, 8-, and 16-bit samples
- resolves generation-correct indirect filter and decode-parameter objects, including chained numeric predictor and LZW values with cycle protection
- treats `/Filter null` like an absent optional entry without bypassing decoded-stream limits
- prevents image, indexed-color, mask, palette, color-key, and soft-mask normalization from interpreting encoded fallback bytes as pixels
- preserves decoded-stream limit exceptions across image, mask, palette, and soft-mask normalization while malformed or unsupported streams remain non-renderable
- makes destructive redaction content/form decoding strict and routes malformed image or soft-mask data through the configured unsupported-image policy
- maps OCR requests, native-text overlap checks, and merged reading order through cropped and rotated visual page coordinates
- preserves nonzero page and reply-target generations for append-only annotation creation
- updates image-redaction planning diagnostics to match the pixel-rewrite and configured fallback behavior
- refreshes the pinned veraPDF proof-validator image after the previous registry tag and digest were retired

## Why it matters

Malformed content streams can no longer be interpreted as raw PDF operators during preflight or destructive redaction, and malformed image filters cannot produce plausible-but-corrupted normalized or redacted pixels. Valid streams can use indirect or null optional decode-parameter values and predictor rows whose selector bytes exceed the final-output budget without being rejected. Valid oversized image streams now preserve the configured read-limit failure instead of being silently omitted as unrenderable. OCR providers receive the same visual coordinate space used by rendered pages, while append-only annotation references remain valid when source objects use nonzero generations.

## Migration

`PdfOcrRequest.PageWidth` and `PageHeight` now describe the cropped, rotated visual page. Providers that used the former unrotated logical dimensions should map pixel results using the request's visual dimensions and `Scale`; `MIGRATION.md` contains the upgrade guidance.

## Validation

- full `OfficeIMO.Pdf.Tests` suite on net10.0: 3,455 passed
- full `OfficeIMO.Pdf.Tests` suite on net8.0: 3,455 passed
- 275 focused image-rendering, extraction, redaction, reader, and decoder tests passed on both targets
- authoritative pinned PDF interoperability corpus: passed on both targets
- independent review, targeted confirmation, and repeated owner-level closure audits completed; all validated P0-P2 findings were addressed
