### PR TITLE
Use corrected Cloudflare discovery links

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -41,7 +41,7 @@ jobs:
 
   website-deploy:
     needs: resolve-post-deploy
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@826b1eeacbddd4960ba803d7745cf1f50a8a5242
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@8cf2d8b0bbf279f19ec65d17b4088cdafa8609d0
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -52,7 +52,7 @@ jobs:
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       dotnet_workloads: wasm-tools
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 826b1eeacbddd4960ba803d7745cf1f50a8a5242
+      powerforge_ref: 8cf2d8b0bbf279f19ec65d17b4088cdafa8609d0
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}
       cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   website-build:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@826b1eeacbddd4960ba803d7745cf1f50a8a5242
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@8cf2d8b0bbf279f19ec65d17b4088cdafa8609d0
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -31,5 +31,5 @@ jobs:
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       dotnet_workloads: wasm-tools
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 826b1eeacbddd4960ba803d7745cf1f50a8a5242
+      powerforge_ref: 8cf2d8b0bbf279f19ec65d17b4088cdafa8609d0
       report_artifact_name: powerforge-website-reports


### PR DESCRIPTION
## Summary

- pin both OfficeIMO website workflows to the reviewed PowerForge head from PR #732
- regenerate the managed Cloudflare policy with web-relative discovery Link targets on Linux
- retain the existing cache and security policy, including HSTS disabled

## Validation

- both workflow YAML files parse successfully
- all four uses/powerforge_ref values pin the exact reviewed PowerForge head
- both reusable workflows exist at that head and expose the powerforge_ref input
- Website/site.json still sets HSTS to false

## Dependency

Depends on merged PowerForge PR #732. The exact reviewed PowerForge feature head is used deliberately so deployment and verification execute the same code that passed Windows, Linux, macOS, focused CI, and the cross-platform URI review.