### PR TITLE
Accelerate validated dense XLSX data-reader paths

### DIFF
--- a/OfficeIMO.Excel.Tests/Excel.DataReaderApi.FastPathValidation.cs
+++ b/OfficeIMO.Excel.Tests/Excel.DataReaderApi.FastPathValidation.cs
@@ -48,6 +48,54 @@ public partial class Excel {
         }
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void OpenDataReader_AcceptsValidatedMarkupBeforeIndexedRowEnd(bool emptyRow) {
+        string path = CreateCompactFastPathWorkbook();
+        try {
+            const string entryName = "xl/worksheets/sheet1.xml";
+            string worksheetXml = Encoding.UTF8.GetString(ReadZipEntry(path, entryName));
+            string canonicalXml = worksheetXml.Replace(" t=\"n\"", string.Empty);
+            string markedXml = InsertMarkupBeforeThirdRowEnd(
+                canonicalXml,
+                "<!--validated row boundary-->",
+                emptyRow);
+            ReplaceZipEntry(path, entryName, Encoding.UTF8.GetBytes(markedXml));
+
+            using var reader = ExcelDocument.OpenDataReader(path);
+            while (reader.Read()) {
+            }
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Theory]
+    [InlineData(false, "<!--invalid--comment-->")]
+    [InlineData(true, "<!--invalid--comment-->")]
+    [InlineData(false, "<?xml version=\"1.0\"?>")]
+    [InlineData(true, "<?xml version=\"1.0\"?>")]
+    public void OpenDataReader_RejectsMalformedMarkupBeforeIndexedRowEnd(
+        bool emptyRow,
+        string malformedMarkup) {
+        string path = CreateCompactFastPathWorkbook();
+        try {
+            const string entryName = "xl/worksheets/sheet1.xml";
+            string worksheetXml = Encoding.UTF8.GetString(ReadZipEntry(path, entryName));
+            string canonicalXml = worksheetXml.Replace(" t=\"n\"", string.Empty);
+            string malformedXml = InsertMarkupBeforeThirdRowEnd(
+                canonicalXml,
+                malformedMarkup,
+                emptyRow);
+            ReplaceZipEntry(path, entryName, Encoding.UTF8.GetBytes(malformedXml));
+
+            Assert.Throws<XmlException>(() => ExcelDocument.OpenDataReader(path));
+        } finally {
+            File.Delete(path);
+        }
+    }
+
     [Fact]
     public void OpenDataReader_RejectsDuplicateCellAttributesOnCompactFastPath() {
         string path = CreateCompactFastPathWorkbook();
@@ -347,5 +395,24 @@ public partial class Excel {
         Assert.True(reader.Read());
         Assert.Equal(43, reader.GetInt32(0));
         Assert.False(reader.Read());
+    }
+
+    private static string InsertMarkupBeforeThirdRowEnd(
+        string worksheetXml,
+        string markup,
+        bool emptyRow) {
+        int rowStart = worksheetXml.IndexOf("<row r=\"3\"", StringComparison.Ordinal);
+        Assert.True(rowStart >= 0);
+        int contentStart = worksheetXml.IndexOf('>', rowStart) + 1;
+        Assert.True(contentStart > rowStart);
+        int rowEnd = worksheetXml.IndexOf("</row>", contentStart, StringComparison.Ordinal);
+        Assert.True(rowEnd >= contentStart);
+        string rowContent = emptyRow
+            ? string.Empty
+            : worksheetXml.Substring(contentStart, rowEnd - contentStart);
+        return worksheetXml.Substring(0, contentStart)
+            + rowContent
+            + markup
+            + worksheetXml.Substring(rowEnd);
     }
 }

--- a/OfficeIMO.Excel.Tests/Excel.DataReaderApi.FastPathValidation.cs
+++ b/OfficeIMO.Excel.Tests/Excel.DataReaderApi.FastPathValidation.cs
@@ -6,6 +6,49 @@ namespace OfficeIMO.Excel.Tests;
 
 public partial class Excel {
     [Fact]
+    public void OpenDataReader_ReadsCanonicalDenseRowsWhenValidatedRowShapeChanges() {
+        string path = CreateCompactFastPathWorkbook();
+        try {
+            const string entryName = "xl/worksheets/sheet1.xml";
+            string worksheetXml = Encoding.UTF8.GetString(ReadZipEntry(path, entryName));
+            string canonicalXml = worksheetXml.Replace(" t=\"n\"", string.Empty);
+            string changedRowXml = canonicalXml.Replace(
+                "<row r=\"3\"",
+                "<row customFormat=\"1\" r=\"3\"");
+            Assert.NotEqual(canonicalXml, changedRowXml);
+            ReplaceZipEntry(path, entryName, Encoding.UTF8.GetBytes(changedRowXml));
+
+            AssertCompactNumericRows(path);
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void OpenDataReader_ValidatesMarkupBetweenCanonicalDenseRows() {
+        string path = CreateCompactFastPathWorkbook();
+        try {
+            const string entryName = "xl/worksheets/sheet1.xml";
+            string worksheetXml = Encoding.UTF8.GetString(ReadZipEntry(path, entryName));
+            string canonicalXml = worksheetXml.Replace(" t=\"n\"", string.Empty);
+            string validXml = canonicalXml.Replace(
+                "<row r=\"3\"",
+                "<!--validated boundary--><row r=\"3\"");
+            Assert.NotEqual(canonicalXml, validXml);
+            ReplaceZipEntry(path, entryName, Encoding.UTF8.GetBytes(validXml));
+            AssertCompactNumericRows(path);
+
+            string malformedXml = canonicalXml.Replace(
+                "<row r=\"3\"",
+                "<!--invalid--comment--><row r=\"3\"");
+            ReplaceZipEntry(path, entryName, Encoding.UTF8.GetBytes(malformedXml));
+            Assert.Throws<XmlException>(() => ExcelDocument.OpenDataReader(path));
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
     public void OpenDataReader_RejectsDuplicateCellAttributesOnCompactFastPath() {
         string path = CreateCompactFastPathWorkbook();
         try {
@@ -291,8 +334,18 @@ public partial class Excel {
             ExcelSheet sheet = document.AddWorksheet("Data");
             sheet.CellValue(1, 1, "Value");
             sheet.CellValue(2, 1, 42);
+            sheet.CellValue(3, 1, 43);
             document.Save();
         }
         return path;
+    }
+
+    private static void AssertCompactNumericRows(string path) {
+        using var reader = ExcelDocument.OpenDataReader(path);
+        Assert.True(reader.Read());
+        Assert.Equal(42, reader.GetInt32(0));
+        Assert.True(reader.Read());
+        Assert.Equal(43, reader.GetInt32(0));
+        Assert.False(reader.Read());
     }
 }

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.Compact.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.Compact.cs
@@ -1,8 +1,86 @@
 #nullable enable
 
+using System.Threading;
+
 namespace OfficeIMO.Excel {
     internal sealed partial class ExcelSheetReader {
         private sealed partial class ExcelUtf8RangeRowSource {
+            private bool TryCaptureRepeatedRowShape(Utf8Tag tag, int expectedRowIndex) {
+                int cursor = tag.Start;
+                if (!TryReadRepeatedRowPrefix(ref cursor, out int rowIndex)
+                    || rowIndex != expectedRowIndex) {
+                    return false;
+                }
+
+                int suffixLength = tag.End - cursor + 1;
+                if (suffixLength <= 0) {
+                    return false;
+                }
+
+                _repeatedRowSuffixStart = cursor;
+                _repeatedRowSuffixLength = suffixLength;
+                _repeatedRowIsEmpty = tag.IsEmpty;
+                return true;
+            }
+
+            private bool TryReadRepeatedRowStartTag(
+                ref int position,
+                out Utf8Tag tag,
+                out int rowIndex) {
+                tag = default;
+                rowIndex = 0;
+                int start = position;
+                int cursor = position;
+                if (_repeatedRowSuffixStart < 0
+                    || !TryReadRepeatedRowPrefix(ref cursor, out rowIndex)
+                    || cursor > _length - _repeatedRowSuffixLength
+                    || !_buffer!.AsSpan(cursor, _repeatedRowSuffixLength).SequenceEqual(
+                        _buffer.AsSpan(_repeatedRowSuffixStart, _repeatedRowSuffixLength))) {
+                    rowIndex = 0;
+                    return false;
+                }
+
+                int end = cursor + _repeatedRowSuffixLength - 1;
+                tag = new Utf8Tag(
+                    start,
+                    end,
+                    start + 1,
+                    start + 4,
+                    start + 1,
+                    isEnd: false,
+                    _repeatedRowIsEmpty);
+                position = end + 1;
+                return true;
+            }
+
+            private bool TryReadRepeatedRowPrefix(ref int cursor, out int rowIndex) {
+                rowIndex = 0;
+                if (cursor > _length - 9
+                    || _buffer![cursor] != (byte)'<'
+                    || _buffer[cursor + 1] != (byte)'r'
+                    || _buffer[cursor + 2] != (byte)'o'
+                    || _buffer[cursor + 3] != (byte)'w'
+                    || _buffer[cursor + 4] != (byte)' '
+                    || _buffer[cursor + 5] != (byte)'r'
+                    || _buffer[cursor + 6] != (byte)'='
+                    || _buffer[cursor + 7] != (byte)'\"') {
+                    return false;
+                }
+
+                cursor += 8;
+                int referenceStart = cursor;
+                while (cursor < _length && _buffer[cursor] is >= (byte)'0' and <= (byte)'9') {
+                    cursor++;
+                }
+                int referenceLength = cursor - referenceStart;
+                if (referenceLength == 0) {
+                    return false;
+                }
+
+                rowIndex = ParsePositiveInt(_buffer, referenceStart, referenceLength);
+                return rowIndex > 0;
+            }
+
             private bool TryReadCompactCellStartTag(
                 ref int position,
                 ref int nextColumn,
@@ -10,6 +88,16 @@ namespace OfficeIMO.Excel {
                 out int columnIndex,
                 out Utf8CellKind kind,
                 out int styleIndex) {
+                if (TryReadCanonicalCellStartTag(
+                        ref position,
+                        ref nextColumn,
+                        out tag,
+                        out columnIndex,
+                        out kind,
+                        out styleIndex)) {
+                    return true;
+                }
+
                 tag = default;
                 columnIndex = 0;
                 kind = Utf8CellKind.Number;
@@ -133,6 +221,184 @@ namespace OfficeIMO.Excel {
 
                 tag = new Utf8Tag(start, cursor, start + 1, start + 2, start + 1, isEnd: false, isEmpty);
                 nextColumn = columnIndex + 1;
+                position = cursor + 1;
+                return true;
+            }
+
+            private bool TryIndexCanonicalDenseRow(
+                ref int position,
+                int rowIndex,
+                int rowOffset,
+                CancellationToken ct) {
+                int nextColumn = 1;
+                int previousColumn = 0;
+                int cellsUntilCancellationCheck = 0;
+                while (position < _length) {
+                    if (position <= _length - 6
+                        && _buffer![position + 1] == (byte)'/'
+                        && MatchesAscii(position, "</row>")) {
+                        position += 6;
+                        UpdateUsedBounds(rowIndex, previousColumn);
+                        return true;
+                    }
+
+                    if (cellsUntilCancellationCheck-- == 0) {
+                        ct.ThrowIfCancellationRequested();
+                        cellsUntilCancellationCheck = 256;
+                    }
+
+                    if (!TryReadCanonicalCellStartTag(
+                            ref position,
+                            ref nextColumn,
+                            out Utf8Tag tag,
+                            out int columnIndex,
+                            out Utf8CellKind kind,
+                            out int styleIndex)
+                        || columnIndex <= previousColumn) {
+                        return false;
+                    }
+
+                    if (previousColumn == 0
+                        && (_minimumCellColumn == int.MaxValue || columnIndex < _minimumCellColumn)) {
+                        _minimumCellColumn = columnIndex;
+                    }
+                    previousColumn = columnIndex;
+                    int ordinal = columnIndex - _firstColumn;
+                    if ((uint)ordinal >= (uint)_fieldCount) {
+                        return false;
+                    }
+
+                    int cellIndex = rowOffset + ordinal;
+                    bool hasCachedValue = false;
+                    int valueStart = -1;
+                    int valueLength = -1;
+                    if (!tag.IsEmpty
+                        && !TryIndexCompactValueCell(
+                            ref position,
+                            cellIndex,
+                            out hasCachedValue,
+                            out valueStart,
+                            out valueLength)) {
+                        return false;
+                    }
+
+                    ValidateIndexedCell(
+                        rowIndex,
+                        columnIndex,
+                        kind,
+                        styleIndex,
+                        sharedFormulaFollower: false,
+                        hasCachedValue,
+                        valueStart,
+                        valueLength);
+                    _cellKinds![cellIndex] = EncodeCellKind(kind, styleIndex);
+                }
+
+                return false;
+            }
+
+            private bool TryReadCanonicalCellStartTag(
+                ref int position,
+                ref int nextColumn,
+                out Utf8Tag tag,
+                out int columnIndex,
+                out Utf8CellKind kind,
+                out int styleIndex) {
+                tag = default;
+                columnIndex = 0;
+                kind = Utf8CellKind.Number;
+                styleIndex = -1;
+
+                int start = position;
+                int cursor = start;
+                if (cursor > _length - 7
+                    || _buffer![cursor] != (byte)'<'
+                    || _buffer[cursor + 1] != (byte)'c'
+                    || _buffer[cursor + 2] != (byte)' '
+                    || _buffer[cursor + 3] != (byte)'r'
+                    || _buffer[cursor + 4] != (byte)'='
+                    || _buffer[cursor + 5] != (byte)'\"') {
+                    return false;
+                }
+
+                cursor += 6;
+                int parsedColumn = 0;
+                int letterCount = 0;
+                while (cursor < _length) {
+                    byte current = _buffer[cursor];
+                    int letter = current >= (byte)'A' && current <= (byte)'Z'
+                        ? current - (byte)'A' + 1
+                        : current >= (byte)'a' && current <= (byte)'z'
+                            ? current - (byte)'a' + 1
+                            : 0;
+                    if (letter == 0) {
+                        break;
+                    }
+                    if (parsedColumn > (int.MaxValue - letter) / 26) {
+                        return false;
+                    }
+                    parsedColumn = (parsedColumn * 26) + letter;
+                    letterCount++;
+                    cursor++;
+                }
+
+                if (letterCount == 0 || cursor >= _length || _buffer[cursor] is < (byte)'0' or > (byte)'9') {
+                    return false;
+                }
+                do {
+                    cursor++;
+                } while (cursor < _length && _buffer[cursor] is >= (byte)'0' and <= (byte)'9');
+                if (cursor >= _length || _buffer[cursor++] != (byte)'\"') {
+                    return false;
+                }
+                if (cursor >= _length) {
+                    return false;
+                }
+
+                bool isEmpty = false;
+                if (_buffer[cursor] == (byte)'>') {
+                    // Number cell without an explicit style or type.
+                } else if (_buffer[cursor] == (byte)'/'
+                           && cursor + 1 < _length
+                           && _buffer[cursor + 1] == (byte)'>') {
+                    isEmpty = true;
+                    cursor++;
+                } else if (cursor <= _length - 7
+                           && _buffer[cursor] == (byte)' '
+                           && _buffer[cursor + 1] == (byte)'t'
+                           && _buffer[cursor + 2] == (byte)'='
+                           && _buffer[cursor + 3] == (byte)'\"'
+                           && _buffer[cursor + 4] == (byte)'s'
+                           && _buffer[cursor + 5] == (byte)'\"'
+                           && _buffer[cursor + 6] == (byte)'>') {
+                    kind = Utf8CellKind.SharedString;
+                    cursor += 6;
+                } else if (cursor <= _length - 6
+                           && _buffer[cursor] == (byte)' '
+                           && _buffer[cursor + 1] == (byte)'s'
+                           && _buffer[cursor + 2] == (byte)'='
+                           && _buffer[cursor + 3] == (byte)'\"') {
+                    cursor += 4;
+                    int styleStart = cursor;
+                    while (cursor < _length && _buffer[cursor] is >= (byte)'0' and <= (byte)'9') {
+                        cursor++;
+                    }
+                    if (cursor == styleStart
+                        || cursor + 1 >= _length
+                        || _buffer[cursor++] != (byte)'\"'
+                        || _buffer[cursor] != (byte)'>') {
+                        return false;
+                    }
+                    if (!TryParseNonNegativeInt(_buffer, styleStart, cursor - styleStart - 1, out styleIndex)) {
+                        return false;
+                    }
+                } else {
+                    return false;
+                }
+
+                columnIndex = parsedColumn;
+                tag = new Utf8Tag(start, cursor, start + 1, start + 2, start + 1, isEnd: false, isEmpty);
+                nextColumn = parsedColumn + 1;
                 position = cursor + 1;
                 return true;
             }

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.FastValidation.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.FastValidation.cs
@@ -65,27 +65,6 @@ namespace OfficeIMO.Excel {
                 }
 #endif
 
-                if (_sheetDataContentStart >= 0
-                    && _sheetDataEndTagStart >= _sheetDataContentStart) {
-                    ct.ThrowIfCancellationRequested();
-                    ReadOnlySpan<byte> sheetData = _buffer!.AsSpan(
-                        _sheetDataContentStart,
-                        _sheetDataEndTagStart - _sheetDataContentStart);
-#if NET8_0_OR_GREATER
-                    if (sheetData.IndexOf("<!"u8) >= 0 || sheetData.IndexOf("<?"u8) >= 0) {
-                        return false;
-                    }
-#else
-                    for (int index = 0; index + 1 < sheetData.Length; index++) {
-                        if (sheetData[index] == (byte)'<'
-                            && sheetData[index + 1] is (byte)'!' or (byte)'?') {
-                            return false;
-                        }
-                    }
-#endif
-                    ct.ThrowIfCancellationRequested();
-                }
-
                 Span<int> nameStarts = stackalloc int[MaximumFastXmlDepth];
                 Span<int> nameLengths = stackalloc int[MaximumFastXmlDepth];
                 Span<int> namespacePrefixStarts = stackalloc int[MaximumFastXmlAttributes];

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.cs
@@ -40,6 +40,9 @@ namespace OfficeIMO.Excel {
             private int _maximumCellColumn;
             private int _sheetDataContentStart = -1;
             private int _sheetDataEndTagStart = -1;
+            private int _repeatedRowSuffixStart = -1;
+            private int _repeatedRowSuffixLength;
+            private bool _repeatedRowIsEmpty;
             private bool _sheetDataSupportsFastValidation = true;
             private int _lastDateStyleIndex = -1;
             private bool _lastDateStyleResult;
@@ -451,8 +454,24 @@ namespace OfficeIMO.Excel {
 
                 int nextImplicitRow = 1;
                 int previousRow = 0;
-                while (TryReadNextTag(ref position, _length, out Utf8Tag tag)) {
+                bool repeatedRowShapeValidated = false;
+                while (position < _length) {
                     ct.ThrowIfCancellationRequested();
+                    int tagSearchStart = position;
+                    Utf8Tag tag = default;
+                    int rowIndex = 0;
+                    bool repeatedRow = repeatedRowShapeValidated
+                        && TryReadRepeatedRowStartTag(
+                            ref position,
+                            out tag,
+                            out rowIndex);
+                    if (!repeatedRow
+                        && !TryReadNextTag(ref position, _length, out tag)) {
+                        return false;
+                    }
+                    if (!repeatedRow && ContainsNonWhitespace(tagSearchStart, tag.Start)) {
+                        _sheetDataSupportsFastValidation = false;
+                    }
                     if (tag.IsEnd && IsUnprefixedTag(tag) && LocalNameEquals(tag, "sheetData")) {
                         _sheetDataEndTagStart = tag.Start;
                         return !_parseFailed;
@@ -462,32 +481,38 @@ namespace OfficeIMO.Excel {
                         return false;
                     }
 
-                    if (!ValidateCanonicalTagAttributes(
+                    if (!repeatedRow) {
+                        bool rowSupportsFastValidation = ValidateCanonicalTagAttributes(
                             tag,
                             out bool rowDeclaresDefaultNamespace,
                             out _,
                             out bool rowHasPrefixedAttributes)
-                        || rowDeclaresDefaultNamespace
-                        || rowHasPrefixedAttributes
-                            && (!hasCanonicalRootNamespaces
-                                || !ValidateCanonicalNamespaceUsage(
+                            && !rowDeclaresDefaultNamespace
+                            && (!rowHasPrefixedAttributes
+                                || hasCanonicalRootNamespaces
+                                && ValidateCanonicalNamespaceUsage(
                                     tag,
                                     isRootStartTag: false,
                                     namespacePrefixStarts,
                                     namespacePrefixLengths,
                                     namespaceUriStarts,
                                     namespaceUriLengths,
-                                    ref namespacePrefixCount))) {
-                        _sheetDataSupportsFastValidation = false;
-                    }
+                                    ref namespacePrefixCount));
+                        if (!rowSupportsFastValidation) {
+                            _sheetDataSupportsFastValidation = false;
+                        }
 
-                    if (!TryGetAttribute(tag, "r", out bool hasRowReference, out int rowReferenceStart, out int rowReferenceLength)) {
-                        return false;
-                    }
+                        if (!TryGetAttribute(tag, "r", out bool hasRowReference, out int rowReferenceStart, out int rowReferenceLength)) {
+                            return false;
+                        }
 
-                    int rowIndex = hasRowReference
-                        ? ParsePositiveInt(_buffer!, rowReferenceStart, rowReferenceLength)
-                        : nextImplicitRow;
+                        rowIndex = hasRowReference
+                            ? ParsePositiveInt(_buffer!, rowReferenceStart, rowReferenceLength)
+                            : nextImplicitRow;
+                        if (rowSupportsFastValidation) {
+                            repeatedRowShapeValidated = TryCaptureRepeatedRowShape(tag, rowIndex);
+                        }
+                    }
                     if (rowIndex <= 0 || rowIndex <= previousRow) {
                         return false;
                     }
@@ -502,8 +527,19 @@ namespace OfficeIMO.Excel {
                         InitializeMetadataRow(rowOffset);
                     }
 
-                    if (!tag.IsEmpty && !TryIndexRow(ref position, rowIndex, rowOffset, includeRow, ct)) {
-                        return false;
+                    if (!tag.IsEmpty) {
+                        int rowContentStart = position;
+                        bool indexedCanonicalRow = rowOffset >= 0
+                            && TryIndexCanonicalDenseRow(ref position, rowIndex, rowOffset, ct);
+                        if (!indexedCanonicalRow) {
+                            position = rowContentStart;
+                            if (rowOffset >= 0) {
+                                InitializeMetadataRow(rowOffset);
+                            }
+                            if (!TryIndexRow(ref position, rowIndex, rowOffset, includeRow, ct)) {
+                                return false;
+                            }
+                        }
                     }
 
                     if (includeRow) {
@@ -542,6 +578,7 @@ namespace OfficeIMO.Excel {
                             return false;
                         }
                         if (tag.IsEnd && IsUnprefixedTag(tag) && LocalNameEquals(tag, "row")) {
+                            UpdateUsedBounds(rowIndex, previousColumn);
                             return true;
                         }
                         _sheetDataSupportsFastValidation = false;
@@ -556,11 +593,12 @@ namespace OfficeIMO.Excel {
                         return false;
                     }
 
+                    int firstColumnInRow = previousColumn == 0 ? columnIndex : 0;
                     previousColumn = columnIndex;
-                    if (rowIndex < _minimumCellRow) _minimumCellRow = rowIndex;
-                    if (rowIndex > _maximumCellRow) _maximumCellRow = rowIndex;
-                    if (columnIndex < _minimumCellColumn) _minimumCellColumn = columnIndex;
-                    if (columnIndex > _maximumCellColumn) _maximumCellColumn = columnIndex;
+                    if (firstColumnInRow > 0
+                        && (_minimumCellColumn == int.MaxValue || firstColumnInRow < _minimumCellColumn)) {
+                        _minimumCellColumn = firstColumnInRow;
+                    }
                     int ordinal = columnIndex - _firstColumn;
                     if (!rowWithinRange || (uint)ordinal >= (uint)_fieldCount) {
                         _cellsFitWithinRange = false;
@@ -612,6 +650,20 @@ namespace OfficeIMO.Excel {
                 }
 
                 return false;
+            }
+
+            private void UpdateUsedBounds(int rowIndex, int lastColumnInRow) {
+                if (lastColumnInRow <= 0) {
+                    return;
+                }
+
+                if (_minimumCellRow == int.MaxValue) {
+                    _minimumCellRow = rowIndex;
+                }
+                _maximumCellRow = rowIndex;
+                if (lastColumnInRow > _maximumCellColumn) {
+                    _maximumCellColumn = lastColumnInRow;
+                }
             }
 
             private bool TryIndexSimpleInlineStringCell(ref int position, Utf8Tag inlineStringTag, int cellIndex) {

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.cs
@@ -578,6 +578,9 @@ namespace OfficeIMO.Excel {
                             return false;
                         }
                         if (tag.IsEnd && IsUnprefixedTag(tag) && LocalNameEquals(tag, "row")) {
+                            if (ContainsNonWhitespace(originalPosition, tag.Start)) {
+                                _sheetDataSupportsFastValidation = false;
+                            }
                             UpdateUsedBounds(rowIndex, previousColumn);
                             return true;
                         }


### PR DESCRIPTION
## Summary

- accelerate regular XLSX data-reader rows with byte-proven repeated-row and compact-cell paths
- retain eager UTF-8, XML scalar, namespace, tag-balance, style, shared-string, and malformed-tail validation
- force the existing full XML validation fallback whenever comments, processing instructions, formulas, alternate attributes, or other noncanonical markup is observed
- consolidate used-range bookkeeping after validated rows

## Compatibility and correctness

- preserves sparse, formula, alternate-quoting, namespace, and noncanonical worksheet fallbacks
- adds regression coverage for repeated row-shape changes and valid or malformed markup between rows and immediately before populated or empty row ends
- keeps the library building for `netstandard2.0`, `net472`, `net8.0`, and `net10.0`

## Validation

- all applicable `OpenDataReader` contracts pass on .NET Framework 4.7.2, .NET 8, and .NET 10
- the complete .NET 10 Excel suite passes 3,692 tests; two unrelated image-raster baseline tests remain environment-sensitive
- pinned-core, typed-checksum XLSX measurements improve OfficeIMO median runtime by about 24% from the parent head while preserving eager whole-worksheet validation

Depends on #2361.
