### PR TITLE
Add existing PDF image editing workflows

### DIFF
--- a/OfficeIMO.Pdf.Tests/Pdf/PdfImageEditorTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfImageEditorTests.cs
@@ -1,0 +1,361 @@
+using System.Globalization;
+using System.Text;
+using OfficeIMO.Pdf;
+using Xunit;
+
+namespace OfficeIMO.Tests.Pdf;
+
+public class PdfImageEditorTests {
+    [Fact]
+    public void AddFindAndRemoveAffectOnlyTheSelectedPlacement() {
+        byte[] source = PdfDocument.Create()
+            .Paragraph(paragraph => paragraph.Text("Keep this text"))
+            .ToBytes();
+        byte[] annotated = PdfDocument.Open(source).Annotations.Add(new PdfAnnotationCreateOptions {
+            PageNumber = 1,
+            Subtype = "Square",
+            Rectangle = new[] { 35D, 75D, 75D, 105D }
+        }).Bytes;
+        PdfDocument first = PdfDocument.Open(annotated).Images.Add(
+            new PdfPageRegion(1, 40D, 80D, 30D, 20D),
+            PdfPngTestImages.CreateRgbPng(255, 0, 0)).Document;
+        PdfDocument second = first.Images.Add(
+            new PdfPageRegion(1, 120D, 80D, 30D, 20D),
+            PdfPngTestImages.CreateRgbPng(0, 255, 0)).Document;
+
+        PdfImagePlacement selected = Assert.Single(second.Images.Find(new PdfPageRegion(1, 35D, 75D, 40D, 30D)));
+        PdfImageEditResult removed = second.Images.Remove(selected);
+        PdfImagePlacement remaining = Assert.Single(removed.Document.Images.Placements());
+
+        Assert.Equal(1, removed.AffectedCount);
+        Assert.InRange(remaining.X, 119.99D, 120.01D);
+        Assert.Contains("Keep this text", removed.Document.Read.Text(), StringComparison.Ordinal);
+        Assert.Single(removed.Document.Read.AnnotationsBySubtype("Square"));
+    }
+
+    [Fact]
+    public void ReplacePreservesPortableGeometryAndUsesReplacementPixels() {
+        byte[] source = PdfStamper.StampImage(
+            CreateTextPdf(),
+            PdfPngTestImages.CreateRgbPng(255, 0, 0),
+            new PdfImageStampOptions {
+                PageNumbers = new[] { 1 },
+                X = 80D,
+                Y = 140D,
+                Width = 60D,
+                Height = 30D,
+                RotationDegrees = 30D
+            });
+        PdfDocument document = PdfDocument.Open(source);
+        PdfImagePlacement original = Assert.Single(document.Images.Placements());
+        byte[] originalPayload = Assert.Single(document.Read.Images()).Bytes;
+
+        PdfImageEditResult result = document.Images.Replace(original, PdfPngTestImages.CreateRgbPng(0, 0, 255));
+        PdfImagePlacement replacement = Assert.Single(result.Document.Images.Placements());
+        byte[] replacementPayload = Assert.Single(result.Document.Read.Images()).Bytes;
+
+        Assert.Equal(original.A, replacement.A, 2);
+        Assert.Equal(original.B, replacement.B, 2);
+        Assert.Equal(original.C, replacement.C, 2);
+        Assert.Equal(original.D, replacement.D, 2);
+        Assert.Equal(original.E, replacement.E, 2);
+        Assert.Equal(original.F, replacement.F, 2);
+        Assert.NotEqual(Convert.ToBase64String(originalPayload), Convert.ToBase64String(replacementPayload));
+        Assert.Contains("Image editor proof", result.Document.Read.Text(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MovePreservesPortableTransformAndMovesByRequestedOffset() {
+        PdfDocument source = PdfDocument.Open(CreateTextPdf()).Images.Add(
+            new PdfPageRegion(1, 50D, 90D, 40D, 25D),
+            PdfPngTestImages.CreateRgbPng(10, 80, 160)).Document;
+        PdfImagePlacement original = Assert.Single(source.Images.Placements());
+
+        PdfImageEditResult result = source.Images.Move(original, 35D, -15D, new PdfImageEditOptions {
+            Layer = PdfImageEditLayer.BehindExistingContent
+        });
+        PdfImagePlacement moved = Assert.Single(result.Document.Images.Placements());
+
+        Assert.Equal(original.E + 35D, moved.E, 2);
+        Assert.Equal(original.F - 15D, moved.F, 2);
+        Assert.Equal(original.A, moved.A, 2);
+        Assert.Equal(original.D, moved.D, 2);
+        Assert.Contains("Image editor proof", result.Document.Read.Text(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RemoveFailsClosedForAnAmbiguousExactPlacement() {
+        byte[] source = BuildRawImagePdf(
+            "q 40 0 0 20 20 30 cm /Im0 Do Q\n" +
+            "q 40 0 0 20 20 30 cm /Im0 Do Q\n");
+        PdfDocument document = PdfDocument.Open(source);
+        PdfImagePlacement selected = document.Images.Placements()[0];
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => document.Images.Remove(selected));
+
+        Assert.Contains("ambiguous", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(2, document.Images.Placements().Count);
+    }
+
+    [Fact]
+    public void ReplaceAndMoveFailClosedWhenPlacementSemanticsCannotBeReproduced() {
+        byte[] clipped = BuildRawImagePdf("q 0 0 15 15 re W n 40 0 0 20 20 30 cm /Im0 Do Q\n");
+        byte[] skewed = BuildRawImagePdf("q 40 5 0 20 20 30 cm /Im0 Do Q\n");
+        PdfDocument clippedDocument = PdfDocument.Open(clipped);
+        PdfDocument skewedDocument = PdfDocument.Open(skewed);
+
+        Assert.Throws<NotSupportedException>(() => clippedDocument.Images.Replace(
+            Assert.Single(clippedDocument.Images.Placements()),
+            PdfPngTestImages.CreateRgbPng(0, 0, 255)));
+        Assert.Throws<NotSupportedException>(() => skewedDocument.Images.Move(
+            Assert.Single(skewedDocument.Images.Placements()),
+            10D,
+            10D));
+    }
+
+    [Fact]
+    public void RemoveSupportsSkewedXObjectsButInlineImagesFailClosed() {
+        byte[] skewed = BuildRawImagePdf("q 40 5 0 20 20 30 cm /Im0 Do Q\n");
+        byte[] inline = BuildRawInlineImagePdf("q 40 0 0 20 20 30 cm BI /W 1 /H 1 /BPC 8 /CS /RGB ID ", new byte[] { 255, 0, 0 }, " EI Q\n");
+        PdfDocument skewedDocument = PdfDocument.Open(skewed);
+        PdfDocument inlineDocument = PdfDocument.Open(inline);
+
+        PdfImageEditResult removed = skewedDocument.Images.Remove(Assert.Single(skewedDocument.Images.Placements()));
+
+        Assert.Empty(removed.Document.Images.Placements());
+        Assert.Throws<NotSupportedException>(() => inlineDocument.Images.Remove(Assert.Single(inlineDocument.Images.Placements())));
+    }
+
+    [Fact]
+    public void RemoveClonesARepeatedFormAndKeepsTheOtherImageInvocation() {
+        byte[] source = BuildRepeatedFormImagePdf();
+        PdfDocument document = PdfDocument.Open(source);
+        PdfImagePlacement left = document.Images.Placements().OrderBy(static placement => placement.X).First();
+
+        PdfImageEditResult result = document.Images.Remove(left);
+        PdfImagePlacement remaining = Assert.Single(result.Document.Images.Placements());
+
+        Assert.InRange(remaining.X, 119.99D, 120.01D);
+    }
+
+    [Fact]
+    public void ExactRemovalKeepsSameNamedImageFromAnotherFormResourceContext() {
+        PdfDocument document = PdfDocument.Open(BuildCollidingFormImagePdf());
+        PdfImagePlacement selected = document.Images.Placements().Single(static placement => placement.ObjectNumber == 8);
+
+        PdfImageEditResult result = document.Images.Remove(selected);
+        PdfImagePlacement remaining = Assert.Single(result.Document.Images.Placements());
+
+        Assert.Equal(2, Assert.Single(result.Document.Read.Images()).Width);
+    }
+
+    [Fact]
+    public void ExactRemovalKeepsSameBoundsPlacementWithDifferentTransform() {
+        byte[] source = BuildRawImagePdf(
+            "q 40 0 0 40 20 30 cm /Im0 Do Q\n" +
+            "q 0 40 -40 0 60 30 cm /Im0 Do Q\n");
+        PdfDocument document = PdfDocument.Open(source);
+        PdfImagePlacement selected = document.Images.Placements().Single(static placement => Math.Abs(placement.A - 40D) < 0.01D);
+
+        PdfImageEditResult result = document.Images.Remove(selected);
+        PdfImagePlacement remaining = Assert.Single(result.Document.Images.Placements());
+
+        Assert.InRange(remaining.B, 39.99D, 40.01D);
+    }
+
+    [Fact]
+    public void ExactRemovalCarriesGraphicsStateAcrossContentStreamArray() {
+        PdfDocument document = PdfDocument.Open(BuildSplitContentImagePdf());
+
+        PdfImageEditResult result = document.Images.Remove(Assert.Single(document.Images.Placements()));
+
+        Assert.Empty(result.Document.Images.Placements());
+    }
+
+    [Fact]
+    public void ReplaceRejectsNonNormalBlendModeAndMoveRejectsJpegDecodeSemantics() {
+        byte[] blended = BuildRawImagePdf(
+            "/GS1 gs q 40 0 0 20 20 30 cm /Im0 Do Q\n",
+            additionalResources: "/ExtGState << /GS1 << /BM /Multiply >> >>");
+        byte[] decodedJpeg = BuildRawImagePdf(
+            "q 40 0 0 20 20 30 cm /Im0 Do Q\n",
+            imageBytes: new byte[] { 0xFF, 0xD8, 0xFF, 0xD9 },
+            imageEntries: "/ColorSpace /DeviceRGB /BitsPerComponent 8 /Filter /DCTDecode /Decode [1 0 1 0 1 0]");
+        PdfDocument blendedDocument = PdfDocument.Open(blended);
+        PdfDocument jpegDocument = PdfDocument.Open(decodedJpeg);
+
+        Assert.Throws<NotSupportedException>(() => blendedDocument.Images.Replace(
+            Assert.Single(blendedDocument.Images.Placements()),
+            PdfPngTestImages.CreateRgbPng(0, 0, 255)));
+        Assert.Throws<NotSupportedException>(() => jpegDocument.Images.Move(
+            Assert.Single(jpegDocument.Images.Placements()),
+            10D,
+            0D));
+    }
+
+    [Fact]
+    public void SoftMaskNoneClearsAnActiveGraphicsStateMaskForLaterImageEditing() {
+        byte[] source = BuildRawImagePdf(
+            "/GSActive gs /GSClear gs q 40 0 0 20 20 30 cm /Im0 Do Q\n",
+            additionalResources: "/ExtGState << /GSActive << /SMask << >> >> /GSClear << /SMask /None >> >>");
+        PdfDocument document = PdfDocument.Open(source);
+
+        PdfImageEditResult result = document.Images.Replace(
+            Assert.Single(document.Images.Placements()),
+            PdfPngTestImages.CreateRgbPng(0, 0, 255));
+
+        Assert.Single(result.Document.Images.Placements());
+    }
+
+    [Fact]
+    public void DegeneratePlacementCannotReportSuccessfulRemoval() {
+        PdfDocument document = PdfDocument.Open(BuildRawImagePdf("q 0 0 0 20 20 30 cm /Im0 Do Q\n"));
+
+        NotSupportedException exception = Assert.Throws<NotSupportedException>(() =>
+            document.Images.Remove(Assert.Single(document.Images.Placements())));
+
+        Assert.Contains("degenerate", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void PlacementFromAnotherDocumentIsRejected() {
+        PdfDocument first = PdfDocument.Open(CreateTextPdf()).Images.Add(
+            new PdfPageRegion(1, 20D, 30D, 30D, 20D),
+            PdfPngTestImages.CreateRgbPng(255, 0, 0)).Document;
+        PdfDocument second = PdfDocument.Open(CreateTextPdf()).Images.Add(
+            new PdfPageRegion(1, 120D, 130D, 30D, 20D),
+            PdfPngTestImages.CreateRgbPng(255, 0, 0)).Document;
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+            second.Images.Remove(Assert.Single(first.Images.Placements())));
+
+        Assert.Contains("does not exist", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ReplaceCarriesExactInputBudgetAcrossRemovalAndStamping() {
+        PdfDocument prepared = PdfDocument.Open(CreateTextPdf()).Images.Add(
+            new PdfPageRegion(1, 40D, 80D, 30D, 20D),
+            PdfPngTestImages.CreateRgbPng(255, 0, 0)).Document;
+        byte[] source = prepared.ToBytes();
+        var readOptions = new PdfReadOptions { Limits = new PdfReadLimits { MaxInputBytes = source.Length } };
+        PdfDocument bounded = PdfDocument.Open(source, readOptions);
+
+        PdfImageEditResult result = bounded.Images.Replace(
+            Assert.Single(bounded.Images.Placements()),
+            PdfPngTestImages.CreateRgbPng(32, 32));
+
+        Assert.Single(result.Document.Images.Placements());
+        Assert.Single(result.Document.Read.Images());
+    }
+
+    [Fact]
+    public void PublicOptionsValidateCoordinatesAndPageSelection() {
+        PdfDocument document = PdfDocument.Open(CreateTextPdf());
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => document.Images.Find(new PdfPageRegion(2, 0D, 0D, 10D, 10D)));
+        Assert.Throws<ArgumentOutOfRangeException>(() => document.Images.Move(
+            new PdfImagePlacement(1, "Im0", 1, 0, 1D, 0D, 0D, 1D, 0D, 0D, 0D, 0D, 1D, 1D),
+            double.NaN,
+            0D));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new PdfImageEditOptions { Layer = (PdfImageEditLayer)999 });
+    }
+
+    private static byte[] CreateTextPdf() => PdfDocument.Create()
+        .Paragraph(paragraph => paragraph.Text("Image editor proof"))
+        .ToBytes();
+
+    private static byte[] BuildRawImagePdf(
+        string content,
+        string additionalResources = "",
+        byte[]? imageBytes = null,
+        string imageEntries = "/ColorSpace /DeviceRGB /BitsPerComponent 8") {
+        byte[] contentBytes = Encoding.ASCII.GetBytes(content);
+        imageBytes ??= new byte[] { 255, 0, 0 };
+        using var output = new MemoryStream();
+        WriteAscii(output, "%PDF-1.7\n");
+        WriteAscii(output, "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+        WriteAscii(output, "2 0 obj\n<< /Type /Pages /Count 1 /Kids [3 0 R] >>\nendobj\n");
+        WriteAscii(output, "3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 120] /Resources << /XObject << /Im0 5 0 R >> " + additionalResources + " >> /Contents 4 0 R >>\nendobj\n");
+        WriteAscii(output, "4 0 obj\n<< /Length " + contentBytes.Length.ToString(CultureInfo.InvariantCulture) + " >>\nstream\n");
+        output.Write(contentBytes, 0, contentBytes.Length);
+        WriteAscii(output, "endstream\nendobj\n");
+        WriteAscii(output, "5 0 obj\n<< /Type /XObject /Subtype /Image /Width 1 /Height 1 " + imageEntries + " /Length " + imageBytes.Length.ToString(CultureInfo.InvariantCulture) + " >>\nstream\n");
+        output.Write(imageBytes, 0, imageBytes.Length);
+        WriteAscii(output, "\nendstream\nendobj\ntrailer\n<< /Root 1 0 R /Size 6 >>\n%%EOF\n");
+        return output.ToArray();
+    }
+
+    private static byte[] BuildRawInlineImagePdf(string prefix, byte[] imageBytes, string suffix) {
+        byte[] prefixBytes = Encoding.ASCII.GetBytes(prefix);
+        byte[] suffixBytes = Encoding.ASCII.GetBytes(suffix);
+        int contentLength = prefixBytes.Length + imageBytes.Length + suffixBytes.Length;
+        using var output = new MemoryStream();
+        WriteAscii(output, "%PDF-1.7\n");
+        WriteAscii(output, "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+        WriteAscii(output, "2 0 obj\n<< /Type /Pages /Count 1 /Kids [3 0 R] >>\nendobj\n");
+        WriteAscii(output, "3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 120] /Contents 4 0 R >>\nendobj\n");
+        WriteAscii(output, "4 0 obj\n<< /Length " + contentLength.ToString(CultureInfo.InvariantCulture) + " >>\nstream\n");
+        output.Write(prefixBytes, 0, prefixBytes.Length);
+        output.Write(imageBytes, 0, imageBytes.Length);
+        output.Write(suffixBytes, 0, suffixBytes.Length);
+        WriteAscii(output, "endstream\nendobj\ntrailer\n<< /Root 1 0 R /Size 5 >>\n%%EOF\n");
+        return output.ToArray();
+    }
+
+    private static byte[] BuildRepeatedFormImagePdf() {
+        const string pageContent = "q 1 0 0 1 20 30 cm /Fx Do Q\nq 1 0 0 1 120 30 cm /Fx Do Q\n";
+        const string formContent = "q 10 0 0 10 0 0 cm /ImShared Do Q\n";
+        const string imageBytes = "abc";
+        string pdf = string.Join("\n", new[] {
+            "%PDF-1.4",
+            "1 0 obj", "<< /Type /Catalog /Pages 2 0 R >>", "endobj",
+            "2 0 obj", "<< /Type /Pages /Count 1 /Kids [3 0 R] /MediaBox [0 0 612 792] /Resources << /XObject << /Fx 6 0 R >> >> >>", "endobj",
+            "3 0 obj", "<< /Type /Page /Parent 2 0 R /Contents 5 0 R >>", "endobj",
+            "5 0 obj", "<< /Length " + Encoding.ASCII.GetByteCount(pageContent).ToString(CultureInfo.InvariantCulture) + " >>", "stream", pageContent.TrimEnd('\n'), "endstream", "endobj",
+            "6 0 obj", "<< /Type /XObject /Subtype /Form /BBox [0 0 20 20] /Resources << /XObject << /ImShared 7 0 R >> >> /Length " + Encoding.ASCII.GetByteCount(formContent).ToString(CultureInfo.InvariantCulture) + " >>", "stream", formContent.TrimEnd('\n'), "endstream", "endobj",
+            "7 0 obj", "<< /Type /XObject /Subtype /Image /Width 1 /Height 1 /ColorSpace /DeviceRGB /BitsPerComponent 8 /Length 3 >>", "stream", imageBytes, "endstream", "endobj",
+            "trailer", "<< /Root 1 0 R >>", "%%EOF"
+        }) + "\n";
+        return Encoding.ASCII.GetBytes(pdf);
+    }
+
+    private static byte[] BuildCollidingFormImagePdf() {
+        const string pageContent = "q /F1 Do Q\nq /F2 Do Q\n";
+        const string formContent = "q 40 0 0 20 20 30 cm /Im0 Do Q\n";
+        string pdf = string.Join("\n", new[] {
+            "%PDF-1.4",
+            "1 0 obj", "<< /Type /Catalog /Pages 2 0 R >>", "endobj",
+            "2 0 obj", "<< /Type /Pages /Count 1 /Kids [3 0 R] >>", "endobj",
+            "3 0 obj", "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 120] /Resources << /XObject << /F1 6 0 R /F2 7 0 R >> >> /Contents 5 0 R >>", "endobj",
+            "5 0 obj", "<< /Length " + Encoding.ASCII.GetByteCount(pageContent).ToString(CultureInfo.InvariantCulture) + " >>", "stream", pageContent.TrimEnd('\n'), "endstream", "endobj",
+            "6 0 obj", "<< /Type /XObject /Subtype /Form /BBox [0 0 200 120] /Resources << /XObject << /Im0 8 0 R >> >> /Length " + Encoding.ASCII.GetByteCount(formContent).ToString(CultureInfo.InvariantCulture) + " >>", "stream", formContent.TrimEnd('\n'), "endstream", "endobj",
+            "7 0 obj", "<< /Type /XObject /Subtype /Form /BBox [0 0 200 120] /Resources << /XObject << /Im0 9 0 R >> >> /Length " + Encoding.ASCII.GetByteCount(formContent).ToString(CultureInfo.InvariantCulture) + " >>", "stream", formContent.TrimEnd('\n'), "endstream", "endobj",
+            "8 0 obj", "<< /Type /XObject /Subtype /Image /Width 1 /Height 1 /ColorSpace /DeviceRGB /BitsPerComponent 8 /Length 3 >>", "stream", "abc", "endstream", "endobj",
+            "9 0 obj", "<< /Type /XObject /Subtype /Image /Width 2 /Height 1 /ColorSpace /DeviceRGB /BitsPerComponent 8 /Length 6 >>", "stream", "xyzuvw", "endstream", "endobj",
+            "trailer", "<< /Root 1 0 R /Size 10 >>", "%%EOF"
+        }) + "\n";
+        return Encoding.ASCII.GetBytes(pdf);
+    }
+
+    private static byte[] BuildSplitContentImagePdf() {
+        const string first = "q 40 0 0 20 20 30 cm\n";
+        const string second = "/Im0 Do Q\n";
+        string pdf = string.Join("\n", new[] {
+            "%PDF-1.4",
+            "1 0 obj", "<< /Type /Catalog /Pages 2 0 R >>", "endobj",
+            "2 0 obj", "<< /Type /Pages /Count 1 /Kids [3 0 R] >>", "endobj",
+            "3 0 obj", "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 120] /Resources << /XObject << /Im0 6 0 R >> >> /Contents [4 0 R 5 0 R] >>", "endobj",
+            "4 0 obj", "<< /Length " + Encoding.ASCII.GetByteCount(first).ToString(CultureInfo.InvariantCulture) + " >>", "stream", first.TrimEnd('\n'), "endstream", "endobj",
+            "5 0 obj", "<< /Length " + Encoding.ASCII.GetByteCount(second).ToString(CultureInfo.InvariantCulture) + " >>", "stream", second.TrimEnd('\n'), "endstream", "endobj",
+            "6 0 obj", "<< /Type /XObject /Subtype /Image /Width 1 /Height 1 /ColorSpace /DeviceRGB /BitsPerComponent 8 /Length 3 >>", "stream", "abc", "endstream", "endobj",
+            "trailer", "<< /Root 1 0 R /Size 7 >>", "%%EOF"
+        }) + "\n";
+        return Encoding.ASCII.GetBytes(pdf);
+    }
+
+    private static void WriteAscii(Stream stream, string value) {
+        byte[] bytes = Encoding.ASCII.GetBytes(value);
+        stream.Write(bytes, 0, bytes.Length);
+    }
+}

--- a/OfficeIMO.Pdf/Core/PdfDocument.Blocks.ImageValidation.cs
+++ b/OfficeIMO.Pdf/Core/PdfDocument.Blocks.ImageValidation.cs
@@ -93,6 +93,16 @@ public sealed partial class PdfDocument {
         }
 
         if (sourceInfo.Format == OfficeImageFormat.Jpeg) {
+            if (PdfWriter.TryGetJpegComponentCount(data, out int componentCount) && componentCount == 4) {
+                if (!OfficeImagePngConverter.TryConvertToPng(data, out byte[] normalizedJpegPng) ||
+                    !OfficeImageReader.TryIdentify(normalizedJpegPng, null, out OfficeImageInfo normalizedJpegInfo)) {
+                    throw new NotSupportedException(SupportedImageMessage + " Four-component JPEG data could not be normalized safely for PDF embedding.");
+                }
+                return new PreparedImage(normalizedJpegPng, normalizedJpegInfo, sourceInfo.Format, wasTranscoded: true);
+            }
+            if (componentCount != 0 && componentCount != 1 && componentCount != 3) {
+                throw new NotSupportedException(SupportedImageMessage + " JPEG component count is not supported for PDF embedding.");
+            }
             return new PreparedImage((byte[])data.Clone(), sourceInfo, sourceInfo.Format, wasTranscoded: false);
         }
 

--- a/OfficeIMO.Pdf/Core/PdfDocument.Meta.cs
+++ b/OfficeIMO.Pdf/Core/PdfDocument.Meta.cs
@@ -29,6 +29,7 @@ public sealed partial class PdfDocument {
         Pages = new PdfDocumentPages(this);
         Read = new PdfDocumentReader(this);
         Text = new PdfDocumentTextEditor(this);
+        Images = new PdfDocumentImageEditor(this);
         Stamp = new PdfDocumentStamper(this);
         Forms = new PdfDocumentForms(this);
         Attachments = new PdfDocumentAttachments(this);
@@ -128,6 +129,9 @@ public sealed partial class PdfDocument {
 
     /// <summary>Existing-page text search and editing operations.</summary>
     public PdfDocumentTextEditor Text { get; }
+
+    /// <summary>Existing-page image placement discovery and editing operations.</summary>
+    public PdfDocumentImageEditor Images { get; }
 
     /// <summary>Existing-document embedded and associated file editing operations.</summary>
     public PdfDocumentAttachments Attachments { get; }

--- a/OfficeIMO.Pdf/Core/PdfDocumentImageEditor.cs
+++ b/OfficeIMO.Pdf/Core/PdfDocumentImageEditor.cs
@@ -1,0 +1,48 @@
+namespace OfficeIMO.Pdf;
+
+/// <summary>Finds and edits image placements on existing PDF pages.</summary>
+public sealed class PdfDocumentImageEditor {
+    private readonly PdfDocument _document;
+
+    internal PdfDocumentImageEditor(PdfDocument document) => _document = document;
+
+    /// <summary>Returns every image placement invocation in page paint order.</summary>
+    public IReadOnlyList<PdfImagePlacement> Placements(PdfReadOptions? readOptions = null) =>
+        PdfImageEditor.Placements(_document.GetBytesForOperation(), readOptions ?? _document.ReadOptions);
+
+    /// <summary>Returns image placements whose page-space bounds intersect a region.</summary>
+    public IReadOnlyList<PdfImagePlacement> Find(PdfPageRegion region, PdfReadOptions? readOptions = null) =>
+        PdfImageEditor.Find(_document.GetBytesForOperation(), region, readOptions ?? _document.ReadOptions);
+
+    /// <summary>Adds an image fitted to a page region.</summary>
+    public PdfImageEditResult Add(PdfPageRegion target, byte[] imageBytes, PdfImageEditOptions? options = null, PdfReadOptions? readOptions = null) =>
+        Apply(input => PdfImageEditor.Add(input, target, imageBytes, options, readOptions ?? _document.ReadOptions), readOptions);
+
+    /// <summary>Removes one exact image placement without removing text, paths, annotations, or other overlapping images.</summary>
+    public PdfImageEditResult Remove(PdfImagePlacement placement, PdfReadOptions? readOptions = null) =>
+        Apply(input => PdfImageEditor.Remove(input, placement, readOptions ?? _document.ReadOptions), readOptions);
+
+    /// <summary>
+    /// Replaces one exact image placement while preserving portable position, size, and rotation. The selected
+    /// <see cref="PdfImageEditOptions.Layer"/> controls its new relation to existing page content.
+    /// </summary>
+    public PdfImageEditResult Replace(PdfImagePlacement placement, byte[] imageBytes, PdfImageEditOptions? options = null, PdfReadOptions? readOptions = null) =>
+        Apply(input => PdfImageEditor.Replace(input, placement, imageBytes, options, readOptions ?? _document.ReadOptions), readOptions);
+
+    /// <summary>
+    /// Moves one exact image placement by a PDF user-space offset. The source payload, portable size, and rotation
+    /// are preserved; the selected <see cref="PdfImageEditOptions.Layer"/> controls its new page-content layer.
+    /// </summary>
+    public PdfImageEditResult Move(PdfImagePlacement placement, double deltaX, double deltaY, PdfImageEditOptions? options = null, PdfReadOptions? readOptions = null) =>
+        Apply(input => PdfImageEditor.Move(input, placement, deltaX, deltaY, options, readOptions ?? _document.ReadOptions), readOptions);
+
+    private PdfImageEditResult Apply(Func<byte[], PdfImageEditor.ImageMutationResult> operation, PdfReadOptions? readOptions) {
+        PdfImageEditor.ImageMutationResult? mutation = null;
+        PdfDocument document = _document.ApplyMutation(input => {
+            mutation = operation(input);
+            return mutation.Bytes;
+        }, readOptions);
+        if (mutation is null) throw new InvalidOperationException("PDF image edit did not produce a mutation result.");
+        return new PdfImageEditResult(document, mutation.AffectedCount);
+    }
+}

--- a/OfficeIMO.Pdf/Manipulation/PdfImageEditingContracts.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfImageEditingContracts.cs
@@ -1,0 +1,44 @@
+namespace OfficeIMO.Pdf;
+
+/// <summary>Controls where a newly added or rewritten image is placed relative to existing page content.</summary>
+public enum PdfImageEditLayer {
+    /// <summary>Places the image after existing page content.</summary>
+    AboveExistingContent,
+    /// <summary>Places the image before existing page content.</summary>
+    BehindExistingContent
+}
+
+/// <summary>Options for adding, replacing, or moving an image on an existing PDF page.</summary>
+public sealed class PdfImageEditOptions {
+    private PdfImageEditLayer _layer = PdfImageEditLayer.AboveExistingContent;
+
+    /// <summary>
+    /// Placement layer for the newly written image. Existing exact paint order cannot be preserved by a portable
+    /// page-content rewrite, so callers choose explicitly between the front and back of existing content.
+    /// </summary>
+    public PdfImageEditLayer Layer {
+        get => _layer;
+        set {
+            if (value != PdfImageEditLayer.AboveExistingContent && value != PdfImageEditLayer.BehindExistingContent) {
+                throw new ArgumentOutOfRangeException(nameof(Layer), "Image edit layer is not supported.");
+            }
+            _layer = value;
+        }
+    }
+
+    internal PdfImageEditOptions Snapshot() => new PdfImageEditOptions { Layer = Layer };
+}
+
+/// <summary>Result of an existing-page image edit.</summary>
+public sealed class PdfImageEditResult {
+    internal PdfImageEditResult(PdfDocument document, int affectedCount) {
+        Document = document;
+        AffectedCount = affectedCount;
+    }
+
+    /// <summary>Edited immutable document.</summary>
+    public PdfDocument Document { get; }
+
+    /// <summary>Number of source placements affected, or one for a successful add.</summary>
+    public int AffectedCount { get; }
+}

--- a/OfficeIMO.Pdf/Manipulation/PdfImageEditor.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfImageEditor.cs
@@ -1,0 +1,244 @@
+using OfficeIMO.Drawing;
+
+namespace OfficeIMO.Pdf;
+
+/// <summary>Canonical placement discovery and mutation owner for images on existing PDF pages.</summary>
+internal static class PdfImageEditor {
+    private const double CoordinateTolerance = 0.01D;
+    private const double TransformTolerance = 0.0001D;
+
+    internal static IReadOnlyList<PdfImagePlacement> Placements(byte[] pdf, PdfReadOptions? readOptions) {
+        Guard.NotNull(pdf, nameof(pdf));
+        return PdfImageExtractor.ExtractImagePlacements(PdfReadDocument.Open(pdf, readOptions));
+    }
+
+    internal static IReadOnlyList<PdfImagePlacement> Find(byte[] pdf, PdfPageRegion region, PdfReadOptions? readOptions) {
+        Guard.NotNull(pdf, nameof(pdf));
+        Guard.NotNull(region, nameof(region));
+        PdfReadDocument document = PdfReadDocument.Open(pdf, readOptions);
+        ValidatePage(region.PageNumber, document.Pages.Count, nameof(region));
+        return document.Pages[region.PageNumber - 1]
+            .GetImagePlacements(region.PageNumber)
+            .Where(placement => Intersects(region, placement))
+            .ToArray();
+    }
+
+    internal static ImageMutationResult Add(byte[] pdf, PdfPageRegion target, byte[] imageBytes, PdfImageEditOptions? options, PdfReadOptions? readOptions) {
+        Guard.NotNull(pdf, nameof(pdf));
+        Guard.NotNull(target, nameof(target));
+        Guard.NotNull(imageBytes, nameof(imageBytes));
+        PdfReadDocument document = PdfReadDocument.Open(pdf, readOptions);
+        ValidatePage(target.PageNumber, document.Pages.Count, nameof(target));
+        PdfImageEditOptions snapshot = (options ?? new PdfImageEditOptions()).Snapshot();
+        byte[] output = PdfStamper.StampImage(pdf, imageBytes, CreateStampOptions(target.PageNumber, target.X, target.Y, target.Width, target.Height, 0D, snapshot), readOptions);
+        return new ImageMutationResult(output, 1);
+    }
+
+    internal static ImageMutationResult Remove(byte[] pdf, PdfImagePlacement placement, PdfReadOptions? readOptions) {
+        Guard.NotNull(pdf, nameof(pdf));
+        PdfImagePlacement current = ResolveUniquePlacement(pdf, placement, readOptions);
+        EnsureRemovablePlacement(current);
+        byte[] output = PdfRedactionApplier.RemoveImagePlacements(pdf, new[] { current }, readOptions);
+        EnsurePlacementRemoved(output, current, PdfReadOptions.WithMinimumInputBytes(readOptions, output.LongLength));
+        return new ImageMutationResult(output, 1);
+    }
+
+    internal static ImageMutationResult Replace(byte[] pdf, PdfImagePlacement placement, byte[] imageBytes, PdfImageEditOptions? options, PdfReadOptions? readOptions) {
+        Guard.NotNull(pdf, nameof(pdf));
+        Guard.NotNull(imageBytes, nameof(imageBytes));
+        PdfImagePlacement current = ResolveUniquePlacement(pdf, placement, readOptions);
+        EnsureRemovablePlacement(current);
+        ImageTransform transform = ResolvePortableTransform(current);
+        PdfImageEditOptions snapshot = (options ?? new PdfImageEditOptions()).Snapshot();
+        byte[] removed = PdfRedactionApplier.RemoveImagePlacements(pdf, new[] { current }, readOptions);
+        PdfReadOptions afterRemovalOptions = PdfReadOptions.WithMinimumInputBytes(readOptions, removed.LongLength);
+        EnsurePlacementRemoved(removed, current, afterRemovalOptions);
+        byte[] output = PdfStamper.StampImage(
+            removed,
+            imageBytes,
+            CreateStampOptions(current.PageNumber, current.E, current.F, transform.Width, transform.Height, transform.RotationDegrees, snapshot),
+            afterRemovalOptions);
+        return new ImageMutationResult(output, 1);
+    }
+
+    internal static ImageMutationResult Move(byte[] pdf, PdfImagePlacement placement, double deltaX, double deltaY, PdfImageEditOptions? options, PdfReadOptions? readOptions) {
+        ValidateFinite(deltaX, nameof(deltaX));
+        ValidateFinite(deltaY, nameof(deltaY));
+        Guard.NotNull(pdf, nameof(pdf));
+        PdfImagePlacement current = ResolveUniquePlacement(pdf, placement, readOptions);
+        EnsureRemovablePlacement(current);
+        ImageTransform transform = ResolvePortableTransform(current);
+        PdfExtractedImage image = ResolveMovableImage(pdf, current, readOptions);
+        PdfImageEditOptions snapshot = (options ?? new PdfImageEditOptions()).Snapshot();
+        byte[] removed = PdfRedactionApplier.RemoveImagePlacements(pdf, new[] { current }, readOptions);
+        PdfReadOptions afterRemovalOptions = PdfReadOptions.WithMinimumInputBytes(readOptions, removed.LongLength);
+        EnsurePlacementRemoved(removed, current, afterRemovalOptions);
+        byte[] output = PdfStamper.StampImage(
+            removed,
+            image.Bytes,
+            CreateStampOptions(current.PageNumber, current.E + deltaX, current.F + deltaY, transform.Width, transform.Height, transform.RotationDegrees, snapshot),
+            afterRemovalOptions);
+        return new ImageMutationResult(output, 1);
+    }
+
+    private static PdfImagePlacement ResolveUniquePlacement(byte[] pdf, PdfImagePlacement placement, PdfReadOptions? readOptions) {
+        Guard.NotNull(placement, nameof(placement));
+        PdfImagePlacement[] matches = Placements(pdf, readOptions)
+            .Where(candidate => SamePlacementIdentity(candidate, placement))
+            .ToArray();
+        if (matches.Length == 0) {
+            throw new InvalidOperationException("The selected image placement does not exist in the current PDF document.");
+        }
+        if (matches.Length > 1) {
+            throw new InvalidOperationException("The selected image placement is ambiguous because multiple invocations have the same resource, transform, and bounds. Select a uniquely placed image before editing.");
+        }
+        return matches[0];
+    }
+
+    private static PdfExtractedImage ResolveMovableImage(byte[] pdf, PdfImagePlacement placement, PdfReadOptions? readOptions) {
+        PdfReadDocument document = PdfReadDocument.Open(pdf, readOptions);
+        PdfImagePlacement[] currentPlacements = document.Pages[placement.PageNumber - 1]
+            .GetImagePlacements(placement.PageNumber)
+            .Where(candidate => SamePlacementIdentity(candidate, placement))
+            .ToArray();
+        if (currentPlacements.Length != 1) {
+            throw new NotSupportedException("The selected image placement could not be resolved uniquely for a safe move.");
+        }
+        PdfImagePlacement current = currentPlacements[0];
+        IReadOnlyList<PdfExtractedImage> images = document.Pages[placement.PageNumber - 1]
+            .GetImages(placement.PageNumber, new[] { current });
+        PdfExtractedImage[] matches = images.Where(image =>
+            image.PageNumber == current.PageNumber &&
+            string.Equals(image.ResourceName, current.ResourceName, StringComparison.Ordinal) &&
+            image.ObjectNumber == current.ObjectNumber &&
+            (image.ObjectNumber > 0 || image.DirectStreamIdentity == current.DirectStreamIdentity)).ToArray();
+        if (matches.Length != 1) {
+            throw new NotSupportedException("The selected image payload could not be resolved uniquely for a safe move.");
+        }
+
+        PdfExtractedImage image = matches[0];
+        if (!image.IsImageFile) {
+            throw new NotSupportedException("Moving this image is not supported because its decoded payload is not a complete portable image file.");
+        }
+        if (image.IsImageMask) {
+            throw new NotSupportedException("Moving an ImageMask placement is not supported because its paint color is owned by page graphics state.");
+        }
+        if (image.HasUnresolvedTransparencyMask) {
+            throw new NotSupportedException("Moving this image is not supported because its PDF transparency mask could not be represented in the extracted image payload.");
+        }
+        if (string.Equals(image.Filter, "DCTDecode", StringComparison.Ordinal)) {
+            if (image.HasExplicitDecode || image.HasDecodeParameters) {
+                throw new NotSupportedException("Moving this JPEG image is not supported because PDF Decode or DecodeParms semantics would be lost during restamping.");
+            }
+            if (image.BitsPerComponent != 8 ||
+                (!string.Equals(image.ColorSpace, "DeviceGray", StringComparison.Ordinal) &&
+                 !string.Equals(image.ColorSpace, "DeviceRGB", StringComparison.Ordinal) &&
+                 !string.Equals(image.ColorSpace, "DeviceCMYK", StringComparison.Ordinal))) {
+                throw new NotSupportedException("Moving this JPEG image is not supported because its PDF color-space or component semantics are not portable to image stamping.");
+            }
+        }
+        return image;
+    }
+
+    private static ImageTransform ResolvePortableTransform(PdfImagePlacement placement) {
+        if (placement.ClipPath != null) {
+            throw new NotSupportedException("Replacing or moving a clipped image placement is not supported because the clip path cannot be preserved by image stamping.");
+        }
+        if (placement.ImageOpacity.HasValue && Math.Abs(placement.ImageOpacity.Value - 1D) > TransformTolerance) {
+            throw new NotSupportedException("Replacing or moving an image placement with graphics-state opacity is not supported because the opacity cannot be preserved by image stamping.");
+        }
+        if (placement.BlendMode.HasValue && placement.BlendMode.Value != OfficeBlendMode.Normal) {
+            throw new NotSupportedException("Replacing or moving an image placement with a non-normal blend mode is not supported because the blend state cannot be preserved by image stamping.");
+        }
+        if (placement.HasSoftMask) {
+            throw new NotSupportedException("Replacing or moving an image placement with a graphics-state soft mask is not supported because the mask cannot be preserved by image stamping.");
+        }
+
+        double width = Math.Sqrt((placement.A * placement.A) + (placement.B * placement.B));
+        double height = Math.Sqrt((placement.C * placement.C) + (placement.D * placement.D));
+        double determinant = (placement.A * placement.D) - (placement.B * placement.C);
+        double dot = (placement.A * placement.C) + (placement.B * placement.D);
+        double scale = Math.Max(1D, width * height);
+        if (width <= TransformTolerance || height <= TransformTolerance || determinant <= TransformTolerance || Math.Abs(dot) > TransformTolerance * scale) {
+            throw new NotSupportedException("Replacing or moving a skewed, reflected, or degenerate image placement is not supported because its transform cannot be reproduced by image stamping.");
+        }
+
+        double rotationDegrees = Math.Atan2(placement.B, placement.A) * (180D / Math.PI);
+        return new ImageTransform(width, height, rotationDegrees);
+    }
+
+    private static void EnsureRemovablePlacement(PdfImagePlacement placement) {
+        if (placement.InlineImageStream != null) {
+            throw new NotSupportedException("Editing an inline-image placement is not supported because its binary content-stream framing cannot yet be rewritten independently. XObject image placements remain fully supported.");
+        }
+        if (placement.Width <= CoordinateTolerance || placement.Height <= CoordinateTolerance) {
+            throw new NotSupportedException("Editing a degenerate image placement with zero visible area is not supported.");
+        }
+    }
+
+    private static void EnsurePlacementRemoved(byte[] pdf, PdfImagePlacement placement, PdfReadOptions? readOptions) {
+        if (Placements(pdf, readOptions).Any(candidate => SamePlacementIdentity(candidate, placement))) {
+            throw new InvalidOperationException("The selected image placement could not be removed safely; no successful edit result was produced.");
+        }
+    }
+
+    private static PdfImageStampOptions CreateStampOptions(int pageNumber, double x, double y, double width, double height, double rotationDegrees, PdfImageEditOptions options) =>
+        new PdfImageStampOptions {
+            PageNumbers = new[] { pageNumber },
+            X = x,
+            Y = y,
+            Width = width,
+            Height = height,
+            RotationDegrees = rotationDegrees,
+            BehindContent = options.Layer == PdfImageEditLayer.BehindExistingContent
+        };
+
+    private static bool SamePlacementIdentity(PdfImagePlacement left, PdfImagePlacement right) =>
+        left.PageNumber == right.PageNumber &&
+        string.Equals(left.ResourceName, right.ResourceName, StringComparison.Ordinal) &&
+        left.ObjectNumber == right.ObjectNumber &&
+        NearlyEqual(left.A, right.A) && NearlyEqual(left.B, right.B) &&
+        NearlyEqual(left.C, right.C) && NearlyEqual(left.D, right.D) &&
+        NearlyEqual(left.E, right.E) && NearlyEqual(left.F, right.F) &&
+        NearlyEqual(left.X, right.X) && NearlyEqual(left.Y, right.Y) &&
+        NearlyEqual(left.Width, right.Width) && NearlyEqual(left.Height, right.Height);
+
+    private static bool Intersects(PdfPageRegion region, PdfImagePlacement placement) =>
+        region.PageNumber == placement.PageNumber &&
+        region.X < placement.X + placement.Width - CoordinateTolerance &&
+        region.Right > placement.X + CoordinateTolerance &&
+        region.Y < placement.Y + placement.Height - CoordinateTolerance &&
+        region.Top > placement.Y + CoordinateTolerance;
+
+    private static bool NearlyEqual(double left, double right) => Math.Abs(left - right) <= CoordinateTolerance;
+
+    private static void ValidatePage(int pageNumber, int pageCount, string parameterName) {
+        if (pageNumber > pageCount) throw new ArgumentOutOfRangeException(parameterName, "Page number is outside the current PDF document.");
+    }
+
+    private static void ValidateFinite(double value, string parameterName) {
+        if (double.IsNaN(value) || double.IsInfinity(value)) throw new ArgumentOutOfRangeException(parameterName, "Image movement offset must be finite.");
+    }
+
+    internal sealed class ImageMutationResult {
+        internal ImageMutationResult(byte[] bytes, int affectedCount) {
+            Bytes = bytes;
+            AffectedCount = affectedCount;
+        }
+
+        internal byte[] Bytes { get; }
+        internal int AffectedCount { get; }
+    }
+
+    private readonly struct ImageTransform {
+        internal ImageTransform(double width, double height, double rotationDegrees) {
+            Width = width;
+            Height = height;
+            RotationDegrees = rotationDegrees;
+        }
+
+        internal double Width { get; }
+        internal double Height { get; }
+        internal double RotationDegrees { get; }
+    }
+}

--- a/OfficeIMO.Pdf/Manipulation/PdfRedactionApplier.Images.PixelRewrite.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfRedactionApplier.Images.PixelRewrite.cs
@@ -30,6 +30,7 @@ internal static partial class PdfRedactionApplier {
         resources = ResolveDictionary(objects, pageDictionary.Items.TryGetValue("Resources", out PdfObject? pageResources) ? pageResources : null) ?? resources;
         bool changed = false;
         PdfObject currentContentsObject = contentsObject;
+        var contentState = new ImageContentGraphicsState(Matrix2D.Identity);
         foreach (PdfReference reference in EnumerateContentReferences(objects, contentsObject)) {
             if (!PdfObjectLookup.TryGet(objects, reference, out PdfIndirectObject? indirect) ||
                 indirect.Value is not PdfStream stream ||
@@ -38,7 +39,7 @@ internal static partial class PdfRedactionApplier {
             }
 
             string content = PdfEncoding.Latin1GetString(StreamDecoder.DecodeRequired(stream.Dictionary, stream.Data, objects));
-            ImagePixelRewriteContentResult result = RewriteImagePixelsInContent(objects, resources, xObjects, content, targets, options, Matrix2D.Identity, referenceCounts, new HashSet<int>(), removedMatches, ref nextObjectNumber);
+            ImagePixelRewriteContentResult result = RewriteImagePixelsInContent(objects, resources, xObjects, content, targets, options, contentState, referenceCounts, new HashSet<int>(), removedMatches, ref nextObjectNumber);
             if (!string.Equals(result.Content, content, StringComparison.Ordinal)) {
                 PdfReference targetReference = reference;
                 if (IsSharedReference(referenceCounts, reference)) {
@@ -65,19 +66,19 @@ internal static partial class PdfRedactionApplier {
         string content,
         ImageRedactionTarget[] targets,
         PdfRedactionApplyOptions options,
-        Matrix2D baseTransform,
+        ImageContentGraphicsState graphicsState,
         IReadOnlyDictionary<int, int> referenceCounts,
         HashSet<int> activeForms,
         List<PdfRedactionMatch> removedMatches,
         ref int nextObjectNumber) {
         bool changed = false;
         string rewrittenContent = content;
-        ImageResourceInvocation[] invocations = ExtractImageResourceInvocations(content);
+        ImageResourceInvocation[] invocations = ExtractImageResourceInvocations(content, graphicsState);
         for (int invocationIndex = invocations.Length - 1; invocationIndex >= 0; invocationIndex--) {
             ImageResourceInvocation invocation = invocations[invocationIndex];
-            Matrix2D invocationTransform = Matrix2D.Multiply(baseTransform, invocation.Transform);
+            Matrix2D invocationTransform = invocation.Transform;
             if (TryGetImageXObject(objects, xObjects, invocation.Name, out PdfReference imageReference, out PdfStream imageStream)) {
-                if (!TryFindImageTarget(invocation.Name, invocationTransform, targets, out ImageRedactionTarget target) ||
+                if (!TryFindImageTarget(invocation.Name, imageReference.ObjectNumber, invocationTransform, targets, out ImageRedactionTarget target) ||
                     !CanRewriteImagePlacementPixels(invocationTransform)) {
                     continue;
                 }
@@ -164,7 +165,7 @@ internal static partial class PdfRedactionApplier {
         PdfDictionary formXObjects = EnsureResourceXObjects(objects, formResources);
         Matrix2D formTransform = ApplyFormMatrix(invocationTransform, formStream.Dictionary);
         string formContent = PdfEncoding.Latin1GetString(StreamDecoder.DecodeRequired(formStream.Dictionary, formStream.Data, objects));
-        ImagePixelRewriteContentResult result = RewriteImagePixelsInContent(objects, formResources, formXObjects, formContent, targets, options, formTransform, referenceCounts, activeForms, removedMatches, ref nextObjectNumber);
+        ImagePixelRewriteContentResult result = RewriteImagePixelsInContent(objects, formResources, formXObjects, formContent, targets, options, new ImageContentGraphicsState(formTransform), referenceCounts, activeForms, removedMatches, ref nextObjectNumber);
         if (!string.Equals(result.Content, formContent, StringComparison.Ordinal)) {
             objects[formReference.ObjectNumber] = new PdfIndirectObject(formReference.ObjectNumber, formReference.Generation, new PdfStream(CleanStreamDictionary(formStream.Dictionary), PdfEncoding.Latin1GetBytes(result.Content)));
         }
@@ -195,10 +196,12 @@ internal static partial class PdfRedactionApplier {
             IsSharedReference(CountIndirectReferenceUsage(objects), reference);
     }
 
-    private static bool TryFindImageTarget(string resourceName, Matrix2D transform, ImageRedactionTarget[] targets, out ImageRedactionTarget target) {
+    private static bool TryFindImageTarget(string resourceName, int objectNumber, Matrix2D transform, ImageRedactionTarget[] targets, out ImageRedactionTarget target) {
         GetUnitRectangleBounds(transform, out double x, out double y, out double width, out double height);
         for (int i = 0; i < targets.Length; i++) {
             if (string.Equals(targets[i].ResourceName, resourceName, StringComparison.Ordinal) &&
+                targets[i].MatchesObjectNumber(objectNumber) &&
+                targets[i].MatchesTransform(transform) &&
                 AreCloseImageCoordinate(targets[i].X, x) &&
                 AreCloseImageCoordinate(targets[i].Y, y) &&
                 AreCloseImageCoordinate(targets[i].Width, width) &&
@@ -212,10 +215,11 @@ internal static partial class PdfRedactionApplier {
         return false;
     }
 
-    private static ImageResourceInvocation[] ExtractImageResourceInvocations(string content) {
+    private static ImageResourceInvocation[] ExtractImageResourceInvocations(string content) =>
+        ExtractImageResourceInvocations(content, new ImageContentGraphicsState(Matrix2D.Identity));
+
+    private static ImageResourceInvocation[] ExtractImageResourceInvocations(string content, ImageContentGraphicsState graphicsState) {
         var invocations = new List<ImageResourceInvocation>();
-        Matrix2D ctm = Matrix2D.Identity;
-        var stack = new Stack<Matrix2D>();
         var args = new List<ImageContentOperand>(8);
         int index = 0;
         int length = content.Length;
@@ -275,16 +279,16 @@ internal static partial class PdfRedactionApplier {
 
             switch (op) {
                 case "q":
-                    stack.Push(ctm);
+                    graphicsState.Stack.Push(graphicsState.Transform);
                     args.Clear();
                     break;
                 case "Q":
-                    ctm = stack.Count > 0 ? stack.Pop() : Matrix2D.Identity;
+                    graphicsState.Transform = graphicsState.Stack.Count > 0 ? graphicsState.Stack.Pop() : graphicsState.BaseTransform;
                     args.Clear();
                     break;
                 case "cm":
                     if (args.Count >= 6) {
-                        ctm = Matrix2D.Multiply(ctm, new Matrix2D(
+                        graphicsState.Transform = Matrix2D.Multiply(graphicsState.Transform, new Matrix2D(
                             args[args.Count - 6].Number,
                             args[args.Count - 5].Number,
                             args[args.Count - 4].Number,
@@ -298,7 +302,7 @@ internal static partial class PdfRedactionApplier {
                 case "Do":
                     if (args.Count >= 1 && !string.IsNullOrEmpty(args[args.Count - 1].Name)) {
                         ImageContentOperand operand = args[args.Count - 1];
-                        invocations.Add(new ImageResourceInvocation(operand.Name!, ctm, operand.Start, operand.End));
+                        invocations.Add(new ImageResourceInvocation(operand.Name!, graphicsState.Transform, operand.Start, operand.End));
                     }
 
                     args.Clear();

--- a/OfficeIMO.Pdf/Manipulation/PdfRedactionApplier.Images.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfRedactionApplier.Images.cs
@@ -24,10 +24,15 @@ internal static partial class PdfRedactionApplier {
         var removedMatches = new List<PdfRedactionMatch>();
         var removedResourceNames = new HashSet<string>(StringComparer.Ordinal);
         Dictionary<int, int> referenceCounts = CountIndirectReferenceUsage(objects);
+        PdfDictionary? pageResources = GetInheritedDictionary(objects, pageDictionary, "Resources");
+        PdfDictionary? pageXObjects = pageResources != null && pageResources.Items.TryGetValue("XObject", out PdfObject? pageXObjectValue)
+            ? ResolveDictionary(objects, pageXObjectValue)
+            : null;
         PdfObject currentContentsObject = contentsObject;
         bool passChanged;
         do {
             passChanged = false;
+            var contentState = new ImageContentGraphicsState(Matrix2D.Identity);
             PdfReference[] contentReferences = EnumerateContentReferences(objects, currentContentsObject).ToArray();
             foreach (PdfReference reference in contentReferences) {
                 if (!PdfObjectLookup.TryGet(objects, reference, out PdfIndirectObject? indirect) ||
@@ -38,7 +43,7 @@ internal static partial class PdfRedactionApplier {
 
                 byte[] contentBytes = StreamDecoder.DecodeRequired(stream.Dictionary, stream.Data, objects);
                 string content = PdfEncoding.Latin1GetString(contentBytes);
-                string scrubbed = RemoveImageInvocations(content, wholeImageTargets, out IReadOnlyList<ImageRedactionTarget> removedTargets);
+                string scrubbed = RemoveImageInvocations(content, wholeImageTargets, pageXObjects, objects, contentState, out IReadOnlyList<ImageRedactionTarget> removedTargets);
                 if (string.Equals(content, scrubbed, StringComparison.Ordinal)) {
                     continue;
                 }
@@ -73,7 +78,7 @@ internal static partial class PdfRedactionApplier {
             .Where(match => match.Kind == PdfRedactionMatchKind.ImagePlacement &&
                 !string.IsNullOrEmpty(match.ResourceName) &&
                 (removeWholeIntersectingImages ? RedactionAreaIntersectsMatch(match.Area, match) : RedactionAreaCoversMatch(match.Area, match)))
-            .Select(match => new ImageRedactionTarget(match, match.ResourceName!, match.X, match.Y, match.Width, match.Height))
+            .Select(match => new ImageRedactionTarget(match))
             .ToArray();
     }
 
@@ -82,7 +87,7 @@ internal static partial class PdfRedactionApplier {
             .Where(match => match.Kind == PdfRedactionMatchKind.ImagePlacement &&
                 !string.IsNullOrEmpty(match.ResourceName) &&
                 RedactionAreaIntersectsMatch(match.Area, match))
-            .Select(match => new ImageRedactionTarget(match, match.ResourceName!, match.X, match.Y, match.Width, match.Height))
+            .Select(match => new ImageRedactionTarget(match))
             .ToArray();
     }
 
@@ -120,6 +125,7 @@ internal static partial class PdfRedactionApplier {
         resources = ResolveDictionary(objects, pageDictionary.Items.TryGetValue("Resources", out PdfObject? pageResources) ? pageResources : null) ?? resources;
         bool changed = false;
         PdfObject currentContentsObject = contentsObject;
+        var contentState = new ImageContentGraphicsState(Matrix2D.Identity);
         foreach (PdfReference reference in EnumerateContentReferences(objects, currentContentsObject)) {
             if (!PdfObjectLookup.TryGet(objects, reference, out PdfIndirectObject? indirect) ||
                 indirect.Value is not PdfStream stream ||
@@ -128,7 +134,7 @@ internal static partial class PdfRedactionApplier {
             }
 
             string content = PdfEncoding.Latin1GetString(StreamDecoder.DecodeRequired(stream.Dictionary, stream.Data, objects));
-            ImagePixelRewriteContentResult result = ScrubImageFormInvocations(objects, resources, xObjects, content, targets, Matrix2D.Identity, referenceCounts, new HashSet<int>(), removedMatches, ref nextObjectNumber);
+            ImagePixelRewriteContentResult result = ScrubImageFormInvocations(objects, resources, xObjects, content, targets, contentState, referenceCounts, new HashSet<int>(), removedMatches, ref nextObjectNumber);
             if (!string.Equals(result.Content, content, StringComparison.Ordinal)) {
                 PdfReference targetReference = reference;
                 if (IsSharedReference(referenceCounts, reference)) {
@@ -154,14 +160,14 @@ internal static partial class PdfRedactionApplier {
         PdfDictionary xObjects,
         string content,
         ImageRedactionTarget[] targets,
-        Matrix2D baseTransform,
+        ImageContentGraphicsState graphicsState,
         IReadOnlyDictionary<int, int> referenceCounts,
         HashSet<int> activeForms,
         List<PdfRedactionMatch> removedMatches,
         ref int nextObjectNumber) {
         bool changed = false;
         string rewrittenContent = content;
-        ImageResourceInvocation[] invocations = ExtractImageResourceInvocations(content);
+        ImageResourceInvocation[] invocations = ExtractImageResourceInvocations(content, graphicsState);
         for (int invocationIndex = invocations.Length - 1; invocationIndex >= 0; invocationIndex--) {
             ImageResourceInvocation invocation = invocations[invocationIndex];
             if (!TryGetFormXObject(objects, xObjects, invocation.Name, out PdfReference reference, out PdfStream formStream) ||
@@ -170,7 +176,7 @@ internal static partial class PdfRedactionApplier {
                 continue;
             }
 
-            Matrix2D invocationTransform = Matrix2D.Multiply(baseTransform, invocation.Transform);
+            Matrix2D invocationTransform = invocation.Transform;
             bool repeatedInvocation = CountResourceInvocations(content, invocation.Name) != 1;
             if (repeatedInvocation &&
                 PdfObjectLookup.TryGet(objects, reference, out PdfIndirectObject? repeatedSourceIndirect)) {
@@ -234,7 +240,7 @@ internal static partial class PdfRedactionApplier {
         PdfDictionary formXObjects = EnsureResourceXObjects(objects, formResources);
         Matrix2D formTransform = ApplyFormMatrix(invocationTransform, formStream.Dictionary);
         string formContent = PdfEncoding.Latin1GetString(StreamDecoder.DecodeRequired(formStream.Dictionary, formStream.Data, objects));
-        string scrubbed = RemoveImageInvocations(formContent, targets, formTransform, out IReadOnlyList<ImageRedactionTarget> removedTargets);
+        string scrubbed = RemoveImageInvocations(formContent, targets, formXObjects, objects, new ImageContentGraphicsState(formTransform), out IReadOnlyList<ImageRedactionTarget> removedTargets);
         bool changed = false;
 
         if (!string.Equals(formContent, scrubbed, StringComparison.Ordinal)) {
@@ -244,7 +250,7 @@ internal static partial class PdfRedactionApplier {
             changed = true;
         }
 
-        ImagePixelRewriteContentResult nestedResult = ScrubImageFormInvocations(objects, formResources, formXObjects, formContent, targets, formTransform, referenceCounts, activeForms, removedMatches, ref nextObjectNumber);
+        ImagePixelRewriteContentResult nestedResult = ScrubImageFormInvocations(objects, formResources, formXObjects, formContent, targets, new ImageContentGraphicsState(formTransform), referenceCounts, activeForms, removedMatches, ref nextObjectNumber);
         if (!string.Equals(nestedResult.Content, formContent, StringComparison.Ordinal)) {
             formContent = nestedResult.Content;
             changed = true;
@@ -257,15 +263,15 @@ internal static partial class PdfRedactionApplier {
         return new ImagePixelRewriteContentResult(changed || nestedResult.HasChanges, formContent);
     }
 
-    private static string RemoveImageInvocations(string content, ImageRedactionTarget[] targets, out IReadOnlyList<ImageRedactionTarget> removedTargets) {
-        return RemoveImageInvocations(content, targets, Matrix2D.Identity, out removedTargets);
-    }
-
-    private static string RemoveImageInvocations(string content, ImageRedactionTarget[] targets, Matrix2D baseTransform, out IReadOnlyList<ImageRedactionTarget> removedTargets) {
+    private static string RemoveImageInvocations(
+        string content,
+        ImageRedactionTarget[] targets,
+        PdfDictionary? xObjects,
+        Dictionary<int, PdfIndirectObject> objects,
+        ImageContentGraphicsState graphicsState,
+        out IReadOnlyList<ImageRedactionTarget> removedTargets) {
         var ranges = new List<RemovalRange>();
         var removed = new List<ImageRedactionTarget>();
-        Matrix2D ctm = baseTransform;
-        var stack = new Stack<Matrix2D>();
         var args = new List<ImageContentOperand>(8);
         int index = 0;
         int length = content.Length;
@@ -327,16 +333,16 @@ internal static partial class PdfRedactionApplier {
 
             switch (op) {
                 case "q":
-                    stack.Push(ctm);
+                    graphicsState.Stack.Push(graphicsState.Transform);
                     args.Clear();
                     break;
                 case "Q":
-                    ctm = stack.Count > 0 ? stack.Pop() : baseTransform;
+                    graphicsState.Transform = graphicsState.Stack.Count > 0 ? graphicsState.Stack.Pop() : graphicsState.BaseTransform;
                     args.Clear();
                     break;
                 case "cm":
                     if (args.Count >= 6) {
-                        ctm = Matrix2D.Multiply(ctm, new Matrix2D(
+                        graphicsState.Transform = Matrix2D.Multiply(graphicsState.Transform, new Matrix2D(
                             args[args.Count - 6].Number,
                             args[args.Count - 5].Number,
                             args[args.Count - 4].Number,
@@ -348,7 +354,7 @@ internal static partial class PdfRedactionApplier {
                     args.Clear();
                     break;
                 case "Do":
-                    if (TryGetImageTarget(args, ctm, targets, out ImageRedactionTarget target, out ImageContentOperand operand)) {
+                    if (TryGetImageTarget(args, graphicsState.Transform, targets, xObjects, objects, out ImageRedactionTarget target, out ImageContentOperand operand)) {
                         ranges.Add(new RemovalRange(operand.Start, operatorEnd));
                         removed.Add(target);
                     }
@@ -365,7 +371,14 @@ internal static partial class PdfRedactionApplier {
         return RemoveRanges(content, ranges);
     }
 
-    private static bool TryGetImageTarget(IReadOnlyList<ImageContentOperand> args, Matrix2D ctm, ImageRedactionTarget[] targets, out ImageRedactionTarget target, out ImageContentOperand operand) {
+    private static bool TryGetImageTarget(
+        IReadOnlyList<ImageContentOperand> args,
+        Matrix2D ctm,
+        ImageRedactionTarget[] targets,
+        PdfDictionary? xObjects,
+        Dictionary<int, PdfIndirectObject> objects,
+        out ImageRedactionTarget target,
+        out ImageContentOperand operand) {
         target = default;
         operand = default;
         if (args.Count == 0 || string.IsNullOrEmpty(args[args.Count - 1].Name)) {
@@ -373,9 +386,12 @@ internal static partial class PdfRedactionApplier {
         }
 
         operand = args[args.Count - 1];
+        int invocationObjectNumber = ResolveImageInvocationObjectNumber(operand.Name!, xObjects, objects);
         GetUnitRectangleBounds(ctm, out double x, out double y, out double width, out double height);
         for (int i = 0; i < targets.Length; i++) {
             if (string.Equals(targets[i].ResourceName, operand.Name, StringComparison.Ordinal) &&
+                targets[i].MatchesObjectNumber(invocationObjectNumber) &&
+                targets[i].MatchesTransform(ctm) &&
                 AreCloseImageCoordinate(targets[i].X, x) &&
                 AreCloseImageCoordinate(targets[i].Y, y) &&
                 AreCloseImageCoordinate(targets[i].Width, width) &&
@@ -387,6 +403,8 @@ internal static partial class PdfRedactionApplier {
 
         for (int i = 0; i < targets.Length; i++) {
             if (string.Equals(targets[i].ResourceName, operand.Name, StringComparison.Ordinal) &&
+                targets[i].MatchesObjectNumber(invocationObjectNumber) &&
+                targets[i].MatchesTransform(ctm) &&
                 RedactionAreaCoversRectangle(targets[i].Match.Area, x, y, width, height)) {
                 target = targets[i];
                 return true;
@@ -394,6 +412,20 @@ internal static partial class PdfRedactionApplier {
         }
 
         return false;
+    }
+
+    private static int ResolveImageInvocationObjectNumber(string resourceName, PdfDictionary? xObjects, Dictionary<int, PdfIndirectObject> objects) {
+        if (xObjects is null || !xObjects.Items.TryGetValue(resourceName, out PdfObject? value)) return 0;
+        if (value is PdfReference reference &&
+            PdfObjectLookup.TryGet(objects, reference, out PdfIndirectObject? indirect) &&
+            indirect.Value is PdfStream stream &&
+            string.Equals(stream.Dictionary.Get<PdfName>("Subtype")?.Name, "Image", StringComparison.Ordinal)) {
+            return reference.ObjectNumber;
+        }
+        return value is PdfStream directStream &&
+            string.Equals(directStream.Dictionary.Get<PdfName>("Subtype")?.Name, "Image", StringComparison.Ordinal)
+                ? 0
+                : int.MinValue;
     }
 
     private static bool RedactionAreaCoversRectangle(PdfRedactionArea area, double x, double y, double width, double height) =>
@@ -670,13 +702,14 @@ internal static partial class PdfRedactionApplier {
     private static bool AreCloseImageCoordinate(double left, double right) => Math.Abs(left - right) <= ImageRedactionTolerance;
 
     private readonly struct ImageRedactionTarget {
-        public ImageRedactionTarget(PdfRedactionMatch match, string resourceName, double x, double y, double width, double height) {
+        public ImageRedactionTarget(PdfRedactionMatch match) {
             Match = match;
-            ResourceName = resourceName;
-            X = x;
-            Y = y;
-            Width = width;
-            Height = height;
+            ResourceName = match.ResourceName!;
+            X = match.X;
+            Y = match.Y;
+            Width = match.Width;
+            Height = match.Height;
+            Placement = match.ImagePlacement;
         }
 
         public PdfRedactionMatch Match { get; }
@@ -690,6 +723,29 @@ internal static partial class PdfRedactionApplier {
         public double Width { get; }
 
         public double Height { get; }
+
+        private PdfImagePlacement? Placement { get; }
+
+        public bool MatchesObjectNumber(int objectNumber) => Placement is null || Placement.ObjectNumber == objectNumber;
+
+        public bool MatchesTransform(Matrix2D transform) => Placement is null ||
+            (AreCloseImageCoordinate(Placement.A, transform.A) &&
+             AreCloseImageCoordinate(Placement.B, transform.B) &&
+             AreCloseImageCoordinate(Placement.C, transform.C) &&
+             AreCloseImageCoordinate(Placement.D, transform.D) &&
+             AreCloseImageCoordinate(Placement.E, transform.E) &&
+             AreCloseImageCoordinate(Placement.F, transform.F));
+    }
+
+    private sealed class ImageContentGraphicsState {
+        public ImageContentGraphicsState(Matrix2D baseTransform) {
+            BaseTransform = baseTransform;
+            Transform = baseTransform;
+        }
+
+        public Matrix2D BaseTransform { get; }
+        public Matrix2D Transform { get; set; }
+        public Stack<Matrix2D> Stack { get; } = new Stack<Matrix2D>();
     }
 
     private readonly struct ImageContentOperand {

--- a/OfficeIMO.Pdf/Manipulation/PdfRedactionApplier.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfRedactionApplier.cs
@@ -43,7 +43,8 @@ internal static partial class PdfRedactionApplier {
             readOptions,
             RedactionMutationScope.All,
             paintMarks: true,
-            PdfMutationOperation.Redact);
+            PdfMutationOperation.Redact,
+            imageTargets: null);
     }
 
     /// <summary>
@@ -68,7 +69,40 @@ internal static partial class PdfRedactionApplier {
             readOptions,
             RedactionMutationScope.Text,
             paintMarks: false,
-            PdfMutationOperation.ModifyPageContent);
+            PdfMutationOperation.ModifyPageContent,
+            imageTargets: null);
+    }
+
+    /// <summary>
+    /// Removes only the exact image placements supplied by the caller. This is the canonical
+    /// destructive image-editing primitive; it leaves text, paths, annotations, and document-level
+    /// residue untouched and does not paint redaction marks.
+    /// </summary>
+    internal static byte[] RemoveImagePlacements(
+        byte[] pdf,
+        IReadOnlyList<PdfImagePlacement> placements,
+        PdfReadOptions? readOptions = null) {
+        Guard.NotNull(pdf, nameof(pdf));
+        Guard.NotNull(placements, nameof(placements));
+        if (placements.Count == 0) return pdf.ToArray();
+        PdfRedactionArea[] areas = placements
+            .Select(static placement => new PdfRedactionArea(placement.PageNumber, placement.X, placement.Y, Math.Max(0.01D, placement.Width), Math.Max(0.01D, placement.Height)))
+            .ToArray();
+        return ApplyCore(
+            pdf,
+            areas,
+            new PdfRedactionApplyOptions {
+                PaintUnmatchedAreas = false,
+                RemoveIntersectingPaths = false,
+                CleanupScope = PdfRedactionCleanupScope.None,
+                UnsupportedImagePolicy = PdfRedactionUnsupportedImagePolicy.RemoveWholePlacement
+            },
+            layoutOptions: null,
+            readOptions,
+            RedactionMutationScope.Images,
+            paintMarks: false,
+            PdfMutationOperation.ModifyPageContent,
+            placements);
     }
 
     private static byte[] ApplyCore(
@@ -79,7 +113,8 @@ internal static partial class PdfRedactionApplier {
         PdfReadOptions? readOptions,
         RedactionMutationScope mutationScope,
         bool paintMarks,
-        PdfMutationOperation mutationOperation) {
+        PdfMutationOperation mutationOperation,
+        IReadOnlyList<PdfImagePlacement>? imageTargets) {
         Guard.NotNull(pdf, nameof(pdf));
         Guard.NotNull(areas, nameof(areas));
         _ = PdfMutationPlanner.RequireFullRewrite(pdf, mutationOperation, readOptions);
@@ -105,7 +140,7 @@ internal static partial class PdfRedactionApplier {
         PdfReadDocument document = PdfReadDocument.Open(pdf, readOptions);
         ValidateRedactionAreas(areaArray, document.Pages.Count);
         int maximumDecodedStreamBytes = readOptions?.Limits.MaxDecodedStreamBytes ?? PdfReadLimits.DefaultMaxDecodedStreamBytes;
-        RedactionMutation mutation = ApplyToObjects(objects, document, plan, areaArray, effectiveOptions, maximumDecodedStreamBytes, mutationScope, paintMarks);
+        RedactionMutation mutation = ApplyToObjects(objects, document, plan, areaArray, effectiveOptions, maximumDecodedStreamBytes, mutationScope, paintMarks, imageTargets);
         bool cleanupChanged = ApplyCleanupPolicy(objects, catalogObjectNumber, effectiveOptions.CleanupScope);
         if (!mutation.HasChanges && !cleanupChanged) {
             return pdf.ToArray();
@@ -178,7 +213,8 @@ internal static partial class PdfRedactionApplier {
         PdfRedactionApplyOptions options,
         int maximumDecodedStreamBytes,
         RedactionMutationScope mutationScope,
-        bool paintMarks) {
+        bool paintMarks,
+        IReadOnlyList<PdfImagePlacement>? imageTargets) {
         var matchesByPage = plan.Matches
             .GroupBy(match => match.PageNumber)
             .ToDictionary(group => group.Key, group => group.ToArray());
@@ -204,11 +240,14 @@ internal static partial class PdfRedactionApplier {
             }
 
             PdfRedactionMatch[] currentMatches = pageMatches ?? Array.Empty<PdfRedactionMatch>();
+            PdfRedactionMatch[] selectedImageMatches = imageTargets is null
+                ? currentMatches
+                : currentMatches.Where(match => imageTargets.Any(target => MatchesExactImagePlacement(match, target))).ToArray();
             ImageRedactionMutation imageMutation = (mutationScope & RedactionMutationScope.Images) != 0
-                ? RemoveMatchedImageObjects(objects, pageDictionary, currentMatches, options, ref nextObjectNumber)
+                ? RemoveMatchedImageObjects(objects, pageDictionary, selectedImageMatches, options, ref nextObjectNumber)
                 : ImageRedactionMutation.None;
             foreach (PdfRedactionMatch removedImage in imageMutation.RemovedMatches) if (removedImage.ObjectNumber.HasValue) removedImageObjectNumbers.Add(removedImage.ObjectNumber.Value);
-            if ((mutationScope & RedactionMutationScope.Images) != 0) ValidateImagePlacementMatches(currentMatches, imageMutation.RemovedMatches, options);
+            if ((mutationScope & RedactionMutationScope.Images) != 0) ValidateImagePlacementMatches(selectedImageMatches, imageMutation.RemovedMatches, options);
             bool pageChanged = imageMutation.HasChanges;
             if ((mutationScope & RedactionMutationScope.Text) != 0) {
                 pageChanged = RemoveMatchedTextObjects(
@@ -238,6 +277,25 @@ internal static partial class PdfRedactionApplier {
         if (removedImageObjectNumbers.Count > 0) changed = RemoveUnusedImageObjectReferences(objects, removedImageObjectNumbers) || changed;
 
         return new RedactionMutation(changed);
+    }
+
+    private static bool MatchesExactImagePlacement(PdfRedactionMatch match, PdfImagePlacement target) {
+        const double tolerance = 0.01D;
+        return match.Kind == PdfRedactionMatchKind.ImagePlacement &&
+            match.PageNumber == target.PageNumber &&
+            string.Equals(match.ResourceName, target.ResourceName, StringComparison.Ordinal) &&
+            (target.ObjectNumber == 0 ? !match.ObjectNumber.HasValue : match.ObjectNumber == target.ObjectNumber) &&
+            (match.ImagePlacement is null ||
+             (Math.Abs(match.ImagePlacement.A - target.A) <= tolerance &&
+              Math.Abs(match.ImagePlacement.B - target.B) <= tolerance &&
+              Math.Abs(match.ImagePlacement.C - target.C) <= tolerance &&
+              Math.Abs(match.ImagePlacement.D - target.D) <= tolerance &&
+              Math.Abs(match.ImagePlacement.E - target.E) <= tolerance &&
+              Math.Abs(match.ImagePlacement.F - target.F) <= tolerance)) &&
+            Math.Abs(match.X - target.X) <= tolerance &&
+            Math.Abs(match.Y - target.Y) <= tolerance &&
+            Math.Abs(match.Width - target.Width) <= tolerance &&
+            Math.Abs(match.Height - target.Height) <= tolerance;
     }
 
     [Flags]
@@ -287,11 +345,13 @@ internal static partial class PdfRedactionApplier {
             PdfRedactionMatch removed = removedMatches[i];
             if (removed.Kind == candidate.Kind &&
                 removed.PageNumber == candidate.PageNumber &&
+                removed.ObjectNumber == candidate.ObjectNumber &&
                 string.Equals(removed.ResourceName, candidate.ResourceName, StringComparison.Ordinal) &&
                 AreSameRedactionCoordinate(removed.X, candidate.X) &&
                 AreSameRedactionCoordinate(removed.Y, candidate.Y) &&
                 AreSameRedactionCoordinate(removed.Width, candidate.Width) &&
-                AreSameRedactionCoordinate(removed.Height, candidate.Height)) {
+                AreSameRedactionCoordinate(removed.Height, candidate.Height) &&
+                AreSameImagePlacementTransform(removed.ImagePlacement, candidate.ImagePlacement)) {
                 return true;
             }
         }
@@ -301,6 +361,15 @@ internal static partial class PdfRedactionApplier {
 
     private static bool AreSameRedactionCoordinate(double left, double right) =>
         Math.Abs(left - right) <= 0.001D;
+
+    private static bool AreSameImagePlacementTransform(PdfImagePlacement? left, PdfImagePlacement? right) =>
+        left is null || right is null ||
+        (AreSameRedactionCoordinate(left.A, right.A) &&
+         AreSameRedactionCoordinate(left.B, right.B) &&
+         AreSameRedactionCoordinate(left.C, right.C) &&
+         AreSameRedactionCoordinate(left.D, right.D) &&
+         AreSameRedactionCoordinate(left.E, right.E) &&
+         AreSameRedactionCoordinate(left.F, right.F));
 
     private static bool RemoveMatchedAnnotations(
         Dictionary<int, PdfIndirectObject> objects,

--- a/OfficeIMO.Pdf/Manipulation/PdfRedactionMatch.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfRedactionMatch.cs
@@ -23,7 +23,8 @@ public sealed class PdfRedactionMatch {
         string? text,
         string? subtype,
         int? objectNumber,
-        string? resourceName = null) {
+        string? resourceName = null,
+        PdfImagePlacement? imagePlacement = null) {
         Kind = kind;
         Area = area;
         PageNumber = pageNumber;
@@ -35,6 +36,7 @@ public sealed class PdfRedactionMatch {
         Subtype = subtype;
         ObjectNumber = objectNumber;
         ResourceName = resourceName;
+        ImagePlacement = imagePlacement;
     }
 
     /// <summary>Matched content kind.</summary>
@@ -69,4 +71,6 @@ public sealed class PdfRedactionMatch {
 
     /// <summary>Related PDF resource name, when matching an image placement.</summary>
     public string? ResourceName { get; }
+
+    internal PdfImagePlacement? ImagePlacement { get; }
 }

--- a/OfficeIMO.Pdf/Manipulation/PdfRedactionPlanner.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfRedactionPlanner.cs
@@ -143,7 +143,8 @@ internal static partial class PdfRedactionPlanner {
                     null,
                     null,
                     placement.ObjectNumber == 0 ? null : placement.ObjectNumber,
-                    placement.ResourceName));
+                    placement.ResourceName,
+                    placement));
 
                 findings.Add(new PdfDiagnosticFinding(
                     PdfDiagnosticSeverity.Warning,

--- a/OfficeIMO.Pdf/README.md
+++ b/OfficeIMO.Pdf/README.md
@@ -615,6 +615,39 @@ Replacement uses the closest standard PDF font unless the caller selects one;
 `PdfTextEditResult.Warnings` reports source-font substitutions that can change
 metrics or letterforms.
 
+### Find and edit existing page images
+
+Image placement coordinates also use PDF points from the page bottom-left.
+Discover placements through the editor, then remove, replace, or move one exact
+invocation without deleting overlapping text, paths, annotations, or unrelated
+images:
+
+```csharp
+PdfDocument document = PdfDocument.Open("contract.pdf");
+PdfImagePlacement logo = document.Images.Find(
+    new PdfPageRegion(pageNumber: 1, x: 36, y: 720, width: 180, height: 60)).Single();
+
+PdfImageEditResult updated = document.Images.Replace(
+    logo,
+    File.ReadAllBytes("new-logo.png"),
+    new PdfImageEditOptions { Layer = PdfImageEditLayer.AboveExistingContent });
+
+PdfImagePlacement replacement = updated.Document.Images.Find(
+    new PdfPageRegion(1, 36, 720, 180, 60)).Single();
+
+updated.Document.Images.Move(replacement, deltaX: 12, deltaY: -8)
+    .Document
+    .Save("contract-with-new-logo.pdf");
+```
+
+`Images.Add(...)` fits a new image to a page region. Replacement and movement
+preserve position, size, and rotation when the source transform is portable;
+callers explicitly choose whether rewritten content is above or behind existing
+page content. The editor fails closed for ambiguous placements and for source
+clipping, opacity, skew/reflection, unresolved transparency, image-mask, raw
+payload, or inline-image semantics that cannot be reproduced safely. Exact
+XObject removal remains available for rotated and skewed placements.
+
 ### Fill and flatten a PDF form
 
 ```csharp

--- a/OfficeIMO.Pdf/Reading/Core/PdfPageDrawingEffect.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfPageDrawingEffect.cs
@@ -18,7 +18,9 @@ internal readonly struct PdfPageDrawingEffect {
 
     public PdfPageDrawingEffect Apply(PdfPageGraphicsStateResource resource) => new PdfPageDrawingEffect(
         resource.BlendMode ?? BlendMode,
-        resource.HasSoftMask ? resource.SoftMask : SoftMask);
+        resource.SoftMaskEnabled.HasValue
+            ? resource.SoftMaskEnabled.Value ? resource.SoftMask : null
+            : SoftMask);
 }
 
 internal readonly struct PdfPageDrawingEffectTransition {

--- a/OfficeIMO.Pdf/Reading/Core/PdfPageGraphicsStateResource.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfPageGraphicsStateResource.cs
@@ -11,7 +11,7 @@ internal readonly struct PdfPageGraphicsStateResource {
         OfficeStrokeLineCap? strokeLineCap,
         OfficeStrokeLineJoin? strokeLineJoin,
         OfficeBlendMode? blendMode = null,
-        bool hasSoftMask = false,
+        bool? softMaskEnabled = null,
         PdfPageSoftMaskResource? softMask = null) {
         FillOpacity = fillOpacity;
         StrokeOpacity = strokeOpacity;
@@ -20,7 +20,7 @@ internal readonly struct PdfPageGraphicsStateResource {
         StrokeLineCap = strokeLineCap;
         StrokeLineJoin = strokeLineJoin;
         BlendMode = blendMode;
-        HasSoftMask = hasSoftMask;
+        SoftMaskEnabled = softMaskEnabled;
         SoftMask = softMask;
     }
 
@@ -38,7 +38,8 @@ internal readonly struct PdfPageGraphicsStateResource {
 
     public OfficeBlendMode? BlendMode { get; }
 
-    public bool HasSoftMask { get; }
+    /// <summary>Null inherits the current mask, false clears it, and true activates a mask.</summary>
+    public bool? SoftMaskEnabled { get; }
 
     public PdfPageSoftMaskResource? SoftMask { get; }
 }

--- a/OfficeIMO.Pdf/Reading/Core/PdfPageXObjectInvocationParser.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfPageXObjectInvocationParser.cs
@@ -45,12 +45,14 @@ internal static class PdfPageXObjectInvocationParser {
         OfficeStrokeLineJoin? initialStrokeLineJoin = null,
         int maxOperations = PdfReadLimits.DefaultMaxContentOperations,
         int maxNestingDepth = PdfReadLimits.DefaultMaxContentNestingDepth,
-        int maxOperands = PdfReadLimits.DefaultMaxContentOperands) {
+        int maxOperands = PdfReadLimits.DefaultMaxContentOperands,
+        OfficeBlendMode initialBlendMode = OfficeBlendMode.Normal,
+        bool initialHasSoftMask = false) {
         if (string.IsNullOrEmpty(content)) {
             return Array.Empty<PdfPageXObjectInvocation>();
         }
 
-        var parser = new Parser(content, baseTransform, pageHeight, graphicsStates, colorSpaces, optionalContentVisibility, initialFillColor, initialFillColorSpace, initialFillOpacity, paintOrderBase, paintOrderScale, paintOrderOffset, initialClipPath, initialStrokeColor, initialStrokeColorSpace, initialStrokeOpacity, initialStrokeWidth, initialStrokeDashStyle, initialStrokeLineCap, initialStrokeLineJoin, maxOperations, maxNestingDepth, maxOperands);
+        var parser = new Parser(content, baseTransform, pageHeight, graphicsStates, colorSpaces, optionalContentVisibility, initialFillColor, initialFillColorSpace, initialFillOpacity, paintOrderBase, paintOrderScale, paintOrderOffset, initialClipPath, initialStrokeColor, initialStrokeColorSpace, initialStrokeOpacity, initialStrokeWidth, initialStrokeDashStyle, initialStrokeLineCap, initialStrokeLineJoin, maxOperations, maxNestingDepth, maxOperands, initialBlendMode, initialHasSoftMask);
         return parser.Parse();
     }
 
@@ -113,13 +115,15 @@ internal static class PdfPageXObjectInvocationParser {
             OfficeStrokeLineJoin? initialStrokeLineJoin,
             int maxOperations,
             int maxNestingDepth,
-            int maxOperands) {
+            int maxOperands,
+            OfficeBlendMode initialBlendMode,
+            bool initialHasSoftMask) {
             _content = content;
             _baseTransform = baseTransform;
             _graphicsStates = graphicsStates;
             _colorSpaces = colorSpaces;
             _optionalContentVisibility = optionalContentVisibility;
-            _initialState = GraphicsState.Create(baseTransform, initialFillColor, initialFillColorSpace, initialFillOpacity, initialClipPath, initialStrokeColor, initialStrokeColorSpace, initialStrokeOpacity, initialStrokeWidth, initialStrokeDashStyle, initialStrokeLineCap, initialStrokeLineJoin);
+            _initialState = GraphicsState.Create(baseTransform, initialFillColor, initialFillColorSpace, initialFillOpacity, initialClipPath, initialStrokeColor, initialStrokeColorSpace, initialStrokeOpacity, initialStrokeWidth, initialStrokeDashStyle, initialStrokeLineCap, initialStrokeLineJoin, initialBlendMode, initialHasSoftMask);
             _state = _initialState;
             _pageHeight = pageHeight;
             _paintOrderBase = paintOrderBase;
@@ -558,7 +562,7 @@ internal static class PdfPageXObjectInvocationParser {
                         _args.Count >= 1 &&
                         _args[_args.Count - 1] is string name &&
                         !string.IsNullOrEmpty(name)) {
-                        _invocations.Add(new PdfPageXObjectInvocation(name, _state.Transform, _state.ClipPath, _state.FillColor, _state.FillColorSpace, _state.FillOpacity, _state.StrokeColor, _state.StrokeColorSpace, _state.StrokeOpacity, _state.StrokeWidth, _state.StrokeDashStyle, _state.StrokeLineCap, _state.StrokeLineJoin, paintOrder));
+                        _invocations.Add(new PdfPageXObjectInvocation(name, _state.Transform, _state.ClipPath, _state.FillColor, _state.FillColorSpace, _state.FillOpacity, _state.StrokeColor, _state.StrokeColorSpace, _state.StrokeOpacity, _state.StrokeWidth, _state.StrokeDashStyle, _state.StrokeLineCap, _state.StrokeLineJoin, paintOrder, _state.BlendMode, _state.HasSoftMask));
                     }
 
                     break;
@@ -568,7 +572,7 @@ internal static class PdfPageXObjectInvocationParser {
                         var inlineImage = new PdfPageInlineImage(
                             "__inline" + (++_inlineImageIndex).ToString(CultureInfo.InvariantCulture),
                             stream);
-                        _invocations.Add(new PdfPageXObjectInvocation(inlineImage, _state.Transform, _state.ClipPath, _state.FillColor, _state.FillColorSpace, _state.FillOpacity, _state.StrokeColor, _state.StrokeColorSpace, _state.StrokeOpacity, _state.StrokeWidth, _state.StrokeDashStyle, _state.StrokeLineCap, _state.StrokeLineJoin, paintOrder));
+                        _invocations.Add(new PdfPageXObjectInvocation(inlineImage, _state.Transform, _state.ClipPath, _state.FillColor, _state.FillColorSpace, _state.FillOpacity, _state.StrokeColor, _state.StrokeColorSpace, _state.StrokeOpacity, _state.StrokeWidth, _state.StrokeDashStyle, _state.StrokeLineCap, _state.StrokeLineJoin, paintOrder, _state.BlendMode, _state.HasSoftMask));
                     }
 
                     break;
@@ -975,7 +979,9 @@ internal static class PdfPageXObjectInvocationParser {
             double strokeWidth,
             OfficeStrokeDashStyle? strokeDashStyle,
             OfficeStrokeLineCap? strokeLineCap,
-            OfficeStrokeLineJoin? strokeLineJoin) {
+            OfficeStrokeLineJoin? strokeLineJoin,
+            OfficeBlendMode blendMode,
+            bool hasSoftMask) {
             Transform = transform;
             ClipPath = clipPath;
             FillColor = fillColor;
@@ -988,6 +994,8 @@ internal static class PdfPageXObjectInvocationParser {
             StrokeDashStyle = strokeDashStyle;
             StrokeLineCap = strokeLineCap;
             StrokeLineJoin = strokeLineJoin;
+            BlendMode = blendMode;
+            HasSoftMask = hasSoftMask;
         }
 
         public Matrix2D Transform { get; }
@@ -1014,8 +1022,12 @@ internal static class PdfPageXObjectInvocationParser {
 
         public OfficeStrokeLineJoin? StrokeLineJoin { get; }
 
+        public OfficeBlendMode BlendMode { get; }
+
+        public bool HasSoftMask { get; }
+
         public static GraphicsState Create(Matrix2D transform) =>
-            Create(transform, null, PdfPageColorSpaceKind.DeviceGray, null, null, null, PdfPageColorSpaceKind.DeviceGray, null, null, null, null, null);
+            Create(transform, null, PdfPageColorSpaceKind.DeviceGray, null, null, null, PdfPageColorSpaceKind.DeviceGray, null, null, null, null, null, OfficeBlendMode.Normal, false);
 
         public static GraphicsState Create(
             Matrix2D transform,
@@ -1029,7 +1041,9 @@ internal static class PdfPageXObjectInvocationParser {
             double? strokeWidth,
             OfficeStrokeDashStyle? strokeDashStyle,
             OfficeStrokeLineCap? strokeLineCap,
-            OfficeStrokeLineJoin? strokeLineJoin) =>
+            OfficeStrokeLineJoin? strokeLineJoin,
+            OfficeBlendMode blendMode,
+            bool hasSoftMask) =>
             new GraphicsState(
                 transform,
                 clipPath,
@@ -1042,31 +1056,33 @@ internal static class PdfPageXObjectInvocationParser {
                 strokeWidth.HasValue ? ResolveStrokeWidth(strokeWidth.Value) : 1D,
                 strokeDashStyle,
                 strokeLineCap,
-                strokeLineJoin);
+                strokeLineJoin,
+                blendMode,
+                hasSoftMask);
 
-        public GraphicsState WithTransform(Matrix2D transform) => new GraphicsState(transform, ClipPath, FillColor, FillColorSpace, FillOpacity, StrokeColor, StrokeColorSpace, StrokeOpacity, StrokeWidth, StrokeDashStyle, StrokeLineCap, StrokeLineJoin);
+        public GraphicsState WithTransform(Matrix2D transform) => new GraphicsState(transform, ClipPath, FillColor, FillColorSpace, FillOpacity, StrokeColor, StrokeColorSpace, StrokeOpacity, StrokeWidth, StrokeDashStyle, StrokeLineCap, StrokeLineJoin, BlendMode, HasSoftMask);
 
-        public GraphicsState WithClipPath(PdfPageClipPath clipPath) => new GraphicsState(Transform, clipPath, FillColor, FillColorSpace, FillOpacity, StrokeColor, StrokeColorSpace, StrokeOpacity, StrokeWidth, StrokeDashStyle, StrokeLineCap, StrokeLineJoin);
+        public GraphicsState WithClipPath(PdfPageClipPath clipPath) => new GraphicsState(Transform, clipPath, FillColor, FillColorSpace, FillOpacity, StrokeColor, StrokeColorSpace, StrokeOpacity, StrokeWidth, StrokeDashStyle, StrokeLineCap, StrokeLineJoin, BlendMode, HasSoftMask);
 
-        public GraphicsState WithFillColor(OfficeColor color) => new GraphicsState(Transform, ClipPath, color, FillColorSpace, FillOpacity, StrokeColor, StrokeColorSpace, StrokeOpacity, StrokeWidth, StrokeDashStyle, StrokeLineCap, StrokeLineJoin);
+        public GraphicsState WithFillColor(OfficeColor color) => new GraphicsState(Transform, ClipPath, color, FillColorSpace, FillOpacity, StrokeColor, StrokeColorSpace, StrokeOpacity, StrokeWidth, StrokeDashStyle, StrokeLineCap, StrokeLineJoin, BlendMode, HasSoftMask);
 
-        public GraphicsState WithFillColor(OfficeColor color, PdfPageColorSpace colorSpace) => new GraphicsState(Transform, ClipPath, color, colorSpace, FillOpacity, StrokeColor, StrokeColorSpace, StrokeOpacity, StrokeWidth, StrokeDashStyle, StrokeLineCap, StrokeLineJoin);
+        public GraphicsState WithFillColor(OfficeColor color, PdfPageColorSpace colorSpace) => new GraphicsState(Transform, ClipPath, color, colorSpace, FillOpacity, StrokeColor, StrokeColorSpace, StrokeOpacity, StrokeWidth, StrokeDashStyle, StrokeLineCap, StrokeLineJoin, BlendMode, HasSoftMask);
 
-        public GraphicsState WithFillColorSpace(PdfPageColorSpace colorSpace) => new GraphicsState(Transform, ClipPath, FillColor, colorSpace, FillOpacity, StrokeColor, StrokeColorSpace, StrokeOpacity, StrokeWidth, StrokeDashStyle, StrokeLineCap, StrokeLineJoin);
+        public GraphicsState WithFillColorSpace(PdfPageColorSpace colorSpace) => new GraphicsState(Transform, ClipPath, FillColor, colorSpace, FillOpacity, StrokeColor, StrokeColorSpace, StrokeOpacity, StrokeWidth, StrokeDashStyle, StrokeLineCap, StrokeLineJoin, BlendMode, HasSoftMask);
 
-        public GraphicsState WithStrokeColor(OfficeColor color) => new GraphicsState(Transform, ClipPath, FillColor, FillColorSpace, FillOpacity, color, StrokeColorSpace, StrokeOpacity, StrokeWidth, StrokeDashStyle, StrokeLineCap, StrokeLineJoin);
+        public GraphicsState WithStrokeColor(OfficeColor color) => new GraphicsState(Transform, ClipPath, FillColor, FillColorSpace, FillOpacity, color, StrokeColorSpace, StrokeOpacity, StrokeWidth, StrokeDashStyle, StrokeLineCap, StrokeLineJoin, BlendMode, HasSoftMask);
 
-        public GraphicsState WithStrokeColor(OfficeColor color, PdfPageColorSpace colorSpace) => new GraphicsState(Transform, ClipPath, FillColor, FillColorSpace, FillOpacity, color, colorSpace, StrokeOpacity, StrokeWidth, StrokeDashStyle, StrokeLineCap, StrokeLineJoin);
+        public GraphicsState WithStrokeColor(OfficeColor color, PdfPageColorSpace colorSpace) => new GraphicsState(Transform, ClipPath, FillColor, FillColorSpace, FillOpacity, color, colorSpace, StrokeOpacity, StrokeWidth, StrokeDashStyle, StrokeLineCap, StrokeLineJoin, BlendMode, HasSoftMask);
 
-        public GraphicsState WithStrokeColorSpace(PdfPageColorSpace colorSpace) => new GraphicsState(Transform, ClipPath, FillColor, FillColorSpace, FillOpacity, StrokeColor, colorSpace, StrokeOpacity, StrokeWidth, StrokeDashStyle, StrokeLineCap, StrokeLineJoin);
+        public GraphicsState WithStrokeColorSpace(PdfPageColorSpace colorSpace) => new GraphicsState(Transform, ClipPath, FillColor, FillColorSpace, FillOpacity, StrokeColor, colorSpace, StrokeOpacity, StrokeWidth, StrokeDashStyle, StrokeLineCap, StrokeLineJoin, BlendMode, HasSoftMask);
 
-        public GraphicsState WithStrokeWidth(double strokeWidth) => new GraphicsState(Transform, ClipPath, FillColor, FillColorSpace, FillOpacity, StrokeColor, StrokeColorSpace, StrokeOpacity, strokeWidth, StrokeDashStyle, StrokeLineCap, StrokeLineJoin);
+        public GraphicsState WithStrokeWidth(double strokeWidth) => new GraphicsState(Transform, ClipPath, FillColor, FillColorSpace, FillOpacity, StrokeColor, StrokeColorSpace, StrokeOpacity, strokeWidth, StrokeDashStyle, StrokeLineCap, StrokeLineJoin, BlendMode, HasSoftMask);
 
-        public GraphicsState WithStrokeDashStyle(OfficeStrokeDashStyle? strokeDashStyle) => new GraphicsState(Transform, ClipPath, FillColor, FillColorSpace, FillOpacity, StrokeColor, StrokeColorSpace, StrokeOpacity, StrokeWidth, strokeDashStyle, StrokeLineCap, StrokeLineJoin);
+        public GraphicsState WithStrokeDashStyle(OfficeStrokeDashStyle? strokeDashStyle) => new GraphicsState(Transform, ClipPath, FillColor, FillColorSpace, FillOpacity, StrokeColor, StrokeColorSpace, StrokeOpacity, StrokeWidth, strokeDashStyle, StrokeLineCap, StrokeLineJoin, BlendMode, HasSoftMask);
 
-        public GraphicsState WithStrokeLineCap(OfficeStrokeLineCap? strokeLineCap) => new GraphicsState(Transform, ClipPath, FillColor, FillColorSpace, FillOpacity, StrokeColor, StrokeColorSpace, StrokeOpacity, StrokeWidth, StrokeDashStyle, strokeLineCap, StrokeLineJoin);
+        public GraphicsState WithStrokeLineCap(OfficeStrokeLineCap? strokeLineCap) => new GraphicsState(Transform, ClipPath, FillColor, FillColorSpace, FillOpacity, StrokeColor, StrokeColorSpace, StrokeOpacity, StrokeWidth, StrokeDashStyle, strokeLineCap, StrokeLineJoin, BlendMode, HasSoftMask);
 
-        public GraphicsState WithStrokeLineJoin(OfficeStrokeLineJoin? strokeLineJoin) => new GraphicsState(Transform, ClipPath, FillColor, FillColorSpace, FillOpacity, StrokeColor, StrokeColorSpace, StrokeOpacity, StrokeWidth, StrokeDashStyle, StrokeLineCap, strokeLineJoin);
+        public GraphicsState WithStrokeLineJoin(OfficeStrokeLineJoin? strokeLineJoin) => new GraphicsState(Transform, ClipPath, FillColor, FillColorSpace, FillOpacity, StrokeColor, StrokeColorSpace, StrokeOpacity, StrokeWidth, StrokeDashStyle, StrokeLineCap, strokeLineJoin, BlendMode, HasSoftMask);
 
         public GraphicsState WithGraphicsStateResource(PdfPageGraphicsStateResource resource) =>
             new GraphicsState(
@@ -1081,7 +1097,9 @@ internal static class PdfPageXObjectInvocationParser {
                 resource.StrokeWidth.HasValue ? ResolveStrokeWidth(resource.StrokeWidth.Value) : StrokeWidth,
                 resource.StrokeDashStyle ?? StrokeDashStyle,
                 resource.StrokeLineCap ?? StrokeLineCap,
-                resource.StrokeLineJoin ?? StrokeLineJoin);
+                resource.StrokeLineJoin ?? StrokeLineJoin,
+                resource.BlendMode ?? BlendMode,
+                resource.SoftMaskEnabled ?? HasSoftMask);
     }
 }
 
@@ -1100,7 +1118,9 @@ internal readonly struct PdfPageXObjectInvocation {
         OfficeStrokeDashStyle? strokeDashStyle,
         OfficeStrokeLineCap? strokeLineCap,
         OfficeStrokeLineJoin? strokeLineJoin,
-        double paintOrder = 0D) {
+        double paintOrder = 0D,
+        OfficeBlendMode blendMode = OfficeBlendMode.Normal,
+        bool hasSoftMask = false) {
         Name = name;
         InlineImage = null;
         Transform = transform;
@@ -1116,6 +1136,8 @@ internal readonly struct PdfPageXObjectInvocation {
         StrokeLineCap = strokeLineCap;
         StrokeLineJoin = strokeLineJoin;
         PaintOrder = paintOrder;
+        BlendMode = blendMode;
+        HasSoftMask = hasSoftMask;
     }
 
     public PdfPageXObjectInvocation(
@@ -1132,7 +1154,9 @@ internal readonly struct PdfPageXObjectInvocation {
         OfficeStrokeDashStyle? strokeDashStyle,
         OfficeStrokeLineCap? strokeLineCap,
         OfficeStrokeLineJoin? strokeLineJoin,
-        double paintOrder = 0D) {
+        double paintOrder = 0D,
+        OfficeBlendMode blendMode = OfficeBlendMode.Normal,
+        bool hasSoftMask = false) {
         Name = inlineImage.ResourceName;
         InlineImage = inlineImage;
         Transform = transform;
@@ -1148,6 +1172,8 @@ internal readonly struct PdfPageXObjectInvocation {
         StrokeLineCap = strokeLineCap;
         StrokeLineJoin = strokeLineJoin;
         PaintOrder = paintOrder;
+        BlendMode = blendMode;
+        HasSoftMask = hasSoftMask;
     }
 
     public string Name { get; }
@@ -1179,4 +1205,8 @@ internal readonly struct PdfPageXObjectInvocation {
     public OfficeStrokeLineJoin? StrokeLineJoin { get; }
 
     public double PaintOrder { get; }
+
+    public OfficeBlendMode BlendMode { get; }
+
+    public bool HasSoftMask { get; }
 }

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadPage.Visual.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadPage.Visual.cs
@@ -757,8 +757,8 @@ public sealed partial class PdfReadPage {
             OfficeStrokeLineCap? strokeLineCap = ReadStrokeLineCap(state);
             OfficeStrokeLineJoin? strokeLineJoin = ReadStrokeLineJoin(state);
             OfficeBlendMode? blendMode = ReadBlendMode(state);
-            bool hasSoftMask = state.Items.ContainsKey("SMask");
-            PdfPageSoftMaskResource? softMask = hasSoftMask ? ReadSoftMask(state) : null;
+            bool? softMaskEnabled = ReadSoftMaskEnabled(state);
+            PdfPageSoftMaskResource? softMask = softMaskEnabled == true ? ReadSoftMask(state) : null;
             if (fillOpacity.HasValue ||
                 strokeOpacity.HasValue ||
                 strokeWidth.HasValue ||
@@ -766,8 +766,8 @@ public sealed partial class PdfReadPage {
                 strokeLineCap.HasValue ||
                 strokeLineJoin.HasValue ||
                 blendMode.HasValue ||
-                hasSoftMask) {
-                result[entry.Key] = new PdfPageGraphicsStateResource(fillOpacity, strokeOpacity, strokeWidth, strokeDashStyle, strokeLineCap, strokeLineJoin, blendMode, hasSoftMask, softMask);
+                softMaskEnabled.HasValue) {
+                result[entry.Key] = new PdfPageGraphicsStateResource(fillOpacity, strokeOpacity, strokeWidth, strokeDashStyle, strokeLineCap, strokeLineJoin, blendMode, softMaskEnabled, softMask);
             }
         }
 

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadPage.VisualEffects.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadPage.VisualEffects.cs
@@ -57,6 +57,11 @@ public sealed partial class PdfReadPage {
         return new PdfPageSoftMaskResource(group, mode, backdrop);
     }
 
+    private bool? ReadSoftMaskEnabled(PdfDictionary state) {
+        if (!state.Items.TryGetValue("SMask", out PdfObject? value)) return null;
+        return ResolveObject(value) is PdfName { Name: "None" } ? false : true;
+    }
+
     private IReadOnlyList<PdfPageDrawingEffectTransition> GetGraphicsEffectTransitions(Matrix2D pageTransform, double pageHeight, PageContentBudget? pageContentBudget = null) {
         pageContentBudget ??= new PageContentBudget(this);
         var transitions = new List<PdfPageDrawingEffectTransition>();

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadPage.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadPage.cs
@@ -610,6 +610,8 @@ public sealed partial class PdfReadPage {
         double paintOrderScale = 1D,
         double paintOrderOffset = 0D,
         PdfPageClipPath? initialClipPath = null,
+        OfficeBlendMode initialBlendMode = OfficeBlendMode.Normal,
+        bool initialHasSoftMask = false,
         int contentNestingDepth = 0,
         PageContentBudget? pageContentBudget = null) {
         EnsureContentNestingBudget(contentNestingDepth);
@@ -628,9 +630,11 @@ public sealed partial class PdfReadPage {
                       paintOrderScale,
                       paintOrderOffset,
                       initialClipPath,
-                      maxOperations: _limits.MaxContentOperations,
-                      maxNestingDepth: _limits.MaxContentNestingDepth,
-                      maxOperands: _limits.MaxContentOperands)) {
+                     maxOperations: _limits.MaxContentOperations,
+                     maxNestingDepth: _limits.MaxContentNestingDepth,
+                     maxOperands: _limits.MaxContentOperands,
+                     initialBlendMode: initialBlendMode,
+                     initialHasSoftMask: initialHasSoftMask)) {
             Matrix2D invocationTransform = invocation.Transform;
             if (invocation.InlineImage != null) {
                 placements.Add(BuildImagePlacement(
@@ -644,12 +648,14 @@ public sealed partial class PdfReadPage {
                     invocation.FillOpacity,
                     invocation.InlineImage.Stream,
                     resources,
-                    invocation.PaintOrder));
+                    invocation.PaintOrder,
+                    invocation.BlendMode,
+                    invocation.HasSoftMask));
                 continue;
             }
 
             if (TryGetImageXObject(resources, invocation.Name, out int imageObjectNumber, out int directStreamIdentity)) {
-                placements.Add(BuildImagePlacement(pageNumber, invocation.Name, imageObjectNumber, directStreamIdentity, invocationTransform, invocation.ClipPath, invocation.FillColor, invocation.FillOpacity, paintOrder: invocation.PaintOrder));
+                placements.Add(BuildImagePlacement(pageNumber, invocation.Name, imageObjectNumber, directStreamIdentity, invocationTransform, invocation.ClipPath, invocation.FillColor, invocation.FillOpacity, paintOrder: invocation.PaintOrder, blendMode: invocation.BlendMode, hasSoftMask: invocation.HasSoftMask));
                 continue;
             }
 
@@ -680,6 +686,8 @@ public sealed partial class PdfReadPage {
                     invocation.PaintOrder,
                     paintOrderScale * 0.000000001D,
                     initialClipPath: invocation.ClipPath,
+                    initialBlendMode: invocation.BlendMode,
+                    initialHasSoftMask: invocation.HasSoftMask,
                     contentNestingDepth: contentNestingDepth + 1,
                     pageContentBudget: pageContentBudget);
             } finally {
@@ -765,7 +773,9 @@ public sealed partial class PdfReadPage {
         double? imageOpacity,
         PdfStream? inlineImageStream = null,
         PdfDictionary? inlineImageResources = null,
-        double paintOrder = 0D) {
+        double paintOrder = 0D,
+        OfficeBlendMode blendMode = OfficeBlendMode.Normal,
+        bool hasSoftMask = false) {
         var p0 = transform.Transform(0D, 0D);
         var p1 = transform.Transform(1D, 0D);
         var p2 = transform.Transform(0D, 1D);
@@ -795,7 +805,9 @@ public sealed partial class PdfReadPage {
             imageOpacity,
             inlineImageStream,
             inlineImageResources,
-            paintOrder);
+            paintOrder,
+            blendMode,
+            hasSoftMask);
     }
 
     private byte[]? GetMarkedContentActualTextBytes(PdfDictionary? resources, string propertyName) {

--- a/OfficeIMO.Pdf/Reading/Core/ResourceResolver.cs
+++ b/OfficeIMO.Pdf/Reading/Core/ResourceResolver.cs
@@ -949,7 +949,9 @@ internal static partial class ResourceResolver {
             transparencyMaskResolved,
             directStreamIdentity,
             isImageMask,
-            imageMaskColor ?? OfficeColor.Black);
+            imageMaskColor ?? OfficeColor.Black,
+            stream.Dictionary.Items.ContainsKey("Decode"),
+            stream.Dictionary.Items.ContainsKey("DecodeParms") || stream.Dictionary.Items.ContainsKey("DP"));
     }
 
     private static string? GetTransparencyMaskKind(PdfDictionary dictionary, Dictionary<int, PdfIndirectObject> objects) {

--- a/OfficeIMO.Pdf/Reading/Model/PdfExtractedImage.cs
+++ b/OfficeIMO.Pdf/Reading/Model/PdfExtractedImage.cs
@@ -25,7 +25,9 @@ public sealed class PdfExtractedImage {
         bool transparencyMaskResolved = false,
         int directStreamIdentity = 0,
         bool isImageMask = false,
-        OfficeColor? imageMaskColor = null) {
+        OfficeColor? imageMaskColor = null,
+        bool hasExplicitDecode = false,
+        bool hasDecodeParameters = false) {
         PageNumber = pageNumber;
         ResourceName = resourceName;
         ObjectNumber = objectNumber;
@@ -43,6 +45,8 @@ public sealed class PdfExtractedImage {
         DirectStreamIdentity = directStreamIdentity;
         IsImageMask = isImageMask;
         ImageMaskColor = imageMaskColor ?? OfficeColor.Black;
+        HasExplicitDecode = hasExplicitDecode;
+        HasDecodeParameters = hasDecodeParameters;
     }
 
     /// <summary>One-based page number containing the image resource.</summary>
@@ -104,4 +108,8 @@ public sealed class PdfExtractedImage {
     public bool IsImageMask { get; }
 
     internal OfficeColor ImageMaskColor { get; }
+
+    internal bool HasExplicitDecode { get; }
+
+    internal bool HasDecodeParameters { get; }
 }

--- a/OfficeIMO.Pdf/Reading/Model/PdfImagePlacement.cs
+++ b/OfficeIMO.Pdf/Reading/Model/PdfImagePlacement.cs
@@ -26,7 +26,9 @@ public sealed class PdfImagePlacement {
         double? imageOpacity = null,
         PdfStream? inlineImageStream = null,
         PdfDictionary? inlineImageResources = null,
-        double paintOrder = 0D) {
+        double paintOrder = 0D,
+        OfficeBlendMode? blendMode = null,
+        bool hasSoftMask = false) {
         PageNumber = pageNumber;
         ResourceName = resourceName;
         ObjectNumber = objectNumber;
@@ -47,6 +49,8 @@ public sealed class PdfImagePlacement {
         InlineImageStream = inlineImageStream;
         InlineImageResources = inlineImageResources;
         PaintOrder = paintOrder;
+        BlendMode = blendMode;
+        HasSoftMask = hasSoftMask;
     }
 
     /// <summary>One-based source page number containing the image invocation.</summary>
@@ -102,6 +106,10 @@ public sealed class PdfImagePlacement {
     internal PdfDictionary? InlineImageResources { get; }
 
     internal double PaintOrder { get; }
+
+    internal OfficeBlendMode? BlendMode { get; }
+
+    internal bool HasSoftMask { get; }
 
     /// <summary>True when the placement matrix is axis-aligned within a small tolerance.</summary>
     public bool IsAxisAligned => Math.Abs(B) <= 0.001D && Math.Abs(C) <= 0.001D;

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Images.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Images.cs
@@ -207,6 +207,30 @@ internal static partial class PdfWriter {
         return true;
     }
 
+    internal static bool TryGetJpegComponentCount(byte[] data, out int componentCount) {
+        componentCount = 0;
+        if (data == null || data.Length < 4 || data[0] != 0xFF || data[1] != 0xD8) return false;
+        int offset = 2;
+        while (offset < data.Length) {
+            if (data[offset] != 0xFF) return false;
+            while (offset < data.Length && data[offset] == 0xFF) offset++;
+            if (offset >= data.Length) return false;
+            byte marker = data[offset++];
+            if (marker == 0xD9 || marker == 0xDA) return false;
+            if (marker == 0x01 || (marker >= 0xD0 && marker <= 0xD7)) continue;
+            if (marker == 0x00 || marker == 0xD8 || offset + 2 > data.Length) return false;
+            int segmentLength = (data[offset] << 8) | data[offset + 1];
+            if (segmentLength < 2 || (long)offset + segmentLength > data.Length) return false;
+            if (marker is 0xC0 or 0xC1 or 0xC2 or 0xC3 or 0xC5 or 0xC6 or 0xC7 or 0xC9 or 0xCA or 0xCB or 0xCD or 0xCE or 0xCF) {
+                if (segmentLength < 8) return false;
+                componentCount = data[offset + 7];
+                return componentCount > 0;
+            }
+            offset += segmentLength;
+        }
+        return false;
+    }
+
     private static bool TryValidatePngPassThroughData(byte[] compressedData, int width, int height, int colors, out string? unsupportedReason) {
         if (!TryDecodePngData(compressedData, out byte[] decoded, out unsupportedReason)) {
             return false;
@@ -795,11 +819,21 @@ internal static partial class PdfWriter {
 
         int pixelWidth = info.Width > 0 ? info.Width : Math.Max(1, (int)Math.Round(fallbackWidth));
         int pixelHeight = info.Height > 0 ? info.Height : Math.Max(1, (int)Math.Round(fallbackHeight));
+        string colorSpace = "/DeviceRGB";
+        if (TryGetJpegComponentCount(data, out int componentCount)) {
+            if (componentCount == 1) colorSpace = "/DeviceGray";
+            else if (componentCount == 4) colorSpace = "/DeviceCMYK";
+            else if (componentCount != 3) {
+                unsupportedReason = "JPEG component count is not supported for PDF embedding.";
+                image = new PdfImageStream();
+                return false;
+            }
+        }
         image = new PdfImageStream {
             Data = data,
             PixelWidth = pixelWidth,
             PixelHeight = pixelHeight,
-            DictionarySuffix = " /ColorSpace /DeviceRGB /BitsPerComponent 8 /Filter /DCTDecode"
+            DictionarySuffix = " /ColorSpace " + colorSpace + " /BitsPerComponent 8 /Filter /DCTDecode"
         };
         return true;
     }


### PR DESCRIPTION
## Summary

- add a focused `PdfDocument.Images` workflow for discovering, adding, removing, replacing, and moving exact image placements
- preserve unrelated text, paths, annotations, images, nested form resources, and page content while reusing the existing stamper and redaction engines
- carry image graphics state through nested forms and content-stream arrays, with exact resource/object/transform matching
- fail closed when clipping, opacity, blend modes, active soft masks, inline images, image masks, ambiguous placements, non-portable transforms, or JPEG decode semantics cannot be reproduced safely
- normalize or reject unsafe multi-component JPEG input instead of silently assigning incorrect PDF color semantics

## Public API

```csharp
PdfDocument document = PdfDocument.Open("contract.pdf");
PdfImagePlacement logo = document.Images.Find(
    new PdfPageRegion(1, 36, 720, 180, 60)).Single();

PdfImageEditResult replaced = document.Images.Replace(
    logo,
    File.ReadAllBytes("new-logo.png"));

PdfImagePlacement replacement = replaced.Document.Images.Find(
    new PdfPageRegion(1, 36, 720, 180, 60)).Single();

replaced.Document.Images.Move(replacement, 12, -8)
    .Document
    .Save("contract-with-new-logo.pdf");
```

This PR is based on and should merge after #2268.
