### PR TITLE
Use Linux-safe Cloudflare website verification

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -41,7 +41,7 @@ jobs:
 
   website-deploy:
     needs: resolve-post-deploy
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@ff53aa685fb039c11de26e50293bb7ea758e6411
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@826b1eeacbddd4960ba803d7745cf1f50a8a5242
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -52,7 +52,7 @@ jobs:
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       dotnet_workloads: wasm-tools
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: ff53aa685fb039c11de26e50293bb7ea758e6411
+      powerforge_ref: 826b1eeacbddd4960ba803d7745cf1f50a8a5242
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}
       cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   website-build:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@ff53aa685fb039c11de26e50293bb7ea758e6411
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@826b1eeacbddd4960ba803d7745cf1f50a8a5242
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -31,5 +31,5 @@ jobs:
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       dotnet_workloads: wasm-tools
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: ff53aa685fb039c11de26e50293bb7ea758e6411
+      powerforge_ref: 826b1eeacbddd4960ba803d7745cf1f50a8a5242
       report_artifact_name: powerforge-website-reports


### PR DESCRIPTION
## Summary

- pin the OfficeIMO website CI and deployment workflows to the reviewed PowerForge Cloudflare verifier
- keep workflow execution and CLI checkout on the same exact PowerForge commit

## Why

The previous PowerForge pin applied the managed Cloudflare policy but failed Linux post-deploy asset discovery because a leading-slash website path was interpreted as a file URI. The new pin preserves deployment-relative paths across platforms while keeping traversal containment checks.

HSTS remains disabled in `Website/site.json`.