### PR TITLE
Enable seven-day Cloudflare edge caching for OfficeIMO

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -41,7 +41,7 @@ jobs:
 
   website-deploy:
     needs: resolve-post-deploy
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@8cf2d8b0bbf279f19ec65d17b4088cdafa8609d0
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@425826116e0c66777984729c5d2311f93ef69cbb
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -52,7 +52,7 @@ jobs:
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       dotnet_workloads: wasm-tools
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 8cf2d8b0bbf279f19ec65d17b4088cdafa8609d0
+      powerforge_ref: 425826116e0c66777984729c5d2311f93ef69cbb
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}
       cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   website-build:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@8cf2d8b0bbf279f19ec65d17b4088cdafa8609d0
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@425826116e0c66777984729c5d2311f93ef69cbb
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -31,5 +31,5 @@ jobs:
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       dotnet_workloads: wasm-tools
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 8cf2d8b0bbf279f19ec65d17b4088cdafa8609d0
+      powerforge_ref: 425826116e0c66777984729c5d2311f93ef69cbb
       report_artifact_name: powerforge-website-reports

--- a/Website/pipeline.cloudflare.json
+++ b/Website/pipeline.cloudflare.json
@@ -20,6 +20,9 @@
         "/",
         "/api/",
         "/api/word/",
+        "/api/word/index.json",
+        "/agents.json",
+        "/.well-known/api-catalog",
         "/apps/officeimo-converter/",
         "/apps/officeimo-converter/converter.css"
       ],

--- a/Website/site.json
+++ b/Website/site.json
@@ -285,6 +285,12 @@
     "WebMcp": false,
     "MarkdownNegotiation": true
   },
+  "Cloudflare": {
+    "Cache": {
+      "EdgeTtlSeconds": 604800
+    },
+    "PurgeMode": "hostname"
+  },
   "EditLinks": {
     "Enabled": true,
     "Template": "https://github.com/EvotecIT/OfficeIMO/edit/master/{path}",


### PR DESCRIPTION
## What changed

- enable a seven-day Cloudflare edge TTL for successful OfficeIMO GET responses
- purge the officeimo.com hostname after deployment so new site output replaces cached content immediately
- pin both website workflows to the reviewed PowerForge cache-profile head from EvotecIT/PSPublishModule#734
- extend post-deploy verification to API JSON, agents.json, and the well-known API catalog in addition to representative HTML, CSS, and Blazor assets

Browser caching remains controlled by the origin. DYNAMIC is not accepted by the deployment check, so a green deployment must demonstrate an actual Cloudflare cache status.

HSTS remains disabled. Smart Tiered Cache is not enabled by this site profile.