### PR TITLE
Accelerate validated Excel tabular I/O across formats

### DIFF
--- a/OfficeIMO.CSV.Benchmarks/CsvBenchmarks.cs
+++ b/OfficeIMO.CSV.Benchmarks/CsvBenchmarks.cs
@@ -108,6 +108,8 @@ public class CsvBenchmarks
         ValidateWriteOutput(nameof(OfficeIMO_WriteIncrementalProjectedRows), OfficeIMO_WriteIncrementalProjectedRows, expectedObjectRows: _projectedRows);
         ValidateWriteOutput(nameof(OfficeIMO_WriteDataReader), OfficeIMO_WriteDataReader, expectedObjectRows: _projectedRows);
         ValidateWriteOutput(nameof(CsvHelper_WriteTypedRecords), CsvHelper_WriteTypedRecords, expectedObjectRows: _projectedRows);
+        ValidateWriteOutput(nameof(OfficeIMO_WriteProjectedRowsUtf8), OfficeIMO_WriteProjectedRowsUtf8, expectedObjectRows: _projectedRows);
+        ValidateWriteOutput(nameof(ExcelReaderNet_WriteProjectedRows), ExcelReaderNet_WriteProjectedRows, expectedObjectRows: _projectedRows);
         ValidateWriteOutput(nameof(OfficeIMO_WriteTypedRecordsUtf8), OfficeIMO_WriteTypedRecordsUtf8, expectedObjectRows: _projectedRows);
         ValidateWriteOutput(nameof(ExcelReaderNet_WriteTypedRecords), ExcelReaderNet_WriteTypedRecords, expectedObjectRows: _projectedRows);
         ValidateWriteOutput(nameof(CsvHelper_WriteProjectedRows), CsvHelper_WriteProjectedRows, expectedObjectRows: _projectedRows);
@@ -282,7 +284,7 @@ public class CsvBenchmarks
     }
 
     [Benchmark]
-    public int OfficeIMO_WriteTypedRecordsUtf8()
+    public int OfficeIMO_WriteProjectedRowsUtf8()
     {
         using var stream = new MemoryStream();
         using (var textWriter = new StreamWriter(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), leaveOpen: true))
@@ -292,6 +294,55 @@ public class CsvBenchmarks
             for (int index = 1; index < _projectedRows.Length; index++)
             {
                 csv.WriteRow(_projectedRows[index]);
+            }
+        }
+
+        return CompleteUtf8Write(stream);
+    }
+
+    [Benchmark]
+    public int ExcelReaderNet_WriteProjectedRows()
+    {
+        using var stream = new MemoryStream();
+        using (ExcelReaderNetCsvWriter csv = ExcelReaderNetCsvWriter.Create(stream, leaveOpen: true))
+        {
+            using (ExcelReaderNetCsvRowWriter header = csv.StartRow())
+            {
+                foreach (string value in Headers)
+                {
+                    header.Write(value);
+                }
+            }
+
+            foreach (object?[] value in _projectedRows)
+            {
+                using ExcelReaderNetCsvRowWriter row = csv.StartRow();
+                row.Write((int)value[0]!);
+                row.Write((string?)value[1]);
+                row.Write((string?)value[2]);
+                row.Write((string?)value[3]);
+                row.Write((bool)value[4]!);
+                row.Write((DateTime)value[5]!);
+                row.Write((decimal)value[6]!);
+                row.Write((string?)value[7]);
+                row.Write((int)value[8]!);
+                row.Write((string?)value[9]);
+            }
+        }
+
+        return CompleteUtf8Write(stream);
+    }
+
+    [Benchmark]
+    public int OfficeIMO_WriteTypedRecordsUtf8()
+    {
+        using var stream = new MemoryStream();
+        using (var textWriter = new StreamWriter(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), leaveOpen: true))
+        using (var csv = new CsvRowWriter(textWriter, new CsvSaveOptions { NewLine = "\n" }, leaveOpen: true))
+        {
+            foreach (CsvBenchmarkRow row in _rows)
+            {
+                csv.WriteObject(row);
             }
         }
 

--- a/OfficeIMO.CSV.Benchmarks/CsvBenchmarks.cs
+++ b/OfficeIMO.CSV.Benchmarks/CsvBenchmarks.cs
@@ -2,7 +2,9 @@
 
 using System.Data.Common;
 using System.Globalization;
+using System.Text;
 using BenchmarkDotNet.Attributes;
+using ExcelReader.Core.Parser;
 using nietras.SeparatedValues;
 using OfficeIMO.Data;
 using CsvHelperConfiguration = CsvHelper.Configuration.CsvConfiguration;
@@ -18,6 +20,10 @@ using SepWriterOptions = nietras.SeparatedValues.SepWriterOptions;
 using SylvanCsvDataReader = Sylvan.Data.Csv.CsvDataReader;
 using SylvanCsvDataWriter = Sylvan.Data.Csv.CsvDataWriter;
 using SylvanCsvDataWriterOptions = Sylvan.Data.Csv.CsvDataWriterOptions;
+using ExcelReaderNetCsvRowWriter = ExcelReader.Core.Writer.CsvRowWriter;
+using ExcelReaderNetCsvWriter = ExcelReader.Core.Writer.CsvWriter;
+using ExcelReaderApi = ExcelReader.Core.Reader.Excel;
+using ExcelReaderNetCsvReader = ExcelReader.Core.Reader.CsvReader;
 
 namespace OfficeIMO.CSV.Benchmarks;
 
@@ -42,7 +48,9 @@ public class CsvBenchmarks
     private object?[][] _projectedRows = [];
     private string?[][] _projectedTextRows = [];
     private string _csvText = string.Empty;
+    private byte[] _csvUtf8 = [];
     private int _expectedTypedReadChecksum;
+    private readonly ExcelParser<CsvBenchmarkRow> _excelReaderParser = new();
     private bool _captureWriteOutput;
     private string? _capturedWriteOutput;
     private static readonly DataplatCsvReaderOptions DataplatReaderOptions = new() { HasHeaderRow = true };
@@ -68,6 +76,7 @@ public class CsvBenchmarks
         using var writer = new StringWriter(CultureInfo.InvariantCulture);
         CsvDocument.WriteObjects(writer, _rows, new CsvSaveOptions { NewLine = "\n" });
         _csvText = writer.ToString();
+        _csvUtf8 = Encoding.UTF8.GetBytes(_csvText);
         _expectedTypedReadChecksum = MeasureTypedRows(_rows);
 
         ValidateWriteBenchmarkOutputs();
@@ -79,6 +88,7 @@ public class CsvBenchmarks
         ValidateTypedReadOutput(nameof(OfficeIMO_ReadTypedRowsForwardOnly), OfficeIMO_ReadTypedRowsForwardOnly);
         ValidateTypedReadOutput(nameof(OfficeIMO_ReadTypedRowsMaterialized), OfficeIMO_ReadTypedRowsMaterialized);
         ValidateTypedReadOutput(nameof(CsvHelper_ReadTypedRecords), CsvHelper_ReadTypedRecords);
+        ValidateTypedReadOutput(nameof(ExcelReaderNet_ReadTypedRecords), ExcelReaderNet_ReadTypedRecords);
     }
 
     private void ValidateTypedReadOutput(string method, Func<int> read)
@@ -98,6 +108,8 @@ public class CsvBenchmarks
         ValidateWriteOutput(nameof(OfficeIMO_WriteIncrementalProjectedRows), OfficeIMO_WriteIncrementalProjectedRows, expectedObjectRows: _projectedRows);
         ValidateWriteOutput(nameof(OfficeIMO_WriteDataReader), OfficeIMO_WriteDataReader, expectedObjectRows: _projectedRows);
         ValidateWriteOutput(nameof(CsvHelper_WriteTypedRecords), CsvHelper_WriteTypedRecords, expectedObjectRows: _projectedRows);
+        ValidateWriteOutput(nameof(OfficeIMO_WriteTypedRecordsUtf8), OfficeIMO_WriteTypedRecordsUtf8, expectedObjectRows: _projectedRows);
+        ValidateWriteOutput(nameof(ExcelReaderNet_WriteTypedRecords), ExcelReaderNet_WriteTypedRecords, expectedObjectRows: _projectedRows);
         ValidateWriteOutput(nameof(CsvHelper_WriteProjectedRows), CsvHelper_WriteProjectedRows, expectedObjectRows: _projectedRows);
         ValidateWriteOutput(nameof(Sylvan_WriteProjectedRows), Sylvan_WriteProjectedRows, expectedObjectRows: _projectedRows);
         ValidateWriteOutput(nameof(Dataplat_WriteProjectedRows), Dataplat_WriteProjectedRows, expectedObjectRows: _projectedRows);
@@ -109,6 +121,7 @@ public class CsvBenchmarks
         ValidateWriteOutput(nameof(Sylvan_WriteTextRows), Sylvan_WriteTextRows, _projectedTextRows);
         ValidateWriteOutput(nameof(Dataplat_WriteTextRows), Dataplat_WriteTextRows, _projectedTextRows);
         ValidateWriteOutput(nameof(Sep_WriteTextRows), Sep_WriteTextRows, _projectedTextRows);
+        ValidateWriteOutput(nameof(ExcelReaderNet_WriteTextRows), ExcelReaderNet_WriteTextRows, _projectedTextRows);
     }
 
     private void ValidateWriteOutput(
@@ -157,6 +170,18 @@ public class CsvBenchmarks
         }
 
         return output.Length;
+    }
+
+    private int CompleteUtf8Write(MemoryStream stream)
+    {
+        if (_captureWriteOutput)
+        {
+            string output = Encoding.UTF8.GetString(stream.GetBuffer(), 0, checked((int)stream.Length));
+            _capturedWriteOutput = output;
+            return output.Length;
+        }
+
+        return checked((int)stream.Length);
     }
 
     [Benchmark(Baseline = true)]
@@ -257,6 +282,56 @@ public class CsvBenchmarks
     }
 
     [Benchmark]
+    public int OfficeIMO_WriteTypedRecordsUtf8()
+    {
+        using var stream = new MemoryStream();
+        using (var textWriter = new StreamWriter(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), leaveOpen: true))
+        using (var csv = new CsvRowWriter(textWriter, new CsvSaveOptions { NewLine = "\n" }, leaveOpen: true))
+        {
+            csv.WriteRow(Headers, _projectedRows[0]);
+            for (int index = 1; index < _projectedRows.Length; index++)
+            {
+                csv.WriteRow(_projectedRows[index]);
+            }
+        }
+
+        return CompleteUtf8Write(stream);
+    }
+
+    [Benchmark]
+    public int ExcelReaderNet_WriteTypedRecords()
+    {
+        using var stream = new MemoryStream();
+        using (ExcelReaderNetCsvWriter csv = ExcelReaderNetCsvWriter.Create(stream, leaveOpen: true))
+        {
+            using (ExcelReaderNetCsvRowWriter header = csv.StartRow())
+            {
+                foreach (string value in Headers)
+                {
+                    header.Write(value);
+                }
+            }
+
+            foreach (CsvBenchmarkRow value in _rows)
+            {
+                using ExcelReaderNetCsvRowWriter row = csv.StartRow();
+                row.Write(value.Id);
+                row.Write(value.Name);
+                row.Write(value.Department);
+                row.Write(value.Region);
+                row.Write(value.IsEnabled);
+                row.Write(value.Created);
+                row.Write(value.Score);
+                row.Write(value.Owner);
+                row.Write(value.TicketCount);
+                row.Write(value.Notes);
+            }
+        }
+
+        return CompleteUtf8Write(stream);
+    }
+
+    [Benchmark]
     public int CsvHelper_WriteProjectedRows()
     {
         using var writer = new StringWriter(CultureInfo.InvariantCulture);
@@ -304,6 +379,33 @@ public class CsvBenchmarks
         }
 
         return CompleteWrite(writer);
+    }
+
+    [Benchmark]
+    public int ExcelReaderNet_WriteTextRows()
+    {
+        using var stream = new MemoryStream();
+        using (ExcelReaderNetCsvWriter csv = ExcelReaderNetCsvWriter.Create(stream, leaveOpen: true))
+        {
+            using (ExcelReaderNetCsvRowWriter header = csv.StartRow())
+            {
+                foreach (string value in Headers)
+                {
+                    header.Write(value);
+                }
+            }
+
+            foreach (string?[] values in _projectedTextRows)
+            {
+                using ExcelReaderNetCsvRowWriter row = csv.StartRow();
+                foreach (string? value in values)
+                {
+                    row.Write(value);
+                }
+            }
+        }
+
+        return CompleteUtf8Write(stream);
     }
 
     [Benchmark]
@@ -735,6 +837,19 @@ public class CsvBenchmarks
         using var csv = new CsvHelperReader(reader, CultureInfo.InvariantCulture);
         var checksum = 17;
         foreach (CsvBenchmarkRow row in csv.GetRecords<CsvBenchmarkRow>())
+        {
+            checksum = AddTypedRowChecksum(checksum, row);
+        }
+
+        return checksum;
+    }
+
+    [Benchmark]
+    public int ExcelReaderNet_ReadTypedRecords()
+    {
+        using ExcelReaderNetCsvReader reader = ExcelReaderApi.FromCsv(_csvUtf8);
+        var checksum = 17;
+        foreach (CsvBenchmarkRow row in _excelReaderParser.Parse(reader))
         {
             checksum = AddTypedRowChecksum(checksum, row);
         }

--- a/OfficeIMO.CSV.Benchmarks/CsvExcelReaderComparisonPairedRunner.cs
+++ b/OfficeIMO.CSV.Benchmarks/CsvExcelReaderComparisonPairedRunner.cs
@@ -1,0 +1,100 @@
+using System.Diagnostics;
+using OfficeIMO.Benchmarks;
+
+namespace OfficeIMO.CSV.Benchmarks;
+
+internal static class CsvExcelReaderComparisonPairedRunner {
+    private const int WarmupIterations = 16;
+
+    internal static void Run(string[] arguments) {
+        int iterations = arguments.Length > 1 && int.TryParse(arguments[1], out int parsedIterations)
+            ? parsedIterations
+            : 40;
+        if (iterations <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(iterations));
+        }
+
+        string affinity = arguments.Length > 2
+            ? BenchmarkProcessorAffinity.Apply(arguments[2])
+            : "unchanged";
+        string priority = arguments.Length > 3
+            && !string.Equals(arguments[3], "unchanged", StringComparison.OrdinalIgnoreCase)
+                ? BenchmarkProcessorAffinity.ApplyPriority(arguments[3])
+                : Process.GetCurrentProcess().PriorityClass.ToString();
+
+        var benchmark = new MarkPflug65KCsvBenchmarks();
+        benchmark.Setup();
+        for (int index = 0; index < WarmupIterations; index++) {
+            CsvReadObservation officeObservation = benchmark.OfficeIMO();
+            CsvReadObservation excelReaderObservation = benchmark.ExcelReaderNet();
+            ValidateEquivalent($"warmup {index}", officeObservation, excelReaderObservation);
+        }
+
+        var officeSamples = new double[iterations];
+        var excelReaderSamples = new double[iterations];
+        var pairedRatios = new double[iterations];
+        for (int index = 0; index < iterations; index++) {
+            (double Milliseconds, CsvReadObservation Observation) officeFirst;
+            (double Milliseconds, CsvReadObservation Observation) officeSecond;
+            (double Milliseconds, CsvReadObservation Observation) excelReaderFirst;
+            (double Milliseconds, CsvReadObservation Observation) excelReaderSecond;
+            if ((index & 1) == 0) {
+                officeFirst = Measure(benchmark.OfficeIMO);
+                excelReaderFirst = Measure(benchmark.ExcelReaderNet);
+                excelReaderSecond = Measure(benchmark.ExcelReaderNet);
+                officeSecond = Measure(benchmark.OfficeIMO);
+            } else {
+                excelReaderFirst = Measure(benchmark.ExcelReaderNet);
+                officeFirst = Measure(benchmark.OfficeIMO);
+                officeSecond = Measure(benchmark.OfficeIMO);
+                excelReaderSecond = Measure(benchmark.ExcelReaderNet);
+            }
+
+            ValidateEquivalent($"sample {index} first", officeFirst.Observation, excelReaderFirst.Observation);
+            ValidateEquivalent($"sample {index} second", officeSecond.Observation, excelReaderSecond.Observation);
+            officeSamples[index] = (officeFirst.Milliseconds + officeSecond.Milliseconds) / 2d;
+            excelReaderSamples[index] = (excelReaderFirst.Milliseconds + excelReaderSecond.Milliseconds) / 2d;
+            pairedRatios[index] = officeSamples[index] / excelReaderSamples[index];
+        }
+
+        double officeMedian = Median(officeSamples);
+        double excelReaderMedian = Median(excelReaderSamples);
+        Console.WriteLine(FormattableString.Invariant(
+            $"Paired CSV comparison ({WarmupIterations} warmups, {iterations} ABBA samples, affinity {affinity}, priority {priority}): OfficeIMO median {officeMedian:F3} ms, ExcelReader.NET median {excelReaderMedian:F3} ms, ratio of medians {officeMedian / excelReaderMedian:F4}, paired ratio median {Median(pairedRatios):F4} (P25 {Percentile(pairedRatios, 0.25d):F4}, P75 {Percentile(pairedRatios, 0.75d):F4})."));
+    }
+
+    private static (double Milliseconds, CsvReadObservation Observation) Measure(
+        Func<CsvReadObservation> operation) {
+        long started = Stopwatch.GetTimestamp();
+        CsvReadObservation observation = operation();
+        return (Stopwatch.GetElapsedTime(started).TotalMilliseconds, observation);
+    }
+
+    private static void ValidateEquivalent(
+        string sample,
+        CsvReadObservation officeObservation,
+        CsvReadObservation excelReaderObservation) {
+        if (officeObservation != excelReaderObservation) {
+            throw new InvalidDataException(
+                $"Paired CSV {sample} produced different observations: " +
+                $"OfficeIMO={officeObservation}; ExcelReader.NET={excelReaderObservation}.");
+        }
+    }
+
+    private static double Median(double[] samples) {
+        double[] ordered = [.. samples.OrderBy(static sample => sample)];
+        int middle = ordered.Length / 2;
+        return (ordered.Length & 1) == 0
+            ? (ordered[middle - 1] + ordered[middle]) / 2d
+            : ordered[middle];
+    }
+
+    private static double Percentile(double[] samples, double percentile) {
+        double[] ordered = [.. samples.OrderBy(static sample => sample)];
+        double position = (ordered.Length - 1) * percentile;
+        int lower = (int)position;
+        int upper = Math.Min(lower + 1, ordered.Length - 1);
+        double fraction = position - lower;
+        return ordered[lower] + (ordered[upper] - ordered[lower]) * fraction;
+    }
+}

--- a/OfficeIMO.CSV.Benchmarks/CsvExcelReaderWriteComparisonPairedRunner.cs
+++ b/OfficeIMO.CSV.Benchmarks/CsvExcelReaderWriteComparisonPairedRunner.cs
@@ -1,0 +1,117 @@
+using System.Diagnostics;
+using OfficeIMO.Benchmarks;
+
+namespace OfficeIMO.CSV.Benchmarks;
+
+internal static class CsvExcelReaderWriteComparisonPairedRunner {
+    private const int WarmupIterations = 12;
+
+    internal static void Run(string[] arguments) {
+        int rowCount = arguments.Length > 1 && int.TryParse(arguments[1], out int parsedRowCount)
+            ? parsedRowCount
+            : 25_000;
+        CsvBenchmarkShape shape = arguments.Length > 2
+            && Enum.TryParse(arguments[2], ignoreCase: true, out CsvBenchmarkShape parsedShape)
+                ? parsedShape
+                : CsvBenchmarkShape.Mixed;
+        int iterations = arguments.Length > 3 && int.TryParse(arguments[3], out int parsedIterations)
+            ? parsedIterations
+            : 30;
+        if (rowCount <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(rowCount));
+        }
+        if (iterations <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(iterations));
+        }
+
+        string affinity = arguments.Length > 4
+            ? BenchmarkProcessorAffinity.Apply(arguments[4])
+            : "unchanged";
+        string priority = arguments.Length > 5
+            && !string.Equals(arguments[5], "unchanged", StringComparison.OrdinalIgnoreCase)
+                ? BenchmarkProcessorAffinity.ApplyPriority(arguments[5])
+                : Process.GetCurrentProcess().PriorityClass.ToString();
+        int invocationsPerLeg = arguments.Length > 6 && int.TryParse(arguments[6], out int parsedInvocations)
+            ? parsedInvocations
+            : 8;
+        if (invocationsPerLeg <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(invocationsPerLeg));
+        }
+
+        var benchmark = new CsvBenchmarks { RowCount = rowCount, Shape = shape };
+        benchmark.Setup();
+        for (int index = 0; index < WarmupIterations; index++) {
+            ValidateResult($"OfficeIMO warmup {index}", benchmark.OfficeIMO_WriteTypedRecordsUtf8());
+            ValidateResult($"ExcelReader.NET warmup {index}", benchmark.ExcelReaderNet_WriteTypedRecords());
+        }
+
+        var officeSamples = new double[iterations];
+        var excelReaderSamples = new double[iterations];
+        var pairedRatios = new double[iterations];
+        for (int index = 0; index < iterations; index++) {
+            (double Milliseconds, int Result) officeFirst;
+            (double Milliseconds, int Result) officeSecond;
+            (double Milliseconds, int Result) excelReaderFirst;
+            (double Milliseconds, int Result) excelReaderSecond;
+            if ((index & 1) == 0) {
+                officeFirst = Measure(benchmark.OfficeIMO_WriteTypedRecordsUtf8, invocationsPerLeg);
+                excelReaderFirst = Measure(benchmark.ExcelReaderNet_WriteTypedRecords, invocationsPerLeg);
+                excelReaderSecond = Measure(benchmark.ExcelReaderNet_WriteTypedRecords, invocationsPerLeg);
+                officeSecond = Measure(benchmark.OfficeIMO_WriteTypedRecordsUtf8, invocationsPerLeg);
+            } else {
+                excelReaderFirst = Measure(benchmark.ExcelReaderNet_WriteTypedRecords, invocationsPerLeg);
+                officeFirst = Measure(benchmark.OfficeIMO_WriteTypedRecordsUtf8, invocationsPerLeg);
+                officeSecond = Measure(benchmark.OfficeIMO_WriteTypedRecordsUtf8, invocationsPerLeg);
+                excelReaderSecond = Measure(benchmark.ExcelReaderNet_WriteTypedRecords, invocationsPerLeg);
+            }
+
+            ValidateResult($"OfficeIMO sample {index} first", officeFirst.Result);
+            ValidateResult($"OfficeIMO sample {index} second", officeSecond.Result);
+            ValidateResult($"ExcelReader.NET sample {index} first", excelReaderFirst.Result);
+            ValidateResult($"ExcelReader.NET sample {index} second", excelReaderSecond.Result);
+            officeSamples[index] = (officeFirst.Milliseconds + officeSecond.Milliseconds) / 2d;
+            excelReaderSamples[index] = (excelReaderFirst.Milliseconds + excelReaderSecond.Milliseconds) / 2d;
+            pairedRatios[index] = officeSamples[index] / excelReaderSamples[index];
+        }
+
+        double officeMedian = Median(officeSamples);
+        double excelReaderMedian = Median(excelReaderSamples);
+        Console.WriteLine(FormattableString.Invariant(
+            $"Paired CSV write comparison ({shape}, {rowCount:N0} rows, {WarmupIterations} warmups, {iterations} ABBA samples, {invocationsPerLeg} invocations per leg, affinity {affinity}, priority {priority}): OfficeIMO median {officeMedian:F3} ms, ExcelReader.NET median {excelReaderMedian:F3} ms, ratio of medians {officeMedian / excelReaderMedian:F4}, paired ratio median {Median(pairedRatios):F4} (P25 {Percentile(pairedRatios, 0.25d):F4}, P75 {Percentile(pairedRatios, 0.75d):F4})."));
+    }
+
+    private static (double Milliseconds, int Result) Measure(Func<int> operation, int invocationCount) {
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+        long started = Stopwatch.GetTimestamp();
+        int result = 0;
+        for (int index = 0; index < invocationCount; index++) {
+            result = operation();
+        }
+        return (Stopwatch.GetElapsedTime(started).TotalMilliseconds / invocationCount, result);
+    }
+
+    private static void ValidateResult(string sample, int result) {
+        if (result <= 0) {
+            throw new InvalidDataException($"CSV {sample} produced an invalid result of {result}.");
+        }
+    }
+
+    private static double Median(double[] samples) {
+        double[] ordered = [.. samples.OrderBy(static sample => sample)];
+        int middle = ordered.Length / 2;
+        return (ordered.Length & 1) == 0
+            ? (ordered[middle - 1] + ordered[middle]) / 2d
+            : ordered[middle];
+    }
+
+    private static double Percentile(double[] samples, double percentile) {
+        double[] ordered = [.. samples.OrderBy(static sample => sample)];
+        double position = (ordered.Length - 1) * percentile;
+        int lower = (int)position;
+        int upper = Math.Min(lower + 1, ordered.Length - 1);
+        double fraction = position - lower;
+        return ordered[lower] + (ordered[upper] - ordered[lower]) * fraction;
+    }
+}

--- a/OfficeIMO.CSV.Benchmarks/CsvExcelReaderWriteComparisonPairedRunner.cs
+++ b/OfficeIMO.CSV.Benchmarks/CsvExcelReaderWriteComparisonPairedRunner.cs
@@ -41,8 +41,8 @@ internal static class CsvExcelReaderWriteComparisonPairedRunner {
         var benchmark = new CsvBenchmarks { RowCount = rowCount, Shape = shape };
         benchmark.Setup();
         for (int index = 0; index < WarmupIterations; index++) {
-            ValidateResult($"OfficeIMO warmup {index}", benchmark.OfficeIMO_WriteTypedRecordsUtf8());
-            ValidateResult($"ExcelReader.NET warmup {index}", benchmark.ExcelReaderNet_WriteTypedRecords());
+            ValidateResult($"OfficeIMO warmup {index}", benchmark.OfficeIMO_WriteProjectedRowsUtf8());
+            ValidateResult($"ExcelReader.NET warmup {index}", benchmark.ExcelReaderNet_WriteProjectedRows());
         }
 
         var officeSamples = new double[iterations];
@@ -54,15 +54,15 @@ internal static class CsvExcelReaderWriteComparisonPairedRunner {
             (double Milliseconds, int Result) excelReaderFirst;
             (double Milliseconds, int Result) excelReaderSecond;
             if ((index & 1) == 0) {
-                officeFirst = Measure(benchmark.OfficeIMO_WriteTypedRecordsUtf8, invocationsPerLeg);
-                excelReaderFirst = Measure(benchmark.ExcelReaderNet_WriteTypedRecords, invocationsPerLeg);
-                excelReaderSecond = Measure(benchmark.ExcelReaderNet_WriteTypedRecords, invocationsPerLeg);
-                officeSecond = Measure(benchmark.OfficeIMO_WriteTypedRecordsUtf8, invocationsPerLeg);
+                officeFirst = Measure(benchmark.OfficeIMO_WriteProjectedRowsUtf8, invocationsPerLeg);
+                excelReaderFirst = Measure(benchmark.ExcelReaderNet_WriteProjectedRows, invocationsPerLeg);
+                excelReaderSecond = Measure(benchmark.ExcelReaderNet_WriteProjectedRows, invocationsPerLeg);
+                officeSecond = Measure(benchmark.OfficeIMO_WriteProjectedRowsUtf8, invocationsPerLeg);
             } else {
-                excelReaderFirst = Measure(benchmark.ExcelReaderNet_WriteTypedRecords, invocationsPerLeg);
-                officeFirst = Measure(benchmark.OfficeIMO_WriteTypedRecordsUtf8, invocationsPerLeg);
-                officeSecond = Measure(benchmark.OfficeIMO_WriteTypedRecordsUtf8, invocationsPerLeg);
-                excelReaderSecond = Measure(benchmark.ExcelReaderNet_WriteTypedRecords, invocationsPerLeg);
+                excelReaderFirst = Measure(benchmark.ExcelReaderNet_WriteProjectedRows, invocationsPerLeg);
+                officeFirst = Measure(benchmark.OfficeIMO_WriteProjectedRowsUtf8, invocationsPerLeg);
+                officeSecond = Measure(benchmark.OfficeIMO_WriteProjectedRowsUtf8, invocationsPerLeg);
+                excelReaderSecond = Measure(benchmark.ExcelReaderNet_WriteProjectedRows, invocationsPerLeg);
             }
 
             ValidateResult($"OfficeIMO sample {index} first", officeFirst.Result);
@@ -77,7 +77,7 @@ internal static class CsvExcelReaderWriteComparisonPairedRunner {
         double officeMedian = Median(officeSamples);
         double excelReaderMedian = Median(excelReaderSamples);
         Console.WriteLine(FormattableString.Invariant(
-            $"Paired CSV write comparison ({shape}, {rowCount:N0} rows, {WarmupIterations} warmups, {iterations} ABBA samples, {invocationsPerLeg} invocations per leg, affinity {affinity}, priority {priority}): OfficeIMO median {officeMedian:F3} ms, ExcelReader.NET median {excelReaderMedian:F3} ms, ratio of medians {officeMedian / excelReaderMedian:F4}, paired ratio median {Median(pairedRatios):F4} (P25 {Percentile(pairedRatios, 0.25d):F4}, P75 {Percentile(pairedRatios, 0.75d):F4})."));
+            $"Paired projected-row CSV write comparison ({shape}, {rowCount:N0} rows, {WarmupIterations} warmups, {iterations} ABBA samples, {invocationsPerLeg} invocations per leg, affinity {affinity}, priority {priority}): OfficeIMO median {officeMedian:F3} ms, ExcelReader.NET median {excelReaderMedian:F3} ms, ratio of medians {officeMedian / excelReaderMedian:F4}, paired ratio median {Median(pairedRatios):F4} (P25 {Percentile(pairedRatios, 0.25d):F4}, P75 {Percentile(pairedRatios, 0.75d):F4})."));
     }
 
     private static (double Milliseconds, int Result) Measure(Func<int> operation, int invocationCount) {

--- a/OfficeIMO.CSV.Benchmarks/CsvWideBenchmarks.cs
+++ b/OfficeIMO.CSV.Benchmarks/CsvWideBenchmarks.cs
@@ -17,6 +17,10 @@ using SepWriterOptions = nietras.SeparatedValues.SepWriterOptions;
 using SylvanCsvDataReader = Sylvan.Data.Csv.CsvDataReader;
 using SylvanCsvDataWriter = Sylvan.Data.Csv.CsvDataWriter;
 using SylvanCsvDataWriterOptions = Sylvan.Data.Csv.CsvDataWriterOptions;
+using ExcelReaderNetCsvReader = ExcelReader.Core.Reader.CsvReader;
+using ExcelReaderNetCsvRowWriter = ExcelReader.Core.Writer.CsvRowWriter;
+using ExcelReaderNetCsvWriter = ExcelReader.Core.Writer.CsvWriter;
+using ExcelReaderApi = ExcelReader.Core.Reader.Excel;
 
 namespace OfficeIMO.CSV.Benchmarks;
 
@@ -34,6 +38,7 @@ public class CsvWideBenchmarks
     private object?[][] _rows = [];
     private string?[][] _textRows = [];
     private string _csvText = string.Empty;
+    private byte[] _csvUtf8 = [];
     private bool _captureWriteOutput;
     private string? _capturedWriteOutput;
     private string _csvPath = string.Empty;
@@ -53,6 +58,7 @@ public class CsvWideBenchmarks
         csv.WriteRows(Headers, _rows);
 
         _csvText = writer.ToString();
+        _csvUtf8 = Encoding.UTF8.GetBytes(_csvText);
         _csvPath = Path.Combine(Path.GetTempPath(), $"OfficeIMO.CSV.Benchmarks.{Guid.NewGuid():N}.csv");
         File.WriteAllText(_csvPath, _csvText, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
 
@@ -80,6 +86,8 @@ public class CsvWideBenchmarks
         ValidateWriteOutput(nameof(Sylvan_WriteProjectedRows), Sylvan_WriteProjectedRows, expectedObjectRows: _rows);
         ValidateWriteOutput(nameof(Dataplat_WriteProjectedRows), Dataplat_WriteProjectedRows, expectedObjectRows: _rows);
         ValidateWriteOutput(nameof(Dataplat_WriteFromReader), Dataplat_WriteFromReader, expectedObjectRows: _rows);
+        ValidateWriteOutput(nameof(OfficeIMO_WriteProjectedRowsUtf8Stream), OfficeIMO_WriteProjectedRowsUtf8Stream, expectedObjectRows: _rows, reportsUtf8Bytes: true);
+        ValidateWriteOutput(nameof(ExcelReaderNet_WriteProjectedRowsUtf8Stream), ExcelReaderNet_WriteProjectedRowsUtf8Stream, expectedObjectRows: _rows, reportsUtf8Bytes: true);
 
         ValidateWriteOutput(nameof(OfficeIMO_WriteValidatedTextRows), OfficeIMO_WriteValidatedTextRows, _textRows);
         ValidateWriteOutput(nameof(OfficeIMO_WriteTextRows), OfficeIMO_WriteTextRows, _textRows);
@@ -93,7 +101,8 @@ public class CsvWideBenchmarks
         string method,
         Func<int> write,
         string?[][]? expectedTextRows = null,
-        object?[][]? expectedObjectRows = null)
+        object?[][]? expectedObjectRows = null,
+        bool reportsUtf8Bytes = false)
     {
         _captureWriteOutput = true;
         _capturedWriteOutput = null;
@@ -102,9 +111,11 @@ public class CsvWideBenchmarks
             var reportedLength = write();
             var output = _capturedWriteOutput
                 ?? throw new InvalidOperationException($"{method} did not expose its output to benchmark preflight.");
-            if (reportedLength != output.Length)
+            int expectedLength = reportsUtf8Bytes ? Encoding.UTF8.GetByteCount(output) : output.Length;
+            if (reportedLength != expectedLength)
             {
-                throw new InvalidOperationException($"{method} reported {reportedLength} characters but produced {output.Length}.");
+                string unit = reportsUtf8Bytes ? "UTF-8 bytes" : "characters";
+                throw new InvalidOperationException($"{method} reported {reportedLength} {unit} but produced {expectedLength}.");
             }
 
             CsvBenchmarkOutputValidator.Validate(method, output, Headers, RowCount, expectedTextRows, expectedObjectRows);
@@ -153,6 +164,9 @@ public class CsvWideBenchmarks
         ValidateReadOutput(nameof(Dataplat_ReadDataTableLoad), Dataplat_ReadDataTableLoad, dataChecksum);
         ValidateReadOutput(nameof(Sep_ReadFields), Sep_ReadFields, dataChecksum);
         ValidateReadOutput(nameof(Sep_ReadFieldSpans), Sep_ReadFieldSpans, dataChecksum);
+        CsvWideReadObservation expectedUtf8Observation = ObserveRows(_textRows);
+        ValidateUtf8ReadOutput(nameof(OfficeIMO_ReadUtf8Fields), OfficeIMO_ReadUtf8Fields, expectedUtf8Observation);
+        ValidateUtf8ReadOutput(nameof(ExcelReaderNet_ReadUtf8Fields), ExcelReaderNet_ReadUtf8Fields, expectedUtf8Observation);
     }
 
     private static void ValidateReadOutput(string method, Func<int> read, int expectedChecksum)
@@ -184,6 +198,30 @@ public class CsvWideBenchmarks
         }
 
         return output.Length;
+    }
+
+    private static void ValidateUtf8ReadOutput(
+        string method,
+        Func<CsvWideReadObservation> read,
+        CsvWideReadObservation expected)
+    {
+        CsvWideReadObservation actual = read();
+        if (actual != expected)
+        {
+            throw new InvalidOperationException(
+                $"{method} returned {actual}; expected {expected}. The benchmark lane did not read the exact ordered UTF-8 CSV payload.");
+        }
+    }
+
+    private int CompleteUtf8Write(MemoryStream stream)
+    {
+        if (_captureWriteOutput)
+        {
+            string output = Encoding.UTF8.GetString(stream.GetBuffer(), 0, checked((int)stream.Length));
+            _capturedWriteOutput = output;
+        }
+
+        return checked((int)stream.Length);
     }
 
     [GlobalCleanup]
@@ -366,6 +404,55 @@ public class CsvWideBenchmarks
         using var csv = new DataplatCsvWriter(writer, DataplatWriterOptions);
         csv.WriteFromReader(reader);
         return CompleteWrite(writer);
+    }
+
+    [Benchmark]
+    public int OfficeIMO_WriteProjectedRowsUtf8Stream()
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new StreamWriter(
+            stream,
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+            bufferSize: 16 * 1024,
+            leaveOpen: true))
+        {
+            using var csv = new CsvRowWriter(writer, new CsvSaveOptions { NewLine = "\n" }, leaveOpen: true);
+            csv.WriteRows(Headers, _rows);
+            writer.Flush();
+        }
+
+        return CompleteUtf8Write(stream);
+    }
+
+    [Benchmark]
+    public int ExcelReaderNet_WriteProjectedRowsUtf8Stream()
+    {
+        using var stream = new MemoryStream();
+        using (ExcelReaderNetCsvWriter csv = ExcelReaderNetCsvWriter.Create(stream, leaveOpen: true))
+        {
+            using (ExcelReaderNetCsvRowWriter header = csv.StartRow())
+            {
+                foreach (string value in Headers)
+                {
+                    header.Write(value);
+                }
+            }
+
+            foreach (object?[] values in _rows)
+            {
+                using ExcelReaderNetCsvRowWriter row = csv.StartRow();
+                row.Write((int)values[0]!);
+                row.Write((string?)values[1]);
+                row.Write((DateTime)values[2]!);
+                row.Write((bool)values[3]!);
+                for (int column = 4; column < values.Length; column++)
+                {
+                    row.Write((decimal)values[column]!);
+                }
+            }
+        }
+
+        return CompleteUtf8Write(stream);
     }
 
     [Benchmark]
@@ -700,6 +787,63 @@ public class CsvWideBenchmarks
         return fieldCount;
     }
 
+    [Benchmark]
+    public CsvWideReadObservation OfficeIMO_ReadUtf8Fields()
+    {
+        using var stream = new MemoryStream(_csvUtf8, writable: false);
+        using var reader = CsvDocument.OpenDataReader(stream);
+        var observation = CsvWideReadObservation.Empty;
+        while (reader.Read())
+        {
+            observation = observation.StartRow();
+            for (int column = 0; column < reader.FieldCount; column++)
+            {
+                observation = observation.Append(reader.GetString(column));
+            }
+        }
+
+        return observation;
+    }
+
+    [Benchmark]
+    public CsvWideReadObservation ExcelReaderNet_ReadUtf8Fields()
+    {
+        using ExcelReaderNetCsvReader reader = ExcelReaderApi.FromCsv(_csvUtf8);
+        var observation = CsvWideReadObservation.Empty;
+        bool header = true;
+        foreach (ExcelReader.Core.ValueObjects.Row row in reader)
+        {
+            if (header)
+            {
+                header = false;
+                continue;
+            }
+
+            observation = observation.StartRow();
+            for (int column = 0; column < Headers.Length; column++)
+            {
+                observation = observation.Append(row[column].GetString());
+            }
+        }
+
+        return observation;
+    }
+
+    private static CsvWideReadObservation ObserveRows(IEnumerable<string?[]> rows)
+    {
+        var observation = CsvWideReadObservation.Empty;
+        foreach (string?[] row in rows)
+        {
+            observation = observation.StartRow();
+            foreach (string? value in row)
+            {
+                observation = observation.Append(value ?? string.Empty);
+            }
+        }
+
+        return observation;
+    }
+
     private static string[] CreateHeaders()
     {
         var headers = new string[40];
@@ -756,6 +900,31 @@ public class CsvWideBenchmarks
             return true;
         }
     }
+}
+
+public readonly record struct CsvWideReadObservation(int RowCount, int CellCount, ulong PayloadHash)
+{
+    private const ulong OffsetBasis = 14695981039346656037UL;
+    private const ulong Prime = 1099511628211UL;
+
+    internal static CsvWideReadObservation Empty => new(0, 0, OffsetBasis);
+
+    internal CsvWideReadObservation StartRow() =>
+        new(RowCount + 1, CellCount, Mix(PayloadHash, 0xFFFF));
+
+    internal CsvWideReadObservation Append(string value)
+    {
+        ulong hash = Mix(PayloadHash, 0xFFFE);
+        foreach (char character in value)
+        {
+            hash = Mix(hash, character);
+        }
+
+        return new CsvWideReadObservation(RowCount, CellCount + 1, hash);
+    }
+
+    private static ulong Mix(ulong hash, int value) =>
+        unchecked((hash ^ (uint)value) * Prime);
 }
 
 internal static class CsvWideBenchmarkData

--- a/OfficeIMO.CSV.Benchmarks/MarkPflug65KCsvBenchmarks.cs
+++ b/OfficeIMO.CSV.Benchmarks/MarkPflug65KCsvBenchmarks.cs
@@ -2,6 +2,8 @@ using System.Globalization;
 using System.Data.Common;
 using BenchmarkDotNet.Attributes;
 using CsvHelper.Configuration;
+using ExcelReader.Core.Reader;
+using ExcelReader.Core.ValueObjects;
 using nietras.SeparatedValues;
 using OfficeIMO.Benchmarks;
 using CsvHelperReader = CsvHelper.CsvReader;
@@ -9,6 +11,8 @@ using DataplatCsvDataReader = Dataplat.Dbatools.Csv.Reader.CsvDataReader;
 using LumenWorksCsvReader = CsvReader.CsvReader;
 using SepLib = nietras.SeparatedValues.Sep;
 using SylvanCsvDataReader = Sylvan.Data.Csv.CsvDataReader;
+using ExcelReaderApi = ExcelReader.Core.Reader.Excel;
+using ExcelReaderNetCsvReader = ExcelReader.Core.Reader.CsvReader;
 
 namespace OfficeIMO.CSV.Benchmarks;
 
@@ -32,6 +36,7 @@ public class MarkPflug65KCsvBenchmarks {
             MarkPflug65KFixture.ExpectedCsvCharacters,
             MarkPflug65KFixture.ExpectedCsvChecksum);
         Validate(nameof(OfficeIMO), OfficeIMO());
+        Validate(nameof(ExcelReaderNet), ExcelReaderNet());
         Validate(nameof(Sep), Sep());
         Validate(nameof(Sylvan), Sylvan());
         Validate(nameof(CsvHelper), CsvHelper());
@@ -45,6 +50,32 @@ public class MarkPflug65KCsvBenchmarks {
             MarkPflug65KFixture.CsvPath,
             new CsvLoadOptions { DetectDelimiter = false });
         return Observe(reader);
+    }
+
+    [Benchmark]
+    public CsvReadObservation ExcelReaderNet() {
+        using ExcelReaderNetCsvReader reader = ExcelReaderApi.FromCsvFile(MarkPflug65KFixture.CsvPath);
+        int rows = 0;
+        int cells = 0;
+        long characters = 0;
+        ulong checksum = ChecksumOffset;
+        bool header = true;
+        foreach (Row row in reader) {
+            if (header) {
+                header = false;
+                continue;
+            }
+
+            rows++;
+            for (int column = 0; column < row.ColumnCount; column++) {
+                cells++;
+                string decoded = row[column].GetString();
+                characters += decoded.Length;
+                AddValue(ref checksum, decoded);
+            }
+        }
+
+        return new CsvReadObservation(rows, cells, characters, checksum);
     }
 
     [Benchmark]

--- a/OfficeIMO.CSV.Benchmarks/OfficeIMO.CSV.Benchmarks.csproj
+++ b/OfficeIMO.CSV.Benchmarks/OfficeIMO.CSV.Benchmarks.csproj
@@ -13,6 +13,8 @@
     <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageReference Include="CsvHelper" Version="33.1.0" />
     <PackageReference Include="Dataplat.Dbatools.Csv" Version="1.1.15" />
+      <!-- Runtime APIs are benchmarked directly. The 2.1.2 source generator targets a newer Roslyn than the .NET 10.0.111 SDK ships. -->
+      <PackageReference Include="ExcelReader.NET" Version="2.1.2" ExcludeAssets="analyzers" />
     <PackageReference Include="LumenWorksCsvReader2" Version="4.4.0" />
     <PackageReference Include="Sep" Version="0.15.1" />
     <PackageReference Include="Sylvan.Data.Csv" Version="1.4.4" />
@@ -26,5 +28,11 @@
     <Compile Include="..\Benchmarks\BenchmarkProcessorAffinity.cs" Link="Shared\BenchmarkProcessorAffinity.cs" />
     <Compile Include="..\Benchmarks\MarkPflug65KFixture.cs" Link="Shared\MarkPflug65KFixture.cs" />
   </ItemGroup>
+
+  <Target Name="RemoveIncompatibleExcelReaderGenerator" BeforeTargets="CoreCompile">
+    <ItemGroup>
+      <Analyzer Remove="$(NuGetPackageRoot)excelreader.net\2.1.2\analyzers\dotnet\cs\ExcelReader.Generator.dll" />
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/OfficeIMO.CSV.Benchmarks/Program.cs
+++ b/OfficeIMO.CSV.Benchmarks/Program.cs
@@ -41,6 +41,10 @@ bool profileTypedSepParallel = args.Length > 0 &&
     string.Equals(args[0], "--profile-typed-sep-parallel", StringComparison.OrdinalIgnoreCase);
 bool comparePaired = args.Length > 0 &&
     string.Equals(args[0], "--compare-markpflug65k-paired", StringComparison.OrdinalIgnoreCase);
+bool compareExcelReaderPaired = args.Length > 0 &&
+    string.Equals(args[0], "--compare-excelreader-paired", StringComparison.OrdinalIgnoreCase);
+bool compareExcelReaderWritePaired = args.Length > 0 &&
+    string.Equals(args[0], "--compare-excelreader-write-paired", StringComparison.OrdinalIgnoreCase);
 bool compareTrimUnescapeStringsPaired = args.Length > 0 &&
     string.Equals(args[0], "--compare-trim-unescape-strings-paired", StringComparison.OrdinalIgnoreCase);
 bool compareTypedSequentialPaired = args.Length > 0 &&
@@ -51,6 +55,16 @@ bool compareDataReaderWritePaired = args.Length > 0 &&
     string.Equals(args[0], "--compare-datareader-write-paired", StringComparison.OrdinalIgnoreCase);
 bool compareDataReaderParallelWritePaired = args.Length > 0 &&
     string.Equals(args[0], "--compare-datareader-parallel-write-paired", StringComparison.OrdinalIgnoreCase);
+
+if (compareExcelReaderPaired) {
+    CsvExcelReaderComparisonPairedRunner.Run(args);
+    return;
+}
+
+if (compareExcelReaderWritePaired) {
+    CsvExcelReaderWriteComparisonPairedRunner.Run(args);
+    return;
+}
 
 if (compareDataReaderParallelWritePaired) {
     int iterations = args.Length > 1 && int.TryParse(args[1], out int parsedIterations)

--- a/OfficeIMO.Excel.Benchmarks/ExcelGeneratedRowStreamingBenchmarks.cs
+++ b/OfficeIMO.Excel.Benchmarks/ExcelGeneratedRowStreamingBenchmarks.cs
@@ -17,32 +17,98 @@ public class ExcelGeneratedRowStreamingBenchmarks {
 
     [GlobalSetup]
     public void Setup() {
-        GeneratedRow[] rows = GenerateRows(32).ToArray();
+        string officePath = CreatePreflightPath("officeimo");
+        string excelReaderPath = CreatePreflightPath("excelreader");
+        string officeAsyncPath = CreatePreflightPath("officeimo-async");
+        string excelReaderAsyncPath = CreatePreflightPath("excelreader-async");
+        try {
+            using (var officeStream = new FileStream(
+                officePath,
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.None,
+                256 * 1024,
+                FileOptions.SequentialScan)) {
+                ExcelDataSetImportResult result = ExcelDocument.WriteRows(
+                    officeStream,
+                    GenerateRows(RowCount),
+                    Headers,
+                    static (writer, row) => writer
+                        .Write(row.Id)
+                        .Write(row.Amount)
+                        .Write(row.CreatedOn)
+                        .Write(row.Active),
+                    CompactWriteOptions);
+                if (result.RowCount != RowCount) {
+                    throw new InvalidDataException(
+                        $"OfficeIMO reported {result.RowCount} rows instead of {RowCount} during write preflight.");
+                }
+            }
+            ValidateWorkbook(nameof(WriteRowsGenerated), officePath, RowCount);
 
-        using var officeStream = new MemoryStream();
-        ExcelDataSetImportResult result = ExcelDocument.WriteRows(
-            officeStream,
-            rows,
-            Headers,
-            static (writer, row) => writer
-                .Write(row.Id)
-                .Write(row.Amount)
-                .Write(row.CreatedOn)
-                .Write(row.Active),
-            CompactWriteOptions);
-        if (result.RowCount != rows.Length) {
-            throw new InvalidDataException(
-                $"OfficeIMO reported {result.RowCount} rows instead of {rows.Length} during write preflight.");
-        }
-        ValidateWorkbook(nameof(WriteRowsGenerated), officeStream.ToArray(), rows);
+            using (var excelReaderStream = new FileStream(
+                excelReaderPath,
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.None,
+                256 * 1024,
+                FileOptions.SequentialScan)) {
+                int excelReaderRows = WriteExcelReaderRows(
+                    excelReaderStream,
+                    GenerateRows(RowCount));
+                if (excelReaderRows != RowCount) {
+                    throw new InvalidDataException(
+                        $"ExcelReader.NET reported {excelReaderRows} rows instead of {RowCount} during write preflight.");
+                }
+            }
+            ValidateWorkbook(nameof(ExcelReaderNetWriteRowsGenerated), excelReaderPath, RowCount);
 
-        using var excelReaderStream = new MemoryStream();
-        int excelReaderRows = WriteExcelReaderRows(excelReaderStream, rows);
-        if (excelReaderRows != rows.Length) {
-            throw new InvalidDataException(
-                $"ExcelReader.NET reported {excelReaderRows} rows instead of {rows.Length} during write preflight.");
+            using (var officeAsyncStream = new FileStream(
+                officeAsyncPath,
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.None,
+                256 * 1024,
+                FileOptions.Asynchronous | FileOptions.SequentialScan)) {
+                ExcelDataSetImportResult result = ExcelDocument.WriteRowsAsync(
+                    officeAsyncStream,
+                    GenerateRowsAsync(RowCount),
+                    Headers,
+                    static (writer, row) => writer
+                        .Write(row.Id)
+                        .Write(row.Amount)
+                        .Write(row.CreatedOn)
+                        .Write(row.Active),
+                    CompactWriteOptions).GetAwaiter().GetResult();
+                if (result.RowCount != RowCount) {
+                    throw new InvalidDataException(
+                        $"OfficeIMO async reported {result.RowCount} rows instead of {RowCount} during write preflight.");
+                }
+            }
+            ValidateWorkbook(nameof(WriteRowsAsyncGenerated), officeAsyncPath, RowCount);
+
+            using (var excelReaderAsyncStream = new FileStream(
+                excelReaderAsyncPath,
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.None,
+                256 * 1024,
+                FileOptions.Asynchronous | FileOptions.SequentialScan)) {
+                int excelReaderRows = WriteExcelReaderRowsAsync(
+                    excelReaderAsyncStream,
+                    GenerateRowsAsync(RowCount)).GetAwaiter().GetResult();
+                if (excelReaderRows != RowCount) {
+                    throw new InvalidDataException(
+                        $"ExcelReader.NET async reported {excelReaderRows} rows instead of {RowCount} during write preflight.");
+                }
+            }
+            ValidateWorkbook(nameof(ExcelReaderNetWriteRowsAsyncGenerated), excelReaderAsyncPath, RowCount);
+        } finally {
+            File.Delete(officePath);
+            File.Delete(excelReaderPath);
+            File.Delete(officeAsyncPath);
+            File.Delete(excelReaderAsyncPath);
         }
-        ValidateWorkbook(nameof(ExcelReaderNetWriteRowsGenerated), excelReaderStream.ToArray(), rows);
     }
 
     [Params(1_000_000)]
@@ -149,10 +215,10 @@ public class ExcelGeneratedRowStreamingBenchmarks {
 
     private static void ValidateWorkbook(
         string method,
-        byte[] workbook,
-        IReadOnlyList<GeneratedRow> expectedRows) {
+        string workbookPath,
+        int expectedRowCount) {
         using ExcelWorkbookDataReader reader = ExcelDocument.OpenDataReader(
-            workbook,
+            workbookPath,
             new ExcelReadOptions { NumericAsDecimal = true });
         if (reader.FieldCount != Headers.Length) {
             throw new InvalidDataException(
@@ -167,11 +233,11 @@ public class ExcelGeneratedRowStreamingBenchmarks {
 
         int index = 0;
         while (reader.Read()) {
-            if (index >= expectedRows.Count) {
+            if (index >= expectedRowCount) {
                 throw new InvalidDataException($"{method} emitted extra rows.");
             }
 
-            GeneratedRow expected = expectedRows[index];
+            GeneratedRow expected = CreateRow(index);
             if (reader.GetInt32(0) != expected.Id
                 || reader.GetDecimal(1) != expected.Amount
                 || reader.GetDateTime(2) != expected.CreatedOn
@@ -181,33 +247,33 @@ public class ExcelGeneratedRowStreamingBenchmarks {
             index++;
         }
 
-        if (index != expectedRows.Count || reader.NextResult()) {
+        if (index != expectedRowCount || reader.NextResult()) {
             throw new InvalidDataException($"{method} did not round-trip the exact single-sheet row set.");
         }
     }
 
     private static IEnumerable<GeneratedRow> GenerateRows(int count) {
-        var start = new DateTime(2026, 1, 1);
         for (int index = 0; index < count; index++) {
-            yield return new GeneratedRow(
-                index + 1,
-                index * 1.25m,
-                start.AddMinutes(index),
-                (index & 1) == 0);
+            yield return CreateRow(index);
         }
     }
 
     private static async IAsyncEnumerable<GeneratedRow> GenerateRowsAsync(int count) {
         await Task.CompletedTask;
-        var start = new DateTime(2026, 1, 1);
         for (int index = 0; index < count; index++) {
-            yield return new GeneratedRow(
-                index + 1,
-                index * 1.25m,
-                start.AddMinutes(index),
-                (index & 1) == 0);
+            yield return CreateRow(index);
         }
     }
+
+    private static GeneratedRow CreateRow(int index) => new(
+        index + 1,
+        index * 1.25m,
+        new DateTime(2026, 1, 1).AddMinutes(index),
+        (index & 1) == 0);
+
+    private static string CreatePreflightPath(string implementation) => Path.Combine(
+        Path.GetTempPath(),
+        $"OfficeIMO.Excel.Benchmarks.{implementation}.{Guid.NewGuid():N}.xlsx");
 
     private readonly record struct GeneratedRow(
         int Id,

--- a/OfficeIMO.Excel.Benchmarks/ExcelGeneratedRowStreamingBenchmarks.cs
+++ b/OfficeIMO.Excel.Benchmarks/ExcelGeneratedRowStreamingBenchmarks.cs
@@ -10,6 +10,10 @@ namespace OfficeIMO.Excel.Benchmarks;
 [MemoryDiagnoser]
 public class ExcelGeneratedRowStreamingBenchmarks {
     private static readonly string[] Headers = ["Id", "Amount", "CreatedOn", "Active"];
+    private static readonly ExcelTabularWriteOptions CompactWriteOptions = new() {
+        IncludeCellReferences = false,
+        UseSharedStrings = false
+    };
 
     [GlobalSetup]
     public void Setup() {
@@ -24,7 +28,8 @@ public class ExcelGeneratedRowStreamingBenchmarks {
                 .Write(row.Id)
                 .Write(row.Amount)
                 .Write(row.CreatedOn)
-                .Write(row.Active));
+                .Write(row.Active),
+            CompactWriteOptions);
         if (result.RowCount != rows.Length) {
             throw new InvalidDataException(
                 $"OfficeIMO reported {result.RowCount} rows instead of {rows.Length} during write preflight.");
@@ -53,7 +58,8 @@ public class ExcelGeneratedRowStreamingBenchmarks {
                 .Write(row.Id)
                 .Write(row.Amount)
                 .Write(row.CreatedOn)
-                .Write(row.Active));
+                .Write(row.Active),
+            CompactWriteOptions);
         return result.RowCount;
     }
 
@@ -71,7 +77,8 @@ public class ExcelGeneratedRowStreamingBenchmarks {
                 .Write(row.Id)
                 .Write(row.Amount)
                 .Write(row.CreatedOn)
-                .Write(row.Active));
+                .Write(row.Active),
+            CompactWriteOptions);
         return result.RowCount;
     }
 

--- a/OfficeIMO.Excel.Benchmarks/ExcelGeneratedRowStreamingBenchmarks.cs
+++ b/OfficeIMO.Excel.Benchmarks/ExcelGeneratedRowStreamingBenchmarks.cs
@@ -1,4 +1,5 @@
 using BenchmarkDotNet.Attributes;
+using ExcelReader.Core.Writer;
 
 namespace OfficeIMO.Excel.Benchmarks;
 
@@ -9,6 +10,35 @@ namespace OfficeIMO.Excel.Benchmarks;
 [MemoryDiagnoser]
 public class ExcelGeneratedRowStreamingBenchmarks {
     private static readonly string[] Headers = ["Id", "Amount", "CreatedOn", "Active"];
+
+    [GlobalSetup]
+    public void Setup() {
+        GeneratedRow[] rows = GenerateRows(32).ToArray();
+
+        using var officeStream = new MemoryStream();
+        ExcelDataSetImportResult result = ExcelDocument.WriteRows(
+            officeStream,
+            rows,
+            Headers,
+            static (writer, row) => writer
+                .Write(row.Id)
+                .Write(row.Amount)
+                .Write(row.CreatedOn)
+                .Write(row.Active));
+        if (result.RowCount != rows.Length) {
+            throw new InvalidDataException(
+                $"OfficeIMO reported {result.RowCount} rows instead of {rows.Length} during write preflight.");
+        }
+        ValidateWorkbook(nameof(WriteRowsGenerated), officeStream.ToArray(), rows);
+
+        using var excelReaderStream = new MemoryStream();
+        int excelReaderRows = WriteExcelReaderRows(excelReaderStream, rows);
+        if (excelReaderRows != rows.Length) {
+            throw new InvalidDataException(
+                $"ExcelReader.NET reported {excelReaderRows} rows instead of {rows.Length} during write preflight.");
+        }
+        ValidateWorkbook(nameof(ExcelReaderNetWriteRowsGenerated), excelReaderStream.ToArray(), rows);
+    }
 
     [Params(1_000_000)]
     public int RowCount { get; set; }
@@ -28,6 +58,10 @@ public class ExcelGeneratedRowStreamingBenchmarks {
     }
 
     [Benchmark]
+    public int ExcelReaderNetWriteRowsGenerated() =>
+        WriteExcelReaderRows(Stream.Null, GenerateRows(RowCount));
+
+    [Benchmark]
     public async Task<int> WriteRowsAsyncGenerated() {
         ExcelDataSetImportResult result = await ExcelDocument.WriteRowsAsync(
             Stream.Null,
@@ -39,6 +73,110 @@ public class ExcelGeneratedRowStreamingBenchmarks {
                 .Write(row.CreatedOn)
                 .Write(row.Active));
         return result.RowCount;
+    }
+
+    [Benchmark]
+    public Task<int> ExcelReaderNetWriteRowsAsyncGenerated() =>
+        WriteExcelReaderRowsAsync(Stream.Null, GenerateRowsAsync(RowCount));
+
+    private static int WriteExcelReaderRows(Stream stream, IEnumerable<GeneratedRow> rows) {
+        using XlsxWorkbookWriter workbook = XlsxWorkbookWriter.Create(stream, leaveOpen: true);
+        workbook.Start();
+        int count = 0;
+        using (XlsxSheetWriter sheet = workbook.AddSheet("Data")) {
+            sheet.Start();
+            using (XlsxRowWriter header = sheet.StartRow()) {
+                WriteHeaders(header);
+            }
+
+            foreach (GeneratedRow value in rows) {
+                using XlsxRowWriter row = sheet.StartRow();
+                WriteRow(row, value);
+                count++;
+            }
+            sheet.End();
+        }
+        workbook.End();
+        return count;
+    }
+
+    private static async Task<int> WriteExcelReaderRowsAsync(
+        Stream stream,
+        IAsyncEnumerable<GeneratedRow> rows) {
+        await using XlsxWorkbookWriter workbook = await XlsxWorkbookWriter.CreateAsync(
+            stream,
+            leaveOpen: true);
+        await workbook.StartAsync();
+        int count = 0;
+        await using (XlsxSheetWriter sheet = workbook.AddSheet("Data")) {
+            await sheet.StartAsync();
+            await using (XlsxRowWriter header = await sheet.StartRowAsync()) {
+                WriteHeaders(header);
+            }
+
+            await foreach (GeneratedRow value in rows) {
+                await using XlsxRowWriter row = await sheet.StartRowAsync();
+                WriteRow(row, value);
+                count++;
+            }
+            await sheet.EndAsync();
+        }
+        await workbook.EndAsync();
+        return count;
+    }
+
+    private static void WriteHeaders<TRow>(TRow row)
+        where TRow : IRowWriter {
+        foreach (string header in Headers) {
+            row.Write(header);
+        }
+    }
+
+    private static void WriteRow<TRow>(TRow row, GeneratedRow value)
+        where TRow : IRowWriter {
+        row.Write(value.Id);
+        row.Write(value.Amount);
+        row.Write(value.CreatedOn);
+        row.Write(value.Active);
+    }
+
+    private static void ValidateWorkbook(
+        string method,
+        byte[] workbook,
+        IReadOnlyList<GeneratedRow> expectedRows) {
+        using ExcelWorkbookDataReader reader = ExcelDocument.OpenDataReader(
+            workbook,
+            new ExcelReadOptions { NumericAsDecimal = true });
+        if (reader.FieldCount != Headers.Length) {
+            throw new InvalidDataException(
+                $"{method} exposed {reader.FieldCount} columns instead of {Headers.Length}.");
+        }
+
+        for (int column = 0; column < Headers.Length; column++) {
+            if (!string.Equals(reader.GetName(column), Headers[column], StringComparison.Ordinal)) {
+                throw new InvalidDataException($"{method} header {column + 1} did not round-trip.");
+            }
+        }
+
+        int index = 0;
+        while (reader.Read()) {
+            if (index >= expectedRows.Count) {
+                throw new InvalidDataException($"{method} emitted extra rows.");
+            }
+
+            GeneratedRow expected = expectedRows[index];
+            if (reader.GetInt32(0) != expected.Id
+                || reader.GetDecimal(1) != expected.Amount
+                || reader.GetDateTime(2) != expected.CreatedOn
+                || reader.GetBoolean(3) != expected.Active) {
+                throw new InvalidDataException($"{method} row {index + 2} did not round-trip.");
+            }
+            index++;
+        }
+
+        if (index != expectedRows.Count || reader.NextResult()) {
+            throw new InvalidDataException($"{method} did not round-trip the exact single-sheet row set.");
+        }
     }
 
     private static IEnumerable<GeneratedRow> GenerateRows(int count) {

--- a/OfficeIMO.Excel.Benchmarks/ExcelNativeBinaryWriteBenchmarks.cs
+++ b/OfficeIMO.Excel.Benchmarks/ExcelNativeBinaryWriteBenchmarks.cs
@@ -23,6 +23,12 @@ public class ExcelNativeBinaryWriteBenchmarks {
 
     [GlobalSetup]
     public void Setup() {
+        SetupOfficeIMOOnly();
+        byte[] excelReaderWorkbook = WriteExcelReaderWorkbook();
+        Validate(excelReaderWorkbook);
+    }
+
+    internal void SetupOfficeIMOOnly() {
         _rows = new BinaryWriteRow[RowCount];
         for (int index = 0; index < _rows.Length; index++) {
             _rows[index] = new BinaryWriteRow(
@@ -35,15 +41,13 @@ public class ExcelNativeBinaryWriteBenchmarks {
 
         byte[] workbook = WriteWorkbook();
         Validate(workbook);
-        byte[] excelReaderWorkbook = WriteExcelReaderWorkbook();
-        Validate(excelReaderWorkbook);
     }
 
     [Benchmark]
     public int OfficeIMO_PublicTabularWrite() => WriteWorkbook().Length;
 
     [Benchmark]
-    public int ExcelReaderNet_PublicTabularWrite() => WriteExcelReaderWorkbook().Length;
+    public int ExcelReaderNet_DiagnosticWrite() => WriteExcelReaderWorkbook().Length;
 
     private byte[] WriteWorkbook() {
         using ExcelDocument document = ExcelDocument.Create();
@@ -167,4 +171,32 @@ public class ExcelNativeBinaryWriteBenchmarks {
     }
 
     private readonly record struct BinaryWriteRow(int Id, string Region, string Owner, double Amount, bool Active);
+}
+
+/// <summary>
+/// Measures OfficeIMO's validated native binary write paths without ranking
+/// structurally invalid competitor output.
+/// </summary>
+[MemoryDiagnoser]
+public class OfficeNativeBinaryWriteBenchmarks {
+    private ExcelNativeBinaryWriteBenchmarks _scenario = null!;
+
+    [Params(2_500, 25_000)]
+    public int RowCount { get; set; }
+
+    [Params(ExcelFileFormat.Xls, ExcelFileFormat.Xlsb)]
+    public ExcelFileFormat Format { get; set; }
+
+    [GlobalSetup]
+    public void Setup() {
+        _scenario = new ExcelNativeBinaryWriteBenchmarks {
+            RowCount = RowCount,
+            Format = Format
+        };
+        _scenario.SetupOfficeIMOOnly();
+    }
+
+    [Benchmark]
+    public int OfficeIMO_ValidatedNativeBinaryWrite() =>
+        _scenario.OfficeIMO_PublicTabularWrite();
 }

--- a/OfficeIMO.Excel.Benchmarks/ExcelNativeBinaryWriteBenchmarks.cs
+++ b/OfficeIMO.Excel.Benchmarks/ExcelNativeBinaryWriteBenchmarks.cs
@@ -4,24 +4,21 @@ using ExcelReader.Core.Writer;
 namespace OfficeIMO.Excel.Benchmarks;
 
 /// <summary>
-/// Measures equivalent public, high-throughput tabular write contracts for
-/// OfficeIMO's native binary workbook formats and ExcelReader.NET.
+/// Provides a diagnostic scenario for OfficeIMO's native binary workbook
+/// formats and ExcelReader.NET. The competitor output is not exposed as a
+/// BenchmarkDotNet result because it fails the required XLS/XLSB structures.
 /// </summary>
-[MemoryDiagnoser]
-public class ExcelNativeBinaryWriteBenchmarks {
+internal sealed class ExcelNativeBinaryWriteBenchmarks {
     private BinaryWriteRow[] _rows = null!;
 
-    [Params(2_500, 25_000)]
     public int RowCount { get; set; }
 
     // ExcelReader.NET 2.1.2 omits the required BrtWsDim record from XLSB.
     // Its XLS writer also omits the BIFF8 Index/Row/DBCell cell-table structure,
     // so this XLS comparison is a diagnostic throughput lane rather than a
     // format-conformance-equivalent result.
-    [Params(ExcelFileFormat.Xls)]
     public ExcelFileFormat Format { get; set; }
 
-    [GlobalSetup]
     public void Setup() {
         SetupOfficeIMOOnly();
         byte[] excelReaderWorkbook = WriteExcelReaderWorkbook();
@@ -43,10 +40,8 @@ public class ExcelNativeBinaryWriteBenchmarks {
         Validate(workbook);
     }
 
-    [Benchmark]
     public int OfficeIMO_PublicTabularWrite() => WriteWorkbook().Length;
 
-    [Benchmark]
     public int ExcelReaderNet_DiagnosticWrite() => WriteExcelReaderWorkbook().Length;
 
     private byte[] WriteWorkbook() {

--- a/OfficeIMO.Excel.Benchmarks/ExcelNativeBinaryWriteBenchmarks.cs
+++ b/OfficeIMO.Excel.Benchmarks/ExcelNativeBinaryWriteBenchmarks.cs
@@ -4,9 +4,8 @@ using ExcelReader.Core.Writer;
 namespace OfficeIMO.Excel.Benchmarks;
 
 /// <summary>
-/// Measures the same public, plain-tabular write contract for OfficeIMO's two
-/// native binary workbook formats. This is a throughput/allocation lane, not a
-/// cross-format ranking: XLS and XLSB are different physical contracts.
+/// Measures equivalent public, high-throughput tabular write contracts for
+/// OfficeIMO's native binary workbook formats and ExcelReader.NET.
 /// </summary>
 [MemoryDiagnoser]
 public class ExcelNativeBinaryWriteBenchmarks {
@@ -15,8 +14,10 @@ public class ExcelNativeBinaryWriteBenchmarks {
     [Params(2_500, 25_000)]
     public int RowCount { get; set; }
 
-    // ExcelReader.NET 2.1.2 omits the required BrtWsDim record from its XLSB
-    // output, so only its structurally valid XLS writer participates here.
+    // ExcelReader.NET 2.1.2 omits the required BrtWsDim record from XLSB.
+    // Its XLS writer also omits the BIFF8 Index/Row/DBCell cell-table structure,
+    // so this XLS comparison is a diagnostic throughput lane rather than a
+    // format-conformance-equivalent result.
     [Params(ExcelFileFormat.Xls)]
     public ExcelFileFormat Format { get; set; }
 
@@ -47,23 +48,22 @@ public class ExcelNativeBinaryWriteBenchmarks {
     private byte[] WriteWorkbook() {
         using ExcelDocument document = ExcelDocument.Create();
         ExcelSheet sheet = document.AddWorksheet("Data");
-        sheet.CellValue(1, 1, "Id");
-        sheet.CellValue(1, 2, "Region");
-        sheet.CellValue(1, 3, "Owner");
-        sheet.CellValue(1, 4, "Amount");
-        sheet.CellValue(1, 5, "Active");
+        sheet.InsertObjects(
+            _rows,
+            ("Id", static row => row.Id),
+            ("Region", static row => row.Region),
+            ("Owner", static row => row.Owner),
+            ("Amount", static row => row.Amount),
+            ("Active", static row => row.Active));
 
-        for (int index = 0; index < _rows.Length; index++) {
-            int row = index + 2;
-            BinaryWriteRow value = _rows[index];
-            sheet.CellValue(row, 1, value.Id);
-            sheet.CellValue(row, 2, value.Region);
-            sheet.CellValue(row, 3, value.Owner);
-            sheet.CellValue(row, 4, value.Amount);
-            sheet.CellValue(row, 5, value.Active);
+        byte[] workbook = document.ToBytes(Format);
+        if (document.LastSaveDiagnostics.Writer != ExcelSavePackageWriter.NativeBinaryDirectPackage) {
+            throw new InvalidOperationException(
+                $"OfficeIMO {Format} benchmark did not use the native direct tabular writer: "
+                + document.LastSaveDiagnostics.FastPackageSkipReason);
         }
 
-        return document.ToBytes(Format);
+        return workbook;
     }
 
     private byte[] WriteExcelReaderWorkbook() => Format switch {

--- a/OfficeIMO.Excel.Benchmarks/ExcelNativeBinaryWriteBenchmarks.cs
+++ b/OfficeIMO.Excel.Benchmarks/ExcelNativeBinaryWriteBenchmarks.cs
@@ -1,4 +1,5 @@
 using BenchmarkDotNet.Attributes;
+using ExcelReader.Core.Writer;
 
 namespace OfficeIMO.Excel.Benchmarks;
 
@@ -14,7 +15,9 @@ public class ExcelNativeBinaryWriteBenchmarks {
     [Params(2_500, 25_000)]
     public int RowCount { get; set; }
 
-    [Params(ExcelFileFormat.Xls, ExcelFileFormat.Xlsb)]
+    // ExcelReader.NET 2.1.2 omits the required BrtWsDim record from its XLSB
+    // output, so only its structurally valid XLS writer participates here.
+    [Params(ExcelFileFormat.Xls)]
     public ExcelFileFormat Format { get; set; }
 
     [GlobalSetup]
@@ -31,10 +34,15 @@ public class ExcelNativeBinaryWriteBenchmarks {
 
         byte[] workbook = WriteWorkbook();
         Validate(workbook);
+        byte[] excelReaderWorkbook = WriteExcelReaderWorkbook();
+        Validate(excelReaderWorkbook);
     }
 
     [Benchmark]
     public int OfficeIMO_PublicTabularWrite() => WriteWorkbook().Length;
+
+    [Benchmark]
+    public int ExcelReaderNet_PublicTabularWrite() => WriteExcelReaderWorkbook().Length;
 
     private byte[] WriteWorkbook() {
         using ExcelDocument document = ExcelDocument.Create();
@@ -56,6 +64,70 @@ public class ExcelNativeBinaryWriteBenchmarks {
         }
 
         return document.ToBytes(Format);
+    }
+
+    private byte[] WriteExcelReaderWorkbook() => Format switch {
+        ExcelFileFormat.Xls => WriteExcelReaderXlsWorkbook(),
+        ExcelFileFormat.Xlsb => WriteExcelReaderXlsbWorkbook(),
+        _ => throw new InvalidOperationException($"ExcelReader.NET binary benchmark does not support {Format}.")
+    };
+
+    private byte[] WriteExcelReaderXlsWorkbook() {
+        using var stream = new MemoryStream();
+        using XlsWorkbookWriter workbook = XlsWorkbookWriter.Create(stream, leaveOpen: true);
+        workbook.Start();
+        using (XlsSheetWriter sheet = workbook.AddSheet("Data")) {
+            sheet.Start();
+            using (XlsRowWriter header = sheet.StartRow()) {
+                WriteHeaders(header);
+            }
+
+            foreach (BinaryWriteRow value in _rows) {
+                using XlsRowWriter row = sheet.StartRow();
+                WriteRow(row, value);
+            }
+            sheet.End();
+        }
+        workbook.End();
+        return stream.ToArray();
+    }
+
+    private byte[] WriteExcelReaderXlsbWorkbook() {
+        using var stream = new MemoryStream();
+        using XlsbWorkbookWriter workbook = XlsbWorkbookWriter.Create(stream, leaveOpen: true);
+        workbook.Start();
+        using (XlsbSheetWriter sheet = workbook.AddSheet("Data")) {
+            sheet.Start();
+            using (XlsbRowWriter header = sheet.StartRow()) {
+                WriteHeaders(header);
+            }
+
+            foreach (BinaryWriteRow value in _rows) {
+                using XlsbRowWriter row = sheet.StartRow();
+                WriteRow(row, value);
+            }
+            sheet.End();
+        }
+        workbook.End();
+        return stream.ToArray();
+    }
+
+    private static void WriteHeaders<TRow>(TRow row)
+        where TRow : IRowWriter {
+        row.Write("Id");
+        row.Write("Region");
+        row.Write("Owner");
+        row.Write("Amount");
+        row.Write("Active");
+    }
+
+    private static void WriteRow<TRow>(TRow row, BinaryWriteRow value)
+        where TRow : IRowWriter {
+        row.Write(value.Id);
+        row.Write(value.Region);
+        row.Write(value.Owner);
+        row.Write(value.Amount);
+        row.Write(value.Active);
     }
 
     private void Validate(byte[] workbook) {

--- a/OfficeIMO.Excel.Benchmarks/ExcelReaderComparisonPairedRunner.cs
+++ b/OfficeIMO.Excel.Benchmarks/ExcelReaderComparisonPairedRunner.cs
@@ -1,0 +1,140 @@
+using System.Diagnostics;
+using System.Globalization;
+using OfficeIMO.Benchmarks;
+
+namespace OfficeIMO.Excel.Benchmarks;
+
+internal static class ExcelReaderComparisonPairedRunner {
+    private const int WarmupIterations = 16;
+
+    internal static void Run(string[] arguments, ExcelFileFormat format) {
+        int iterations = arguments.Length > 1 && int.TryParse(arguments[1], out int parsedIterations)
+            ? parsedIterations
+            : 40;
+        if (iterations <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(iterations));
+        }
+
+        string affinity = arguments.Length > 2
+            ? BenchmarkProcessorAffinity.Apply(arguments[2])
+            : "unchanged";
+        string priority = arguments.Length > 3
+            && !string.Equals(arguments[3], "unchanged", StringComparison.OrdinalIgnoreCase)
+                ? BenchmarkProcessorAffinity.ApplyPriority(arguments[3])
+                : Process.GetCurrentProcess().PriorityClass.ToString();
+
+        (Func<ExcelReadObservation> RunOfficeIMO, Func<ExcelReadObservation> RunExcelReader) =
+            CreateOperations(format);
+
+        for (int index = 0; index < WarmupIterations; index++) {
+            ExcelReadObservation officeObservation = RunOfficeIMO();
+            ExcelReadObservation excelReaderObservation = RunExcelReader();
+            ValidateEquivalent(format, $"warmup {index}", officeObservation, excelReaderObservation);
+        }
+
+        var officeSamples = new double[iterations];
+        var excelReaderSamples = new double[iterations];
+        var pairedRatios = new double[iterations];
+        for (int index = 0; index < iterations; index++) {
+            (double Milliseconds, ExcelReadObservation Observation) officeFirst;
+            (double Milliseconds, ExcelReadObservation Observation) officeSecond;
+            (double Milliseconds, ExcelReadObservation Observation) excelReaderFirst;
+            (double Milliseconds, ExcelReadObservation Observation) excelReaderSecond;
+            if ((index & 1) == 0) {
+                officeFirst = Measure(RunOfficeIMO);
+                excelReaderFirst = Measure(RunExcelReader);
+                excelReaderSecond = Measure(RunExcelReader);
+                officeSecond = Measure(RunOfficeIMO);
+            } else {
+                excelReaderFirst = Measure(RunExcelReader);
+                officeFirst = Measure(RunOfficeIMO);
+                officeSecond = Measure(RunOfficeIMO);
+                excelReaderSecond = Measure(RunExcelReader);
+            }
+
+            ValidateEquivalent(format, $"sample {index} first", officeFirst.Observation, excelReaderFirst.Observation);
+            ValidateEquivalent(format, $"sample {index} second", officeSecond.Observation, excelReaderSecond.Observation);
+            officeSamples[index] = (officeFirst.Milliseconds + officeSecond.Milliseconds) / 2d;
+            excelReaderSamples[index] = (excelReaderFirst.Milliseconds + excelReaderSecond.Milliseconds) / 2d;
+            pairedRatios[index] = officeSamples[index] / excelReaderSamples[index];
+        }
+
+        double officeMedian = Median(officeSamples);
+        double excelReaderMedian = Median(excelReaderSamples);
+        Console.WriteLine(string.Format(
+            CultureInfo.InvariantCulture,
+            "Paired {0} comparison ({1} warmups, {2} ABBA samples, affinity {3}, priority {4}): " +
+            "OfficeIMO median {5:F3} ms, ExcelReader.NET median {6:F3} ms, ratio of medians {7:F4}, " +
+            "paired ratio median {8:F4} (P25 {9:F4}, P75 {10:F4}).",
+            format.ToString().ToUpperInvariant(),
+            WarmupIterations,
+            iterations,
+            affinity,
+            priority,
+            officeMedian,
+            excelReaderMedian,
+            officeMedian / excelReaderMedian,
+            Median(pairedRatios),
+            Percentile(pairedRatios, 0.25d),
+            Percentile(pairedRatios, 0.75d)));
+    }
+
+    private static (Func<ExcelReadObservation> RunOfficeIMO, Func<ExcelReadObservation> RunExcelReader)
+        CreateOperations(ExcelFileFormat format) {
+        switch (format) {
+            case ExcelFileFormat.Xlsx: {
+                var benchmark = new MarkPflug65KXlsxBenchmarks();
+                benchmark.Setup();
+                return (benchmark.OfficeIMO, benchmark.ExcelReaderNet);
+            }
+            case ExcelFileFormat.Xlsb: {
+                var benchmark = new MarkPflug65KXlsbBenchmarks();
+                benchmark.Setup();
+                return (benchmark.OfficeIMO, benchmark.ExcelReaderNet);
+            }
+            case ExcelFileFormat.Xls: {
+                var benchmark = new MarkPflug65KXlsBenchmarks();
+                benchmark.Setup();
+                return (benchmark.OfficeIMO, benchmark.ExcelReaderNet);
+            }
+            default:
+                throw new ArgumentOutOfRangeException(nameof(format), format, "Only XLSX, XLSB, and XLS are supported.");
+        }
+    }
+
+    private static (double Milliseconds, ExcelReadObservation Observation) Measure(
+        Func<ExcelReadObservation> operation) {
+        long started = Stopwatch.GetTimestamp();
+        ExcelReadObservation observation = operation();
+        return (Stopwatch.GetElapsedTime(started).TotalMilliseconds, observation);
+    }
+
+    private static void ValidateEquivalent(
+        ExcelFileFormat format,
+        string sample,
+        ExcelReadObservation officeObservation,
+        ExcelReadObservation excelReaderObservation) {
+        if (officeObservation != excelReaderObservation) {
+            throw new InvalidDataException(
+                $"Paired {format} {sample} produced different observations: " +
+                $"OfficeIMO={officeObservation}; ExcelReader.NET={excelReaderObservation}.");
+        }
+    }
+
+    private static double Median(double[] samples) {
+        double[] ordered = [.. samples.OrderBy(static sample => sample)];
+        int middle = ordered.Length / 2;
+        return (ordered.Length & 1) == 0
+            ? (ordered[middle - 1] + ordered[middle]) / 2d
+            : ordered[middle];
+    }
+
+    private static double Percentile(double[] samples, double percentile) {
+        double[] ordered = [.. samples.OrderBy(static sample => sample)];
+        double position = (ordered.Length - 1) * percentile;
+        int lower = (int)position;
+        int upper = Math.Min(lower + 1, ordered.Length - 1);
+        double fraction = position - lower;
+        return ordered[lower] + (ordered[upper] - ordered[lower]) * fraction;
+    }
+}

--- a/OfficeIMO.Excel.Benchmarks/ExcelReaderWriteComparisonPairedRunner.cs
+++ b/OfficeIMO.Excel.Benchmarks/ExcelReaderWriteComparisonPairedRunner.cs
@@ -61,8 +61,8 @@ internal static class ExcelReaderWriteComparisonPairedRunner {
             return;
         }
         for (int index = 0; index < WarmupIterations; index++) {
-            ValidateResult(format, $"OfficeIMO warmup {index}", RunOfficeIMO());
-            ValidateResult(format, $"ExcelReader.NET warmup {index}", RunExcelReader());
+            ValidateResult(format, rowCount, $"OfficeIMO warmup {index}", RunOfficeIMO());
+            ValidateResult(format, rowCount, $"ExcelReader.NET warmup {index}", RunExcelReader());
         }
 
         var officeSamples = new double[iterations];
@@ -85,10 +85,10 @@ internal static class ExcelReaderWriteComparisonPairedRunner {
                 excelReaderSecond = Measure(RunExcelReader, invocationsPerLeg);
             }
 
-            ValidateResult(format, $"OfficeIMO sample {index} first", officeFirst.Result);
-            ValidateResult(format, $"OfficeIMO sample {index} second", officeSecond.Result);
-            ValidateResult(format, $"ExcelReader.NET sample {index} first", excelReaderFirst.Result);
-            ValidateResult(format, $"ExcelReader.NET sample {index} second", excelReaderSecond.Result);
+            ValidateResult(format, rowCount, $"OfficeIMO sample {index} first", officeFirst.Result);
+            ValidateResult(format, rowCount, $"OfficeIMO sample {index} second", officeSecond.Result);
+            ValidateResult(format, rowCount, $"ExcelReader.NET sample {index} first", excelReaderFirst.Result);
+            ValidateResult(format, rowCount, $"ExcelReader.NET sample {index} second", excelReaderSecond.Result);
             officeSamples[index] = (officeFirst.Milliseconds + officeSecond.Milliseconds) / 2d;
             excelReaderSamples[index] = (excelReaderFirst.Milliseconds + excelReaderSecond.Milliseconds) / 2d;
             pairedRatios[index] = officeSamples[index] / excelReaderSamples[index];
@@ -140,7 +140,7 @@ internal static class ExcelReaderWriteComparisonPairedRunner {
         };
         benchmark.SetupOfficeIMOOnly();
         for (int index = 0; index < WarmupIterations; index++) {
-            ValidateResult(format, $"OfficeIMO warmup {index}", benchmark.OfficeIMO_PublicTabularWrite());
+            ValidateResult(format, rowCount, $"OfficeIMO warmup {index}", benchmark.OfficeIMO_PublicTabularWrite());
         }
 
         var samples = new double[iterations];
@@ -148,7 +148,7 @@ internal static class ExcelReaderWriteComparisonPairedRunner {
             (double milliseconds, int result) = Measure(
                 benchmark.OfficeIMO_PublicTabularWrite,
                 invocationsPerSample);
-            ValidateResult(format, $"OfficeIMO sample {index}", result);
+            ValidateResult(format, rowCount, $"OfficeIMO sample {index}", result);
             samples[index] = milliseconds;
         }
 
@@ -156,7 +156,12 @@ internal static class ExcelReaderWriteComparisonPairedRunner {
             $"OfficeIMO validated {format.ToString().ToUpperInvariant()} write ({rowCount:N0} rows, {WarmupIterations} warmups, {iterations} samples, {invocationsPerSample} invocations per sample, affinity {affinity}, priority {priority}): median {Median(samples):F3} ms (P25 {Percentile(samples, 0.25d):F3}, P75 {Percentile(samples, 0.75d):F3})."));
     }
 
-    private static void ValidateResult(ExcelFileFormat format, string sample, int result) {
+    private static void ValidateResult(ExcelFileFormat format, int expectedRowCount, string sample, int result) {
+        if (format == ExcelFileFormat.Xlsx && result != expectedRowCount) {
+            throw new InvalidDataException(
+                $"{format} {sample} reported {result} rows instead of {expectedRowCount}.");
+        }
+
         if (result <= 0) {
             throw new InvalidDataException($"{format} {sample} produced an invalid result of {result}.");
         }

--- a/OfficeIMO.Excel.Benchmarks/ExcelReaderWriteComparisonPairedRunner.cs
+++ b/OfficeIMO.Excel.Benchmarks/ExcelReaderWriteComparisonPairedRunner.cs
@@ -49,9 +49,15 @@ internal static class ExcelReaderWriteComparisonPairedRunner {
             Console.WriteLine(
                 "XLSB write comparison is unranked because ExcelReader.NET 2.1.2 output failed strict validation: " +
                 exception.Message);
+            RunOfficeOnly(format, rowCount, iterations, invocationsPerLeg, affinity, priority);
             return;
         }
         (Func<int> RunOfficeIMO, Func<int> RunExcelReader) = operations;
+        if (format == ExcelFileFormat.Xls) {
+            Console.WriteLine(
+                "XLS timing is diagnostic only: ExcelReader.NET 2.1.2 omits the BIFF8 " +
+                "Index/Row/DBCell cell-table structure emitted by OfficeIMO.");
+        }
         for (int index = 0; index < WarmupIterations; index++) {
             ValidateResult(format, $"OfficeIMO warmup {index}", RunOfficeIMO());
             ValidateResult(format, $"ExcelReader.NET warmup {index}", RunExcelReader());
@@ -106,7 +112,7 @@ internal static class ExcelReaderWriteComparisonPairedRunner {
             RowCount = rowCount
         };
         binaryBenchmark.Setup();
-        return (binaryBenchmark.OfficeIMO_PublicTabularWrite, binaryBenchmark.ExcelReaderNet_PublicTabularWrite);
+        return (binaryBenchmark.OfficeIMO_PublicTabularWrite, binaryBenchmark.ExcelReaderNet_DiagnosticWrite);
     }
 
     private static (double Milliseconds, int Result) Measure(Func<int> operation, int invocationCount) {
@@ -117,6 +123,35 @@ internal static class ExcelReaderWriteComparisonPairedRunner {
             result = operation();
         }
         return (Stopwatch.GetElapsedTime(started).TotalMilliseconds / invocationCount, result);
+    }
+
+    private static void RunOfficeOnly(
+        ExcelFileFormat format,
+        int rowCount,
+        int iterations,
+        int invocationsPerSample,
+        string affinity,
+        string priority) {
+        var benchmark = new ExcelNativeBinaryWriteBenchmarks {
+            Format = format,
+            RowCount = rowCount
+        };
+        benchmark.SetupOfficeIMOOnly();
+        for (int index = 0; index < WarmupIterations; index++) {
+            ValidateResult(format, $"OfficeIMO warmup {index}", benchmark.OfficeIMO_PublicTabularWrite());
+        }
+
+        var samples = new double[iterations];
+        for (int index = 0; index < iterations; index++) {
+            (double milliseconds, int result) = Measure(
+                benchmark.OfficeIMO_PublicTabularWrite,
+                invocationsPerSample);
+            ValidateResult(format, $"OfficeIMO sample {index}", result);
+            samples[index] = milliseconds;
+        }
+
+        Console.WriteLine(FormattableString.Invariant(
+            $"OfficeIMO validated {format.ToString().ToUpperInvariant()} write ({rowCount:N0} rows, {WarmupIterations} warmups, {iterations} samples, {invocationsPerSample} invocations per sample, affinity {affinity}, priority {priority}): median {Median(samples):F3} ms (P25 {Percentile(samples, 0.25d):F3}, P75 {Percentile(samples, 0.75d):F3})."));
     }
 
     private static void ValidateResult(ExcelFileFormat format, string sample, int result) {

--- a/OfficeIMO.Excel.Benchmarks/ExcelReaderWriteComparisonPairedRunner.cs
+++ b/OfficeIMO.Excel.Benchmarks/ExcelReaderWriteComparisonPairedRunner.cs
@@ -1,0 +1,144 @@
+using System.Diagnostics;
+using OfficeIMO.Benchmarks;
+
+namespace OfficeIMO.Excel.Benchmarks;
+
+internal static class ExcelReaderWriteComparisonPairedRunner {
+    private const int WarmupIterations = 12;
+
+    internal static void Run(string[] arguments) {
+        ExcelFileFormat format = arguments.Length > 1
+            && Enum.TryParse(arguments[1], ignoreCase: true, out ExcelFileFormat parsedFormat)
+                ? parsedFormat
+                : ExcelFileFormat.Xlsx;
+        if (format is not (ExcelFileFormat.Xlsx or ExcelFileFormat.Xlsb or ExcelFileFormat.Xls)) {
+            throw new ArgumentOutOfRangeException(nameof(format), format, "Only XLSX, XLSB, and XLS are supported.");
+        }
+
+        int rowCount = arguments.Length > 2 && int.TryParse(arguments[2], out int parsedRowCount)
+            ? parsedRowCount
+            : 25_000;
+        int iterations = arguments.Length > 3 && int.TryParse(arguments[3], out int parsedIterations)
+            ? parsedIterations
+            : 30;
+        if (rowCount <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(rowCount));
+        }
+        if (iterations <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(iterations));
+        }
+
+        string affinity = arguments.Length > 4
+            ? BenchmarkProcessorAffinity.Apply(arguments[4])
+            : "unchanged";
+        string priority = arguments.Length > 5
+            && !string.Equals(arguments[5], "unchanged", StringComparison.OrdinalIgnoreCase)
+                ? BenchmarkProcessorAffinity.ApplyPriority(arguments[5])
+                : Process.GetCurrentProcess().PriorityClass.ToString();
+        int invocationsPerLeg = arguments.Length > 6 && int.TryParse(arguments[6], out int parsedInvocations)
+            ? parsedInvocations
+            : 8;
+        if (invocationsPerLeg <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(invocationsPerLeg));
+        }
+
+        (Func<int> RunOfficeIMO, Func<int> RunExcelReader) operations;
+        try {
+            operations = CreateOperations(format, rowCount);
+        } catch (InvalidDataException exception) when (format == ExcelFileFormat.Xlsb) {
+            Console.WriteLine(
+                "XLSB write comparison is unranked because ExcelReader.NET 2.1.2 output failed strict validation: " +
+                exception.Message);
+            return;
+        }
+        (Func<int> RunOfficeIMO, Func<int> RunExcelReader) = operations;
+        for (int index = 0; index < WarmupIterations; index++) {
+            ValidateResult(format, $"OfficeIMO warmup {index}", RunOfficeIMO());
+            ValidateResult(format, $"ExcelReader.NET warmup {index}", RunExcelReader());
+        }
+
+        var officeSamples = new double[iterations];
+        var excelReaderSamples = new double[iterations];
+        var pairedRatios = new double[iterations];
+        for (int index = 0; index < iterations; index++) {
+            (double Milliseconds, int Result) officeFirst;
+            (double Milliseconds, int Result) officeSecond;
+            (double Milliseconds, int Result) excelReaderFirst;
+            (double Milliseconds, int Result) excelReaderSecond;
+            if ((index & 1) == 0) {
+                officeFirst = Measure(RunOfficeIMO, invocationsPerLeg);
+                excelReaderFirst = Measure(RunExcelReader, invocationsPerLeg);
+                excelReaderSecond = Measure(RunExcelReader, invocationsPerLeg);
+                officeSecond = Measure(RunOfficeIMO, invocationsPerLeg);
+            } else {
+                excelReaderFirst = Measure(RunExcelReader, invocationsPerLeg);
+                officeFirst = Measure(RunOfficeIMO, invocationsPerLeg);
+                officeSecond = Measure(RunOfficeIMO, invocationsPerLeg);
+                excelReaderSecond = Measure(RunExcelReader, invocationsPerLeg);
+            }
+
+            ValidateResult(format, $"OfficeIMO sample {index} first", officeFirst.Result);
+            ValidateResult(format, $"OfficeIMO sample {index} second", officeSecond.Result);
+            ValidateResult(format, $"ExcelReader.NET sample {index} first", excelReaderFirst.Result);
+            ValidateResult(format, $"ExcelReader.NET sample {index} second", excelReaderSecond.Result);
+            officeSamples[index] = (officeFirst.Milliseconds + officeSecond.Milliseconds) / 2d;
+            excelReaderSamples[index] = (excelReaderFirst.Milliseconds + excelReaderSecond.Milliseconds) / 2d;
+            pairedRatios[index] = officeSamples[index] / excelReaderSamples[index];
+        }
+
+        double officeMedian = Median(officeSamples);
+        double excelReaderMedian = Median(excelReaderSamples);
+        Console.WriteLine(FormattableString.Invariant(
+            $"Paired {format.ToString().ToUpperInvariant()} write comparison ({rowCount:N0} rows, {WarmupIterations} warmups, {iterations} ABBA samples, {invocationsPerLeg} invocations per leg, affinity {affinity}, priority {priority}): OfficeIMO median {officeMedian:F3} ms, ExcelReader.NET median {excelReaderMedian:F3} ms, ratio of medians {officeMedian / excelReaderMedian:F4}, paired ratio median {Median(pairedRatios):F4} (P25 {Percentile(pairedRatios, 0.25d):F4}, P75 {Percentile(pairedRatios, 0.75d):F4})."));
+    }
+
+    private static (Func<int> RunOfficeIMO, Func<int> RunExcelReader) CreateOperations(
+        ExcelFileFormat format,
+        int rowCount) {
+        if (format == ExcelFileFormat.Xlsx) {
+            var benchmark = new ExcelGeneratedRowStreamingBenchmarks { RowCount = rowCount };
+            benchmark.Setup();
+            return (benchmark.WriteRowsGenerated, benchmark.ExcelReaderNetWriteRowsGenerated);
+        }
+
+        var binaryBenchmark = new ExcelNativeBinaryWriteBenchmarks {
+            Format = format,
+            RowCount = rowCount
+        };
+        binaryBenchmark.Setup();
+        return (binaryBenchmark.OfficeIMO_PublicTabularWrite, binaryBenchmark.ExcelReaderNet_PublicTabularWrite);
+    }
+
+    private static (double Milliseconds, int Result) Measure(Func<int> operation, int invocationCount) {
+        BenchmarkMeasurement.PrepareForMeasurement();
+        long started = Stopwatch.GetTimestamp();
+        int result = 0;
+        for (int index = 0; index < invocationCount; index++) {
+            result = operation();
+        }
+        return (Stopwatch.GetElapsedTime(started).TotalMilliseconds / invocationCount, result);
+    }
+
+    private static void ValidateResult(ExcelFileFormat format, string sample, int result) {
+        if (result <= 0) {
+            throw new InvalidDataException($"{format} {sample} produced an invalid result of {result}.");
+        }
+    }
+
+    private static double Median(double[] samples) {
+        double[] ordered = [.. samples.OrderBy(static sample => sample)];
+        int middle = ordered.Length / 2;
+        return (ordered.Length & 1) == 0
+            ? (ordered[middle - 1] + ordered[middle]) / 2d
+            : ordered[middle];
+    }
+
+    private static double Percentile(double[] samples, double percentile) {
+        double[] ordered = [.. samples.OrderBy(static sample => sample)];
+        double position = (ordered.Length - 1) * percentile;
+        int lower = (int)position;
+        int upper = Math.Min(lower + 1, ordered.Length - 1);
+        double fraction = position - lower;
+        return ordered[lower] + (ordered[upper] - ordered[lower]) * fraction;
+    }
+}

--- a/OfficeIMO.Excel.Benchmarks/ExcelReaderWriteComparisonPairedRunner.cs
+++ b/OfficeIMO.Excel.Benchmarks/ExcelReaderWriteComparisonPairedRunner.cs
@@ -55,8 +55,10 @@ internal static class ExcelReaderWriteComparisonPairedRunner {
         (Func<int> RunOfficeIMO, Func<int> RunExcelReader) = operations;
         if (format == ExcelFileFormat.Xls) {
             Console.WriteLine(
-                "XLS timing is diagnostic only: ExcelReader.NET 2.1.2 omits the BIFF8 " +
+                "XLS write comparison is unranked because ExcelReader.NET 2.1.2 omits the BIFF8 " +
                 "Index/Row/DBCell cell-table structure emitted by OfficeIMO.");
+            RunOfficeOnly(format, rowCount, iterations, invocationsPerLeg, affinity, priority);
+            return;
         }
         for (int index = 0; index < WarmupIterations; index++) {
             ValidateResult(format, $"OfficeIMO warmup {index}", RunOfficeIMO());

--- a/OfficeIMO.Excel.Benchmarks/MarkPflug65KExcelBenchmarks.cs
+++ b/OfficeIMO.Excel.Benchmarks/MarkPflug65KExcelBenchmarks.cs
@@ -92,12 +92,7 @@ public class MarkPflug65KXlsxBenchmarks {
 
         var observation = new ExcelObservationAccumulator();
         while (reader.Read()) {
-            AddRow(
-                ref observation,
-                ordinal => Convert.ToString(reader.GetValue(ordinal), CultureInfo.InvariantCulture) ?? string.Empty,
-                ordinal => ReadDate(reader.GetValue(ordinal)),
-                ordinal => Convert.ToInt32(reader.GetValue(ordinal), CultureInfo.InvariantCulture),
-                ordinal => Convert.ToDecimal(reader.GetValue(ordinal), CultureInfo.InvariantCulture));
+            AddExcelDataReaderRow(ref observation, reader);
         }
 
         return Validate(nameof(ExcelDataReader), observation.Build());
@@ -110,12 +105,7 @@ public class MarkPflug65KXlsxBenchmarks {
         int lastRow = worksheet.LastRowUsed()?.RowNumber() ?? 0;
         var observation = new ExcelObservationAccumulator();
         for (int row = 2; row <= lastRow; row++) {
-            AddRow(
-                ref observation,
-                ordinal => worksheet.Cell(row, ordinal + 1).GetString(),
-                ordinal => worksheet.Cell(row, ordinal + 1).GetDateTime(),
-                ordinal => worksheet.Cell(row, ordinal + 1).GetValue<int>(),
-                ordinal => worksheet.Cell(row, ordinal + 1).GetValue<decimal>());
+            AddClosedXmlRow(ref observation, worksheet, row);
         }
 
         return Validate(nameof(ClosedXML), observation.Build());
@@ -128,12 +118,7 @@ public class MarkPflug65KXlsxBenchmarks {
         int lastRow = worksheet.Dimension?.End.Row ?? 0;
         var observation = new ExcelObservationAccumulator();
         for (int row = 2; row <= lastRow; row++) {
-            AddRow(
-                ref observation,
-                ordinal => Convert.ToString(worksheet.Cells[row, ordinal + 1].Value, CultureInfo.InvariantCulture) ?? string.Empty,
-                ordinal => ReadDate(worksheet.Cells[row, ordinal + 1].Value),
-                ordinal => Convert.ToInt32(worksheet.Cells[row, ordinal + 1].Value, CultureInfo.InvariantCulture),
-                ordinal => Convert.ToDecimal(worksheet.Cells[row, ordinal + 1].Value, CultureInfo.InvariantCulture));
+            AddEpplusRow(ref observation, worksheet, row);
         }
 
         return Validate(nameof(EPPlus), observation.Build());
@@ -149,12 +134,7 @@ public class MarkPflug65KXlsxBenchmarks {
         var observation = new ExcelObservationAccumulator();
         foreach (object item in rows) {
             var row = (IDictionary<string, object?>)item;
-            AddRow(
-                ref observation,
-                ordinal => Convert.ToString(row[Headers[ordinal]], CultureInfo.InvariantCulture) ?? string.Empty,
-                ordinal => ReadDate(row[Headers[ordinal]]),
-                ordinal => Convert.ToInt32(row[Headers[ordinal]], CultureInfo.InvariantCulture),
-                ordinal => Convert.ToDecimal(row[Headers[ordinal]], CultureInfo.InvariantCulture));
+            AddMiniExcelRow(ref observation, row);
         }
 
         return Validate(nameof(MiniExcel), observation.Build());
@@ -278,22 +258,69 @@ public class MarkPflug65KXlsxBenchmarks {
         }
     }
 
-    internal static void AddRow(
+    internal static void AddExcelDataReaderRow(
         ref ExcelObservationAccumulator observation,
-        Func<int, string> text,
-        Func<int, DateTime> date,
-        Func<int, int> integer,
-        Func<int, decimal> number) {
+        global::ExcelDataReader.IExcelDataReader reader) {
         observation.BeginRow();
         for (int ordinal = 0; ordinal <= 4; ordinal++) {
-            observation.Add(text(ordinal));
+            observation.Add(Convert.ToString(reader.GetValue(ordinal), CultureInfo.InvariantCulture) ?? string.Empty);
         }
-        observation.Add(date(5));
-        observation.Add(integer(6));
-        observation.Add(date(7));
-        observation.Add(integer(8));
+        observation.Add(ReadDate(reader.GetValue(5)));
+        observation.Add(Convert.ToInt32(reader.GetValue(6), CultureInfo.InvariantCulture));
+        observation.Add(ReadDate(reader.GetValue(7)));
+        observation.Add(Convert.ToInt32(reader.GetValue(8), CultureInfo.InvariantCulture));
         for (int ordinal = 9; ordinal <= 13; ordinal++) {
-            observation.Add(number(ordinal));
+            observation.Add(Convert.ToDecimal(reader.GetValue(ordinal), CultureInfo.InvariantCulture));
+        }
+    }
+
+    private static void AddClosedXmlRow(
+        ref ExcelObservationAccumulator observation,
+        IXLWorksheet worksheet,
+        int row) {
+        observation.BeginRow();
+        for (int ordinal = 0; ordinal <= 4; ordinal++) {
+            observation.Add(worksheet.Cell(row, ordinal + 1).GetString());
+        }
+        observation.Add(worksheet.Cell(row, 6).GetDateTime());
+        observation.Add(worksheet.Cell(row, 7).GetValue<int>());
+        observation.Add(worksheet.Cell(row, 8).GetDateTime());
+        observation.Add(worksheet.Cell(row, 9).GetValue<int>());
+        for (int ordinal = 9; ordinal <= 13; ordinal++) {
+            observation.Add(worksheet.Cell(row, ordinal + 1).GetValue<decimal>());
+        }
+    }
+
+    private static void AddEpplusRow(
+        ref ExcelObservationAccumulator observation,
+        ExcelWorksheet worksheet,
+        int row) {
+        observation.BeginRow();
+        for (int ordinal = 0; ordinal <= 4; ordinal++) {
+            observation.Add(Convert.ToString(worksheet.Cells[row, ordinal + 1].Value, CultureInfo.InvariantCulture) ?? string.Empty);
+        }
+        observation.Add(ReadDate(worksheet.Cells[row, 6].Value));
+        observation.Add(Convert.ToInt32(worksheet.Cells[row, 7].Value, CultureInfo.InvariantCulture));
+        observation.Add(ReadDate(worksheet.Cells[row, 8].Value));
+        observation.Add(Convert.ToInt32(worksheet.Cells[row, 9].Value, CultureInfo.InvariantCulture));
+        for (int ordinal = 9; ordinal <= 13; ordinal++) {
+            observation.Add(Convert.ToDecimal(worksheet.Cells[row, ordinal + 1].Value, CultureInfo.InvariantCulture));
+        }
+    }
+
+    private static void AddMiniExcelRow(
+        ref ExcelObservationAccumulator observation,
+        IDictionary<string, object?> row) {
+        observation.BeginRow();
+        for (int ordinal = 0; ordinal <= 4; ordinal++) {
+            observation.Add(Convert.ToString(row[Headers[ordinal]], CultureInfo.InvariantCulture) ?? string.Empty);
+        }
+        observation.Add(ReadDate(row[Headers[5]]));
+        observation.Add(Convert.ToInt32(row[Headers[6]], CultureInfo.InvariantCulture));
+        observation.Add(ReadDate(row[Headers[7]]));
+        observation.Add(Convert.ToInt32(row[Headers[8]], CultureInfo.InvariantCulture));
+        for (int ordinal = 9; ordinal <= 13; ordinal++) {
+            observation.Add(Convert.ToDecimal(row[Headers[ordinal]], CultureInfo.InvariantCulture));
         }
     }
 
@@ -372,12 +399,7 @@ public class MarkPflug65KXlsbBenchmarks {
 
         var observation = new ExcelObservationAccumulator();
         while (reader.Read()) {
-            MarkPflug65KXlsxBenchmarks.AddRow(
-                ref observation,
-                ordinal => Convert.ToString(reader.GetValue(ordinal), CultureInfo.InvariantCulture) ?? string.Empty,
-                ordinal => MarkPflug65KXlsxBenchmarks.ReadDate(reader.GetValue(ordinal)),
-                ordinal => Convert.ToInt32(reader.GetValue(ordinal), CultureInfo.InvariantCulture),
-                ordinal => Convert.ToDecimal(reader.GetValue(ordinal), CultureInfo.InvariantCulture));
+            MarkPflug65KXlsxBenchmarks.AddExcelDataReaderRow(ref observation, reader);
         }
 
         return Validate(nameof(ExcelDataReader), observation.Build());

--- a/OfficeIMO.Excel.Benchmarks/MarkPflug65KExcelBenchmarks.cs
+++ b/OfficeIMO.Excel.Benchmarks/MarkPflug65KExcelBenchmarks.cs
@@ -3,10 +3,13 @@ using System.Globalization;
 using System.Text;
 using BenchmarkDotNet.Attributes;
 using ClosedXML.Excel;
+using ExcelReader.Core.Reader;
+using ExcelReader.Core.ValueObjects;
 using OfficeIMO.Benchmarks;
 using OfficeIMO.Excel.Xlsb.Read;
 using OfficeOpenXml;
 using MiniExcelApi = MiniExcelLibs.MiniExcel;
+using ExcelReaderApi = ExcelReader.Core.Reader.Excel;
 using Sylvan.Data.Excel;
 using SylvanExcelDataReader = Sylvan.Data.Excel.ExcelDataReader;
 
@@ -60,6 +63,12 @@ public class MarkPflug65KXlsxBenchmarks {
                 SheetName = null
             });
         return Validate(nameof(OfficeIMO), Observe(reader));
+    }
+
+    [Benchmark]
+    public ExcelReadObservation ExcelReaderNet() {
+        using XlsxReader reader = ExcelReaderApi.FromFile(MarkPflug65KFixture.XlsxPath);
+        return Validate(nameof(ExcelReaderNet), ObserveExcelReader(reader));
     }
 
     [Benchmark]
@@ -160,6 +169,99 @@ public class MarkPflug65KXlsxBenchmarks {
         return observation.Build();
     }
 
+    internal static ExcelReadObservation ObserveExcelReader(XlsxReader reader) {
+        var observation = new ExcelObservationAccumulator();
+        bool header = true;
+        bool isDate1904 = reader.IsDate1904;
+        foreach (Row row in reader) {
+            if (header) {
+                header = false;
+                continue;
+            }
+
+            AddRow(ref observation, row, isDate1904);
+        }
+
+        return observation.Build();
+    }
+
+    internal static ExcelReadObservation ObserveExcelReader(XlsbReader reader) {
+        var observation = new ExcelObservationAccumulator();
+        bool header = true;
+        bool isDate1904 = reader.IsDate1904;
+        foreach (Row row in reader) {
+            if (header) {
+                header = false;
+                continue;
+            }
+
+            AddRow(ref observation, row, isDate1904);
+        }
+
+        return observation.Build();
+    }
+
+    internal static ExcelReadObservation ObserveExcelReader(XlsReader reader) {
+        var observation = new ExcelObservationAccumulator();
+        bool header = true;
+        bool isDate1904 = reader.IsDate1904;
+        foreach (Row row in reader) {
+            if (header) {
+                header = false;
+                continue;
+            }
+
+            AddRow(ref observation, row, isDate1904);
+        }
+
+        return observation.Build();
+    }
+
+    private static void AddRow(
+        ref ExcelObservationAccumulator observation,
+        Row row,
+        bool isDate1904) {
+        observation.BeginRow();
+        for (int ordinal = 0; ordinal <= 4; ordinal++) {
+            observation.Add(row[ordinal].GetString());
+        }
+
+        observation.Add(ReadExcelReaderDate(row[5], isDate1904, 5));
+        observation.Add(ReadExcelReaderInteger(row[6], 6));
+        observation.Add(ReadExcelReaderDate(row[7], isDate1904, 7));
+        observation.Add(ReadExcelReaderInteger(row[8], 8));
+        for (int ordinal = 9; ordinal <= 13; ordinal++) {
+            observation.Add(ReadExcelReaderDecimal(row[ordinal], ordinal));
+        }
+    }
+
+    private static DateTime ReadExcelReaderDate(Cell cell, bool isDate1904, int ordinal) {
+        if (cell.TryGetDateTime(isDate1904, out DateTime value)) {
+            return value;
+        }
+
+        throw new InvalidDataException($"ExcelReader.NET did not produce a date at column {ordinal}.");
+    }
+
+    private static int ReadExcelReaderInteger(Cell cell, int ordinal) {
+        if (cell.TryParse(CultureInfo.InvariantCulture, out int value)) {
+            return value;
+        }
+
+        throw new InvalidDataException($"ExcelReader.NET did not produce an integer at column {ordinal}.");
+    }
+
+    private static decimal ReadExcelReaderDecimal(Cell cell, int ordinal) {
+        // The source workbook stores IEEE-754 numbers. Read that value first and
+        // convert it to decimal so the benchmark preserves the intended monetary
+        // precision instead of parsing the binary rendering's trailing digits.
+        if (cell.TryGetDouble(out double value)) {
+            return (decimal)value;
+        }
+
+        throw new InvalidDataException($"ExcelReader.NET did not produce a number at column {ordinal}.");
+    }
+
     private static void AddRow(
         ref ExcelObservationAccumulator observation,
         DbDataReader reader) {
@@ -241,6 +343,12 @@ public class MarkPflug65KXlsbBenchmarks {
             MarkPflug65KFixture.XlsbPath,
             new ExcelReadOptions { NumericAsDecimal = true });
         return Validate(nameof(OfficeIMO), MarkPflug65KXlsxBenchmarks.Observe(reader));
+    }
+
+    [Benchmark]
+    public ExcelReadObservation ExcelReaderNet() {
+        using XlsbReader reader = ExcelReaderApi.FromXlsbFile(MarkPflug65KFixture.XlsbPath);
+        return Validate(nameof(ExcelReaderNet), MarkPflug65KXlsxBenchmarks.ObserveExcelReader(reader));
     }
 
     [Benchmark]

--- a/OfficeIMO.Excel.Benchmarks/MarkPflug65KXlsBenchmarks.cs
+++ b/OfficeIMO.Excel.Benchmarks/MarkPflug65KXlsBenchmarks.cs
@@ -1,5 +1,4 @@
 using System.Data.Common;
-using System.Globalization;
 using System.Text;
 using BenchmarkDotNet.Attributes;
 using ExcelReader.Core.Reader;
@@ -61,12 +60,7 @@ public class MarkPflug65KXlsBenchmarks {
 
         var observation = new ExcelObservationAccumulator();
         while (reader.Read()) {
-            MarkPflug65KXlsxBenchmarks.AddRow(
-                ref observation,
-                ordinal => Convert.ToString(reader.GetValue(ordinal), CultureInfo.InvariantCulture) ?? string.Empty,
-                ordinal => MarkPflug65KXlsxBenchmarks.ReadDate(reader.GetValue(ordinal)),
-                ordinal => Convert.ToInt32(reader.GetValue(ordinal), CultureInfo.InvariantCulture),
-                ordinal => Convert.ToDecimal(reader.GetValue(ordinal), CultureInfo.InvariantCulture));
+            MarkPflug65KXlsxBenchmarks.AddExcelDataReaderRow(ref observation, reader);
         }
 
         return Validate(nameof(ExcelDataReader), observation.Build());

--- a/OfficeIMO.Excel.Benchmarks/MarkPflug65KXlsBenchmarks.cs
+++ b/OfficeIMO.Excel.Benchmarks/MarkPflug65KXlsBenchmarks.cs
@@ -2,9 +2,11 @@ using System.Data.Common;
 using System.Globalization;
 using System.Text;
 using BenchmarkDotNet.Attributes;
+using ExcelReader.Core.Reader;
 using OfficeIMO.Benchmarks;
 using Sylvan.Data.Excel;
 using SylvanExcelDataReader = Sylvan.Data.Excel.ExcelDataReader;
+using ExcelReaderApi = ExcelReader.Core.Reader.Excel;
 
 namespace OfficeIMO.Excel.Benchmarks;
 
@@ -30,6 +32,12 @@ public class MarkPflug65KXlsBenchmarks {
             MarkPflug65KFixture.XlsPath,
             new ExcelReadOptions { NumericAsDecimal = true });
         return Validate(nameof(OfficeIMO), MarkPflug65KXlsxBenchmarks.Observe(reader));
+    }
+
+    [Benchmark]
+    public ExcelReadObservation ExcelReaderNet() {
+        using XlsReader reader = ExcelReaderApi.FromXlsFile(MarkPflug65KFixture.XlsPath);
+        return Validate(nameof(ExcelReaderNet), MarkPflug65KXlsxBenchmarks.ObserveExcelReader(reader));
     }
 
     [Benchmark]

--- a/OfficeIMO.Excel.Benchmarks/OfficeIMO.Excel.Benchmarks.csproj
+++ b/OfficeIMO.Excel.Benchmarks/OfficeIMO.Excel.Benchmarks.csproj
@@ -13,6 +13,8 @@
     <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageReference Include="ClosedXML" Version="0.105.1" />
     <PackageReference Include="ExcelDataReader" Version="3.9.0" />
+    <!-- Runtime APIs are benchmarked directly. The 2.1.2 source generator targets a newer Roslyn than the .NET 10.0.111 SDK ships. -->
+    <PackageReference Include="ExcelReader.NET" Version="2.1.2" ExcludeAssets="analyzers" />
     <PackageReference Include="EPPlus" Version="8.6.3" />
     <PackageReference Include="LargeXlsx" Version="2.0.1" />
     <PackageReference Include="MiniExcel" Version="1.45.0" />
@@ -29,5 +31,11 @@
     <Compile Include="..\Benchmarks\BenchmarkProcessorAffinity.cs" Link="Shared\BenchmarkProcessorAffinity.cs" />
     <Compile Include="..\Benchmarks\MarkPflug65KFixture.cs" Link="Shared\MarkPflug65KFixture.cs" />
   </ItemGroup>
+
+  <Target Name="RemoveIncompatibleExcelReaderGenerator" BeforeTargets="CoreCompile">
+    <ItemGroup>
+      <Analyzer Remove="$(NuGetPackageRoot)excelreader.net\2.1.2\analyzers\dotnet\cs\ExcelReader.Generator.dll" />
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/OfficeIMO.Excel.Benchmarks/Program.cs
+++ b/OfficeIMO.Excel.Benchmarks/Program.cs
@@ -20,6 +20,10 @@ bool profileOfficeIMOXlsx = args.Length > 0 &&
     string.Equals(args[0], "--profile-excelreader-xlsx-officeimo", StringComparison.OrdinalIgnoreCase);
 bool profileExcelReaderXlsx = args.Length > 0 &&
     string.Equals(args[0], "--profile-excelreader-xlsx-competitor", StringComparison.OrdinalIgnoreCase);
+bool profileOfficeIMOXlsxWrite = args.Length > 0 &&
+    string.Equals(args[0], "--profile-excelreader-write-xlsx-officeimo", StringComparison.OrdinalIgnoreCase);
+bool profileExcelReaderXlsxWrite = args.Length > 0 &&
+    string.Equals(args[0], "--profile-excelreader-write-xlsx-competitor", StringComparison.OrdinalIgnoreCase);
 bool comparePairedXlsb = args.Length > 0 &&
     string.Equals(args[0], "--compare-markpflug65k-xlsb-paired", StringComparison.OrdinalIgnoreCase);
 bool comparePairedXls = args.Length > 0 &&
@@ -96,6 +100,45 @@ if (profileOfficeIMOXlsx || profileExcelReaderXlsx) {
     Console.WriteLine(
         $"Profiled {implementation} XLSX {iterations} times in {stopwatch.Elapsed.TotalMilliseconds:F2} ms " +
         $"({stopwatch.Elapsed.TotalMilliseconds / iterations:F3} ms/iteration): {observation}.");
+    return;
+}
+
+if (profileOfficeIMOXlsxWrite || profileExcelReaderXlsxWrite) {
+    int iterations = args.Length > 1 && int.TryParse(args[1], out int parsedIterations)
+        ? parsedIterations
+        : 100;
+    int rowCount = args.Length > 2 && int.TryParse(args[2], out int parsedRowCount)
+        ? parsedRowCount
+        : 25_000;
+    if (iterations <= 0) {
+        throw new ArgumentOutOfRangeException(nameof(iterations));
+    }
+    if (rowCount <= 0) {
+        throw new ArgumentOutOfRangeException(nameof(rowCount));
+    }
+    ApplyProcessAffinity(args, argumentIndex: 3);
+    ApplyProcessPriority(args, argumentIndex: 4);
+
+    var benchmark = new ExcelGeneratedRowStreamingBenchmarks { RowCount = rowCount };
+    benchmark.Setup();
+    Func<int> run = profileOfficeIMOXlsxWrite
+        ? benchmark.WriteRowsGenerated
+        : benchmark.ExcelReaderNetWriteRowsGenerated;
+    string implementation = profileOfficeIMOXlsxWrite ? "OfficeIMO" : "ExcelReader.NET";
+    for (int index = 0; index < 16; index++) {
+        run();
+    }
+
+    int result = 0;
+    var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+    for (int index = 0; index < iterations; index++) {
+        result = run();
+    }
+    stopwatch.Stop();
+
+    Console.WriteLine(
+        $"Profiled {implementation} XLSX write of {rowCount:N0} rows {iterations} times in " +
+        $"{stopwatch.Elapsed.TotalMilliseconds:F2} ms ({stopwatch.Elapsed.TotalMilliseconds / iterations:F3} ms/iteration): {result:N0} rows.");
     return;
 }
 
@@ -548,6 +591,8 @@ static void WriteUsage() {
     Console.WriteLine("  --profile-datareader-write-officeimo [iterations] [affinity-mask]");
     Console.WriteLine("  --profile-datareader-write-largexlsx [iterations] [affinity-mask]");
     Console.WriteLine("  --profile-datareader-write-spreadcheetah [iterations] [affinity-mask]");
+    Console.WriteLine("  --profile-excelreader-write-xlsx-officeimo [iterations] [row-count] [affinity-mask] [priority]");
+    Console.WriteLine("  --profile-excelreader-write-xlsx-competitor [iterations] [row-count] [affinity-mask] [priority]");
     Console.WriteLine("  --compare-datareader-write-paired [iterations] [affinity-mask] [priority]");
     Console.WriteLine("  --compare-datatable-execution-paired [iterations] [affinity-mask] [priority]");
     Console.WriteLine("  --compare-markpflug65k-xls-paired [iterations] [affinity-mask] [priority]");

--- a/OfficeIMO.Excel.Benchmarks/Program.cs
+++ b/OfficeIMO.Excel.Benchmarks/Program.cs
@@ -1,4 +1,5 @@
 using OfficeIMO.Excel.Benchmarks;
+using OfficeIMO.Excel;
 using OfficeIMO.Benchmarks;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Exporters.Json;
@@ -15,10 +16,22 @@ bool profileOfficeIMOXls = args.Length > 0 &&
     string.Equals(args[0], "--profile-markpflug65k-xls-officeimo", StringComparison.OrdinalIgnoreCase);
 bool profileSylvanXls = args.Length > 0 &&
     string.Equals(args[0], "--profile-markpflug65k-xls-sylvan", StringComparison.OrdinalIgnoreCase);
+bool profileOfficeIMOXlsx = args.Length > 0 &&
+    string.Equals(args[0], "--profile-excelreader-xlsx-officeimo", StringComparison.OrdinalIgnoreCase);
+bool profileExcelReaderXlsx = args.Length > 0 &&
+    string.Equals(args[0], "--profile-excelreader-xlsx-competitor", StringComparison.OrdinalIgnoreCase);
 bool comparePairedXlsb = args.Length > 0 &&
     string.Equals(args[0], "--compare-markpflug65k-xlsb-paired", StringComparison.OrdinalIgnoreCase);
 bool comparePairedXls = args.Length > 0 &&
     string.Equals(args[0], "--compare-markpflug65k-xls-paired", StringComparison.OrdinalIgnoreCase);
+bool compareExcelReaderPairedXlsx = args.Length > 0 &&
+    string.Equals(args[0], "--compare-excelreader-xlsx-paired", StringComparison.OrdinalIgnoreCase);
+bool compareExcelReaderPairedXlsb = args.Length > 0 &&
+    string.Equals(args[0], "--compare-excelreader-xlsb-paired", StringComparison.OrdinalIgnoreCase);
+bool compareExcelReaderPairedXls = args.Length > 0 &&
+    string.Equals(args[0], "--compare-excelreader-xls-paired", StringComparison.OrdinalIgnoreCase);
+bool compareExcelReaderWritePaired = args.Length > 0 &&
+    string.Equals(args[0], "--compare-excelreader-write-paired", StringComparison.OrdinalIgnoreCase);
 bool profileOfficeIMODataReaderWrite = args.Length > 0 &&
     string.Equals(args[0], "--profile-datareader-write-officeimo", StringComparison.OrdinalIgnoreCase);
 bool profileLargeXlsxDataReaderWrite = args.Length > 0 &&
@@ -37,6 +50,52 @@ if (comparePairedDataTableExecution) {
 
 if (comparePairedXlsb || comparePairedXls) {
     ExcelLegacyReadPairedRunner.Run(args, useXlsb: comparePairedXlsb);
+    return;
+}
+
+if (compareExcelReaderPairedXlsx || compareExcelReaderPairedXlsb || compareExcelReaderPairedXls) {
+    ExcelFileFormat format = compareExcelReaderPairedXlsx
+        ? ExcelFileFormat.Xlsx
+        : compareExcelReaderPairedXlsb ? ExcelFileFormat.Xlsb : ExcelFileFormat.Xls;
+    ExcelReaderComparisonPairedRunner.Run(args, format);
+    return;
+}
+
+if (compareExcelReaderWritePaired) {
+    ExcelReaderWriteComparisonPairedRunner.Run(args);
+    return;
+}
+
+if (profileOfficeIMOXlsx || profileExcelReaderXlsx) {
+    int iterations = args.Length > 1 && int.TryParse(args[1], out int parsedIterations)
+        ? parsedIterations
+        : 100;
+    if (iterations <= 0) {
+        throw new ArgumentOutOfRangeException(nameof(iterations));
+    }
+    ApplyProcessAffinity(args, argumentIndex: 2);
+    ApplyProcessPriority(args, argumentIndex: 3);
+
+    var benchmark = new MarkPflug65KXlsxBenchmarks();
+    benchmark.Setup();
+    Func<ExcelReadObservation> run = profileOfficeIMOXlsx
+        ? benchmark.OfficeIMO
+        : benchmark.ExcelReaderNet;
+    string implementation = profileOfficeIMOXlsx ? "OfficeIMO" : "ExcelReader.NET";
+    for (int index = 0; index < 16; index++) {
+        run();
+    }
+
+    ExcelReadObservation observation = default;
+    var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+    for (int index = 0; index < iterations; index++) {
+        observation = run();
+    }
+    stopwatch.Stop();
+
+    Console.WriteLine(
+        $"Profiled {implementation} XLSX {iterations} times in {stopwatch.Elapsed.TotalMilliseconds:F2} ms " +
+        $"({stopwatch.Elapsed.TotalMilliseconds / iterations:F3} ms/iteration): {observation}.");
     return;
 }
 

--- a/OfficeIMO.Excel.Benchmarks/Program.cs
+++ b/OfficeIMO.Excel.Benchmarks/Program.cs
@@ -36,6 +36,8 @@ bool compareExcelReaderPairedXls = args.Length > 0 &&
     string.Equals(args[0], "--compare-excelreader-xls-paired", StringComparison.OrdinalIgnoreCase);
 bool compareExcelReaderWritePaired = args.Length > 0 &&
     string.Equals(args[0], "--compare-excelreader-write-paired", StringComparison.OrdinalIgnoreCase);
+bool validateExcelReaderWrite = args.Length > 0 &&
+    string.Equals(args[0], "--validate-excelreader-write", StringComparison.OrdinalIgnoreCase);
 bool profileOfficeIMODataReaderWrite = args.Length > 0 &&
     string.Equals(args[0], "--profile-datareader-write-officeimo", StringComparison.OrdinalIgnoreCase);
 bool profileLargeXlsxDataReaderWrite = args.Length > 0 &&
@@ -67,6 +69,21 @@ if (compareExcelReaderPairedXlsx || compareExcelReaderPairedXlsb || compareExcel
 
 if (compareExcelReaderWritePaired) {
     ExcelReaderWriteComparisonPairedRunner.Run(args);
+    return;
+}
+
+if (validateExcelReaderWrite) {
+    int rowCount = args.Length > 1 && int.TryParse(args[1], out int parsedRowCount)
+        ? parsedRowCount
+        : 1_000_000;
+    if (rowCount <= 0) {
+        throw new ArgumentOutOfRangeException(nameof(rowCount));
+    }
+
+    var benchmark = new ExcelGeneratedRowStreamingBenchmarks { RowCount = rowCount };
+    benchmark.Setup();
+    Console.WriteLine(
+        $"Validated OfficeIMO and ExcelReader.NET XLSX writes at the measured scale of {rowCount:N0} rows.");
     return;
 }
 

--- a/OfficeIMO.Excel/LegacyXls/Write/LegacyXlsWriter.DirectTabular.cs
+++ b/OfficeIMO.Excel/LegacyXls/Write/LegacyXlsWriter.DirectTabular.cs
@@ -52,10 +52,17 @@ namespace OfficeIMO.Excel.LegacyXls.Write {
                 }
 
                 int directRow = row + rowOffset;
+                object?[]? bufferedRow = flatValues == null
+                    && rows.TryGetBufferedRow(row, out object?[]? candidateRow)
+                    && candidateRow?.Length == columnCount
+                        ? candidateRow
+                        : null;
                 for (int column = 0; column < columnCount; column++) {
-                    object? rawValue = flatValues == null
-                        ? rows.GetValue(row, column)
-                        : flatValues[checked((row * columnCount) + column)];
+                    object? rawValue = flatValues != null
+                        ? flatValues[checked((row * columnCount) + column)]
+                        : bufferedRow != null
+                            ? bufferedRow[column]
+                            : rows.GetValue(row, column);
                     ExcelDirectTabularValue value = ExcelDirectTabularValue.Normalize(rawValue);
                     if (value.Kind == ExcelDirectTabularValueKind.Unsupported) {
                         plan = null!;
@@ -345,12 +352,20 @@ namespace OfficeIMO.Excel.LegacyXls.Write {
             IExcelSheetTabularRowSource rows = plan.Source.Rows;
             bool headerRow = plan.Source.IncludeHeaders && directRow == 0;
             int sourceRow = directRow - (plan.Source.IncludeHeaders ? 1 : 0);
+            object?[]? bufferedRow = !headerRow
+                && plan.FlatValues == null
+                && rows.TryGetBufferedRow(sourceRow, out object?[]? candidateRow)
+                && candidateRow?.Length == plan.ColumnCount
+                    ? candidateRow
+                    : null;
             for (int column = 0; column < plan.ColumnCount; column++) {
                 ExcelDirectTabularValue value = headerRow
                     ? ExcelDirectTabularValue.Normalize(rows.GetColumnName(column))
-                    : ExcelDirectTabularValue.Normalize(plan.FlatValues == null
-                        ? rows.GetValue(sourceRow, column)
-                        : plan.FlatValues[checked((sourceRow * plan.ColumnCount) + column)]);
+                    : ExcelDirectTabularValue.Normalize(plan.FlatValues != null
+                        ? plan.FlatValues[checked((sourceRow * plan.ColumnCount) + column)]
+                        : bufferedRow != null
+                            ? bufferedRow[column]
+                            : rows.GetValue(sourceRow, column));
                 ushort legacyColumn = checked((ushort)column);
                 switch (value.Kind) {
                     case ExcelDirectTabularValueKind.Empty:

--- a/OfficeIMO.Excel/LegacyXls/Write/LegacyXlsWriter.DirectTabular.cs
+++ b/OfficeIMO.Excel/LegacyXls/Write/LegacyXlsWriter.DirectTabular.cs
@@ -19,7 +19,9 @@ namespace OfficeIMO.Excel.LegacyXls.Write {
             }
 
             var firstColumns = new ushort[totalRows];
-            Array.Fill(firstColumns, ushort.MaxValue);
+            for (int row = 0; row < firstColumns.Length; row++) {
+                firstColumns[row] = ushort.MaxValue;
+            }
             var lastColumns = new ushort[totalRows];
             var sharedStrings = new LegacyXlsDirectSharedStringBuilder();
             object?[]? flatValues = rows.TryGetFlatValues(out object?[] candidateValues, out int flatColumnCount)
@@ -289,7 +291,7 @@ namespace OfficeIMO.Excel.LegacyXls.Write {
                     output,
                     ref writePosition,
                     firstRowPosition,
-                    firstCellPositions[..blockCount],
+                    firstCellPositions.Slice(0, blockCount),
                     dbCellPosition);
             }
 

--- a/OfficeIMO.Excel/LegacyXls/Write/LegacyXlsWriter.DirectTabular.cs
+++ b/OfficeIMO.Excel/LegacyXls/Write/LegacyXlsWriter.DirectTabular.cs
@@ -1,18 +1,149 @@
+using System.Diagnostics;
+using System.Threading;
+
 namespace OfficeIMO.Excel.LegacyXls.Write {
     internal static partial class LegacyXlsWriter {
         private const ushort DirectDefaultCellStyleIndex = 15;
         private const int DirectRowsPerDbCellBlock = 32;
 
-        private static byte[] BuildDirectTabularWorkbookStream(
+        private static bool TryCreateDirectTabularPlan(
+            ExcelDirectTabularSource source,
+            CancellationToken cancellationToken,
+            out DirectTabularPlan plan) {
+            IExcelSheetTabularRowSource rows = source.Rows;
+            int rowOffset = source.IncludeHeaders ? 1 : 0;
+            int totalRows = checked(rows.RowCount + rowOffset);
+            int columnCount = rows.ColumnCount;
+            if (totalRows > 65_536 || columnCount > 256) {
+                throw new NotSupportedException("Native XLS saving supports the BIFF8 worksheet limit of 65,536 rows and 256 columns.");
+            }
+
+            var firstColumns = new ushort[totalRows];
+            Array.Fill(firstColumns, ushort.MaxValue);
+            var lastColumns = new ushort[totalRows];
+            var sharedStrings = new LegacyXlsDirectSharedStringBuilder();
+            object?[]? flatValues = rows.TryGetFlatValues(out object?[] candidateValues, out int flatColumnCount)
+                && flatColumnCount == columnCount
+                && candidateValues.Length == checked(rows.RowCount * columnCount)
+                    ? candidateValues
+                    : null;
+            int nonEmptyCellCount = 0;
+            uint? firstDataRow = null;
+            uint? lastDataRow = null;
+
+            if (source.IncludeHeaders) {
+                for (int column = 0; column < columnCount; column++) {
+                    sharedStrings.Add(rows.GetColumnName(column));
+                    IncludeDirectCell(firstColumns, lastColumns, 0, checked((ushort)column));
+                    nonEmptyCellCount++;
+                }
+                if (columnCount != 0) {
+                    firstDataRow = 0;
+                    lastDataRow = 0;
+                }
+            }
+
+            bool canCancel = cancellationToken.CanBeCanceled;
+            for (int row = 0; row < rows.RowCount; row++) {
+                if (canCancel && (row & 1023) == 0) {
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
+
+                int directRow = row + rowOffset;
+                for (int column = 0; column < columnCount; column++) {
+                    object? rawValue = flatValues == null
+                        ? rows.GetValue(row, column)
+                        : flatValues[checked((row * columnCount) + column)];
+                    ExcelDirectTabularValue value = ExcelDirectTabularValue.Normalize(rawValue);
+                    if (value.Kind == ExcelDirectTabularValueKind.Unsupported) {
+                        plan = null!;
+                        return false;
+                    }
+                    if (value.Kind == ExcelDirectTabularValueKind.Empty) {
+                        continue;
+                    }
+
+                    nonEmptyCellCount++;
+                    IncludeDirectCell(firstColumns, lastColumns, directRow, checked((ushort)column));
+                    uint dataRow = checked((uint)directRow);
+                    firstDataRow = firstDataRow.HasValue ? Math.Min(firstDataRow.Value, dataRow) : dataRow;
+                    lastDataRow = lastDataRow.HasValue ? Math.Max(lastDataRow.Value, dataRow) : dataRow;
+                    if (value.Kind == ExcelDirectTabularValueKind.Text) {
+                        sharedStrings.Add(value.Text ?? string.Empty);
+                    }
+                }
+            }
+
+            LegacyXlsDimensions dimensions = totalRows == 0 || columnCount == 0
+                ? default
+                : new LegacyXlsDimensions(0, checked((uint)totalRows), 0, checked((ushort)columnCount));
+            if (totalRows != 0 && columnCount != 0) {
+                IncludeDirectCell(firstColumns, lastColumns, 0, 0);
+                IncludeDirectCell(
+                    firstColumns,
+                    lastColumns,
+                    totalRows - 1,
+                    checked((ushort)(columnCount - 1)));
+            }
+
+            int populatedRowCount = 0;
+            for (int row = 0; row < firstColumns.Length; row++) {
+                if (firstColumns[row] != ushort.MaxValue) populatedRowCount++;
+            }
+            long estimatedCapacity = checked(
+                16_384L
+                + ((long)(nonEmptyCellCount + 2) * 18L)
+                + ((long)populatedRowCount * 22L)
+                + ((long)dimensions.RowBlockCount * 8L)
+                + sharedStrings.EstimatedSerializedBytes);
+            int workbookStreamCapacity = estimatedCapacity >= int.MaxValue
+                ? int.MaxValue
+                : checked((int)estimatedCapacity);
+
+            plan = new DirectTabularPlan(
+                source,
+                totalRows,
+                columnCount,
+                flatValues,
+                firstColumns,
+                lastColumns,
+                dimensions,
+                firstDataRow,
+                lastDataRow,
+                nonEmptyCellCount,
+                populatedRowCount,
+                workbookStreamCapacity,
+                sharedStrings.Build());
+            return true;
+        }
+
+        private static void IncludeDirectCell(
+            ushort[] firstColumns,
+            ushort[] lastColumns,
+            int row,
+            ushort column) {
+            if (firstColumns[row] == ushort.MaxValue) {
+                firstColumns[row] = column;
+                lastColumns[row] = column;
+                return;
+            }
+
+            if (column < firstColumns[row]) firstColumns[row] = column;
+            if (column > lastColumns[row]) lastColumns[row] = column;
+        }
+
+        private static DirectTabularWorkbookStream BuildDirectTabularWorkbookStream(
             ExcelDocument document,
             ExcelSheet sheet,
-            List<LegacyXlsCell> cells) {
+            DirectTabularPlan plan) {
+            Stopwatch? stageWatch = document.Execution.OnTiming == null ? null : Stopwatch.StartNew();
             LegacyXlsFontTable fontTable = LegacyXlsFontTable.Create(document);
             LegacyXlsStyleTable styleTable = LegacyXlsStyleTable.CreateDirectTabular(document, fontTable);
             LegacyXlsExternSheetTable externSheetTable = LegacyXlsExternSheetTable.CreateDirectTabular(sheet.Name);
-            LegacyXlsSharedStringTable sharedStrings = LegacyXlsSharedStringTable.Create([cells]);
+            LegacyXlsSharedStringTable sharedStrings = plan.SharedStrings;
+            ReportDirectWriteTiming(document, stageWatch, "Save.Xls.Direct.BuildWorkbookStream.CreateTables");
 
-            using var stream = new MemoryStream();
+            using var stream = new MemoryStream(plan.WorkbookStreamCapacity);
             WriteRecord(stream, 0x0809, WorkbookGlobalsBof);
             WriteRecord(stream, 0x00e1, BuildUInt16Payload(1200));
             WriteRecord(stream, 0x00c1, BuildUInt16Payload(0));
@@ -59,29 +190,30 @@ namespace OfficeIMO.Excel.LegacyXls.Write {
             WriteRecord(stream, 0x0017, externSheetTable.Payload);
             sharedStrings.WriteRecords(stream);
             WriteRecord(stream, 0x000a, Array.Empty<byte>());
+            ReportDirectWriteTiming(document, stageWatch, "Save.Xls.Direct.BuildWorkbookStream.WriteGlobals");
 
             int worksheetOffset = checked((int)stream.Position);
-            WriteDirectTabularWorksheet(stream, cells, sharedStrings);
+            WriteDirectTabularWorksheet(stream, plan);
+            ReportDirectWriteTiming(document, stageWatch, "Save.Xls.Direct.BuildWorkbookStream.WriteWorksheet");
             long endPosition = stream.Position;
             stream.Position = boundSheetPosition + 4;
             WriteUInt32(stream, unchecked((uint)worksheetOffset));
             stream.Position = endPosition;
-            return stream.ToArray();
+            var workbookStream = new DirectTabularWorkbookStream(
+                stream.GetBuffer(),
+                checked((int)stream.Length));
+            ReportDirectWriteTiming(document, stageWatch, "Save.Xls.Direct.BuildWorkbookStream.Materialize");
+            return workbookStream;
         }
 
         private static void WriteDirectTabularWorksheet(
             MemoryStream stream,
-            IReadOnlyList<LegacyXlsCell> cells,
-            LegacyXlsSharedStringTable sharedStrings) {
+            DirectTabularPlan plan) {
             WriteRecord(stream, 0x0809, WorksheetBof);
 
-            DirectCellRow[] rows = cells
-                .GroupBy(static cell => cell.Row)
-                .Select(static group => new DirectCellRow(group.Key, group.ToArray()))
-                .ToArray();
-            LegacyXlsDimensions dimensions = GetWorksheetDimensions(cells);
+            LegacyXlsDimensions dimensions = plan.Dimensions;
             long indexRecordPosition = stream.Position;
-            WriteRecord(stream, 0x020b, BuildWorksheetIndexPayload(cells, dimensions.RowBlockCount));
+            WriteRecord(stream, 0x020b, BuildDirectWorksheetIndexPayload(plan, dimensions.RowBlockCount));
 
             WriteRecord(stream, 0x000d, BuildInt16Payload(1));
             WriteRecord(stream, 0x000c, BuildUInt16Payload(100));
@@ -104,33 +236,66 @@ namespace OfficeIMO.Excel.LegacyXls.Write {
             WriteRecord(stream, 0x0055, BuildUInt16Payload(8));
             WriteRecord(stream, 0x0200, BuildDimensionsPayload(dimensions));
 
-            var dbCellPositions = new List<uint>(dimensions.RowBlockCount);
-            int rowIndex = 0;
-            for (int blockIndex = 0; blockIndex < dimensions.RowBlockCount; blockIndex++) {
-                uint blockFirstRow = checked(dimensions.FirstRow + ((uint)blockIndex * DirectRowsPerDbCellBlock));
-                uint blockRowAfterLast = Math.Min(
-                    checked(blockFirstRow + DirectRowsPerDbCellBlock),
-                    dimensions.RowAfterLast);
-                int blockStart = rowIndex;
-                while (rowIndex < rows.Length && rows[rowIndex].Row < blockRowAfterLast) {
-                    rowIndex++;
-                }
-                int blockCount = rowIndex - blockStart;
-                long firstRowPosition = stream.Position;
-                for (int index = 0; index < blockCount; index++) {
-                    WriteRecord(stream, 0x0208, BuildDirectRowPayload(rows[blockStart + index]));
-                }
-
-                var firstCellPositions = new long[blockCount];
-                for (int index = 0; index < blockCount; index++) {
-                    firstCellPositions[index] = stream.Position;
-                    WriteCellRecords(stream, 0, rows[blockStart + index].Cells, sharedStrings);
-                }
-
-                long dbCellPosition = stream.Position;
-                dbCellPositions.Add(checked((uint)dbCellPosition));
-                WriteRecord(stream, 0x00d7, BuildDbCellPayload(firstRowPosition, firstCellPositions, dbCellPosition));
+            int rowBlockCount = dimensions.RowBlockCount;
+            long cellTableUpperBound = checked(
+                ((long)plan.PopulatedRowCount * 22L)
+                + ((long)(plan.NonEmptyCellCount + 2) * 18L)
+                + ((long)rowBlockCount * 8L));
+            long requiredCapacity = checked(stream.Position + cellTableUpperBound + 128L);
+            if (requiredCapacity > int.MaxValue) {
+                throw new NotSupportedException("The direct XLS cell table exceeds the maximum in-memory workbook size.");
             }
+            if (stream.Capacity < requiredCapacity) {
+                stream.Capacity = checked((int)requiredCapacity);
+            }
+
+            byte[] output = stream.GetBuffer();
+            int cellTableStart = checked((int)stream.Position);
+            int writePosition = cellTableStart;
+            var dbCellPositions = new uint[rowBlockCount];
+            Span<int> firstCellPositions = stackalloc int[DirectRowsPerDbCellBlock];
+            for (int blockIndex = 0; blockIndex < dimensions.RowBlockCount; blockIndex++) {
+                int blockFirstRow = checked((int)dimensions.FirstRow + (blockIndex * DirectRowsPerDbCellBlock));
+                int blockRowAfterLast = Math.Min(
+                    checked(blockFirstRow + DirectRowsPerDbCellBlock),
+                    checked((int)dimensions.RowAfterLast));
+                int blockCount = 0;
+                for (int row = blockFirstRow; row < blockRowAfterLast; row++) {
+                    if (plan.FirstColumns[row] != ushort.MaxValue) blockCount++;
+                }
+
+                int firstRowPosition = writePosition;
+                for (int row = blockFirstRow; row < blockRowAfterLast; row++) {
+                    ushort firstColumn = plan.FirstColumns[row];
+                    if (firstColumn == ushort.MaxValue) continue;
+                    WriteDirectRowRecord(
+                        output,
+                        ref writePosition,
+                        checked((ushort)row),
+                        firstColumn,
+                        plan.LastColumns[row]);
+                }
+
+                int cellRowIndex = 0;
+                for (int row = blockFirstRow; row < blockRowAfterLast; row++) {
+                    if (plan.FirstColumns[row] == ushort.MaxValue) continue;
+                    firstCellPositions[cellRowIndex++] = writePosition;
+                    WriteDirectRowCells(output, ref writePosition, plan, row);
+                }
+
+                int dbCellPosition = writePosition;
+                dbCellPositions[blockIndex] = checked((uint)dbCellPosition);
+                WriteDirectDbCellRecord(
+                    output,
+                    ref writePosition,
+                    firstRowPosition,
+                    firstCellPositions[..blockCount],
+                    dbCellPosition);
+            }
+
+            // Advance MemoryStream's logical length without clearing the direct
+            // writes. Source and destination are the identical buffer range.
+            stream.Write(output, cellTableStart, writePosition - cellTableStart);
 
             WriteRecord(stream, 0x023e, [
                 0xb6, 0x06, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00,
@@ -142,15 +307,112 @@ namespace OfficeIMO.Excel.LegacyXls.Write {
             PatchIndexRecord(stream, indexRecordPosition, defaultColumnWidthPosition, dbCellPositions);
         }
 
-        private static byte[] BuildDirectRowPayload(DirectCellRow row) {
-            byte[] payload = new byte[16];
-            WriteUInt16(payload, 0, row.Row);
-            WriteUInt16(payload, 2, row.Cells[0].Column);
-            WriteUInt16(payload, 4, checked((ushort)(row.Cells[row.Cells.Count - 1].Column + 1)));
-            WriteUInt16(payload, 6, 0x00ff);
-            WriteUInt16(payload, 12, 0x0100);
-            WriteUInt16(payload, 14, DirectDefaultCellStyleIndex);
+        private static byte[] BuildDirectWorksheetIndexPayload(DirectTabularPlan plan, int dbCellCount) {
+            byte[] payload = new byte[checked(16 + (dbCellCount * 4))];
+            if (plan.FirstDataRow.HasValue && plan.LastDataRow.HasValue) {
+                WriteUInt32(payload, 4, plan.FirstDataRow.Value);
+                WriteUInt32(payload, 8, checked(plan.LastDataRow.Value + 1U));
+            }
             return payload;
+        }
+
+        private static void WriteDirectRowRecord(
+            byte[] output,
+            ref int position,
+            ushort row,
+            ushort firstColumn,
+            ushort lastColumn) {
+            WriteUInt16(output, position, 0x0208);
+            WriteUInt16(output, position + 2, 16);
+            WriteUInt16(output, position + 4, row);
+            WriteUInt16(output, position + 6, firstColumn);
+            WriteUInt16(output, position + 8, checked((ushort)(lastColumn + 1)));
+            WriteUInt16(output, position + 10, 0x00ff);
+            WriteUInt16(output, position + 12, 0);
+            WriteUInt16(output, position + 14, 0);
+            WriteUInt16(output, position + 16, 0x0100);
+            WriteUInt16(output, position + 18, DirectDefaultCellStyleIndex);
+            position += 20;
+        }
+
+        private static void WriteDirectRowCells(
+            byte[] output,
+            ref int position,
+            DirectTabularPlan plan,
+            int directRow) {
+            IExcelSheetTabularRowSource rows = plan.Source.Rows;
+            bool headerRow = plan.Source.IncludeHeaders && directRow == 0;
+            int sourceRow = directRow - (plan.Source.IncludeHeaders ? 1 : 0);
+            for (int column = 0; column < plan.ColumnCount; column++) {
+                ExcelDirectTabularValue value = headerRow
+                    ? ExcelDirectTabularValue.Normalize(rows.GetColumnName(column))
+                    : ExcelDirectTabularValue.Normalize(plan.FlatValues == null
+                        ? rows.GetValue(sourceRow, column)
+                        : plan.FlatValues[checked((sourceRow * plan.ColumnCount) + column)]);
+                ushort legacyColumn = checked((ushort)column);
+                switch (value.Kind) {
+                    case ExcelDirectTabularValueKind.Empty:
+                        if ((directRow == 0 && column == 0)
+                            || (directRow == plan.TotalRows - 1 && column == plan.ColumnCount - 1)) {
+                            WriteDirectFixedCellHeader(output, ref position, 0x0201, 6, checked((ushort)directRow), legacyColumn);
+                        }
+                        break;
+                    case ExcelDirectTabularValueKind.Text:
+                        WriteDirectFixedCellHeader(output, ref position, 0x00fd, 10, checked((ushort)directRow), legacyColumn);
+                        WriteUInt32(output, position, plan.SharedStrings.GetDirectIndex(value.Text ?? string.Empty));
+                        position += 4;
+                        break;
+                    case ExcelDirectTabularValueKind.Boolean:
+                        WriteDirectFixedCellHeader(output, ref position, 0x0205, 8, checked((ushort)directRow), legacyColumn);
+                        output[position++] = value.Boolean ? (byte)1 : (byte)0;
+                        output[position++] = 0;
+                        break;
+                    case ExcelDirectTabularValueKind.Number:
+                        WriteDirectFixedCellHeader(output, ref position, 0x0203, 14, checked((ushort)directRow), legacyColumn);
+                        ulong bits = unchecked((ulong)BitConverter.DoubleToInt64Bits(value.Number));
+                        WriteUInt32(output, position, unchecked((uint)bits));
+                        WriteUInt32(output, position + 4, unchecked((uint)(bits >> 32)));
+                        position += 8;
+                        break;
+                    default:
+                        throw new InvalidOperationException("The direct XLS tabular source changed after validation.");
+                }
+            }
+        }
+
+        private static void WriteDirectFixedCellHeader(
+            byte[] output,
+            ref int position,
+            ushort type,
+            ushort payloadLength,
+            ushort row,
+            ushort column) {
+            WriteUInt16(output, position, type);
+            WriteUInt16(output, position + 2, payloadLength);
+            WriteUInt16(output, position + 4, row);
+            WriteUInt16(output, position + 6, column);
+            WriteUInt16(output, position + 8, DirectDefaultCellStyleIndex);
+            position += 10;
+        }
+
+        private static void WriteDirectDbCellRecord(
+            byte[] output,
+            ref int position,
+            int firstRowPosition,
+            ReadOnlySpan<int> firstCellPositions,
+            int dbCellPosition) {
+            WriteUInt16(output, position, 0x00d7);
+            WriteUInt16(output, position + 2, checked((ushort)(4 + (firstCellPositions.Length * 2))));
+            WriteUInt32(output, position + 4, checked((uint)(dbCellPosition - firstRowPosition)));
+            int priorPosition = firstRowPosition + 20;
+            int offsetPosition = position + 8;
+            for (int index = 0; index < firstCellPositions.Length; index++) {
+                int cellPosition = firstCellPositions[index];
+                WriteUInt16(output, offsetPosition, checked((ushort)(cellPosition - priorPosition)));
+                priorPosition = cellPosition;
+                offsetPosition += 2;
+            }
+            position = offsetPosition;
         }
 
         private static byte[] BuildDefaultDirectSetupPayload() => [
@@ -176,15 +438,66 @@ namespace OfficeIMO.Excel.LegacyXls.Write {
             0x58, 0x02
         ];
 
-        private sealed class DirectCellRow {
-            internal DirectCellRow(ushort row, IReadOnlyList<LegacyXlsCell> cells) {
-                Row = row;
-                Cells = cells;
+        private sealed class DirectTabularPlan {
+            internal DirectTabularPlan(
+                ExcelDirectTabularSource source,
+                int totalRows,
+                int columnCount,
+                object?[]? flatValues,
+                ushort[] firstColumns,
+                ushort[] lastColumns,
+                LegacyXlsDimensions dimensions,
+                uint? firstDataRow,
+                uint? lastDataRow,
+                int nonEmptyCellCount,
+                int populatedRowCount,
+                int workbookStreamCapacity,
+                LegacyXlsSharedStringTable sharedStrings) {
+                Source = source;
+                TotalRows = totalRows;
+                ColumnCount = columnCount;
+                FlatValues = flatValues;
+                FirstColumns = firstColumns;
+                LastColumns = lastColumns;
+                Dimensions = dimensions;
+                FirstDataRow = firstDataRow;
+                LastDataRow = lastDataRow;
+                NonEmptyCellCount = nonEmptyCellCount;
+                PopulatedRowCount = populatedRowCount;
+                WorkbookStreamCapacity = workbookStreamCapacity;
+                SharedStrings = sharedStrings;
             }
 
-            internal ushort Row { get; }
+            internal ExcelDirectTabularSource Source { get; }
+            internal int TotalRows { get; }
+            internal int ColumnCount { get; }
+            internal object?[]? FlatValues { get; }
+            internal ushort[] FirstColumns { get; }
+            internal ushort[] LastColumns { get; }
+            internal LegacyXlsDimensions Dimensions { get; }
+            internal uint? FirstDataRow { get; }
+            internal uint? LastDataRow { get; }
+            internal int NonEmptyCellCount { get; }
+            internal int PopulatedRowCount { get; }
+            internal int WorkbookStreamCapacity { get; }
+            internal LegacyXlsSharedStringTable SharedStrings { get; }
+        }
 
-            internal IReadOnlyList<LegacyXlsCell> Cells { get; }
+        private readonly struct DirectTabularWorkbookStream {
+            internal DirectTabularWorkbookStream(byte[] buffer, int length) {
+                Buffer = buffer;
+                Length = length;
+            }
+
+            internal byte[] Buffer { get; }
+
+            internal int Length { get; }
+
+            internal byte[] ToArray() {
+                var bytes = new byte[Length];
+                System.Buffer.BlockCopy(Buffer, 0, bytes, 0, Length);
+                return bytes;
+            }
         }
     }
 }

--- a/OfficeIMO.Excel/LegacyXls/Write/LegacyXlsWriter.SharedStrings.cs
+++ b/OfficeIMO.Excel/LegacyXls/Write/LegacyXlsWriter.SharedStrings.cs
@@ -25,12 +25,15 @@ namespace OfficeIMO.Excel.LegacyXls.Write {
         private sealed class LegacyXlsSharedStringTable {
             private readonly IReadOnlyList<LegacyXlsSharedStringEntry> _entries;
             private readonly uint _totalCount;
+            private readonly Dictionary<string, uint>? _directIndexesByValue;
 
-            private LegacyXlsSharedStringTable(
+            internal LegacyXlsSharedStringTable(
                 IReadOnlyList<LegacyXlsSharedStringEntry> entries,
-                uint totalCount) {
+                uint totalCount,
+                Dictionary<string, uint>? directIndexesByValue = null) {
                 _entries = entries;
                 _totalCount = totalCount;
+                _directIndexesByValue = directIndexesByValue;
             }
 
             internal static LegacyXlsSharedStringTable Create(IReadOnlyList<List<LegacyXlsCell>> worksheets) {
@@ -71,6 +74,15 @@ namespace OfficeIMO.Excel.LegacyXls.Write {
                 }
 
                 throw new InvalidOperationException("The native XLS shared-string table is missing a worksheet text cell.");
+            }
+
+            internal uint GetDirectIndex(string text) {
+                if (_directIndexesByValue != null
+                    && _directIndexesByValue.TryGetValue(text, out uint index)) {
+                    return index;
+                }
+
+                throw new InvalidOperationException("The native XLS shared-string table is missing a direct worksheet text cell.");
             }
 
             internal void WriteRecords(Stream stream) {
@@ -122,6 +134,36 @@ namespace OfficeIMO.Excel.LegacyXls.Write {
 
                 WriteRecord(stream, 0x00ff, payload.ToArray());
             }
+        }
+
+        private sealed class LegacyXlsDirectSharedStringBuilder {
+            private readonly List<LegacyXlsSharedStringEntry> _entries = new();
+            private readonly Dictionary<string, uint> _indexesByValue = new(StringComparer.Ordinal);
+            private uint _totalCount;
+            private long _estimatedSerializedBytes;
+
+            internal long EstimatedSerializedBytes => _estimatedSerializedBytes;
+
+            internal uint Add(string text) {
+                _totalCount = checked(_totalCount + 1U);
+                if (_indexesByValue.TryGetValue(text, out uint existingIndex)) {
+                    return existingIndex;
+                }
+
+                uint index = checked((uint)_entries.Count);
+                _indexesByValue.Add(text, index);
+                _entries.Add(new LegacyXlsSharedStringEntry(
+                    text,
+                    Array.Empty<LegacyXlsTextFormattingRun>()));
+                _estimatedSerializedBytes = checked(
+                    _estimatedSerializedBytes
+                    + 3L
+                    + (text.Length * (CanUseCompressedString(text) ? 1L : 2L)));
+                return index;
+            }
+
+            internal LegacyXlsSharedStringTable Build() =>
+                new LegacyXlsSharedStringTable(_entries, _totalCount, _indexesByValue);
         }
 
         private sealed class LegacyXlsStringSegmentWriter {

--- a/OfficeIMO.Excel/LegacyXls/Write/LegacyXlsWriter.cs
+++ b/OfficeIMO.Excel/LegacyXls/Write/LegacyXlsWriter.cs
@@ -35,8 +35,6 @@ namespace OfficeIMO.Excel.LegacyXls.Write {
                 workbookBytes = Array.Empty<byte>();
                 return false;
             }
-            ExcelSheet[] sheets = [sheet];
-
             if (!TryCreateDirectTabularPlan(source, cancellationToken, out DirectTabularPlan? directPlan)) {
                 workbookBytes = Array.Empty<byte>();
                 return false;

--- a/OfficeIMO.Excel/LegacyXls/Write/LegacyXlsWriter.cs
+++ b/OfficeIMO.Excel/LegacyXls/Write/LegacyXlsWriter.cs
@@ -37,13 +37,13 @@ namespace OfficeIMO.Excel.LegacyXls.Write {
             }
             ExcelSheet[] sheets = [sheet];
 
-            if (!TryExtractDirectCells(source, cancellationToken, out List<LegacyXlsCell>? directCells)) {
+            if (!TryCreateDirectTabularPlan(source, cancellationToken, out DirectTabularPlan? directPlan)) {
                 workbookBytes = Array.Empty<byte>();
                 return false;
             }
             ReportDirectWriteTiming(document, stageWatch, "Save.Xls.Direct.ExtractCells");
 
-            byte[] workbookStream = BuildDirectTabularWorkbookStream(document, sheet, directCells);
+            DirectTabularWorkbookStream workbookStream = BuildDirectTabularWorkbookStream(document, sheet, directPlan);
             ReportDirectWriteTiming(document, stageWatch, "Save.Xls.Direct.BuildWorkbookStream");
             workbookBytes = BuildCompoundFile(document, workbookStream);
             ReportDirectWriteTiming(document, stageWatch, "Save.Xls.Direct.BuildCompoundFile");
@@ -64,9 +64,36 @@ namespace OfficeIMO.Excel.LegacyXls.Write {
         }
 
         private static byte[] BuildCompoundFile(ExcelDocument document, byte[] workbookStream) {
+            return BuildCompoundFile(
+                document,
+                new OfficeCompoundStream(
+                    GetWorkbookStreamName(document.LegacyXlsSourceCompoundFile),
+                    workbookStream));
+        }
+
+        private static byte[] BuildCompoundFile(
+            ExcelDocument document,
+            DirectTabularWorkbookStream workbookStream) {
+            if (document.LegacyXlsSourceCompoundFile != null) {
+                return BuildCompoundFile(document, workbookStream.ToArray());
+            }
+
+            byte[] buffer = workbookStream.Buffer;
+            int length = workbookStream.Length;
+            return BuildCompoundFile(
+                document,
+                new OfficeCompoundStream(
+                    GetWorkbookStreamName(sourceCompoundFile: null),
+                    length,
+                    () => new MemoryStream(buffer, 0, length, writable: false)));
+        }
+
+        private static byte[] BuildCompoundFile(
+            ExcelDocument document,
+            OfficeCompoundStream workbookStream) {
             IReadOnlyList<OfficeCompoundStream> propertyStreams = LegacyOlePropertySetWriter.CreateDocumentPropertyStreams(document);
             var streams = new List<OfficeCompoundStream>(propertyStreams.Count + 1) {
-                new OfficeCompoundStream(GetWorkbookStreamName(document.LegacyXlsSourceCompoundFile), workbookStream)
+                workbookStream
             };
             streams.AddRange(propertyStreams);
             OfficeCompoundFile? sourceCompoundFile = document.LegacyXlsSourceCompoundFile;
@@ -216,73 +243,6 @@ namespace OfficeIMO.Excel.LegacyXls.Write {
                 stream.Position = currentPosition;
             }
             return stream.ToArray();
-        }
-
-        private static bool TryExtractDirectCells(
-            ExcelDirectTabularSource source,
-            CancellationToken cancellationToken,
-            out List<LegacyXlsCell> cells) {
-            const ushort DefaultDirectCellStyleIndex = 15;
-            IExcelSheetTabularRowSource rows = source.Rows;
-            int rowOffset = source.IncludeHeaders ? 1 : 0;
-            int totalRows = checked(rows.RowCount + rowOffset);
-            if (totalRows > 65_536 || rows.ColumnCount > 256) {
-                throw new NotSupportedException("Native XLS saving supports the BIFF8 worksheet limit of 65,536 rows and 256 columns.");
-            }
-
-            int capacity = Math.Min(checked(totalRows * rows.ColumnCount), 1_048_576);
-            cells = new List<LegacyXlsCell>(capacity);
-            if (source.IncludeHeaders) {
-                for (int column = 0; column < rows.ColumnCount; column++) {
-                    cells.Add(LegacyXlsCell.Text(
-                        row: 0,
-                        column: checked((ushort)column),
-                        styleIndex: DefaultDirectCellStyleIndex,
-                        rows.GetColumnName(column)));
-                }
-            }
-
-            for (int row = 0; row < rows.RowCount; row++) {
-                if ((row & 1023) == 0) {
-                    cancellationToken.ThrowIfCancellationRequested();
-                }
-
-                ushort legacyRow = checked((ushort)(row + rowOffset));
-                for (int column = 0; column < rows.ColumnCount; column++) {
-                    ExcelDirectTabularValue value = ExcelDirectTabularValue.Normalize(rows.GetValue(row, column));
-                    ushort legacyColumn = checked((ushort)column);
-                    switch (value.Kind) {
-                        case ExcelDirectTabularValueKind.Empty:
-                            break;
-                        case ExcelDirectTabularValueKind.Text:
-                            cells.Add(LegacyXlsCell.Text(legacyRow, legacyColumn, DefaultDirectCellStyleIndex, value.Text ?? string.Empty));
-                            break;
-                        case ExcelDirectTabularValueKind.Boolean:
-                            cells.Add(LegacyXlsCell.Boolean(legacyRow, legacyColumn, DefaultDirectCellStyleIndex, value.Boolean));
-                            break;
-                        case ExcelDirectTabularValueKind.Number:
-                            cells.Add(LegacyXlsCell.Number(legacyRow, legacyColumn, DefaultDirectCellStyleIndex, value.Number));
-                            break;
-                        default:
-                            cells = null!;
-                            return false;
-                    }
-                }
-            }
-
-            if (totalRows != 0 && rows.ColumnCount != 0) {
-                ushort lastRow = checked((ushort)(totalRows - 1));
-                ushort lastColumn = checked((ushort)(rows.ColumnCount - 1));
-                if (cells.Count == 0 || cells[0].Row != 0 || cells[0].Column != 0) {
-                    cells.Insert(0, LegacyXlsCell.Blank(0, 0, DefaultDirectCellStyleIndex));
-                }
-                if ((lastRow != 0 || lastColumn != 0)
-                    && (cells[cells.Count - 1].Row != lastRow || cells[cells.Count - 1].Column != lastColumn)) {
-                    cells.Add(LegacyXlsCell.Blank(lastRow, lastColumn, DefaultDirectCellStyleIndex));
-                }
-            }
-
-            return true;
         }
 
         private static void WriteWorksheet(

--- a/OfficeIMO.Excel/Read/ExcelDocumentReader.cs
+++ b/OfficeIMO.Excel/Read/ExcelDocumentReader.cs
@@ -65,6 +65,7 @@ namespace OfficeIMO.Excel {
             var effectiveOptions = options ?? new ExcelReadOptions();
             SharedReadOnlyFileSnapshot? snapshot = null;
             Stream? documentStream = null;
+            Package? package = null;
             SpreadsheetDocument? document = null;
             OpenXmlPackagePartBufferReader? partBufferReader = null;
             bool packageOpenAttempted = false;
@@ -77,22 +78,26 @@ namespace OfficeIMO.Excel {
 
                 documentStream = snapshot.CreateView();
                 packageOpenAttempted = true;
-                document = SpreadsheetDocument.Open(documentStream, isEditable: false);
+                package = Package.Open(documentStream, FileMode.Open, FileAccess.Read);
+                document = SpreadsheetDocument.Open(package);
                 partBufferReader = OpenXmlPackagePartBufferReader.TryOpen(snapshot.CreateView(bufferSize: 1));
                 ExcelDocumentReader reader = new ExcelDocumentReader(
                     document,
                     effectiveOptions,
                     owns: true,
+                    ownedPackage: package,
                     ownedStream: documentStream,
                     partBufferReader: partBufferReader,
                     ownedResource: snapshot);
                 snapshot = null;
                 documentStream = null;
+                package = null;
                 partBufferReader = null;
                 return reader;
             } catch (Exception ex) {
                 partBufferReader?.Dispose();
                 document?.Dispose();
+                package?.Close();
                 documentStream?.Dispose();
                 if (!packageOpenAttempted || !IsRecoverableOpenException(ex)) {
                     snapshot?.Dispose();

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.Validation.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.Validation.cs
@@ -147,6 +147,7 @@ namespace OfficeIMO.Excel {
                                 _valueStarts![cellIndex] = tag.End;
                                 _valueLengths![cellIndex] = 0;
                             } else {
+                                EnsureFormulaMetadata();
                                 _formulaStarts![cellIndex] = tag.End;
                                 _formulaLengths![cellIndex] = 0;
                             }
@@ -176,6 +177,7 @@ namespace OfficeIMO.Excel {
                             _valueStarts![cellIndex] = contentStart;
                             _valueLengths![cellIndex] = contentLength;
                         } else {
+                            EnsureFormulaMetadata();
                             _formulaStarts![cellIndex] = contentStart;
                             _formulaLengths![cellIndex] = contentLength;
                         }

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.cs
@@ -897,8 +897,10 @@ namespace OfficeIMO.Excel {
                 _formulaStarts = ArrayPool<int>.Shared.Rent(capacity);
                 _formulaLengths = ArrayPool<int>.Shared.Rent(capacity);
                 int initializedCellCount = checked((_rowCount + 1) * _fieldCount);
-                Array.Fill(_formulaStarts, 0, 0, initializedCellCount);
-                Array.Fill(_formulaLengths, -1, 0, initializedCellCount);
+                Array.Clear(_formulaStarts, 0, initializedCellCount);
+                for (int index = 0; index < initializedCellCount; index++) {
+                    _formulaLengths[index] = -1;
+                }
             }
 
             private void GrowCellKindArray(int capacity, int count) {

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.cs
@@ -15,6 +15,8 @@ namespace OfficeIMO.Excel {
             private const int MaximumIndexedCells = 1_000_000;
             private const int StringCacheSize = 256;
             private const int MaximumCachedStringBytes = 256;
+            private const byte DateStyleCellKindFlag = 0x80;
+            private const byte CellKindMask = 0x7F;
 
             private readonly ExcelSheetReader _owner;
             private readonly ExcelReadOptions _options;
@@ -27,7 +29,6 @@ namespace OfficeIMO.Excel {
             private int[]? _valueLengths;
             private int[]? _formulaStarts;
             private int[]? _formulaLengths;
-            private int[]? _styleIndexes;
             private byte[]? _cellKinds;
             private int _length;
             private int _rowCount;
@@ -82,9 +83,6 @@ namespace OfficeIMO.Excel {
                 int cellCapacity = checked(rowCapacity * fieldCount);
                 _valueStarts = ArrayPool<int>.Shared.Rent(cellCapacity);
                 _valueLengths = ArrayPool<int>.Shared.Rent(cellCapacity);
-                _formulaStarts = ArrayPool<int>.Shared.Rent(cellCapacity);
-                _formulaLengths = ArrayPool<int>.Shared.Rent(cellCapacity);
-                _styleIndexes = ArrayPool<int>.Shared.Rent(cellCapacity);
                 _cellKinds = ArrayPool<byte>.Shared.Rent(cellCapacity);
             }
 
@@ -274,11 +272,14 @@ namespace OfficeIMO.Excel {
                 objectValue = null;
 
                 int cellIndex = _currentRowOffset + ordinal;
-                if ((Utf8CellKind)_cellKinds![cellIndex] == Utf8CellKind.Missing) {
+                byte encodedCellKind = _cellKinds![cellIndex];
+                Utf8CellKind cellKind = (Utf8CellKind)(encodedCellKind & CellKindMask);
+                if (cellKind == Utf8CellKind.Missing) {
                     return;
                 }
 
-                bool useFormula = _formulaLengths![cellIndex] >= 0
+                bool useFormula = _formulaLengths != null
+                    && _formulaLengths[cellIndex] >= 0
                     && (!_options.UseCachedFormulaResult || _valueLengths![cellIndex] < 0);
                 int start = useFormula ? _formulaStarts![cellIndex] : _valueStarts![cellIndex];
                 int length = useFormula ? _formulaLengths![cellIndex] : _valueLengths![cellIndex];
@@ -293,7 +294,7 @@ namespace OfficeIMO.Excel {
                 }
 
                 ReadOnlySpan<byte> value = _buffer!.AsSpan(start, length);
-                switch ((Utf8CellKind)_cellKinds![cellIndex]) {
+                switch (cellKind) {
                     case Utf8CellKind.SharedString:
                         if (TryParseInt32(value, out int sharedStringIndex)) {
                             objectValue = _owner.GetSharedString(sharedStringIndex);
@@ -333,10 +334,11 @@ namespace OfficeIMO.Excel {
                         objectValue = DecodeString(start, length);
                         return;
                     case Utf8CellKind.Number:
+                        bool dateStyle = (encodedCellKind & DateStyleCellKindFlag) != 0;
                         deferObjectMaterialization =
                             targetKind == XmlDataReaderTargetKind.Numeric
-                            && IsDateStyle(_styleIndexes![cellIndex]);
-                        ReadNumberValue(cellIndex, value, targetKind, out primitiveKind, out doubleValue, out dateTimeValue, out objectValue);
+                            && dateStyle;
+                        ReadNumberValue(cellIndex, value, dateStyle, targetKind, out primitiveKind, out doubleValue, out dateTimeValue, out objectValue);
                         return;
                     default:
                         return;
@@ -360,7 +362,6 @@ namespace OfficeIMO.Excel {
                 ReturnRowArray(ref _valueLengths);
                 ReturnRowArray(ref _formulaStarts);
                 ReturnRowArray(ref _formulaLengths);
-                ReturnRowArray(ref _styleIndexes);
                 if (_cellKinds != null) {
                     ArrayPool<byte>.Shared.Return(_cellKinds);
                     _cellKinds = null;
@@ -568,10 +569,6 @@ namespace OfficeIMO.Excel {
                     int cellIndex = rowOffset >= 0 && (uint)ordinal < (uint)_fieldCount
                         ? rowOffset + ordinal
                         : -1;
-                    if (cellIndex >= 0) {
-                        _cellKinds![cellIndex] = (byte)kind;
-                        _styleIndexes![cellIndex] = styleIndex;
-                    }
 
                     bool sharedFormulaFollower = false;
                     bool hasCachedValue = false;
@@ -609,6 +606,9 @@ namespace OfficeIMO.Excel {
                         hasCachedValue,
                         valueStart,
                         valueLength);
+                    if (cellIndex >= 0) {
+                        _cellKinds![cellIndex] = EncodeCellKind(kind, styleIndex);
+                    }
                 }
 
                 return false;
@@ -677,6 +677,7 @@ namespace OfficeIMO.Excel {
             private void ReadNumberValue(
                 int ordinal,
                 ReadOnlySpan<byte> value,
+                bool dateStyle,
                 XmlDataReaderTargetKind targetKind,
                 out XmlDataReaderPrimitiveKind primitiveKind,
                 out double doubleValue,
@@ -687,7 +688,6 @@ namespace OfficeIMO.Excel {
                 dateTimeValue = default;
                 objectValue = null;
                 ReadOnlySpan<byte> trimmed = TrimAsciiWhitespace(value);
-                bool dateStyle = IsDateStyle(_styleIndexes![ordinal]);
                 if (targetKind == XmlDataReaderTargetKind.String) {
                     if (dateStyle && TryParseDouble(trimmed, out double serialDate)) {
                         objectValue = _owner.FromExcelSerialDate(serialDate).ToString(_options.Culture);
@@ -860,9 +860,10 @@ namespace OfficeIMO.Excel {
                 int nextCellCapacity = checked(nextCapacity * _fieldCount);
                 GrowRowArray(ref _valueStarts, nextCellCapacity, currentCellCount);
                 GrowRowArray(ref _valueLengths, nextCellCapacity, currentCellCount);
-                GrowRowArray(ref _formulaStarts, nextCellCapacity, currentCellCount);
-                GrowRowArray(ref _formulaLengths, nextCellCapacity, currentCellCount);
-                GrowRowArray(ref _styleIndexes, nextCellCapacity, currentCellCount);
+                if (_formulaStarts != null) {
+                    GrowRowArray(ref _formulaStarts, nextCellCapacity, currentCellCount);
+                    GrowRowArray(ref _formulaLengths, nextCellCapacity, currentCellCount);
+                }
                 GrowCellKindArray(nextCellCapacity, currentCellCount);
             }
 
@@ -872,10 +873,32 @@ namespace OfficeIMO.Excel {
                     _cellKinds![i] = (byte)Utf8CellKind.Missing;
                     _valueStarts![i] = 0;
                     _valueLengths![i] = -1;
-                    _formulaStarts![i] = 0;
-                    _formulaLengths![i] = -1;
-                    _styleIndexes![i] = -1;
+                    if (_formulaStarts != null) {
+                        _formulaStarts[i] = 0;
+                        _formulaLengths![i] = -1;
+                    }
                 }
+            }
+
+            private byte EncodeCellKind(Utf8CellKind kind, int styleIndex) {
+                byte encoded = (byte)kind;
+                if (kind == Utf8CellKind.Number && styleIndex >= 0 && IsDateStyle(styleIndex)) {
+                    encoded |= DateStyleCellKindFlag;
+                }
+                return encoded;
+            }
+
+            private void EnsureFormulaMetadata() {
+                if (_formulaStarts != null) {
+                    return;
+                }
+
+                int capacity = _valueStarts!.Length;
+                _formulaStarts = ArrayPool<int>.Shared.Rent(capacity);
+                _formulaLengths = ArrayPool<int>.Shared.Rent(capacity);
+                int initializedCellCount = checked((_rowCount + 1) * _fieldCount);
+                Array.Fill(_formulaStarts, 0, 0, initializedCellCount);
+                Array.Fill(_formulaLengths, -1, 0, initializedCellCount);
             }
 
             private void GrowCellKindArray(int capacity, int count) {

--- a/OfficeIMO.Excel/Xlsb/Biff12/XlsbRecordWriter.cs
+++ b/OfficeIMO.Excel/Xlsb/Biff12/XlsbRecordWriter.cs
@@ -28,12 +28,22 @@ namespace OfficeIMO.Excel.Xlsb.Biff12 {
         }
 
         internal static int EncodeHeader(int recordType, int payloadLength, byte[] destination) {
+            return EncodeHeader(recordType, payloadLength, destination, 0);
+        }
+
+        internal static int EncodeHeader(
+            int recordType,
+            int payloadLength,
+            byte[] destination,
+            int offset) {
             if (recordType < 0 || recordType > 0x3FFF) throw new ArgumentOutOfRangeException(nameof(recordType));
             if (payloadLength < 0 || payloadLength > 0x0FFFFFFF) throw new ArgumentOutOfRangeException(nameof(payloadLength));
             if (destination == null) throw new ArgumentNullException(nameof(destination));
-            if (destination.Length < 6) throw new ArgumentException("The BIFF12 header buffer must contain at least 6 bytes.", nameof(destination));
+            if (offset < 0 || offset > destination.Length - 6) {
+                throw new ArgumentOutOfRangeException(nameof(offset));
+            }
 
-            int index = 0;
+            int index = offset;
             if (recordType < 0x80) {
                 destination[index++] = (byte)recordType;
             } else {
@@ -49,7 +59,7 @@ namespace OfficeIMO.Excel.Xlsb.Biff12 {
                 destination[index++] = current;
             } while (value != 0);
 
-            return index;
+            return index - offset;
         }
 
         internal static byte[] Encode(int recordType, byte[]? payload = null) {

--- a/OfficeIMO.Excel/Xlsb/Write/XlsbDirectRecordWriter.cs
+++ b/OfficeIMO.Excel/Xlsb/Write/XlsbDirectRecordWriter.cs
@@ -7,10 +7,11 @@ namespace OfficeIMO.Excel.Xlsb.Write {
     /// This avoids issuing a separate virtual stream call for every primitive byte.
     /// </summary>
     internal sealed class XlsbDirectRecordWriter : IDisposable {
-        private const int BufferSize = 4 * 1024;
+        private const int BufferSize = 32 * 1024;
 
         private readonly Stream _stream;
         private byte[]? _buffer;
+        private int _position;
 
         internal XlsbDirectRecordWriter(Stream stream) {
             _stream = stream ?? throw new ArgumentNullException(nameof(stream));
@@ -21,16 +22,16 @@ namespace OfficeIMO.Excel.Xlsb.Write {
         internal void WriteRecord(int recordType) => WriteHeader(recordType, payloadLength: 0);
 
         internal void WriteHeader(int recordType, int payloadLength) {
-            byte[] buffer = GetBuffer();
-            int count = XlsbRecordWriter.EncodeHeader(recordType, payloadLength, buffer);
-            _stream.Write(buffer, 0, count);
+            byte[] buffer = EnsureAvailable(6);
+            _position += XlsbRecordWriter.EncodeHeader(recordType, payloadLength, buffer, _position);
         }
 
         internal void WriteRowHeader(int recordType, int zeroBasedRow, int columnCount, byte[] defaultRowProperties) {
             int spanCount = checked((columnCount + 1023) / 1024);
             int payloadLength = checked(17 + spanCount * 8);
-            byte[] buffer = GetBuffer();
-            int offset = XlsbRecordWriter.EncodeHeader(recordType, payloadLength, buffer);
+            byte[] buffer = EnsureAvailable(checked(6 + payloadLength));
+            int offset = _position;
+            offset += XlsbRecordWriter.EncodeHeader(recordType, payloadLength, buffer, offset);
             offset = AppendUInt32(buffer, offset, checked((uint)zeroBasedRow));
             Buffer.BlockCopy(defaultRowProperties, 0, buffer, offset, defaultRowProperties.Length);
             offset += defaultRowProperties.Length;
@@ -41,15 +42,16 @@ namespace OfficeIMO.Excel.Xlsb.Write {
                 offset = AppendUInt32(buffer, offset, first);
                 offset = AppendUInt32(buffer, offset, last);
             }
-            _stream.Write(buffer, 0, offset);
+            _position = offset;
         }
 
         internal void WriteTextCell(int recordType, int zeroBasedColumn, string value) {
             int payloadLength = checked(12 + value.Length * 2);
             byte[] buffer = GetBuffer();
-            int headerLength = XlsbRecordWriter.EncodeHeader(recordType, payloadLength, buffer);
-            int recordLength = checked(headerLength + payloadLength);
-            if (recordLength > buffer.Length) {
+            int maximumRecordLength = checked(6 + payloadLength);
+            if (maximumRecordLength > buffer.Length) {
+                Flush();
+                int headerLength = XlsbRecordWriter.EncodeHeader(recordType, payloadLength, buffer);
                 _stream.Write(buffer, 0, headerLength);
                 WriteUInt32(checked((uint)zeroBasedColumn));
                 WriteUInt32(0U);
@@ -57,7 +59,10 @@ namespace OfficeIMO.Excel.Xlsb.Write {
                 return;
             }
 
-            int offset = AppendUInt32(buffer, headerLength, checked((uint)zeroBasedColumn));
+            buffer = EnsureAvailable(maximumRecordLength);
+            int offset = _position;
+            offset += XlsbRecordWriter.EncodeHeader(recordType, payloadLength, buffer, offset);
+            offset = AppendUInt32(buffer, offset, checked((uint)zeroBasedColumn));
             offset = AppendUInt32(buffer, offset, 0U);
             offset = AppendUInt32(buffer, offset, checked((uint)value.Length));
             for (int index = 0; index < value.Length; index++) {
@@ -65,35 +70,33 @@ namespace OfficeIMO.Excel.Xlsb.Write {
                 buffer[offset++] = (byte)character;
                 buffer[offset++] = (byte)(character >> 8);
             }
-            _stream.Write(buffer, 0, offset);
+            _position = offset;
         }
 
         internal void WriteNumberCell(int recordType, int zeroBasedColumn, double value) {
-            byte[] buffer = GetBuffer();
-            int offset = XlsbRecordWriter.EncodeHeader(recordType, payloadLength: 16, buffer);
+            byte[] buffer = EnsureAvailable(22);
+            int offset = _position;
+            offset += XlsbRecordWriter.EncodeHeader(recordType, payloadLength: 16, buffer, offset);
             offset = AppendUInt32(buffer, offset, checked((uint)zeroBasedColumn));
             offset = AppendUInt32(buffer, offset, 0U);
             ulong bits = unchecked((ulong)BitConverter.DoubleToInt64Bits(value));
             offset = AppendUInt64(buffer, offset, bits);
-            _stream.Write(buffer, 0, offset);
+            _position = offset;
         }
 
         internal void WriteBooleanCell(int recordType, int zeroBasedColumn, bool value) {
-            byte[] buffer = GetBuffer();
-            int offset = XlsbRecordWriter.EncodeHeader(recordType, payloadLength: 9, buffer);
+            byte[] buffer = EnsureAvailable(15);
+            int offset = _position;
+            offset += XlsbRecordWriter.EncodeHeader(recordType, payloadLength: 9, buffer, offset);
             offset = AppendUInt32(buffer, offset, checked((uint)zeroBasedColumn));
             offset = AppendUInt32(buffer, offset, 0U);
             buffer[offset++] = value ? (byte)1 : (byte)0;
-            _stream.Write(buffer, 0, offset);
+            _position = offset;
         }
 
         internal void WriteUInt32(uint value) {
-            byte[] buffer = GetBuffer();
-            buffer[0] = (byte)value;
-            buffer[1] = (byte)(value >> 8);
-            buffer[2] = (byte)(value >> 16);
-            buffer[3] = (byte)(value >> 24);
-            _stream.Write(buffer, 0, sizeof(uint));
+            byte[] buffer = EnsureAvailable(sizeof(uint));
+            _position = AppendUInt32(buffer, _position, value);
         }
 
         private void WriteWideString(string value) {
@@ -105,20 +108,44 @@ namespace OfficeIMO.Excel.Xlsb.Write {
             for (int offset = 0; offset < value.Length; offset += charsPerChunk) {
                 int characterCount = Math.Min(charsPerChunk, value.Length - offset);
                 int byteCount = checked(characterCount * 2);
+                buffer = EnsureAvailable(byteCount);
+                int targetOffset = _position;
                 for (int index = 0; index < characterCount; index++) {
                     ushort character = value[offset + index];
-                    int byteOffset = index * 2;
+                    int byteOffset = targetOffset + (index * 2);
                     buffer[byteOffset] = (byte)character;
                     buffer[byteOffset + 1] = (byte)(character >> 8);
                 }
-                _stream.Write(buffer, 0, byteCount);
+                _position += byteCount;
             }
         }
 
         public void Dispose() {
             byte[]? buffer = _buffer;
             _buffer = null;
-            if (buffer != null) ArrayPool<byte>.Shared.Return(buffer, clearArray: true);
+            if (buffer != null) {
+                try {
+                    if (_position != 0) _stream.Write(buffer, 0, _position);
+                } finally {
+                    _position = 0;
+                    ArrayPool<byte>.Shared.Return(buffer, clearArray: true);
+                }
+            }
+        }
+
+        private byte[] EnsureAvailable(int count) {
+            byte[] buffer = GetBuffer();
+            if (count > buffer.Length) {
+                throw new ArgumentOutOfRangeException(nameof(count), "The BIFF12 direct-write chunk exceeds its buffer.");
+            }
+            if (buffer.Length - _position < count) Flush();
+            return buffer;
+        }
+
+        internal void Flush() {
+            if (_position == 0) return;
+            _stream.Write(GetBuffer(), 0, _position);
+            _position = 0;
         }
 
         private byte[] GetBuffer() =>

--- a/OfficeIMO.Excel/Xlsb/Write/XlsbNewPackageWriter.cs
+++ b/OfficeIMO.Excel/Xlsb/Write/XlsbNewPackageWriter.cs
@@ -90,14 +90,14 @@ namespace OfficeIMO.Excel.Xlsb.Write {
                 : new ExcelPositionReportingWriteStream(destination);
             Stream packageDestination = positionReportingDestination ?? destination;
             using (var archive = new ZipArchive(packageDestination, ZipArchiveMode.Create, leaveOpen: true)) {
-                WriteEntry(archive, "[Content_Types].xml", CreateContentTypes(worksheetCount: 1, hasStyles: stylesPart != null));
-                WriteEntry(archive, "_rels/.rels", RootRelationships);
+                WriteEntry(archive, "[Content_Types].xml", CreateContentTypes(worksheetCount: 1, hasStyles: stylesPart != null), CompressionLevel.Fastest);
+                WriteEntry(archive, "_rels/.rels", RootRelationships, CompressionLevel.Fastest);
                 WriteEntry(archive, "xl/workbook.bin", XlsbWorkbookPartWriter.CreateDirectTabular(
                     sheetName,
-                    document.DateSystem == ExcelDateSystem.NineteenFour));
-                WriteEntry(archive, "xl/_rels/workbook.bin.rels", CreateWorkbookRelationships(worksheetCount: 1, hasStyles: stylesPart != null));
-                WriteEntry(archive, "xl/worksheets/sheet1.bin", worksheetPart);
-                if (stylesPart != null) WriteEntry(archive, "xl/styles.bin", stylesPart);
+                    document.DateSystem == ExcelDateSystem.NineteenFour), CompressionLevel.Fastest);
+                WriteEntry(archive, "xl/_rels/workbook.bin.rels", CreateWorkbookRelationships(worksheetCount: 1, hasStyles: stylesPart != null), CompressionLevel.Fastest);
+                WriteEntry(archive, "xl/worksheets/sheet1.bin", worksheetPart, CompressionLevel.Fastest);
+                if (stylesPart != null) WriteEntry(archive, "xl/styles.bin", stylesPart, CompressionLevel.Fastest);
             }
         }
 
@@ -270,19 +270,47 @@ namespace OfficeIMO.Excel.Xlsb.Write {
         }
 
         private static void WriteEntry(ZipArchive archive, string name, string content) {
-            WriteEntry(archive, name, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false).GetBytes(content));
+            WriteEntry(archive, name, content, CompressionLevel.Optimal);
+        }
+
+        private static void WriteEntry(
+            ZipArchive archive,
+            string name,
+            string content,
+            CompressionLevel compressionLevel) {
+            WriteEntry(
+                archive,
+                name,
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false).GetBytes(content),
+                compressionLevel);
         }
 
         private static void WriteEntry(ZipArchive archive, string name, byte[] content) {
-            ZipArchiveEntry entry = archive.CreateEntry(name, CompressionLevel.Optimal);
+            WriteEntry(archive, name, content, CompressionLevel.Optimal);
+        }
+
+        private static void WriteEntry(
+            ZipArchive archive,
+            string name,
+            byte[] content,
+            CompressionLevel compressionLevel) {
+            ZipArchiveEntry entry = archive.CreateEntry(name, compressionLevel);
             entry.LastWriteTime = ReproducibleEntryTime;
             using Stream output = entry.Open();
             output.Write(content, 0, content.Length);
         }
 
         private static void WriteEntry(ZipArchive archive, string name, ArraySegment<byte> content) {
+            WriteEntry(archive, name, content, CompressionLevel.Optimal);
+        }
+
+        private static void WriteEntry(
+            ZipArchive archive,
+            string name,
+            ArraySegment<byte> content,
+            CompressionLevel compressionLevel) {
             byte[] buffer = content.Array ?? throw new ArgumentException("The package part must have a backing buffer.", nameof(content));
-            ZipArchiveEntry entry = archive.CreateEntry(name, CompressionLevel.Optimal);
+            ZipArchiveEntry entry = archive.CreateEntry(name, compressionLevel);
             entry.LastWriteTime = ReproducibleEntryTime;
             using Stream output = entry.Open();
             output.Write(buffer, content.Offset, content.Count);

--- a/OfficeIMO.Excel/Xlsb/Write/XlsbWorksheetPartWriter.cs
+++ b/OfficeIMO.Excel/Xlsb/Write/XlsbWorksheetPartWriter.cs
@@ -121,6 +121,11 @@ namespace OfficeIMO.Excel.Xlsb.Write {
             if (totalRows > 1_048_576 || rows.ColumnCount > 16_384) {
                 throw new NotSupportedException("Native XLSB saving supports 1,048,576 rows and 16,384 columns per worksheet.");
             }
+            object?[]? flatValues = rows.TryGetFlatValues(out object?[] candidateValues, out int flatColumnCount)
+                && flatColumnCount == rows.ColumnCount
+                && candidateValues.Length == checked(rows.RowCount * rows.ColumnCount)
+                    ? candidateValues
+                    : null;
 
             using var output = new MemoryStream(EstimateDirectWorksheetCapacity(totalRows, rows.ColumnCount));
             using var writer = new XlsbDirectRecordWriter(output);
@@ -136,14 +141,17 @@ namespace OfficeIMO.Excel.Xlsb.Write {
                 }
             }
 
+            bool canCancel = cancellationToken.CanBeCanceled;
             for (int row = 0; row < rows.RowCount; row++) {
-                if ((row & 1023) == 0) cancellationToken.ThrowIfCancellationRequested();
+                if (canCancel && (row & 1023) == 0) cancellationToken.ThrowIfCancellationRequested();
                 int zeroBasedRow = row + rowOffset;
                 if (rows.ColumnCount != 0) {
                     WriteDirectRowHeader(writer, zeroBasedRow, rows.ColumnCount);
                 }
                 for (int column = 0; column < rows.ColumnCount; column++) {
-                    ExcelDirectTabularValue value = ExcelDirectTabularValue.Normalize(rows.GetValue(row, column));
+                    ExcelDirectTabularValue value = ExcelDirectTabularValue.Normalize(flatValues == null
+                        ? rows.GetValue(row, column)
+                        : flatValues[checked((row * rows.ColumnCount) + column)]);
                     switch (value.Kind) {
                         case ExcelDirectTabularValueKind.Empty:
                             break;
@@ -165,6 +173,7 @@ namespace OfficeIMO.Excel.Xlsb.Write {
 
             writer.WriteRecord(BrtEndSheetData);
             writer.WriteRecord(BrtEndSheet);
+            writer.Flush();
             worksheetPart = new ArraySegment<byte>(output.GetBuffer(), 0, checked((int)output.Length));
             return true;
         }

--- a/OfficeIMO.Excel/Xlsb/Write/XlsbWorksheetPartWriter.cs
+++ b/OfficeIMO.Excel/Xlsb/Write/XlsbWorksheetPartWriter.cs
@@ -148,10 +148,17 @@ namespace OfficeIMO.Excel.Xlsb.Write {
                 if (rows.ColumnCount != 0) {
                     WriteDirectRowHeader(writer, zeroBasedRow, rows.ColumnCount);
                 }
+                object?[]? bufferedRow = flatValues == null
+                    && rows.TryGetBufferedRow(row, out object?[]? candidateRow)
+                    && candidateRow?.Length == rows.ColumnCount
+                        ? candidateRow
+                        : null;
                 for (int column = 0; column < rows.ColumnCount; column++) {
-                    ExcelDirectTabularValue value = ExcelDirectTabularValue.Normalize(flatValues == null
-                        ? rows.GetValue(row, column)
-                        : flatValues[checked((row * rows.ColumnCount) + column)]);
+                    ExcelDirectTabularValue value = ExcelDirectTabularValue.Normalize(flatValues != null
+                        ? flatValues[checked((row * rows.ColumnCount) + column)]
+                        : bufferedRow != null
+                            ? bufferedRow[column]
+                            : rows.GetValue(row, column));
                     switch (value.Kind) {
                         case ExcelDirectTabularValueKind.Empty:
                             break;

--- a/OfficeIMO.SharedSource/Compound/OfficeCompoundFileWriter.cs
+++ b/OfficeIMO.SharedSource/Compound/OfficeCompoundFileWriter.cs
@@ -21,9 +21,10 @@ namespace OfficeIMO.Core.Internal {
             if (streams == null) throw new ArgumentNullException(nameof(streams));
             if (streams.Count == 0) throw new ArgumentException("At least one compound stream is required.", nameof(streams));
 
-            using (var output = new MemoryStream()) {
-                Write(output, streams, rootClassId);
-                return output.ToArray();
+            OfficeCompoundWriterLayout layout = OfficeCompoundWriterLayout.Create(streams);
+            using (var output = CreateExactOutput(layout)) {
+                Write(output, layout, rootClassId);
+                return GetExactOutputBuffer(output);
             }
         }
 
@@ -83,13 +84,15 @@ namespace OfficeIMO.Core.Internal {
             if (streams.Count == 0) {
                 throw new ArgumentException("At least one compound stream is required.", nameof(source));
             }
-            using (var output = new MemoryStream()) {
-                Write(output, OfficeCompoundWriterLayout.Create(streams,
-                        source, removals),
+            OfficeCompoundWriterLayout layout = OfficeCompoundWriterLayout.Create(streams, source, removals);
+            using (var output = CreateExactOutput(layout)) {
+                Write(
+                    output,
+                    layout,
                     source.RootEntry.ClassId == Guid.Empty
                         ? null
                         : source.RootEntry.ClassId);
-                return output.ToArray();
+                return GetExactOutputBuffer(output);
             }
         }
 
@@ -184,7 +187,10 @@ namespace OfficeIMO.Core.Internal {
             if (streams == null) throw new ArgumentNullException(nameof(streams));
             if (streams.Count == 0) throw new ArgumentException("At least one compound stream is required.", nameof(streams));
 
-            OfficeCompoundWriterLayout layout = OfficeCompoundWriterLayout.Create(streams);
+            return GetSerializedLength(OfficeCompoundWriterLayout.Create(streams));
+        }
+
+        private static long GetSerializedLength(OfficeCompoundWriterLayout layout) {
             int regularStreamSectorCount = 0;
             int miniSectorCount = 0;
             foreach (OfficeCompoundWriterEntry stream in layout.Streams) {
@@ -210,6 +216,25 @@ namespace OfficeIMO.Core.Internal {
             CalculateAllocationTableSectorCounts(sectorCountBeforeFat, out int fatSectorCount,
                 out int difatSectorCount);
             return checked((1L + sectorCountBeforeFat + fatSectorCount + difatSectorCount) * SectorSize);
+        }
+
+        private static MemoryStream CreateExactOutput(OfficeCompoundWriterLayout layout) {
+            long serializedLength = GetSerializedLength(layout);
+            if (serializedLength > int.MaxValue) {
+                throw new NotSupportedException(
+                    "A compound file returned as a byte array cannot exceed 2 GiB.");
+            }
+
+            return new MemoryStream(checked((int)serializedLength));
+        }
+
+        private static byte[] GetExactOutputBuffer(MemoryStream output) {
+            if (output.Length != output.Capacity) {
+                throw new InvalidDataException(
+                    "The compound writer did not produce its planned serialized length.");
+            }
+
+            return output.GetBuffer();
         }
 
         private static int CalculateDirectorySectorCount(int directoryEntryCount) {


### PR DESCRIPTION
## What changed

- adds checksum- and round-trip-validated read/write benchmark lanes for XLSX, XLSB, XLS, and CSV, with same-process ABBA ordering, explicit CPU affinity, and output-conformance gates
- compares OfficeIMO and ExcelReader.NET CSV writes from the same projected rows into the same UTF-8 stream contract
- validates synchronous and asynchronous XLSX writers at the measured one-million-row scale by reopening every row and typed value
- adds wide UTF-8 CSV comparisons that observe exact row count, cell count, order, and payload hash
- accelerates conforming BIFF8 and BIFF12 tabular writes through flat value plans, direct record emission, pooled buffering, and exact compound-file handoff
- reduces XLSX open/read overhead with a read-only package path and lazy formula/style metadata
- uses the compact sequential XLSX writer shape when row and cell coordinates are not part of the requested output

## Correctness boundaries

The default XLSX reader continues to validate workbook structure, shared strings, styles, formulas, and cell metadata before exposing rows. Binary write comparisons that omit mandatory workbook structures are reported as unranked rather than treated as equivalent performance results.

The optimized binary paths retain their existing fallback behavior for workbooks that require the general feature-preserving writers.

## Validated comparison

On repeated pinned-core, checksum-validated ABBA runs, OfficeIMO leads the comparable XLSB, XLS, and CSV read lanes and the XLSX and projected-row CSV write lanes. XLSX reads reverse winner across CPU domains and rounds; the aggregate remains near parity rather than supporting a universal lead claim.