### PR TITLE
Coordinate OfficeIMO 3.2.1 release metadata

### DIFF
--- a/.agents/plugins/officeimo-document-tools/.mcp.json
+++ b/.agents/plugins/officeimo-document-tools/.mcp.json
@@ -5,7 +5,7 @@
       "command": "dotnet",
       "args": [
         "dnx",
-        "OfficeIMO.Tool@3.2.0",
+        "OfficeIMO.Tool@3.2.1",
         "mcp",
         "serve",
         "--stdio"

--- a/.agents/plugins/officeimo-document-tools/README.md
+++ b/.agents/plugins/officeimo-document-tools/README.md
@@ -5,7 +5,7 @@ This repo-local Codex plugin exposes compact OfficeIMO tools for working with lo
 The bundled STDIO MCP server runs from the versioned `OfficeIMO.Tool` package:
 
 ```powershell
-dotnet dnx OfficeIMO.Tool@3.2.0 mcp serve --stdio
+dotnet dnx OfficeIMO.Tool@3.2.1 mcp serve --stdio
 ```
 
 It exposes five bounded tools:

--- a/OfficeIMO.MarkdownRenderer.Wpf/packages.lock.json
+++ b/OfficeIMO.MarkdownRenderer.Wpf/packages.lock.json
@@ -123,28 +123,28 @@
         "dependencies": {
           "AngleSharp": "[1.7.1, )",
           "AngleSharp.Css": "[1.0.1, )",
-          "OfficeIMO.Core": "[3.2.0, )",
+          "OfficeIMO.Core": "[3.2.1, )",
           "System.Text.Encoding.CodePages": "[8.0.0, )"
         }
       },
       "officeimo.markdown": {
         "type": "Project",
         "dependencies": {
-          "OfficeIMO.Core": "[3.2.0, )"
+          "OfficeIMO.Core": "[3.2.1, )"
         }
       },
       "officeimo.markdown.html": {
         "type": "Project",
         "dependencies": {
-          "OfficeIMO.Html": "[3.2.0, )",
-          "OfficeIMO.Markdown": "[3.2.0, )"
+          "OfficeIMO.Html": "[3.2.1, )",
+          "OfficeIMO.Markdown": "[3.2.1, )"
         }
       },
       "officeimo.markdownrenderer": {
         "type": "Project",
         "dependencies": {
-          "OfficeIMO.Markdown": "[3.2.0, )",
-          "OfficeIMO.Markdown.Html": "[3.2.0, )",
+          "OfficeIMO.Markdown": "[3.2.1, )",
+          "OfficeIMO.Markdown.Html": "[3.2.1, )",
           "System.Text.Json": "[10.0.7, 11.0.0)"
         }
       }
@@ -171,27 +171,27 @@
         "dependencies": {
           "AngleSharp": "[1.7.1, )",
           "AngleSharp.Css": "[1.0.1, )",
-          "OfficeIMO.Core": "[3.2.0, )"
+          "OfficeIMO.Core": "[3.2.1, )"
         }
       },
       "officeimo.markdown": {
         "type": "Project",
         "dependencies": {
-          "OfficeIMO.Core": "[3.2.0, )"
+          "OfficeIMO.Core": "[3.2.1, )"
         }
       },
       "officeimo.markdown.html": {
         "type": "Project",
         "dependencies": {
-          "OfficeIMO.Html": "[3.2.0, )",
-          "OfficeIMO.Markdown": "[3.2.0, )"
+          "OfficeIMO.Html": "[3.2.1, )",
+          "OfficeIMO.Markdown": "[3.2.1, )"
         }
       },
       "officeimo.markdownrenderer": {
         "type": "Project",
         "dependencies": {
-          "OfficeIMO.Markdown": "[3.2.0, )",
-          "OfficeIMO.Markdown.Html": "[3.2.0, )"
+          "OfficeIMO.Markdown": "[3.2.1, )",
+          "OfficeIMO.Markdown.Html": "[3.2.1, )"
         }
       }
     },
@@ -223,27 +223,27 @@
         "dependencies": {
           "AngleSharp": "[1.7.1, )",
           "AngleSharp.Css": "[1.0.1, )",
-          "OfficeIMO.Core": "[3.2.0, )"
+          "OfficeIMO.Core": "[3.2.1, )"
         }
       },
       "officeimo.markdown": {
         "type": "Project",
         "dependencies": {
-          "OfficeIMO.Core": "[3.2.0, )"
+          "OfficeIMO.Core": "[3.2.1, )"
         }
       },
       "officeimo.markdown.html": {
         "type": "Project",
         "dependencies": {
-          "OfficeIMO.Html": "[3.2.0, )",
-          "OfficeIMO.Markdown": "[3.2.0, )"
+          "OfficeIMO.Html": "[3.2.1, )",
+          "OfficeIMO.Markdown": "[3.2.1, )"
         }
       },
       "officeimo.markdownrenderer": {
         "type": "Project",
         "dependencies": {
-          "OfficeIMO.Markdown": "[3.2.0, )",
-          "OfficeIMO.Markdown.Html": "[3.2.0, )"
+          "OfficeIMO.Markdown": "[3.2.1, )",
+          "OfficeIMO.Markdown.Html": "[3.2.1, )"
         }
       }
     },
@@ -269,27 +269,27 @@
         "dependencies": {
           "AngleSharp": "[1.7.1, )",
           "AngleSharp.Css": "[1.0.1, )",
-          "OfficeIMO.Core": "[3.2.0, )"
+          "OfficeIMO.Core": "[3.2.1, )"
         }
       },
       "officeimo.markdown": {
         "type": "Project",
         "dependencies": {
-          "OfficeIMO.Core": "[3.2.0, )"
+          "OfficeIMO.Core": "[3.2.1, )"
         }
       },
       "officeimo.markdown.html": {
         "type": "Project",
         "dependencies": {
-          "OfficeIMO.Html": "[3.2.0, )",
-          "OfficeIMO.Markdown": "[3.2.0, )"
+          "OfficeIMO.Html": "[3.2.1, )",
+          "OfficeIMO.Markdown": "[3.2.1, )"
         }
       },
       "officeimo.markdownrenderer": {
         "type": "Project",
         "dependencies": {
-          "OfficeIMO.Markdown": "[3.2.0, )",
-          "OfficeIMO.Markdown.Html": "[3.2.0, )"
+          "OfficeIMO.Markdown": "[3.2.1, )",
+          "OfficeIMO.Markdown.Html": "[3.2.1, )"
         }
       }
     },
@@ -321,27 +321,27 @@
         "dependencies": {
           "AngleSharp": "[1.7.1, )",
           "AngleSharp.Css": "[1.0.1, )",
-          "OfficeIMO.Core": "[3.2.0, )"
+          "OfficeIMO.Core": "[3.2.1, )"
         }
       },
       "officeimo.markdown": {
         "type": "Project",
         "dependencies": {
-          "OfficeIMO.Core": "[3.2.0, )"
+          "OfficeIMO.Core": "[3.2.1, )"
         }
       },
       "officeimo.markdown.html": {
         "type": "Project",
         "dependencies": {
-          "OfficeIMO.Html": "[3.2.0, )",
-          "OfficeIMO.Markdown": "[3.2.0, )"
+          "OfficeIMO.Html": "[3.2.1, )",
+          "OfficeIMO.Markdown": "[3.2.1, )"
         }
       },
       "officeimo.markdownrenderer": {
         "type": "Project",
         "dependencies": {
-          "OfficeIMO.Markdown": "[3.2.0, )",
-          "OfficeIMO.Markdown.Html": "[3.2.0, )"
+          "OfficeIMO.Markdown": "[3.2.1, )",
+          "OfficeIMO.Markdown.Html": "[3.2.1, )"
         }
       }
     }


### PR DESCRIPTION
## Summary

- update the OfficeIMO document-tools MCP command and README to the coordinated 3.2.1 release
- refresh the MarkdownRenderer WPF lock-file dependency requirements from 3.2.0 to 3.2.1
- restore the repository release-packaging guardrails after the coordinated project-version bump

## Validation

- ReleasePackagingGuardrails: 5/5 passed on net8.0
- ReleasePackagingGuardrails: 5/5 passed on net10.0
- NuGet public index contains OfficeIMO.Tool 3.2.1 and its package endpoint returns HTTP 200
- representative dotnet dnx OfficeIMO.Tool@3.2.1 restore/run succeeds and exposes the MCP server command