### PR TITLE
Repin converter workflows and stabilize deployment CI proof

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -60,7 +60,7 @@ jobs:
       packages: read
       pages: write
       id-token: write
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@c7f346e4fbb8a67ccb0b6c741438179d67effac5
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@d40a1dfc5440bcf1a94400374444f8ea52affebe
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -71,7 +71,7 @@ jobs:
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       dotnet_workloads: wasm-tools
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: c7f346e4fbb8a67ccb0b6c741438179d67effac5
+      powerforge_ref: d40a1dfc5440bcf1a94400374444f8ea52affebe
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}
       cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -350,7 +350,9 @@ jobs:
   opendocument-schema:
     name: 'OpenDocument schema and LibreOffice'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # Cold Ubuntu mirrors can spend most of the former 20-minute budget fetching
+    # the full Writer/Calc/Impress dependency graph before validation starts.
+    timeout-minutes: 40
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -431,7 +433,9 @@ jobs:
   office-corpus-libreoffice:
     name: 'Office binary corpus and LibreOffice'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # Leave room for a cold LibreOffice install plus corpus conversion and the
+    # always-run evidence upload. Slow mirrors must not cancel the proof itself.
+    timeout-minutes: 40
     steps:
       - name: Checkout code
         uses: actions/checkout@v7

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   website-build:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@c7f346e4fbb8a67ccb0b6c741438179d67effac5
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@d40a1dfc5440bcf1a94400374444f8ea52affebe
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -31,5 +31,5 @@ jobs:
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       dotnet_workloads: wasm-tools
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: c7f346e4fbb8a67ccb0b6c741438179d67effac5
+      powerforge_ref: d40a1dfc5440bcf1a94400374444f8ea52affebe
       report_artifact_name: powerforge-website-reports

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -31,12 +31,12 @@ jobs:
       actions: write
       contents: read
       packages: read
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@c7f346e4fbb8a67ccb0b6c741438179d67effac5
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@d40a1dfc5440bcf1a94400374444f8ea52affebe
     with:
       website_root: Website
       pipeline_config: Website/pipeline.maintenance.json
       engine_mode: source
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: c7f346e4fbb8a67ccb0b6c741438179d67effac5
+      powerforge_ref: d40a1dfc5440bcf1a94400374444f8ea52affebe
       report_artifact_name: powerforge-website-maintenance-reports

--- a/OfficeIMO.Pdf.Tests/Pdf/OfficeColorSpaceConverterTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/OfficeColorSpaceConverterTests.cs
@@ -534,6 +534,13 @@ public class OfficeColorSpaceConverterTests {
         Assert.True(profile.TryConvertToDevice(source, OfficeIccRenderingIntent.Saturation, destination));
         Assert.True(profile.TrySoftProof(source, OfficeIccRenderingIntent.Saturation, out _));
 
+        // Cross the tiered-compilation threshold before measuring the steady-state
+        // caller-owned buffer paths. Runtime/JIT bookkeeping is not conversion allocation.
+        for (int index = 0; index < 4096; index++) {
+            Assert.True(profile.TryConvertToDevice(source, OfficeIccRenderingIntent.Saturation, destination));
+            Assert.True(profile.TrySoftProof(source, OfficeIccRenderingIntent.Saturation, out _));
+        }
+
         long before = GC.GetAllocatedBytesForCurrentThread();
         bool succeeded = true;
         for (int index = 0; index < 1000; index++) {


### PR DESCRIPTION
## What changed

- repins OfficeIMO website build, deploy, and maintenance workflows to merged PowerForge commit `d40a1dfc5440bcf1a94400374444f8ea52affebe`
- keeps each reusable workflow reference and its `powerforge_ref` input aligned to the same immutable owner revision
- gives the two full LibreOffice interoperability lanes enough time for cold Ubuntu package mirrors, corpus conversion, and evidence upload
- warms the ICC buffered conversion paths through tiered compilation before measuring their steady-state allocation contract

## Why it matters

The merged PowerForge revision discovers fingerprinted runtime modules declared through HTML import maps. OfficeIMO's post-deploy cache verification can now validate the native and runtime modules used by the browser converter without consumer-specific parsing logic.

The prior 20-minute LibreOffice budgets twice expired while the hosted runner was still downloading packages, before product validation began. The revised budgets preserve those proof lanes instead of allowing mirror latency to cancel them.

The Linux PDF lane also exposed runtime/JIT bookkeeping inside a zero-allocation measurement. The test now uses the same steady-state warmup pattern as adjacent allocation proofs while retaining the exact zero-allocation assertion for the measured conversion loop.

## Validation

- checksum-pinned Actionlint passes the website caller workflows and updated .NET workflow
- GitHub resolves all three reusable workflow files at the pinned commit
- the pinned commit is reachable from PowerForge `main`
- exact-head logs reproduced the LibreOffice timeout twice before product validation began
- focused ICC allocation proof passed 10/10 on Windows and 10/10 on Linux/.NET 10
- full Linux/.NET 10 PDF suite passed 5,252/5,252