### PR TITLE
Preserve OfficeIMO cache across deployments

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -60,7 +60,7 @@ jobs:
       packages: read
       pages: write
       id-token: write
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@d40a1dfc5440bcf1a94400374444f8ea52affebe
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@21f62dfd5356ed82ccdf9aae792e0ec94b614846
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -71,7 +71,7 @@ jobs:
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       dotnet_workloads: wasm-tools
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: d40a1dfc5440bcf1a94400374444f8ea52affebe
+      powerforge_ref: 21f62dfd5356ed82ccdf9aae792e0ec94b614846
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}
       cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   website-build:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@d40a1dfc5440bcf1a94400374444f8ea52affebe
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@21f62dfd5356ed82ccdf9aae792e0ec94b614846
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -31,5 +31,5 @@ jobs:
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       dotnet_workloads: wasm-tools
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: d40a1dfc5440bcf1a94400374444f8ea52affebe
+      powerforge_ref: 21f62dfd5356ed82ccdf9aae792e0ec94b614846
       report_artifact_name: powerforge-website-reports

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -31,12 +31,12 @@ jobs:
       actions: write
       contents: read
       packages: read
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@d40a1dfc5440bcf1a94400374444f8ea52affebe
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@21f62dfd5356ed82ccdf9aae792e0ec94b614846
     with:
       website_root: Website
       pipeline_config: Website/pipeline.maintenance.json
       engine_mode: source
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: d40a1dfc5440bcf1a94400374444f8ea52affebe
+      powerforge_ref: 21f62dfd5356ed82ccdf9aae792e0ec94b614846
       report_artifact_name: powerforge-website-maintenance-reports

--- a/Website/pipeline.cloudflare.json
+++ b/Website/pipeline.cloudflare.json
@@ -2,18 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/EvotecIT/PSPublishModule/main/Schemas/powerforge.web.pipelinespec.schema.json",
   "steps": [
     {
-      "task": "cloudflare",
-      "id": "purge-site-query-variants",
-      "operation": "purge",
-      "siteConfig": "./site.json",
-      "purgeMode": "hostname",
-      "zoneIdEnv": "CLOUDFLARE_ZONE_ID",
-      "tokenEnv": "CLOUDFLARE_API_TOKEN"
-    },
-    {
       "task": "deployment-verify",
       "id": "verify-converter-deployment",
-      "dependsOn": "purge-site-query-variants",
       "pathPrefixes": "/apps/officeimo-converter/",
       "attempts": 12,
       "delayMs": 30000,

--- a/Website/site.json
+++ b/Website/site.json
@@ -299,7 +299,11 @@
     "Cache": {
       "EdgeTtlSeconds": 604800
     },
-    "PurgeMode": "hostname",
+    "PurgeMode": "incremental",
+    "AlwaysPurgePaths": [
+      "/apps/officeimo-converter/",
+      "/apps/officeimo-converter/?embedded=1"
+    ],
     "SmartTieredCache": true
   },
   "EditLinks": {


### PR DESCRIPTION
## Summary
- switch OfficeIMO deployments from hostname-wide cache purges to safe incremental manifest purges
- always invalidate the mutable converter entry point and its `?embedded=1` cache-key variant
- remove the redundant post-deploy hostname purge while retaining full converter artifact verification
- pin deploy, CI, and maintenance workflows to the immutable PowerForge merge that owns this behavior

## Expected effect
Unchanged fingerprinted CSS, JavaScript, WASM, API, and documentation assets remain warm across deployments. Changed files and the two mutable converter entry URLs are still invalidated, while PowerForge retains its fail-closed hostname fallback for missing baselines, policy changes, deployment gaps, host changes, or oversized diffs.

## Validation
- site and post-deploy JSON parse
- all three workflow YAML files parse
- immutable owner ancestry and reusable `powerforge_ref` contracts verified
- exact owner CLI resolves `PurgeMode` as `incremental`
- identical-manifest dry-run selected exactly 2 URLs in 1 file-purge batch
- edge TTL remains 604800, Smart Tiered Cache remains enabled, HSTS remains disabled
