### PR TITLE
Accelerate invariant XLSX number parsing

### DIFF
--- a/OfficeIMO.Excel.Tests/Excel.Utf8NumberParser.cs
+++ b/OfficeIMO.Excel.Tests/Excel.Utf8NumberParser.cs
@@ -19,11 +19,60 @@ public partial class Excel {
     [InlineData("0.0000000000000000000001")]
     [InlineData("123456789012345")]
     [InlineData("1.23456789012345")]
+    [InlineData("999999999999999")]
+    [InlineData("0.999999999999999")]
+    [InlineData("0.100000000000005")]
+    [InlineData("-0.0000000000000000000001")]
+    [InlineData("000000000000000000000000000000001.25")]
     public void Utf8NumberParser_CommonFixedPointMatchesGeneralParser(string text) {
         byte[] utf8 = Encoding.UTF8.GetBytes(text);
         Assert.True(Utf8Parser.TryParse(utf8, out double expected, out int consumed));
         Assert.Equal(utf8.Length, consumed);
 
+        Assert.True(ExcelUtf8NumberParser.TryParseCommonFixedPoint(utf8, out double actual));
+        Assert.Equal(BitConverter.DoubleToInt64Bits(expected), BitConverter.DoubleToInt64Bits(actual));
+    }
+
+    [Fact]
+    public void Utf8NumberParser_AllSupportedScalesMatchGeneralParserBitForBit() {
+        var random = new Random(0x51CA1E);
+        for (int scale = 1; scale <= 22; scale++) {
+            for (int sample = 0; sample < 1_000; sample++) {
+                int digitCount = random.Next(1, 16);
+                long lowerBound = digitCount == 1
+                    ? 1
+                    : (long)Math.Pow(10, digitCount - 1);
+                long upperBound = digitCount == 15
+                    ? 1_000_000_000_000_000L
+                    : (long)Math.Pow(10, digitCount);
+                long mantissa = random.NextInt64(lowerBound, upperBound);
+                string digits = mantissa.ToString(CultureInfo.InvariantCulture);
+                string unsigned = scale < digits.Length
+                    ? digits.Insert(digits.Length - scale, ".")
+                    : "0." + new string('0', scale - digits.Length) + digits;
+                string text = (sample & 1) == 0 ? unsigned : "-" + unsigned;
+                AssertCommonParserMatchesGeneralParser(text);
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData("1234567890123456")]
+    [InlineData("0.00000000000000000000001")]
+    [InlineData("1.000000000000000")]
+    public void Utf8NumberParser_AdjacentPrecisionBoundariesUseGeneralFallback(string text) {
+        byte[] utf8 = Encoding.UTF8.GetBytes(text);
+        Assert.False(ExcelUtf8NumberParser.TryParseCommonFixedPoint(utf8, out _));
+        Assert.True(ExcelUtf8NumberParser.TryParseDouble(utf8, out double actual));
+        Assert.True(Utf8Parser.TryParse(utf8, out double expected, out int consumed));
+        Assert.Equal(utf8.Length, consumed);
+        Assert.Equal(BitConverter.DoubleToInt64Bits(expected), BitConverter.DoubleToInt64Bits(actual));
+    }
+
+    private static void AssertCommonParserMatchesGeneralParser(string text) {
+        byte[] utf8 = Encoding.UTF8.GetBytes(text);
+        Assert.True(Utf8Parser.TryParse(utf8, out double expected, out int consumed));
+        Assert.Equal(utf8.Length, consumed);
         Assert.True(ExcelUtf8NumberParser.TryParseCommonFixedPoint(utf8, out double actual));
         Assert.Equal(BitConverter.DoubleToInt64Bits(expected), BitConverter.DoubleToInt64Bits(actual));
     }

--- a/OfficeIMO.Excel.Tests/Excel.Utf8NumberParser.cs
+++ b/OfficeIMO.Excel.Tests/Excel.Utf8NumberParser.cs
@@ -1,0 +1,86 @@
+using System.Buffers.Text;
+using System.Globalization;
+using System.Text;
+using Xunit;
+
+namespace OfficeIMO.Excel.Tests;
+
+public partial class Excel {
+#if NET8_0_OR_GREATER
+    [Theory]
+    [InlineData("0")]
+    [InlineData("-0")]
+    [InlineData("+0")]
+    [InlineData("42")]
+    [InlineData("-42")]
+    [InlineData(".5")]
+    [InlineData("1.")]
+    [InlineData("000000000000000123")]
+    [InlineData("0.0000000000000000000001")]
+    [InlineData("123456789012345")]
+    [InlineData("1.23456789012345")]
+    public void Utf8NumberParser_CommonFixedPointMatchesGeneralParser(string text) {
+        byte[] utf8 = Encoding.UTF8.GetBytes(text);
+        Assert.True(Utf8Parser.TryParse(utf8, out double expected, out int consumed));
+        Assert.Equal(utf8.Length, consumed);
+
+        Assert.True(ExcelUtf8NumberParser.TryParseCommonFixedPoint(utf8, out double actual));
+        Assert.Equal(BitConverter.DoubleToInt64Bits(expected), BitConverter.DoubleToInt64Bits(actual));
+    }
+#endif
+
+    [Theory]
+    [InlineData("1234567890123456")]
+    [InlineData("1.234567890123456")]
+    [InlineData("1E+100")]
+    [InlineData("5e-324")]
+    public void Utf8NumberParser_UncommonFormsRetainGeneralParserFallback(string text) {
+        byte[] utf8 = Encoding.UTF8.GetBytes(text);
+#if NET8_0_OR_GREATER
+        Assert.False(ExcelUtf8NumberParser.TryParseCommonFixedPoint(utf8, out _));
+#endif
+        Assert.True(Utf8Parser.TryParse(utf8, out double expected, out int consumed));
+        Assert.Equal(utf8.Length, consumed);
+
+        Assert.True(ExcelUtf8NumberParser.TryParseDouble(utf8, out double actual));
+        Assert.Equal(BitConverter.DoubleToInt64Bits(expected), BitConverter.DoubleToInt64Bits(actual));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("+")]
+    [InlineData(".")]
+    [InlineData("1.2.3")]
+    [InlineData("12x")]
+    [InlineData(" 12")]
+    [InlineData("12 ")]
+    public void Utf8NumberParser_RejectsIncompleteOrPartiallyConsumedInput(string text) {
+        Assert.False(ExcelUtf8NumberParser.TryParseDouble(Encoding.UTF8.GetBytes(text), out _));
+    }
+
+    [Fact]
+    public void Utf8NumberParser_RandomCommonValuesMatchGeneralParserBitForBit() {
+        var random = new Random(0x5EED);
+        for (int index = 0; index < 10_000; index++) {
+            int whole = random.Next(0, 1_000_000_000);
+            int fraction = random.Next(0, 1_000_000);
+            string sign = (index & 1) == 0 ? string.Empty : "-";
+            string text = string.Format(
+                CultureInfo.InvariantCulture,
+                "{0}{1}.{2:D6}",
+                sign,
+                whole,
+                fraction);
+            byte[] utf8 = Encoding.UTF8.GetBytes(text);
+
+            Assert.True(Utf8Parser.TryParse(utf8, out double expected, out int consumed));
+            Assert.Equal(utf8.Length, consumed);
+#if NET8_0_OR_GREATER
+            Assert.True(ExcelUtf8NumberParser.TryParseCommonFixedPoint(utf8, out double actual));
+#else
+            Assert.True(ExcelUtf8NumberParser.TryParseDouble(utf8, out double actual));
+#endif
+            Assert.Equal(BitConverter.DoubleToInt64Bits(expected), BitConverter.DoubleToInt64Bits(actual));
+        }
+    }
+}

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Utf8.cs
@@ -994,7 +994,7 @@ namespace OfficeIMO.Excel {
             }
 
             private static bool TryParseDouble(ReadOnlySpan<byte> value, out double result) {
-                return Utf8Parser.TryParse(value, out result, out int consumed) && consumed == value.Length;
+                return ExcelUtf8NumberParser.TryParseDouble(value, out result);
             }
 
             private static bool TryParseInt32(ReadOnlySpan<byte> value, out int result) {

--- a/OfficeIMO.Excel/Read/ExcelUtf8NumberParser.cs
+++ b/OfficeIMO.Excel/Read/ExcelUtf8NumberParser.cs
@@ -1,0 +1,117 @@
+#nullable enable
+
+using System.Buffers.Text;
+
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Parses invariant UTF-8 numbers emitted by spreadsheet formats while preserving the
+    /// general-purpose parser as a fallback for uncommon or high-precision representations.
+    /// </summary>
+    internal static class ExcelUtf8NumberParser {
+        /// <summary>
+        /// Parses a complete invariant UTF-8 double value.
+        /// </summary>
+        internal static bool TryParseDouble(ReadOnlySpan<byte> value, out double result) {
+#if NET8_0_OR_GREATER
+            return TryParseCommonFixedPoint(value, out result)
+                || (Utf8Parser.TryParse(value, out result, out int consumed) && consumed == value.Length);
+#else
+            return Utf8Parser.TryParse(value, out result, out int consumed) && consumed == value.Length;
+#endif
+        }
+
+#if NET8_0_OR_GREATER
+        /// <summary>
+        /// Parses the common fixed-point form without entering the general-purpose floating-point
+        /// parser. The conservative bounds keep the integer mantissa exactly representable.
+        /// </summary>
+        internal static bool TryParseCommonFixedPoint(ReadOnlySpan<byte> value, out double result) {
+            result = 0;
+            if (value.IsEmpty) {
+                return false;
+            }
+
+            int index = 0;
+            bool negative = value[0] == (byte)'-';
+            if (negative || value[0] == (byte)'+') {
+                index++;
+                if (index == value.Length) {
+                    return false;
+                }
+            }
+
+            ulong mantissa = 0;
+            int significantDigits = 0;
+            int fractionalDigits = 0;
+            bool hasDigit = false;
+            bool hasDecimalPoint = false;
+            for (; index < value.Length; index++) {
+                byte current = value[index];
+                if (current == (byte)'.') {
+                    if (hasDecimalPoint) {
+                        return false;
+                    }
+
+                    hasDecimalPoint = true;
+                    continue;
+                }
+
+                uint digit = (uint)(current - (byte)'0');
+                if (digit > 9) {
+                    return false;
+                }
+
+                hasDigit = true;
+                if (mantissa != 0 || digit != 0) {
+                    significantDigits++;
+                    if (significantDigits > 15) {
+                        return false;
+                    }
+                }
+
+                mantissa = (mantissa * 10) + digit;
+                if (hasDecimalPoint && ++fractionalDigits > 22) {
+                    return false;
+                }
+            }
+
+            if (!hasDigit) {
+                return false;
+            }
+
+            double parsed = mantissa;
+            if (fractionalDigits != 0) {
+                parsed /= PowerOfTen(fractionalDigits);
+            }
+
+            result = negative ? -parsed : parsed;
+            return true;
+        }
+
+        private static double PowerOfTen(int exponent) => exponent switch {
+            1 => 1e1,
+            2 => 1e2,
+            3 => 1e3,
+            4 => 1e4,
+            5 => 1e5,
+            6 => 1e6,
+            7 => 1e7,
+            8 => 1e8,
+            9 => 1e9,
+            10 => 1e10,
+            11 => 1e11,
+            12 => 1e12,
+            13 => 1e13,
+            14 => 1e14,
+            15 => 1e15,
+            16 => 1e16,
+            17 => 1e17,
+            18 => 1e18,
+            19 => 1e19,
+            20 => 1e20,
+            21 => 1e21,
+            _ => 1e22
+        };
+#endif
+    }
+}


### PR DESCRIPTION
Depends on #2364.

## Summary

- add a conservative invariant UTF-8 fixed-point parser for the common numeric representation emitted by XLSX writers
- retain the general parser for exponent notation, high-precision values, malformed input, and every unsupported shape
- preserve the original UTF-8 parser unchanged on netstandard2.0 and .NET Framework, where floating-point edge semantics differ from modern .NET
- keep exact numeric, serial-date, formula, and eager worksheet-validation behavior while reducing typed scan overhead

## Validation

- OfficeIMO.Excel builds cleanly for netstandard2.0, net472, net8.0, and net10.0
- focused parser coverage exercises accepted boundaries, adjacent fallback boundaries, and 22 decimal scales with deterministic randomized differential cases
- boundary and randomized differential tests are bit-identical to the general parser; an independent 200,000-case .NET 10 differential sweep found zero mismatches
- repeated alternating-core, checksum-validated 40-sample ABBA rounds reversed the winner; the median paired ratio across eight rounds was about 1.018, so the final XLSX read result is near parity and does not support claiming a universal lead
- full net10.0 suite: 3,722 passed, 5 skipped; two pre-existing image raster baseline differences remain unrelated, and one transient Excel COM/RPC failure passed on immediate isolated rerun
- independent local review and targeted confirmation found no remaining actionable P0-P2 numeric-parser or package-validation issue