### PR TITLE
Accelerate validated XLSX package setup

### DIFF
--- a/OfficeIMO.Excel.Tests/Excel.DataReaderApi.XlsxNative.PackageContracts.cs
+++ b/OfficeIMO.Excel.Tests/Excel.DataReaderApi.XlsxNative.PackageContracts.cs
@@ -1,6 +1,7 @@
 using DocumentFormat.OpenXml.Packaging;
 using System.IO.Compression;
 using System.Text;
+using System.Threading;
 using System.Xml.Linq;
 using Xunit;
 
@@ -12,24 +13,198 @@ public partial class Excel {
     private const string OfficeRelationshipsNamespace =
         "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
 
-    [Fact]
-    public void XlsxNativePackage_RejectsWorksheetWithUnexpectedContentType() {
+    [Theory]
+    [InlineData("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml", false)]
+    [InlineData("application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml", true)]
+    [InlineData("application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml", true)]
+    [InlineData("application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml", true)]
+    public void XlsxNativePackage_PreservesSdkBehaviorForUnexpectedContentType(
+        string expectedContentType,
+        bool sdkRejectsPackage) {
         string path = CreateCompactFastPathWorkbook();
         try {
             const string entryName = "[Content_Types].xml";
             string contentTypes = Encoding.UTF8.GetString(ReadZipEntry(path, entryName));
             string malformed = contentTypes.Replace(
-                "application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml",
+                expectedContentType,
                 "text/plain");
             Assert.NotEqual(contentTypes, malformed);
             ReplaceZipEntry(path, entryName, Encoding.UTF8.GetBytes(malformed));
 
-            IOException exception = Assert.Throws<IOException>(() => ExcelDocument.OpenDataReader(path));
-            Assert.IsType<OpenXmlPackageException>(exception.InnerException);
+            if (sdkRejectsPackage) {
+                IOException exception = Assert.Throws<IOException>(() => {
+                    using var reader = ExcelDocument.OpenDataReader(path);
+                    while (reader.Read()) {
+                        _ = reader.GetInt32(0);
+                    }
+                });
+                Assert.IsType<OpenXmlPackageException>(exception.InnerException);
+            } else {
+                AssertCompactNumericRows(path);
+            }
         } finally {
             File.Delete(path);
         }
     }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void XlsxNativePackage_RejectsMissingOrDuplicateRootRelationshipId(bool duplicate) {
+        string path = CreateCompactFastPathWorkbook();
+        try {
+            const string entryName = "_rels/.rels";
+            XDocument relationships = LoadZipXml(path, entryName);
+            XNamespace packageRelationships = PackageRelationshipsNamespace;
+            XElement workbookRelationship = relationships.Root!
+                .Elements(packageRelationships + "Relationship")
+                .Single(element => ((string?)element.Attribute("Type"))?.EndsWith(
+                    "/officeDocument",
+                    StringComparison.Ordinal) == true);
+            if (duplicate) {
+                relationships.Root.Add(new XElement(
+                    packageRelationships + "Relationship",
+                    new XAttribute("Id", (string)workbookRelationship.Attribute("Id")!),
+                    new XAttribute("Type", OfficeRelationshipsNamespace + "/metadata/core-properties"),
+                    new XAttribute("Target", "docProps/unused.xml")));
+            } else {
+                workbookRelationship.Attribute("Id")!.Remove();
+            }
+            ReplaceZipXml(path, entryName, relationships);
+
+            Assert.Throws<IOException>(() => ExcelDocument.OpenDataReader(path));
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void XlsxNativePackage_RejectsMalformedUnusedContentTypeEntries(bool duplicateOverride) {
+        string path = CreateCompactFastPathWorkbook();
+        try {
+            const string entryName = "[Content_Types].xml";
+            XDocument contentTypes = LoadZipXml(path, entryName);
+            XNamespace contentTypeNamespace =
+                "http://schemas.openxmlformats.org/package/2006/content-types";
+            if (duplicateOverride) {
+                contentTypes.Root!.Add(
+                    new XElement(
+                        contentTypeNamespace + "Override",
+                        new XAttribute("PartName", "/unused/metadata.xml"),
+                        new XAttribute("ContentType", "application/x-officeimo-unused")),
+                    new XElement(
+                        contentTypeNamespace + "Override",
+                        new XAttribute("PartName", "/unused/metadata.xml"),
+                        new XAttribute("ContentType", "application/x-officeimo-duplicate")));
+            } else {
+                contentTypes.Root!.Add(
+                    new XElement(
+                        contentTypeNamespace + "Default",
+                        new XAttribute("Extension", "unused"),
+                        new XAttribute("ContentType", "application/x-officeimo-unused")),
+                    new XElement(
+                        contentTypeNamespace + "Default",
+                        new XAttribute("Extension", "unused"),
+                        new XAttribute("ContentType", "application/x-officeimo-duplicate")));
+            }
+            ReplaceZipXml(path, entryName, contentTypes);
+
+            Assert.Throws<ArgumentException>(() => ExcelDocument.OpenDataReader(path));
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Theory]
+    [InlineData("/unused/metadata.xml", "application/x invalid")]
+    [InlineData("//unused/metadata.xml", "application/x-officeimo-unused")]
+    public void XlsxNativePackage_FallsBackForMalformedUnusedContentTypeDeclaration(
+        string partName,
+        string contentType) {
+        string path = CreateCompactFastPathWorkbook();
+        try {
+            const string entryName = "[Content_Types].xml";
+            XDocument contentTypes = LoadZipXml(path, entryName);
+            XNamespace contentTypeNamespace =
+                "http://schemas.openxmlformats.org/package/2006/content-types";
+            contentTypes.Root!.Add(new XElement(
+                contentTypeNamespace + "Override",
+                new XAttribute("PartName", partName),
+                new XAttribute("ContentType", contentType)));
+            ReplaceZipXml(path, entryName, contentTypes);
+
+            Assert.Throws<XlsxTabularFastPathNotSupportedException>(() =>
+                XlsxTabularWorkbook.Open(path, new ExcelReadOptions()));
+            Assert.ThrowsAny<ArgumentException>(() => ExcelDocument.OpenDataReader(path));
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void XlsxNativePackage_UsesNativePathForExplicitSheetIndex() {
+        string path = Path.Combine(
+            Path.GetTempPath(),
+            $"OfficeIMO.Excel.XlsxNativeSheetIndex.{Guid.NewGuid():N}.xlsx");
+        try {
+            using (var document = ExcelDocument.Create(path)) {
+                ExcelSheet first = document.AddWorksheet("First");
+                first.CellValue(1, 1, "Value");
+                first.CellValue(2, 1, 11);
+                ExcelSheet second = document.AddWorksheet("Second");
+                second.CellValue(1, 1, "Value");
+                second.CellValue(2, 1, 22);
+                document.Save();
+            }
+
+            using var workbook = XlsxTabularWorkbook.Open(
+                path,
+                new ExcelReadOptions { SheetIndex = 1 });
+            Assert.Equal(new[] { "First", "Second" }, workbook.TableNames);
+            using var reader = workbook.OpenTable(
+                "Second",
+                hasHeaderRow: true,
+                CancellationToken.None);
+            Assert.True(reader.Read());
+            Assert.Equal(22, reader.GetInt32(0));
+            Assert.False(reader.Read());
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+#if !NETFRAMEWORK
+    [Fact]
+    public void XlsxNativePackage_FallsBackForWorksheetLargerThanNativeBuffer() {
+        string path = CreateCompactFastPathWorkbook();
+        try {
+            const string entryName = "xl/worksheets/sheet1.xml";
+            byte[] worksheet = ReadZipEntry(path, entryName);
+            byte[] closingTag = "</worksheet>"u8.ToArray();
+            int closingTagOffset = worksheet.AsSpan().LastIndexOf(closingTag);
+            Assert.True(closingTagOffset >= 0);
+
+            using (ZipArchive archive = ZipFile.Open(path, ZipArchiveMode.Update)) {
+                ZipArchiveEntry original = archive.GetEntry(entryName)!;
+                original.Delete();
+                ZipArchiveEntry replacement = archive.CreateEntry(entryName, CompressionLevel.Optimal);
+                using Stream destination = replacement.Open();
+                destination.Write(worksheet, 0, closingTagOffset);
+                byte[] padding = Enumerable.Repeat((byte)' ', 64 * 1024).ToArray();
+                for (int index = 0; index <= 1024; index++) {
+                    destination.Write(padding, 0, padding.Length);
+                }
+                destination.Write(worksheet, closingTagOffset, worksheet.Length - closingTagOffset);
+            }
+
+            AssertCompactNumericRows(path);
+        } finally {
+            File.Delete(path);
+        }
+    }
+#endif
 
     [Fact]
     public void XlsxNativePackage_RejectsUnknownWorkbookRelationshipTargetMode() {

--- a/OfficeIMO.Excel.Tests/Excel.DataReaderApi.XlsxNative.PackageContracts.cs
+++ b/OfficeIMO.Excel.Tests/Excel.DataReaderApi.XlsxNative.PackageContracts.cs
@@ -1,0 +1,110 @@
+using DocumentFormat.OpenXml.Packaging;
+using System.IO.Compression;
+using System.Text;
+using System.Xml.Linq;
+using Xunit;
+
+namespace OfficeIMO.Excel.Tests;
+
+public partial class Excel {
+    private const string PackageRelationshipsNamespace =
+        "http://schemas.openxmlformats.org/package/2006/relationships";
+    private const string OfficeRelationshipsNamespace =
+        "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+
+    [Fact]
+    public void XlsxNativePackage_RejectsWorksheetWithUnexpectedContentType() {
+        string path = CreateCompactFastPathWorkbook();
+        try {
+            const string entryName = "[Content_Types].xml";
+            string contentTypes = Encoding.UTF8.GetString(ReadZipEntry(path, entryName));
+            string malformed = contentTypes.Replace(
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml",
+                "text/plain");
+            Assert.NotEqual(contentTypes, malformed);
+            ReplaceZipEntry(path, entryName, Encoding.UTF8.GetBytes(malformed));
+
+            IOException exception = Assert.Throws<IOException>(() => ExcelDocument.OpenDataReader(path));
+            Assert.IsType<OpenXmlPackageException>(exception.InnerException);
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void XlsxNativePackage_RejectsUnknownWorkbookRelationshipTargetMode() {
+        string path = CreateCompactFastPathWorkbook();
+        try {
+            const string entryName = "xl/_rels/workbook.xml.rels";
+            XDocument relationships = LoadZipXml(path, entryName);
+            XNamespace packageRelationships = PackageRelationshipsNamespace;
+            XElement worksheetRelationship = relationships.Root!
+                .Elements(packageRelationships + "Relationship")
+                .Single(element => ((string?)element.Attribute("Type"))?.EndsWith(
+                    "/worksheet",
+                    StringComparison.Ordinal) == true);
+            worksheetRelationship.SetAttributeValue("TargetMode", "Bogus");
+            ReplaceZipXml(path, entryName, relationships);
+
+            IOException exception = Assert.Throws<IOException>(() => ExcelDocument.OpenDataReader(path));
+            var xmlException = Assert.IsType<System.Xml.XmlException>(exception.InnerException);
+            Assert.IsType<ArgumentException>(xmlException.InnerException);
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void XlsxNativePackage_RejectsMissingNonWorksheetSheetPart() {
+        string path = CreateCompactFastPathWorkbook();
+        try {
+            const string relationshipId = "rIdMissingChart";
+            const string relationshipsEntry = "xl/_rels/workbook.xml.rels";
+            XDocument relationships = LoadZipXml(path, relationshipsEntry);
+            XNamespace packageRelationships = PackageRelationshipsNamespace;
+            relationships.Root!.Add(new XElement(
+                packageRelationships + "Relationship",
+                new XAttribute("Id", relationshipId),
+                new XAttribute("Type", OfficeRelationshipsNamespace + "/chartsheet"),
+                new XAttribute("Target", "chartsheets/missing.xml")));
+            ReplaceZipXml(path, relationshipsEntry, relationships);
+
+            const string workbookEntry = "xl/workbook.xml";
+            XDocument workbook = LoadZipXml(path, workbookEntry);
+            XNamespace spreadsheet = workbook.Root!.Name.Namespace;
+            XNamespace officeRelationships = OfficeRelationshipsNamespace;
+            workbook.Root.Element(spreadsheet + "sheets")!.Add(new XElement(
+                spreadsheet + "sheet",
+                new XAttribute("name", "MissingChart"),
+                new XAttribute("sheetId", "2"),
+                new XAttribute(officeRelationships + "id", relationshipId)));
+            ReplaceZipXml(path, workbookEntry, workbook);
+
+            Assert.Throws<InvalidOperationException>(() => ExcelDocument.OpenDataReader(path));
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+#if !NETFRAMEWORK
+    [Fact]
+    public void XlsxNativePackage_IgnoresUnusedZipEntryUnsupportedByNativeIndex() {
+        string path = CreateCompactFastPathWorkbook();
+        try {
+            using (ZipArchive archive = ZipFile.Open(path, ZipArchiveMode.Update)) {
+                archive.CreateEntry(" ");
+            }
+
+            AssertCompactNumericRows(path);
+        } finally {
+            File.Delete(path);
+        }
+    }
+#endif
+
+    private static XDocument LoadZipXml(string path, string entryName) =>
+        XDocument.Parse(Encoding.UTF8.GetString(ReadZipEntry(path, entryName)));
+
+    private static void ReplaceZipXml(string path, string entryName, XDocument document) =>
+        ReplaceZipEntry(path, entryName, Encoding.UTF8.GetBytes(document.ToString(SaveOptions.DisableFormatting)));
+}

--- a/OfficeIMO.Excel.Tests/Excel.DataReaderApi.XlsxNative.cs
+++ b/OfficeIMO.Excel.Tests/Excel.DataReaderApi.XlsxNative.cs
@@ -1,0 +1,70 @@
+using System.Data.Common;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+namespace OfficeIMO.Excel.Tests;
+
+public partial class Excel {
+    [Fact]
+    public void XlsxTabularWorkbook_ReadsCanonicalPackageWithoutSdkProjection() {
+        string path = CreateCompactFastPathWorkbook();
+        try {
+            var options = new ExcelReadOptions();
+            using var workbook = XlsxTabularWorkbook.Open(path, options);
+
+            Assert.Equal(new[] { "Data" }, workbook.TableNames);
+            using DbDataReader reader = workbook.OpenTable(
+                "Data",
+                hasHeaderRow: true,
+                CancellationToken.None);
+            Assert.True(reader.Read());
+            Assert.Equal(42, reader.GetInt32(0));
+            Assert.True(reader.Read());
+            Assert.Equal(43, reader.GetInt32(0));
+            Assert.False(reader.Read());
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void OpenDataReader_ReusesValidatedSharedStringIndexForCachedFormula() {
+        string path = Path.Combine(
+            Path.GetTempPath(),
+            $"OfficeIMO.Excel.XlsxNativeSharedFormula.{Guid.NewGuid():N}.xlsx");
+        try {
+            using (var document = ExcelDocument.Create(path)) {
+                ExcelSheet sheet = document.AddWorksheet("Data");
+                sheet.CellValue(1, 1, "Value");
+                sheet.CellValue(2, 1, "Cached");
+                document.Save();
+            }
+
+            const string entryName = "xl/worksheets/sheet1.xml";
+            string worksheetXml = Encoding.UTF8.GetString(ReadZipEntry(path, entryName));
+            int cellStart = worksheetXml.IndexOf("<c r=\"A2\"", StringComparison.Ordinal);
+            Assert.True(cellStart >= 0);
+            int cellContentStart = worksheetXml.IndexOf('>', cellStart) + 1;
+            Assert.True(cellContentStart > cellStart);
+            worksheetXml = worksheetXml.Insert(
+                cellContentStart,
+                "<f>CONCAT(\"Cache\",\"d\")</f>");
+            ReplaceZipEntry(path, entryName, Encoding.UTF8.GetBytes(worksheetXml));
+
+            using (DbDataReader cached = ExcelDocument.OpenDataReader(path)) {
+                Assert.True(cached.Read());
+                Assert.Equal("Cached", cached.GetString(0));
+            }
+
+            using (DbDataReader formula = ExcelDocument.OpenDataReader(
+                       path,
+                       new ExcelReadOptions { UseCachedFormulaResult = false })) {
+                Assert.True(formula.Read());
+                Assert.Equal("CONCAT(\"Cache\",\"d\")", formula.GetString(0));
+            }
+        } finally {
+            File.Delete(path);
+        }
+    }
+}

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.Compact.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.Compact.cs
@@ -282,7 +282,7 @@ namespace OfficeIMO.Excel {
                         return false;
                     }
 
-                    ValidateIndexedCell(
+                    int sharedStringIndex = ValidateIndexedCell(
                         rowIndex,
                         columnIndex,
                         kind,
@@ -291,6 +291,10 @@ namespace OfficeIMO.Excel {
                         hasCachedValue,
                         valueStart,
                         valueLength);
+                    if (sharedStringIndex >= 0) {
+                        _valueStarts![cellIndex] = sharedStringIndex;
+                        _valueLengths![cellIndex] = SharedStringIndexValueLength;
+                    }
                     _cellKinds![cellIndex] = EncodeCellKind(kind, styleIndex);
                 }
 

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.Validation.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.Validation.cs
@@ -213,7 +213,7 @@ namespace OfficeIMO.Excel {
                         StringComparison.OrdinalIgnoreCase);
             }
 
-            private void ValidateIndexedCell(
+            private int ValidateIndexedCell(
                 int rowIndex,
                 int columnIndex,
                 Utf8CellKind kind,
@@ -222,6 +222,7 @@ namespace OfficeIMO.Excel {
                 bool hasCachedValue,
                 int valueStart,
                 int valueLength) {
+                int validatedSharedStringIndex = -1;
                 if (styleIndex >= 0 && (uint)styleIndex >= (uint)_owner.Styles.CellFormatCount) {
                     string reference = A1.CellReference(rowIndex, columnIndex);
                     throw new InvalidDataException(
@@ -244,6 +245,8 @@ namespace OfficeIMO.Excel {
                         throw new InvalidDataException(
                             $"Worksheet '{_owner._sheetName}' cell {reference} references a missing shared string.");
                     }
+
+                    validatedSharedStringIndex = index;
                 }
 
                 if (sharedFormulaFollower
@@ -254,6 +257,8 @@ namespace OfficeIMO.Excel {
                         $"'{_owner._sheetName}'!{reference}. Read the workbook through ExcelDocument when resolved " +
                         "shared-formula text is required.");
                 }
+
+                return validatedSharedStringIndex;
             }
         }
     }

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.cs
@@ -17,6 +17,7 @@ namespace OfficeIMO.Excel {
             private const int MaximumCachedStringBytes = 256;
             private const byte DateStyleCellKindFlag = 0x80;
             private const byte CellKindMask = 0x7F;
+            private const int SharedStringIndexValueLength = -2;
 
             private readonly ExcelSheetReader _owner;
             private readonly ExcelReadOptions _options;
@@ -283,9 +284,17 @@ namespace OfficeIMO.Excel {
 
                 bool useFormula = _formulaLengths != null
                     && _formulaLengths[cellIndex] >= 0
-                    && (!_options.UseCachedFormulaResult || _valueLengths![cellIndex] < 0);
+                    && (!_options.UseCachedFormulaResult
+                        || (_valueLengths![cellIndex] < 0
+                            && _valueLengths[cellIndex] != SharedStringIndexValueLength));
                 int start = useFormula ? _formulaStarts![cellIndex] : _valueStarts![cellIndex];
                 int length = useFormula ? _formulaLengths![cellIndex] : _valueLengths![cellIndex];
+                if (!useFormula
+                    && cellKind == Utf8CellKind.SharedString
+                    && length == SharedStringIndexValueLength) {
+                    objectValue = _owner.GetSharedString(start);
+                    return;
+                }
                 if (length < 0) {
                     return;
                 }
@@ -638,7 +647,7 @@ namespace OfficeIMO.Excel {
                         }
                     }
 
-                    ValidateIndexedCell(
+                    int sharedStringIndex = ValidateIndexedCell(
                         rowIndex,
                         columnIndex,
                         kind,
@@ -648,6 +657,10 @@ namespace OfficeIMO.Excel {
                         valueStart,
                         valueLength);
                     if (cellIndex >= 0) {
+                        if (sharedStringIndex >= 0) {
+                            _valueStarts![cellIndex] = sharedStringIndex;
+                            _valueLengths![cellIndex] = SharedStringIndexValueLength;
+                        }
                         _cellKinds![cellIndex] = EncodeCellKind(kind, styleIndex);
                     }
                 }

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.cs
@@ -222,6 +222,7 @@ namespace OfficeIMO.Excel {
                     return true;
                 }
 
+                owner.RequireSdkWorksheetPart();
                 using var stream = owner._wsPart.GetStream(FileMode.Open, FileAccess.Read);
                 RewindWorksheetStream(stream);
                 return TryReadWorksheetBuffer(stream, ct, out buffer, out length);

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.cs
@@ -22,6 +22,8 @@ namespace OfficeIMO.Excel {
                 return indexedReader!;
             }
 
+            RequireSdkWorksheetPart();
+
             if (TryGetWorksheetCellPresence(out bool hasCells, ct) && !hasCells) {
                 return new ExcelRangeDataReader(
                     Array.Empty<RangeChunk>(),

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.cs
@@ -18,6 +18,8 @@ namespace OfficeIMO.Excel {
             "http://purl.oclc.org/ooxml/spreadsheetml/main";
         private readonly string _sheetName;
         private readonly WorksheetPart _wsPart;
+        private readonly string _worksheetPartName;
+        private readonly bool _hasSdkWorksheetPart;
         private readonly SharedStringCache _sst;
         private readonly StylesCacheProvider _styles;
         private readonly ExcelReadOptions _opt;
@@ -46,12 +48,35 @@ namespace OfficeIMO.Excel {
             OpenXmlPackagePartBufferReader? partBufferReader = null) {
             _sheetName = sheetName;
             _wsPart = wsPart;
+            _worksheetPartName = wsPart.Uri.OriginalString;
+            _hasSdkWorksheetPart = true;
             _sst = sst;
             _styles = styles;
             _opt = opt;
             _dateSystem = dateSystem;
             _canStreamWorksheetPart = canStreamWorksheetPart;
             _partBufferReader = partBufferReader;
+        }
+
+        internal ExcelSheetReader(
+            string sheetName,
+            string worksheetPartName,
+            SharedStringCache sst,
+            StylesCacheProvider styles,
+            ExcelReadOptions opt,
+            ExcelDateSystem dateSystem,
+            OpenXmlPackagePartBufferReader partBufferReader) {
+            _sheetName = sheetName;
+            _wsPart = null!;
+            _worksheetPartName = worksheetPartName;
+            _hasSdkWorksheetPart = false;
+            _sst = sst;
+            _styles = styles;
+            _opt = opt;
+            _dateSystem = dateSystem;
+            _canStreamWorksheetPart = true;
+            _partBufferReader = partBufferReader;
+            _hasWorksheetPartStreamContent = true;
         }
 
         private bool TryReadWorksheetPartBuffer(
@@ -63,11 +88,18 @@ namespace OfficeIMO.Excel {
             length = 0;
             return _partBufferReader != null
                 && _partBufferReader.TryRead(
-                _wsPart.Uri,
+                _worksheetPartName,
                 maximumBytes,
                 cancellationToken,
                 out buffer,
                 out length);
+        }
+
+        private void RequireSdkWorksheetPart() {
+            if (!_hasSdkWorksheetPart) {
+                throw new XlsxTabularFastPathNotSupportedException(
+                    $"Worksheet '{_sheetName}' requires the Open XML SDK fallback path.");
+            }
         }
 
         private DateTime FromExcelSerialDate(double serial) => ExcelDateSystemConverter.FromSerial(serial, _dateSystem);

--- a/OfficeIMO.Excel/Read/ExcelWorkbookDataReader.cs
+++ b/OfficeIMO.Excel/Read/ExcelWorkbookDataReader.cs
@@ -70,11 +70,30 @@ namespace OfficeIMO.Excel {
             return this;
         }
 
-        internal static ExcelWorkbookDataReader OpenOpenXml(string path, ExcelReadOptions options) =>
-            CreateOpenXml(ExcelDocumentReader.Open(path, options), options);
+        internal static ExcelWorkbookDataReader OpenOpenXml(string path, ExcelReadOptions options) {
+            if (CanUseNativeOpenXmlPath(options)
+                && string.Equals(Path.GetExtension(path), ".xlsx", StringComparison.OrdinalIgnoreCase)) {
+                try {
+                    return CreateNativeOpenXml(XlsxTabularWorkbook.Open(path, options), options);
+                } catch (XlsxTabularFastPathNotSupportedException) {
+                    // Unusual package and worksheet shapes retain the complete SDK path.
+                }
+            }
 
-        internal static ExcelWorkbookDataReader OpenOpenXml(byte[] bytes, ExcelReadOptions options) =>
-            CreateOpenXml(ExcelDocumentReader.Open(bytes, options), options);
+            return CreateOpenXml(ExcelDocumentReader.Open(path, options), options);
+        }
+
+        internal static ExcelWorkbookDataReader OpenOpenXml(byte[] bytes, ExcelReadOptions options) {
+            if (CanUseNativeOpenXmlPath(options)) {
+                try {
+                    return CreateNativeOpenXml(XlsxTabularWorkbook.Open(bytes, options), options);
+                } catch (XlsxTabularFastPathNotSupportedException) {
+                    // Unusual package and worksheet shapes retain the complete SDK path.
+                }
+            }
+
+            return CreateOpenXml(ExcelDocumentReader.Open(bytes, options), options);
+        }
 
         internal static ExcelWorkbookDataReader WrapOpenXml(ExcelDocumentReader owner, ExcelReadOptions options) =>
             CreateOpenXml(owner, options);
@@ -289,6 +308,40 @@ namespace OfficeIMO.Excel {
                 throw;
             }
         }
+
+        private static ExcelWorkbookDataReader CreateNativeOpenXml(
+            XlsxTabularWorkbook owner,
+            ExcelReadOptions options) {
+            try {
+                ValidateUniqueSheetNames(owner.TableNames, options.CancellationToken);
+                IReadOnlyList<SheetSelection> sheets = SelectSheets(owner.TableNames, options);
+                if (sheets.Count != 1) {
+                    throw new XlsxTabularFastPathNotSupportedException(
+                        "Multi-result XLSX reads retain the complete Open XML SDK path.");
+                }
+
+                return new ExcelWorkbookDataReader(
+                    sheets,
+                    index => owner.OpenTable(
+                        sheets[index].Name,
+                        options.HasHeaderRow,
+                        options.CancellationToken),
+                    owner,
+                    options.Culture,
+                    options.TypeConverter,
+                    options.StrictTypedMapping,
+                    options.MappingErrorValuePolicy,
+                    options.CancellationToken);
+            } catch {
+                owner.Dispose();
+                throw;
+            }
+        }
+
+        private static bool CanUseNativeOpenXmlPath(ExcelReadOptions options) =>
+            !options.InferSchema
+            && string.IsNullOrWhiteSpace(options.A1Range)
+            && options.CellValueConverter == null;
 
         private static DbDataReader OpenOpenXmlSheet(
             ExcelDocumentReader owner,

--- a/OfficeIMO.Excel/Read/Helpers/SharedStringCache.cs
+++ b/OfficeIMO.Excel/Read/Helpers/SharedStringCache.cs
@@ -11,6 +11,7 @@ namespace OfficeIMO.Excel {
         private static readonly XmlReaderSettings SharedStringXmlReaderSettings = CreateSharedStringXmlReaderSettings();
 
         private readonly Lazy<SharedStringTablePart?> _part;
+        private readonly Func<Stream>? _openPartStream;
         private readonly bool _preferDom;
         private readonly int _maxSharedStringItems;
         private readonly int _maxSharedStringItemCharacters;
@@ -23,6 +24,7 @@ namespace OfficeIMO.Excel {
 
         private SharedStringCache(WorkbookPart? workbookPart, bool preferDom, ExcelReadOptions options) {
             _part = new Lazy<SharedStringTablePart?>(() => workbookPart?.SharedStringTablePart, LazyThreadSafetyMode.ExecutionAndPublication);
+            _openPartStream = null;
             _preferDom = preferDom;
             _maxSharedStringItems = options.MaxSharedStringItems;
             _maxSharedStringItemCharacters = options.MaxSharedStringItemCharacters;
@@ -31,12 +33,51 @@ namespace OfficeIMO.Excel {
             _items = new Lazy<List<string>>(LoadItems, LazyThreadSafetyMode.ExecutionAndPublication);
         }
 
+        private SharedStringCache(Func<Stream> openPartStream, ExcelReadOptions options) {
+            _part = new Lazy<SharedStringTablePart?>(() => null, LazyThreadSafetyMode.ExecutionAndPublication);
+            _openPartStream = openPartStream ?? throw new ArgumentNullException(nameof(openPartStream));
+            _preferDom = false;
+            _maxSharedStringItems = options.MaxSharedStringItems;
+            _maxSharedStringItemCharacters = options.MaxSharedStringItemCharacters;
+            _maxSharedStringCharacters = options.MaxSharedStringCharacters;
+            _cancellationToken = options.CancellationToken;
+            _items = new Lazy<List<string>>(LoadItems, LazyThreadSafetyMode.ExecutionAndPublication);
+        }
+
+        private SharedStringCache(List<string> items, ExcelReadOptions options) {
+            _part = new Lazy<SharedStringTablePart?>(() => null, LazyThreadSafetyMode.ExecutionAndPublication);
+            _openPartStream = null;
+            _preferDom = false;
+            _maxSharedStringItems = options.MaxSharedStringItems;
+            _maxSharedStringItemCharacters = options.MaxSharedStringItemCharacters;
+            _maxSharedStringCharacters = options.MaxSharedStringCharacters;
+            _cancellationToken = options.CancellationToken;
+            _loadedItems = items ?? throw new ArgumentNullException(nameof(items));
+            _items = new Lazy<List<string>>(() => items, LazyThreadSafetyMode.ExecutionAndPublication);
+        }
+
         public static SharedStringCache Build(SpreadsheetDocument doc, ExcelReadOptions? options = null) {
             return new SharedStringCache(doc.WorkbookPart, doc.FileOpenAccess != FileAccess.Read, options ?? new ExcelReadOptions());
         }
 
+        internal static SharedStringCache Build(Func<Stream> openPartStream, ExcelReadOptions options) =>
+            new(openPartStream, options);
+
+        internal static SharedStringCache Empty(ExcelReadOptions options) =>
+            new(new List<string>(), options);
+
         private List<string> LoadItems() {
             _cancellationToken.ThrowIfCancellationRequested();
+            if (_openPartStream != null) {
+                using Stream stream = _openPartStream();
+                if (TryLoadItemsXmlFast(stream, out List<string> nativeItems)) {
+                    return nativeItems;
+                }
+
+                throw new XlsxTabularFastPathNotSupportedException(
+                    "The shared-string table requires the Open XML SDK fallback path.");
+            }
+
             SharedStringTablePart? part = GetSharedStringTablePart();
             if (part == null) return new List<string>();
             if (_preferDom && part.SharedStringTable != null) {
@@ -80,11 +121,15 @@ namespace OfficeIMO.Excel {
         }
 
         private bool TryLoadItemsXmlFast(SharedStringTablePart part, out List<string> items) {
+            using var stream = part.GetStream(FileMode.Open, FileAccess.Read);
+            return TryLoadItemsXmlFast(stream, out items);
+        }
+
+        private bool TryLoadItemsXmlFast(Stream stream, out List<string> items) {
             items = new List<string>();
             long totalCharacters = 0;
 
             try {
-                using var stream = part.GetStream(FileMode.Open, FileAccess.Read);
                 using var reader = XmlReader.Create(stream, SharedStringXmlReaderSettings);
                 int nodesRead = 0;
                 while (reader.Read()) {

--- a/OfficeIMO.Excel/Read/Helpers/StylesCache.cs
+++ b/OfficeIMO.Excel/Read/Helpers/StylesCache.cs
@@ -6,12 +6,22 @@ using System.Xml;
 
 namespace OfficeIMO.Excel {
     internal sealed class StylesCacheProvider {
-        private readonly SpreadsheetDocument _doc;
+        private readonly SpreadsheetDocument? _doc;
+        private readonly Func<Stream>? _openPartStream;
         private readonly object _gate = new();
         private StylesCache? _value;
 
         public StylesCacheProvider(SpreadsheetDocument doc) {
             _doc = doc;
+            _openPartStream = null;
+        }
+
+        internal StylesCacheProvider(Func<Stream> openPartStream) {
+            _openPartStream = openPartStream ?? throw new ArgumentNullException(nameof(openPartStream));
+        }
+
+        internal StylesCacheProvider(StylesCache value) {
+            _value = value ?? throw new ArgumentNullException(nameof(value));
         }
 
         public StylesCache Value {
@@ -22,7 +32,16 @@ namespace OfficeIMO.Excel {
                 }
 
                 lock (_gate) {
-                    return _value ??= StylesCache.Build(_doc);
+                    if (_value != null) {
+                        return _value;
+                    }
+
+                    if (_openPartStream != null) {
+                        using Stream stream = _openPartStream();
+                        return _value = StylesCache.Build(stream);
+                    }
+
+                    return _value = StylesCache.Build(_doc!);
                 }
             }
         }
@@ -102,13 +121,29 @@ namespace OfficeIMO.Excel {
             return cache;
         }
 
+        internal static StylesCache Build(Stream stream) {
+            var cache = new StylesCache();
+            if (!TryBuildXmlFast(stream, cache)) {
+                throw new XlsxTabularFastPathNotSupportedException(
+                    "The styles part requires the Open XML SDK fallback path.");
+            }
+
+            return cache;
+        }
+
+        internal static StylesCache Empty() => new();
+
         public bool IsDateLike(uint styleIndex) => styleIndex < (uint)_dateStyleIndexes.Length && _dateStyleIndexes[styleIndex];
 
         public bool IsDateSystemShiftStyle(uint styleIndex) => styleIndex < (uint)_dateSystemShiftStyleIndexes.Length && _dateSystemShiftStyleIndexes[styleIndex];
 
         private static bool TryBuildXmlFast(WorkbookStylesPart sp, StylesCache cache) {
+            using var stream = sp.GetStream(FileMode.Open, FileAccess.Read);
+            return TryBuildXmlFast(stream, cache);
+        }
+
+        private static bool TryBuildXmlFast(Stream stream, StylesCache cache) {
             try {
-                using var stream = sp.GetStream(FileMode.Open, FileAccess.Read);
                 using var reader = XmlReader.Create(stream, StylesXmlReaderSettings);
                 Dictionary<uint, string>? nf = null;
 

--- a/OfficeIMO.Excel/Read/OpenXmlPackagePartBufferReader.cs
+++ b/OfficeIMO.Excel/Read/OpenXmlPackagePartBufferReader.cs
@@ -12,11 +12,13 @@ namespace OfficeIMO.Excel {
     internal sealed class OpenXmlPackagePartBufferReader : IDisposable {
         private readonly Stream _stream;
         private readonly ZipArchive _archive;
+        private readonly Dictionary<string, ZipArchiveEntry> _entries;
         private bool _disposed;
 
         private OpenXmlPackagePartBufferReader(Stream stream) {
             _stream = stream;
             _archive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: true);
+            _entries = BuildEntryIndex(_archive);
         }
 
         /// <summary>
@@ -68,14 +70,31 @@ namespace OfficeIMO.Excel {
             cancellationToken.ThrowIfCancellationRequested();
             buffer = null;
             length = 0;
-            string partName = partUri.OriginalString.TrimStart('/').Replace('\\', '/');
-            ZipArchiveEntry? entry = null;
-            foreach (ZipArchiveEntry candidate in _archive.Entries) {
-                if (string.Equals(candidate.FullName, partName, StringComparison.OrdinalIgnoreCase)) {
-                    entry = candidate;
-                    break;
-                }
+            return TryRead(
+                partUri.OriginalString,
+                maximumBytes,
+                cancellationToken,
+                out buffer,
+                out length);
+        }
+
+        internal bool TryRead(
+            string partName,
+            int maximumBytes,
+            CancellationToken cancellationToken,
+            out byte[]? buffer,
+            out int length) {
+            if (_disposed) {
+                throw new ObjectDisposedException(nameof(OpenXmlPackagePartBufferReader));
             }
+            if (maximumBytes < 0) {
+                throw new ArgumentOutOfRangeException(nameof(maximumBytes));
+            }
+            cancellationToken.ThrowIfCancellationRequested();
+            buffer = null;
+            length = 0;
+            string normalizedPartName = NormalizePartName(partName);
+            _entries.TryGetValue(normalizedPartName, out ZipArchiveEntry? entry);
             if (entry == null || entry.Length < 0 || entry.Length > maximumBytes || entry.Length > int.MaxValue) {
                 return false;
             }
@@ -90,14 +109,14 @@ namespace OfficeIMO.Excel {
                     int read = input.Read(output, offset, length - offset);
                     if (read == 0) {
                         throw new EndOfStreamException(
-                            $"Package part '{partName}' ended after {offset} of {length} declared bytes.");
+                            $"Package part '{normalizedPartName}' ended after {offset} of {length} declared bytes.");
                     }
                     offset += read;
                 }
                 cancellationToken.ThrowIfCancellationRequested();
                 if (input.ReadByte() >= 0) {
                     throw new InvalidDataException(
-                        $"Package part '{partName}' exceeds its declared decompressed length of {length} bytes.");
+                        $"Package part '{normalizedPartName}' exceeds its declared decompressed length of {length} bytes.");
                 }
                 buffer = output;
                 return true;
@@ -107,6 +126,68 @@ namespace OfficeIMO.Excel {
                 length = 0;
                 throw;
             }
+        }
+
+        internal bool ContainsPart(string partName) {
+            if (_disposed) {
+                throw new ObjectDisposedException(nameof(OpenXmlPackagePartBufferReader));
+            }
+
+            return _entries.ContainsKey(NormalizePartName(partName));
+        }
+
+        internal Stream OpenPart(string partName, int maximumBytes) {
+            if (_disposed) {
+                throw new ObjectDisposedException(nameof(OpenXmlPackagePartBufferReader));
+            }
+            if (maximumBytes < 0) {
+                throw new ArgumentOutOfRangeException(nameof(maximumBytes));
+            }
+
+            string normalizedPartName = NormalizePartName(partName);
+            if (!_entries.TryGetValue(normalizedPartName, out ZipArchiveEntry? entry)) {
+                throw new InvalidDataException($"Package part '{normalizedPartName}' is missing.");
+            }
+            if (entry.Length < 0 || entry.Length > maximumBytes || entry.Length > int.MaxValue) {
+                throw new InvalidDataException(
+                    $"Package part '{normalizedPartName}' declares {entry.Length} bytes, exceeding the supported limit of {maximumBytes} bytes.");
+            }
+
+            return entry.Open();
+        }
+
+        private static Dictionary<string, ZipArchiveEntry> BuildEntryIndex(ZipArchive archive) {
+            var entries = new Dictionary<string, ZipArchiveEntry>(StringComparer.OrdinalIgnoreCase);
+            foreach (ZipArchiveEntry entry in archive.Entries) {
+                if (string.IsNullOrEmpty(entry.Name)) {
+                    continue;
+                }
+
+                string normalized = NormalizePartName(entry.FullName);
+                if (entries.ContainsKey(normalized)) {
+                    throw new InvalidDataException($"The Open XML package contains duplicate part name '{normalized}'.");
+                }
+
+                entries.Add(normalized, entry);
+            }
+
+            return entries;
+        }
+
+        private static string NormalizePartName(string partName) {
+            if (string.IsNullOrWhiteSpace(partName)) {
+                throw new ArgumentException("Package part name cannot be empty.", nameof(partName));
+            }
+            if (partName.IndexOf('\\') >= 0) {
+                throw new InvalidDataException($"Package part name '{partName}' contains a backslash.");
+            }
+
+            string normalized = partName.TrimStart('/');
+            if (normalized.Split('/').Any(static segment => segment == "..")) {
+                throw new InvalidDataException($"Package part name '{partName}' is not safe.");
+            }
+
+            return normalized;
         }
 
         public void Dispose() {

--- a/OfficeIMO.Excel/Read/OpenXmlPackagePartBufferReader.cs
+++ b/OfficeIMO.Excel/Read/OpenXmlPackagePartBufferReader.cs
@@ -42,6 +42,9 @@ namespace OfficeIMO.Excel {
             } catch (NotSupportedException) {
                 stream.Dispose();
                 return null;
+            } catch (ArgumentException) {
+                stream.Dispose();
+                return null;
             }
         }
 
@@ -53,6 +56,9 @@ namespace OfficeIMO.Excel {
                 stream = null;
                 return reader;
             } catch (InvalidDataException) {
+                stream?.Dispose();
+                return null;
+            } catch (ArgumentException) {
                 stream?.Dispose();
                 return null;
             }

--- a/OfficeIMO.Excel/Read/XlsxTabularFastPathNotSupportedException.cs
+++ b/OfficeIMO.Excel/Read/XlsxTabularFastPathNotSupportedException.cs
@@ -1,0 +1,13 @@
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Signals that a forward-only XLSX package or worksheet needs the complete Open XML SDK path.
+    /// It is an internal routing signal, not a public failure contract.
+    /// </summary>
+    internal sealed class XlsxTabularFastPathNotSupportedException : Exception {
+        internal XlsxTabularFastPathNotSupportedException(string message)
+            : base(message) { }
+
+        internal XlsxTabularFastPathNotSupportedException(string message, Exception innerException)
+            : base(message, innerException) { }
+    }
+}

--- a/OfficeIMO.Excel/Read/XlsxTabularWorkbook.cs
+++ b/OfficeIMO.Excel/Read/XlsxTabularWorkbook.cs
@@ -52,7 +52,8 @@ namespace OfficeIMO.Excel {
         private readonly SharedStringCache _sharedStrings;
         private readonly StylesCacheProvider _styles;
         private readonly ExcelReadOptions _options;
-        private readonly XDocument _contentTypes;
+        private readonly Dictionary<string, string> _contentTypeOverrides;
+        private readonly Dictionary<string, string> _contentTypeDefaults;
         private readonly XlsxTabularSheet[] _sheets;
         private readonly string[] _tableNames;
         private bool _disposed;
@@ -66,7 +67,7 @@ namespace OfficeIMO.Excel {
             _options = options;
             options.CancellationToken.ThrowIfCancellationRequested();
 
-            _contentTypes = ReadContentTypes();
+            (_contentTypeOverrides, _contentTypeDefaults) = ReadContentTypes();
             string workbookPartName = ReadWorkbookPartName();
             ValidatePartContentType(
                 workbookPartName,
@@ -198,36 +199,19 @@ namespace OfficeIMO.Excel {
         }
 
         private string ReadWorkbookPartName() {
-            XDocument relationships = ReadXmlPart("_rels/.rels", MaximumMetadataPartBytes);
-            XNamespace ns = PackageRelationshipsNamespace;
-            if (relationships.Root?.Name != ns + "Relationships") {
-                throw new XlsxTabularFastPathNotSupportedException(
-                    "The package root relationship namespace is not supported by the native path.");
-            }
-
-            var candidates = relationships.Root
-                .Elements(ns + "Relationship")
-                .Select(element => new {
-                    Element = element,
-                    IsExternal = ReadRelationshipTargetMode(element)
-                })
-                .Where(candidate =>
-                    IsOfficeRelationship(
-                        (string?)candidate.Element.Attribute("Type"),
-                        "/officeDocument"))
+            IReadOnlyDictionary<string, PackageRelationship> relationships =
+                ReadRelationships(string.Empty);
+            PackageRelationship[] candidates = relationships.Values
+                .Where(relationship => IsOfficeRelationship(
+                    relationship.Type,
+                    "/officeDocument"))
                 .ToArray();
             if (candidates.Length != 1 || candidates[0].IsExternal) {
                 throw new XlsxTabularFastPathNotSupportedException(
                     "The package does not contain one internal Office workbook relationship.");
             }
 
-            string? target = (string?)candidates[0].Element.Attribute("Target");
-            if (string.IsNullOrWhiteSpace(target)) {
-                throw new XlsxTabularFastPathNotSupportedException(
-                    "The package workbook relationship has no target.");
-            }
-
-            string workbookPartName = ResolveTarget(string.Empty, target!);
+            string workbookPartName = ResolveTarget(string.Empty, candidates[0].Target);
             if (!_parts.ContainsPart(workbookPartName)) {
                 throw new XlsxTabularFastPathNotSupportedException(
                     "The package workbook relationship target is missing.");
@@ -236,7 +220,8 @@ namespace OfficeIMO.Excel {
             return workbookPartName;
         }
 
-        private XDocument ReadContentTypes() {
+        private (Dictionary<string, string> Overrides, Dictionary<string, string> Defaults)
+            ReadContentTypes() {
             XDocument contentTypes = ReadXmlPart("[Content_Types].xml", MaximumMetadataPartBytes);
             XNamespace ns = PackageContentTypesNamespace;
             if (contentTypes.Root?.Name != ns + "Types") {
@@ -244,7 +229,43 @@ namespace OfficeIMO.Excel {
                     "The package content-type manifest namespace is not supported by the native path.");
             }
 
-            return contentTypes;
+            var overrides = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var defaults = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (XElement element in contentTypes.Root.Elements()) {
+                _options.CancellationToken.ThrowIfCancellationRequested();
+                if (element.Name == ns + "Override") {
+                    string? rawPartName = (string?)element.Attribute("PartName");
+                    string? contentType = (string?)element.Attribute("ContentType");
+                    string normalizedPartName = NormalizeContentTypePartName(rawPartName);
+                    if (normalizedPartName.Length == 0
+                        || rawPartName![0] != '/'
+                        || !IsValidContentType(contentType)
+                        || overrides.ContainsKey(normalizedPartName)) {
+                        throw new XlsxTabularFastPathNotSupportedException(
+                            "The package content-type overrides require the Open XML SDK fallback path.");
+                    }
+                    overrides.Add(normalizedPartName, contentType!);
+                    continue;
+                }
+
+                if (element.Name == ns + "Default") {
+                    string? extension = (string?)element.Attribute("Extension");
+                    string? contentType = (string?)element.Attribute("ContentType");
+                    if (!IsValidContentTypeExtension(extension)
+                        || !IsValidContentType(contentType)
+                        || defaults.ContainsKey(extension!)) {
+                        throw new XlsxTabularFastPathNotSupportedException(
+                            "The package content-type defaults require the Open XML SDK fallback path.");
+                    }
+                    defaults.Add(extension!, contentType!);
+                    continue;
+                }
+
+                throw new XlsxTabularFastPathNotSupportedException(
+                    "The package content-type manifest requires the Open XML SDK fallback path.");
+            }
+
+            return (overrides, defaults);
         }
 
         private void ValidatePartContentType(
@@ -268,25 +289,9 @@ namespace OfficeIMO.Excel {
         }
 
         private string? GetPartContentType(string partName) {
-            XNamespace ns = PackageContentTypesNamespace;
-            XElement root = _contentTypes.Root!;
-
             string expectedPartName = "/" + partName.TrimStart('/');
-            string?[] matches = root
-                .Elements(ns + "Override")
-                .Where(element => string.Equals(
-                    NormalizeContentTypePartName((string?)element.Attribute("PartName")),
-                    expectedPartName,
-                    StringComparison.OrdinalIgnoreCase))
-                .Select(element => (string?)element.Attribute("ContentType"))
-                .Take(2)
-                .ToArray();
-            if (matches.Length > 1) {
-                throw new XlsxTabularFastPathNotSupportedException(
-                    "Duplicate package content-type overrides require the Open XML SDK fallback path.");
-            }
-            if (matches.Length == 1) {
-                return matches[0];
+            if (_contentTypeOverrides.TryGetValue(expectedPartName, out string? contentType)) {
+                return contentType;
             }
 
             int extensionSeparator = partName.LastIndexOf('.');
@@ -295,21 +300,9 @@ namespace OfficeIMO.Excel {
             }
 
             string extension = partName.Substring(extensionSeparator + 1);
-            matches = root
-                .Elements(ns + "Default")
-                .Where(element => string.Equals(
-                    (string?)element.Attribute("Extension"),
-                    extension,
-                    StringComparison.OrdinalIgnoreCase))
-                .Select(element => (string?)element.Attribute("ContentType"))
-                .Take(2)
-                .ToArray();
-            if (matches.Length > 1) {
-                throw new XlsxTabularFastPathNotSupportedException(
-                    "Duplicate package content-type defaults require the Open XML SDK fallback path.");
-            }
-
-            return matches.Length == 1 ? matches[0] : null;
+            return _contentTypeDefaults.TryGetValue(extension, out contentType)
+                ? contentType
+                : null;
         }
 
         private IReadOnlyDictionary<string, PackageRelationship> ReadRelationships(
@@ -321,21 +314,28 @@ namespace OfficeIMO.Excel {
             XNamespace ns = PackageRelationshipsNamespace;
             if (relationships.Root?.Name != ns + "Relationships") {
                 throw new XlsxTabularFastPathNotSupportedException(
-                    "The workbook relationship namespace is not supported by the native path.");
+                    "The package relationship namespace is not supported by the native path.");
             }
 
             var result = new Dictionary<string, PackageRelationship>(StringComparer.Ordinal);
-            foreach (XElement element in relationships.Root.Elements(ns + "Relationship")) {
+            foreach (XElement element in relationships.Root.Elements()) {
                 _options.CancellationToken.ThrowIfCancellationRequested();
+                if (element.Name != ns + "Relationship") {
+                    throw new XlsxTabularFastPathNotSupportedException(
+                        "The package relationships require the Open XML SDK fallback path.");
+                }
+
                 string? id = (string?)element.Attribute("Id");
                 string? type = (string?)element.Attribute("Type");
                 string? target = (string?)element.Attribute("Target");
                 if (string.IsNullOrWhiteSpace(id)
                     || string.IsNullOrWhiteSpace(type)
                     || string.IsNullOrWhiteSpace(target)
+                    || !IsValidRelationshipId(id!)
+                    || !Uri.TryCreate(target, UriKind.RelativeOrAbsolute, out _)
                     || result.ContainsKey(id!)) {
                     throw new XlsxTabularFastPathNotSupportedException(
-                        "The workbook relationships require the Open XML SDK fallback path.");
+                        "The package relationships require the Open XML SDK fallback path.");
                 }
 
                 result.Add(
@@ -380,10 +380,21 @@ namespace OfficeIMO.Excel {
                     "The workbook has no sheets collection.");
             }
 
+            XElement[] workbookSheets = sheetsElement.Elements(spreadsheet + "sheet").ToArray();
+            if (string.IsNullOrWhiteSpace(_options.SheetName)
+                && !_options.SheetIndex.HasValue
+                && workbookSheets.Length > 1) {
+                // The public multi-result reader still uses the SDK path. Stop before
+                // resolving every sheet and optional global part so that fallback does
+                // not pay the complete native metadata probe first.
+                throw new XlsxTabularFastPathNotSupportedException(
+                    "Multi-result XLSX reads retain the complete Open XML SDK path.");
+            }
+
             XNamespace transitionalRelationships = TransitionalOfficeRelationshipsNamespace;
             XNamespace strictRelationships = StrictOfficeRelationshipsNamespace;
             var sheets = new List<XlsxTabularSheet>();
-            foreach (XElement sheet in sheetsElement.Elements(spreadsheet + "sheet")) {
+            foreach (XElement sheet in workbookSheets) {
                 _options.CancellationToken.ThrowIfCancellationRequested();
                 string? name = (string?)sheet.Attribute("name");
                 string? relationshipId = (string?)sheet.Attribute(transitionalRelationships + "id")
@@ -518,11 +529,78 @@ namespace OfficeIMO.Excel {
         }
 
         private static string NormalizeContentTypePartName(string? partName) {
-            if (string.IsNullOrWhiteSpace(partName) || partName!.IndexOf('\\') >= 0) {
+            if (string.IsNullOrWhiteSpace(partName)
+                || !partName!.StartsWith("/", StringComparison.Ordinal)
+                || partName.StartsWith("//", StringComparison.Ordinal)
+                || partName.EndsWith("/", StringComparison.Ordinal)
+                || partName!.IndexOf('\\') >= 0
+                || partName.IndexOf('?') >= 0
+                || partName.IndexOf('#') >= 0
+                || partName.Any(static character => !IsNativeContentTypePartNameCharacter(character))) {
                 return string.Empty;
             }
 
-            return "/" + partName.TrimStart('/');
+            string[] segments = partName.Split('/');
+            if (segments.Length < 2
+                || segments.Skip(1).Any(static segment =>
+                    segment.Length == 0 || segment == "." || segment == "..")) {
+                return string.Empty;
+            }
+
+            return partName;
+        }
+
+        private static bool IsNativeContentTypePartNameCharacter(char character) =>
+            character is >= 'a' and <= 'z'
+            || character is >= 'A' and <= 'Z'
+            || character is >= '0' and <= '9'
+            || character is '/' or '-' or '_' or '.' or '~';
+
+        private static bool IsValidContentType(string? contentType) {
+            if (string.IsNullOrWhiteSpace(contentType)
+                || !string.Equals(contentType, contentType!.Trim(), StringComparison.Ordinal)) {
+                return false;
+            }
+
+            int separator = contentType.IndexOf('/');
+            return separator > 0
+                && separator == contentType.LastIndexOf('/')
+                && separator < contentType.Length - 1
+                && IsContentTypeToken(contentType, 0, separator)
+                && IsContentTypeToken(contentType, separator + 1, contentType.Length);
+        }
+
+        private static bool IsContentTypeToken(string contentType, int start, int end) {
+            for (int index = start; index < end; index++) {
+                if (!IsContentTypeTokenCharacter(contentType[index])) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private static bool IsContentTypeTokenCharacter(char character) =>
+            character is >= 'a' and <= 'z'
+            || character is >= 'A' and <= 'Z'
+            || character is >= '0' and <= '9'
+            || character is '!' or '#' or '$' or '%' or '&' or '\'' or '*'
+                or '+' or '-' or '.' or '^' or '_' or '`' or '|' or '~';
+
+        private static bool IsValidContentTypeExtension(string? extension) =>
+            !string.IsNullOrWhiteSpace(extension)
+            && extension!.All(static character =>
+                character is >= 'a' and <= 'z'
+                || character is >= 'A' and <= 'Z'
+                || character is >= '0' and <= '9'
+                || character is '-' or '_');
+
+        private static bool IsValidRelationshipId(string id) {
+            try {
+                XmlConvert.VerifyNCName(id);
+                return true;
+            } catch (XmlException) {
+                return false;
+            }
         }
 
         private static bool ReadRelationshipTargetMode(XElement relationship) {

--- a/OfficeIMO.Excel/Read/XlsxTabularWorkbook.cs
+++ b/OfficeIMO.Excel/Read/XlsxTabularWorkbook.cs
@@ -1,0 +1,524 @@
+#nullable enable
+
+using OfficeIMO.Core.Internal;
+using System.Data.Common;
+using System.Threading;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Owns the minimal validated package state needed by the forward-only XLSX reader.
+    /// Unsupported package shapes route back to <see cref="ExcelDocumentReader"/>.
+    /// </summary>
+    internal sealed class XlsxTabularWorkbook : IDisposable {
+        private const string PackageRelationshipsNamespace =
+            "http://schemas.openxmlformats.org/package/2006/relationships";
+        private const string PackageContentTypesNamespace =
+            "http://schemas.openxmlformats.org/package/2006/content-types";
+        private const string TransitionalOfficeRelationshipsNamespace =
+            "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+        private const string StrictOfficeRelationshipsNamespace =
+            "http://purl.oclc.org/ooxml/officeDocument/relationships";
+        private const string TransitionalSpreadsheetNamespace =
+            "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+        private const string StrictSpreadsheetNamespace =
+            "http://purl.oclc.org/ooxml/spreadsheetml/main";
+        private const string WorksheetRelationshipSuffix = "/worksheet";
+        private const string ChartSheetRelationshipSuffix = "/chartsheet";
+        private const string DialogSheetRelationshipSuffix = "/dialogsheet";
+        private const string MacroSheetRelationshipSuffix = "/macrosheet";
+        private const string InternationalMacroSheetRelationshipSuffix = "/intlMacrosheet";
+        private const string SharedStringsRelationshipSuffix = "/sharedStrings";
+        private const string StylesRelationshipSuffix = "/styles";
+        private const int MaximumMetadataPartBytes = 16 * 1024 * 1024;
+
+        private static readonly HashSet<string> SupportedWorkbookContentTypes = new(StringComparer.OrdinalIgnoreCase) {
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml",
+            "application/vnd.ms-excel.sheet.macroEnabled.main+xml",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.template.main+xml",
+            "application/vnd.ms-excel.template.macroEnabled.main+xml",
+            "application/vnd.ms-excel.addin.macroEnabled.main+xml"
+        };
+
+        private readonly OpenXmlPackagePartBufferReader _parts;
+        private readonly IDisposable? _ownedResource;
+        private readonly SharedStringCache _sharedStrings;
+        private readonly StylesCacheProvider _styles;
+        private readonly ExcelReadOptions _options;
+        private readonly XlsxTabularSheet[] _sheets;
+        private readonly string[] _tableNames;
+        private bool _disposed;
+
+        private XlsxTabularWorkbook(
+            OpenXmlPackagePartBufferReader parts,
+            IDisposable? ownedResource,
+            ExcelReadOptions options) {
+            _parts = parts;
+            _ownedResource = ownedResource;
+            _options = options;
+            options.CancellationToken.ThrowIfCancellationRequested();
+
+            string workbookPartName = ReadWorkbookPartName();
+            ValidateWorkbookContentType(workbookPartName);
+            IReadOnlyDictionary<string, PackageRelationship> workbookRelationships =
+                ReadRelationships(workbookPartName);
+            (_sheets, ExcelDateSystem dateSystem) = ReadWorkbook(
+                workbookPartName,
+                workbookRelationships);
+            if (_sheets.Length == 0) {
+                throw new XlsxTabularFastPathNotSupportedException(
+                    "The workbook contains no native-path worksheets.");
+            }
+
+            DateSystem = dateSystem;
+            _tableNames = _sheets.Select(static sheet => sheet.Name).ToArray();
+            int maximumPartBytes = options.MaxInputBytes > int.MaxValue
+                ? int.MaxValue
+                : checked((int)options.MaxInputBytes);
+
+            string? sharedStringsPart = ResolveOptionalPart(
+                workbookPartName,
+                workbookRelationships,
+                SharedStringsRelationshipSuffix,
+                "shared-string table");
+            _sharedStrings = sharedStringsPart == null
+                ? SharedStringCache.Empty(options)
+                : SharedStringCache.Build(
+                    () => _parts.OpenPart(sharedStringsPart, maximumPartBytes),
+                    options);
+
+            string? stylesPart = ResolveOptionalPart(
+                workbookPartName,
+                workbookRelationships,
+                StylesRelationshipSuffix,
+                "styles");
+            _styles = stylesPart == null
+                ? new StylesCacheProvider(StylesCache.Empty())
+                : new StylesCacheProvider(
+                    () => _parts.OpenPart(stylesPart, maximumPartBytes));
+        }
+
+        internal IReadOnlyList<string> TableNames => _tableNames;
+
+        internal ExcelDateSystem DateSystem { get; }
+
+        internal static XlsxTabularWorkbook Open(string path, ExcelReadOptions options) {
+            if (string.IsNullOrWhiteSpace(path)) {
+                throw new ArgumentException("File path cannot be empty.", nameof(path));
+            }
+            if (options == null) {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            SharedReadOnlyFileSnapshot? snapshot = null;
+            OpenXmlPackagePartBufferReader? parts = null;
+            try {
+                snapshot = SharedReadOnlyFileSnapshot.Open(path);
+                if (snapshot.Length > options.MaxInputBytes) {
+                    throw new InvalidDataException(
+                        $"Workbook input contains {snapshot.Length} bytes, exceeding the configured limit of {options.MaxInputBytes} bytes.");
+                }
+
+                parts = OpenXmlPackagePartBufferReader.TryOpen(snapshot.CreateView(bufferSize: 1))
+                    ?? throw new XlsxTabularFastPathNotSupportedException(
+                        "The workbook is not a readable Open XML package.");
+                var workbook = new XlsxTabularWorkbook(parts, snapshot, options);
+                parts = null;
+                snapshot = null;
+                return workbook;
+            } catch {
+                parts?.Dispose();
+                snapshot?.Dispose();
+                throw;
+            }
+        }
+
+        internal static XlsxTabularWorkbook Open(byte[] bytes, ExcelReadOptions options) {
+            if (bytes == null) {
+                throw new ArgumentNullException(nameof(bytes));
+            }
+            if (options == null) {
+                throw new ArgumentNullException(nameof(options));
+            }
+            if (bytes.LongLength > options.MaxInputBytes) {
+                throw new InvalidDataException(
+                    $"Workbook input contains {bytes.LongLength} bytes, exceeding the configured limit of {options.MaxInputBytes} bytes.");
+            }
+
+            OpenXmlPackagePartBufferReader parts = OpenXmlPackagePartBufferReader.TryOpen(bytes)
+                ?? throw new XlsxTabularFastPathNotSupportedException(
+                    "The workbook is not a readable Open XML package.");
+            try {
+                var workbook = new XlsxTabularWorkbook(parts, ownedResource: null, options);
+                parts = null!;
+                return workbook;
+            } catch {
+                parts.Dispose();
+                throw;
+            }
+        }
+
+        internal DbDataReader OpenTable(
+            string tableName,
+            bool hasHeaderRow,
+            CancellationToken cancellationToken) {
+            ThrowIfDisposed();
+            XlsxTabularSheet? sheet = _sheets.FirstOrDefault(
+                candidate => string.Equals(candidate.Name, tableName, StringComparison.OrdinalIgnoreCase));
+            if (sheet == null) {
+                throw new KeyNotFoundException($"Worksheet '{tableName}' was not found.");
+            }
+
+            var reader = new ExcelSheetReader(
+                sheet.Name,
+                sheet.PartName,
+                _sharedStrings,
+                _styles,
+                _options,
+                DateSystem,
+                _parts);
+            return (DbDataReader)reader.ReadUsedRangeAsDataReader(
+                hasHeaderRow,
+                schemaSampleRows: 0,
+                cancellationToken);
+        }
+
+        private string ReadWorkbookPartName() {
+            XDocument relationships = ReadXmlPart("_rels/.rels", MaximumMetadataPartBytes);
+            XNamespace ns = PackageRelationshipsNamespace;
+            if (relationships.Root?.Name != ns + "Relationships") {
+                throw new XlsxTabularFastPathNotSupportedException(
+                    "The package root relationship namespace is not supported by the native path.");
+            }
+
+            XElement[] candidates = relationships.Root
+                .Elements(ns + "Relationship")
+                .Where(element =>
+                    IsOfficeRelationship(
+                        (string?)element.Attribute("Type"),
+                        "/officeDocument"))
+                .ToArray();
+            if (candidates.Length != 1
+                || string.Equals(
+                    (string?)candidates[0].Attribute("TargetMode"),
+                    "External",
+                    StringComparison.OrdinalIgnoreCase)) {
+                throw new XlsxTabularFastPathNotSupportedException(
+                    "The package does not contain one internal Office workbook relationship.");
+            }
+
+            string? target = (string?)candidates[0].Attribute("Target");
+            if (string.IsNullOrWhiteSpace(target)) {
+                throw new XlsxTabularFastPathNotSupportedException(
+                    "The package workbook relationship has no target.");
+            }
+
+            string workbookPartName = ResolveTarget(string.Empty, target!);
+            if (!_parts.ContainsPart(workbookPartName)) {
+                throw new XlsxTabularFastPathNotSupportedException(
+                    "The package workbook relationship target is missing.");
+            }
+
+            return workbookPartName;
+        }
+
+        private void ValidateWorkbookContentType(string workbookPartName) {
+            XDocument contentTypes = ReadXmlPart("[Content_Types].xml", MaximumMetadataPartBytes);
+            XNamespace ns = PackageContentTypesNamespace;
+            if (contentTypes.Root?.Name != ns + "Types") {
+                throw new XlsxTabularFastPathNotSupportedException(
+                    "The package content-type manifest namespace is not supported by the native path.");
+            }
+
+            string expectedPartName = "/" + workbookPartName.TrimStart('/');
+            string?[] matches = contentTypes.Root
+                .Elements(ns + "Override")
+                .Where(element => string.Equals(
+                    NormalizeContentTypePartName((string?)element.Attribute("PartName")),
+                    expectedPartName,
+                    StringComparison.OrdinalIgnoreCase))
+                .Select(element => (string?)element.Attribute("ContentType"))
+                .Take(2)
+                .ToArray();
+            if (matches.Length != 1
+                || string.IsNullOrWhiteSpace(matches[0])
+                || !SupportedWorkbookContentTypes.Contains(matches[0]!)) {
+                throw new XlsxTabularFastPathNotSupportedException(
+                    "The workbook content type is not supported by the native path.");
+            }
+        }
+
+        private IReadOnlyDictionary<string, PackageRelationship> ReadRelationships(
+            string sourcePartName) {
+            string relationshipPartName = GetRelationshipPartName(sourcePartName);
+            XDocument relationships = ReadXmlPart(
+                relationshipPartName,
+                MaximumMetadataPartBytes);
+            XNamespace ns = PackageRelationshipsNamespace;
+            if (relationships.Root?.Name != ns + "Relationships") {
+                throw new XlsxTabularFastPathNotSupportedException(
+                    "The workbook relationship namespace is not supported by the native path.");
+            }
+
+            var result = new Dictionary<string, PackageRelationship>(StringComparer.Ordinal);
+            foreach (XElement element in relationships.Root.Elements(ns + "Relationship")) {
+                _options.CancellationToken.ThrowIfCancellationRequested();
+                string? id = (string?)element.Attribute("Id");
+                string? type = (string?)element.Attribute("Type");
+                string? target = (string?)element.Attribute("Target");
+                if (string.IsNullOrWhiteSpace(id)
+                    || string.IsNullOrWhiteSpace(type)
+                    || string.IsNullOrWhiteSpace(target)
+                    || result.ContainsKey(id!)) {
+                    throw new XlsxTabularFastPathNotSupportedException(
+                        "The workbook relationships require the Open XML SDK fallback path.");
+                }
+
+                result.Add(
+                    id!,
+                    new PackageRelationship(
+                        type!,
+                        target!,
+                        string.Equals(
+                            (string?)element.Attribute("TargetMode"),
+                            "External",
+                            StringComparison.OrdinalIgnoreCase)));
+            }
+
+            return result;
+        }
+
+        private (XlsxTabularSheet[] Sheets, ExcelDateSystem DateSystem) ReadWorkbook(
+            string workbookPartName,
+            IReadOnlyDictionary<string, PackageRelationship> relationships) {
+            XDocument workbook = ReadXmlPart(workbookPartName, MaximumMetadataPartBytes);
+            if (workbook.Root == null
+                || (workbook.Root.Name.NamespaceName != TransitionalSpreadsheetNamespace
+                    && workbook.Root.Name.NamespaceName != StrictSpreadsheetNamespace)
+                || workbook.Root.Name.LocalName != "workbook") {
+                throw new XlsxTabularFastPathNotSupportedException(
+                    "The workbook XML namespace is not supported by the native path.");
+            }
+
+            XNamespace spreadsheet = workbook.Root.Name.Namespace;
+            ExcelDateSystem dateSystem = ExcelDateSystem.NineteenHundred;
+            XElement? workbookProperties = workbook.Root.Element(spreadsheet + "workbookPr");
+            string? date1904 = (string?)workbookProperties?.Attribute("date1904");
+            if (!string.IsNullOrEmpty(date1904)) {
+                if (date1904 == "1" || string.Equals(date1904, "true", StringComparison.OrdinalIgnoreCase)) {
+                    dateSystem = ExcelDateSystem.NineteenFour;
+                } else if (date1904 != "0" && !string.Equals(date1904, "false", StringComparison.OrdinalIgnoreCase)) {
+                    throw new XlsxTabularFastPathNotSupportedException(
+                        "The workbook date-system flag requires the Open XML SDK fallback path.");
+                }
+            }
+
+            XElement? sheetsElement = workbook.Root.Element(spreadsheet + "sheets");
+            if (sheetsElement == null) {
+                throw new XlsxTabularFastPathNotSupportedException(
+                    "The workbook has no sheets collection.");
+            }
+
+            XNamespace transitionalRelationships = TransitionalOfficeRelationshipsNamespace;
+            XNamespace strictRelationships = StrictOfficeRelationshipsNamespace;
+            var sheets = new List<XlsxTabularSheet>();
+            foreach (XElement sheet in sheetsElement.Elements(spreadsheet + "sheet")) {
+                _options.CancellationToken.ThrowIfCancellationRequested();
+                string? name = (string?)sheet.Attribute("name");
+                string? relationshipId = (string?)sheet.Attribute(transitionalRelationships + "id")
+                    ?? (string?)sheet.Attribute(strictRelationships + "id");
+                if (string.IsNullOrEmpty(name)
+                    || string.IsNullOrEmpty(relationshipId)
+                    || !relationships.TryGetValue(relationshipId!, out PackageRelationship? relationship)) {
+                    throw new XlsxTabularFastPathNotSupportedException(
+                        "A workbook sheet requires the Open XML SDK fallback path.");
+                }
+                if (relationship.IsExternal) {
+                    throw new InvalidDataException(
+                        $"The OpenXML worksheet '{name}' references external relationship '{relationshipId}'.");
+                }
+                if (!IsOfficeRelationship(relationship.Type, WorksheetRelationshipSuffix)) {
+                    if (IsSupportedNonWorksheetRelationship(relationship.Type)) {
+                        continue;
+                    }
+
+                    throw new XlsxTabularFastPathNotSupportedException(
+                        "A workbook sheet relationship requires the Open XML SDK fallback path.");
+                }
+
+                string partName = ResolveTarget(workbookPartName, relationship.Target);
+                if (!_parts.ContainsPart(partName)) {
+                    throw new InvalidDataException(
+                        $"The OpenXML worksheet '{name}' references missing relationship '{relationshipId}'.");
+                }
+                sheets.Add(new XlsxTabularSheet(name!, partName));
+            }
+
+            return (sheets.ToArray(), dateSystem);
+        }
+
+        private string? ResolveOptionalPart(
+            string workbookPartName,
+            IReadOnlyDictionary<string, PackageRelationship> relationships,
+            string relationshipSuffix,
+            string relationshipName) {
+            PackageRelationship[] matches = relationships.Values
+                .Where(relationship => IsOfficeRelationship(
+                    relationship.Type,
+                    relationshipSuffix))
+                .Take(2)
+                .ToArray();
+            if (matches.Length == 0) {
+                return null;
+            }
+            if (matches.Length != 1 || matches[0].IsExternal) {
+                throw new XlsxTabularFastPathNotSupportedException(
+                    $"The workbook {relationshipName} relationship requires the Open XML SDK fallback path.");
+            }
+
+            string partName = ResolveTarget(workbookPartName, matches[0].Target);
+            if (!_parts.ContainsPart(partName)) {
+                throw new InvalidDataException(
+                    $"The workbook {relationshipName} part '{partName}' is missing.");
+            }
+
+            return partName;
+        }
+
+        private XDocument ReadXmlPart(string partName, int maximumBytes) {
+            try {
+                using Stream stream = _parts.OpenPart(partName, maximumBytes);
+                using XmlReader reader = XmlReader.Create(stream, new XmlReaderSettings {
+                    DtdProcessing = DtdProcessing.Prohibit,
+                    XmlResolver = null,
+                    CloseInput = false,
+                    MaxCharactersInDocument = maximumBytes
+                });
+                return XDocument.Load(reader, LoadOptions.None);
+            } catch (XmlException exception) {
+                throw new XlsxTabularFastPathNotSupportedException(
+                    $"Package part '{partName}' requires the Open XML SDK fallback path.",
+                    exception);
+            }
+        }
+
+        private static string ResolveTarget(string sourcePartName, string target) {
+            if (string.IsNullOrWhiteSpace(target)
+                || target.IndexOf('\\') >= 0
+                || Uri.TryCreate(target, UriKind.Absolute, out _)) {
+                throw new XlsxTabularFastPathNotSupportedException(
+                    "A package relationship target is not supported by the native path.");
+            }
+
+            string source = sourcePartName.TrimStart('/');
+            int separator = source.LastIndexOf('/');
+            string directory = separator < 0 ? string.Empty : source.Substring(0, separator + 1);
+            string combined = target.StartsWith("/", StringComparison.Ordinal)
+                ? target.TrimStart('/')
+                : directory + target;
+            var segments = new List<string>();
+            foreach (string segment in combined.Split('/')) {
+                if (segment.Length == 0 || segment == ".") {
+                    continue;
+                }
+                if (segment == "..") {
+                    if (segments.Count == 0) {
+                        throw new XlsxTabularFastPathNotSupportedException(
+                            "A package relationship target escapes the package root.");
+                    }
+                    segments.RemoveAt(segments.Count - 1);
+                    continue;
+                }
+                if (segment.IndexOf('%') >= 0) {
+                    throw new XlsxTabularFastPathNotSupportedException(
+                        "An encoded package relationship target requires the Open XML SDK fallback path.");
+                }
+                segments.Add(segment);
+            }
+
+            if (segments.Count == 0) {
+                throw new XlsxTabularFastPathNotSupportedException(
+                    "A package relationship target does not identify a part.");
+            }
+
+            return string.Join("/", segments);
+        }
+
+        private static string GetRelationshipPartName(string sourcePartName) {
+            string source = sourcePartName.TrimStart('/');
+            int separator = source.LastIndexOf('/');
+            string directory = separator < 0 ? string.Empty : source.Substring(0, separator + 1);
+            string fileName = separator < 0 ? source : source.Substring(separator + 1);
+            return directory + "_rels/" + fileName + ".rels";
+        }
+
+        private static string NormalizeContentTypePartName(string? partName) {
+            if (string.IsNullOrWhiteSpace(partName) || partName!.IndexOf('\\') >= 0) {
+                return string.Empty;
+            }
+
+            return "/" + partName.TrimStart('/');
+        }
+
+        private static bool IsSupportedNonWorksheetRelationship(string relationshipType) =>
+            IsOfficeRelationship(relationshipType, ChartSheetRelationshipSuffix)
+            || IsOfficeRelationship(relationshipType, DialogSheetRelationshipSuffix)
+            || IsOfficeRelationship(relationshipType, MacroSheetRelationshipSuffix)
+            || IsOfficeRelationship(relationshipType, InternationalMacroSheetRelationshipSuffix);
+
+        private static bool IsOfficeRelationship(string? relationshipType, string suffix) =>
+            string.Equals(
+                relationshipType,
+                TransitionalOfficeRelationshipsNamespace + suffix,
+                StringComparison.Ordinal)
+            || string.Equals(
+                relationshipType,
+                StrictOfficeRelationshipsNamespace + suffix,
+                StringComparison.Ordinal);
+
+        private void ThrowIfDisposed() {
+            if (_disposed) {
+                throw new ObjectDisposedException(nameof(XlsxTabularWorkbook));
+            }
+        }
+
+        public void Dispose() {
+            if (_disposed) {
+                return;
+            }
+
+            _disposed = true;
+            try {
+                _parts.Dispose();
+            } finally {
+                _ownedResource?.Dispose();
+            }
+        }
+
+        private sealed class PackageRelationship {
+            internal PackageRelationship(string type, string target, bool isExternal) {
+                Type = type;
+                Target = target;
+                IsExternal = isExternal;
+            }
+
+            internal string Type { get; }
+
+            internal string Target { get; }
+
+            internal bool IsExternal { get; }
+        }
+
+        private sealed class XlsxTabularSheet {
+            internal XlsxTabularSheet(string name, string partName) {
+                Name = name;
+                PartName = partName;
+            }
+
+            internal string Name { get; }
+
+            internal string PartName { get; }
+        }
+    }
+}

--- a/OfficeIMO.Excel/Read/XlsxTabularWorkbook.cs
+++ b/OfficeIMO.Excel/Read/XlsxTabularWorkbook.cs
@@ -32,6 +32,12 @@ namespace OfficeIMO.Excel {
         private const string SharedStringsRelationshipSuffix = "/sharedStrings";
         private const string StylesRelationshipSuffix = "/styles";
         private const int MaximumMetadataPartBytes = 16 * 1024 * 1024;
+        private const string WorksheetContentType =
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml";
+        private const string SharedStringsContentType =
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml";
+        private const string StylesContentType =
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml";
 
         private static readonly HashSet<string> SupportedWorkbookContentTypes = new(StringComparer.OrdinalIgnoreCase) {
             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml",
@@ -46,6 +52,7 @@ namespace OfficeIMO.Excel {
         private readonly SharedStringCache _sharedStrings;
         private readonly StylesCacheProvider _styles;
         private readonly ExcelReadOptions _options;
+        private readonly XDocument _contentTypes;
         private readonly XlsxTabularSheet[] _sheets;
         private readonly string[] _tableNames;
         private bool _disposed;
@@ -59,8 +66,12 @@ namespace OfficeIMO.Excel {
             _options = options;
             options.CancellationToken.ThrowIfCancellationRequested();
 
+            _contentTypes = ReadContentTypes();
             string workbookPartName = ReadWorkbookPartName();
-            ValidateWorkbookContentType(workbookPartName);
+            ValidatePartContentType(
+                workbookPartName,
+                SupportedWorkbookContentTypes,
+                "workbook");
             IReadOnlyDictionary<string, PackageRelationship> workbookRelationships =
                 ReadRelationships(workbookPartName);
             (_sheets, ExcelDateSystem dateSystem) = ReadWorkbook(
@@ -81,7 +92,8 @@ namespace OfficeIMO.Excel {
                 workbookPartName,
                 workbookRelationships,
                 SharedStringsRelationshipSuffix,
-                "shared-string table");
+                "shared-string table",
+                SharedStringsContentType);
             _sharedStrings = sharedStringsPart == null
                 ? SharedStringCache.Empty(options)
                 : SharedStringCache.Build(
@@ -92,7 +104,8 @@ namespace OfficeIMO.Excel {
                 workbookPartName,
                 workbookRelationships,
                 StylesRelationshipSuffix,
-                "styles");
+                "styles",
+                StylesContentType);
             _styles = stylesPart == null
                 ? new StylesCacheProvider(StylesCache.Empty())
                 : new StylesCacheProvider(
@@ -192,23 +205,23 @@ namespace OfficeIMO.Excel {
                     "The package root relationship namespace is not supported by the native path.");
             }
 
-            XElement[] candidates = relationships.Root
+            var candidates = relationships.Root
                 .Elements(ns + "Relationship")
-                .Where(element =>
+                .Select(element => new {
+                    Element = element,
+                    IsExternal = ReadRelationshipTargetMode(element)
+                })
+                .Where(candidate =>
                     IsOfficeRelationship(
-                        (string?)element.Attribute("Type"),
+                        (string?)candidate.Element.Attribute("Type"),
                         "/officeDocument"))
                 .ToArray();
-            if (candidates.Length != 1
-                || string.Equals(
-                    (string?)candidates[0].Attribute("TargetMode"),
-                    "External",
-                    StringComparison.OrdinalIgnoreCase)) {
+            if (candidates.Length != 1 || candidates[0].IsExternal) {
                 throw new XlsxTabularFastPathNotSupportedException(
                     "The package does not contain one internal Office workbook relationship.");
             }
 
-            string? target = (string?)candidates[0].Attribute("Target");
+            string? target = (string?)candidates[0].Element.Attribute("Target");
             if (string.IsNullOrWhiteSpace(target)) {
                 throw new XlsxTabularFastPathNotSupportedException(
                     "The package workbook relationship has no target.");
@@ -223,7 +236,7 @@ namespace OfficeIMO.Excel {
             return workbookPartName;
         }
 
-        private void ValidateWorkbookContentType(string workbookPartName) {
+        private XDocument ReadContentTypes() {
             XDocument contentTypes = ReadXmlPart("[Content_Types].xml", MaximumMetadataPartBytes);
             XNamespace ns = PackageContentTypesNamespace;
             if (contentTypes.Root?.Name != ns + "Types") {
@@ -231,8 +244,35 @@ namespace OfficeIMO.Excel {
                     "The package content-type manifest namespace is not supported by the native path.");
             }
 
-            string expectedPartName = "/" + workbookPartName.TrimStart('/');
-            string?[] matches = contentTypes.Root
+            return contentTypes;
+        }
+
+        private void ValidatePartContentType(
+            string partName,
+            ISet<string> supportedContentTypes,
+            string role) {
+            string? contentType = GetPartContentType(partName);
+            if (string.IsNullOrWhiteSpace(contentType)
+                || !supportedContentTypes.Contains(contentType!)) {
+                throw new XlsxTabularFastPathNotSupportedException(
+                    $"The {role} content type is not supported by the native path.");
+            }
+        }
+
+        private void ValidatePartContentType(string partName, string expectedContentType, string role) {
+            string? contentType = GetPartContentType(partName);
+            if (!string.Equals(contentType, expectedContentType, StringComparison.OrdinalIgnoreCase)) {
+                throw new XlsxTabularFastPathNotSupportedException(
+                    $"The {role} content type is not supported by the native path.");
+            }
+        }
+
+        private string? GetPartContentType(string partName) {
+            XNamespace ns = PackageContentTypesNamespace;
+            XElement root = _contentTypes.Root!;
+
+            string expectedPartName = "/" + partName.TrimStart('/');
+            string?[] matches = root
                 .Elements(ns + "Override")
                 .Where(element => string.Equals(
                     NormalizeContentTypePartName((string?)element.Attribute("PartName")),
@@ -241,12 +281,35 @@ namespace OfficeIMO.Excel {
                 .Select(element => (string?)element.Attribute("ContentType"))
                 .Take(2)
                 .ToArray();
-            if (matches.Length != 1
-                || string.IsNullOrWhiteSpace(matches[0])
-                || !SupportedWorkbookContentTypes.Contains(matches[0]!)) {
+            if (matches.Length > 1) {
                 throw new XlsxTabularFastPathNotSupportedException(
-                    "The workbook content type is not supported by the native path.");
+                    "Duplicate package content-type overrides require the Open XML SDK fallback path.");
             }
+            if (matches.Length == 1) {
+                return matches[0];
+            }
+
+            int extensionSeparator = partName.LastIndexOf('.');
+            if (extensionSeparator < 0 || extensionSeparator == partName.Length - 1) {
+                return null;
+            }
+
+            string extension = partName.Substring(extensionSeparator + 1);
+            matches = root
+                .Elements(ns + "Default")
+                .Where(element => string.Equals(
+                    (string?)element.Attribute("Extension"),
+                    extension,
+                    StringComparison.OrdinalIgnoreCase))
+                .Select(element => (string?)element.Attribute("ContentType"))
+                .Take(2)
+                .ToArray();
+            if (matches.Length > 1) {
+                throw new XlsxTabularFastPathNotSupportedException(
+                    "Duplicate package content-type defaults require the Open XML SDK fallback path.");
+            }
+
+            return matches.Length == 1 ? matches[0] : null;
         }
 
         private IReadOnlyDictionary<string, PackageRelationship> ReadRelationships(
@@ -280,10 +343,7 @@ namespace OfficeIMO.Excel {
                     new PackageRelationship(
                         type!,
                         target!,
-                        string.Equals(
-                            (string?)element.Attribute("TargetMode"),
-                            "External",
-                            StringComparison.OrdinalIgnoreCase)));
+                        ReadRelationshipTargetMode(element)));
             }
 
             return result;
@@ -340,7 +400,8 @@ namespace OfficeIMO.Excel {
                 }
                 if (!IsOfficeRelationship(relationship.Type, WorksheetRelationshipSuffix)) {
                     if (IsSupportedNonWorksheetRelationship(relationship.Type)) {
-                        continue;
+                        throw new XlsxTabularFastPathNotSupportedException(
+                            "Non-worksheet sheet relationships require the Open XML SDK fallback path.");
                     }
 
                     throw new XlsxTabularFastPathNotSupportedException(
@@ -352,6 +413,7 @@ namespace OfficeIMO.Excel {
                     throw new InvalidDataException(
                         $"The OpenXML worksheet '{name}' references missing relationship '{relationshipId}'.");
                 }
+                ValidatePartContentType(partName, WorksheetContentType, "worksheet");
                 sheets.Add(new XlsxTabularSheet(name!, partName));
             }
 
@@ -362,7 +424,8 @@ namespace OfficeIMO.Excel {
             string workbookPartName,
             IReadOnlyDictionary<string, PackageRelationship> relationships,
             string relationshipSuffix,
-            string relationshipName) {
+            string relationshipName,
+            string expectedContentType) {
             PackageRelationship[] matches = relationships.Values
                 .Where(relationship => IsOfficeRelationship(
                     relationship.Type,
@@ -382,6 +445,7 @@ namespace OfficeIMO.Excel {
                 throw new InvalidDataException(
                     $"The workbook {relationshipName} part '{partName}' is missing.");
             }
+            ValidatePartContentType(partName, expectedContentType, relationshipName);
 
             return partName;
         }
@@ -459,6 +523,19 @@ namespace OfficeIMO.Excel {
             }
 
             return "/" + partName.TrimStart('/');
+        }
+
+        private static bool ReadRelationshipTargetMode(XElement relationship) {
+            XAttribute? attribute = relationship.Attribute("TargetMode");
+            if (attribute == null || attribute.Value == "Internal") {
+                return false;
+            }
+            if (attribute.Value == "External") {
+                return true;
+            }
+
+            throw new XlsxTabularFastPathNotSupportedException(
+                "A package relationship target mode requires the Open XML SDK fallback path.");
         }
 
         private static bool IsSupportedNonWorksheetRelationship(string relationshipType) =>


### PR DESCRIPTION
Depends on #2362.

## Summary

- add a package-native setup path for canonical single-worksheet XLSX data-reader workloads
- retain eager worksheet validation and route unsupported or ambiguous package shapes through the Open XML SDK
- validate workbook, worksheet, shared-string, and styles relationships, content types, targets, and package bounds before use
- reuse validated shared-string indexes during typed reads without weakening formula behavior
- preserve path/byte-array ownership and compatibility when the optional native ZIP index cannot represent an otherwise SDK-readable package

## Validation

- OfficeIMO.Excel builds cleanly for netstandard2.0, net472, net8.0, and net10.0
- focused data-reader/package tests pass on net472, net8.0, and net10.0
- full net10.0 suite: 3,704 passed, 5 skipped; two pre-existing image raster baseline differences remain unrelated to this change
- independent local review and targeted confirmation found no remaining P0-P2 package-validation issues