### PR TITLE
Enable incremental Cloudflare deployment purges

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -18,6 +18,7 @@ on:
 permissions:
   actions: write
   contents: read
+  deployments: read
   packages: read
   pages: write
   id-token: write
@@ -43,7 +44,7 @@ jobs:
 
   website-deploy:
     needs: resolve-post-deploy
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@683531aed9652851a03b1301624b9c769ce62d52
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@8fd0b2204844bbdcebed5fbfab4cdc65289c702c
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -54,7 +55,7 @@ jobs:
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       dotnet_workloads: wasm-tools
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 683531aed9652851a03b1301624b9c769ce62d52
+      powerforge_ref: 8fd0b2204844bbdcebed5fbfab4cdc65289c702c
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}
       cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   website-build:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@683531aed9652851a03b1301624b9c769ce62d52
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@8fd0b2204844bbdcebed5fbfab4cdc65289c702c
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -31,5 +31,5 @@ jobs:
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       dotnet_workloads: wasm-tools
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 683531aed9652851a03b1301624b9c769ce62d52
+      powerforge_ref: 8fd0b2204844bbdcebed5fbfab4cdc65289c702c
       report_artifact_name: powerforge-website-reports

--- a/Website/site.json
+++ b/Website/site.json
@@ -289,7 +289,7 @@
     "Cache": {
       "EdgeTtlSeconds": 604800
     },
-    "PurgeMode": "hostname"
+    "PurgeMode": "incremental"
   },
   "EditLinks": {
     "Enabled": true,


### PR DESCRIPTION
## What changed

- pin the OfficeIMO website deploy and CI workflows to the reviewed PowerForge incremental-purge implementation
- grant the deploy caller read access to GitHub Pages deployment history
- switch the managed Cloudflare purge mode from `hostname` to `incremental`

OfficeIMO keeps its seven-day edge TTL and origin-controlled browser caching. The first deployment, an expired or incompatible baseline, policy drift, or an oversized diff still falls back to a hostname purge. Later deployments purge only added, changed, and removed canonical URLs within the bounded Cloudflare limits.

HSTS remains explicitly disabled.

## Validation

- parsed the changed JSON and workflow YAML
- verified both reusable workflow input contracts at the exact PowerForge commit
- confirmed the exact owner commit is available from GitHub
- ran the exact PowerForge CLI Cloudflare inspection against the OfficeIMO site config
- completed an authenticated `officeimo.com` site-policy dry-run
- passed the focused diff and repository hygiene checks