### PR TITLE
Add scalable fixed-schema tables for rich Excel workbooks

### DIFF
--- a/OfficeIMO.Core/Data/ObjectDictionaryAdapter.cs
+++ b/OfficeIMO.Core/Data/ObjectDictionaryAdapter.cs
@@ -111,7 +111,10 @@ namespace OfficeIMO.Data {
                 }
             }
             if (entries.Count >= maximumEntries) {
-                throw new InvalidDataException($"The dictionary exceeds the {maximumEntries}-column flattening limit.");
+                throw ObjectFlattener.CreateRawColumnLimitException(
+                    "Dictionary flattening",
+                    checked(entries.Count + 1),
+                    maximumEntries);
             }
             if (retainedIndexes != null) retainedIndexes.Add(resolvedKey!, entries.Count);
             entries.Add(entry);

--- a/OfficeIMO.Core/Data/ObjectFlattener.Rows.cs
+++ b/OfficeIMO.Core/Data/ObjectFlattener.Rows.cs
@@ -15,7 +15,9 @@ namespace OfficeIMO.Data {
             string consumerName,
             int headerRowCount,
             bool enforceEmptyProjectionLimits = true,
-            int? renderedColumnCountForCellLimit = null) {
+            int? renderedColumnCountForCellLimit = null,
+            string? columnLimitGuidance = null,
+            string? cellLimitGuidance = null) {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (options == null) throw new ArgumentNullException(nameof(options));
             options = options.CreateProjectionSnapshot();
@@ -46,21 +48,23 @@ namespace OfficeIMO.Data {
             List<string>? explicitColumns = null;
             bool hasExplicitColumns = options.Columns != null && options.Columns.Length > 0;
             if (hasExplicitColumns) {
-                explicitColumns = ResolveExplicitColumns(options, consumerName);
+                explicitColumns = ResolveExplicitColumns(options, consumerName, columnLimitGuidance);
                 if (knownRowCount > 0) {
                     EnsureTableCellLimit(
                         knownRowCount,
                         GetRenderedColumnCount(explicitColumns.Count, renderedColumnCountForCellLimit),
                         headerRowCount,
                         options,
-                        consumerName);
+                        consumerName,
+                        cellLimitGuidance);
                     if (renderedColumnCountForCellLimit.HasValue) {
                         EnsureIntermediateCellLimit(
                             knownRowCount,
                             explicitColumns.Count,
                             headerRowCount,
                             options,
-                            consumerName);
+                            consumerName,
+                            cellLimitGuidance);
                     }
                 }
             }
@@ -80,13 +84,18 @@ namespace OfficeIMO.Data {
                         requiredColumns,
                         columnLimit,
                         consumerName,
-                        exception);
+                        exception,
+                        columnLimitGuidance);
                 }
                 rows.Add(row);
                 foreach (string path in row.Keys) {
                     if (!string.IsNullOrWhiteSpace(path) && discoveredColumnSet.Add(path)) {
                         if (discoveredColumns.Count >= options.MaxColumns) {
-                            throw CreateColumnLimitException(checked(discoveredColumns.Count + 1), options.MaxColumns, consumerName);
+                            throw CreateColumnLimitException(
+                                checked(discoveredColumns.Count + 1),
+                                options.MaxColumns,
+                                consumerName,
+                                limitGuidance: columnLimitGuidance);
                         }
                         discoveredColumns.Add(path);
                     }
@@ -97,14 +106,16 @@ namespace OfficeIMO.Data {
                     GetRenderedColumnCount(materializedColumnCount, renderedColumnCountForCellLimit),
                     headerRowCount,
                     options,
-                    consumerName);
+                    consumerName,
+                    cellLimitGuidance);
                 if (renderedColumnCountForCellLimit.HasValue) {
                     EnsureIntermediateCellLimit(
                         rows.Count,
                         materializedColumnCount,
                         headerRowCount,
                         options,
-                        consumerName);
+                        consumerName,
+                        cellLimitGuidance);
                 }
             }
 
@@ -121,7 +132,7 @@ namespace OfficeIMO.Data {
                     return new ObjectTableProjection(rows, new List<string>());
                 }
                 if (hasExplicitColumns) {
-                    explicitColumns = ResolveExplicitColumns(options, consumerName);
+                    explicitColumns = ResolveExplicitColumns(options, consumerName, columnLimitGuidance);
                 } else if (!ObjectDictionaryAdapter.IsDictionaryType(typeof(T))) {
                     discoveredColumns.AddRange(GetPathsPrepared(typeof(T), options));
                 }
@@ -129,16 +140,27 @@ namespace OfficeIMO.Data {
 
             List<string> columns = explicitColumns ?? ResolvePathsPrepared(discoveredColumns, options);
             if (columns.Count > options.MaxColumns) {
-                throw CreateColumnLimitException(columns.Count, options.MaxColumns, consumerName);
+                throw CreateColumnLimitException(
+                    columns.Count,
+                    options.MaxColumns,
+                    consumerName,
+                    limitGuidance: columnLimitGuidance);
             }
             EnsureTableCellLimit(
                 rows.Count,
                 GetRenderedColumnCount(columns.Count, renderedColumnCountForCellLimit),
                 headerRowCount,
                 options,
-                consumerName);
+                consumerName,
+                cellLimitGuidance);
             if (renderedColumnCountForCellLimit.HasValue) {
-                EnsureIntermediateCellLimit(rows.Count, columns.Count, headerRowCount, options, consumerName);
+                EnsureIntermediateCellLimit(
+                    rows.Count,
+                    columns.Count,
+                    headerRowCount,
+                    options,
+                    consumerName,
+                    cellLimitGuidance);
             }
             return new ObjectTableProjection(rows, columns);
         }
@@ -153,7 +175,8 @@ namespace OfficeIMO.Data {
             int columnCount,
             int headerRowCount,
             ObjectFlattenerOptions options,
-            string consumerName) {
+            string consumerName,
+            string? limitGuidance) {
             long maximumIntermediateCells = Math.Max(options.MaxCells, ObjectFlattenerOptions.DefaultMaxCells);
             long intermediateCells = ((long)rowCount + headerRowCount) * columnCount;
             if (intermediateCells > maximumIntermediateCells) {
@@ -164,22 +187,25 @@ namespace OfficeIMO.Data {
                     intermediateCells,
                     maximumIntermediateCells,
                     consumerName,
-                    "intermediate materialization");
+                    "intermediate materialization",
+                    limitGuidance);
             }
         }
 
         private List<string> ResolveExplicitColumns(
             ObjectFlattenerOptions options,
-            string consumerName) {
+            string consumerName,
+            string? limitGuidance) {
             var explicitColumnCandidates = new List<string>(Math.Min(options.Columns!.Length, options.MaxColumns));
-            AddExplicitColumnsBounded(explicitColumnCandidates, options, consumerName);
+            AddExplicitColumnsBounded(explicitColumnCandidates, options, consumerName, limitGuidance);
             return ResolvePathsPrepared(explicitColumnCandidates, options);
         }
 
         private static void AddExplicitColumnsBounded(
             List<string> columns,
             ObjectFlattenerOptions options,
-            string consumerName) {
+            string consumerName,
+            string? limitGuidance) {
             var added = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (string column in options.Columns!) {
                 if (string.IsNullOrWhiteSpace(column) || !added.Add(column)) {
@@ -189,7 +215,11 @@ namespace OfficeIMO.Data {
                     continue;
                 }
                 if (columns.Count >= options.MaxColumns) {
-                    throw CreateColumnLimitException(checked(columns.Count + 1), options.MaxColumns, consumerName);
+                    throw CreateColumnLimitException(
+                        checked(columns.Count + 1),
+                        options.MaxColumns,
+                        consumerName,
+                        limitGuidance: limitGuidance);
                 }
                 columns.Add(column);
             }
@@ -200,7 +230,8 @@ namespace OfficeIMO.Data {
             int columnCount,
             int headerRowCount,
             ObjectFlattenerOptions options,
-            string consumerName) {
+            string consumerName,
+            string? limitGuidance) {
             long projectedCells = ((long)rowCount + headerRowCount) * columnCount;
             if (projectedCells > options.MaxCells) {
                 throw CreateCellLimitException(
@@ -210,7 +241,8 @@ namespace OfficeIMO.Data {
                     projectedCells,
                     options.MaxCells,
                     consumerName,
-                    "materialization");
+                    "materialization",
+                    limitGuidance);
             }
         }
 
@@ -221,16 +253,17 @@ namespace OfficeIMO.Data {
             long projectedCells,
             long limit,
             string consumerName,
-            string limitKind) {
+            string limitKind,
+            string? limitGuidance = null) {
             string rows = headerRowCount == 0
                 ? FormatCount(rowCount, "row", "rows")
                 : FormatCount(rowCount, "data row", "data rows") + " + "
                     + FormatCount(headerRowCount, "header row", "header rows");
             string requiredCells = projectedCells.ToString(CultureInfo.InvariantCulture);
-            string overrideHint = string.Equals(consumerName, "TableFrom", StringComparison.Ordinal)
+            string overrideHint = limitGuidance ?? (string.Equals(consumerName, "TableFrom", StringComparison.Ordinal)
                 ? "For intentionally materialized object rows, raise the limit with configure: options => options.MaxCells = " + requiredCells + ". "
                     + "For fixed-schema data, use the TableFrom(DataTable) overload, which avoids generic object flattening."
-                : "If this materialization is intentional, set ObjectFlattenerOptions.MaxCells to at least " + requiredCells + ".";
+                : "If this materialization is intentional, set ObjectFlattenerOptions.MaxCells to at least " + requiredCells + ".");
 
             return new InvalidDataException(
                 consumerName + " requires at least " + requiredCells
@@ -254,11 +287,12 @@ namespace OfficeIMO.Data {
             int requiredColumns,
             int limit,
             string consumerName,
-            Exception? innerException = null) {
+            Exception? innerException = null,
+            string? limitGuidance = null) {
             string required = requiredColumns.ToString(CultureInfo.InvariantCulture);
-            string overrideHint = string.Equals(consumerName, "TableFrom", StringComparison.Ordinal)
+            string overrideHint = limitGuidance ?? (string.Equals(consumerName, "TableFrom", StringComparison.Ordinal)
                 ? "If this materialization is intentional, raise the limit with configure: options => options.MaxColumns = " + required + "."
-                : "If this materialization is intentional, set ObjectFlattenerOptions.MaxColumns to at least " + required + ".";
+                : "If this materialization is intentional, set ObjectFlattenerOptions.MaxColumns to at least " + required + ".");
             string message = consumerName + " requires at least " + FormatCount(requiredColumns, "column", "columns")
                 + ", exceeding the " + limit.ToString(CultureInfo.InvariantCulture)
                 + "-column materialization limit (MaxColumns). " + overrideHint;

--- a/OfficeIMO.Core/Data/ObjectFlattener.Rows.cs
+++ b/OfficeIMO.Core/Data/ObjectFlattener.Rows.cs
@@ -16,8 +16,8 @@ namespace OfficeIMO.Data {
             int headerRowCount,
             bool enforceEmptyProjectionLimits = true,
             int? renderedColumnCountForCellLimit = null,
-            string? columnLimitGuidance = null,
-            string? cellLimitGuidance = null) {
+            Func<int, string?>? columnLimitGuidance = null,
+            Func<long, string?>? cellLimitGuidance = null) {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (options == null) throw new ArgumentNullException(nameof(options));
             options = options.CreateProjectionSnapshot();
@@ -176,7 +176,7 @@ namespace OfficeIMO.Data {
             int headerRowCount,
             ObjectFlattenerOptions options,
             string consumerName,
-            string? limitGuidance) {
+            Func<long, string?>? limitGuidance) {
             long maximumIntermediateCells = Math.Max(options.MaxCells, ObjectFlattenerOptions.DefaultMaxCells);
             long intermediateCells = ((long)rowCount + headerRowCount) * columnCount;
             if (intermediateCells > maximumIntermediateCells) {
@@ -195,7 +195,7 @@ namespace OfficeIMO.Data {
         private List<string> ResolveExplicitColumns(
             ObjectFlattenerOptions options,
             string consumerName,
-            string? limitGuidance) {
+            Func<int, string?>? limitGuidance) {
             var explicitColumnCandidates = new List<string>(Math.Min(options.Columns!.Length, options.MaxColumns));
             AddExplicitColumnsBounded(explicitColumnCandidates, options, consumerName, limitGuidance);
             return ResolvePathsPrepared(explicitColumnCandidates, options);
@@ -205,7 +205,7 @@ namespace OfficeIMO.Data {
             List<string> columns,
             ObjectFlattenerOptions options,
             string consumerName,
-            string? limitGuidance) {
+            Func<int, string?>? limitGuidance) {
             var added = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (string column in options.Columns!) {
                 if (string.IsNullOrWhiteSpace(column) || !added.Add(column)) {
@@ -231,7 +231,7 @@ namespace OfficeIMO.Data {
             int headerRowCount,
             ObjectFlattenerOptions options,
             string consumerName,
-            string? limitGuidance) {
+            Func<long, string?>? limitGuidance) {
             long projectedCells = ((long)rowCount + headerRowCount) * columnCount;
             if (projectedCells > options.MaxCells) {
                 throw CreateCellLimitException(
@@ -254,13 +254,13 @@ namespace OfficeIMO.Data {
             long limit,
             string consumerName,
             string limitKind,
-            string? limitGuidance = null) {
+            Func<long, string?>? limitGuidance = null) {
             string rows = headerRowCount == 0
                 ? FormatCount(rowCount, "row", "rows")
                 : FormatCount(rowCount, "data row", "data rows") + " + "
                     + FormatCount(headerRowCount, "header row", "header rows");
             string requiredCells = projectedCells.ToString(CultureInfo.InvariantCulture);
-            string overrideHint = limitGuidance ?? (string.Equals(consumerName, "TableFrom", StringComparison.Ordinal)
+            string overrideHint = limitGuidance?.Invoke(projectedCells) ?? (string.Equals(consumerName, "TableFrom", StringComparison.Ordinal)
                 ? "For intentionally materialized object rows, raise the limit with configure: options => options.MaxCells = " + requiredCells + ". "
                     + "For fixed-schema data, use the TableFrom(DataTable) overload, which avoids generic object flattening."
                 : "If this materialization is intentional, set ObjectFlattenerOptions.MaxCells to at least " + requiredCells + ".");
@@ -288,9 +288,9 @@ namespace OfficeIMO.Data {
             int limit,
             string consumerName,
             Exception? innerException = null,
-            string? limitGuidance = null) {
+            Func<int, string?>? limitGuidance = null) {
             string required = requiredColumns.ToString(CultureInfo.InvariantCulture);
-            string overrideHint = limitGuidance ?? (string.Equals(consumerName, "TableFrom", StringComparison.Ordinal)
+            string overrideHint = limitGuidance?.Invoke(requiredColumns) ?? (string.Equals(consumerName, "TableFrom", StringComparison.Ordinal)
                 ? "If this materialization is intentional, raise the limit with configure: options => options.MaxColumns = " + required + "."
                 : "If this materialization is intentional, set ObjectFlattenerOptions.MaxColumns to at least " + required + ".");
             string message = consumerName + " requires at least " + FormatCount(requiredColumns, "column", "columns")

--- a/OfficeIMO.Core/Data/ObjectFlattener.Rows.cs
+++ b/OfficeIMO.Core/Data/ObjectFlattener.Rows.cs
@@ -60,7 +60,7 @@ namespace OfficeIMO.Data {
             var discoveredColumnSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             List<string>? explicitColumns = null;
             bool hasExplicitColumns = options.Columns != null && options.Columns.Length > 0;
-            if (hasExplicitColumns) {
+            if (hasExplicitColumns && hasKnownRowCount) {
                 explicitColumns = ResolveExplicitColumns(options, consumerName, columnLimitGuidance);
                 if (knownRowCount > 0) {
                     EnsureTableCellLimit(
@@ -83,6 +83,9 @@ namespace OfficeIMO.Data {
             }
 
             void AddProjectedRow(T item) {
+                if (hasExplicitColumns && explicitColumns == null) {
+                    explicitColumns = ResolveExplicitColumns(options, consumerName, columnLimitGuidance);
+                }
                 if (rows.Count >= options.MaxRows) {
                     throw CreateRowLimitException(
                         checked(rows.Count + 1),

--- a/OfficeIMO.Core/Data/ObjectFlattener.Rows.cs
+++ b/OfficeIMO.Core/Data/ObjectFlattener.Rows.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.IO;
 
 namespace OfficeIMO.Data {
@@ -34,8 +35,7 @@ namespace OfficeIMO.Data {
                     ? collection.Count
                     : 0;
             if (knownRowCount > options.MaxRows) {
-                throw new InvalidDataException(
-                    $"{consumerName} exceeds the {options.MaxRows}-row materialization limit.");
+                throw CreateRowLimitException(knownRowCount, options.MaxRows, consumerName);
             }
 
             var rows = knownRowCount > 0
@@ -45,23 +45,48 @@ namespace OfficeIMO.Data {
             var discoveredColumnSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             List<string>? explicitColumns = null;
             bool hasExplicitColumns = options.Columns != null && options.Columns.Length > 0;
+            if (hasExplicitColumns) {
+                explicitColumns = ResolveExplicitColumns(options, consumerName);
+                if (knownRowCount > 0) {
+                    EnsureTableCellLimit(
+                        knownRowCount,
+                        GetRenderedColumnCount(explicitColumns.Count, renderedColumnCountForCellLimit),
+                        headerRowCount,
+                        options,
+                        consumerName);
+                    if (renderedColumnCountForCellLimit.HasValue) {
+                        EnsureIntermediateCellLimit(
+                            knownRowCount,
+                            explicitColumns.Count,
+                            headerRowCount,
+                            options,
+                            consumerName);
+                    }
+                }
+            }
 
             void AddProjectedRow(T item) {
                 if (rows.Count >= options.MaxRows) {
-                    throw new InvalidDataException(
-                        $"{consumerName} exceeds the {options.MaxRows}-row materialization limit.");
+                    throw CreateRowLimitException(checked(rows.Count + 1), options.MaxRows, consumerName);
                 }
-                if (hasExplicitColumns && explicitColumns == null) {
-                    explicitColumns = ResolveExplicitColumns(options, consumerName);
+                Dictionary<string, object?> row;
+                try {
+                    row = FlattenPrepared(item, options);
+                } catch (InvalidDataException exception) {
+                    if (!TryGetRawColumnLimit(exception, out int requiredColumns, out int columnLimit)) {
+                        throw;
+                    }
+                    throw CreateColumnLimitException(
+                        requiredColumns,
+                        columnLimit,
+                        consumerName,
+                        exception);
                 }
-
-                Dictionary<string, object?> row = FlattenPrepared(item, options);
                 rows.Add(row);
                 foreach (string path in row.Keys) {
                     if (!string.IsNullOrWhiteSpace(path) && discoveredColumnSet.Add(path)) {
                         if (discoveredColumns.Count >= options.MaxColumns) {
-                            throw new InvalidDataException(
-                                $"{consumerName} exceeds the {options.MaxColumns}-column materialization limit.");
+                            throw CreateColumnLimitException(checked(discoveredColumns.Count + 1), options.MaxColumns, consumerName);
                         }
                         discoveredColumns.Add(path);
                     }
@@ -104,8 +129,7 @@ namespace OfficeIMO.Data {
 
             List<string> columns = explicitColumns ?? ResolvePathsPrepared(discoveredColumns, options);
             if (columns.Count > options.MaxColumns) {
-                throw new InvalidDataException(
-                    $"{consumerName} exceeds the {options.MaxColumns}-column materialization limit.");
+                throw CreateColumnLimitException(columns.Count, options.MaxColumns, consumerName);
             }
             EnsureTableCellLimit(
                 rows.Count,
@@ -133,8 +157,14 @@ namespace OfficeIMO.Data {
             long maximumIntermediateCells = Math.Max(options.MaxCells, ObjectFlattenerOptions.DefaultMaxCells);
             long intermediateCells = ((long)rowCount + headerRowCount) * columnCount;
             if (intermediateCells > maximumIntermediateCells) {
-                throw new InvalidDataException(
-                    $"{consumerName} exceeds the {maximumIntermediateCells}-cell intermediate materialization limit.");
+                throw CreateCellLimitException(
+                    rowCount,
+                    columnCount,
+                    headerRowCount,
+                    intermediateCells,
+                    maximumIntermediateCells,
+                    consumerName,
+                    "intermediate materialization");
             }
         }
 
@@ -159,8 +189,7 @@ namespace OfficeIMO.Data {
                     continue;
                 }
                 if (columns.Count >= options.MaxColumns) {
-                    throw new InvalidDataException(
-                        $"{consumerName} exceeds the {options.MaxColumns}-column materialization limit.");
+                    throw CreateColumnLimitException(checked(columns.Count + 1), options.MaxColumns, consumerName);
                 }
                 columns.Add(column);
             }
@@ -174,9 +203,102 @@ namespace OfficeIMO.Data {
             string consumerName) {
             long projectedCells = ((long)rowCount + headerRowCount) * columnCount;
             if (projectedCells > options.MaxCells) {
-                throw new InvalidDataException(
-                    $"{consumerName} exceeds the {options.MaxCells}-cell materialization limit.");
+                throw CreateCellLimitException(
+                    rowCount,
+                    columnCount,
+                    headerRowCount,
+                    projectedCells,
+                    options.MaxCells,
+                    consumerName,
+                    "materialization");
             }
+        }
+
+        private static InvalidDataException CreateCellLimitException(
+            int rowCount,
+            int columnCount,
+            int headerRowCount,
+            long projectedCells,
+            long limit,
+            string consumerName,
+            string limitKind) {
+            string rows = headerRowCount == 0
+                ? FormatCount(rowCount, "row", "rows")
+                : FormatCount(rowCount, "data row", "data rows") + " + "
+                    + FormatCount(headerRowCount, "header row", "header rows");
+            string requiredCells = projectedCells.ToString(CultureInfo.InvariantCulture);
+            string overrideHint = string.Equals(consumerName, "TableFrom", StringComparison.Ordinal)
+                ? "For intentionally materialized object rows, raise the limit with configure: options => options.MaxCells = " + requiredCells + ". "
+                    + "For fixed-schema data, use the TableFrom(DataTable) overload, which avoids generic object flattening."
+                : "If this materialization is intentional, set ObjectFlattenerOptions.MaxCells to at least " + requiredCells + ".";
+
+            return new InvalidDataException(
+                consumerName + " requires at least " + requiredCells
+                + " cells (" + rows + " x " + columnCount.ToString(CultureInfo.InvariantCulture)
+                + " columns), exceeding the " + limit.ToString(CultureInfo.InvariantCulture)
+                + "-cell " + limitKind + " limit (MaxCells). " + overrideHint);
+        }
+
+        private static InvalidDataException CreateRowLimitException(int requiredRows, int limit, string consumerName) {
+            string required = requiredRows.ToString(CultureInfo.InvariantCulture);
+            string overrideHint = string.Equals(consumerName, "TableFrom", StringComparison.Ordinal)
+                ? "If this materialization is intentional, raise the limit with configure: options => options.MaxRows = " + required + "."
+                : "If this materialization is intentional, set ObjectFlattenerOptions.MaxRows to at least " + required + ".";
+            return new InvalidDataException(
+                consumerName + " requires at least " + FormatCount(requiredRows, "data row", "data rows")
+                + ", exceeding the " + limit.ToString(CultureInfo.InvariantCulture)
+                + "-row materialization limit (MaxRows). " + overrideHint);
+        }
+
+        private static InvalidDataException CreateColumnLimitException(
+            int requiredColumns,
+            int limit,
+            string consumerName,
+            Exception? innerException = null) {
+            string required = requiredColumns.ToString(CultureInfo.InvariantCulture);
+            string overrideHint = string.Equals(consumerName, "TableFrom", StringComparison.Ordinal)
+                ? "If this materialization is intentional, raise the limit with configure: options => options.MaxColumns = " + required + "."
+                : "If this materialization is intentional, set ObjectFlattenerOptions.MaxColumns to at least " + required + ".";
+            string message = consumerName + " requires at least " + FormatCount(requiredColumns, "column", "columns")
+                + ", exceeding the " + limit.ToString(CultureInfo.InvariantCulture)
+                + "-column materialization limit (MaxColumns). " + overrideHint;
+            return innerException == null
+                ? new InvalidDataException(message)
+                : new InvalidDataException(message, innerException);
+        }
+
+        private static string FormatCount(int count, string singular, string plural) {
+            return count.ToString(CultureInfo.InvariantCulture) + " " + (count == 1 ? singular : plural);
+        }
+
+        internal static InvalidDataException CreateRawColumnLimitException(
+            string operation,
+            int requiredColumns,
+            int limit) {
+            var exception = new InvalidDataException(
+                operation + " requires at least " + requiredColumns.ToString(CultureInfo.InvariantCulture)
+                + " columns, exceeding the " + limit.ToString(CultureInfo.InvariantCulture)
+                + "-column limit (MaxColumns). Set ObjectFlattenerOptions.MaxColumns to at least "
+                + requiredColumns.ToString(CultureInfo.InvariantCulture) + ".");
+            exception.Data["OfficeIMO.RequiredColumns"] = requiredColumns;
+            exception.Data["OfficeIMO.MaxColumns"] = limit;
+            return exception;
+        }
+
+        private static bool TryGetRawColumnLimit(
+            InvalidDataException exception,
+            out int requiredColumns,
+            out int limit) {
+            if (exception.Data["OfficeIMO.RequiredColumns"] is int required
+                && exception.Data["OfficeIMO.MaxColumns"] is int configuredLimit) {
+                requiredColumns = required;
+                limit = configuredLimit;
+                return true;
+            }
+
+            requiredColumns = 0;
+            limit = 0;
+            return false;
         }
     }
 

--- a/OfficeIMO.Core/Data/ObjectFlattener.Rows.cs
+++ b/OfficeIMO.Core/Data/ObjectFlattener.Rows.cs
@@ -16,6 +16,7 @@ namespace OfficeIMO.Data {
             int headerRowCount,
             bool enforceEmptyProjectionLimits = true,
             int? renderedColumnCountForCellLimit = null,
+            Func<int, string?>? rowLimitGuidance = null,
             Func<int, string?>? columnLimitGuidance = null,
             Func<long, string?>? cellLimitGuidance = null) {
             if (source == null) throw new ArgumentNullException(nameof(source));
@@ -31,13 +32,25 @@ namespace OfficeIMO.Data {
                     "MaxRows must be greater than zero.");
             }
 
-            int knownRowCount = source is IReadOnlyCollection<T> readOnlyCollection
-                ? readOnlyCollection.Count
-                : source is ICollection<T> collection
-                    ? collection.Count
-                    : 0;
-            if (knownRowCount > options.MaxRows) {
-                throw CreateRowLimitException(knownRowCount, options.MaxRows, consumerName);
+            bool hasKnownRowCount;
+            int knownRowCount;
+            if (source is IReadOnlyCollection<T> readOnlyCollection) {
+                knownRowCount = readOnlyCollection.Count;
+                hasKnownRowCount = true;
+            } else if (source is ICollection<T> collection) {
+                knownRowCount = collection.Count;
+                hasKnownRowCount = true;
+            } else {
+                knownRowCount = 0;
+                hasKnownRowCount = false;
+            }
+            if (hasKnownRowCount && knownRowCount > options.MaxRows) {
+                throw CreateRowLimitException(knownRowCount, options.MaxRows, consumerName, rowLimitGuidance);
+            }
+            if (hasKnownRowCount && knownRowCount == 0 && !enforceEmptyProjectionLimits) {
+                return new ObjectTableProjection(
+                    new List<Dictionary<string, object?>>(),
+                    new List<string>());
             }
 
             var rows = knownRowCount > 0
@@ -71,7 +84,11 @@ namespace OfficeIMO.Data {
 
             void AddProjectedRow(T item) {
                 if (rows.Count >= options.MaxRows) {
-                    throw CreateRowLimitException(checked(rows.Count + 1), options.MaxRows, consumerName);
+                    throw CreateRowLimitException(
+                        checked(rows.Count + 1),
+                        options.MaxRows,
+                        consumerName,
+                        rowLimitGuidance);
                 }
                 Dictionary<string, object?> row;
                 try {
@@ -272,11 +289,15 @@ namespace OfficeIMO.Data {
                 + "-cell " + limitKind + " limit (MaxCells). " + overrideHint);
         }
 
-        private static InvalidDataException CreateRowLimitException(int requiredRows, int limit, string consumerName) {
+        private static InvalidDataException CreateRowLimitException(
+            int requiredRows,
+            int limit,
+            string consumerName,
+            Func<int, string?>? limitGuidance = null) {
             string required = requiredRows.ToString(CultureInfo.InvariantCulture);
-            string overrideHint = string.Equals(consumerName, "TableFrom", StringComparison.Ordinal)
+            string overrideHint = limitGuidance?.Invoke(requiredRows) ?? (string.Equals(consumerName, "TableFrom", StringComparison.Ordinal)
                 ? "If this materialization is intentional, raise the limit with configure: options => options.MaxRows = " + required + "."
-                : "If this materialization is intentional, set ObjectFlattenerOptions.MaxRows to at least " + required + ".";
+                : "If this materialization is intentional, set ObjectFlattenerOptions.MaxRows to at least " + required + ".");
             return new InvalidDataException(
                 consumerName + " requires at least " + FormatCount(requiredRows, "data row", "data rows")
                 + ", exceeding the " + limit.ToString(CultureInfo.InvariantCulture)

--- a/OfficeIMO.Core/Data/ObjectFlattener.cs
+++ b/OfficeIMO.Core/Data/ObjectFlattener.cs
@@ -184,8 +184,7 @@ namespace OfficeIMO.Data {
             var result = new Dictionary<string, object?>(capacity, StringComparer.OrdinalIgnoreCase);
             FlattenInternal(source, result, string.Empty, 0, opts, new HashSet<object>(ObjectReferenceComparer.Instance));
             if (result.Count > opts.MaxColumns) {
-                throw new InvalidDataException(
-                    $"Object flattening exceeds the {opts.MaxColumns}-column limit.");
+                throw CreateRawColumnLimitException("Object flattening", result.Count, opts.MaxColumns);
             }
 
             List<string> selectedPaths = ResolvePathsPrepared(result.Keys, opts);
@@ -234,8 +233,7 @@ namespace OfficeIMO.Data {
                     continue;
                 }
                 if (filtered.Count >= opts.MaxColumns) {
-                    throw new InvalidDataException(
-                        $"Resolved paths exceed the {opts.MaxColumns}-column limit.");
+                    throw CreateRawColumnLimitException("Path resolution", checked(filtered.Count + 1), opts.MaxColumns);
                 }
                 filtered.Add(path);
             }
@@ -558,8 +556,7 @@ namespace OfficeIMO.Data {
             if (!IsPathSelectedForMaterialization(path, opts)) return;
             if (!addedPaths.Add(path)) return;
             if (paths.Count >= opts.MaxColumns) {
-                throw new InvalidDataException(
-                    $"Object path discovery exceeds the {opts.MaxColumns}-column limit.");
+                throw CreateRawColumnLimitException("Object path discovery", checked(paths.Count + 1), opts.MaxColumns);
             }
             paths.Add(path);
         }
@@ -735,8 +732,7 @@ namespace OfficeIMO.Data {
             string path,
             ObjectFlattenerOptions options) {
             if (columns.Count >= options.MaxColumns && !columns.ContainsKey(path)) {
-                throw new InvalidDataException(
-                    $"Object flattening exceeds the {options.MaxColumns}-column limit.");
+                throw CreateRawColumnLimitException("Object flattening", checked(columns.Count + 1), options.MaxColumns);
             }
         }
 
@@ -1054,8 +1050,7 @@ namespace OfficeIMO.Data {
                 }
                 if (available.TryGetValue(column, out string? match) && added.Add(match)) {
                     if (result.Count >= maxColumns) {
-                        throw new InvalidDataException(
-                            $"Resolved explicit columns exceed the {maxColumns}-column limit.");
+                        throw CreateRawColumnLimitException("Explicit column resolution", checked(result.Count + 1), maxColumns);
                     }
                     result.Add(match);
                 }

--- a/OfficeIMO.Excel.Tests/Excel.DataTableInsert.cs
+++ b/OfficeIMO.Excel.Tests/Excel.DataTableInsert.cs
@@ -187,6 +187,50 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_InsertTabularRowSourceAsTable_FallbackPreservesRuntimeCellTypes() {
+            string filePath = Path.Combine(_directoryWithFiles, "TabularSourceFallbackTypes.xlsx");
+            var recorded = new DateTime(2026, 8, 12, 14, 30, 0, DateTimeKind.Unspecified);
+            var duration = new TimeSpan(2, 15, 30);
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorksheet("Data");
+                sheet.CellValue(10, 1, "Existing");
+
+                string range = sheet.InsertTabularRowSourceAsTable(
+                    new TypedTabularRowSource(recorded, duration),
+                    tableName: "TypedFallback");
+
+                Assert.Equal("A1:D2", range);
+                Assert.True(sheet.TryGetCellText(10, 1, out string? existing));
+                Assert.Equal("Existing", existing);
+                document.Save();
+            }
+
+            using (var spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                var cells = worksheetPart.Worksheet.Descendants<Cell>().ToList();
+
+                Cell GetCell(string reference) => cells.First(cell => cell.CellReference == reference);
+
+                Cell recordedCell = GetCell("B2");
+                Assert.True(recordedCell.DataType == null || recordedCell.DataType.Value == CellValues.Number);
+                AssertRoundTripNumericText(recorded.ToOADate(), recordedCell.CellValue!.Text);
+                Assert.NotNull(recordedCell.StyleIndex);
+
+                Cell durationCell = GetCell("C2");
+                Assert.True(durationCell.DataType == null || durationCell.DataType.Value == CellValues.Number);
+                AssertRoundTripNumericText(duration.TotalDays, durationCell.CellValue!.Text);
+                Assert.NotNull(durationCell.StyleIndex);
+
+                Cell amountCell = GetCell("D2");
+                Assert.True(amountCell.DataType == null || amountCell.DataType.Value == CellValues.Number);
+                Assert.Equal("42", amountCell.CellValue!.Text);
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
         public void Test_InsertDataSet_CreatesWorksheetPerTableWithSafeNames() {
             string filePath = Path.Combine(_directoryWithFiles, "DataSetImport.xlsx");
 
@@ -945,6 +989,52 @@ namespace OfficeIMO.Tests {
 
                 values = new object?[] { "Alpha", 10 };
                 return true;
+            }
+
+            public bool TryGetFlatValues(out object?[] values, out int columnCount) {
+                values = Array.Empty<object?>();
+                columnCount = 0;
+                return false;
+            }
+        }
+
+        private sealed class TypedTabularRowSource : IExcelSheetTabularRowSource {
+            private readonly DateTime _recorded;
+            private readonly TimeSpan _duration;
+
+            internal TypedTabularRowSource(DateTime recorded, TimeSpan duration) {
+                _recorded = recorded;
+                _duration = duration;
+            }
+
+            public int ColumnCount => 4;
+
+            public int RowCount => 1;
+
+            public string GetColumnName(int index) => index switch {
+                0 => "Name",
+                1 => "Recorded",
+                2 => "Duration",
+                _ => "Amount"
+            };
+
+            public Type GetColumnType(int index) => index switch {
+                0 => typeof(string),
+                1 => typeof(DateTime),
+                2 => typeof(TimeSpan),
+                _ => typeof(int)
+            };
+
+            public object? GetValue(int rowIndex, int columnIndex) => columnIndex switch {
+                0 => "Alpha",
+                1 => _recorded,
+                2 => _duration,
+                _ => 42
+            };
+
+            public bool TryGetBufferedRow(int rowIndex, out object?[]? values) {
+                values = null;
+                return false;
             }
 
             public bool TryGetFlatValues(out object?[] values, out int columnCount) {

--- a/OfficeIMO.Excel.Tests/Excel.SheetComposer.DataTable.cs
+++ b/OfficeIMO.Excel.Tests/Excel.SheetComposer.DataTable.cs
@@ -293,6 +293,42 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void SheetComposer_TitledDataTableAppliesVisualsToItsActualHeaderRow() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+            try {
+                DataTable members = CreateMembersTable();
+                using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                    document.Compose("Members", composer => {
+                        string range = composer.TableFrom(
+                            members,
+                            title: "Members",
+                            freezeHeaderRow: false,
+                            visuals: options => options.NumericColumnFormats["Enabled"] = "0.0000");
+                        Assert.Equal("A2:D4", range);
+                    });
+                    document.Save();
+                }
+
+                using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false);
+                WorkbookPart workbookPart = spreadsheet.WorkbookPart!;
+                WorksheetPart worksheetPart = workbookPart.WorksheetParts.First();
+                Cell dataCell = worksheetPart.Worksheet.Descendants<Cell>()
+                    .Single(cell => cell.CellReference?.Value == "B3");
+                Assert.NotNull(dataCell.StyleIndex);
+
+                Stylesheet stylesheet = workbookPart.WorkbookStylesPart!.Stylesheet!;
+                CellFormat cellFormat = stylesheet.CellFormats!.Elements<CellFormat>()
+                    .ElementAt((int)dataCell.StyleIndex!.Value);
+                Assert.True(cellFormat.ApplyNumberFormat?.Value);
+                NumberingFormat numberFormat = stylesheet.NumberingFormats!.Elements<NumberingFormat>()
+                    .Single(format => format.NumberFormatId?.Value == cellFormat.NumberFormatId?.Value);
+                Assert.Equal("0.0000", numberFormat.FormatCode?.Value);
+            } finally {
+                if (File.Exists(filePath)) File.Delete(filePath);
+            }
+        }
+
+        [Fact]
         public void SheetComposer_DataTableExplainsHardExcelColumnBoundary() {
             var table = new DataTable("Wide");
             for (int index = 0; index <= A1.MaxColumns; index++) {

--- a/OfficeIMO.Excel.Tests/Excel.SheetComposer.DataTable.cs
+++ b/OfficeIMO.Excel.Tests/Excel.SheetComposer.DataTable.cs
@@ -88,6 +88,53 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void SheetComposer_DataTableCanonicalizesUniqueExplicitColumnCasing() {
+            DataTable members = CreateMembersTable();
+            using ExcelDocument document = ExcelDocument.Create();
+
+            document.Compose("Members", composer => {
+                string range = composer.TableFrom(
+                    members,
+                    configure: options => options.Columns = new[] { "adstate" },
+                    freezeHeaderRow: false);
+                Assert.Equal("A1:A3", range);
+            });
+
+            ExcelSheet sheet = document["Members"];
+            Assert.True(sheet.TryGetCellText(1, 1, out string? header));
+            Assert.True(sheet.TryGetCellText(2, 1, out string? value));
+            Assert.Equal("AD State", header);
+            Assert.Equal("Disabled", value);
+        }
+
+        [Fact]
+        public void SheetComposer_DataTableFallsBackWhenLaterWorksheetContentExists() {
+            DataTable members = CreateMembersTable();
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+            try {
+                using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                    document.Compose("Members", composer => {
+                        composer.Sheet.Cell(100, 1, "Footer");
+                        string range = composer.TableFrom(members, freezeHeaderRow: false);
+                        Assert.Equal("A1:D3", range);
+                    });
+                    document.Save();
+                }
+
+                using ExcelDocument reloaded = ExcelDocument.Load(
+                    filePath,
+                    new ExcelLoadOptions { AccessMode = OfficeIMO.DocumentAccessMode.ReadOnly });
+                ExcelSheet sheet = reloaded["Members"];
+                Assert.True(sheet.TryGetCellText(2, 1, out string? endpoint));
+                Assert.True(sheet.TryGetCellText(100, 1, out string? footer));
+                Assert.Equal("PC-01", endpoint);
+                Assert.Equal("Footer", footer);
+            } finally {
+                if (File.Exists(filePath)) File.Delete(filePath);
+            }
+        }
+
+        [Fact]
         public void SheetComposer_DataTablePreservesCaseDistinctSchemaColumns() {
             var table = new DataTable("CaseDistinct");
             table.Columns.Add("Name", typeof(string));

--- a/OfficeIMO.Excel.Tests/Excel.SheetComposer.DataTable.cs
+++ b/OfficeIMO.Excel.Tests/Excel.SheetComposer.DataTable.cs
@@ -108,6 +108,84 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void SheetComposer_DataTableExplicitColumnsDoNotMatchLastPathSegments() {
+            var table = new DataTable("Members");
+            table.Columns.Add("Customer.Name", typeof(string));
+            table.Rows.Add("Alice");
+            using ExcelDocument document = ExcelDocument.Create();
+
+            document.Compose("Members", composer => {
+                string range = composer.TableFrom(
+                    table,
+                    configure: options => options.Columns = new[] { "Name" },
+                    freezeHeaderRow: false);
+                Assert.Equal("A1:A2", range);
+            });
+
+            ExcelSheet sheet = document["Members"];
+            Assert.True(sheet.TryGetCellText(1, 1, out string? header));
+            Assert.True(sheet.TryGetCellText(2, 1, out string? value));
+            Assert.Equal("Name", header);
+            Assert.True(string.IsNullOrEmpty(value));
+        }
+
+        [Fact]
+        public void SheetComposer_DataTableTreatsDottedColumnNamesAsLiteralSchema() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+            try {
+                var table = new DataTable("Members");
+                table.Columns.Add("Customer.Name", typeof(string));
+                table.Rows.Add("Alice");
+                using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                    document.Compose("Members", composer =>
+                        composer.TableFrom(table, freezeHeaderRow: false));
+                    document.Save();
+                }
+
+                using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false);
+                Worksheet worksheet = spreadsheet.WorkbookPart!.WorksheetParts.Single().Worksheet;
+                Assert.Empty(worksheet.Descendants<ConditionalFormatting>());
+            } finally {
+                if (File.Exists(filePath)) File.Delete(filePath);
+            }
+        }
+
+        [Fact]
+        public void SheetComposer_EmptyObjectTableSkipsExemptProjectionLimits() {
+            using ExcelDocument document = ExcelDocument.Create();
+
+            document.Compose("Data", composer => {
+                string range = composer.TableFrom(
+                    Array.Empty<object>(),
+                    configure: options => {
+                        options.Columns = new[] { "First", "Second" };
+                        options.MaxColumns = 1;
+                    },
+                    freezeHeaderRow: false);
+                Assert.Equal("A1:A1", range);
+            });
+
+            Assert.True(document["Data"].TryGetCellText(1, 1, out string? text));
+            Assert.Equal("(no data)", text);
+        }
+
+        [Fact]
+        public void SheetComposer_ObjectTableExplainsHardExcelRowBoundary() {
+            using ExcelDocument document = ExcelDocument.Create();
+
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+                document.Compose("Data", composer => composer.TableFrom(
+                    new CountOnlyRows(A1.MaxRows),
+                    configure: options => options.MaxRows = int.MaxValue,
+                    freezeHeaderRow: false)));
+
+            Assert.Contains("room for at most 1048575 data rows", exception.Message, StringComparison.Ordinal);
+            Assert.Contains("split the data across multiple worksheets", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("cannot be overridden", exception.Message, StringComparison.Ordinal);
+            Assert.DoesNotContain("options.MaxRows = 1048576", exception.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void SheetComposer_DataTableFallsBackWhenLaterWorksheetContentExists() {
             DataTable members = CreateMembersTable();
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
@@ -355,6 +433,19 @@ namespace OfficeIMO.Tests {
             table.Rows.Add("PC-01", true, "Disabled", "one");
             table.Rows.Add("PC-02", false, "Gone", "two");
             return table;
+        }
+
+        private sealed class CountOnlyRows : IReadOnlyCollection<int> {
+            internal CountOnlyRows(int count) {
+                Count = count;
+            }
+
+            public int Count { get; }
+
+            public IEnumerator<int> GetEnumerator() =>
+                throw new InvalidOperationException("The known row-count check must run before enumeration.");
+
+            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
         }
     }
 }

--- a/OfficeIMO.Excel.Tests/Excel.SheetComposer.DataTable.cs
+++ b/OfficeIMO.Excel.Tests/Excel.SheetComposer.DataTable.cs
@@ -1,0 +1,177 @@
+using System.Data;
+using System.IO;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class ExcelSheetComposerDataTableTests {
+        [Fact]
+        public void SheetComposer_DataTablePreservesSelectedSchemaAndRichWorkbookFeatures() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+            try {
+                DataTable members = CreateMembersTable();
+                using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                    document.Compose("Summary", composer => {
+                        composer.Title("Directory report");
+                        composer.Finish(autoFitColumns: false);
+                    });
+                    document.Compose("Members", composer => {
+                        string range = composer.TableFrom(
+                            members,
+                            title: "Members",
+                            configure: options => {
+                                options.Columns = new[] { "Enabled", "ADState", "Endpoint", "Missing" };
+                                options.MaxCells = 1;
+                            },
+                            style: ExcelTableStyle.TableStyleMedium2,
+                            visuals: options => options.ShowRowStripes = false);
+                        Assert.Equal("A2:D4", range);
+                        composer.Finish(autoFitColumns: false);
+                    });
+                    document.Compose("Notes", composer => {
+                        composer.Paragraph("Generated after the report table.");
+                        composer.Finish(autoFitColumns: false);
+                    });
+                    document.Save();
+                }
+
+                using (ExcelDocument document = ExcelDocument.Load(
+                    filePath,
+                    new ExcelLoadOptions { AccessMode = OfficeIMO.DocumentAccessMode.ReadOnly })) {
+                    Assert.Equal(3, document.Sheets.Count);
+                    ExcelSheet sheet = document["Members"];
+                    Assert.Equal("A2:D4", sheet.GetTableRange("Members"));
+                    Assert.True(sheet.TryGetCellText(2, 1, out string? enabledHeader));
+                    Assert.True(sheet.TryGetCellText(2, 2, out string? adStateHeader));
+                    Assert.True(sheet.TryGetCellText(2, 3, out string? endpointHeader));
+                    Assert.True(sheet.TryGetCellText(2, 4, out string? missingHeader));
+                    Assert.True(sheet.TryGetCellText(3, 1, out string? enabled));
+                    Assert.True(sheet.TryGetCellText(3, 2, out string? adState));
+                    Assert.True(sheet.TryGetCellText(3, 3, out string? endpoint));
+                    Assert.True(sheet.TryGetCellText(3, 4, out string? missing));
+                    Assert.Equal("Enabled", enabledHeader);
+                    Assert.Equal("AD State", adStateHeader);
+                    Assert.Equal("Endpoint", endpointHeader);
+                    Assert.Equal("Missing", missingHeader);
+                    Assert.Equal("1", enabled);
+                    Assert.Equal("Disabled", adState);
+                    Assert.Equal("PC-01", endpoint);
+                    Assert.True(string.IsNullOrEmpty(missing));
+                }
+
+                using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                    WorksheetPart membersPart = spreadsheet.WorkbookPart!.WorksheetParts.ElementAt(1);
+                    TableDefinitionPart tablePart = Assert.Single(membersPart.TableDefinitionParts);
+                    TableStyleInfo style = Assert.IsType<TableStyleInfo>(tablePart.Table!.TableStyleInfo);
+                    Assert.Equal("TableStyleMedium2", style.Name?.Value);
+                    Assert.False(style.ShowRowStripes?.Value);
+                }
+            } finally {
+                if (File.Exists(filePath)) File.Delete(filePath);
+            }
+        }
+
+        [Fact]
+        public void SheetComposer_DataTableUsesExcelRowBoundaryInsteadOfGenericCellLimit() {
+            DataTable members = CreateMembersTable();
+            using ExcelDocument document = ExcelDocument.Create();
+
+            document.Compose("Members", composer => {
+                string range = composer.TableFrom(
+                    members,
+                    configure: options => options.MaxCells = 1,
+                    freezeHeaderRow: false);
+                Assert.Equal("A1:D3", range);
+            });
+        }
+
+        [Fact]
+        public void SheetComposer_DataTablePreservesCaseDistinctSchemaColumns() {
+            var table = new DataTable("CaseDistinct");
+            table.Columns.Add("Name", typeof(string));
+            table.Columns.Add("name", typeof(string));
+            table.Rows.Add("Upper", "Lower");
+            using ExcelDocument document = ExcelDocument.Create();
+
+            document.Compose("Data", composer => {
+                string range = composer.TableFrom(table, freezeHeaderRow: false);
+                Assert.Equal("A1:B2", range);
+            });
+
+            ExcelSheet sheet = document["Data"];
+            Assert.True(sheet.TryGetCellText(1, 1, out string? firstHeader));
+            Assert.True(sheet.TryGetCellText(1, 2, out string? secondHeader));
+            Assert.True(sheet.TryGetCellText(2, 1, out string? firstValue));
+            Assert.True(sheet.TryGetCellText(2, 2, out string? secondValue));
+            Assert.Equal("Name", firstHeader);
+            Assert.Equal("Name (2)", secondHeader);
+            Assert.Equal("Upper", firstValue);
+            Assert.Equal("Lower", secondValue);
+        }
+
+        [Fact]
+        public void SheetComposer_DataTablePreservesExplicitCaseDistinctColumnsAndRejectsAmbiguousFallback() {
+            var table = new DataTable("CaseDistinct");
+            table.Columns.Add("Name", typeof(string));
+            table.Columns.Add("name", typeof(string));
+            table.Rows.Add("Upper", "Lower");
+
+            using (var document = ExcelDocument.Create()) {
+                document.Compose("Data", composer => {
+                    string range = composer.TableFrom(
+                        table,
+                        configure: options => options.Columns = new[] { "Name", "name" },
+                        freezeHeaderRow: false);
+                    Assert.Equal("A1:B2", range);
+                });
+
+                ExcelSheet sheet = document["Data"];
+                Assert.True(sheet.TryGetCellText(2, 1, out string? firstValue));
+                Assert.True(sheet.TryGetCellText(2, 2, out string? secondValue));
+                Assert.Equal("Upper", firstValue);
+                Assert.Equal("Lower", secondValue);
+            }
+
+            using var ambiguousDocument = ExcelDocument.Create();
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+                ambiguousDocument.Compose("Data", composer =>
+                    composer.TableFrom(
+                        table,
+                        configure: options => options.Columns = new[] { "NAME" },
+                        freezeHeaderRow: false)));
+            Assert.Contains("ambiguous", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("exact column casing", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void SheetComposer_DataTableExplainsHardExcelColumnBoundary() {
+            var table = new DataTable("Wide");
+            for (int index = 0; index <= A1.MaxColumns; index++) {
+                table.Columns.Add("Column" + index, typeof(string));
+            }
+            table.Rows.Add(table.NewRow());
+            using ExcelDocument document = ExcelDocument.Create();
+
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+                document.Compose("Data", composer => composer.TableFrom(table, freezeHeaderRow: false)));
+
+            Assert.Contains("requires at least 16385 columns", exception.Message, StringComparison.Ordinal);
+            Assert.Contains("Select fewer columns or split the data across multiple worksheets", exception.Message, StringComparison.Ordinal);
+            Assert.Contains("cannot be overridden", exception.Message, StringComparison.Ordinal);
+            Assert.DoesNotContain("options.MaxColumns = 16385", exception.Message, StringComparison.Ordinal);
+        }
+
+        private static DataTable CreateMembersTable() {
+            var table = new DataTable("Members");
+            table.Columns.Add("Endpoint", typeof(string));
+            table.Columns.Add("Enabled", typeof(bool));
+            table.Columns.Add("ADState", typeof(string));
+            table.Columns.Add("Ignored", typeof(string));
+            table.Rows.Add("PC-01", true, "Disabled", "one");
+            table.Rows.Add("PC-02", false, "Gone", "two");
+            return table;
+        }
+    }
+}

--- a/OfficeIMO.Excel.Tests/Excel.SheetComposer.DataTable.cs
+++ b/OfficeIMO.Excel.Tests/Excel.SheetComposer.DataTable.cs
@@ -146,6 +146,61 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void SheetComposer_DataTableProjectionRulesPreserveAndOrderCaseDistinctColumns() {
+            var table = new DataTable("CaseDistinct");
+            table.Columns.Add("Name", typeof(string));
+            table.Columns.Add("name", typeof(string));
+            table.Columns.Add("Value", typeof(int));
+            table.Rows.Add("Upper", "Lower", 42);
+            using ExcelDocument document = ExcelDocument.Create();
+
+            document.Compose("Data", composer => {
+                string range = composer.TableFrom(
+                    table,
+                    configure: options => {
+                        options.Ignore = new[] { "Missing" };
+                        options.PinnedFirst = new[] { "name" };
+                        options.PropertyPriority["Value"] = -1;
+                    },
+                    freezeHeaderRow: false);
+                Assert.Equal("A1:C2", range);
+            });
+
+            ExcelSheet sheet = document["Data"];
+            Assert.True(sheet.TryGetCellText(1, 1, out string? firstHeader));
+            Assert.True(sheet.TryGetCellText(1, 2, out string? secondHeader));
+            Assert.True(sheet.TryGetCellText(1, 3, out string? thirdHeader));
+            Assert.True(sheet.TryGetCellText(2, 1, out string? firstValue));
+            Assert.True(sheet.TryGetCellText(2, 2, out string? secondValue));
+            Assert.True(sheet.TryGetCellText(2, 3, out string? thirdValue));
+            Assert.Equal("Name", firstHeader);
+            Assert.Equal("Value", secondHeader);
+            Assert.Equal("Name (2)", thirdHeader);
+            Assert.Equal("Lower", firstValue);
+            Assert.Equal("42", secondValue);
+            Assert.Equal("Upper", thirdValue);
+        }
+
+        [Fact]
+        public void SheetComposer_DataTableProjectionRulesRejectAmbiguousCaseInsensitiveTargets() {
+            var table = new DataTable("CaseDistinct");
+            table.Columns.Add("Name", typeof(string));
+            table.Columns.Add("name", typeof(string));
+            table.Rows.Add("Upper", "Lower");
+            using ExcelDocument document = ExcelDocument.Create();
+
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+                document.Compose("Data", composer =>
+                    composer.TableFrom(
+                        table,
+                        configure: options => options.PinnedFirst = new[] { "NAME" },
+                        freezeHeaderRow: false)));
+
+            Assert.Contains("ambiguous", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("exact full column name and casing", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
         public void SheetComposer_DataTableExplainsHardExcelColumnBoundary() {
             var table = new DataTable("Wide");
             for (int index = 0; index <= A1.MaxColumns; index++) {

--- a/OfficeIMO.Excel.Tests/Excel.SheetComposer.DataTable.cs
+++ b/OfficeIMO.Excel.Tests/Excel.SheetComposer.DataTable.cs
@@ -170,6 +170,25 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void SheetComposer_EmptyIteratorSkipsExemptProjectionLimits() {
+            using ExcelDocument document = ExcelDocument.Create();
+
+            document.Compose("Data", composer => {
+                string range = composer.TableFrom(
+                    EmptyRows(),
+                    configure: options => {
+                        options.Columns = new[] { "First", "Second" };
+                        options.MaxColumns = 1;
+                    },
+                    freezeHeaderRow: false);
+                Assert.Equal("A1:A1", range);
+            });
+
+            Assert.True(document["Data"].TryGetCellText(1, 1, out string? text));
+            Assert.Equal("(no data)", text);
+        }
+
+        [Fact]
         public void SheetComposer_ObjectTableExplainsHardExcelRowBoundary() {
             using ExcelDocument document = ExcelDocument.Create();
 
@@ -422,6 +441,31 @@ namespace OfficeIMO.Tests {
             Assert.Contains("Select fewer columns or split the data across multiple worksheets", exception.Message, StringComparison.Ordinal);
             Assert.Contains("cannot be overridden", exception.Message, StringComparison.Ordinal);
             Assert.DoesNotContain("options.MaxColumns = 16385", exception.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void SheetComposer_DataTablePrefersHardExcelColumnBoundaryOverLowerConfiguredLimit() {
+            var table = new DataTable("Wide");
+            for (int index = 0; index <= A1.MaxColumns; index++) {
+                table.Columns.Add("Column" + index, typeof(string));
+            }
+            table.Rows.Add(table.NewRow());
+            using ExcelDocument document = ExcelDocument.Create();
+
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+                document.Compose("Data", composer => composer.TableFrom(
+                    table,
+                    configure: options => options.MaxColumns = 10,
+                    freezeHeaderRow: false)));
+
+            Assert.Contains("requires at least 16385 columns", exception.Message, StringComparison.Ordinal);
+            Assert.Contains("Select fewer columns or split the data across multiple worksheets", exception.Message, StringComparison.Ordinal);
+            Assert.Contains("cannot be overridden", exception.Message, StringComparison.Ordinal);
+            Assert.DoesNotContain("options.MaxColumns = 16385", exception.Message, StringComparison.Ordinal);
+        }
+
+        private static IEnumerable<object> EmptyRows() {
+            yield break;
         }
 
         private static DataTable CreateMembersTable() {

--- a/OfficeIMO.Excel.Tests/Excel.SheetComposer.DataTable.cs
+++ b/OfficeIMO.Excel.Tests/Excel.SheetComposer.DataTable.cs
@@ -248,6 +248,51 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void SheetComposer_DataTableFiltersCaseDistinctColumnsByExactSchemaIdentity() {
+            var table = new DataTable("CaseDistinct");
+            table.Columns.Add("Name", typeof(string));
+            table.Columns.Add("name", typeof(string));
+            table.Columns.Add("Value", typeof(int));
+            table.Rows.Add("Upper", "Lower", 42);
+
+            using (var includeDocument = ExcelDocument.Create()) {
+                includeDocument.Compose("Data", composer => composer.TableFrom(
+                    table,
+                    configure: options => options.IncludeProperties = new[] { "Name" },
+                    freezeHeaderRow: false));
+                ExcelSheet sheet = includeDocument["Data"];
+                Assert.True(sheet.TryGetCellText(2, 1, out string? value));
+                Assert.Equal("Upper", value);
+                Assert.False(sheet.TryGetCellText(1, 2, out _));
+            }
+
+            foreach (bool useIgnore in new[] { false, true }) {
+                using var excludeDocument = ExcelDocument.Create();
+                excludeDocument.Compose("Data", composer => composer.TableFrom(
+                    table,
+                    configure: options => {
+                        if (useIgnore) options.Ignore = new[] { "Name" };
+                        else options.ExcludeProperties = new[] { "Name" };
+                    },
+                    freezeHeaderRow: false));
+                ExcelSheet sheet = excludeDocument["Data"];
+                Assert.True(sheet.TryGetCellText(2, 1, out string? lower));
+                Assert.True(sheet.TryGetCellText(2, 2, out string? number));
+                Assert.Equal("Lower", lower);
+                Assert.Equal("42", number);
+            }
+
+            using var ambiguousDocument = ExcelDocument.Create();
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+                ambiguousDocument.Compose("Data", composer => composer.TableFrom(
+                    table,
+                    configure: options => options.ExcludeProperties = new[] { "NAME" },
+                    freezeHeaderRow: false)));
+            Assert.Contains("ambiguous", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("ExcludeProperties", exception.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void SheetComposer_DataTableExplainsHardExcelColumnBoundary() {
             var table = new DataTable("Wide");
             for (int index = 0; index <= A1.MaxColumns; index++) {

--- a/OfficeIMO.Excel.Tests/Excel.SheetComposer.DictionaryRows.cs
+++ b/OfficeIMO.Excel.Tests/Excel.SheetComposer.DictionaryRows.cs
@@ -80,8 +80,35 @@ namespace OfficeIMO.Tests {
                 new ReadOnlyDictionaryRow(("A", 3), ("B", 4))
             };
 
-            Assert.Throws<InvalidDataException>(() => document.Compose("Report", composer =>
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() => document.Compose("Report", composer =>
                 composer.TableFrom(rows, configure: options => options.MaxCells = 5)));
+
+            Assert.Contains("requires at least 6 cells", exception.Message, StringComparison.Ordinal);
+            Assert.Contains("2 data rows + 1 header row x 2 columns", exception.Message, StringComparison.Ordinal);
+            Assert.Contains("options.MaxCells = 6", exception.Message, StringComparison.Ordinal);
+            Assert.Contains("TableFrom(DataTable)", exception.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void SheetComposer_ExplainsHowToOverrideRowAndColumnLimits() {
+            var rows = new[] {
+                new ReadOnlyDictionaryRow(("A", 1), ("B", 2)),
+                new ReadOnlyDictionaryRow(("A", 3), ("B", 4))
+            };
+
+            using var rowDocument = ExcelDocument.Create();
+            InvalidDataException rowException = Assert.Throws<InvalidDataException>(() =>
+                rowDocument.Compose("Rows", composer =>
+                    composer.TableFrom(rows, configure: options => options.MaxRows = 1)));
+            Assert.Contains("requires at least 2 data rows", rowException.Message, StringComparison.Ordinal);
+            Assert.Contains("options.MaxRows = 2", rowException.Message, StringComparison.Ordinal);
+
+            using var columnDocument = ExcelDocument.Create();
+            InvalidDataException columnException = Assert.Throws<InvalidDataException>(() =>
+                columnDocument.Compose("Columns", composer =>
+                    composer.TableFrom(rows, configure: options => options.MaxColumns = 1)));
+            Assert.Contains("requires at least 2 columns", columnException.Message, StringComparison.Ordinal);
+            Assert.Contains("options.MaxColumns = 2", columnException.Message, StringComparison.Ordinal);
         }
 
         [Fact]

--- a/OfficeIMO.Excel.Tests/Excel.SheetComposer.DictionaryRows.cs
+++ b/OfficeIMO.Excel.Tests/Excel.SheetComposer.DictionaryRows.cs
@@ -112,6 +112,26 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void SheetComposer_ExplainsHardExcelColumnBoundaryForObjectRows() {
+            (string Key, object? Value)[] entries = Enumerable.Range(0, A1.MaxColumns + 1)
+                .Select(index => ("Column" + index, (object?)index))
+                .ToArray();
+            var rows = new[] { new ReadOnlyDictionaryRow(entries) };
+            using ExcelDocument document = ExcelDocument.Create();
+
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+                document.Compose("Data", composer => composer.TableFrom(
+                    rows,
+                    configure: options => options.MaxColumns = int.MaxValue,
+                    freezeHeaderRow: false)));
+
+            Assert.Contains("requires at least 16385 columns", exception.Message, StringComparison.Ordinal);
+            Assert.Contains("Select fewer columns or split the data across multiple worksheets", exception.Message, StringComparison.Ordinal);
+            Assert.Contains("cannot be overridden", exception.Message, StringComparison.Ordinal);
+            Assert.DoesNotContain("options.MaxColumns = 16385", exception.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void SheetComposer_RendersDictionaryRowsAsRealColumns() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
             try {

--- a/OfficeIMO.Excel/ExcelSheet.DataTable.AppendRows.cs
+++ b/OfficeIMO.Excel/ExcelSheet.DataTable.AppendRows.cs
@@ -271,41 +271,68 @@ namespace OfficeIMO.Excel {
             Dictionary<string, int>? sharedStringIndexes = null;
             int rowIndex = startRow;
             bool canCancel = ct.CanBeCanceled;
-            List<Row> pendingRows = new List<Row>(rowCount + (includeHeaders ? 1 : 0));
+            List<Row>? pendingRows = canCancel ? new List<Row>(rowCount + (includeHeaders ? 1 : 0)) : null;
             object?[]? flatValues = null;
             bool useFlatValues = source.TryGetFlatValues(out var sourceFlatValues, out int flatColumnCount) && flatColumnCount == columnCount;
             if (useFlatValues) {
                 flatValues = sourceFlatValues;
             }
 
-            if (includeHeaders) {
-                Row headerRow = CreateTabularRowSourceHeaderRow(rowIndex++, columnReferencePrefixes, source, useDirectStringCells, ref sharedStringIndexes, canCancel, ct);
-                pendingRows.Add(headerRow);
-            }
-
-            for (int sourceRowIndex = 0; sourceRowIndex < rowCount; sourceRowIndex++) {
-                if (canCancel) {
-                    ct.ThrowIfCancellationRequested();
+            Row? firstAppendedRow = null;
+            try {
+                if (includeHeaders) {
+                    Row headerRow = CreateTabularRowSourceHeaderRow(rowIndex++, columnReferencePrefixes, source, useDirectStringCells, ref sharedStringIndexes, canCancel, ct);
+                    if (pendingRows != null) {
+                        pendingRows.Add(headerRow);
+                    } else {
+                        sheetData.Append(headerRow);
+                        firstAppendedRow = headerRow;
+                    }
                 }
 
-                Row valueRow;
-                if (flatValues != null && !canCancel) {
-                    valueRow = CreateTabularRowSourceValueRow(rowIndex++, columnReferencePrefixes, flatValues, sourceRowIndex * columnCount, columnCount, columnKinds, styleIndexes, objectDateTimeStyleIndex, objectTimeSpanStyleIndex, useDirectStringCells, ref sharedStringIndexes);
-                } else if (flatValues != null) {
-                    valueRow = CreateTabularRowSourceValueRow(rowIndex++, columnReferencePrefixes, flatValues, sourceRowIndex * columnCount, columnCount, columnKinds, styleIndexes, objectDateTimeStyleIndex, objectTimeSpanStyleIndex, useDirectStringCells, ref sharedStringIndexes, canCancel, ct);
-                } else if (source.TryGetBufferedRow(sourceRowIndex, out var rowValues) && rowValues != null && !canCancel) {
-                    valueRow = CreateTabularRowSourceValueRow(rowIndex++, columnReferencePrefixes, rowValues, 0, columnCount, columnKinds, styleIndexes, objectDateTimeStyleIndex, objectTimeSpanStyleIndex, useDirectStringCells, ref sharedStringIndexes);
-                } else if (rowValues != null) {
-                    valueRow = CreateTabularRowSourceValueRow(rowIndex++, columnReferencePrefixes, rowValues, 0, columnCount, columnKinds, styleIndexes, objectDateTimeStyleIndex, objectTimeSpanStyleIndex, useDirectStringCells, ref sharedStringIndexes, canCancel, ct);
-                } else {
-                    valueRow = CreateTabularRowSourceValueRow(rowIndex++, columnReferencePrefixes, source, sourceRowIndex, columnKinds, styleIndexes, objectDateTimeStyleIndex, objectTimeSpanStyleIndex, useDirectStringCells, ref sharedStringIndexes, canCancel, ct);
+                for (int sourceRowIndex = 0; sourceRowIndex < rowCount; sourceRowIndex++) {
+                    if (canCancel) {
+                        ct.ThrowIfCancellationRequested();
+                    }
+
+                    Row valueRow;
+                    if (flatValues != null && !canCancel) {
+                        valueRow = CreateTabularRowSourceValueRow(rowIndex++, columnReferencePrefixes, flatValues, sourceRowIndex * columnCount, columnCount, columnKinds, styleIndexes, objectDateTimeStyleIndex, objectTimeSpanStyleIndex, useDirectStringCells, ref sharedStringIndexes);
+                    } else if (flatValues != null) {
+                        valueRow = CreateTabularRowSourceValueRow(rowIndex++, columnReferencePrefixes, flatValues, sourceRowIndex * columnCount, columnCount, columnKinds, styleIndexes, objectDateTimeStyleIndex, objectTimeSpanStyleIndex, useDirectStringCells, ref sharedStringIndexes, canCancel, ct);
+                    } else if (source.TryGetBufferedRow(sourceRowIndex, out var rowValues) && rowValues != null && !canCancel) {
+                        valueRow = CreateTabularRowSourceValueRow(rowIndex++, columnReferencePrefixes, rowValues, 0, columnCount, columnKinds, styleIndexes, objectDateTimeStyleIndex, objectTimeSpanStyleIndex, useDirectStringCells, ref sharedStringIndexes);
+                    } else if (rowValues != null) {
+                        valueRow = CreateTabularRowSourceValueRow(rowIndex++, columnReferencePrefixes, rowValues, 0, columnCount, columnKinds, styleIndexes, objectDateTimeStyleIndex, objectTimeSpanStyleIndex, useDirectStringCells, ref sharedStringIndexes, canCancel, ct);
+                    } else {
+                        valueRow = CreateTabularRowSourceValueRow(rowIndex++, columnReferencePrefixes, source, sourceRowIndex, columnKinds, styleIndexes, objectDateTimeStyleIndex, objectTimeSpanStyleIndex, useDirectStringCells, ref sharedStringIndexes, canCancel, ct);
+                    }
+
+                    if (pendingRows != null) {
+                        pendingRows.Add(valueRow);
+                    } else {
+                        sheetData.Append(valueRow);
+                        firstAppendedRow ??= valueRow;
+                    }
                 }
 
-                pendingRows.Add(valueRow);
-            }
+                if (pendingRows != null) {
+                    foreach (var pendingRow in pendingRows) {
+                        sheetData.Append(pendingRow);
+                    }
+                }
+            } catch {
+                // The direct path avoids retaining every generated row in a second collection.
+                // If the source fails, remove the appended tail to preserve the existing
+                // all-or-nothing worksheet contract without paying that steady-state cost.
+                OpenXmlElement? current = firstAppendedRow;
+                while (current != null) {
+                    OpenXmlElement? next = current.NextSibling();
+                    current.Remove();
+                    current = next;
+                }
 
-            foreach (var pendingRow in pendingRows) {
-                sheetData.Append(pendingRow);
+                throw;
             }
 
             ClearHeaderCacheForPreparedAppend();

--- a/OfficeIMO.Excel/ExcelSheet.DataTable.RowSource.cs
+++ b/OfficeIMO.Excel/ExcelSheet.DataTable.RowSource.cs
@@ -1,0 +1,75 @@
+using System.Data;
+using System.IO;
+
+namespace OfficeIMO.Excel {
+    internal sealed class DataTableTabularRowSource : IExcelSheetTabularRowSource {
+        private readonly DataTable _table;
+        private readonly DataColumn?[] _columns;
+        private readonly string[] _headers;
+
+        internal DataTableTabularRowSource(
+            DataTable table,
+            IReadOnlyList<string> columnNames,
+            IReadOnlyList<string> headers) {
+            _table = table ?? throw new ArgumentNullException(nameof(table));
+            if (columnNames == null) throw new ArgumentNullException(nameof(columnNames));
+            if (headers == null) throw new ArgumentNullException(nameof(headers));
+            if (columnNames.Count != headers.Count) {
+                throw new ArgumentException("Column and header counts must match.", nameof(headers));
+            }
+
+            var availableColumns = table.Columns
+                .Cast<DataColumn>()
+                .ToDictionary(column => column.ColumnName, StringComparer.Ordinal);
+            _columns = new DataColumn?[columnNames.Count];
+            _headers = new string[headers.Count];
+            for (int index = 0; index < columnNames.Count; index++) {
+                string name = columnNames[index];
+                if (!availableColumns.TryGetValue(name, out DataColumn? column)) {
+                    column = FindCaseInsensitiveColumn(table.Columns, name);
+                }
+                _columns[index] = column;
+                _headers[index] = headers[index];
+            }
+        }
+
+        private static DataColumn? FindCaseInsensitiveColumn(DataColumnCollection columns, string name) {
+            DataColumn? match = null;
+            foreach (DataColumn column in columns) {
+                if (!string.Equals(column.ColumnName, name, StringComparison.OrdinalIgnoreCase)) continue;
+                if (match != null) {
+                    throw new InvalidDataException(
+                        $"DataTable column '{name}' is ambiguous because the schema contains case-distinct matches. Use the exact column casing in the projection.");
+                }
+                match = column;
+            }
+            return match;
+        }
+
+        public int ColumnCount => _columns.Length;
+
+        public int RowCount => _table.Rows.Count;
+
+        public string GetColumnName(int index) => _headers[index];
+
+        public Type GetColumnType(int index) => _columns[index]?.DataType ?? typeof(object);
+
+        public object? GetValue(int rowIndex, int columnIndex) {
+            DataRow row = _table.Rows[rowIndex];
+            DataColumn? column = _columns[columnIndex];
+            if (column == null) return null;
+            return row.IsNull(column) ? null : row[column];
+        }
+
+        public bool TryGetBufferedRow(int rowIndex, out object?[]? values) {
+            values = null;
+            return false;
+        }
+
+        public bool TryGetFlatValues(out object?[] values, out int columnCount) {
+            values = Array.Empty<object?>();
+            columnCount = 0;
+            return false;
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelSheet.DataTable.Tables.cs
+++ b/OfficeIMO.Excel/ExcelSheet.DataTable.Tables.cs
@@ -8,6 +8,68 @@ using System.Threading.Tasks;
 
 namespace OfficeIMO.Excel {
     public partial class ExcelSheet {
+        internal string InsertTabularRowSourceAsTable(
+            IExcelSheetTabularRowSource source,
+            int startRow = 1,
+            int startColumn = 1,
+            bool includeHeaders = true,
+            string? tableName = null,
+            ExcelTableStyle style = ExcelTableStyle.TableStyleMedium2,
+            bool includeAutoFilter = true,
+            CancellationToken ct = default) {
+            string range = InsertTabularRowSourceAsTableForDeferredMaterialization(
+                source,
+                startRow,
+                startColumn,
+                includeHeaders,
+                tableName,
+                style,
+                includeAutoFilter,
+                ct);
+            if (!string.IsNullOrEmpty(range)) return range;
+
+            DataTable fallback = MaterializeTabularRowSource(source, ct);
+            return InsertDataTableAsTable(
+                fallback,
+                startRow,
+                startColumn,
+                includeHeaders,
+                tableName,
+                style,
+                includeAutoFilter,
+                mode: null,
+                ct);
+        }
+
+        private static DataTable MaterializeTabularRowSource(
+            IExcelSheetTabularRowSource source,
+            CancellationToken ct) {
+            ct.ThrowIfCancellationRequested();
+            var table = new DataTable {
+                Locale = CultureInfo.InvariantCulture
+            };
+            for (int columnIndex = 0; columnIndex < source.ColumnCount; columnIndex++) {
+                ct.ThrowIfCancellationRequested();
+                table.Columns.Add(source.GetColumnName(columnIndex), source.GetColumnType(columnIndex));
+            }
+
+            table.BeginLoadData();
+            try {
+                for (int rowIndex = 0; rowIndex < source.RowCount; rowIndex++) {
+                    ct.ThrowIfCancellationRequested();
+                    DataRow row = table.NewRow();
+                    for (int columnIndex = 0; columnIndex < source.ColumnCount; columnIndex++) {
+                        object? value = source.GetValue(rowIndex, columnIndex);
+                        row[columnIndex] = value ?? DBNull.Value;
+                    }
+                    table.Rows.Add(row);
+                }
+            } finally {
+                table.EndLoadData();
+            }
+            return table;
+        }
+
         internal string InsertTabularRowSourceAsTableForDeferredMaterialization(
             IExcelSheetTabularRowSource source,
             int startRow = 1,

--- a/OfficeIMO.Excel/ExcelSheet.DataTable.Tables.cs
+++ b/OfficeIMO.Excel/ExcelSheet.DataTable.Tables.cs
@@ -50,7 +50,11 @@ namespace OfficeIMO.Excel {
             };
             for (int columnIndex = 0; columnIndex < source.ColumnCount; columnIndex++) {
                 ct.ThrowIfCancellationRequested();
-                table.Columns.Add(source.GetColumnName(columnIndex), source.GetColumnType(columnIndex));
+                // The fallback only transports already-materialized cell values. Object columns preserve
+                // those runtime values without forcing every caller-provided schema Type to root public
+                // members for trimming. InsertDataTableAsTable still infers cell kinds and date/time styles
+                // from each value, matching the direct row-source path.
+                table.Columns.Add(source.GetColumnName(columnIndex), typeof(object));
             }
 
             table.BeginLoadData();

--- a/OfficeIMO.Excel/Fluent/SheetComposer.Table.DataTable.cs
+++ b/OfficeIMO.Excel/Fluent/SheetComposer.Table.DataTable.cs
@@ -355,7 +355,7 @@ namespace OfficeIMO.Excel.Fluent {
 
         private static void EnsureDataTableColumnLimit(int requiredColumns, int configuredMaxColumns) {
             if (requiredColumns <= configuredMaxColumns && requiredColumns <= A1.MaxColumns) return;
-            if (requiredColumns > A1.MaxColumns && configuredMaxColumns >= A1.MaxColumns) {
+            if (requiredColumns > A1.MaxColumns) {
                 throw CreateExcelColumnLimitException(requiredColumns);
             }
 

--- a/OfficeIMO.Excel/Fluent/SheetComposer.Table.DataTable.cs
+++ b/OfficeIMO.Excel/Fluent/SheetComposer.Table.DataTable.cs
@@ -65,14 +65,11 @@ namespace OfficeIMO.Excel.Fluent {
             } else if (hasExplicitColumns) {
                 paths = ResolveExplicitDataTablePaths(flattener, options);
             } else {
-                try {
-                    paths = flattener.ResolvePaths(sourceColumnNames, options);
-                } catch (InvalidDataException exception) {
-                    if (exception.Data["OfficeIMO.RequiredColumns"] is int requiredColumns) {
-                        EnsureDataTableColumnLimit(requiredColumns, configuredMaxColumns);
-                    }
-                    throw;
-                }
+                paths = ResolveProjectedDataTablePaths(
+                    flattener,
+                    options,
+                    sourceColumnNames,
+                    configuredMaxColumns);
             }
             if (paths.Count == 0) {
                 Sheet.Cell(_row, 1, "(no tabular columns for the DataTable schema)");
@@ -122,6 +119,108 @@ namespace OfficeIMO.Excel.Fluent {
             }
             return paths;
         }
+
+        private static List<string> ResolveProjectedDataTablePaths(
+            ObjectFlattener flattener,
+            ObjectFlattenerOptions options,
+            IReadOnlyList<string> sourceColumnNames,
+            int configuredMaxColumns) {
+            var selected = new List<string>(sourceColumnNames.Count);
+            foreach (string sourceColumnName in sourceColumnNames) {
+                List<string> resolved = flattener.ResolvePaths(new[] { sourceColumnName }, options);
+                if (resolved.Count != 0) selected.Add(sourceColumnName);
+            }
+
+            EnsureDataTableColumnLimit(selected.Count, configuredMaxColumns);
+            return ApplyDataTableOrdering(selected, options);
+        }
+
+        private static List<string> ApplyDataTableOrdering(
+            IReadOnlyList<string> paths,
+            ObjectFlattenerOptions options) {
+            if (paths.Count == 0) return new List<string>();
+
+            var pinnedFirst = ResolveDataTableRules(paths, options.PinnedFirst, nameof(options.PinnedFirst));
+            var pinnedLast = ResolveDataTableRules(paths, options.PinnedLast, nameof(options.PinnedLast));
+            var firstSet = new HashSet<string>(pinnedFirst, StringComparer.Ordinal);
+            var lastSet = new HashSet<string>(pinnedLast, StringComparer.Ordinal);
+            lastSet.ExceptWith(firstSet);
+
+            var priorities = new Dictionary<string, int>(StringComparer.Ordinal);
+            foreach (KeyValuePair<string, int> priority in options.PropertyPriority) {
+                string? path = ResolveDataTableRule(paths, priority.Key, nameof(options.PropertyPriority));
+                if (path != null && !priorities.ContainsKey(path)) priorities[path] = priority.Value;
+            }
+
+            var remaining = paths
+                .Select((path, index) => new {
+                    Path = path,
+                    Index = index,
+                    Priority = priorities.TryGetValue(path, out int priority) ? priority : 0
+                })
+                .Where(item => !firstSet.Contains(item.Path) && !lastSet.Contains(item.Path))
+                .OrderBy(item => item.Priority)
+                .ThenBy(item => item.Index)
+                .Select(item => item.Path);
+
+            var result = new List<string>(paths.Count);
+            result.AddRange(pinnedFirst);
+            result.AddRange(remaining);
+            result.AddRange(pinnedLast.Where(path => !firstSet.Contains(path)));
+            return result;
+        }
+
+        private static List<string> ResolveDataTableRules(
+            IReadOnlyList<string> paths,
+            IEnumerable<string>? rules,
+            string optionName) {
+            var result = new List<string>();
+            var added = new HashSet<string>(StringComparer.Ordinal);
+            foreach (string rule in rules ?? Array.Empty<string>()) {
+                string? path = ResolveDataTableRule(paths, rule, optionName);
+                if (path != null && added.Add(path)) result.Add(path);
+            }
+            return result;
+        }
+
+        private static string? ResolveDataTableRule(
+            IReadOnlyList<string> paths,
+            string rule,
+            string optionName) {
+            if (string.IsNullOrWhiteSpace(rule)) return null;
+
+            string? exactPath = paths.FirstOrDefault(path => string.Equals(path, rule, StringComparison.Ordinal));
+            if (exactPath != null) return exactPath;
+
+            List<string> exactSegments = paths
+                .Where(path => string.Equals(GetLastSegment(path), rule, StringComparison.Ordinal))
+                .ToList();
+            if (exactSegments.Count == 1) return exactSegments[0];
+            if (exactSegments.Count > 1) throw CreateAmbiguousDataTableRuleException(rule, optionName);
+
+            List<string> insensitivePaths = paths
+                .Where(path => string.Equals(path, rule, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            if (insensitivePaths.Count == 1) return insensitivePaths[0];
+            if (insensitivePaths.Count > 1) throw CreateAmbiguousDataTableRuleException(rule, optionName);
+
+            List<string> insensitiveSegments = paths
+                .Where(path => string.Equals(GetLastSegment(path), rule, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            if (insensitiveSegments.Count == 1) return insensitiveSegments[0];
+            if (insensitiveSegments.Count > 1) throw CreateAmbiguousDataTableRuleException(rule, optionName);
+            return null;
+        }
+
+        private static string GetLastSegment(string path) {
+            int separator = path.LastIndexOf('.');
+            return separator >= 0 ? path.Substring(separator + 1) : path;
+        }
+
+        private static InvalidDataException CreateAmbiguousDataTableRuleException(string rule, string optionName) =>
+            new InvalidDataException(
+                $"DataTable column rule '{rule}' in {optionName} is ambiguous because the schema contains case-distinct or repeated matches. "
+                + "Use the exact full column name and casing in the projection rule.");
 
         private static void EnsureDataTableColumnLimit(int requiredColumns, int configuredMaxColumns) {
             if (requiredColumns <= configuredMaxColumns && requiredColumns <= A1.MaxColumns) return;

--- a/OfficeIMO.Excel/Fluent/SheetComposer.Table.DataTable.cs
+++ b/OfficeIMO.Excel/Fluent/SheetComposer.Table.DataTable.cs
@@ -95,7 +95,16 @@ namespace OfficeIMO.Excel.Fluent {
                 tableName: title ?? "Table",
                 style: style,
                 includeAutoFilter: autoFilter);
-            return CompleteTable(range, paths, headers, headerRow, lastRow, style, freezeHeaderRow, visuals);
+            return CompleteTable(
+                range,
+                paths,
+                headers,
+                headerRow,
+                lastRow,
+                style,
+                freezeHeaderRow,
+                visuals,
+                pathsRepresentFlattenedObjects: false);
         }
 
         private static List<string> ResolveExplicitDataTablePaths(
@@ -108,7 +117,7 @@ namespace OfficeIMO.Excel.Fluent {
             var selectedSourceColumnSet = new HashSet<string>(selectedSourceColumns, StringComparer.Ordinal);
             foreach (string candidate in options.Columns!) {
                 if (string.IsNullOrWhiteSpace(candidate)) continue;
-                string canonicalCandidate = ResolveDataTableRule(
+                string canonicalCandidate = ResolveExplicitDataTableColumn(
                     sourceColumnNames,
                     candidate,
                     nameof(options.Columns)) ?? candidate;
@@ -126,6 +135,24 @@ namespace OfficeIMO.Excel.Fluent {
                 paths.Add(canonicalCandidate);
             }
             return paths;
+        }
+
+        private static string? ResolveExplicitDataTableColumn(
+            IReadOnlyList<string> paths,
+            string candidate,
+            string optionName) {
+            string? exactPath = paths.FirstOrDefault(path =>
+                string.Equals(path, candidate, StringComparison.Ordinal));
+            if (exactPath != null) return exactPath;
+
+            List<string> insensitivePaths = paths
+                .Where(path => string.Equals(path, candidate, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            if (insensitivePaths.Count == 1) return insensitivePaths[0];
+            if (insensitivePaths.Count > 1) {
+                throw CreateAmbiguousDataTableRuleException(candidate, optionName);
+            }
+            return null;
         }
 
         private static List<string> ResolveProjectedDataTablePaths(

--- a/OfficeIMO.Excel/Fluent/SheetComposer.Table.DataTable.cs
+++ b/OfficeIMO.Excel/Fluent/SheetComposer.Table.DataTable.cs
@@ -63,7 +63,7 @@ namespace OfficeIMO.Excel.Fluent {
                 EnsureDataTableColumnLimit(sourceColumnNames.Length, configuredMaxColumns);
                 paths = sourceColumnNames.ToList();
             } else if (hasExplicitColumns) {
-                paths = ResolveExplicitDataTablePaths(flattener, options);
+                paths = ResolveExplicitDataTablePaths(flattener, options, sourceColumnNames);
             } else {
                 paths = ResolveProjectedDataTablePaths(
                     flattener,
@@ -88,7 +88,7 @@ namespace OfficeIMO.Excel.Fluent {
             List<string> headers = BuildTransformedHeaders(paths, options);
             EnsureUniqueTableHeaders(headers);
             var source = new DataTableTabularRowSource(table, paths, headers);
-            string range = Sheet.InsertTabularRowSourceAsTableForDeferredMaterialization(
+            string range = Sheet.InsertTabularRowSourceAsTable(
                 source,
                 startRow: headerRow,
                 startColumn: 1,
@@ -96,26 +96,28 @@ namespace OfficeIMO.Excel.Fluent {
                 tableName: title ?? "Table",
                 style: style,
                 includeAutoFilter: autoFilter);
-            if (string.IsNullOrEmpty(range)) {
-                throw new InvalidOperationException("The fixed-schema DataTable could not be inserted into the target worksheet.");
-            }
-
             return CompleteTable(range, paths, headers, headerRow, lastRow, style, freezeHeaderRow, visuals);
         }
 
         private static List<string> ResolveExplicitDataTablePaths(
             ObjectFlattener flattener,
-            ObjectFlattenerOptions options) {
+            ObjectFlattenerOptions options,
+            IReadOnlyList<string> sourceColumnNames) {
             var paths = new List<string>();
             var added = new HashSet<string>(StringComparer.Ordinal);
             foreach (string candidate in options.Columns!) {
-                if (string.IsNullOrWhiteSpace(candidate) || !added.Add(candidate)) continue;
-                List<string> selected = flattener.ResolvePaths(new[] { candidate }, options);
+                if (string.IsNullOrWhiteSpace(candidate)) continue;
+                string canonicalCandidate = ResolveDataTableRule(
+                    sourceColumnNames,
+                    candidate,
+                    nameof(options.Columns)) ?? candidate;
+                if (!added.Add(canonicalCandidate)) continue;
+                List<string> selected = flattener.ResolvePaths(new[] { canonicalCandidate }, options);
                 if (selected.Count == 0) continue;
                 if (paths.Count >= options.MaxColumns) {
                     EnsureDataTableColumnLimit(checked(paths.Count + 1), options.MaxColumns);
                 }
-                paths.Add(selected[0]);
+                paths.Add(canonicalCandidate);
             }
             return paths;
         }
@@ -220,7 +222,7 @@ namespace OfficeIMO.Excel.Fluent {
         private static InvalidDataException CreateAmbiguousDataTableRuleException(string rule, string optionName) =>
             new InvalidDataException(
                 $"DataTable column rule '{rule}' in {optionName} is ambiguous because the schema contains case-distinct or repeated matches. "
-                + "Use the exact full column name and casing in the projection rule.");
+                + "Use the exact column casing by specifying the exact full column name and casing in the projection rule.");
 
         private static void EnsureDataTableColumnLimit(int requiredColumns, int configuredMaxColumns) {
             if (requiredColumns <= configuredMaxColumns && requiredColumns <= A1.MaxColumns) return;

--- a/OfficeIMO.Excel/Fluent/SheetComposer.Table.DataTable.cs
+++ b/OfficeIMO.Excel/Fluent/SheetComposer.Table.DataTable.cs
@@ -66,7 +66,6 @@ namespace OfficeIMO.Excel.Fluent {
                 paths = ResolveExplicitDataTablePaths(flattener, options, sourceColumnNames);
             } else {
                 paths = ResolveProjectedDataTablePaths(
-                    flattener,
                     options,
                     sourceColumnNames,
                     configuredMaxColumns);
@@ -105,6 +104,8 @@ namespace OfficeIMO.Excel.Fluent {
             IReadOnlyList<string> sourceColumnNames) {
             var paths = new List<string>();
             var added = new HashSet<string>(StringComparer.Ordinal);
+            var selectedSourceColumns = ResolveDataTableFilterSelection(sourceColumnNames, options);
+            var selectedSourceColumnSet = new HashSet<string>(selectedSourceColumns, StringComparer.Ordinal);
             foreach (string candidate in options.Columns!) {
                 if (string.IsNullOrWhiteSpace(candidate)) continue;
                 string canonicalCandidate = ResolveDataTableRule(
@@ -112,8 +113,13 @@ namespace OfficeIMO.Excel.Fluent {
                     candidate,
                     nameof(options.Columns)) ?? candidate;
                 if (!added.Add(canonicalCandidate)) continue;
-                List<string> selected = flattener.ResolvePaths(new[] { canonicalCandidate }, options);
-                if (selected.Count == 0) continue;
+                bool isSourceColumn = sourceColumnNames.Contains(canonicalCandidate, StringComparer.Ordinal);
+                if (isSourceColumn) {
+                    if (!selectedSourceColumnSet.Contains(canonicalCandidate)) continue;
+                } else {
+                    List<string> selected = flattener.ResolvePaths(new[] { canonicalCandidate }, options);
+                    if (selected.Count == 0) continue;
+                }
                 if (paths.Count >= options.MaxColumns) {
                     EnsureDataTableColumnLimit(checked(paths.Count + 1), options.MaxColumns);
                 }
@@ -123,18 +129,114 @@ namespace OfficeIMO.Excel.Fluent {
         }
 
         private static List<string> ResolveProjectedDataTablePaths(
-            ObjectFlattener flattener,
             ObjectFlattenerOptions options,
             IReadOnlyList<string> sourceColumnNames,
             int configuredMaxColumns) {
-            var selected = new List<string>(sourceColumnNames.Count);
-            foreach (string sourceColumnName in sourceColumnNames) {
-                List<string> resolved = flattener.ResolvePaths(new[] { sourceColumnName }, options);
-                if (resolved.Count != 0) selected.Add(sourceColumnName);
-            }
-
+            List<string> selected = ResolveDataTableFilterSelection(sourceColumnNames, options);
             EnsureDataTableColumnLimit(selected.Count, configuredMaxColumns);
             return ApplyDataTableOrdering(selected, options);
+        }
+
+        private static List<string> ResolveDataTableFilterSelection(
+            IReadOnlyList<string> sourceColumnNames,
+            ObjectFlattenerOptions options) {
+            var selected = new List<string>(sourceColumnNames);
+            var ignored = ResolveDataTableFilterMatches(
+                sourceColumnNames,
+                options.Ignore,
+                nameof(options.Ignore),
+                prefixMatch: true);
+            var excluded = ResolveDataTableFilterMatches(
+                sourceColumnNames,
+                options.ExcludeProperties,
+                nameof(options.ExcludeProperties),
+                prefixMatch: false);
+            var removed = new HashSet<string>(ignored, StringComparer.Ordinal);
+            removed.UnionWith(excluded);
+            selected.RemoveAll(removed.Contains);
+
+            if (options.IncludeProperties.Length > 0) {
+                var included = new HashSet<string>(
+                    ResolveDataTableFilterMatches(
+                        sourceColumnNames,
+                        options.IncludeProperties,
+                        nameof(options.IncludeProperties),
+                        prefixMatch: false),
+                    StringComparer.Ordinal);
+                selected.RemoveAll(path => !included.Contains(path));
+            }
+
+            return selected;
+        }
+
+        private static List<string> ResolveDataTableFilterMatches(
+            IReadOnlyList<string> paths,
+            IEnumerable<string>? rules,
+            string optionName,
+            bool prefixMatch) {
+            var result = new List<string>();
+            var added = new HashSet<string>(StringComparer.Ordinal);
+            foreach (string rule in rules ?? Array.Empty<string>()) {
+                if (string.IsNullOrWhiteSpace(rule)) continue;
+
+                List<string> exactPaths = paths
+                    .Where(path => prefixMatch
+                        ? path.StartsWith(rule, StringComparison.Ordinal)
+                        : string.Equals(path, rule, StringComparison.Ordinal))
+                    .ToList();
+                if (exactPaths.Count > 0) {
+                    foreach (string path in exactPaths) if (added.Add(path)) result.Add(path);
+                    continue;
+                }
+
+                if (!prefixMatch) {
+                    List<string> exactSegments = paths
+                        .Where(path => string.Equals(GetLastSegment(path), rule, StringComparison.Ordinal))
+                        .ToList();
+                    if (exactSegments.Count > 0) {
+                        foreach (string path in exactSegments) if (added.Add(path)) result.Add(path);
+                        continue;
+                    }
+                }
+
+                List<string> insensitivePaths = paths
+                    .Where(path => prefixMatch
+                        ? path.StartsWith(rule, StringComparison.OrdinalIgnoreCase)
+                        : string.Equals(path, rule, StringComparison.OrdinalIgnoreCase))
+                    .ToList();
+                if (insensitivePaths.Count > 0) {
+                    EnsureUnambiguousDataTableFilterFallback(insensitivePaths, rule, optionName, prefixMatch);
+                    foreach (string path in insensitivePaths) if (added.Add(path)) result.Add(path);
+                    continue;
+                }
+
+                if (!prefixMatch) {
+                    List<string> insensitiveSegments = paths
+                        .Where(path => string.Equals(GetLastSegment(path), rule, StringComparison.OrdinalIgnoreCase))
+                        .ToList();
+                    if (insensitiveSegments.Count > 0) {
+                        EnsureUnambiguousDataTableFilterFallback(insensitiveSegments, rule, optionName, prefixMatch: false, compareLastSegment: true);
+                        foreach (string path in insensitiveSegments) if (added.Add(path)) result.Add(path);
+                    }
+                }
+            }
+            return result;
+        }
+
+        private static void EnsureUnambiguousDataTableFilterFallback(
+            IReadOnlyList<string> matches,
+            string rule,
+            string optionName,
+            bool prefixMatch,
+            bool compareLastSegment = false) {
+            var spellings = new HashSet<string>(StringComparer.Ordinal);
+            foreach (string match in matches) {
+                string spelling = compareLastSegment
+                    ? GetLastSegment(match)
+                    : prefixMatch ? match.Substring(0, Math.Min(rule.Length, match.Length)) : match;
+                spellings.Add(spelling);
+            }
+            if (spellings.Count > 1) throw CreateAmbiguousDataTableRuleException(rule, optionName);
         }
 
         private static List<string> ApplyDataTableOrdering(

--- a/OfficeIMO.Excel/Fluent/SheetComposer.Table.DataTable.cs
+++ b/OfficeIMO.Excel/Fluent/SheetComposer.Table.DataTable.cs
@@ -1,0 +1,142 @@
+using System.Data;
+using System.IO;
+using OfficeIMO.Data;
+
+namespace OfficeIMO.Excel.Fluent {
+    public sealed partial class SheetComposer {
+        /// <summary>
+        /// Renders a fixed-schema <see cref="DataTable"/> as an editable Excel table without generic object flattening.
+        /// The DataTable schema order is preserved unless the projection configuration selects another order.
+        /// </summary>
+        /// <param name="table">Source table whose rows and schema are already materialized.</param>
+        /// <param name="title">Optional section title and table name.</param>
+        /// <param name="configure">
+        /// Optional column selection, exclusion, ordering, and header configuration. Generic object-expansion and
+        /// cell-materialization limits are not used by this fixed-schema overload.
+        /// </param>
+        /// <param name="style">Built-in Excel table style.</param>
+        /// <param name="autoFilter">Whether table filter buttons are included.</param>
+        /// <param name="freezeHeaderRow">Whether rows through the table header are frozen.</param>
+        /// <param name="visuals">Optional table visual configuration.</param>
+        /// <returns>The A1 range occupied by the table.</returns>
+        public string TableFrom(
+            DataTable table,
+            string? title = null,
+            Action<ObjectFlattenerOptions>? configure = null,
+            ExcelTableStyle style = ExcelTableStyle.TableStyleMedium9,
+            bool autoFilter = true,
+            bool freezeHeaderRow = true,
+            Action<TableVisualOptions>? visuals = null) {
+            if (table == null) throw new ArgumentNullException(nameof(table));
+            if (!string.IsNullOrWhiteSpace(title)) Section(title!);
+
+            if (table.Rows.Count == 0) {
+                Sheet.Cell(_row, 1, "(no data)");
+                _row++;
+                return $"A{_row - 1}:A{_row - 1}";
+            }
+
+            var options = new ObjectFlattenerOptions();
+            configure?.Invoke(options);
+            int configuredMaxColumns = options.MaxColumns;
+            if (configuredMaxColumns <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(options.MaxColumns), "MaxColumns must be greater than zero.");
+            }
+            options.MaxColumns = Math.Min(options.MaxColumns, A1.MaxColumns);
+
+            var sourceColumnNames = table.Columns
+                .Cast<DataColumn>()
+                .Select(column => column.ColumnName)
+                .ToArray();
+            var flattener = new ObjectFlattener();
+            bool hasExplicitColumns = options.Columns is { Length: > 0 };
+            bool hasProjectionRules = hasExplicitColumns
+                || options.Ignore?.Length > 0
+                || options.IncludeProperties?.Length > 0
+                || options.ExcludeProperties?.Length > 0
+                || options.PinnedFirst?.Length > 0
+                || options.PinnedLast?.Length > 0
+                || options.PropertyPriority.Count > 0
+                || options.MaxColumns < sourceColumnNames.Length;
+            List<string> paths;
+            if (!hasProjectionRules) {
+                EnsureDataTableColumnLimit(sourceColumnNames.Length, configuredMaxColumns);
+                paths = sourceColumnNames.ToList();
+            } else if (hasExplicitColumns) {
+                paths = ResolveExplicitDataTablePaths(flattener, options);
+            } else {
+                try {
+                    paths = flattener.ResolvePaths(sourceColumnNames, options);
+                } catch (InvalidDataException exception) {
+                    if (exception.Data["OfficeIMO.RequiredColumns"] is int requiredColumns) {
+                        EnsureDataTableColumnLimit(requiredColumns, configuredMaxColumns);
+                    }
+                    throw;
+                }
+            }
+            if (paths.Count == 0) {
+                Sheet.Cell(_row, 1, "(no tabular columns for the DataTable schema)");
+                _row++;
+                return $"A{_row - 1}:A{_row - 1}";
+            }
+
+            int headerRow = _row;
+            int lastRow = checked(headerRow + table.Rows.Count);
+            if (lastRow > A1.MaxRows) {
+                throw new InvalidDataException(
+                    $"TableFrom(DataTable) requires rows {headerRow} through {lastRow}, exceeding Excel's {A1.MaxRows}-row worksheet limit. "
+                    + "Split the data across multiple worksheets or start the table earlier; Excel's worksheet row limit cannot be overridden.");
+            }
+
+            List<string> headers = BuildTransformedHeaders(paths, options);
+            EnsureUniqueTableHeaders(headers);
+            var source = new DataTableTabularRowSource(table, paths, headers);
+            string range = Sheet.InsertTabularRowSourceAsTableForDeferredMaterialization(
+                source,
+                startRow: headerRow,
+                startColumn: 1,
+                includeHeaders: true,
+                tableName: title ?? "Table",
+                style: style,
+                includeAutoFilter: autoFilter);
+            if (string.IsNullOrEmpty(range)) {
+                throw new InvalidOperationException("The fixed-schema DataTable could not be inserted into the target worksheet.");
+            }
+
+            return CompleteTable(range, paths, headers, headerRow, lastRow, style, freezeHeaderRow, visuals);
+        }
+
+        private static List<string> ResolveExplicitDataTablePaths(
+            ObjectFlattener flattener,
+            ObjectFlattenerOptions options) {
+            var paths = new List<string>();
+            var added = new HashSet<string>(StringComparer.Ordinal);
+            foreach (string candidate in options.Columns!) {
+                if (string.IsNullOrWhiteSpace(candidate) || !added.Add(candidate)) continue;
+                List<string> selected = flattener.ResolvePaths(new[] { candidate }, options);
+                if (selected.Count == 0) continue;
+                if (paths.Count >= options.MaxColumns) {
+                    EnsureDataTableColumnLimit(checked(paths.Count + 1), options.MaxColumns);
+                }
+                paths.Add(selected[0]);
+            }
+            return paths;
+        }
+
+        private static void EnsureDataTableColumnLimit(int requiredColumns, int configuredMaxColumns) {
+            if (requiredColumns <= configuredMaxColumns && requiredColumns <= A1.MaxColumns) return;
+            if (requiredColumns > A1.MaxColumns && configuredMaxColumns >= A1.MaxColumns) {
+                throw CreateExcelColumnLimitException(requiredColumns);
+            }
+
+            throw new InvalidDataException(
+                $"TableFrom(DataTable) requires at least {requiredColumns} columns, exceeding the {configuredMaxColumns}-column materialization limit (MaxColumns). "
+                + $"If this projection is intentional, raise the limit with configure: options => options.MaxColumns = {requiredColumns}.");
+        }
+
+        private static InvalidDataException CreateExcelColumnLimitException(int requiredColumns) =>
+            new InvalidDataException(
+                $"TableFrom(DataTable) requires at least {requiredColumns} columns, exceeding Excel's {A1.MaxColumns}-column worksheet limit. "
+                + "Select fewer columns or split the data across multiple worksheets; Excel's worksheet column limit cannot be overridden.");
+    }
+}

--- a/OfficeIMO.Excel/Fluent/SheetComposer.Table.Visuals.cs
+++ b/OfficeIMO.Excel/Fluent/SheetComposer.Table.Visuals.cs
@@ -1,0 +1,97 @@
+namespace OfficeIMO.Excel.Fluent {
+    public sealed partial class SheetComposer {
+        private string CompleteTable(
+            string range,
+            IReadOnlyList<string> paths,
+            List<string> headers,
+            int headerRow,
+            int lastRow,
+            ExcelTableStyle style,
+            bool freezeHeaderRow,
+            Action<TableVisualOptions>? visuals) {
+            _row = lastRow + 1;
+            var visualOptions = new TableVisualOptions {
+                FreezeHeaderRow = freezeHeaderRow
+            };
+            visuals?.Invoke(visualOptions);
+            Sheet.SetTableStyle(
+                range,
+                style,
+                visualOptions.ShowFirstColumn,
+                visualOptions.ShowLastColumn,
+                visualOptions.ShowRowStripes,
+                visualOptions.ShowColumnStripes);
+            if (visualOptions.FreezeHeaderRow) Sheet.Freeze(topRows: headerRow, leftCols: 0);
+
+            const int startColumn = 1;
+            for (int index = 0; index < headers.Count; index++) {
+                string header = headers[index];
+                string columnRange = $"{ColumnLetter(startColumn + index)}{headerRow + 1}:{ColumnLetter(startColumn + index)}{lastRow}";
+
+                if (visualOptions.NumericColumnFormats.TryGetValue(header, out string? format)) {
+                    if (Sheet.TryGetColumnIndexByHeader(header, out _))
+                        Sheet.ColumnStyleByHeader(header).NumberFormat(format);
+                } else if (visualOptions.NumericColumnDecimals.TryGetValue(header, out int decimals)) {
+                    if (Sheet.TryGetColumnIndexByHeader(header, out _))
+                        Sheet.ColumnStyleByHeader(header).Number(decimals);
+                }
+
+                if (visualOptions.DataBars.TryGetValue(header, out var color))
+                    Sheet.AddConditionalDataBar(columnRange, color);
+
+                if (visualOptions.IconSets.TryGetValue(header, out var iconOptions))
+                    Sheet.AddConditionalIconSet(columnRange, iconOptions.IconSet, iconOptions.ShowValue, iconOptions.ReverseOrder, iconOptions.PercentThresholds, iconOptions.NumberThresholds);
+                else if (visualOptions.IconSetColumns.Contains(header))
+                    Sheet.AddConditionalIconSet(columnRange);
+
+                if (visualOptions.TextBackgrounds.TryGetValue(header, out var backgroundMap)) {
+                    if (Sheet.TryGetColumnIndexByHeader(header, out _)) {
+                        Sheet.ColumnStyleByHeader(header).BackgroundByTextMap(backgroundMap);
+                    } else {
+                        for (int row = headerRow + 1; row <= lastRow; row++)
+                            if (Sheet.TryGetCellText(row, startColumn + index, out string? text) && text != null && backgroundMap.TryGetValue(text, out string? colorHex))
+                                Sheet.CellBackground(row, startColumn + index, colorHex);
+                    }
+                }
+
+                if (visualOptions.BoldByText.TryGetValue(header, out var boldValues)) {
+                    if (Sheet.TryGetColumnIndexByHeader(header, out _)) {
+                        Sheet.ColumnStyleByHeader(header).BoldByTextSet(boldValues);
+                    } else {
+                        var values = new HashSet<string>(boldValues, StringComparer.OrdinalIgnoreCase);
+                        for (int row = headerRow + 1; row <= lastRow; row++)
+                            if (Sheet.TryGetCellText(row, startColumn + index, out string? text) && !string.IsNullOrEmpty(text) && values.Contains(text))
+                                Sheet.CellBold(row, startColumn + index, true);
+                    }
+                }
+            }
+
+            if (visualOptions.AutoFormatDynamicCollections) {
+                for (int index = 0; index < paths.Count; index++) {
+                    if (!paths[index].Contains('.')) continue;
+                    string header = headers[index];
+                    if (Sheet.TryGetColumnIndexByHeader(header, out _))
+                        Sheet.ColumnStyleByHeader(header).Number(visualOptions.AutoFormatDecimals);
+                    string columnRange = $"{ColumnLetter(startColumn + index)}{headerRow + 1}:{ColumnLetter(startColumn + index)}{lastRow}";
+                    Sheet.AddConditionalDataBar(columnRange, visualOptions.AutoFormatDataBarColor);
+                }
+            }
+
+            Spacer();
+            return range;
+        }
+
+        private static void EnsureUniqueTableHeaders(List<string> headers) {
+            var usedHeaders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            for (int index = 0; index < headers.Count; index++) {
+                string baseName = string.IsNullOrWhiteSpace(headers[index]) ? $"Column{index + 1}" : headers[index];
+                string candidate = baseName;
+                int suffix = 2;
+                while (!usedHeaders.Add(candidate)) {
+                    candidate = $"{baseName} ({suffix++})";
+                }
+                headers[index] = candidate;
+            }
+        }
+    }
+}

--- a/OfficeIMO.Excel/Fluent/SheetComposer.Table.Visuals.cs
+++ b/OfficeIMO.Excel/Fluent/SheetComposer.Table.Visuals.cs
@@ -27,13 +27,16 @@ namespace OfficeIMO.Excel.Fluent {
             for (int index = 0; index < headers.Count; index++) {
                 string header = headers[index];
                 string columnRange = $"{ColumnLetter(startColumn + index)}{headerRow + 1}:{ColumnLetter(startColumn + index)}{lastRow}";
+                var columnStyle = new ExcelColumnStyleByHeaderBuilder(
+                    Sheet,
+                    startColumn + index,
+                    headerRow + 1,
+                    lastRow);
 
                 if (visualOptions.NumericColumnFormats.TryGetValue(header, out string? format)) {
-                    if (Sheet.TryGetColumnIndexByHeader(header, out _))
-                        Sheet.ColumnStyleByHeader(header).NumberFormat(format);
+                    columnStyle.NumberFormat(format);
                 } else if (visualOptions.NumericColumnDecimals.TryGetValue(header, out int decimals)) {
-                    if (Sheet.TryGetColumnIndexByHeader(header, out _))
-                        Sheet.ColumnStyleByHeader(header).Number(decimals);
+                    columnStyle.Number(decimals);
                 }
 
                 if (visualOptions.DataBars.TryGetValue(header, out var color))
@@ -45,33 +48,23 @@ namespace OfficeIMO.Excel.Fluent {
                     Sheet.AddConditionalIconSet(columnRange);
 
                 if (visualOptions.TextBackgrounds.TryGetValue(header, out var backgroundMap)) {
-                    if (Sheet.TryGetColumnIndexByHeader(header, out _)) {
-                        Sheet.ColumnStyleByHeader(header).BackgroundByTextMap(backgroundMap);
-                    } else {
-                        for (int row = headerRow + 1; row <= lastRow; row++)
-                            if (Sheet.TryGetCellText(row, startColumn + index, out string? text) && text != null && backgroundMap.TryGetValue(text, out string? colorHex))
-                                Sheet.CellBackground(row, startColumn + index, colorHex);
-                    }
+                    columnStyle.BackgroundByTextMap(backgroundMap);
                 }
 
                 if (visualOptions.BoldByText.TryGetValue(header, out var boldValues)) {
-                    if (Sheet.TryGetColumnIndexByHeader(header, out _)) {
-                        Sheet.ColumnStyleByHeader(header).BoldByTextSet(boldValues);
-                    } else {
-                        var values = new HashSet<string>(boldValues, StringComparer.OrdinalIgnoreCase);
-                        for (int row = headerRow + 1; row <= lastRow; row++)
-                            if (Sheet.TryGetCellText(row, startColumn + index, out string? text) && !string.IsNullOrEmpty(text) && values.Contains(text))
-                                Sheet.CellBold(row, startColumn + index, true);
-                    }
+                    columnStyle.BoldByTextSet(boldValues);
                 }
             }
 
             if (visualOptions.AutoFormatDynamicCollections) {
                 for (int index = 0; index < paths.Count; index++) {
                     if (!paths[index].Contains('.')) continue;
-                    string header = headers[index];
-                    if (Sheet.TryGetColumnIndexByHeader(header, out _))
-                        Sheet.ColumnStyleByHeader(header).Number(visualOptions.AutoFormatDecimals);
+                    var columnStyle = new ExcelColumnStyleByHeaderBuilder(
+                        Sheet,
+                        startColumn + index,
+                        headerRow + 1,
+                        lastRow);
+                    columnStyle.Number(visualOptions.AutoFormatDecimals);
                     string columnRange = $"{ColumnLetter(startColumn + index)}{headerRow + 1}:{ColumnLetter(startColumn + index)}{lastRow}";
                     Sheet.AddConditionalDataBar(columnRange, visualOptions.AutoFormatDataBarColor);
                 }

--- a/OfficeIMO.Excel/Fluent/SheetComposer.Table.Visuals.cs
+++ b/OfficeIMO.Excel/Fluent/SheetComposer.Table.Visuals.cs
@@ -8,7 +8,8 @@ namespace OfficeIMO.Excel.Fluent {
             int lastRow,
             ExcelTableStyle style,
             bool freezeHeaderRow,
-            Action<TableVisualOptions>? visuals) {
+            Action<TableVisualOptions>? visuals,
+            bool pathsRepresentFlattenedObjects = true) {
             _row = lastRow + 1;
             var visualOptions = new TableVisualOptions {
                 FreezeHeaderRow = freezeHeaderRow
@@ -56,7 +57,7 @@ namespace OfficeIMO.Excel.Fluent {
                 }
             }
 
-            if (visualOptions.AutoFormatDynamicCollections) {
+            if (pathsRepresentFlattenedObjects && visualOptions.AutoFormatDynamicCollections) {
                 for (int index = 0; index < paths.Count; index++) {
                     if (!paths[index].Contains('.')) continue;
                     var columnStyle = new ExcelColumnStyleByHeaderBuilder(

--- a/OfficeIMO.Excel/Fluent/SheetComposer.Table.cs
+++ b/OfficeIMO.Excel/Fluent/SheetComposer.Table.cs
@@ -20,11 +20,19 @@ namespace OfficeIMO.Excel.Fluent {
 
             var opts = new ObjectFlattenerOptions();
             configure?.Invoke(opts);
+            string? maxColumnsGuidance = opts.MaxColumns >= A1.MaxColumns
+                ? $"Select fewer columns or split the data across multiple worksheets; Excel's {A1.MaxColumns}-column worksheet limit cannot be overridden."
+                : null;
             opts.MaxColumns = System.Math.Min(opts.MaxColumns, A1.MaxColumns);
             var flattener = new ObjectFlattener();
 
             ObjectTableProjection projection = flattener.FlattenRows(
-                items, opts, "TableFrom", headerRowCount: 1, enforceEmptyProjectionLimits: false);
+                items,
+                opts,
+                "TableFrom",
+                headerRowCount: 1,
+                enforceEmptyProjectionLimits: false,
+                columnLimitGuidance: maxColumnsGuidance);
             IReadOnlyList<System.Collections.Generic.Dictionary<string, object?>> rows = projection.Rows;
             if (rows.Count == 0) {
                 Sheet.Cell(_row, 1, "(no data)");

--- a/OfficeIMO.Excel/Fluent/SheetComposer.Table.cs
+++ b/OfficeIMO.Excel/Fluent/SheetComposer.Table.cs
@@ -20,7 +20,7 @@ namespace OfficeIMO.Excel.Fluent {
 
             var opts = new ObjectFlattenerOptions();
             configure?.Invoke(opts);
-            string? maxColumnsGuidance = opts.MaxColumns >= A1.MaxColumns
+            Func<int, string?> maxColumnsGuidance = requiredColumns => requiredColumns > A1.MaxColumns
                 ? $"Select fewer columns or split the data across multiple worksheets; Excel's {A1.MaxColumns}-column worksheet limit cannot be overridden."
                 : null;
             opts.MaxColumns = System.Math.Min(opts.MaxColumns, A1.MaxColumns);

--- a/OfficeIMO.Excel/Fluent/SheetComposer.Table.cs
+++ b/OfficeIMO.Excel/Fluent/SheetComposer.Table.cs
@@ -20,6 +20,11 @@ namespace OfficeIMO.Excel.Fluent {
 
             var opts = new ObjectFlattenerOptions();
             configure?.Invoke(opts);
+            int maximumDataRows = A1.MaxRows - _row;
+            Func<int, string?> maxRowsGuidance = requiredRows => requiredRows > maximumDataRows
+                ? $"Split the data across multiple worksheets; this table has room for at most {maximumDataRows} data rows after its title and header, and Excel's {A1.MaxRows}-row worksheet limit cannot be overridden."
+                : null;
+            opts.MaxRows = System.Math.Min(opts.MaxRows, maximumDataRows);
             Func<int, string?> maxColumnsGuidance = requiredColumns => requiredColumns > A1.MaxColumns
                 ? $"Select fewer columns or split the data across multiple worksheets; Excel's {A1.MaxColumns}-column worksheet limit cannot be overridden."
                 : null;
@@ -32,6 +37,7 @@ namespace OfficeIMO.Excel.Fluent {
                 "TableFrom",
                 headerRowCount: 1,
                 enforceEmptyProjectionLimits: false,
+                rowLimitGuidance: maxRowsGuidance,
                 columnLimitGuidance: maxColumnsGuidance);
             IReadOnlyList<System.Collections.Generic.Dictionary<string, object?>> rows = projection.Rows;
             if (rows.Count == 0) {

--- a/OfficeIMO.Excel/Fluent/SheetComposer.Table.cs
+++ b/OfficeIMO.Excel/Fluent/SheetComposer.Table.cs
@@ -46,18 +46,8 @@ namespace OfficeIMO.Excel.Fluent {
 
             int headerRow = _row;
             var cells = new List<(int Row, int Column, object Value)>(System.Math.Max(1, (rows.Count + 1) * System.Math.Max(1, paths.Count)));
-            var headersT = paths.Select(p => TransformHeader(p, opts)).ToList();
-            // De-duplicate header captions to avoid Excel silently renaming duplicates
-            var usedHeaders = new System.Collections.Generic.HashSet<string>(System.StringComparer.OrdinalIgnoreCase);
-            for (int i = 0; i < headersT.Count; i++) {
-                string baseName = string.IsNullOrWhiteSpace(headersT[i]) ? $"Column{i + 1}" : headersT[i];
-                string candidate = baseName;
-                int suffix = 2;
-                while (!usedHeaders.Add(candidate)) {
-                    candidate = $"{baseName} ({suffix++})";
-                }
-                headersT[i] = candidate;
-            }
+            var headersT = BuildTransformedHeaders(paths, opts);
+            EnsureUniqueTableHeaders(headersT);
             for (int i = 0; i < headersT.Count; i++) {
                 cells.Add((_row, i + 1, headersT[i]));
             }
@@ -79,67 +69,7 @@ namespace OfficeIMO.Excel.Fluent {
 
             var tableName = title ?? "Table";
             Sheet.AddTable(range, hasHeader: true, name: tableName, style: style, includeAutoFilter: autoFilter);
-
-            var viz = new TableVisualOptions();
-            viz.FreezeHeaderRow = freezeHeaderRow; visuals?.Invoke(viz);
-            Sheet.SetTableStyle(range, style, viz.ShowFirstColumn, viz.ShowLastColumn, viz.ShowRowStripes, viz.ShowColumnStripes);
-            if (viz.FreezeHeaderRow) Sheet.Freeze(topRows: headerRow, leftCols: 0);
-
-            var headers = headersT; int startCol = 1;
-            for (int i = 0; i < headers.Count; i++) {
-                string hdr = headers[i];
-                string colRange = $"{ColumnLetter(startCol + i)}{headerRow + 1}:{ColumnLetter(startCol + i)}{_row - 1}";
-
-                if (viz.NumericColumnFormats.TryGetValue(hdr, out var fmt)) {
-                    if (Sheet.TryGetColumnIndexByHeader(hdr, out _))
-                        Sheet.ColumnStyleByHeader(hdr).NumberFormat(fmt);
-                } else if (viz.NumericColumnDecimals.TryGetValue(hdr, out var dec)) {
-                    if (Sheet.TryGetColumnIndexByHeader(hdr, out _))
-                        Sheet.ColumnStyleByHeader(hdr).Number(dec);
-                }
-
-                if (viz.DataBars.TryGetValue(hdr, out var color))
-                    Sheet.AddConditionalDataBar(colRange, color);
-
-                if (viz.IconSets.TryGetValue(hdr, out var iconOpts))
-                    Sheet.AddConditionalIconSet(colRange, iconOpts.IconSet, iconOpts.ShowValue, iconOpts.ReverseOrder, iconOpts.PercentThresholds, iconOpts.NumberThresholds);
-                else if (viz.IconSetColumns.Contains(hdr))
-                    Sheet.AddConditionalIconSet(colRange);
-
-                if (viz.TextBackgrounds.TryGetValue(hdr, out var map)) {
-                    if (Sheet.TryGetColumnIndexByHeader(hdr, out _)) {
-                        Sheet.ColumnStyleByHeader(hdr).BackgroundByTextMap(map);
-                    } else {
-                        for (int r = headerRow + 1; r <= _row - 1; r++)
-                            if (Sheet.TryGetCellText(r, startCol + i, out var t) && t != null && map.TryGetValue(t, out var colorHex))
-                                Sheet.CellBackground(r, startCol + i, colorHex);
-                    }
-                }
-                if (viz.BoldByText.TryGetValue(hdr, out var boldSet)) {
-                    if (Sheet.TryGetColumnIndexByHeader(hdr, out _)) {
-                        Sheet.ColumnStyleByHeader(hdr).BoldByTextSet(boldSet);
-                    } else {
-                        var setCI = new System.Collections.Generic.HashSet<string>(boldSet, System.StringComparer.OrdinalIgnoreCase);
-                        for (int r = headerRow + 1; r <= _row - 1; r++)
-                            if (Sheet.TryGetCellText(r, startCol + i, out var t) && !string.IsNullOrEmpty(t) && setCI.Contains(t))
-                                Sheet.CellBold(r, startCol + i, true);
-                    }
-                }
-            }
-
-            if (viz.AutoFormatDynamicCollections) {
-                for (int i = 0; i < paths.Count; i++) {
-                    if (paths[i].Contains('.')) {
-                        var hdr = headers[i];
-                        if (Sheet.TryGetColumnIndexByHeader(hdr, out _))
-                            Sheet.ColumnStyleByHeader(hdr).Number(viz.AutoFormatDecimals);
-                        string colRangeAuto = $"{ColumnLetter(startCol + i)}{headerRow + 1}:{ColumnLetter(startCol + i)}{_row - 1}";
-                        Sheet.AddConditionalDataBar(colRangeAuto, viz.AutoFormatDataBarColor);
-                    }
-                }
-            }
-            Spacer();
-            return range;
+            return CompleteTable(range, paths, headersT, headerRow, lastRow, style, freezeHeaderRow, visuals);
         }
 
     }

--- a/OfficeIMO.Excel/README.md
+++ b/OfficeIMO.Excel/README.md
@@ -726,6 +726,32 @@ document.Compose("Report", composer => {
 document.Save();
 ```
 
+When rows already have a fixed schema, pass a `DataTable` directly. This keeps
+its column order, avoids generic object flattening, and does not apply the
+generic `MaxCells` materialization guard. Excel's worksheet row and column
+limits still apply; select or split data that exceeds them.
+
+```csharp
+using System.Data;
+using OfficeIMO.Excel;
+
+var rows = new DataTable("Members");
+rows.Columns.Add("Enabled", typeof(bool));
+rows.Columns.Add("AD State", typeof(string));
+rows.Rows.Add(true, "Enabled");
+rows.Rows.Add(false, "Disabled");
+
+using var document = ExcelDocument.Create("members.xlsx");
+document.Compose("Members", composer => {
+    composer.TableFrom(
+        rows,
+        title: "Members",
+        configure: options => options.Columns = new[] { "Enabled", "AD State" });
+    composer.Finish(autoFitColumns: true);
+});
+document.Save();
+```
+
 ## Managed image export
 
 Ranges, worksheets, and workbook batches can be exported as PNG, JPEG, TIFF, lossless WebP, or SVG:

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.Tables.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.Tables.cs
@@ -73,7 +73,7 @@ namespace OfficeIMO.Tests {
             InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
                 slide.AddTable(rows, options => {
                     options.Columns = columns;
-                    options.MaxCells = long.MaxValue;
+                    options.MaxCells = 50_000;
                 }));
 
             Assert.Contains("requires at least 101000 cells", exception.Message, StringComparison.Ordinal);

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.Tables.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.Tables.cs
@@ -42,6 +42,47 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void ObjectTableExplainsHardColumnBoundary() {
+            using var stream = new MemoryStream();
+            using PowerPointPresentation presentation = PowerPointPresentation.Create(stream);
+            PowerPointSlide slide = presentation.AddSlide();
+            var row = Enumerable.Range(0, 1_025)
+                .ToDictionary(index => "Column" + index, index => (object?)index);
+
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+                slide.AddTable(new[] { row }, options => options.MaxColumns = int.MaxValue));
+
+            Assert.Contains("requires at least 1025 columns", exception.Message, StringComparison.Ordinal);
+            Assert.Contains("Select fewer columns or split the data across multiple tables", exception.Message, StringComparison.Ordinal);
+            Assert.Contains("cannot be overridden", exception.Message, StringComparison.Ordinal);
+            Assert.DoesNotContain("MaxColumns to at least 1025", exception.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ObjectTableExplainsHardCellBoundary() {
+            using var stream = new MemoryStream();
+            using PowerPointPresentation presentation = PowerPointPresentation.Create(stream);
+            PowerPointSlide slide = presentation.AddSlide();
+            var rows = Enumerable.Range(0, 100)
+                .Select(_ => new System.Collections.Generic.Dictionary<string, object?>())
+                .ToArray();
+            string[] columns = Enumerable.Range(0, 1_000)
+                .Select(index => "Column" + index)
+                .ToArray();
+
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+                slide.AddTable(rows, options => {
+                    options.Columns = columns;
+                    options.MaxCells = long.MaxValue;
+                }));
+
+            Assert.Contains("requires at least 101000 cells", exception.Message, StringComparison.Ordinal);
+            Assert.Contains("Select fewer rows or columns, or split the data across multiple tables", exception.Message, StringComparison.Ordinal);
+            Assert.Contains("cannot be overridden", exception.Message, StringComparison.Ordinal);
+            Assert.DoesNotContain("MaxCells to at least 101000", exception.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void ObjectTableRejectsNonPositiveRowLimitBeforeInspectingSource() {
             using var stream = new MemoryStream();
             using PowerPointPresentation presentation = PowerPointPresentation.Create(stream);
@@ -67,10 +108,12 @@ namespace OfficeIMO.Tests {
                 }
             };
 
-            Assert.Throws<InvalidDataException>(() => slide.AddTable(rows, options => {
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() => slide.AddTable(rows, options => {
                 options.MaxCells = 5;
                 options.CollectionMode = OfficeIMO.Data.CollectionMode.ExpandRows;
             }));
+            Assert.Contains("requires at least 6 cells", exception.Message, StringComparison.Ordinal);
+            Assert.Contains("options.MaxCells = 6", exception.Message, StringComparison.Ordinal);
         }
 
         [Fact]

--- a/OfficeIMO.PowerPoint/PowerPointSlide.Tables.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSlide.Tables.cs
@@ -178,12 +178,23 @@ namespace OfficeIMO.PowerPoint {
 
             var options = new ObjectFlattenerOptions();
             configure?.Invoke(options);
+            string? maxColumnsGuidance = options.MaxColumns >= MaximumObjectTableColumns
+                ? $"Select fewer columns or split the data across multiple tables; PowerPoint AddTable's {MaximumObjectTableColumns}-column limit cannot be overridden."
+                : null;
+            string? maxCellsGuidance = options.MaxCells >= MaximumObjectTableCells
+                ? $"Select fewer rows or columns, or split the data across multiple tables; PowerPoint AddTable's {MaximumObjectTableCells}-cell limit cannot be overridden."
+                : null;
             options.MaxColumns = Math.Min(options.MaxColumns, MaximumObjectTableColumns);
             options.MaxCells = Math.Min(options.MaxCells, MaximumObjectTableCells);
             var flattener = new ObjectFlattener();
 
             ObjectTableProjection projection = flattener.FlattenRows(
-                data, options, "PowerPoint AddTable", includeHeaders ? 1 : 0);
+                data,
+                options,
+                "PowerPoint AddTable",
+                includeHeaders ? 1 : 0,
+                columnLimitGuidance: maxColumnsGuidance,
+                cellLimitGuidance: maxCellsGuidance);
             IReadOnlyList<string> paths = projection.Columns;
 
             if (paths.Count == 0) {
@@ -210,7 +221,11 @@ namespace OfficeIMO.PowerPoint {
                                     $"PowerPoint AddTable nested expansion exceeds the {options.MaxRows}-row materialization limit.");
                             }
                             EnsureObjectTableCellLimit(
-                                rowsData.Count + 1, paths.Count, includeHeaders, options.MaxCells);
+                                rowsData.Count + 1,
+                                paths.Count,
+                                includeHeaders,
+                                options.MaxCells,
+                                maxCellsGuidance);
                             expanded = true;
                             var rowValues = paths.Select(p => p == collectionPath ? element :
                                 dict.TryGetValue(p, out var v) ? v :
@@ -224,7 +239,11 @@ namespace OfficeIMO.PowerPoint {
                                     $"PowerPoint AddTable exceeds the {options.MaxRows}-row materialization limit.");
                             }
                             EnsureObjectTableCellLimit(
-                                rowsData.Count + 1, paths.Count, includeHeaders, options.MaxCells);
+                                rowsData.Count + 1,
+                                paths.Count,
+                                includeHeaders,
+                                options.MaxCells,
+                                maxCellsGuidance);
                             rowsData.Add(paths.Select(p => dict.TryGetValue(p, out var v) ? v :
                                 (options.DefaultValues.TryGetValue(p, out var d) ? d : null)).ToArray());
                         }
@@ -237,7 +256,11 @@ namespace OfficeIMO.PowerPoint {
                         $"PowerPoint AddTable exceeds the {options.MaxRows}-row materialization limit.");
                 }
                 EnsureObjectTableCellLimit(
-                    rowsData.Count + 1, paths.Count, includeHeaders, options.MaxCells);
+                    rowsData.Count + 1,
+                    paths.Count,
+                    includeHeaders,
+                    options.MaxCells,
+                    maxCellsGuidance);
                 rowsData.Add(paths.Select(p => dict.TryGetValue(p, out var v) ? v :
                     (options.DefaultValues.TryGetValue(p, out var d) ? d : null)).ToArray());
             }
@@ -278,11 +301,14 @@ namespace OfficeIMO.PowerPoint {
             int dataRowCount,
             int columnCount,
             bool includeHeaders,
-            long maximumCells) {
+            long maximumCells,
+            string? limitGuidance = null) {
             long projectedCells = ((long)dataRowCount + (includeHeaders ? 1L : 0L)) * columnCount;
             if (projectedCells > maximumCells) {
+                string guidance = limitGuidance
+                    ?? $"If this materialization is intentional, raise the limit with configure: options => options.MaxCells = {projectedCells}.";
                 throw new InvalidDataException(
-                    $"PowerPoint AddTable exceeds the {maximumCells}-cell materialization limit.");
+                    $"PowerPoint AddTable requires at least {projectedCells} cells, exceeding the {maximumCells}-cell materialization limit (MaxCells). {guidance}");
             }
         }
 

--- a/OfficeIMO.PowerPoint/PowerPointSlide.Tables.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSlide.Tables.cs
@@ -178,12 +178,8 @@ namespace OfficeIMO.PowerPoint {
 
             var options = new ObjectFlattenerOptions();
             configure?.Invoke(options);
-            string? maxColumnsGuidance = options.MaxColumns >= MaximumObjectTableColumns
-                ? $"Select fewer columns or split the data across multiple tables; PowerPoint AddTable's {MaximumObjectTableColumns}-column limit cannot be overridden."
-                : null;
-            string? maxCellsGuidance = options.MaxCells >= MaximumObjectTableCells
-                ? $"Select fewer rows or columns, or split the data across multiple tables; PowerPoint AddTable's {MaximumObjectTableCells}-cell limit cannot be overridden."
-                : null;
+            Func<int, string?> maxColumnsGuidance = GetObjectTableColumnLimitGuidance;
+            Func<long, string?> maxCellsGuidance = GetObjectTableCellLimitGuidance;
             options.MaxColumns = Math.Min(options.MaxColumns, MaximumObjectTableColumns);
             options.MaxCells = Math.Min(options.MaxCells, MaximumObjectTableCells);
             var flattener = new ObjectFlattener();
@@ -302,10 +298,10 @@ namespace OfficeIMO.PowerPoint {
             int columnCount,
             bool includeHeaders,
             long maximumCells,
-            string? limitGuidance = null) {
+            Func<long, string?>? limitGuidance = null) {
             long projectedCells = ((long)dataRowCount + (includeHeaders ? 1L : 0L)) * columnCount;
             if (projectedCells > maximumCells) {
-                string guidance = limitGuidance
+                string guidance = limitGuidance?.Invoke(projectedCells)
                     ?? $"If this materialization is intentional, raise the limit with configure: options => options.MaxCells = {projectedCells}.";
                 throw new InvalidDataException(
                     $"PowerPoint AddTable requires at least {projectedCells} cells, exceeding the {maximumCells}-cell materialization limit (MaxCells). {guidance}");
@@ -339,7 +335,12 @@ namespace OfficeIMO.PowerPoint {
                 data,
                 maximumDataRows,
                 $"PowerPoint AddTable exceeds the {MaximumObjectTableCells}-cell materialization limit.");
-            EnsureObjectTableCellLimit(items.Count, columnList.Count, includeHeaders, MaximumObjectTableCells);
+            EnsureObjectTableCellLimit(
+                items.Count,
+                columnList.Count,
+                includeHeaders,
+                MaximumObjectTableCells,
+                GetObjectTableCellLimitGuidance);
 
             int totalRows = items.Count + (includeHeaders ? 1 : 0);
             if (totalRows == 0) {
@@ -370,6 +371,16 @@ namespace OfficeIMO.PowerPoint {
             ApplyColumnWidths(table, width, columnList);
             return table;
         }
+
+        private static string? GetObjectTableColumnLimitGuidance(int requiredColumns) =>
+            requiredColumns > MaximumObjectTableColumns
+                ? $"Select fewer columns or split the data across multiple tables; PowerPoint AddTable's {MaximumObjectTableColumns}-column limit cannot be overridden."
+                : null;
+
+        private static string? GetObjectTableCellLimitGuidance(long requiredCells) =>
+            requiredCells > MaximumObjectTableCells
+                ? $"Select fewer rows or columns, or split the data across multiple tables; PowerPoint AddTable's {MaximumObjectTableCells}-cell limit cannot be overridden."
+                : null;
 
         private static List<TItem> MaterializeObjectTableItemsBounded<TItem>(
             IEnumerable<TItem> source,


### PR DESCRIPTION
## Summary

- add `SheetComposer.TableFrom(DataTable)` for fixed-schema data in rich, editable workbooks
- preserve DataTable schema order, canonical source names, case-distinct column identities, projection rules, styles, multiple sheets, and surrounding worksheet content
- resolve include, exclude, and ignore rules against the complete DataTable schema so exact case-distinct names remain independent and ambiguous non-exact rules fail with casing guidance
- resolve explicit DataTable columns only against complete source names, keeping dotted column names literal rather than treating them as flattened object paths
- use the direct append/deferred materialization path when possible and safely fall back when an existing worksheet layout prevents that optimization
- avoid dictionary-per-row and a second steady-state Open XML row buffer on the fast path while retaining cancellation and source-failure atomicity
- keep known-empty object tables and iterators exempt from projection limits, even when an explicit schema is supplied
- make configurable row, column, and cell failures report the required size and exact override
- distinguish hard Excel and PowerPoint consumer caps from configurable limits based on the actual required size, recommending selection or splitting instead of impossible overrides
- calculate Excel's remaining data-row capacity after the title/header and report the exact non-overridable worksheet boundary
- apply table visuals to the exact generated header and data range, while keeping literal fixed-schema dotted columns out of dynamic-collection auto-formatting
- document the fixed-schema overload and its limit behavior in the package README

## Why

Large fixed-schema reports should not fail at the generic one-million-cell object-flattening guard. The new overload takes the fixed-schema route automatically, while the guard remains in place for unknown object graphs. This keeps the rich-workbook API easy to use without weakening generic materialization safety.

Case-distinct DataTable columns remain distinct through filtering, pinning, priority ordering, and explicit selection. Unique case-insensitive explicit names resolve back to the exact source schema name; ambiguous non-exact rules fail with exact-casing guidance.

## Validation

- full OfficeIMO.Excel .NET 8 suite: 3,687 passed, 5 expected skipped, 0 failed
- full OfficeIMO.PowerPoint .NET 8 suite: 1,692 passed, 2 expected skipped, 0 failed
- focused DataTable contracts: 17/17 on .NET Framework 4.7.2, .NET 8, and .NET 10
- focused PowerPoint object-table contracts: 9/9 on .NET Framework 4.7.2, .NET 8, and .NET 10
- actual save/reload workbook proof preserves a pre-existing footer when the fixed-schema fast path must fall back
- forced fallback preserves numeric, date, and duration cells on .NET Framework 4.7.2, .NET 8, and .NET 10
- broad win-x64 NativeAOT production-library publish and native execution pass with no trim diagnostics
- actual PSWriteOffice rich three-sheet workbook: 50,001 rows x 20 columns, 1,000,040 table cells, valid 6.5 MiB XLSX in 6.22 seconds
- alternating 5,000 x 20 timing sanity check: direct path averaged 216.2 ms; case-safe projected path averaged 213.1 ms
- downstream PowerShell 7 and Windows PowerShell 5.1 tabular/report contracts: 23/23 on each host

