### PR TITLE
Configure grouped low-noise Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,56 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
   - package-ecosystem: "nuget"
     directory: "/"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "daily"
+    cooldown:
+      default-days: 7
+      include:
+        - "*"
+    open-pull-requests-limit: 1
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+    reviewers:
+      - "PrzemyslawKlys"
+    labels:
+      - "dependencies"
+      - "automated"
+
+  - package-ecosystem: "npm"
+    directory: "/OfficeIMO.Markup.VSCode"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7
+      include:
+        - "*"
+    open-pull-requests-limit: 1
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+    reviewers:
+      - "PrzemyslawKlys"
+    labels:
+      - "dependencies"
+      - "automated"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7
+      include:
+        - "*"
+    open-pull-requests-limit: 1
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
     reviewers:
       - "PrzemyslawKlys"
     labels:


### PR DESCRIPTION
## Summary

Reduce Dependabot noise while keeping OfficeIMO current:

- check NuGet, npm, and GitHub Actions daily;
- wait seven days before proposing ordinary releases;
- combine eligible updates into one PR per ecosystem;
- keep at most one version-update PR open per ecosystem.

Dependabot security updates remain immediate and are not subject to the cooldown.
