### PR TITLE
Fix large Excel workbooks and table header styling

### DIFF
--- a/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.StructuredTableStyles.cs
+++ b/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.StructuredTableStyles.cs
@@ -17,7 +17,10 @@ namespace OfficeIMO.Excel.Pdf {
                     continue;
                 }
 
-                if (!TryCreateStructuredTablePalette(document, table.StyleName, out StructuredTablePalette? palette)) {
+                if (!ExcelBuiltInTableStylePaletteResolver.TryCreate(
+                        document,
+                        table.StyleName,
+                        out ExcelBuiltInTableStylePalette? palette)) {
                     if (!string.IsNullOrWhiteSpace(table.StyleName)) {
                         AddWarning(
                             options,
@@ -75,167 +78,6 @@ namespace OfficeIMO.Excel.Pdf {
             return null;
         }
 
-        private static bool TryCreateStructuredTablePalette(
-            ExcelDocument document,
-            string? styleName,
-            out StructuredTablePalette? palette) {
-            palette = null;
-            if (!TryParseBuiltInTableStyle(styleName, out string? family, out int index)) {
-                return false;
-            }
-
-            string light = ResolveThemeRgb(document, 0U, null, "FFFFFF");
-            string dark = ResolveThemeRgb(document, 1U, null, "000000");
-            int familyIndex = (index - 1) % 7;
-            string baseColor = ResolveFamilyBaseColor(document, familyIndex);
-            string paleColor = ResolveFamilyTintColor(document, familyIndex, 0.8D);
-            string stripeColor = ResolveFamilyTintColor(document, familyIndex, 0.6D);
-            string mutedColor = ResolveFamilyTintColor(document, familyIndex, -0.25D);
-
-            switch (family) {
-                case "Light":
-                    if (index <= 7) {
-                        palette = new StructuredTablePalette(
-                            headerFill: null,
-                            headerText: familyIndex == 0 ? dark : mutedColor,
-                            bodyFill: null,
-                            stripeFill: paleColor,
-                            bodyText: familyIndex == 0 ? dark : mutedColor,
-                            border: familyIndex == 0 ? ResolveThemeRgb(document, 0U, -0.35D, "A6A6A6") : baseColor,
-                            headerBold: true);
-                    } else if (index <= 14) {
-                        palette = new StructuredTablePalette(
-                            baseColor,
-                            light,
-                            bodyFill: null,
-                            stripeFill: null,
-                            dark,
-                            baseColor,
-                            headerBold: true);
-                    } else {
-                        palette = new StructuredTablePalette(
-                            headerFill: null,
-                            headerText: dark,
-                            bodyFill: null,
-                            stripeFill: paleColor,
-                            bodyText: dark,
-                            border: familyIndex == 0 ? ResolveThemeRgb(document, 0U, -0.35D, "A6A6A6") : baseColor,
-                            headerBold: true);
-                    }
-                    return true;
-
-                case "Medium":
-                    if (index <= 7) {
-                        palette = new StructuredTablePalette(baseColor, light, null, paleColor, dark, baseColor, headerBold: true);
-                    } else if (index <= 14) {
-                        palette = new StructuredTablePalette(baseColor, light, paleColor, stripeColor, dark, baseColor, headerBold: true);
-                    } else if (index <= 21) {
-                        string neutralStripe = ResolveThemeRgb(document, 0U, -0.15D, "D9D9D9");
-                        palette = new StructuredTablePalette(baseColor, light, null, neutralStripe, dark, baseColor, headerBold: true);
-                    } else {
-                        palette = new StructuredTablePalette(paleColor, dark, paleColor, stripeColor, dark, baseColor, headerBold: true);
-                    }
-                    return true;
-
-                case "Dark":
-                    if (index <= 7) {
-                        string bodyFill = familyIndex == 0
-                            ? ResolveThemeRgb(document, 1U, 0.45D, "737373")
-                            : baseColor;
-                        string bodyStripe = familyIndex == 0
-                            ? ResolveThemeRgb(document, 1U, 0.25D, "404040")
-                            : mutedColor;
-                        palette = new StructuredTablePalette(dark, light, bodyFill, bodyStripe, light, baseColor, headerBold: true);
-                    } else if (index == 8) {
-                        palette = new StructuredTablePalette(
-                            dark,
-                            light,
-                            ResolveThemeRgb(document, 0U, -0.15D, "D9D9D9"),
-                            ResolveThemeRgb(document, 0U, -0.35D, "A6A6A6"),
-                            dark,
-                            ResolveThemeRgb(document, 0U, -0.35D, "A6A6A6"),
-                            headerBold: false);
-                    } else {
-                        uint headerTheme = index == 9 ? 5U : index == 10 ? 7U : 9U;
-                        uint bodyTheme = index == 9 ? 4U : index == 10 ? 6U : 8U;
-                        string header = ResolveThemeRgb(document, headerTheme, null, index == 9 ? "E97132" : index == 10 ? "0F9ED5" : "4EA72E");
-                        string body = ResolveThemeRgb(document, bodyTheme, 0.8D, index == 9 ? "C0E6F5" : index == 10 ? "C1F0C8" : "F2CEEF");
-                        string stripe = ResolveThemeRgb(document, bodyTheme, 0.6D, index == 9 ? "83CCEB" : index == 10 ? "83E28E" : "E49EDD");
-                        palette = new StructuredTablePalette(header, light, body, stripe, dark, header, headerBold: false);
-                    }
-                    return true;
-            }
-
-            return false;
-        }
-
-        private static bool TryParseBuiltInTableStyle(string? styleName, out string? family, out int index) {
-            family = null;
-            index = 0;
-            if (string.IsNullOrWhiteSpace(styleName) ||
-                !styleName!.StartsWith("TableStyle", StringComparison.OrdinalIgnoreCase)) {
-                return false;
-            }
-
-            string suffix = styleName.Substring("TableStyle".Length);
-            foreach (string candidate in new[] { "Light", "Medium", "Dark" }) {
-                if (!suffix.StartsWith(candidate, StringComparison.OrdinalIgnoreCase) ||
-                    !int.TryParse(suffix.Substring(candidate.Length), out int parsed)) {
-                    continue;
-                }
-
-                int maximum = candidate == "Light" ? 21 : candidate == "Medium" ? 28 : 11;
-                if (parsed < 1 || parsed > maximum) {
-                    return false;
-                }
-
-                family = candidate;
-                index = parsed;
-                return true;
-            }
-
-            return false;
-        }
-
-        private static string ResolveFamilyBaseColor(ExcelDocument document, int familyIndex) {
-            if (familyIndex == 0) {
-                return ResolveThemeRgb(document, 1U, null, "000000");
-            }
-
-            string[] fallbacks = { "156082", "E97132", "196B24", "0F9ED5", "A02B93", "4EA72E" };
-            return ResolveThemeRgb(document, (uint)(familyIndex + 3), null, fallbacks[familyIndex - 1]);
-        }
-
-        private static string ResolveFamilyTintColor(ExcelDocument document, int familyIndex, double tint) {
-            if (familyIndex == 0) {
-                string neutralFallback = tint >= 0D
-                    ? tint >= 0.7D ? "D9D9D9" : tint >= 0.5D ? "A6A6A6" : "737373"
-                    : "A6A6A6";
-                double lightTint = tint >= 0D ? tint - 0.95D : tint;
-                return ResolveThemeRgb(document, 0U, lightTint, neutralFallback);
-            }
-
-            string[] paleFallbacks = { "C0E6F5", "FBE2D5", "C1F0C8", "CAEDFB", "F2CEEF", "DAF2D0" };
-            string[] stripeFallbacks = { "83CCEB", "F7C7AC", "83E28E", "94DCF8", "E49EDD", "B5E6A2" };
-            string[] mutedFallbacks = { "104861", "BE5014", "12501A", "0C769E", "782170", "3C7D22" };
-            string fallback = tint >= 0.7D
-                ? paleFallbacks[familyIndex - 1]
-                : tint >= 0D
-                    ? stripeFallbacks[familyIndex - 1]
-                    : mutedFallbacks[familyIndex - 1];
-            return ResolveThemeRgb(document, (uint)(familyIndex + 3), tint, fallback);
-        }
-
-        private static string ResolveThemeRgb(ExcelDocument document, uint themeIndex, double? tint, string fallback) {
-            string? argb = document.ResolveThemeColorArgb(themeIndex, tint);
-            if (string.IsNullOrWhiteSpace(argb)) {
-                return fallback;
-            }
-
-            string normalized = argb!.Trim().TrimStart('#');
-            return normalized.Length == 8 ? normalized.Substring(2) : normalized.Length == 6 ? normalized : fallback;
-        }
-
         private sealed class StructuredTableVisualData {
             private readonly int _firstRow;
             private readonly int _firstColumn;
@@ -247,9 +89,9 @@ namespace OfficeIMO.Excel.Pdf {
             private readonly bool _showLastColumn;
             private readonly bool _showRowStripes;
             private readonly bool _showColumnStripes;
-            private readonly StructuredTablePalette _palette;
+            private readonly ExcelBuiltInTableStylePalette _palette;
 
-            public StructuredTableVisualData(
+            internal StructuredTableVisualData(
                 int firstRow,
                 int firstColumn,
                 int lastRow,
@@ -260,7 +102,7 @@ namespace OfficeIMO.Excel.Pdf {
                 bool showLastColumn,
                 bool showRowStripes,
                 bool showColumnStripes,
-                StructuredTablePalette palette) {
+                ExcelBuiltInTableStylePalette palette) {
                 _firstRow = firstRow;
                 _firstColumn = firstColumn;
                 _lastRow = lastRow;
@@ -274,7 +116,7 @@ namespace OfficeIMO.Excel.Pdf {
                 _palette = palette;
             }
 
-            public bool TryResolve(int row, int column, out StructuredTableCellVisual? visual) {
+            internal bool TryResolve(int row, int column, out StructuredTableCellVisual? visual) {
                 visual = null;
                 if (row < _firstRow || row > _lastRow || column < _firstColumn || column > _lastColumn) {
                     return false;
@@ -306,45 +148,18 @@ namespace OfficeIMO.Excel.Pdf {
             }
         }
 
-        private sealed class StructuredTablePalette {
-            public StructuredTablePalette(
-                string? headerFill,
-                string? headerText,
-                string? bodyFill,
-                string? stripeFill,
-                string? bodyText,
-                string? border,
-                bool headerBold) {
-                HeaderFill = headerFill;
-                HeaderText = headerText;
-                BodyFill = bodyFill;
-                StripeFill = stripeFill;
-                BodyText = bodyText;
-                Border = border;
-                HeaderBold = headerBold;
-            }
-
-            public string? HeaderFill { get; }
-            public string? HeaderText { get; }
-            public string? BodyFill { get; }
-            public string? StripeFill { get; }
-            public string? BodyText { get; }
-            public string? Border { get; }
-            public bool HeaderBold { get; }
-        }
-
         private sealed class StructuredTableCellVisual {
-            public StructuredTableCellVisual(string? fill, string? text, bool bold, string? border) {
+            internal StructuredTableCellVisual(string? fill, string? text, bool bold, string? border) {
                 Fill = fill;
                 Text = text;
                 Bold = bold;
                 Border = border;
             }
 
-            public string? Fill { get; }
-            public string? Text { get; }
-            public bool Bold { get; }
-            public string? Border { get; }
+            internal string? Fill { get; }
+            internal string? Text { get; }
+            internal bool Bold { get; }
+            internal string? Border { get; }
         }
     }
 }

--- a/OfficeIMO.Excel.Tests/Excel.PerformanceReviewRegression.cs
+++ b/OfficeIMO.Excel.Tests/Excel.PerformanceReviewRegression.cs
@@ -5915,6 +5915,47 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void PerformanceReview_SharedStringIndexesAbove65535RemainValid() {
+            using var memory = new MemoryStream();
+            var history = new DataTable("History");
+            history.Columns.Add("Date", typeof(string));
+            history.Columns.Add("ITCrew", typeof(string));
+            history.Columns.Add("Value", typeof(int));
+            history.Rows.Add("6/3/2026 8:56:31 PM", "ITISC01", 10);
+            history.Rows.Add("6/4/2026 9:21:01 PM", "ITISC02", 20);
+
+            using (var document = ExcelDocument.Create(new MemoryStream())) {
+                for (int index = 0; index < 65_536; index++) {
+                    document.GetSharedStringIndex("Existing " + index.ToString(CultureInfo.InvariantCulture));
+                }
+
+                var historySheet = document.AddWorksheet("History 01");
+                historySheet.InsertDataTableAsTable(
+                    history,
+                    startRow: 3,
+                    tableName: "HistoryData01",
+                    style: OfficeIMO.Excel.ExcelTableStyle.TableStyleMedium6);
+
+                document.Save(memory);
+            }
+
+            memory.Position = 0;
+            using var spreadsheet = SpreadsheetDocument.Open(memory, false);
+            var historyPart = spreadsheet.WorkbookPart!.Workbook.Sheets!
+                .Elements<Sheet>()
+                .Where(sheet => string.Equals(sheet.Name?.Value, "History 01", StringComparison.Ordinal))
+                .Select(sheet => (WorksheetPart)spreadsheet.WorkbookPart.GetPartById(sheet.Id!))
+                .Single();
+            var cells = historyPart.Worksheet.Descendants<Cell>()
+                .ToDictionary(cell => cell.CellReference!.Value!);
+
+            Assert.Equal("Date", GetSpreadsheetCellText(spreadsheet, cells["A3"]));
+            Assert.Equal("ITCrew", GetSpreadsheetCellText(spreadsheet, cells["B3"]));
+            Assert.Equal("6/3/2026 8:56:31 PM", GetSpreadsheetCellText(spreadsheet, cells["A4"]));
+            Assert.Empty(new OpenXmlValidator().Validate(spreadsheet).ToList());
+        }
+
+        [Fact]
         public void PerformanceReview_InsertObjectsThenAddTable_ExternalMutationPreservesDirectPackageCandidate() {
             using var memory = new MemoryStream();
             var rows = new[] {

--- a/OfficeIMO.Excel.Tests/Excel.SheetComposer.Report.cs
+++ b/OfficeIMO.Excel.Tests/Excel.SheetComposer.Report.cs
@@ -325,6 +325,128 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void EmptyTableOfContents_KeepsReadableStyledHeaders() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+
+            using (var doc = ExcelDocument.Create(filePath)) {
+                doc.AddTableOfContents(sheetName: "Index", styled: true);
+                doc.Save();
+            }
+
+            using (var ss = SpreadsheetDocument.Open(filePath, false)) {
+                var worksheet = ss.WorkbookPart!.WorksheetParts.First().Worksheet;
+                var headerCells = worksheet.Descendants<Cell>()
+                    .Where(cell => cell.CellReference?.Value == "A3" || cell.CellReference?.Value == "B3")
+                    .ToList();
+
+                Assert.Equal(2, headerCells.Count);
+                Assert.All(headerCells, cell => Assert.NotNull(cell.StyleIndex));
+            }
+
+            using (ExcelDocument doc = ExcelDocument.Load(filePath)) {
+                ExcelCellStyleSnapshot firstHeader = doc.Sheets[0].GetCellStyle(3, 1);
+                ExcelCellStyleSnapshot secondHeader = doc.Sheets[0].GetCellStyle(3, 2);
+                Assert.True(firstHeader.Bold);
+                Assert.True(secondHeader.Bold);
+                Assert.EndsWith("F2F2F2", firstHeader.FillColorArgb, StringComparison.OrdinalIgnoreCase);
+                Assert.EndsWith("F2F2F2", secondHeader.FillColorArgb, StringComparison.OrdinalIgnoreCase);
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public void Composer_TableFrom_ManagedSvgResolvesBuiltInHeaderStyle() {
+            using var doc = ExcelDocument.Create();
+            ExcelSheet? report = null;
+            doc.Compose("Report", c => {
+                report = c.Sheet;
+                c.TableFrom(new[] { new ComposerTableRow("Alpha", 10) }, style: ExcelTableStyle.TableStyleMedium9);
+                c.Finish(autoFitColumns: false);
+            });
+
+            string svg = report!.Range("A1:B2").ToSvg(new ExcelImageExportOptions { ShowGridlines = false });
+            string accentArgb = Assert.IsType<string>(doc.ResolveThemeColorArgb(4U));
+            string expectedAccent = accentArgb.Substring(accentArgb.Length - 6);
+
+            int headerTextIndex = svg.IndexOf(">Name</text>", StringComparison.Ordinal);
+            Assert.True(headerTextIndex > 0);
+            int headerElementStart = svg.LastIndexOf("<text ", headerTextIndex, StringComparison.Ordinal);
+            Assert.True(headerElementStart >= 0);
+            string headerTextElement = svg.Substring(headerElementStart, headerTextIndex - headerElementStart);
+            Assert.Contains("font-weight=\"700\"", headerTextElement, StringComparison.Ordinal);
+            Assert.Contains("fill=\"#FFFFFF\"", headerTextElement, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains($"fill=\"#{expectedAccent}\"", svg, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Composer_TableFrom_ManagedSvgPreservesDirectHeaderStyle() {
+            using var doc = ExcelDocument.Create();
+            ExcelSheet? report = null;
+            doc.Compose("Report", c => {
+                report = c.Sheet;
+                c.TableFrom(new[] { new ComposerTableRow("Alpha", 10) }, style: ExcelTableStyle.TableStyleMedium9);
+                c.Finish(autoFitColumns: false);
+            });
+            report!.Range("A1").SetFillColor("C00000").SetFontColor("FFFF00");
+
+            string svg = report.Range("A1:B2").ToSvg(new ExcelImageExportOptions { ShowGridlines = false });
+
+            int headerTextIndex = svg.IndexOf(">Name</text>", StringComparison.Ordinal);
+            Assert.True(headerTextIndex > 0);
+            int headerElementStart = svg.LastIndexOf("<text ", headerTextIndex, StringComparison.Ordinal);
+            Assert.True(headerElementStart >= 0);
+            string headerTextElement = svg.Substring(headerElementStart, headerTextIndex - headerElementStart);
+            Assert.Contains("fill=\"#FFFF00\"", headerTextElement, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("font-weight=\"700\"", headerTextElement, StringComparison.Ordinal);
+            Assert.Contains("fill=\"#C00000\"", svg, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Composer_TableFrom_ManagedSvgKeepsTableBoldWhenOnlyDirectFillIsSet() {
+            using var doc = ExcelDocument.Create();
+            ExcelSheet? report = null;
+            doc.Compose("Report", c => {
+                report = c.Sheet;
+                c.TableFrom(new[] { new ComposerTableRow("Alpha", 10) }, style: ExcelTableStyle.TableStyleMedium9);
+                c.Finish(autoFitColumns: false);
+            });
+            report!.Range("A1").SetFillColor("C00000");
+
+            string svg = report.Range("A1:B2").ToSvg(new ExcelImageExportOptions { ShowGridlines = false });
+
+            int headerTextIndex = svg.IndexOf(">Name</text>", StringComparison.Ordinal);
+            Assert.True(headerTextIndex > 0);
+            int headerElementStart = svg.LastIndexOf("<text ", headerTextIndex, StringComparison.Ordinal);
+            Assert.True(headerElementStart >= 0);
+            string headerTextElement = svg.Substring(headerElementStart, headerTextIndex - headerElementStart);
+            Assert.Contains("font-weight=\"700\"", headerTextElement, StringComparison.Ordinal);
+            Assert.Contains("fill=\"#FFFFFF\"", headerTextElement, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("fill=\"#C00000\"", svg, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Composer_TableFrom_ManagedSvgPreservesNonBoldDarkHeaderContract() {
+            using var doc = ExcelDocument.Create();
+            ExcelSheet? report = null;
+            doc.Compose("Report", c => {
+                report = c.Sheet;
+                c.TableFrom(new[] { new ComposerTableRow("Alpha", 10) }, style: ExcelTableStyle.TableStyleDark8);
+                c.Finish(autoFitColumns: false);
+            });
+
+            string svg = report!.Range("A1:B2").ToSvg(new ExcelImageExportOptions { ShowGridlines = false });
+
+            int headerTextIndex = svg.IndexOf(">Name</text>", StringComparison.Ordinal);
+            Assert.True(headerTextIndex > 0);
+            int headerElementStart = svg.LastIndexOf("<text ", headerTextIndex, StringComparison.Ordinal);
+            Assert.True(headerElementStart >= 0);
+            string headerTextElement = svg.Substring(headerElementStart, headerTextIndex - headerElementStart);
+            Assert.DoesNotContain("font-weight=\"700\"", headerTextElement, StringComparison.Ordinal);
+            Assert.Contains("fill=\"#FFFFFF\"", headerTextElement, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
         public void Composer_ColumnTableFrom_SummarizeOverflowPreservesMoreColumn() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
             var rows = new[] {

--- a/OfficeIMO.Excel.Tests/Excel.SheetComposer.Report.cs
+++ b/OfficeIMO.Excel.Tests/Excel.SheetComposer.Report.cs
@@ -426,6 +426,86 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Composer_TableFrom_ManagedSvgPreservesDirectHeaderGradientFill() {
+            using var doc = ExcelDocument.Create();
+            ExcelSheet? report = null;
+            doc.Compose("Report", c => {
+                report = c.Sheet;
+                c.TableFrom(new[] { new ComposerTableRow("Alpha", 10) }, style: ExcelTableStyle.TableStyleMedium9);
+                c.Finish(autoFitColumns: false);
+            });
+            report!.CellAt(1, 1).SetGradientFill("C00000", "00A000", 45D);
+
+            ExcelRangeVisualSnapshot snapshot = report.Range("A1:B2").CreateVisualSnapshot();
+            string svg = report.Range("A1:B2").ToSvg(new ExcelImageExportOptions { ShowGridlines = false });
+
+            ExcelVisualCell header = Assert.Single(snapshot.Cells, cell => cell.Row == 1 && cell.Column == 1);
+            Assert.Equal("FFC00000", header.Style.FillGradientStartColorArgb);
+            Assert.Equal("FF00A000", header.Style.FillGradientEndColorArgb);
+            Assert.Equal(45D, header.Style.FillGradientDegree);
+            Assert.Contains("xl-gradient-1-1", svg, StringComparison.Ordinal);
+            Assert.Contains("stop-color=\"#C00000\"", svg, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("stop-color=\"#00A000\"", svg, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Composer_TableFrom_ManagedSvgProjectsLightTableHeaderBorder() {
+            using var doc = ExcelDocument.Create();
+            ExcelSheet? report = null;
+            doc.Compose("Report", c => {
+                report = c.Sheet;
+                c.TableFrom(new[] { new ComposerTableRow("Alpha", 10) }, style: ExcelTableStyle.TableStyleLight1);
+                c.Finish(autoFitColumns: false);
+            });
+
+            ExcelRangeVisualSnapshot snapshot = report!.Range("A1:B2").CreateVisualSnapshot();
+            string svg = report.Range("A1:B2").ToSvg(new ExcelImageExportOptions { ShowGridlines = false });
+            string borderArgb = Assert.IsType<string>(doc.ResolveThemeColorArgb(0U, -0.35D));
+            string expectedBorder = borderArgb.Substring(borderArgb.Length - 6);
+
+            ExcelVisualCell header = Assert.Single(snapshot.Cells, cell => cell.Row == 1 && cell.Column == 1);
+            Assert.Equal(expectedBorder, header.Style.Border?.Bottom?.ColorArgb, ignoreCase: true);
+            Assert.Contains($"stroke=\"#{expectedBorder}\"", svg, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Composer_TableFrom_ManagedSvgPreservesDirectHeaderBorder() {
+            using var doc = ExcelDocument.Create();
+            ExcelSheet? report = null;
+            doc.Compose("Report", c => {
+                report = c.Sheet;
+                c.TableFrom(new[] { new ComposerTableRow("Alpha", 10) }, style: ExcelTableStyle.TableStyleLight1);
+                c.Finish(autoFitColumns: false);
+            });
+            report!.CellAt(1, 1).SetBorder(ExcelBorderStyle.Double, "C00000");
+
+            ExcelRangeVisualSnapshot snapshot = report.Range("A1:B2").CreateVisualSnapshot();
+            string svg = report.Range("A1:B2").ToSvg(new ExcelImageExportOptions { ShowGridlines = false });
+
+            ExcelVisualCell header = Assert.Single(snapshot.Cells, cell => cell.Row == 1 && cell.Column == 1);
+            Assert.Equal("double", header.Style.Border?.Bottom?.Style);
+            Assert.Equal("FFC00000", header.Style.Border?.Bottom?.ColorArgb);
+            Assert.Contains("stroke=\"#C00000\"", svg, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void TableHeaderVisualStyleResolver_PreservesDirectPatternFill() {
+            var directStyle = new ExcelCellStyleSnapshot {
+                StyleIndex = 1U,
+                FillPatternType = "darkGrid",
+                FillPatternForegroundColorArgb = "FFC00000",
+                FillPatternBackgroundColorArgb = "FFFFE5E5"
+            };
+            var tableStyle = new ExcelTableHeaderVisualStyle("FF4472C4", "FFFFFFFF", bold: true, borderColorArgb: "FF4472C4");
+
+            ExcelCellStyleSnapshot resolved = ExcelTableHeaderVisualStyleResolver.Apply(directStyle, tableStyle);
+
+            Assert.Equal("darkGrid", resolved.FillPatternType);
+            Assert.Equal("FFC00000", resolved.FillPatternForegroundColorArgb);
+            Assert.Equal("FFFFE5E5", resolved.FillPatternBackgroundColorArgb);
+        }
+
+        [Fact]
         public void Composer_TableFrom_ManagedSvgPreservesNonBoldDarkHeaderContract() {
             using var doc = ExcelDocument.Create();
             ExcelSheet? report = null;

--- a/OfficeIMO.Excel.Tests/Excel.SheetComposer.Report.cs
+++ b/OfficeIMO.Excel.Tests/Excel.SheetComposer.Report.cs
@@ -227,6 +227,104 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Composer_TableFrom_LeavesHeaderAppearanceToTheTableStyle() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+            var rows = new[] { new ComposerTableRow("Alpha", 10) };
+
+            using (var doc = ExcelDocument.Create(filePath)) {
+                doc.Compose("Report", c => {
+                    c.TableFrom(rows, style: ExcelTableStyle.TableStyleMedium9);
+                    c.Finish(autoFitColumns: false);
+                });
+                doc.Save();
+            }
+
+            using (var ss = SpreadsheetDocument.Open(filePath, false)) {
+                var worksheet = ss.WorkbookPart!.WorksheetParts.First().Worksheet;
+                var headerCells = worksheet.Descendants<Cell>()
+                    .Where(cell => cell.CellReference?.Value == "A1" || cell.CellReference?.Value == "B1")
+                    .ToList();
+
+                Assert.Equal(2, headerCells.Count);
+                Assert.All(headerCells, cell => Assert.Null(cell.StyleIndex));
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public void Composer_TableFrom_PreservesAdAsAHeaderAcronym() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+            var rows = new[] { new AdStateComposerTableRow("Enabled") };
+
+            using (var doc = ExcelDocument.Create(filePath)) {
+                doc.Compose("Report", c => {
+                    c.TableFrom(rows);
+                    c.Finish(autoFitColumns: false);
+                });
+                doc.Save();
+            }
+
+            using (var ss = SpreadsheetDocument.Open(filePath, false)) {
+                var worksheet = ss.WorkbookPart!.WorksheetParts.First();
+                Assert.Equal("AD State", GetCellText(ss, worksheet, "A1"));
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public void Composer_ColumnTableFrom_LeavesHeaderAppearanceToTheTableStyle() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+            var rows = new[] { new ComposerTableRow("Alpha", 10) };
+
+            using (var doc = ExcelDocument.Create(filePath)) {
+                doc.Compose("Report", c => {
+                    c.Columns(2, columns => {
+                        columns[0].TableFrom(rows, style: ExcelTableStyle.TableStyleMedium4);
+                    });
+                    c.Finish(autoFitColumns: false);
+                });
+                doc.Save();
+            }
+
+            using (var ss = SpreadsheetDocument.Open(filePath, false)) {
+                var worksheet = ss.WorkbookPart!.WorksheetParts.First().Worksheet;
+                var headerCells = worksheet.Descendants<Cell>()
+                    .Where(cell => cell.CellReference?.Value == "A1" || cell.CellReference?.Value == "B1")
+                    .ToList();
+
+                Assert.Equal(2, headerCells.Count);
+                Assert.All(headerCells, cell => Assert.Null(cell.StyleIndex));
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public void TableOfContents_LeavesHeaderAppearanceToTheTableStyle() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+
+            using (var doc = ExcelDocument.Create(filePath)) {
+                doc.AddWorksheet("Data").Cell(1, 1, "Value");
+                doc.AddTableOfContents(sheetName: "Index", styled: true);
+                doc.Save();
+            }
+
+            using (var ss = SpreadsheetDocument.Open(filePath, false)) {
+                var worksheet = ss.WorkbookPart!.WorksheetParts.First().Worksheet;
+                var headerCells = worksheet.Descendants<Cell>()
+                    .Where(cell => cell.CellReference?.Value == "A3" || cell.CellReference?.Value == "B3")
+                    .ToList();
+
+                Assert.Equal(2, headerCells.Count);
+                Assert.All(headerCells, cell => Assert.Null(cell.StyleIndex));
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
         public void Composer_ColumnTableFrom_SummarizeOverflowPreservesMoreColumn() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
             var rows = new[] {
@@ -267,6 +365,14 @@ namespace OfficeIMO.Tests {
             public string Name { get; }
 
             public int Score { get; }
+        }
+
+        private sealed class AdStateComposerTableRow {
+            public AdStateComposerTableRow(string adState) {
+                ADState = adState;
+            }
+
+            public string ADState { get; }
         }
 
         private sealed class WideComposerTableRow {

--- a/OfficeIMO.Excel.Tests/Excel.SheetNameValidationAndPreflight.cs
+++ b/OfficeIMO.Excel.Tests/Excel.SheetNameValidationAndPreflight.cs
@@ -1345,6 +1345,43 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Preflight_DoesNotAllocateAnUnboundedSharedStringRepairGap() {
+            string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+            string savePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+
+            using (var doc = ExcelDocument.Create(path)) {
+                doc.AddWorksheet("Strings").CellValue(1, 1, "Alpha");
+                doc.Save(path);
+            }
+
+            using (var package = SpreadsheetDocument.Open(path, true)) {
+                var worksheetPart = package.WorkbookPart!.WorksheetParts.First();
+                var cell = worksheetPart.Worksheet.Descendants<Cell>().Single();
+                cell.DataType = CellValues.SharedString;
+                cell.RemoveAllChildren<CellValue>();
+                cell.RemoveAllChildren<InlineString>();
+                cell.AppendChild(new CellValue("2000000"));
+                worksheetPart.Worksheet.Save();
+            }
+
+            using (var doc = ExcelDocument.Load(path)) {
+                doc.Save(savePath, new ExcelSaveOptions { DisableFastPackageWriter = true, SafePreflight = true });
+            }
+
+            using (var package = SpreadsheetDocument.Open(savePath, false)) {
+                var sharedStrings = package.WorkbookPart!.SharedStringTablePart!.SharedStringTable!;
+                Assert.Single(sharedStrings.Elements<SharedStringItem>());
+
+                var cell = package.WorkbookPart.WorksheetParts.First().Worksheet.Descendants<Cell>().Single();
+                Assert.Equal("inlineStr", cell.DataType!.InnerText);
+                Assert.Equal("2000000", cell.InlineString!.InnerText);
+            }
+
+            File.Delete(path);
+            File.Delete(savePath);
+        }
+
+        [Fact]
         public void Preflight_CreatesWorkbookViewAndNormalizesSheetViewReferenceBeforeSave() {
             string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
             string savePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");

--- a/OfficeIMO.Excel/ExcelBuiltInTableStylePaletteResolver.cs
+++ b/OfficeIMO.Excel/ExcelBuiltInTableStylePaletteResolver.cs
@@ -1,0 +1,187 @@
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Resolves the visual palette of built-in Excel table styles for non-Excel renderers.
+    /// </summary>
+    internal static class ExcelBuiltInTableStylePaletteResolver {
+        internal static bool TryCreate(
+            ExcelDocument document,
+            string? styleName,
+            out ExcelBuiltInTableStylePalette? palette) {
+            palette = null;
+            if (!TryParse(styleName, out string? family, out int index)) {
+                return false;
+            }
+
+            string light = ResolveThemeRgb(document, 0U, null, "FFFFFF");
+            string dark = ResolveThemeRgb(document, 1U, null, "000000");
+            int familyIndex = (index - 1) % 7;
+            string baseColor = ResolveFamilyBaseColor(document, familyIndex);
+            string paleColor = ResolveFamilyTintColor(document, familyIndex, 0.8D);
+            string stripeColor = ResolveFamilyTintColor(document, familyIndex, 0.6D);
+            string mutedColor = ResolveFamilyTintColor(document, familyIndex, -0.25D);
+
+            switch (family) {
+                case "Light":
+                    if (index <= 7) {
+                        palette = new ExcelBuiltInTableStylePalette(
+                            headerFill: null,
+                            headerText: familyIndex == 0 ? dark : mutedColor,
+                            bodyFill: null,
+                            stripeFill: paleColor,
+                            bodyText: familyIndex == 0 ? dark : mutedColor,
+                            border: familyIndex == 0 ? ResolveThemeRgb(document, 0U, -0.35D, "A6A6A6") : baseColor,
+                            headerBold: true);
+                    } else if (index <= 14) {
+                        palette = new ExcelBuiltInTableStylePalette(baseColor, light, null, null, dark, baseColor, headerBold: true);
+                    } else {
+                        palette = new ExcelBuiltInTableStylePalette(
+                            headerFill: null,
+                            headerText: dark,
+                            bodyFill: null,
+                            stripeFill: paleColor,
+                            bodyText: dark,
+                            border: familyIndex == 0 ? ResolveThemeRgb(document, 0U, -0.35D, "A6A6A6") : baseColor,
+                            headerBold: true);
+                    }
+                    return true;
+
+                case "Medium":
+                    if (index <= 7) {
+                        palette = new ExcelBuiltInTableStylePalette(baseColor, light, null, paleColor, dark, baseColor, headerBold: true);
+                    } else if (index <= 14) {
+                        palette = new ExcelBuiltInTableStylePalette(baseColor, light, paleColor, stripeColor, dark, baseColor, headerBold: true);
+                    } else if (index <= 21) {
+                        string neutralStripe = ResolveThemeRgb(document, 0U, -0.15D, "D9D9D9");
+                        palette = new ExcelBuiltInTableStylePalette(baseColor, light, null, neutralStripe, dark, baseColor, headerBold: true);
+                    } else {
+                        palette = new ExcelBuiltInTableStylePalette(paleColor, dark, paleColor, stripeColor, dark, baseColor, headerBold: true);
+                    }
+                    return true;
+
+                case "Dark":
+                    if (index <= 7) {
+                        string bodyFill = familyIndex == 0
+                            ? ResolveThemeRgb(document, 1U, 0.45D, "737373")
+                            : baseColor;
+                        string bodyStripe = familyIndex == 0
+                            ? ResolveThemeRgb(document, 1U, 0.25D, "404040")
+                            : mutedColor;
+                        palette = new ExcelBuiltInTableStylePalette(dark, light, bodyFill, bodyStripe, light, baseColor, headerBold: true);
+                    } else if (index == 8) {
+                        palette = new ExcelBuiltInTableStylePalette(
+                            dark,
+                            light,
+                            ResolveThemeRgb(document, 0U, -0.15D, "D9D9D9"),
+                            ResolveThemeRgb(document, 0U, -0.35D, "A6A6A6"),
+                            dark,
+                            ResolveThemeRgb(document, 0U, -0.35D, "A6A6A6"),
+                            headerBold: false);
+                    } else {
+                        uint headerTheme = index == 9 ? 5U : index == 10 ? 7U : 9U;
+                        uint bodyTheme = index == 9 ? 4U : index == 10 ? 6U : 8U;
+                        string header = ResolveThemeRgb(document, headerTheme, null, index == 9 ? "E97132" : index == 10 ? "0F9ED5" : "4EA72E");
+                        string body = ResolveThemeRgb(document, bodyTheme, 0.8D, index == 9 ? "C0E6F5" : index == 10 ? "C1F0C8" : "F2CEEF");
+                        string stripe = ResolveThemeRgb(document, bodyTheme, 0.6D, index == 9 ? "83CCEB" : index == 10 ? "83E28E" : "E49EDD");
+                        palette = new ExcelBuiltInTableStylePalette(header, light, body, stripe, dark, header, headerBold: false);
+                    }
+                    return true;
+            }
+
+            return false;
+        }
+
+        private static bool TryParse(string? styleName, out string? family, out int index) {
+            family = null;
+            index = 0;
+            if (string.IsNullOrWhiteSpace(styleName) ||
+                !styleName!.StartsWith("TableStyle", StringComparison.OrdinalIgnoreCase)) {
+                return false;
+            }
+
+            string suffix = styleName.Substring("TableStyle".Length);
+            foreach (string candidate in new[] { "Light", "Medium", "Dark" }) {
+                if (!suffix.StartsWith(candidate, StringComparison.OrdinalIgnoreCase) ||
+                    !int.TryParse(suffix.Substring(candidate.Length), out int parsed)) {
+                    continue;
+                }
+
+                int maximum = candidate == "Light" ? 21 : candidate == "Medium" ? 28 : 11;
+                if (parsed < 1 || parsed > maximum) {
+                    return false;
+                }
+
+                family = candidate;
+                index = parsed;
+                return true;
+            }
+
+            return false;
+        }
+
+        private static string ResolveFamilyBaseColor(ExcelDocument document, int familyIndex) {
+            if (familyIndex == 0) {
+                return ResolveThemeRgb(document, 1U, null, "000000");
+            }
+
+            string[] fallbacks = { "156082", "E97132", "196B24", "0F9ED5", "A02B93", "4EA72E" };
+            return ResolveThemeRgb(document, (uint)(familyIndex + 3), null, fallbacks[familyIndex - 1]);
+        }
+
+        private static string ResolveFamilyTintColor(ExcelDocument document, int familyIndex, double tint) {
+            if (familyIndex == 0) {
+                string neutralFallback = tint >= 0D
+                    ? tint >= 0.7D ? "D9D9D9" : tint >= 0.5D ? "A6A6A6" : "737373"
+                    : "A6A6A6";
+                double lightTint = tint >= 0D ? tint - 0.95D : tint;
+                return ResolveThemeRgb(document, 0U, lightTint, neutralFallback);
+            }
+
+            string[] paleFallbacks = { "C0E6F5", "FBE2D5", "C1F0C8", "CAEDFB", "F2CEEF", "DAF2D0" };
+            string[] stripeFallbacks = { "83CCEB", "F7C7AC", "83E28E", "94DCF8", "E49EDD", "B5E6A2" };
+            string[] mutedFallbacks = { "104861", "BE5014", "12501A", "0C769E", "782170", "3C7D22" };
+            string fallback = tint >= 0.7D
+                ? paleFallbacks[familyIndex - 1]
+                : tint >= 0D
+                    ? stripeFallbacks[familyIndex - 1]
+                    : mutedFallbacks[familyIndex - 1];
+            return ResolveThemeRgb(document, (uint)(familyIndex + 3), tint, fallback);
+        }
+
+        private static string ResolveThemeRgb(ExcelDocument document, uint themeIndex, double? tint, string fallback) {
+            string? argb = document.ResolveThemeColorArgb(themeIndex, tint);
+            if (string.IsNullOrWhiteSpace(argb)) {
+                return fallback;
+            }
+
+            string normalized = argb!.Trim().TrimStart('#');
+            return normalized.Length == 8 ? normalized.Substring(2) : normalized.Length == 6 ? normalized : fallback;
+        }
+    }
+
+    internal sealed class ExcelBuiltInTableStylePalette {
+        internal ExcelBuiltInTableStylePalette(
+            string? headerFill,
+            string? headerText,
+            string? bodyFill,
+            string? stripeFill,
+            string? bodyText,
+            string? border,
+            bool headerBold) {
+            HeaderFill = headerFill;
+            HeaderText = headerText;
+            BodyFill = bodyFill;
+            StripeFill = stripeFill;
+            BodyText = bodyText;
+            Border = border;
+            HeaderBold = headerBold;
+        }
+
+        internal string? HeaderFill { get; }
+        internal string? HeaderText { get; }
+        internal string? BodyFill { get; }
+        internal string? StripeFill { get; }
+        internal string? BodyText { get; }
+        internal string? Border { get; }
+        internal bool HeaderBold { get; }
+    }
+}

--- a/OfficeIMO.Excel/ExcelDocument.StyleAndSharedStringCleanup.cs
+++ b/OfficeIMO.Excel/ExcelDocument.StyleAndSharedStringCleanup.cs
@@ -81,6 +81,7 @@ namespace OfficeIMO.Excel {
             var sharedStringTable = sharedStringTablePart?.SharedStringTable;
             int itemCount = sharedStringTable?.Elements<SharedStringItem>().Count() ?? 0;
             int sharedStringCellCount = 0;
+            int remainingSharedStringRepairItems = MaximumSharedStringRepairItems;
             bool sharedStringTableChanged = false;
 
             foreach (var worksheetPart in workbookPart.WorksheetParts) {
@@ -95,29 +96,27 @@ namespace OfficeIMO.Excel {
                             }
 
                             string rawValue = cell.CellValue?.Text ?? cell.InnerText ?? string.Empty;
-                            if (!TryParseSharedStringIndex(rawValue, out int sharedStringIndex)
-                                || sharedStringIndex >= MaximumSharedStringRepairItems) {
-                                cell.DataType = CellValues.InlineString;
-                                cell.RemoveAllChildren<CellValue>();
-                                cell.RemoveAllChildren<InlineString>();
-                                cell.AppendChild(new InlineString(new Text(rawValue)));
+                            if (!TryParseSharedStringIndex(rawValue, out int sharedStringIndex)) {
+                                ConvertSharedStringCellToInlineString(cell, rawValue);
                                 worksheetChanged = true;
                                 continue;
-                            }
-
-                            while (sharedStringTable != null && itemCount <= sharedStringIndex) {
-                                sharedStringTable.AppendChild(new SharedStringItem(new Text(string.Empty)));
-                                itemCount++;
-                                sharedStringTableChanged = true;
                             }
 
                             if (sharedStringIndex >= itemCount) {
-                                cell.DataType = CellValues.InlineString;
-                                cell.RemoveAllChildren<CellValue>();
-                                cell.RemoveAllChildren<InlineString>();
-                                cell.AppendChild(new InlineString(new Text(rawValue)));
-                                worksheetChanged = true;
-                                continue;
+                                long repairGap = (long)sharedStringIndex - itemCount + 1L;
+                                if (sharedStringTablePart == null || repairGap > remainingSharedStringRepairItems) {
+                                    ConvertSharedStringCellToInlineString(cell, rawValue);
+                                    worksheetChanged = true;
+                                    continue;
+                                }
+
+                                sharedStringTable ??= sharedStringTablePart.SharedStringTable = new SharedStringTable();
+                                remainingSharedStringRepairItems -= (int)repairGap;
+                                while (itemCount <= sharedStringIndex) {
+                                    sharedStringTable.AppendChild(new SharedStringItem(new Text(string.Empty)));
+                                    itemCount++;
+                                }
+                                sharedStringTableChanged = true;
                             }
 
                             sharedStringCellCount++;
@@ -179,6 +178,13 @@ namespace OfficeIMO.Excel {
             var dataType = cell.DataType;
             return dataType?.Value == CellValues.SharedString
                 || string.Equals(dataType?.InnerText, "s", StringComparison.Ordinal);
+        }
+
+        private static void ConvertSharedStringCellToInlineString(Cell cell, string rawValue) {
+            cell.DataType = CellValues.InlineString;
+            cell.RemoveAllChildren<CellValue>();
+            cell.RemoveAllChildren<InlineString>();
+            cell.AppendChild(new InlineString(new Text(rawValue)));
         }
 
         private static void EnsureStylesheetPrimitives(Stylesheet stylesheet) {

--- a/OfficeIMO.Excel/ExcelDocument.Toc.cs
+++ b/OfficeIMO.Excel/ExcelDocument.Toc.cs
@@ -79,10 +79,20 @@ namespace OfficeIMO.Excel {
             }
             int rowsEnd = r - 1;
 
-            if (styled && rowsEnd >= rowsStart) {
-                string endCol = includeNamedRanges ? "C" : "B";
-                string tableRange = $"A{headerRow}:{endCol}{rowsEnd}";
-                toc.AddTable(tableRange, hasHeader: true, name: "TOC_Items", style: ExcelTableStyle.TableStyleMedium2, includeAutoFilter: true);
+            if (styled) {
+                int endColumn = includeNamedRanges ? 3 : 2;
+                if (rowsEnd >= rowsStart) {
+                    string endCol = includeNamedRanges ? "C" : "B";
+                    string tableRange = $"A{headerRow}:{endCol}{rowsEnd}";
+                    toc.AddTable(tableRange, hasHeader: true, name: "TOC_Items", style: ExcelTableStyle.TableStyleMedium2, includeAutoFilter: true);
+                } else {
+                    // With no data rows there is no table to own the header appearance.
+                    // Keep the styled contract explicit and readable for this empty state.
+                    for (int column = 1; column <= endColumn; column++) {
+                        toc.CellBold(headerRow, column, true);
+                        toc.CellBackground(headerRow, column, "#F2F2F2");
+                    }
+                }
                 try { toc.Freeze(topRows: headerRow, leftCols: 0); } catch { }
                 toc.AutoFitColumns();
             }

--- a/OfficeIMO.Excel/ExcelDocument.Toc.cs
+++ b/OfficeIMO.Excel/ExcelDocument.Toc.cs
@@ -41,9 +41,9 @@ namespace OfficeIMO.Excel {
 
             // Header
             int headerRow = r;
-            toc.Cell(headerRow, 1, "Sheet"); toc.CellBold(headerRow, 1, true); toc.CellBackground(headerRow, 1, "#F2F2F2");
-            toc.Cell(headerRow, 2, "Details"); toc.CellBold(headerRow, 2, true); toc.CellBackground(headerRow, 2, "#F2F2F2");
-            if (includeNamedRanges) { toc.Cell(headerRow, 3, "Named Ranges"); toc.CellBold(headerRow, 3, true); toc.CellBackground(headerRow, 3, "#F2F2F2"); }
+            toc.Cell(headerRow, 1, "Sheet");
+            toc.Cell(headerRow, 2, "Details");
+            if (includeNamedRanges) toc.Cell(headerRow, 3, "Named Ranges");
             r++;
 
             var rowsStart = r;

--- a/OfficeIMO.Excel/Fluent/SheetComposer.ColumnsLayout.cs
+++ b/OfficeIMO.Excel/Fluent/SheetComposer.ColumnsLayout.cs
@@ -200,10 +200,6 @@ namespace OfficeIMO.Excel.Fluent {
                 }
 
                 _sheet.CellValues(cells);
-                for (int i = 0; i < headersT.Count; i++) {
-                    _sheet.CellBold(headerRow, _baseCol + i, true);
-                    _sheet.CellBackground(headerRow, _baseCol + i, _theme.KeyFillHex);
-                }
 
                 int lastRow = _row - 1;
                 string start = SheetComposer.ColumnLetter(_baseCol) + headerRow.ToString();

--- a/OfficeIMO.Excel/Fluent/SheetComposer.Table.cs
+++ b/OfficeIMO.Excel/Fluent/SheetComposer.Table.cs
@@ -71,10 +71,6 @@ namespace OfficeIMO.Excel.Fluent {
                 _row++;
             }
             Sheet.CellValues(cells);
-            for (int i = 0; i < paths.Count; i++) {
-                Sheet.CellBold(headerRow, i + 1, true);
-                Sheet.CellBackground(headerRow, i + 1, _theme.KeyFillHex);
-            }
 
             int lastRow = _row - 1;
             string start = $"A{headerRow}";

--- a/OfficeIMO.Excel/Fluent/SheetComposer.cs
+++ b/OfficeIMO.Excel/Fluent/SheetComposer.cs
@@ -11,7 +11,7 @@ namespace OfficeIMO.Excel.Fluent {
         private ExcelSheet _sheet;
         private int _row;
         private static readonly HashSet<string> HeaderAcronyms = new HashSet<string>(new[] {
-            "ID", "URL", "URI", "DNS", "MX", "SPF", "DKIM", "DMARC", "BIMI", "IP", "TLS", "AAA", "AAAA", "SRV", "TXT", "CNAME", "NS", "CAA", "MTA", "STS", "TLS-RPT"
+            "AD", "ID", "URL", "URI", "DNS", "MX", "SPF", "DKIM", "DMARC", "BIMI", "IP", "TLS", "AAA", "AAAA", "SRV", "TXT", "CNAME", "NS", "CAA", "MTA", "STS", "TLS-RPT"
         }, StringComparer.OrdinalIgnoreCase);
 
         /// <summary>

--- a/OfficeIMO.Excel/Imaging/ExcelRangeVisualSnapshotBuilder.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelRangeVisualSnapshotBuilder.cs
@@ -115,6 +115,13 @@ namespace OfficeIMO.Excel {
 
             Dictionary<int, ExcelVisualColumn> columnsByIndex = columns.ToDictionary(column => column.Index);
             Dictionary<int, ExcelVisualRow> rowsByIndex = rows.ToDictionary(row => row.Index);
+            IReadOnlyDictionary<string, ExcelTableHeaderVisualStyle> tableHeaderStyles =
+                ExcelTableHeaderVisualStyleResolver.Build(
+                    sheet,
+                    firstRow,
+                    firstColumn,
+                    lastRow,
+                    lastColumn);
             var coveredByMerge = new HashSet<string>(StringComparer.Ordinal);
             var mergeOrigins = new Dictionary<string, (double Width, double Height)>(StringComparer.Ordinal);
             var fullMergeGeometry = new HashSet<string>(StringComparer.Ordinal);
@@ -197,6 +204,9 @@ namespace OfficeIMO.Excel {
                     }
 
                     ExcelCellStyleSnapshot style = sheet.GetCellStyle(row.Index, column.Index);
+                    if (tableHeaderStyles.TryGetValue(A1.CellReference(row.Index, column.Index), out ExcelTableHeaderVisualStyle tableHeaderStyle)) {
+                        style = ExcelTableHeaderVisualStyleResolver.Apply(style, tableHeaderStyle);
+                    }
                     ExcelCellData valueData = covered
                         ? new ExcelCellData(ExcelCellDataKind.Blank, null)
                         : sheet.GetCellValueSnapshot(row.Index, column.Index);

--- a/OfficeIMO.Excel/Imaging/ExcelTableHeaderVisualStyleResolver.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelTableHeaderVisualStyleResolver.cs
@@ -2,10 +2,11 @@ using DocumentFormat.OpenXml.Packaging;
 
 namespace OfficeIMO.Excel {
     internal readonly struct ExcelTableHeaderVisualStyle {
-        internal ExcelTableHeaderVisualStyle(string? fillColorArgb, string fontColorArgb, bool bold) {
+        internal ExcelTableHeaderVisualStyle(string? fillColorArgb, string fontColorArgb, bool bold, string? borderColorArgb) {
             FillColorArgb = fillColorArgb;
             FontColorArgb = fontColorArgb;
             Bold = bold;
+            BorderColorArgb = borderColorArgb;
         }
 
         internal string? FillColorArgb { get; }
@@ -13,6 +14,8 @@ namespace OfficeIMO.Excel {
         internal string FontColorArgb { get; }
 
         internal bool Bold { get; }
+
+        internal string? BorderColorArgb { get; }
     }
 
     /// <summary>
@@ -49,7 +52,8 @@ namespace OfficeIMO.Excel {
                 var visualStyle = new ExcelTableHeaderVisualStyle(
                     palette!.HeaderFill,
                     palette.HeaderText ?? "000000",
-                    palette.HeaderBold);
+                    palette.HeaderBold,
+                    palette.Border);
 
                 int startColumn = Math.Max(firstColumn, tableFirstColumn);
                 int endColumn = Math.Min(lastColumn, tableLastColumn);
@@ -64,10 +68,10 @@ namespace OfficeIMO.Excel {
         internal static ExcelCellStyleSnapshot Apply(ExcelCellStyleSnapshot style, ExcelTableHeaderVisualStyle tableStyle) {
             bool hasDirectStyle = style.StyleIndex != 0U;
             bool hasDirectFontStyle = style.IsFontFamilyExplicit;
-            bool preserveDirectFill = hasDirectStyle && !string.IsNullOrWhiteSpace(style.FillColorArgb);
-            string? fillColorArgb = preserveDirectFill
-                ? style.FillColorArgb
-                : tableStyle.FillColorArgb ?? style.FillColorArgb;
+            bool preserveDirectFill = hasDirectStyle && HasDirectFill(style);
+            bool useTableFill = !preserveDirectFill && !string.IsNullOrWhiteSpace(tableStyle.FillColorArgb);
+            bool preserveDirectBorder = hasDirectStyle && style.Border != null;
+            string? fillColorArgb = useTableFill ? tableStyle.FillColorArgb : style.FillColorArgb;
             string? fontColorArgb = hasDirectFontStyle
                 ? style.FontColorArgb ?? "000000"
                 : tableStyle.FontColorArgb;
@@ -87,21 +91,44 @@ namespace OfficeIMO.Excel {
                 TextRotation = style.TextRotation,
                 FontColorArgb = fontColorArgb,
                 FillColorArgb = fillColorArgb,
-                FillPatternType = tableStyle.FillColorArgb == null || preserveDirectFill ? style.FillPatternType : "solid",
-                FillPatternForegroundColorArgb = tableStyle.FillColorArgb == null || preserveDirectFill ? style.FillPatternForegroundColorArgb : tableStyle.FillColorArgb,
-                FillPatternBackgroundColorArgb = tableStyle.FillColorArgb == null || preserveDirectFill ? style.FillPatternBackgroundColorArgb : tableStyle.FillColorArgb,
-                FillGradientUnsupported = (tableStyle.FillColorArgb == null || preserveDirectFill) && style.FillGradientUnsupported,
-                FillGradientStartColorArgb = tableStyle.FillColorArgb == null || preserveDirectFill ? style.FillGradientStartColorArgb : null,
-                FillGradientEndColorArgb = tableStyle.FillColorArgb == null || preserveDirectFill ? style.FillGradientEndColorArgb : null,
-                FillGradientStops = tableStyle.FillColorArgb == null || preserveDirectFill ? style.FillGradientStops : Array.Empty<ExcelGradientFillStopSnapshot>(),
-                FillGradientDegree = tableStyle.FillColorArgb == null || preserveDirectFill ? style.FillGradientDegree : null,
-                Border = style.Border,
+                FillPatternType = useTableFill ? "solid" : style.FillPatternType,
+                FillPatternForegroundColorArgb = useTableFill ? tableStyle.FillColorArgb : style.FillPatternForegroundColorArgb,
+                FillPatternBackgroundColorArgb = useTableFill ? tableStyle.FillColorArgb : style.FillPatternBackgroundColorArgb,
+                FillGradientUnsupported = !useTableFill && style.FillGradientUnsupported,
+                FillGradientStartColorArgb = useTableFill ? null : style.FillGradientStartColorArgb,
+                FillGradientEndColorArgb = useTableFill ? null : style.FillGradientEndColorArgb,
+                FillGradientStops = useTableFill ? Array.Empty<ExcelGradientFillStopSnapshot>() : style.FillGradientStops,
+                FillGradientDegree = useTableFill ? null : style.FillGradientDegree,
+                Border = preserveDirectBorder ? style.Border : CreateTableBorder(tableStyle.BorderColorArgb),
                 HorizontalAlignment = style.HorizontalAlignment,
                 VerticalAlignment = style.VerticalAlignment,
                 TextIndent = style.TextIndent,
                 WrapText = style.WrapText,
                 ShrinkToFit = style.ShrinkToFit
             };
+        }
+
+        private static bool HasDirectFill(ExcelCellStyleSnapshot style) =>
+            !string.IsNullOrWhiteSpace(style.FillColorArgb) ||
+            !string.IsNullOrWhiteSpace(style.FillPatternType) ||
+            !string.IsNullOrWhiteSpace(style.FillPatternForegroundColorArgb) ||
+            !string.IsNullOrWhiteSpace(style.FillPatternBackgroundColorArgb) ||
+            style.FillGradientUnsupported ||
+            !string.IsNullOrWhiteSpace(style.FillGradientStartColorArgb) ||
+            !string.IsNullOrWhiteSpace(style.FillGradientEndColorArgb) ||
+            style.FillGradientStops.Count > 0 ||
+            style.FillGradientDegree.HasValue;
+
+        private static ExcelCellBorderSnapshot? CreateTableBorder(string? colorArgb) {
+            if (string.IsNullOrWhiteSpace(colorArgb)) {
+                return null;
+            }
+
+            return new ExcelCellBorderSnapshot(
+                left: new ExcelBorderSideSnapshot("thin", colorArgb),
+                right: new ExcelBorderSideSnapshot("thin", colorArgb),
+                top: new ExcelBorderSideSnapshot("thin", colorArgb),
+                bottom: new ExcelBorderSideSnapshot("thin", colorArgb));
         }
 
     }

--- a/OfficeIMO.Excel/Imaging/ExcelTableHeaderVisualStyleResolver.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelTableHeaderVisualStyleResolver.cs
@@ -1,0 +1,108 @@
+using DocumentFormat.OpenXml.Packaging;
+
+namespace OfficeIMO.Excel {
+    internal readonly struct ExcelTableHeaderVisualStyle {
+        internal ExcelTableHeaderVisualStyle(string? fillColorArgb, string fontColorArgb, bool bold) {
+            FillColorArgb = fillColorArgb;
+            FontColorArgb = fontColorArgb;
+            Bold = bold;
+        }
+
+        internal string? FillColorArgb { get; }
+
+        internal string FontColorArgb { get; }
+
+        internal bool Bold { get; }
+    }
+
+    /// <summary>
+    /// Projects built-in table header appearance into dependency-free image snapshots.
+    /// Excel stores built-in table styles as table metadata rather than cell style indexes,
+    /// so managed SVG/PNG rendering needs this narrow visual projection.
+    /// </summary>
+    internal static class ExcelTableHeaderVisualStyleResolver {
+        internal static IReadOnlyDictionary<string, ExcelTableHeaderVisualStyle> Build(
+            ExcelSheet sheet,
+            int firstRow,
+            int firstColumn,
+            int lastRow,
+            int lastColumn) {
+            var styles = new Dictionary<string, ExcelTableHeaderVisualStyle>(StringComparer.OrdinalIgnoreCase);
+            foreach (TableDefinitionPart tablePart in sheet.WorksheetPart.TableDefinitionParts) {
+                DocumentFormat.OpenXml.Spreadsheet.Table? table = tablePart.Table;
+                string? reference = table?.Reference?.Value;
+                if (string.IsNullOrWhiteSpace(reference)
+                    || table!.HeaderRowCount?.Value == 0U
+                    || !A1.TryParseRange(reference!, out int tableFirstRow, out int tableFirstColumn, out _, out int tableLastColumn)
+                    || tableFirstRow < firstRow
+                    || tableFirstRow > lastRow) {
+                    continue;
+                }
+
+                if (!ExcelBuiltInTableStylePaletteResolver.TryCreate(
+                        sheet.Document,
+                        table.TableStyleInfo?.Name?.Value,
+                        out ExcelBuiltInTableStylePalette? palette)) {
+                    continue;
+                }
+
+                var visualStyle = new ExcelTableHeaderVisualStyle(
+                    palette!.HeaderFill,
+                    palette.HeaderText ?? "000000",
+                    palette.HeaderBold);
+
+                int startColumn = Math.Max(firstColumn, tableFirstColumn);
+                int endColumn = Math.Min(lastColumn, tableLastColumn);
+                for (int column = startColumn; column <= endColumn; column++) {
+                    styles[A1.CellReference(tableFirstRow, column)] = visualStyle;
+                }
+            }
+
+            return styles;
+        }
+
+        internal static ExcelCellStyleSnapshot Apply(ExcelCellStyleSnapshot style, ExcelTableHeaderVisualStyle tableStyle) {
+            bool hasDirectStyle = style.StyleIndex != 0U;
+            bool hasDirectFontStyle = style.IsFontFamilyExplicit;
+            bool preserveDirectFill = hasDirectStyle && !string.IsNullOrWhiteSpace(style.FillColorArgb);
+            string? fillColorArgb = preserveDirectFill
+                ? style.FillColorArgb
+                : tableStyle.FillColorArgb ?? style.FillColorArgb;
+            string? fontColorArgb = hasDirectFontStyle
+                ? style.FontColorArgb ?? "000000"
+                : tableStyle.FontColorArgb;
+
+            return new ExcelCellStyleSnapshot {
+                StyleIndex = style.StyleIndex,
+                NumberFormatId = style.NumberFormatId,
+                NumberFormatCode = style.NumberFormatCode,
+                IsDateLike = style.IsDateLike,
+                Bold = hasDirectFontStyle ? style.Bold : tableStyle.Bold,
+                Italic = style.Italic,
+                Underline = style.Underline,
+                Strikethrough = style.Strikethrough,
+                FontName = style.FontName,
+                IsFontFamilyExplicit = style.IsFontFamilyExplicit,
+                FontSize = style.FontSize,
+                TextRotation = style.TextRotation,
+                FontColorArgb = fontColorArgb,
+                FillColorArgb = fillColorArgb,
+                FillPatternType = tableStyle.FillColorArgb == null || preserveDirectFill ? style.FillPatternType : "solid",
+                FillPatternForegroundColorArgb = tableStyle.FillColorArgb == null || preserveDirectFill ? style.FillPatternForegroundColorArgb : tableStyle.FillColorArgb,
+                FillPatternBackgroundColorArgb = tableStyle.FillColorArgb == null || preserveDirectFill ? style.FillPatternBackgroundColorArgb : tableStyle.FillColorArgb,
+                FillGradientUnsupported = (tableStyle.FillColorArgb == null || preserveDirectFill) && style.FillGradientUnsupported,
+                FillGradientStartColorArgb = tableStyle.FillColorArgb == null || preserveDirectFill ? style.FillGradientStartColorArgb : null,
+                FillGradientEndColorArgb = tableStyle.FillColorArgb == null || preserveDirectFill ? style.FillGradientEndColorArgb : null,
+                FillGradientStops = tableStyle.FillColorArgb == null || preserveDirectFill ? style.FillGradientStops : Array.Empty<ExcelGradientFillStopSnapshot>(),
+                FillGradientDegree = tableStyle.FillColorArgb == null || preserveDirectFill ? style.FillGradientDegree : null,
+                Border = style.Border,
+                HorizontalAlignment = style.HorizontalAlignment,
+                VerticalAlignment = style.VerticalAlignment,
+                TextIndent = style.TextIndent,
+                WrapText = style.WrapText,
+                ShrinkToFit = style.ShrinkToFit
+            };
+        }
+
+    }
+}


### PR DESCRIPTION
## Summary

- preserve valid shared-string indexes above 65,535 while bounding malformed-gap repair allocation
- let built-in table styles own header appearance in workbooks and managed SVG/PNG exports
- preserve explicit solid, pattern, gradient, font, and border formatting ahead of table-style projection
- keep styled table-of-contents headers readable even when an empty workbook has no table rows
- share one built-in table-style palette between Excel image and PDF renderers
- render `ADState` as `AD State` through the shared header acronym handling

## Behavior

Large generated workbooks no longer reinterpret valid high shared-string indexes as literal numbers during cleanup. Missing or malformed indexes remain fail-safe without allowing unbounded shared-string allocation.

Table filter headers now rely on the selected Excel table style in the workbook, avoiding conflicting direct fill/font combinations. Managed image exports project the same built-in fill, font, and border palette. Explicit cell formatting keeps precedence across solid fills, patterns, gradients, fonts, and borders. Empty styled table-of-contents sheets receive a readable direct fallback because no table exists to provide the header appearance.

## Release note

PSWriteOffice must be repinned to the OfficeIMO version that contains this change before downstream PowerShell modules receive the workbook repair and styling fixes.