### PR TITLE
Keep Cloudflare post-deploy verification read-only

### DIFF
--- a/Website/pipeline.cloudflare.json
+++ b/Website/pipeline.cloudflare.json
@@ -3,16 +3,7 @@
   "steps": [
     {
       "task": "cloudflare",
-      "id": "purge-cache",
-      "operation": "purge",
-      "siteConfig": "./site.json",
-      "zoneIdEnv": "CLOUDFLARE_ZONE_ID",
-      "tokenEnv": "CLOUDFLARE_API_TOKEN"
-    },
-    {
-      "task": "cloudflare",
       "id": "verify-cache",
-      "dependsOn": "purge-cache",
       "operation": "verify",
       "siteConfig": "./site.json",
       "warmupRequests": 1,


### PR DESCRIPTION
## Summary
- keep the post-deploy Cloudflare pipeline verification-only
- leave policy reconciliation and incremental cache invalidation with the managed deployment action

## Why
The managed Cloudflare action already applied policy and completed the first safe incremental purge. The following post-deploy pipeline tried to purge a second time without the private deployment manifest and correctly failed closed. Removing that duplicate mutation lets the final stage verify the deployed cache and headers without changing cache state again.

## Validation
- exact post-merge policy job completed successfully before the reproduced failure
- the revised pipeline has one `verify` step and no purge dependency
- live local execution verified nine representative URLs with acceptable Cloudflare cache statuses
- incremental mode, seven-day edge TTL, and HSTS disabled remain unchanged