### PR TITLE
Stabilize converter post-deploy asset verification

### DIFF
--- a/Website/pipeline.cloudflare.json
+++ b/Website/pipeline.cloudflare.json
@@ -22,7 +22,11 @@
         "-BaseUri",
         "https://officeimo.com/apps/officeimo-converter/?embedded=1",
         "-ExpectedDeploymentIdEnvironment",
-        "GITHUB_SHA"
+        "GITHUB_SHA",
+        "-RemoteVerificationAttempts",
+        "12",
+        "-RemoteVerificationRetryDelaySeconds",
+        "30"
       ],
       "workingDirectory": "."
     },

--- a/Website/scripts/Test-ConverterAssetGraph.ps1
+++ b/Website/scripts/Test-ConverterAssetGraph.ps1
@@ -8,7 +8,13 @@ param(
 
     [string] $ExpectedDeploymentId,
 
-    [string] $ExpectedDeploymentIdEnvironment
+    [string] $ExpectedDeploymentIdEnvironment,
+
+    [ValidateRange(1, 20)]
+    [int] $RemoteVerificationAttempts = 6,
+
+    [ValidateRange(0, 300)]
+    [int] $RemoteVerificationRetryDelaySeconds = 15
 )
 
 $ErrorActionPreference = 'Stop'
@@ -208,7 +214,8 @@ function Get-Sha256Hex {
     return [Convert]::ToHexString([System.Security.Cryptography.SHA256]::HashData($Bytes)).ToLowerInvariant()
 }
 
-try {
+function Invoke-ConverterDeploymentVerification {
+$assetByteCache.Clear()
 $deploymentManifestBytes = Get-AssetBytes -RelativePath 'deployment-assets.json' -MaximumBytes $maximumDeploymentManifestBytes
 $deploymentManifest = Get-Utf8Text -Bytes $deploymentManifestBytes | ConvertFrom-Json
 if ($deploymentManifest.schemaVersion -ne 1 -or [string] $deploymentManifest.deploymentId -notmatch '^[A-Fa-f0-9]{40}$|^[A-Fa-f0-9]{64}$') {
@@ -373,6 +380,29 @@ if ($verified.Count -lt 10) {
 }
 
 Write-Output "Converter deployment verified: $($manifestPaths.Count) public assets and $($verified.Count) fingerprinted runtime resources for $($deploymentManifest.deploymentId)."
+}
+
+try {
+    $verificationAttempts = if ($isLocal) { 1 } else { $RemoteVerificationAttempts }
+    # A freshly deployed manifest can reach one edge before stable-named assets do. Retry the
+    # complete graph from empty cache; every attempt must still satisfy all length and hash checks.
+    for ($verificationAttempt = 1; $verificationAttempt -le $verificationAttempts; $verificationAttempt++) {
+        try {
+            Invoke-ConverterDeploymentVerification
+            break
+        } catch {
+            if ($verificationAttempt -ge $verificationAttempts) {
+                throw
+            }
+
+            $retryMessage = "Converter deployment verification attempt $verificationAttempt/$verificationAttempts failed: " +
+                "$($_.Exception.Message) Retrying after $RemoteVerificationRetryDelaySeconds second(s)."
+            Write-Warning $retryMessage
+            if ($RemoteVerificationRetryDelaySeconds -gt 0) {
+                Start-Sleep -Seconds $RemoteVerificationRetryDelaySeconds
+            }
+        }
+    }
 } finally {
     if ($null -ne $remoteClient) {
         $remoteClient.Dispose()


### PR DESCRIPTION
## Summary

- retry the complete remote converter asset graph from an empty cache during edge convergence
- give the production post-deploy check a bounded multi-minute convergence window
- keep local verification single-pass and preserve every deployment ID, byte-length, SHA-256, import-map, and runtime-resource check
- report the failed attempt and asset reason before retrying

## Why

The Pages deployment in [workflow run 32111566701](https://github.com/EvotecIT/OfficeIMO/actions/runs/32111566701) succeeded, but both the initial post-deploy check and a later failed-job rerun received an asset larger than the new manifest declaration. The same exact deployment verifies clean from Windows and Ubuntu/WSL. Individual sub-second download retries cannot handle regional Pages/Cloudflare consistency windows.

## Validation

- deterministic stale-asset proxy: first complete graph rejected, second complete graph verified
- live deployment verified on Windows and Ubuntu/WSL: 109 public assets and 97 runtime resources
- production pipeline arguments executed successfully from the checked-in JSON configuration
- PowerShell parsing and diff checks passed
- independent read-only review found no actionable issues