### PR TITLE
Codify Smart Tiered Cache for OfficeIMO

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -44,7 +44,7 @@ jobs:
 
   website-deploy:
     needs: resolve-post-deploy
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@7ed77bb8e6728e362bc906eb4fbf1585dcd47693
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@1dbcec06df408947ee5f0dad3f71a11b0d31b0b6
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -55,7 +55,7 @@ jobs:
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       dotnet_workloads: wasm-tools
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 7ed77bb8e6728e362bc906eb4fbf1585dcd47693
+      powerforge_ref: 1dbcec06df408947ee5f0dad3f71a11b0d31b0b6
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}
       cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   website-build:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@7ed77bb8e6728e362bc906eb4fbf1585dcd47693
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@1dbcec06df408947ee5f0dad3f71a11b0d31b0b6
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -31,5 +31,5 @@ jobs:
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       dotnet_workloads: wasm-tools
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 7ed77bb8e6728e362bc906eb4fbf1585dcd47693
+      powerforge_ref: 1dbcec06df408947ee5f0dad3f71a11b0d31b0b6
       report_artifact_name: powerforge-website-reports

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -16,12 +16,12 @@ concurrency:
 
 jobs:
   website-maintenance:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@7ed77bb8e6728e362bc906eb4fbf1585dcd47693
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@1dbcec06df408947ee5f0dad3f71a11b0d31b0b6
     with:
       website_root: Website
       pipeline_config: Website/pipeline.maintenance.json
       engine_mode: source
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 7ed77bb8e6728e362bc906eb4fbf1585dcd47693
+      powerforge_ref: 1dbcec06df408947ee5f0dad3f71a11b0d31b0b6
       report_artifact_name: powerforge-website-maintenance-reports

--- a/Website/pipeline.cloudflare.json
+++ b/Website/pipeline.cloudflare.json
@@ -22,6 +22,14 @@
       "allowStatuses": "HIT,REVALIDATED,EXPIRED,STALE",
       "reportPath": "./_reports/cloudflare-cache.json",
       "summaryPath": "./_reports/cloudflare-cache.md"
+    },
+    {
+      "task": "agent-ready",
+      "id": "verify-agent-readiness-live",
+      "dependsOn": "verify-cache",
+      "operation": "scan",
+      "config": "./site.json",
+      "failOnFailures": true
     }
   ]
 }

--- a/Website/site.json
+++ b/Website/site.json
@@ -289,7 +289,8 @@
     "Cache": {
       "EdgeTtlSeconds": 604800
     },
-    "PurgeMode": "incremental"
+    "PurgeMode": "incremental",
+    "SmartTieredCache": true
   },
   "EditLinks": {
     "Enabled": true,

--- a/Website/site.json
+++ b/Website/site.json
@@ -283,7 +283,7 @@
     "McpServerCard": { "Enabled": false },
     "OpenApi": { "Enabled": false },
     "WebMcp": false,
-    "MarkdownNegotiation": true
+    "MarkdownNegotiation": false
   },
   "Cloudflare": {
     "Cache": {


### PR DESCRIPTION
## Summary

- record the already-enabled Smart Tiered Cache setting so repository configuration and Cloudflare state cannot drift
- pin deployment, CI, and maintenance to the current shared PowerForge owner
- add fail-gated live agent and security verification after cache verification
- stop advertising unsupported Markdown negotiation on static GitHub Pages

Incremental purge, the seven-day edge TTL, origin-controlled browser caching, and HSTS-disabled recovery posture remain unchanged.