### PR TITLE
Pin corrected Cloudflare deployment workflow

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -44,7 +44,7 @@ jobs:
 
   website-deploy:
     needs: resolve-post-deploy
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@157b315852b43d2607110a9c53e62b8b2886abb7
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@f2c4e9b4fc5bd624dcee64b2d766b471c4676387
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -55,7 +55,7 @@ jobs:
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       dotnet_workloads: wasm-tools
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 157b315852b43d2607110a9c53e62b8b2886abb7
+      powerforge_ref: f2c4e9b4fc5bd624dcee64b2d766b471c4676387
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}
       cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -44,7 +44,7 @@ jobs:
 
   website-deploy:
     needs: resolve-post-deploy
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@8fd0b2204844bbdcebed5fbfab4cdc65289c702c
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@157b315852b43d2607110a9c53e62b8b2886abb7
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -55,7 +55,7 @@ jobs:
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       dotnet_workloads: wasm-tools
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 8fd0b2204844bbdcebed5fbfab4cdc65289c702c
+      powerforge_ref: 157b315852b43d2607110a9c53e62b8b2886abb7
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}
       cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   website-build:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@8fd0b2204844bbdcebed5fbfab4cdc65289c702c
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@157b315852b43d2607110a9c53e62b8b2886abb7
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -31,5 +31,5 @@ jobs:
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       dotnet_workloads: wasm-tools
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 8fd0b2204844bbdcebed5fbfab4cdc65289c702c
+      powerforge_ref: 157b315852b43d2607110a9c53e62b8b2886abb7
       report_artifact_name: powerforge-website-reports

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   website-build:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@157b315852b43d2607110a9c53e62b8b2886abb7
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@f2c4e9b4fc5bd624dcee64b2d766b471c4676387
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -31,5 +31,5 @@ jobs:
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       dotnet_workloads: wasm-tools
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 157b315852b43d2607110a9c53e62b8b2886abb7
+      powerforge_ref: f2c4e9b4fc5bd624dcee64b2d766b471c4676387
       report_artifact_name: powerforge-website-reports


### PR DESCRIPTION
## Summary
- pin OfficeIMO website deployment and PR validation to the immutable PowerForge merge containing both Cloudflare deployment corrections
- retain incremental Cloudflare purge, the seven-day edge cache profile, and the existing no-HSTS policy

## Why
The first deployment reached GitHub Pages but Cloudflare policy processing stopped because GitHub's top-level deployment array was interpreted as one nested object. After that fix, exact-head Linux website CI exposed a second shared issue: a UTF-8 BOM in the generated package-publication catalog was rejected by the LLMS reader. Both fixes are now merged in PowerForge, and this PR pins their combined immutable commit.

## Validation
- both reusable workflow files and `powerforge_ref` inputs resolve at the combined PowerForge commit
- the pin contains both reviewed corrective heads
- workflow YAML and site JSON parse successfully
- `PurgeMode` remains `incremental`, edge TTL remains 604800 seconds, and HSTS remains disabled