### PR TITLE
Add safe document JavaScript editing

### DIFF
--- a/OfficeIMO.Pdf.Tests/Pdf/PdfJavaScriptEditorTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfJavaScriptEditorTests.cs
@@ -1,0 +1,493 @@
+using System.Text;
+using OfficeIMO.Pdf;
+using Xunit;
+
+namespace OfficeIMO.Tests.Pdf;
+
+public class PdfJavaScriptEditorTests {
+    [Fact]
+    public void Edit_AddsListsAndReplacesNamedScriptsWithPlannerProof() {
+        byte[] source = PdfDocument.Create()
+            .Paragraph(paragraph => paragraph.Text("Document JavaScript preservation marker"))
+            .ToBytes();
+
+        PdfJavaScriptEditResult created = PdfDocument.Open(source).JavaScript.Edit(scripts => scripts
+            .AddOrReplace("Initialize", "this.zoom = 100;")
+            .AddOrReplace("Calculate", "var total = 40 + 2;"));
+
+        Assert.Equal(PdfMutationOperation.ModifyJavaScript, created.MutationPlan.Operation);
+        Assert.Equal(PdfMutationExecutionMode.FullRewrite, created.MutationPlan.ExecutionMode);
+        Assert.Contains(PdfMutationStructure.ActiveContent, created.MutationPlan.AffectedStructures);
+        Assert.Contains(PdfMutationProof.JavaScriptReadback, created.MutationPlan.RequiredProofs);
+        Assert.Contains(created.MutationPlan.CapabilityRecords, static capability =>
+            capability.Kind == PdfMutationCapabilityKind.ActiveContentChanges);
+        Assert.True(created.PreservationReport.IsPreserved,
+            string.Join(" ", created.PreservationReport.Issues.Select(static issue => issue.Message)));
+        Assert.Equal(new[] { "Calculate", "Initialize" }, created.JavaScripts.Select(static script => script.Name));
+        Assert.Equal("this.zoom = 100;", Assert.Single(created.JavaScripts, static script => script.Name == "Initialize").Script);
+
+        PdfDocument opened = created.ToDocument();
+        Assert.Equal(created.JavaScripts.Select(static script => script.Script), opened.JavaScript.List().Select(static script => script.Script));
+        Assert.True(opened.Inspect().HasActiveContent);
+        Assert.Contains("Document JavaScript preservation marker", opened.Read.Text(), StringComparison.Ordinal);
+
+        PdfJavaScriptEditResult replaced = opened.JavaScript.AddOrReplace("Initialize", "this.zoom = 125;");
+        Assert.Equal(2, replaced.JavaScripts.Count);
+        Assert.Equal("this.zoom = 125;", Assert.Single(replaced.JavaScripts, static script => script.Name == "Initialize").Script);
+        Assert.Equal("var total = 40 + 2;", Assert.Single(replaced.JavaScripts, static script => script.Name == "Calculate").Script);
+    }
+
+    [Fact]
+    public void RemoveAndClear_PruneNameTreeAndRemainCompatibleWithSanitizer() {
+        byte[] source = PdfDocument.Create()
+            .Paragraph(paragraph => paragraph.Text("JavaScript cleanup"))
+            .ToBytes();
+        PdfJavaScriptEditResult authored = PdfDocument.Open(source).JavaScript.Edit(scripts => scripts
+            .AddOrReplace("One", "app.alert('one');")
+            .AddOrReplace("Two", "app.alert('two');"));
+
+        Assert.Contains(PdfSanitizer.Analyze(authored.ToBytes()), static finding =>
+            finding.Kind == PdfSanitizationFindingKind.ActiveAction && finding.Detail == "JavaScript");
+
+        PdfJavaScriptEditResult removed = authored.ToDocument().JavaScript.Remove("One");
+        Assert.Equal("Two", Assert.Single(removed.JavaScripts).Name);
+
+        PdfJavaScriptEditResult cleared = removed.ToDocument().JavaScript.Clear();
+        Assert.Empty(cleared.JavaScripts);
+        Assert.Empty(cleared.ToDocument().Read.JavaScripts());
+        Assert.False(PdfInspector.Inspect(cleared.ToBytes()).HasActiveContent);
+        Assert.DoesNotContain("app.alert", PdfEncoding.Latin1GetString(cleared.ToBytes()), StringComparison.Ordinal);
+
+        PdfRewritePreservationReport strictPreservation = PdfRewritePreservation.Assess(
+            authored.ToBytes(),
+            cleared.ToBytes(),
+            new PdfRewritePreservationOptions { PreserveRevisionStructure = false });
+        Assert.False(strictPreservation.IsPreserved);
+        Assert.Contains(strictPreservation.Issues, static issue => issue.Feature == "CatalogActions.Count");
+
+        PdfSanitizationResult sanitized = authored.ToDocument().Sanitize();
+        Assert.Empty(sanitized.ToDocument().JavaScript.List());
+        Assert.False(sanitized.ToDocument().Inspect().HasActiveContent);
+    }
+
+    [Fact]
+    public void Reader_DecodesUtf16JavaScriptStreamAndHonorsConfiguredBudget() {
+        const string script = "app.alert('Zażółć');";
+        byte[] source = BuildJavaScriptStreamPdf("Startup", script);
+
+        PdfJavaScript saved = Assert.Single(PdfDocument.Open(source).Read.JavaScripts());
+        Assert.Equal("Startup", saved.Name);
+        Assert.Equal(script, saved.Script);
+
+        var options = new PdfReadOptions {
+            Limits = new PdfReadLimits { MaxJavaScriptBytes = 8 }
+        };
+        PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() =>
+            PdfDocument.Open(source, options).Read.JavaScripts());
+        Assert.Equal(PdfReadLimitKind.DecodedStreamBytes, exception.Kind);
+        Assert.Equal(8, exception.Limit);
+    }
+
+    [Fact]
+    public void Edit_RejectsMissingCommandsAndEmptyScriptSource() {
+        byte[] source = PdfDocument.Create()
+            .Paragraph(paragraph => paragraph.Text("JavaScript validation"))
+            .ToBytes();
+        PdfDocument document = PdfDocument.Open(source);
+
+        Assert.Throws<ArgumentException>(() => document.JavaScript.Edit(static _ => { }));
+        Assert.Throws<ArgumentException>(() => document.JavaScript.AddOrReplace("Startup", string.Empty));
+        Assert.Throws<ArgumentException>(() => document.JavaScript.AddOrReplace(string.Empty, "app.alert('x');"));
+    }
+
+    [Fact]
+    public void Edit_FailsClosedWhenCatalogNamesDictionaryIsUnreadable() {
+        byte[] source = Encoding.ASCII.GetBytes(string.Join("\n", new[] {
+            "%PDF-1.7",
+            "1 0 obj",
+            "<< /Type /Catalog /Pages 2 0 R /Names 99 0 R >>",
+            "endobj",
+            "2 0 obj",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "endobj",
+            "3 0 obj",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] >>",
+            "endobj",
+            "trailer",
+            "<< /Root 1 0 R /Size 4 >>",
+            "%%EOF",
+            string.Empty
+        }));
+
+        Assert.Throws<InvalidDataException>(() => PdfDocument.Open(source).JavaScript.AddOrReplace("Startup", "app.alert('x');"));
+    }
+
+    [Fact]
+    public void Edit_MatchesWhitespaceKeysExactlyAndPreservesUntouchedScripts() {
+        byte[] source = PdfDocument.Create()
+            .Paragraph(paragraph => paragraph.Text("Exact key matching"))
+            .ToBytes();
+        PdfJavaScriptEditResult authored = PdfDocument.Open(source).JavaScript.Edit(scripts => scripts
+            .AddOrReplace("Startup", "app.alert('plain');")
+            .AddOrReplace(" Startup ", "app.alert('spaced');"));
+
+        PdfJavaScriptEditResult removed = authored.ToDocument().JavaScript.Remove(" Startup ");
+
+        PdfJavaScript remaining = Assert.Single(removed.JavaScripts);
+        Assert.Equal("Startup", remaining.Name);
+        Assert.Equal("app.alert('plain');", remaining.Script);
+    }
+
+    [Fact]
+    public void Edit_ReplacesSourceWithoutDroppingNextActionsOrExtensionFields() {
+        byte[] source = BuildJavaScriptActionChainPdf();
+
+        PdfJavaScriptEditResult result = PdfDocument.Open(source).JavaScript
+            .AddOrReplace("Startup", "app.alert('updated');");
+        byte[] output = result.ToBytes();
+        PdfReadDocument saved = PdfReadDocument.Open(output);
+
+        Assert.True(result.PreservationReport.IsPreserved);
+        Assert.Equal("app.alert('updated');", Assert.Single(saved.JavaScripts).Script);
+        Assert.Contains(saved.CatalogActions, static action =>
+            action.Name == "Startup.Next" && action.ActionType == "Launch" && action.IsChainedAction);
+        Assert.Equal("extension-marker", ReadFirstJavaScriptAction(output).Get<PdfStringObj>("OfficeIMOExtension")?.Value);
+        Assert.Equal(Encoding.ASCII.GetBytes("Startup"), ReadFirstJavaScriptKeyBytes(output));
+    }
+
+    [Fact]
+    public void Reader_UsesPdfDocEncodingAndEnforcesCountAndAggregateBudgets() {
+        byte[] source = BuildPdfDocEncodedJavaScriptPdf();
+        PdfJavaScript script = Assert.Single(PdfReadDocument.Open(source).JavaScripts);
+        Assert.Equal("\u2022", script.Script);
+
+        var countOptions = new PdfReadOptions {
+            Limits = new PdfReadLimits { MaxJavaScripts = 1 }
+        };
+        PdfReadLimitException countException = Assert.Throws<PdfReadLimitException>(() =>
+            PdfReadDocument.Open(BuildTwoScriptPdf(), countOptions));
+        Assert.Equal(PdfReadLimitKind.JavaScripts, countException.Kind);
+
+        var totalOptions = new PdfReadOptions {
+            Limits = new PdfReadLimits { MaxTotalJavaScriptBytes = 1 }
+        };
+        PdfReadLimitException totalException = Assert.Throws<PdfReadLimitException>(() =>
+            PdfReadDocument.Open(BuildTwoScriptPdf(), totalOptions));
+        Assert.Equal(PdfReadLimitKind.JavaScriptBytes, totalException.Kind);
+
+        PdfReadLimitException invalidTextException = Assert.Throws<PdfReadLimitException>(() =>
+            PdfReadDocument.Open(BuildTwoInvalidTextStreamPdf(), totalOptions));
+        Assert.Equal(PdfReadLimitKind.JavaScriptBytes, invalidTextException.Kind);
+    }
+
+    [Fact]
+    public void Edit_EmitsByteSortedUnicodeKeysAndRetainsCustomReadLimitsForResult() {
+        byte[] source = PdfDocument.Create()
+            .Paragraph(paragraph => paragraph.Text("Unicode JavaScript keys"))
+            .ToBytes();
+        var options = new PdfReadOptions {
+            Limits = new PdfReadLimits {
+                MaxJavaScriptBytes = 5_000_000,
+                MaxTotalJavaScriptBytes = 6_000_000,
+                MaxObjectCharacters = 10_000_000
+            }
+        };
+        string largeScript = new string('x', 2_100_000);
+
+        PdfJavaScriptEditResult result = PdfDocument.Open(source, options).JavaScript.Edit(scripts => scripts
+            .AddOrReplace("Ā", largeScript)
+            .AddOrReplace("ÿ", "app.alert('small');"));
+
+        Assert.Equal(largeScript.Length, Assert.Single(result.JavaScripts, static script => script.Name == "Ā").Script.Length);
+        Assert.Equal(2, result.ToDocument().JavaScript.List().Count);
+        AssertNameTreeKeysAreByteSorted(result.ToBytes(), options);
+    }
+
+    [Fact]
+    public void Edit_ExplicitlyBlocksEncryptedInputsEvenWithOwnerAuthorization() {
+        byte[] source = PdfDocument.Create(new PdfOptions().SetEncryption("open", "owner"))
+            .Paragraph(paragraph => paragraph.Text("Encrypted JavaScript edit"))
+            .ToBytes();
+        PdfDocument document = PdfDocument.Open(source, new PdfReadOptions { Password = "owner" });
+
+        PdfMutationBlockedException exception = Assert.Throws<PdfMutationBlockedException>(() =>
+            document.JavaScript.AddOrReplace("Startup", "app.alert('x');"));
+
+        Assert.Equal(PdfMutationOperation.ModifyJavaScript, exception.Plan.Operation);
+        Assert.Contains(exception.Plan.BlockerCodes, static blocker => blocker.Contains("Encryption", StringComparison.Ordinal));
+
+        PdfMutationBlockedException signedException = Assert.Throws<PdfMutationBlockedException>(() =>
+            PdfDocument.Open(PdfRewritePreservationTestSupport.BuildSignedIncrementalProofPdf())
+                .JavaScript.AddOrReplace("Startup", "app.alert('x');"));
+        Assert.Contains("FullRewrite.AppendOnlyRequired", signedException.Plan.BlockerCodes);
+    }
+
+    [Fact]
+    public void Edit_PreservesUntouchedOpaqueActionsAndFailsClosedForAmbiguousReplacement() {
+        byte[] opaqueSource = BuildOpaqueJavaScriptPdf();
+
+        byte[] output = PdfDocument.Open(opaqueSource).JavaScript
+            .AddOrReplace("New", "app.alert('new');")
+            .ToBytes();
+        var (objects, _) = PdfSyntax.ParseObjects(output);
+
+        Assert.Contains(objects.Values, static item =>
+            item.Value is PdfStream stream && Encoding.ASCII.GetString(stream.Data) == "OPAQUE-JAVASCRIPT-BYTES");
+        Assert.Equal("app.alert('new');", Assert.Single(PdfReadDocument.Open(output).JavaScripts).Script);
+
+        Assert.Throws<InvalidDataException>(() => PdfDocument.Open(BuildDuplicateJavaScriptNamePdf())
+            .JavaScript.AddOrReplace("Duplicate", "app.alert('replacement');"));
+    }
+
+    [Fact]
+    public void Edit_PreservesDuplicateRawKeyOrderWhenAddingAnUnrelatedScript() {
+        byte[] output = PdfDocument.Open(BuildDuplicateJavaScriptNamePdf()).JavaScript
+            .AddOrReplace("Unrelated", "app.alert('new');")
+            .ToBytes();
+        var (objects, _) = PdfSyntax.ParseObjects(output);
+        PdfArray values = ReadJavaScriptNameTree(output);
+        string[] duplicateSources = Enumerable.Range(0, values.Items.Count / 2)
+            .Where(index => Assert.IsType<PdfStringObj>(PdfObjectLookup.Resolve(objects, values.Items[index * 2])).Value == "Duplicate")
+            .Select(index => Assert.IsType<PdfDictionary>(PdfObjectLookup.Resolve(objects, values.Items[(index * 2) + 1]))
+                .Get<PdfStringObj>("JS")?.Value)
+            .OfType<string>()
+            .ToArray();
+
+        Assert.Equal(new[] { "one", "two" }, duplicateSources);
+    }
+
+    [Fact]
+    public void Edit_UsesReaderNodeCountingForDirectRootAndIndirectLeaf() {
+        var options = new PdfReadOptions {
+            Limits = new PdfReadLimits { MaxNameTreeNodes = 1 }
+        };
+        byte[] source = BuildIndirectJavaScriptLeafPdf();
+
+        Assert.Equal("Existing", Assert.Single(PdfDocument.Open(source, options).Read.JavaScripts()).Name);
+        PdfJavaScriptEditResult result = PdfDocument.Open(source, options).JavaScript
+            .AddOrReplace("Added", "app.alert('added');");
+
+        Assert.Equal(new[] { "Added", "Existing" }, result.JavaScripts.Select(static script => script.Name));
+    }
+
+    private static byte[] BuildJavaScriptStreamPdf(string name, string script) {
+        byte[] encodedScript = Encoding.BigEndianUnicode.GetPreamble()
+            .Concat(Encoding.BigEndianUnicode.GetBytes(script))
+            .ToArray();
+        using var output = new MemoryStream();
+        WriteAscii(output, "%PDF-1.7\n");
+        WriteAscii(output, "1 0 obj\n<< /Type /Catalog /Pages 2 0 R /Names << /JavaScript << /Names [(" + name + ") 5 0 R] >> >> >>\nendobj\n");
+        WriteAscii(output, "2 0 obj\n<< /Type /Pages /Count 1 /Kids [3 0 R] >>\nendobj\n");
+        WriteAscii(output, "3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R >>\nendobj\n");
+        WriteAscii(output, "4 0 obj\n<< /Length 0 >>\nstream\n\nendstream\nendobj\n");
+        WriteAscii(output, "5 0 obj\n<< /S /JavaScript /JS 6 0 R >>\nendobj\n");
+        WriteAscii(output, "6 0 obj\n<< /Length " + encodedScript.Length.ToString(System.Globalization.CultureInfo.InvariantCulture) + " >>\nstream\n");
+        output.Write(encodedScript, 0, encodedScript.Length);
+        WriteAscii(output, "\nendstream\nendobj\ntrailer\n<< /Root 1 0 R /Size 7 >>\n%%EOF\n");
+        return output.ToArray();
+    }
+
+    private static byte[] BuildJavaScriptActionChainPdf() => Encoding.ASCII.GetBytes(string.Join("\n", new[] {
+        "%PDF-1.7",
+        "1 0 obj",
+        "<< /Type /Catalog /Pages 2 0 R /Names << /JavaScript << /Names [(Startup) 5 0 R] >> >> >>",
+        "endobj",
+        "2 0 obj",
+        "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+        "endobj",
+        "3 0 obj",
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] >>",
+        "endobj",
+        "5 0 obj",
+        "<< /S /JavaScript /JS (app.alert('old')) /Next 6 0 R /OfficeIMOExtension (extension-marker) >>",
+        "endobj",
+        "6 0 obj",
+        "<< /S /Launch /F (tool.exe) >>",
+        "endobj",
+        "trailer",
+        "<< /Root 1 0 R /Size 7 >>",
+        "%%EOF",
+        string.Empty
+    }));
+
+    private static byte[] BuildPdfDocEncodedJavaScriptPdf() => Encoding.ASCII.GetBytes(string.Join("\n", new[] {
+        "%PDF-1.7",
+        "1 0 obj",
+        "<< /Type /Catalog /Pages 2 0 R /Names << /JavaScript << /Names [(Startup) 5 0 R] >> >> >>",
+        "endobj",
+        "2 0 obj",
+        "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+        "endobj",
+        "3 0 obj",
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] >>",
+        "endobj",
+        "5 0 obj",
+        "<< /S /JavaScript /JS <80> >>",
+        "endobj",
+        "trailer",
+        "<< /Root 1 0 R /Size 6 >>",
+        "%%EOF",
+        string.Empty
+    }));
+
+    private static byte[] BuildTwoScriptPdf() => Encoding.ASCII.GetBytes(string.Join("\n", new[] {
+        "%PDF-1.7",
+        "1 0 obj",
+        "<< /Type /Catalog /Pages 2 0 R /Names << /JavaScript << /Names [(One) 5 0 R (Two) 6 0 R] >> >> >>",
+        "endobj",
+        "2 0 obj",
+        "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+        "endobj",
+        "3 0 obj",
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] >>",
+        "endobj",
+        "5 0 obj",
+        "<< /S /JavaScript /JS (a) >>",
+        "endobj",
+        "6 0 obj",
+        "<< /S /JavaScript /JS (b) >>",
+        "endobj",
+        "trailer",
+        "<< /Root 1 0 R /Size 7 >>",
+        "%%EOF",
+        string.Empty
+    }));
+
+    private static byte[] BuildTwoInvalidTextStreamPdf() {
+        using var output = new MemoryStream();
+        WriteAscii(output, "%PDF-1.7\n");
+        WriteAscii(output, "1 0 obj\n<< /Type /Catalog /Pages 2 0 R /Names << /JavaScript << /Names [(One) 5 0 R (Two) 6 0 R] >> >> >>\nendobj\n");
+        WriteAscii(output, "2 0 obj\n<< /Type /Pages /Count 1 /Kids [3 0 R] >>\nendobj\n");
+        WriteAscii(output, "3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] >>\nendobj\n");
+        WriteAscii(output, "5 0 obj\n<< /S /JavaScript /JS 7 0 R >>\nendobj\n");
+        WriteAscii(output, "6 0 obj\n<< /S /JavaScript /JS 8 0 R >>\nendobj\n");
+        WriteAscii(output, "7 0 obj\n<< /Length 1 >>\nstream\n");
+        output.WriteByte(0x7F);
+        WriteAscii(output, "\nendstream\nendobj\n8 0 obj\n<< /Length 1 >>\nstream\n");
+        output.WriteByte(0x7F);
+        WriteAscii(output, "\nendstream\nendobj\ntrailer\n<< /Root 1 0 R /Size 9 >>\n%%EOF\n");
+        return output.ToArray();
+    }
+
+    private static byte[] BuildIndirectJavaScriptLeafPdf() => Encoding.ASCII.GetBytes(string.Join("\n", new[] {
+        "%PDF-1.7",
+        "1 0 obj",
+        "<< /Type /Catalog /Pages 2 0 R /Names << /JavaScript << /Kids [5 0 R] >> >> >>",
+        "endobj",
+        "2 0 obj",
+        "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+        "endobj",
+        "3 0 obj",
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] >>",
+        "endobj",
+        "5 0 obj",
+        "<< /Names [(Existing) 6 0 R] >>",
+        "endobj",
+        "6 0 obj",
+        "<< /S /JavaScript /JS (app.alert('existing')) >>",
+        "endobj",
+        "trailer",
+        "<< /Root 1 0 R /Size 7 >>",
+        "%%EOF",
+        string.Empty
+    }));
+
+    private static byte[] BuildOpaqueJavaScriptPdf() => Encoding.ASCII.GetBytes(string.Join("\n", new[] {
+        "%PDF-1.7",
+        "1 0 obj",
+        "<< /Type /Catalog /Pages 2 0 R /Names << /JavaScript << /Names [(Opaque) 5 0 R] >> >> >>",
+        "endobj",
+        "2 0 obj",
+        "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+        "endobj",
+        "3 0 obj",
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] >>",
+        "endobj",
+        "5 0 obj",
+        "<< /S /JavaScript /JS 6 0 R >>",
+        "endobj",
+        "6 0 obj",
+        "<< /Length 23 /Filter /DCTDecode >>",
+        "stream",
+        "OPAQUE-JAVASCRIPT-BYTES",
+        "endstream",
+        "endobj",
+        "trailer",
+        "<< /Root 1 0 R /Size 7 >>",
+        "%%EOF",
+        string.Empty
+    }));
+
+    private static byte[] BuildDuplicateJavaScriptNamePdf() => Encoding.ASCII.GetBytes(string.Join("\n", new[] {
+        "%PDF-1.7",
+        "1 0 obj",
+        "<< /Type /Catalog /Pages 2 0 R /Names << /JavaScript << /Names [(Duplicate) 5 0 R (Duplicate) 6 0 R] >> >> >>",
+        "endobj",
+        "2 0 obj",
+        "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+        "endobj",
+        "3 0 obj",
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] >>",
+        "endobj",
+        "5 0 obj",
+        "<< /S /JavaScript /JS (one) >>",
+        "endobj",
+        "6 0 obj",
+        "<< /S /JavaScript /JS (two) >>",
+        "endobj",
+        "trailer",
+        "<< /Root 1 0 R /Size 7 >>",
+        "%%EOF",
+        string.Empty
+    }));
+
+    private static void AssertNameTreeKeysAreByteSorted(byte[] pdf, PdfReadOptions? options = null) {
+        var (objects, _) = PdfSyntax.ParseObjects(pdf, options);
+        PdfDictionary catalog = FindCatalog(objects);
+        PdfDictionary names = Assert.IsType<PdfDictionary>(PdfObjectLookup.Resolve(objects, catalog.Items["Names"]));
+        PdfDictionary tree = Assert.IsType<PdfDictionary>(PdfObjectLookup.Resolve(objects, names.Items["JavaScript"]));
+        PdfArray values = Assert.IsType<PdfArray>(PdfObjectLookup.Resolve(objects, tree.Items["Names"]));
+        byte[][] keys = Enumerable.Range(0, values.Items.Count / 2)
+            .Select(index => Assert.IsType<PdfStringObj>(PdfObjectLookup.Resolve(objects, values.Items[index * 2])).RawBytes)
+            .ToArray();
+        for (int i = 1; i < keys.Length; i++) Assert.True(CompareBytes(keys[i - 1], keys[i]) <= 0);
+    }
+
+    private static PdfDictionary ReadFirstJavaScriptAction(byte[] pdf) {
+        var (objects, _) = PdfSyntax.ParseObjects(pdf);
+        PdfArray values = ReadJavaScriptNameTree(pdf);
+        return Assert.IsType<PdfDictionary>(PdfObjectLookup.Resolve(objects, values.Items[1]));
+    }
+
+    private static byte[] ReadFirstJavaScriptKeyBytes(byte[] pdf) {
+        var (objects, _) = PdfSyntax.ParseObjects(pdf);
+        PdfArray values = ReadJavaScriptNameTree(pdf);
+        return Assert.IsType<PdfStringObj>(PdfObjectLookup.Resolve(objects, values.Items[0])).RawBytes;
+    }
+
+    private static PdfArray ReadJavaScriptNameTree(byte[] pdf) {
+        var (objects, _) = PdfSyntax.ParseObjects(pdf);
+        PdfDictionary catalog = FindCatalog(objects);
+        PdfDictionary names = Assert.IsType<PdfDictionary>(PdfObjectLookup.Resolve(objects, catalog.Items["Names"]));
+        PdfDictionary tree = Assert.IsType<PdfDictionary>(PdfObjectLookup.Resolve(objects, names.Items["JavaScript"]));
+        return Assert.IsType<PdfArray>(PdfObjectLookup.Resolve(objects, tree.Items["Names"]));
+    }
+
+    private static PdfDictionary FindCatalog(Dictionary<int, PdfIndirectObject> objects) => Assert.IsType<PdfDictionary>(Assert.Single(
+        objects.Values,
+        static item => (item.Value as PdfDictionary)?.Get<PdfName>("Type")?.Name == "Catalog").Value);
+
+    private static int CompareBytes(byte[] left, byte[] right) {
+        int count = Math.Min(left.Length, right.Length);
+        for (int i = 0; i < count; i++) {
+            int comparison = left[i].CompareTo(right[i]);
+            if (comparison != 0) return comparison;
+        }
+        return left.Length.CompareTo(right.Length);
+    }
+
+    private static void WriteAscii(Stream stream, string value) {
+        byte[] bytes = Encoding.ASCII.GetBytes(value);
+        stream.Write(bytes, 0, bytes.Length);
+    }
+}

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfJavaScriptEditorTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfJavaScriptEditorTests.cs
@@ -161,6 +161,9 @@ public class PdfJavaScriptEditorTests {
         PdfJavaScript script = Assert.Single(PdfReadDocument.Open(source).JavaScripts);
         Assert.Equal("\u2022", script.Script);
 
+        PdfJavaScript controls = Assert.Single(PdfReadDocument.Open(BuildPdfDocControlEncodedJavaScriptPdf()).JavaScripts);
+        Assert.Equal("\0\f\u0017", controls.Script);
+
         var countOptions = new PdfReadOptions {
             Limits = new PdfReadLimits { MaxJavaScripts = 1 }
         };
@@ -237,6 +240,25 @@ public class PdfJavaScriptEditorTests {
 
         Assert.Throws<InvalidDataException>(() => PdfDocument.Open(BuildDuplicateJavaScriptNamePdf())
             .JavaScript.AddOrReplace("Duplicate", "app.alert('replacement');"));
+    }
+
+    [Fact]
+    public void EditResult_SnapshotsOperationsWhenTheCallbackRetainsItsSession() {
+        byte[] source = PdfDocument.Create()
+            .Paragraph(paragraph => paragraph.Text("Immutable JavaScript edit result"))
+            .ToBytes();
+        PdfJavaScriptEditSession? retained = null;
+
+        PdfJavaScriptEditResult result = PdfDocument.Open(source).JavaScript.Edit(session => {
+            retained = session;
+            session.AddOrReplace("Startup", "app.alert('saved');");
+        });
+        retained!.Clear();
+
+        Assert.Equal(new[] { "AddOrReplace:Startup" }, result.Operations);
+        PdfJavaScript saved = Assert.Single(result.JavaScripts);
+        Assert.Equal("Startup", saved.Name);
+        Assert.Equal("app.alert('saved');", saved.Script);
     }
 
     [Fact]
@@ -323,6 +345,26 @@ public class PdfJavaScriptEditorTests {
         "endobj",
         "5 0 obj",
         "<< /S /JavaScript /JS <80> >>",
+        "endobj",
+        "trailer",
+        "<< /Root 1 0 R /Size 6 >>",
+        "%%EOF",
+        string.Empty
+    }));
+
+    private static byte[] BuildPdfDocControlEncodedJavaScriptPdf() => Encoding.ASCII.GetBytes(string.Join("\n", new[] {
+        "%PDF-1.7",
+        "1 0 obj",
+        "<< /Type /Catalog /Pages 2 0 R /Names << /JavaScript << /Names [(Startup) 5 0 R] >> >> >>",
+        "endobj",
+        "2 0 obj",
+        "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+        "endobj",
+        "3 0 obj",
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] >>",
+        "endobj",
+        "5 0 obj",
+        "<< /S /JavaScript /JS <000C17> >>",
         "endobj",
         "trailer",
         "<< /Root 1 0 R /Size 6 >>",

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfPublicApiContractTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfPublicApiContractTests.cs
@@ -22,6 +22,7 @@ public sealed class PdfPublicApiContractTests {
         "PdfImageExtractor",
         "PdfIncrementalUpdater",
         "PdfInspector",
+        "PdfJavaScriptEditor",
         "PdfLayoutDebugOverlay",
         "PdfMerger",
         "PdfMetadataEditor",
@@ -254,25 +255,8 @@ public sealed class PdfPublicApiContractTests {
     }
 
     [Fact]
-    public void PublicSurfaceAndRuntimeDependenciesStayBounded() {
+    public void RuntimeDependencyOwnershipStaysBounded() {
         Assembly assembly = typeof(PdfDocument).Assembly;
-        Type[] exportedTypes = assembly.GetExportedTypes();
-        int publicMemberCount = exportedTypes.Sum(type =>
-            type.GetMembers(
-                BindingFlags.Public |
-                BindingFlags.Instance |
-                BindingFlags.Static |
-                BindingFlags.DeclaredOnly).Length);
-
-        Assert.InRange(exportedTypes.Length, 1, 512);
-        Assert.InRange(publicMemberCount, 1, 9867);
-        Assert.InRange(
-            typeof(PdfDocument)
-                .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly)
-                .Count(method => !method.IsSpecialName),
-            1,
-            65);
-
         string[] officeReferences = assembly.GetReferencedAssemblies()
             .Select(reference => reference.Name)
             .Where(name => name != null && name.StartsWith("OfficeIMO.", StringComparison.Ordinal))

--- a/OfficeIMO.Pdf/Core/PdfDocument.Meta.cs
+++ b/OfficeIMO.Pdf/Core/PdfDocument.Meta.cs
@@ -33,6 +33,7 @@ public sealed partial class PdfDocument {
         Attachments = new PdfDocumentAttachments(this);
         Bookmarks = new PdfDocumentBookmarks(this);
         Annotations = new PdfDocumentAnnotations(this);
+        JavaScript = new PdfDocumentJavaScript(this);
         Security = new PdfDocumentSecurity(this);
         Redactions = new PdfDocumentRedactions(this);
         Optimization = new PdfDocumentOptimization(this);
@@ -132,6 +133,9 @@ public sealed partial class PdfDocument {
 
     /// <summary>Existing-document annotation editing operations.</summary>
     public PdfDocumentAnnotations Annotations { get; }
+
+    /// <summary>Explicit active-content operations for named document-level JavaScript.</summary>
+    public PdfDocumentJavaScript JavaScript { get; }
 
     /// <summary>Password encryption and digital-signature operations for this PDF.</summary>
     public PdfDocumentSecurity Security { get; }

--- a/OfficeIMO.Pdf/Core/PdfDocumentJavaScript.cs
+++ b/OfficeIMO.Pdf/Core/PdfDocumentJavaScript.cs
@@ -1,0 +1,30 @@
+namespace OfficeIMO.Pdf;
+
+/// <summary>Explicit active-content operations for named document-level JavaScript.</summary>
+public sealed class PdfDocumentJavaScript {
+    private readonly PdfDocument _document;
+
+    internal PdfDocumentJavaScript(PdfDocument document) { _document = document; }
+
+    /// <summary>Lists named document-level scripts and their exact source text.</summary>
+    public IReadOnlyList<PdfJavaScript> List() => _document.Read.JavaScripts();
+
+    /// <summary>
+    /// Applies a transactional named-script collection edit. JavaScript is active content and may execute in capable PDF viewers.
+    /// The default sanitization policy removes authored scripts unless JavaScript is explicitly allowed.
+    /// </summary>
+    public PdfJavaScriptEditResult Edit(Action<PdfJavaScriptEditSession> edit) =>
+        PdfJavaScriptEditor.Edit(_document.GetBytesForOperation(), edit, _document.ReadOptions);
+
+    /// <summary>Adds a named script or replaces the source of an existing script with the same name.</summary>
+    public PdfJavaScriptEditResult AddOrReplace(string name, string script) =>
+        PdfJavaScriptEditor.AddOrReplace(_document.GetBytesForOperation(), name, script, _document.ReadOptions);
+
+    /// <summary>Removes a named script when it exists.</summary>
+    public PdfJavaScriptEditResult Remove(string name) =>
+        PdfJavaScriptEditor.Remove(_document.GetBytesForOperation(), name, _document.ReadOptions);
+
+    /// <summary>Removes every named document-level script.</summary>
+    public PdfJavaScriptEditResult Clear() =>
+        PdfJavaScriptEditor.Clear(_document.GetBytesForOperation(), _document.ReadOptions);
+}

--- a/OfficeIMO.Pdf/Core/PdfDocumentReader.Actions.cs
+++ b/OfficeIMO.Pdf/Core/PdfDocumentReader.Actions.cs
@@ -4,6 +4,14 @@ namespace OfficeIMO.Pdf;
 /// Fluent active-action readback operations for a <see cref="PdfDocument"/>.
 /// </summary>
 public sealed partial class PdfDocumentReader {
+    /// <summary>Reads named document-level JavaScript actions and their exact source text.</summary>
+    public IReadOnlyList<PdfJavaScript> JavaScripts(PdfReadOptions? readOptions = null) =>
+        ReadDocument(readOptions).JavaScripts;
+
+    /// <summary>Attempts to read named document-level JavaScript actions, returning diagnostics when blocked or failed.</summary>
+    public PdfOperationResult<IReadOnlyList<PdfJavaScript>> TryJavaScripts(PdfReadOptions? options = null) =>
+        _document.TryOperation("Read document JavaScript", PdfPreflightCapability.ReadLogicalObjects, () => JavaScripts(options), ResolveReadOptions(options));
+
     /// <summary>
     /// Reads catalog-level actions discovered from supported catalog slots and name trees.
     /// </summary>

--- a/OfficeIMO.Pdf/Manipulation/PdfJavaScriptEditModels.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfJavaScriptEditModels.cs
@@ -97,8 +97,12 @@ public sealed class PdfJavaScriptEditResult {
         _readOptions = readOptions;
         MutationPlan = mutationPlan;
         PreservationReport = preservationReport;
-        JavaScripts = javaScripts;
-        Operations = operations;
+        JavaScripts = javaScripts.Count == 0
+            ? Array.Empty<PdfJavaScript>()
+            : Array.AsReadOnly(javaScripts.ToArray());
+        Operations = operations.Count == 0
+            ? Array.Empty<string>()
+            : Array.AsReadOnly(operations.ToArray());
     }
 
     /// <summary>Shared full-rewrite mutation plan.</summary>

--- a/OfficeIMO.Pdf/Manipulation/PdfJavaScriptEditModels.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfJavaScriptEditModels.cs
@@ -1,0 +1,121 @@
+namespace OfficeIMO.Pdf;
+
+/// <summary>Transactional collection editor for named document-level JavaScript actions.</summary>
+public sealed class PdfJavaScriptEditSession {
+    private readonly List<EditCommand> _commands = new List<EditCommand>();
+    private readonly List<string> _operations = new List<string>();
+    private readonly int _maxJavaScriptBytes;
+    private readonly int _maxJavaScripts;
+    private readonly long _maxTotalJavaScriptBytes;
+    private long _commandJavaScriptBytes;
+
+    internal PdfJavaScriptEditSession(PdfReadLimits limits) {
+        _maxJavaScriptBytes = limits.MaxJavaScriptBytes;
+        _maxJavaScripts = limits.MaxJavaScripts;
+        _maxTotalJavaScriptBytes = limits.MaxTotalJavaScriptBytes;
+    }
+
+    /// <summary>Adds a named script or replaces the source of an existing script with the same name.</summary>
+    public PdfJavaScriptEditSession AddOrReplace(string name, string script) {
+        Guard.NotNull(name, nameof(name));
+        Guard.NotNull(script, nameof(script));
+        if (name.Length == 0) throw new ArgumentException("JavaScript name cannot be empty.", nameof(name));
+        if (script.Length == 0) throw new ArgumentException("JavaScript source cannot be empty.", nameof(script));
+        byte[] encodedName = PdfJavaScriptStringEncoding.EncodeUnicode(name, nameof(name));
+        byte[] encodedScript = PdfJavaScriptStringEncoding.EncodeUnicode(script, nameof(script));
+        int byteCount = encodedScript.Length;
+        if (byteCount > _maxJavaScriptBytes) {
+            throw PdfReadLimitException.Create(PdfReadLimitKind.DecodedStreamBytes, _maxJavaScriptBytes, byteCount);
+        }
+        EnsureCommandBudget(byteCount);
+        _commands.Add(new EditCommand(EditKind.AddOrReplace, name, script, encodedName, encodedScript));
+        _operations.Add("AddOrReplace:" + name);
+        return this;
+    }
+
+    /// <summary>Removes a named script when it exists.</summary>
+    public PdfJavaScriptEditSession Remove(string name) {
+        Guard.NotNull(name, nameof(name));
+        if (name.Length == 0) throw new ArgumentException("JavaScript name cannot be empty.", nameof(name));
+        byte[] encodedName = PdfJavaScriptStringEncoding.EncodeUnicode(name, nameof(name));
+        EnsureCommandBudget(0L);
+        _commands.Add(new EditCommand(EditKind.Remove, name, null, encodedName, null));
+        _operations.Add("Remove:" + name);
+        return this;
+    }
+
+    /// <summary>Removes every named document-level script.</summary>
+    public PdfJavaScriptEditSession Clear() {
+        EnsureCommandBudget(0L);
+        _commands.Add(new EditCommand(EditKind.Clear, null, null, null, null));
+        _operations.Add("Clear");
+        return this;
+    }
+
+    internal IReadOnlyList<string> Operations => _operations.AsReadOnly();
+    internal IReadOnlyList<EditCommand> Commands => _commands.AsReadOnly();
+
+    private void EnsureCommandBudget(long additionalBytes) {
+        int nextCount = checked(_commands.Count + 1);
+        if (nextCount > _maxJavaScripts) {
+            throw PdfReadLimitException.Create(PdfReadLimitKind.JavaScripts, _maxJavaScripts, nextCount);
+        }
+        long nextBytes = checked(_commandJavaScriptBytes + additionalBytes);
+        if (nextBytes > _maxTotalJavaScriptBytes) {
+            throw PdfReadLimitException.Create(PdfReadLimitKind.JavaScriptBytes, _maxTotalJavaScriptBytes, nextBytes);
+        }
+        _commandJavaScriptBytes = nextBytes;
+    }
+
+    internal enum EditKind { AddOrReplace, Remove, Clear }
+
+    internal sealed class EditCommand {
+        internal EditCommand(EditKind kind, string? name, string? script, byte[]? encodedName, byte[]? encodedScript) {
+            Kind = kind; Name = name; Script = script; EncodedName = encodedName; EncodedScript = encodedScript;
+        }
+        internal EditKind Kind { get; }
+        internal string? Name { get; }
+        internal string? Script { get; }
+        internal byte[]? EncodedName { get; }
+        internal byte[]? EncodedScript { get; }
+    }
+}
+
+/// <summary>Edited PDF bytes with exact named-script readback and rewrite-preservation proof.</summary>
+public sealed class PdfJavaScriptEditResult {
+    private readonly byte[] _pdf;
+    private readonly PdfReadOptions _readOptions;
+
+    internal PdfJavaScriptEditResult(
+        byte[] pdf,
+        PdfMutationPlan mutationPlan,
+        PdfRewritePreservationReport preservationReport,
+        IReadOnlyList<PdfJavaScript> javaScripts,
+        IReadOnlyList<string> operations,
+        PdfReadOptions readOptions) {
+        _pdf = (byte[])pdf.Clone();
+        _readOptions = readOptions;
+        MutationPlan = mutationPlan;
+        PreservationReport = preservationReport;
+        JavaScripts = javaScripts;
+        Operations = operations;
+    }
+
+    /// <summary>Shared full-rewrite mutation plan.</summary>
+    public PdfMutationPlan MutationPlan { get; }
+
+    /// <summary>Proof that structures outside the document JavaScript name tree survived the rewrite.</summary>
+    public PdfRewritePreservationReport PreservationReport { get; }
+
+    /// <summary>Named scripts read back from the saved artifact.</summary>
+    public IReadOnlyList<PdfJavaScript> JavaScripts { get; }
+
+    /// <summary>Stable operation descriptions applied in transaction order.</summary>
+    public IReadOnlyList<string> Operations { get; }
+
+    /// <summary>Returns a defensive copy of the edited PDF.</summary>
+    public byte[] ToBytes() => (byte[])_pdf.Clone();
+
+    /// <summary>Opens the edited artifact as a fluent PDF document.</summary>
+    public PdfDocument ToDocument() => PdfDocument.Open(_pdf, _readOptions);
+}

--- a/OfficeIMO.Pdf/Manipulation/PdfJavaScriptEditor.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfJavaScriptEditor.cs
@@ -1,0 +1,133 @@
+namespace OfficeIMO.Pdf;
+
+/// <summary>Edits the catalog JavaScript name tree through the shared object-graph rewrite owner.</summary>
+internal static class PdfJavaScriptEditor {
+    internal static PdfJavaScriptEditResult Edit(
+        byte[] pdf,
+        Action<PdfJavaScriptEditSession> edit,
+        PdfReadOptions? readOptions = null) {
+        Guard.NotNull(pdf, nameof(pdf));
+        Guard.NotNull(edit, nameof(edit));
+
+        PdfReadDocument source = PdfReadDocument.Open(pdf, readOptions);
+        var session = new PdfJavaScriptEditSession(source.ReadOptions.Limits);
+        edit(session);
+        if (session.Operations.Count == 0) {
+            throw new ArgumentException("At least one document JavaScript edit command is required.", nameof(edit));
+        }
+
+        PdfMutationPlan plan = PdfMutationPlanner.RequireFullRewrite(
+            pdf,
+            PdfMutationOperation.ModifyJavaScript,
+            readOptions);
+        byte[] untouchedJavaScriptSnapshot = PdfJavaScriptNameTreeEditor.CreateUntouchedSnapshot(
+            source.Objects,
+            source.Security,
+            session.Commands,
+            source.ReadOptions.Limits);
+        byte[] output = PdfDocumentObjectGraphRewriter.Rewrite(
+            pdf,
+            readOptions,
+            outputEncryption: null,
+            (objects, security) => {
+                PdfJavaScriptNameTreeEditor.Rewrite(objects, security, session.Commands, source.ReadOptions.Limits);
+                return security.InfoObjectNumber.HasValue && objects.ContainsKey(security.InfoObjectNumber.Value)
+                    ? security.InfoObjectNumber
+                    : null;
+            });
+
+        PdfReadOptions rewrittenReadOptions = PdfReadOptions.WithMinimumInputBytes(source.ReadOptions, output.LongLength);
+        PdfReadDocument savedDocument = PdfReadDocument.Open(output, rewrittenReadOptions);
+        IReadOnlyList<PdfJavaScript> saved = savedDocument.JavaScripts;
+        ValidateReadback(session.Commands, saved);
+        ValidateUntouchedJavaScript(
+            untouchedJavaScriptSnapshot,
+            PdfJavaScriptNameTreeEditor.CreateUntouchedSnapshot(
+                savedDocument.Objects,
+                savedDocument.Security,
+                session.Commands,
+                savedDocument.ReadOptions.Limits));
+        ValidateOtherCatalogActions(source.CatalogActions, savedDocument.CatalogActions);
+        var preservationOptions = new PdfRewritePreservationOptions {
+            OriginalReadOptions = source.ReadOptions,
+            RewrittenReadOptions = rewrittenReadOptions,
+            PreserveCatalogActions = false,
+            PreserveRevisionStructure = false
+        };
+        PdfRewritePreservationReport preservation = PdfRewritePreservation.AssertPreserved(
+            pdf,
+            output,
+            preservationOptions);
+        return new PdfJavaScriptEditResult(output, plan, preservation, saved, session.Operations, rewrittenReadOptions);
+    }
+
+    internal static PdfJavaScriptEditResult AddOrReplace(
+        byte[] pdf,
+        string name,
+        string script,
+        PdfReadOptions? readOptions = null) =>
+        Edit(pdf, session => session.AddOrReplace(name, script), readOptions);
+
+    internal static PdfJavaScriptEditResult Remove(
+        byte[] pdf,
+        string name,
+        PdfReadOptions? readOptions = null) =>
+        Edit(pdf, session => session.Remove(name), readOptions);
+
+    internal static PdfJavaScriptEditResult Clear(byte[] pdf, PdfReadOptions? readOptions = null) =>
+        Edit(pdf, static session => session.Clear(), readOptions);
+
+    private static void ValidateReadback(
+        IReadOnlyList<PdfJavaScriptEditSession.EditCommand> commands,
+        IReadOnlyList<PdfJavaScript> actual) {
+        var expected = new Dictionary<string, string?>(StringComparer.Ordinal);
+        bool cleared = false;
+        for (int i = 0; i < commands.Count; i++) {
+            PdfJavaScriptEditSession.EditCommand command = commands[i];
+            if (command.Kind == PdfJavaScriptEditSession.EditKind.Clear) {
+                expected.Clear(); cleared = true;
+            } else {
+                expected[command.Name!] = command.Kind == PdfJavaScriptEditSession.EditKind.Remove ? null : command.Script;
+            }
+        }
+        foreach (KeyValuePair<string, string?> expectation in expected) {
+            PdfJavaScript[] matches = actual.Where(script => string.Equals(script.Name, expectation.Key, StringComparison.Ordinal)).ToArray();
+            if (expectation.Value is null && matches.Length == 0) continue;
+            if (expectation.Value is not null && matches.Length == 1 && string.Equals(matches[0].Script, expectation.Value, StringComparison.Ordinal)) continue;
+            throw new InvalidOperationException("PDF document JavaScript post-save validation found a name or source mismatch; the artifact was not returned.");
+        }
+        if (cleared && actual.Count != expected.Count(static item => item.Value is not null)) {
+            throw new InvalidOperationException("PDF document JavaScript post-save validation found an unexpected script after clearing the name tree; the artifact was not returned.");
+        }
+    }
+
+    private static void ValidateOtherCatalogActions(
+        IReadOnlyList<PdfCatalogAction> expected,
+        IReadOnlyList<PdfCatalogAction> actual) {
+        string[] expectedValues = expected
+            .Where(static action => !string.Equals(action.Source, "Names/JavaScript", StringComparison.Ordinal))
+            .Select(GetCatalogActionIdentity)
+            .ToArray();
+        string[] actualValues = actual
+            .Where(static action => !string.Equals(action.Source, "Names/JavaScript", StringComparison.Ordinal))
+            .Select(GetCatalogActionIdentity)
+            .ToArray();
+        if (!expectedValues.SequenceEqual(actualValues, StringComparer.Ordinal)) {
+            throw new InvalidOperationException("PDF document JavaScript post-save validation found an unrelated catalog-action change; the artifact was not returned.");
+        }
+    }
+
+    private static void ValidateUntouchedJavaScript(byte[] expected, byte[] actual) {
+        if (!expected.SequenceEqual(actual)) {
+            throw new InvalidOperationException("PDF document JavaScript post-save validation found an untouched name-tree entry or action-graph change; the artifact was not returned.");
+        }
+    }
+
+    private static string GetCatalogActionIdentity(PdfCatalogAction action) =>
+        action.Name + "\u001f" +
+        action.ActionType + "\u001f" +
+        action.Source + "\u001f" +
+        (action.TriggerName ?? string.Empty) + "\u001f" +
+        (action.ActionPath ?? string.Empty) + "\u001f" +
+        (action.IsChainedAction ? "1" : "0");
+}

--- a/OfficeIMO.Pdf/Manipulation/PdfJavaScriptNameTreeEditor.Preservation.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfJavaScriptNameTreeEditor.Preservation.cs
@@ -1,0 +1,164 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace OfficeIMO.Pdf;
+
+internal static partial class PdfJavaScriptNameTreeEditor {
+    internal static byte[] CreateUntouchedSnapshot(
+        Dictionary<int, PdfIndirectObject> objects,
+        PdfDocumentSecurityInfo security,
+        IReadOnlyList<PdfJavaScriptEditSession.EditCommand> commands,
+        PdfReadLimits limits) {
+        int lastClear = -1;
+        var affectedNames = new HashSet<string>(StringComparer.Ordinal);
+        for (int i = 0; i < commands.Count; i++) {
+            if (commands[i].Kind == PdfJavaScriptEditSession.EditKind.Clear) {
+                lastClear = i;
+                affectedNames.Clear();
+            } else if (i > lastClear && commands[i].Name is string name) {
+                affectedNames.Add(name);
+            }
+        }
+
+        using var fingerprint = new ObjectGraphFingerprint(objects);
+        if (lastClear >= 0 ||
+            !security.RootObjectNumber.HasValue ||
+            !objects.TryGetValue(security.RootObjectNumber.Value, out PdfIndirectObject? root) ||
+            root.Value is not PdfDictionary catalog ||
+            !catalog.Items.TryGetValue("Names", out PdfObject? namesObject) ||
+            ResolveDictionary(objects, namesObject) is not PdfDictionary names ||
+            !names.Items.TryGetValue("JavaScript", out PdfObject? treeObject)) {
+            return fingerprint.Complete();
+        }
+
+        var entries = new List<NameTreeEntry>();
+        int traversedNodes = 0;
+        CollectEntries(
+            objects,
+            treeObject,
+            entries,
+            new HashSet<(int ObjectNumber, int Generation)>(),
+            0,
+            ref traversedNodes,
+            limits);
+
+        for (int i = 0; i < entries.Count; i++) {
+            NameTreeEntry entry = entries[i];
+            if (entry.Name is not null && affectedNames.Contains(entry.Name)) continue;
+            fingerprint.AppendEntry(entry.KeyBytes, entry.Value);
+        }
+        return fingerprint.Complete();
+    }
+
+    private sealed class ObjectGraphFingerprint : IDisposable {
+        private readonly Dictionary<int, PdfIndirectObject> _objects;
+        private readonly IncrementalHash _hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        private readonly Dictionary<(int ObjectNumber, int Generation), int> _references = new();
+        private readonly byte[] _int32Bytes = new byte[sizeof(int)];
+        private readonly byte[] _singleByte = new byte[1];
+
+        internal ObjectGraphFingerprint(Dictionary<int, PdfIndirectObject> objects) {
+            _objects = objects;
+        }
+
+        internal void AppendEntry(byte[] keyBytes, PdfObject value) {
+            AppendByte(1);
+            AppendBytes(keyBytes);
+            AppendObject(value);
+        }
+
+        internal byte[] Complete() => _hash.GetHashAndReset();
+
+        public void Dispose() => _hash.Dispose();
+
+        private void AppendObject(PdfObject value) {
+            switch (value) {
+                case PdfNumber number:
+                    AppendByte(2);
+                    AppendString(number.Value.ToString("R", CultureInfo.InvariantCulture));
+                    break;
+                case PdfBoolean boolean:
+                    AppendByte(boolean.Value ? (byte)3 : (byte)4);
+                    break;
+                case PdfName name:
+                    AppendByte(5);
+                    AppendString(name.Name);
+                    break;
+                case PdfStringObj text:
+                    AppendByte(6);
+                    AppendBytes(text.RawBytes);
+                    break;
+                case PdfArray array:
+                    AppendByte(7);
+                    AppendInt32(array.Items.Count);
+                    for (int i = 0; i < array.Items.Count; i++) AppendObject(array.Items[i]);
+                    break;
+                case PdfDictionary dictionary:
+                    AppendDictionary(8, dictionary);
+                    break;
+                case PdfReference reference:
+                    AppendReference(reference);
+                    break;
+                case PdfStream stream:
+                    AppendDictionary(10, stream.Dictionary);
+                    AppendBytes(stream.Data);
+                    break;
+                case PdfNull:
+                    AppendByte(11);
+                    break;
+                default:
+                    throw new InvalidDataException("The PDF JavaScript action graph contains an unsupported object type.");
+            }
+        }
+
+        private void AppendReference(PdfReference reference) {
+            var key = (reference.ObjectNumber, reference.Generation);
+            if (_references.TryGetValue(key, out int existingId)) {
+                AppendByte(12);
+                AppendInt32(existingId);
+                return;
+            }
+
+            int id = _references.Count;
+            _references[key] = id;
+            AppendByte(13);
+            AppendInt32(id);
+            if (PdfObjectLookup.TryGet(_objects, reference, out PdfIndirectObject? indirect)) {
+                AppendByte(14);
+                AppendObject(indirect.Value);
+            } else {
+                AppendByte(15);
+            }
+        }
+
+        private void AppendDictionary(byte marker, PdfDictionary dictionary) {
+            AppendByte(marker);
+            AppendInt32(dictionary.Items.Count);
+            foreach (KeyValuePair<string, PdfObject> item in dictionary.Items.OrderBy(static item => item.Key, StringComparer.Ordinal)) {
+                AppendString(item.Key);
+                AppendObject(item.Value);
+            }
+        }
+
+        private void AppendString(string value) => AppendBytes(Encoding.UTF8.GetBytes(value));
+
+        private void AppendBytes(byte[] value) {
+            AppendInt32(value.Length);
+            _hash.AppendData(value);
+        }
+
+        private void AppendInt32(int value) {
+            _int32Bytes[0] = (byte)value;
+            _int32Bytes[1] = (byte)(value >> 8);
+            _int32Bytes[2] = (byte)(value >> 16);
+            _int32Bytes[3] = (byte)(value >> 24);
+            _hash.AppendData(_int32Bytes);
+        }
+
+        private void AppendByte(byte value) {
+            _singleByte[0] = value;
+            _hash.AppendData(_singleByte);
+        }
+    }
+}

--- a/OfficeIMO.Pdf/Manipulation/PdfJavaScriptNameTreeEditor.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfJavaScriptNameTreeEditor.cs
@@ -1,0 +1,216 @@
+namespace OfficeIMO.Pdf;
+
+/// <summary>Applies exact-key commands while preserving untouched JavaScript name-tree values.</summary>
+internal static partial class PdfJavaScriptNameTreeEditor {
+    internal static void Rewrite(
+        Dictionary<int, PdfIndirectObject> objects,
+        PdfDocumentSecurityInfo security,
+        IReadOnlyList<PdfJavaScriptEditSession.EditCommand> commands,
+        PdfReadLimits limits) {
+        if (!security.RootObjectNumber.HasValue ||
+            !objects.TryGetValue(security.RootObjectNumber.Value, out PdfIndirectObject? root) ||
+            root.Value is not PdfDictionary catalog) {
+            throw new InvalidOperationException("PDF catalog is not readable.");
+        }
+
+        bool hasNames = catalog.Items.TryGetValue("Names", out PdfObject? namesObject);
+        PdfDictionary? names = ResolveDictionary(objects, hasNames ? namesObject : null);
+        if (hasNames && names is null) {
+            throw new InvalidDataException("The PDF catalog /Names entry is not a readable name-tree dictionary.");
+        }
+
+        int lastClear = -1;
+        for (int i = 0; i < commands.Count; i++) {
+            if (commands[i].Kind == PdfJavaScriptEditSession.EditKind.Clear) lastClear = i;
+        }
+
+        var entries = new List<NameTreeEntry>();
+        if (lastClear < 0 && names is not null && names.Items.TryGetValue("JavaScript", out PdfObject? treeObject)) {
+            int traversedNodes = 0;
+            CollectEntries(
+                objects,
+                treeObject,
+                entries,
+                new HashSet<(int ObjectNumber, int Generation)>(),
+                0,
+                ref traversedNodes,
+                limits);
+        }
+
+        int firstCommand = lastClear < 0 ? 0 : lastClear + 1;
+        for (int i = firstCommand; i < commands.Count; i++) {
+            ApplyCommand(objects, entries, commands[i]);
+        }
+
+        if (entries.Count > limits.MaxJavaScripts) {
+            throw PdfReadLimitException.Create(PdfReadLimitKind.JavaScripts, limits.MaxJavaScripts, entries.Count);
+        }
+        if (entries.Count == 0) {
+            if (names is not null) {
+                names.Items.Remove("JavaScript");
+                if (names.Items.Count == 0) catalog.Items.Remove("Names");
+            }
+            return;
+        }
+
+        if (names is null) {
+            names = new PdfDictionary();
+            catalog.Items["Names"] = names;
+        }
+
+        entries.Sort(NameTreeEntryComparer.Instance);
+        var values = new PdfArray();
+        for (int i = 0; i < entries.Count; i++) {
+            values.Items.Add(new PdfStringObj(entries[i].KeyBytes, useTextStringEncoding: true));
+            values.Items.Add(entries[i].Value);
+        }
+        var tree = new PdfDictionary();
+        tree.Items["Names"] = values;
+        names.Items["JavaScript"] = tree;
+    }
+
+    private static void ApplyCommand(
+        Dictionary<int, PdfIndirectObject> objects,
+        List<NameTreeEntry> entries,
+        PdfJavaScriptEditSession.EditCommand command) {
+        if (command.Kind == PdfJavaScriptEditSession.EditKind.Clear) {
+            entries.Clear();
+            return;
+        }
+
+        var matches = new List<int>();
+        for (int i = 0; i < entries.Count; i++) {
+            if (string.Equals(entries[i].Name, command.Name, StringComparison.Ordinal)) matches.Add(i);
+        }
+        if (command.Kind == PdfJavaScriptEditSession.EditKind.Remove) {
+            for (int i = matches.Count - 1; i >= 0; i--) entries.RemoveAt(matches[i]);
+            return;
+        }
+
+        if (matches.Count > 1) {
+            throw new InvalidDataException("The PDF JavaScript name tree contains duplicate entries for the edited key.");
+        }
+
+        PdfDictionary replacement;
+        if (matches.Count == 1) {
+            PdfObject? existing = PdfObjectLookup.Resolve(objects, entries[matches[0]].Value);
+            if (existing is not PdfDictionary action ||
+                !action.Items.TryGetValue("S", out PdfObject? actionTypeObject) ||
+                PdfObjectLookup.Resolve(objects, actionTypeObject) is not PdfName actionType ||
+                actionType.Name != "JavaScript") {
+                throw new InvalidDataException("The edited PDF JavaScript name does not reference a readable JavaScript action dictionary.");
+            }
+            replacement = CloneDictionary(action);
+            replacement.Items["JS"] = new PdfStringObj(command.EncodedScript!, useTextStringEncoding: true);
+            NameTreeEntry existingEntry = entries[matches[0]];
+            entries[matches[0]] = new NameTreeEntry(
+                existingEntry.KeyBytes,
+                command.Name!,
+                replacement,
+                existingEntry.OriginalPosition);
+            return;
+        }
+
+        replacement = new PdfDictionary();
+        replacement.Items["S"] = new PdfName("JavaScript");
+        replacement.Items["JS"] = new PdfStringObj(command.EncodedScript!, useTextStringEncoding: true);
+        entries.Add(new NameTreeEntry(command.EncodedName!, command.Name!, replacement, entries.Count));
+    }
+
+    private static void CollectEntries(
+        Dictionary<int, PdfIndirectObject> objects,
+        PdfObject treeObject,
+        List<NameTreeEntry> entries,
+        HashSet<(int ObjectNumber, int Generation)> visited,
+        int depth,
+        ref int traversedNodes,
+        PdfReadLimits limits) {
+        if (depth > limits.MaxNameTreeDepth) {
+            throw PdfReadLimitException.Create(PdfReadLimitKind.NameTreeDepth, limits.MaxNameTreeDepth, depth);
+        }
+        if (treeObject is PdfReference reference) {
+            if (!visited.Add((reference.ObjectNumber, reference.Generation))) {
+                throw new InvalidDataException("The PDF JavaScript name tree contains a reference cycle.");
+            }
+            traversedNodes++;
+            if (traversedNodes > limits.MaxNameTreeNodes) {
+                throw PdfReadLimitException.Create(PdfReadLimitKind.NameTreeNodes, limits.MaxNameTreeNodes, traversedNodes);
+            }
+            if (!PdfObjectLookup.TryGet(objects, reference, out PdfIndirectObject? indirect)) {
+                throw new InvalidDataException("The PDF JavaScript name tree contains an unresolved reference.");
+            }
+            treeObject = indirect.Value;
+        }
+        if (treeObject is not PdfDictionary tree) {
+            throw new InvalidDataException("The PDF catalog JavaScript entry is not a readable name tree.");
+        }
+        foreach (string key in tree.Items.Keys) {
+            if (key != "Names" && key != "Kids" && key != "Limits") {
+                throw new InvalidDataException("The PDF JavaScript name tree contains unsupported extension data that cannot be normalized losslessly.");
+            }
+        }
+        bool hasValues = tree.Items.TryGetValue("Names", out PdfObject? valuesObject);
+        bool hasKids = tree.Items.TryGetValue("Kids", out PdfObject? kidsObject);
+        if (hasValues && hasKids) {
+            throw new InvalidDataException("The PDF JavaScript name tree node contains both /Names and /Kids.");
+        }
+        if (hasValues) {
+            if (PdfObjectLookup.Resolve(objects, valuesObject) is not PdfArray values || (values.Items.Count & 1) != 0) {
+                throw new InvalidDataException("The PDF JavaScript name tree contains an invalid /Names array.");
+            }
+            for (int i = 0; i < values.Items.Count; i += 2) {
+                if (PdfObjectLookup.Resolve(objects, values.Items[i]) is not PdfStringObj key) {
+                    throw new InvalidDataException("The PDF JavaScript name tree contains a non-string key.");
+                }
+                string? name = PdfJavaScriptStringEncoding.TryDecode(key.RawBytes, out string decoded) ? decoded : null;
+                entries.Add(new NameTreeEntry(key.RawBytes, name, values.Items[i + 1], entries.Count));
+                if (entries.Count > limits.MaxJavaScripts) {
+                    throw PdfReadLimitException.Create(PdfReadLimitKind.JavaScripts, limits.MaxJavaScripts, entries.Count);
+                }
+            }
+        }
+        if (hasKids) {
+            if (PdfObjectLookup.Resolve(objects, kidsObject) is not PdfArray kids) {
+                throw new InvalidDataException("The PDF JavaScript name tree contains an invalid /Kids array.");
+            }
+            for (int i = 0; i < kids.Items.Count; i++) {
+                CollectEntries(objects, kids.Items[i], entries, visited, depth + 1, ref traversedNodes, limits);
+            }
+        }
+    }
+
+    private static PdfDictionary CloneDictionary(PdfDictionary source) {
+        var clone = new PdfDictionary();
+        foreach (KeyValuePair<string, PdfObject> item in source.Items) clone.Items[item.Key] = item.Value;
+        return clone;
+    }
+
+    private static PdfDictionary? ResolveDictionary(Dictionary<int, PdfIndirectObject> objects, PdfObject? value) =>
+        PdfObjectLookup.Resolve(objects, value) as PdfDictionary;
+
+    private sealed class NameTreeEntry {
+        internal NameTreeEntry(byte[] keyBytes, string? name, PdfObject value, int originalPosition) {
+            KeyBytes = (byte[])keyBytes.Clone(); Name = name; Value = value; OriginalPosition = originalPosition;
+        }
+        internal byte[] KeyBytes { get; }
+        internal string? Name { get; }
+        internal PdfObject Value { get; }
+        internal int OriginalPosition { get; }
+    }
+
+    private sealed class NameTreeEntryComparer : IComparer<NameTreeEntry> {
+        internal static NameTreeEntryComparer Instance { get; } = new NameTreeEntryComparer();
+        public int Compare(NameTreeEntry? x, NameTreeEntry? y) {
+            if (ReferenceEquals(x, y)) return 0;
+            if (x is null) return -1;
+            if (y is null) return 1;
+            int count = Math.Min(x.KeyBytes.Length, y.KeyBytes.Length);
+            for (int i = 0; i < count; i++) {
+                int comparison = x.KeyBytes[i].CompareTo(y.KeyBytes[i]);
+                if (comparison != 0) return comparison;
+            }
+            int lengthComparison = x.KeyBytes.Length.CompareTo(y.KeyBytes.Length);
+            return lengthComparison != 0 ? lengthComparison : x.OriginalPosition.CompareTo(y.OriginalPosition);
+        }
+    }
+}

--- a/OfficeIMO.Pdf/Manipulation/PdfMutationCapabilityKind.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfMutationCapabilityKind.cs
@@ -27,5 +27,8 @@ public enum PdfMutationCapabilityKind {
     EncryptionChanges,
 
     /// <summary>Signature fields, byte ranges, permissions, timestamps, and validation evidence.</summary>
-    SignatureChanges
+    SignatureChanges,
+
+    /// <summary>Executable catalog, page, annotation, or form actions.</summary>
+    ActiveContentChanges
 }

--- a/OfficeIMO.Pdf/Manipulation/PdfMutationOperation.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfMutationOperation.cs
@@ -60,5 +60,8 @@ public enum PdfMutationOperation {
     SynchronizeMetadata,
 
     /// <summary>Remove or quarantine active content and embedded payloads according to an explicit policy.</summary>
-    Sanitize
+    Sanitize,
+
+    /// <summary>Add, replace, or remove named document-level JavaScript through an explicit active-content edit.</summary>
+    ModifyJavaScript
 }

--- a/OfficeIMO.Pdf/Manipulation/PdfMutationPlanner.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfMutationPlanner.cs
@@ -227,6 +227,8 @@ internal static class PdfMutationPlanner {
                 return CanSynchronizeMetadata(preflight);
             case PdfMutationOperation.Sanitize:
                 return CanSanitize(preflight);
+            case PdfMutationOperation.ModifyJavaScript:
+                return CanModifyJavaScript(preflight);
             case PdfMutationOperation.ModifyAttachments:
                 return CanModifyAttachments(preflight);
             case PdfMutationOperation.FillFormFields:
@@ -327,7 +329,9 @@ internal static class PdfMutationPlanner {
             case PdfMutationOperation.SynchronizeMetadata:
                 return ReadOnly(PdfMutationStructure.InfoDictionary, PdfMutationStructure.XmpMetadata);
             case PdfMutationOperation.Sanitize:
-                return ReadOnly(PdfMutationStructure.Catalog, PdfMutationStructure.ObjectGraph, PdfMutationStructure.Annotations, PdfMutationStructure.Attachments, PdfMutationStructure.AcroForm);
+                return ReadOnly(PdfMutationStructure.Catalog, PdfMutationStructure.ObjectGraph, PdfMutationStructure.ActiveContent, PdfMutationStructure.Annotations, PdfMutationStructure.Attachments, PdfMutationStructure.AcroForm);
+            case PdfMutationOperation.ModifyJavaScript:
+                return ReadOnly(PdfMutationStructure.Catalog, PdfMutationStructure.ActiveContent, PdfMutationStructure.ObjectGraph);
             case PdfMutationOperation.FillFormFields:
                 return ReadOnly(PdfMutationStructure.AcroForm, PdfMutationStructure.AppearanceStreams, PdfMutationStructure.Annotations);
             case PdfMutationOperation.FlattenFormFields:
@@ -495,6 +499,9 @@ internal static class PdfMutationPlanner {
                 break;
             case PdfMutationOperation.Sanitize:
                 Add(proofs, PdfMutationProof.SanitizationReadback);
+                break;
+            case PdfMutationOperation.ModifyJavaScript:
+                Add(proofs, PdfMutationProof.JavaScriptReadback);
                 break;
         }
 
@@ -881,6 +888,11 @@ internal static class PdfMutationPlanner {
                 blocker != PdfRewriteBlockerKind.CatalogNameTrees;
         }
 
+        if (operation == PdfMutationOperation.ModifyJavaScript) {
+            return blocker != PdfRewriteBlockerKind.ActiveContent &&
+                blocker != PdfRewriteBlockerKind.CatalogNameTrees;
+        }
+
         if (operation == PdfMutationOperation.MergeDocuments) {
             return blocker != PdfRewriteBlockerKind.Forms;
         }
@@ -922,6 +934,15 @@ internal static class PdfMutationPlanner {
         if (!preflight.CanRead) return false;
         for (int i = 0; i < preflight.RewriteBlockers.Count; i++) {
             if (IsFullRewriteBlockerForOperation(preflight.RewriteBlockers[i].Kind, PdfMutationOperation.ModifyAttachments)) return false;
+        }
+        return true;
+    }
+
+    private static bool CanModifyJavaScript(PdfDocumentPreflight preflight) {
+        if (!preflight.CanRead) return false;
+        for (int i = 0; i < preflight.RewriteBlockers.Count; i++) {
+            PdfRewriteBlockerKind blocker = preflight.RewriteBlockers[i].Kind;
+            if (IsFullRewriteBlockerForOperation(blocker, PdfMutationOperation.ModifyJavaScript)) return false;
         }
         return true;
     }
@@ -990,12 +1011,16 @@ internal static class PdfMutationPlanner {
                 return PdfMutationCapabilityKind.EncryptionChanges;
             case PdfMutationStructure.Signatures:
                 return PdfMutationCapabilityKind.SignatureChanges;
+            case PdfMutationStructure.ActiveContent:
+                return PdfMutationCapabilityKind.ActiveContentChanges;
             case PdfMutationStructure.ObjectGraph when operation == PdfMutationOperation.PrepareExternalSignature || operation == PdfMutationOperation.FinalizeExternalSignature || operation == PdfMutationOperation.EnrichLongTermValidation:
                 return PdfMutationCapabilityKind.SignatureChanges;
             case PdfMutationStructure.ObjectGraph when operation == PdfMutationOperation.ModifyAttachments:
                 return PdfMutationCapabilityKind.AttachmentChanges;
             case PdfMutationStructure.ObjectGraph when operation == PdfMutationOperation.ChangeEncryption:
                 return PdfMutationCapabilityKind.EncryptionChanges;
+            case PdfMutationStructure.ObjectGraph when operation == PdfMutationOperation.ModifyJavaScript:
+                return PdfMutationCapabilityKind.ActiveContentChanges;
             case PdfMutationStructure.ObjectGraph:
                 return PdfMutationCapabilityKind.ContentChanges;
             default:
@@ -1013,7 +1038,7 @@ internal static class PdfMutationPlanner {
 
     private static void ValidateOperation(PdfMutationOperation operation) {
         int value = (int)operation;
-        if (value < (int)PdfMutationOperation.UpdateMetadata || value > (int)PdfMutationOperation.Sanitize) {
+        if (value < (int)PdfMutationOperation.UpdateMetadata || value > (int)PdfMutationOperation.ModifyJavaScript) {
             throw new ArgumentOutOfRangeException(nameof(operation), operation, "Unsupported PDF mutation operation.");
         }
     }

--- a/OfficeIMO.Pdf/Manipulation/PdfMutationProof.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfMutationProof.cs
@@ -51,5 +51,8 @@ public enum PdfMutationProof {
     LongTermValidationReadback,
 
     /// <summary>The post-save active-content and embedded-payload inventory must match the sanitization policy.</summary>
-    SanitizationReadback
+    SanitizationReadback,
+
+    /// <summary>Named scripts, exact source text, and untouched name-tree entry/action graphs must match after readback.</summary>
+    JavaScriptReadback
 }

--- a/OfficeIMO.Pdf/Manipulation/PdfMutationStructure.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfMutationStructure.cs
@@ -45,5 +45,8 @@ public enum PdfMutationStructure {
     Encryption,
 
     /// <summary>Tagged-PDF structure and marked-content references.</summary>
-    TaggedContent
+    TaggedContent,
+
+    /// <summary>Executable document, catalog, page, annotation, or form actions.</summary>
+    ActiveContent
 }

--- a/OfficeIMO.Pdf/Manipulation/PdfRewritePreservation.Actions.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfRewritePreservation.Actions.cs
@@ -42,7 +42,11 @@ public static partial class PdfRewritePreservation {
     }
 
     private static void CompareCatalogActions(List<PdfRewritePreservationIssue> issues, IReadOnlyList<PdfCatalogAction> original, IReadOnlyList<PdfCatalogAction> rewritten, PdfRewritePreservationOptions options) {
-        if (!options.PreserveCatalogActions || original.Count != rewritten.Count) {
+        if (!options.PreserveCatalogActions) {
+            return;
+        }
+        if (original.Count != rewritten.Count) {
+            issues.Add(CreateIssue("CatalogActions.Count", original.Count.ToString(System.Globalization.CultureInfo.InvariantCulture), rewritten.Count.ToString(System.Globalization.CultureInfo.InvariantCulture)));
             return;
         }
 
@@ -67,6 +71,10 @@ public static partial class PdfRewritePreservation {
             IReadOnlyList<PdfPageAction> original = originalPages[i].PageActions;
             IReadOnlyList<PdfPageAction> rewritten = rewrittenPages[i].PageActions;
             if (original.Count != rewritten.Count) {
+                issues.Add(CreateIssue(
+                    "PageActions[" + originalPages[i].PageNumber.ToString(System.Globalization.CultureInfo.InvariantCulture) + "].Count",
+                    original.Count.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                    rewritten.Count.ToString(System.Globalization.CultureInfo.InvariantCulture)));
                 continue;
             }
 

--- a/OfficeIMO.Pdf/README.md
+++ b/OfficeIMO.Pdf/README.md
@@ -78,6 +78,31 @@ enforces the same `PdfReadOptions` limits before buffering, snapshots caller
 input once, and reuses one parsed document across read, inspection, preflight,
 diagnostic, optimization, signature, and compliance operations.
 
+### Read and edit named document JavaScript
+
+```csharp
+using OfficeIMO.Pdf;
+
+PdfDocument document = PdfDocument.Open("input.pdf");
+
+foreach (PdfJavaScript script in document.JavaScript.List()) {
+    Console.WriteLine(script.Name);
+}
+
+PdfJavaScriptEditResult edited = document.JavaScript.Edit(scripts => scripts
+    .AddOrReplace("Initialize", "this.zoom = 100;")
+    .Remove("Obsolete"));
+
+File.WriteAllBytes("output.pdf", edited.ToBytes());
+```
+
+Script names use exact, case-sensitive matching. Editing preserves untouched
+name-tree entries and action data, then reads the saved artifact back before
+returning it. Per-script, script-count, and aggregate-byte limits come from
+`PdfReadOptions.Limits`. Document JavaScript is active content: the default
+sanitizer removes it, and full-rewrite edits are blocked for encrypted or signed
+inputs rather than weakening their security or revision contracts.
+
 For a single health and capability view:
 
 ```csharp

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.CatalogActions.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.CatalogActions.cs
@@ -1,18 +1,30 @@
 namespace OfficeIMO.Pdf;
 
 public sealed partial class PdfReadDocument {
-    private IReadOnlyList<PdfCatalogAction> ExtractCatalogActions() {
+    private IReadOnlyList<PdfCatalogAction> ExtractCatalogActions(out IReadOnlyList<PdfJavaScript> javaScripts) {
         PdfDictionary? catalog = FindCatalog();
         if (catalog is null) {
+            javaScripts = Array.Empty<PdfJavaScript>();
             return Array.Empty<PdfCatalogAction>();
         }
 
         var result = new List<PdfCatalogAction>();
+        var scripts = new List<PdfJavaScript>();
         if (catalog.Items.TryGetValue("Names", out var namesObject) &&
             ResolveDict(namesObject) is PdfDictionary namesDictionary &&
             namesDictionary.Items.TryGetValue("JavaScript", out var javaScriptNameTree)) {
             int traversedNameTreeNodes = 0;
-            AddCatalogActionsFromNameTree(javaScriptNameTree, result, new HashSet<int>(), 0, ref traversedNameTreeNodes);
+            int discoveredJavaScripts = 0;
+            long totalJavaScriptBytes = 0L;
+            AddCatalogActionsFromNameTree(
+                javaScriptNameTree,
+                result,
+                scripts,
+                new HashSet<(int ObjectNumber, int Generation)>(),
+                0,
+                ref traversedNameTreeNodes,
+                ref discoveredJavaScripts,
+                ref totalJavaScriptBytes);
         }
 
         if (catalog.Items.TryGetValue("OpenAction", out var openAction)) {
@@ -26,18 +38,24 @@ public sealed partial class PdfReadDocument {
             }
         }
 
+        javaScripts = scripts.Count == 0
+            ? Array.Empty<PdfJavaScript>()
+            : scripts.OrderBy(static script => script.Name, StringComparer.Ordinal).ToList().AsReadOnly();
         return result.Count == 0 ? Array.Empty<PdfCatalogAction>() : result.AsReadOnly();
     }
 
     private void AddCatalogActionsFromNameTree(
         PdfObject treeObject,
         List<PdfCatalogAction> result,
-        HashSet<int> visitedReferences,
+        List<PdfJavaScript> scripts,
+        HashSet<(int ObjectNumber, int Generation)> visitedReferences,
         int depth,
-        ref int traversedNodes) {
+        ref int traversedNodes,
+        ref int discoveredJavaScripts,
+        ref long totalJavaScriptBytes) {
         EnsureNameTreeBudget(depth, traversedNodes);
         if (treeObject is PdfReference reference) {
-            if (visitedReferences.Contains(reference.ObjectNumber)) {
+            if (!visitedReferences.Add((reference.ObjectNumber, reference.Generation))) {
                 return;
             }
 
@@ -46,7 +64,6 @@ public sealed partial class PdfReadDocument {
                 return;
             }
 
-            visitedReferences.Add(reference.ObjectNumber);
             treeObject = indirect.Value;
         }
 
@@ -57,8 +74,20 @@ public sealed partial class PdfReadDocument {
         if (tree.Items.TryGetValue("Names", out var actionNamesObject) &&
             ResolveArray(actionNamesObject) is PdfArray actionNames) {
             for (int i = 0; i + 1 < actionNames.Items.Count; i += 2) {
+                discoveredJavaScripts++;
+                if (discoveredJavaScripts > _options.Limits.MaxJavaScripts) {
+                    throw PdfReadLimitException.Create(PdfReadLimitKind.JavaScripts, _options.Limits.MaxJavaScripts, discoveredJavaScripts);
+                }
                 if (TryReadCatalogActionName(actionNames.Items[i], out string? name)) {
                     AddCatalogAction(name!, "Names/JavaScript", null, actionNames.Items[i + 1], result, new HashSet<int>());
+                    bool hasReadableSource = TryReadJavaScriptSource(actionNames.Items[i + 1], out string? script, out long sourceBytes);
+                    totalJavaScriptBytes = checked(totalJavaScriptBytes + sourceBytes);
+                    if (totalJavaScriptBytes > _options.Limits.MaxTotalJavaScriptBytes) {
+                        throw PdfReadLimitException.Create(PdfReadLimitKind.JavaScriptBytes, _options.Limits.MaxTotalJavaScriptBytes, totalJavaScriptBytes);
+                    }
+                    if (hasReadableSource) {
+                        scripts.Add(new PdfJavaScript(name!, script!));
+                    }
                 }
             }
         }
@@ -66,16 +95,65 @@ public sealed partial class PdfReadDocument {
         if (tree.Items.TryGetValue("Kids", out var kidsObject) &&
             ResolveArray(kidsObject) is PdfArray kids) {
             foreach (var kid in kids.Items) {
-                AddCatalogActionsFromNameTree(kid, result, visitedReferences, depth + 1, ref traversedNodes);
+                AddCatalogActionsFromNameTree(
+                    kid,
+                    result,
+                    scripts,
+                    visitedReferences,
+                    depth + 1,
+                    ref traversedNodes,
+                    ref discoveredJavaScripts,
+                    ref totalJavaScriptBytes);
             }
         }
+    }
+
+    private bool TryReadJavaScriptSource(PdfObject actionObject, out string? script, out long sourceBytes) {
+        if (ResolveObject(actionObject) is not PdfDictionary action ||
+            !TryReadCatalogActionType(action, out string? actionType) ||
+            !string.Equals(actionType, "JavaScript", StringComparison.Ordinal) ||
+            !action.Items.TryGetValue("JS", out PdfObject? sourceObject)) {
+            script = null;
+            sourceBytes = 0L;
+            return false;
+        }
+
+        PdfObject? source = ResolveObject(sourceObject);
+        if (source is PdfStringObj text) {
+            int byteCount = text.RawBytes.Length;
+            int maximumBytes = Math.Min(_options.Limits.MaxJavaScriptBytes, _options.Limits.MaxDecodedStreamBytes);
+            if (byteCount > maximumBytes) {
+                throw PdfReadLimitException.Create(PdfReadLimitKind.DecodedStreamBytes, maximumBytes, byteCount);
+            }
+            sourceBytes = byteCount;
+            return PdfJavaScriptStringEncoding.TryDecode(text.RawBytes, out script!);
+        }
+
+        if (source is PdfStream stream) {
+            try {
+                byte[] decoded = Filters.StreamDecoder.DecodeRequired(
+                    stream.Dictionary,
+                    stream.Data,
+                    _objects,
+                    Math.Min(_options.Limits.MaxJavaScriptBytes, _options.Limits.MaxDecodedStreamBytes));
+                sourceBytes = decoded.LongLength;
+                return PdfJavaScriptStringEncoding.TryDecode(decoded, out script!);
+            } catch (InvalidDataException) {
+                script = null;
+                sourceBytes = 0L;
+                return false;
+            }
+        }
+
+        script = null;
+        sourceBytes = 0L;
+        return false;
     }
 
     private bool TryReadCatalogActionName(PdfObject obj, out string? name) {
         switch (ResolveObject(obj)) {
             case PdfStringObj text:
-                name = text.Value;
-                return !string.IsNullOrEmpty(name);
+                return PdfJavaScriptStringEncoding.TryDecode(text.RawBytes, out name!) && !string.IsNullOrEmpty(name);
             case PdfName pdfName:
                 name = pdfName.Name;
                 return !string.IsNullOrEmpty(name);

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.cs
@@ -17,6 +17,7 @@ public sealed partial class PdfReadDocument {
     private readonly IReadOnlyList<PdfPageLabel> _pageLabels;
     private readonly IReadOnlyList<PdfNamedDestination> _namedDestinations;
     private readonly IReadOnlyList<PdfCatalogAction> _catalogActions;
+    private readonly IReadOnlyList<PdfJavaScript> _javaScripts;
     private readonly IReadOnlyList<PdfAttachmentInfo> _attachments;
     private readonly PdfTaggedContentInfo? _taggedContent;
     private readonly PdfOptionalContentProperties? _optionalContent;
@@ -46,7 +47,7 @@ public sealed partial class PdfReadDocument {
         _metadata = ExtractMetadata();
         _pageLabels = ExtractPageLabels();
         _namedDestinations = ExtractNamedDestinations();
-        _catalogActions = ExtractCatalogActions();
+        _catalogActions = ExtractCatalogActions(out _javaScripts);
         _attachments = ExtractAttachmentInfos();
         _outputIntents = ExtractOutputIntents();
         _xmpMetadata = ExtractXmpMetadata();
@@ -85,6 +86,9 @@ public sealed partial class PdfReadDocument {
 
     /// <summary>Catalog-level actions discovered from supported name trees.</summary>
     public IReadOnlyList<PdfCatalogAction> CatalogActions => ReadLogicalContent(_catalogActions);
+
+    /// <summary>Named document-level JavaScript actions discovered from the catalog name tree.</summary>
+    public IReadOnlyList<PdfJavaScript> JavaScripts => ReadLogicalContent(_javaScripts);
 
     /// <summary>Simple document open action discovered from the document catalog, when supported.</summary>
     public PdfDocumentOpenAction? OpenAction => ReadLogicalContent(_openAction);
@@ -138,6 +142,7 @@ public sealed partial class PdfReadDocument {
     internal IReadOnlyList<PdfPageLabel> UncheckedPageLabels => _pageLabels;
     internal IReadOnlyList<PdfNamedDestination> UncheckedNamedDestinations => _namedDestinations;
     internal IReadOnlyList<PdfCatalogAction> UncheckedCatalogActions => _catalogActions;
+    internal IReadOnlyList<PdfJavaScript> UncheckedJavaScripts => _javaScripts;
     internal IReadOnlyList<PdfAttachmentInfo> UncheckedAttachments => _attachments;
     internal PdfTaggedContentInfo? UncheckedTaggedContent => _taggedContent;
     internal PdfOptionalContentProperties? UncheckedOptionalContent => _optionalContent;

--- a/OfficeIMO.Pdf/Reading/Model/PdfJavaScript.cs
+++ b/OfficeIMO.Pdf/Reading/Model/PdfJavaScript.cs
@@ -1,0 +1,15 @@
+namespace OfficeIMO.Pdf;
+
+/// <summary>A named document-level JavaScript action from the catalog JavaScript name tree.</summary>
+public sealed class PdfJavaScript {
+    internal PdfJavaScript(string name, string script) {
+        Name = name;
+        Script = script;
+    }
+
+    /// <summary>Name-tree key that identifies the script.</summary>
+    public string Name { get; }
+
+    /// <summary>Exact JavaScript source stored by the PDF action.</summary>
+    public string Script { get; }
+}

--- a/OfficeIMO.Pdf/Reading/Options/PdfReadLimitKind.cs
+++ b/OfficeIMO.Pdf/Reading/Options/PdfReadLimitKind.cs
@@ -96,5 +96,11 @@ public enum PdfReadLimitKind {
     Attachments = 30,
 
     /// <summary>Aggregate decoded bytes retained for unique embedded attachment streams.</summary>
-    AttachmentBytes = 31
+    AttachmentBytes = 31,
+
+    /// <summary>Named document-level JavaScript entries discovered in the catalog name tree.</summary>
+    JavaScripts = 32,
+
+    /// <summary>Aggregate decoded source bytes retained for named document-level JavaScript.</summary>
+    JavaScriptBytes = 33
 }

--- a/OfficeIMO.Pdf/Reading/Options/PdfReadLimits.cs
+++ b/OfficeIMO.Pdf/Reading/Options/PdfReadLimits.cs
@@ -11,6 +11,9 @@ public sealed class PdfReadLimits {
     internal const int DefaultMaxDecodedTextCharacters = 10_000_000;
     internal const int DefaultMaxNameTreeNodes = 100_000;
     internal const int DefaultMaxNameTreeDepth = 128;
+    internal const int DefaultMaxJavaScriptBytes = 4_000_000;
+    internal const int DefaultMaxJavaScripts = 10_000;
+    internal const long DefaultMaxTotalJavaScriptBytes = 32L * 1024L * 1024L;
     internal const int DefaultMaxAttachments = 100_000;
     internal const long DefaultMaxTotalAttachmentBytes = 256L * 1024L * 1024L;
 
@@ -74,6 +77,15 @@ public sealed class PdfReadLimits {
     /// <summary>Maximum nested PDF name-tree depth. Default: 128.</summary>
     public int MaxNameTreeDepth { get; init; } = DefaultMaxNameTreeDepth;
 
+    /// <summary>Maximum decoded source bytes retained for one document-level JavaScript action. Default: 4,000,000.</summary>
+    public int MaxJavaScriptBytes { get; init; } = DefaultMaxJavaScriptBytes;
+
+    /// <summary>Maximum named document-level JavaScript entries discovered in one PDF. Default: 10,000.</summary>
+    public int MaxJavaScripts { get; init; } = DefaultMaxJavaScripts;
+
+    /// <summary>Maximum aggregate decoded source bytes retained for document-level JavaScript. Default: 32 MiB.</summary>
+    public long MaxTotalJavaScriptBytes { get; init; } = DefaultMaxTotalJavaScriptBytes;
+
     /// <summary>Maximum attachment records discovered across name trees, associated files, and annotations. Default: 100,000.</summary>
     public int MaxAttachments { get; init; } = DefaultMaxAttachments;
 
@@ -119,6 +131,9 @@ public sealed class PdfReadLimits {
             MaxFormFieldDepth = MaxFormFieldDepth,
             MaxNameTreeNodes = MaxNameTreeNodes,
             MaxNameTreeDepth = MaxNameTreeDepth,
+            MaxJavaScriptBytes = MaxJavaScriptBytes,
+            MaxJavaScripts = MaxJavaScripts,
+            MaxTotalJavaScriptBytes = MaxTotalJavaScriptBytes,
             MaxAttachments = MaxAttachments,
             MaxTotalAttachmentBytes = MaxTotalAttachmentBytes,
             MaxFormFieldAppearanceStates = MaxFormFieldAppearanceStates,
@@ -175,6 +190,11 @@ public sealed class PdfReadLimits {
         ValidatePositive(MaxFormFieldDepth, nameof(MaxFormFieldDepth), "Maximum form-field depth must be positive.");
         ValidatePositive(MaxNameTreeNodes, nameof(MaxNameTreeNodes), "Maximum name-tree nodes must be positive.");
         ValidatePositive(MaxNameTreeDepth, nameof(MaxNameTreeDepth), "Maximum name-tree depth must be positive.");
+        ValidatePositive(MaxJavaScriptBytes, nameof(MaxJavaScriptBytes), "Maximum document JavaScript bytes must be positive.");
+        ValidatePositive(MaxJavaScripts, nameof(MaxJavaScripts), "Maximum document JavaScript entries must be positive.");
+        if (MaxTotalJavaScriptBytes <= 0L) {
+            throw new ArgumentOutOfRangeException(nameof(MaxTotalJavaScriptBytes), MaxTotalJavaScriptBytes, "Maximum aggregate document JavaScript bytes must be positive.");
+        }
         ValidatePositive(MaxAttachments, nameof(MaxAttachments), "Maximum attachments must be positive.");
         if (MaxTotalAttachmentBytes <= 0L) {
             throw new ArgumentOutOfRangeException(nameof(MaxTotalAttachmentBytes), MaxTotalAttachmentBytes, "Maximum aggregate attachment bytes must be positive.");

--- a/OfficeIMO.Pdf/Reading/Util/PdfDocEncoding.cs
+++ b/OfficeIMO.Pdf/Reading/Util/PdfDocEncoding.cs
@@ -3,6 +3,7 @@ namespace OfficeIMO.Pdf;
 /// <summary>PDFDocEncoding conversion for PDF text strings without a Unicode byte-order marker.</summary>
 internal static class PdfDocEncoding {
     private static readonly char[] Map = BuildMap();
+    private static readonly bool[] Defined = BuildDefinedMap();
 
     internal static bool TryDecode(byte[] bytes, out string value) {
         if (bytes.Length == 0) {
@@ -12,12 +13,12 @@ internal static class PdfDocEncoding {
 
         var characters = new char[bytes.Length];
         for (int i = 0; i < bytes.Length; i++) {
-            char character = Map[bytes[i]];
-            if (character == '\0') {
+            byte encoded = bytes[i];
+            if (!Defined[encoded]) {
                 value = string.Empty;
                 return false;
             }
-            characters[i] = character;
+            characters[i] = Map[encoded];
         }
         value = new string(characters);
         return true;
@@ -25,7 +26,7 @@ internal static class PdfDocEncoding {
 
     private static char[] BuildMap() {
         var map = new char[256];
-        map[9] = '\t'; map[10] = '\n'; map[13] = '\r';
+        for (int value = 0; value <= 23; value++) map[value] = (char)value;
         map[24] = '\u02D8'; map[25] = '\u02C7'; map[26] = '\u02C6'; map[27] = '\u02D9';
         map[28] = '\u02DD'; map[29] = '\u02DB'; map[30] = '\u02DA'; map[31] = '\u02DC';
         for (int value = 32; value <= 126; value++) map[value] = (char)value;
@@ -40,5 +41,15 @@ internal static class PdfDocEncoding {
         for (int value = 161; value <= 172; value++) map[value] = (char)value;
         for (int value = 174; value <= 255; value++) map[value] = (char)value;
         return map;
+    }
+
+    private static bool[] BuildDefinedMap() {
+        var defined = new bool[256];
+        for (int value = 0; value <= 126; value++) defined[value] = true;
+        for (int value = 128; value <= 158; value++) defined[value] = true;
+        defined[160] = true;
+        for (int value = 161; value <= 172; value++) defined[value] = true;
+        for (int value = 174; value <= 255; value++) defined[value] = true;
+        return defined;
     }
 }

--- a/OfficeIMO.Pdf/Reading/Util/PdfDocEncoding.cs
+++ b/OfficeIMO.Pdf/Reading/Util/PdfDocEncoding.cs
@@ -1,0 +1,44 @@
+namespace OfficeIMO.Pdf;
+
+/// <summary>PDFDocEncoding conversion for PDF text strings without a Unicode byte-order marker.</summary>
+internal static class PdfDocEncoding {
+    private static readonly char[] Map = BuildMap();
+
+    internal static bool TryDecode(byte[] bytes, out string value) {
+        if (bytes.Length == 0) {
+            value = string.Empty;
+            return true;
+        }
+
+        var characters = new char[bytes.Length];
+        for (int i = 0; i < bytes.Length; i++) {
+            char character = Map[bytes[i]];
+            if (character == '\0') {
+                value = string.Empty;
+                return false;
+            }
+            characters[i] = character;
+        }
+        value = new string(characters);
+        return true;
+    }
+
+    private static char[] BuildMap() {
+        var map = new char[256];
+        map[9] = '\t'; map[10] = '\n'; map[13] = '\r';
+        map[24] = '\u02D8'; map[25] = '\u02C7'; map[26] = '\u02C6'; map[27] = '\u02D9';
+        map[28] = '\u02DD'; map[29] = '\u02DB'; map[30] = '\u02DA'; map[31] = '\u02DC';
+        for (int value = 32; value <= 126; value++) map[value] = (char)value;
+        char[] specials = {
+            '\u2022', '\u2020', '\u2021', '\u2026', '\u2014', '\u2013', '\u0192', '\u2044',
+            '\u2039', '\u203A', '\u2212', '\u2030', '\u201E', '\u201C', '\u201D', '\u2018',
+            '\u2019', '\u201A', '\u2122', '\uFB01', '\uFB02', '\u0141', '\u0152', '\u0160',
+            '\u0178', '\u017D', '\u0131', '\u0142', '\u0153', '\u0161', '\u017E'
+        };
+        for (int index = 0; index < specials.Length; index++) map[128 + index] = specials[index];
+        map[160] = '\u20AC';
+        for (int value = 161; value <= 172; value++) map[value] = (char)value;
+        for (int value = 174; value <= 255; value++) map[value] = (char)value;
+        return map;
+    }
+}

--- a/OfficeIMO.Pdf/Reading/Util/PdfJavaScriptStringEncoding.cs
+++ b/OfficeIMO.Pdf/Reading/Util/PdfJavaScriptStringEncoding.cs
@@ -1,0 +1,57 @@
+namespace OfficeIMO.Pdf;
+
+/// <summary>Text-string encoding used by named PDF JavaScript keys and sources.</summary>
+internal static class PdfJavaScriptStringEncoding {
+    internal static bool TryDecode(byte[] bytes, out string value) {
+        if (bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF) {
+            try {
+                value = new System.Text.UTF8Encoding(false, true).GetString(bytes, 3, bytes.Length - 3);
+                return IsWellFormedUtf16(value);
+            } catch (System.Text.DecoderFallbackException) {
+                value = string.Empty;
+                return false;
+            }
+        }
+        if (bytes.Length >= 2 &&
+            (bytes[0] == 0xFE && bytes[1] == 0xFF || bytes[0] == 0xFF && bytes[1] == 0xFE)) {
+            if (((bytes.Length - 2) & 1) != 0) {
+                value = string.Empty;
+                return false;
+            }
+            try {
+                value = PdfTextString.Decode(bytes);
+                return IsWellFormedUtf16(value);
+            } catch {
+                value = string.Empty;
+                return false;
+            }
+        }
+        return PdfDocEncoding.TryDecode(bytes, out value);
+    }
+
+    internal static byte[] EncodeUnicode(string value, string parameterName) {
+        if (!IsWellFormedUtf16(value)) {
+            throw new ArgumentException("PDF JavaScript text must contain well-formed Unicode.", parameterName);
+        }
+        var bytes = new byte[2 + checked(value.Length * 2)];
+        bytes[0] = 0xFE;
+        bytes[1] = 0xFF;
+        for (int i = 0; i < value.Length; i++) {
+            bytes[2 + (i * 2)] = (byte)(value[i] >> 8);
+            bytes[3 + (i * 2)] = (byte)value[i];
+        }
+        return bytes;
+    }
+
+    private static bool IsWellFormedUtf16(string value) {
+        for (int i = 0; i < value.Length; i++) {
+            char character = value[i];
+            if (char.IsHighSurrogate(character)) {
+                if (i + 1 >= value.Length || !char.IsLowSurrogate(value[++i])) return false;
+            } else if (char.IsLowSurrogate(character)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
## What changed

- adds a fluent PdfDocument.JavaScript surface for listing, adding, replacing, removing, and clearing named document scripts
- reads PDFDocEncoding and Unicode text strings, including stream-backed script sources
- preserves untouched name-tree entries, chained actions, extension data, opaque values, and stable duplicate ordering
- integrates JavaScript edits with mutation planning, artifact readback, rewrite-preservation evidence, and active-content sanitization

## Safety and limits

Script names use exact ordinal matching. Reader and editor paths enforce per-script, script-count, aggregate-byte, name-tree depth, and node limits. Encrypted and signed inputs remain blocked because this operation requires a full rewrite.

## Validation

- OfficeIMO.Pdf focused contracts: 115 passed on net8.0 and net10.0
- full OfficeIMO.Pdf.Tests: 3,468 passed on net8.0 and net10.0
- OfficeIMO.Pdf netstandard2.0 build: clean with zero warnings
- independent read-only review plus one targeted confirmation completed; all validated P1/P2 findings addressed