### PR TITLE
Validate pinned website workflows before deployment

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -13,18 +13,26 @@ on:
       - "OfficeIMO.Excel/OfficeIMO.Excel.csproj"
       - "OfficeIMO.PowerPoint/OfficeIMO.PowerPoint.csproj"
       - ".github/workflows/deploy-website.yml"
+  pull_request:
+    branches: [master]
+    paths:
+      - ".github/workflows/deploy-website.yml"
   workflow_dispatch:
 
 permissions:
-  actions: write
   contents: read
-  deployments: read
-  packages: read
-  pages: write
-  id-token: write
 
 jobs:
+  workflow-contract:
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Confirm reusable deployment workflow resolved
+        run: echo "GitHub resolved the pinned PowerForge deployment workflow."
+
   resolve-post-deploy:
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     outputs:
       post_deploy_pipeline_config: ${{ steps.cloudflare.outputs.post_deploy_pipeline_config }}
@@ -43,8 +51,16 @@ jobs:
           fi
 
   website-deploy:
+    if: ${{ github.event_name != 'pull_request' }}
     needs: resolve-post-deploy
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@a5beb1daef277d375a80c0025c6a5a1bed0c6684
+    permissions:
+      actions: write
+      contents: read
+      deployments: read
+      packages: read
+      pages: write
+      id-token: write
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@c7f346e4fbb8a67ccb0b6c741438179d67effac5
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -55,7 +71,7 @@ jobs:
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       dotnet_workloads: wasm-tools
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: a5beb1daef277d375a80c0025c6a5a1bed0c6684
+      powerforge_ref: c7f346e4fbb8a67ccb0b6c741438179d67effac5
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}
       cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   website-build:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@1dbcec06df408947ee5f0dad3f71a11b0d31b0b6
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@c7f346e4fbb8a67ccb0b6c741438179d67effac5
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -31,5 +31,5 @@ jobs:
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       dotnet_workloads: wasm-tools
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 1dbcec06df408947ee5f0dad3f71a11b0d31b0b6
+      powerforge_ref: c7f346e4fbb8a67ccb0b6c741438179d67effac5
       report_artifact_name: powerforge-website-reports

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -3,25 +3,40 @@ name: Website Maintenance
 on:
   schedule:
     - cron: "0 3 * * 0"
+  pull_request:
+    branches: [master]
+    paths:
+      - ".github/workflows/website-maintenance.yml"
   workflow_dispatch:
 
 permissions:
-  actions: write
   contents: read
-  packages: read
 
 concurrency:
   group: website-maintenance-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
+  workflow-contract:
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Confirm reusable maintenance workflow resolved
+        run: echo "GitHub resolved the pinned PowerForge maintenance workflow."
+
   website-maintenance:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@1dbcec06df408947ee5f0dad3f71a11b0d31b0b6
+    if: ${{ github.event_name != 'pull_request' }}
+    permissions:
+      actions: write
+      contents: read
+      packages: read
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@c7f346e4fbb8a67ccb0b6c741438179d67effac5
     with:
       website_root: Website
       pipeline_config: Website/pipeline.maintenance.json
       engine_mode: source
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 1dbcec06df408947ee5f0dad3f71a11b0d31b0b6
+      powerforge_ref: c7f346e4fbb8a67ccb0b6c741438179d67effac5
       report_artifact_name: powerforge-website-maintenance-reports


### PR DESCRIPTION
## What changed

- repins OfficeIMO website build, deploy, and maintenance callers to merged PowerForge commit `c7f346e4fbb8a67ccb0b6c741438179d67effac5`
- makes deploy and maintenance workflow changes participate in pull-request graph validation without running production jobs
- keeps pull-request proof read-only while preserving the original production permissions on the reusable jobs

## Why it matters

The prior deploy referenced an intermediate PowerForge PR commit that became unavailable to GitHub's reusable-workflow resolver after squash merge. That caused the production workflow to fail before any job started. These immutable merged pins remove that release-state mismatch, and future caller changes will be parsed during their pull request instead of first being discovered after merge.

## Validation

- Actionlint passes all three OfficeIMO caller workflows
- GitHub's API resolves all three reusable workflow files at the pinned PowerForge commit
- the pinned commit is on PowerForge `main`
- independent local review found no actionable P0-P3 issues