### PR TITLE
Accelerate inferred-schema XLSX data readers

### DIFF
--- a/OfficeIMO.Excel.Tests/Excel.DataReaderApi.XlsxNative.cs
+++ b/OfficeIMO.Excel.Tests/Excel.DataReaderApi.XlsxNative.cs
@@ -29,6 +29,119 @@ public partial class Excel {
     }
 
     [Fact]
+    public void XlsxTabularWorkbook_InfersSchemaAndReplaysAnExplicitRange() {
+        string path = CreateCompactFastPathWorkbook();
+        try {
+            var options = new ExcelReadOptions {
+                A1Range = "A1:A3",
+                InferSchema = true,
+                SchemaSampleRows = 1
+            };
+            using var workbook = XlsxTabularWorkbook.Open(path, options);
+            using DbDataReader reader = workbook.OpenTable(
+                "Data",
+                hasHeaderRow: true,
+                CancellationToken.None);
+
+            Assert.Equal(typeof(double), reader.GetFieldType(0));
+            DataReaderSchemaContractAssertions.AssertCanonicalSchema(reader);
+            Assert.True(reader.Read());
+            Assert.Equal(42, reader.GetInt32(0));
+            Assert.True(reader.Read());
+            Assert.Equal(43, reader.GetInt32(0));
+            Assert.False(reader.Read());
+            reader.Close();
+            Assert.False(reader.HasRows);
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void XlsxTabularWorkbook_EnforcesTheSchemaSampleRowLimit() {
+        string path = CreateCompactFastPathWorkbook();
+        try {
+            var options = new ExcelReadOptions {
+                InferSchema = true,
+                SchemaSampleRows = 2,
+                MaxDataReaderSchemaSampleRows = 1
+            };
+            using var workbook = XlsxTabularWorkbook.Open(path, options);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => workbook.OpenTable(
+                "Data",
+                hasHeaderRow: true,
+                CancellationToken.None));
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void XlsxTabularWorkbook_ChargesOnlyRowsActuallyBufferedForSchema() {
+        string path = CreateCompactFastPathWorkbook();
+        try {
+            var options = new ExcelReadOptions {
+                A1Range = "A1:A3",
+                InferSchema = true,
+                SchemaSampleRows = 1024,
+                MaxDataReaderBufferedCells = 2
+            };
+            using var workbook = XlsxTabularWorkbook.Open(path, options);
+            using DbDataReader reader = workbook.OpenTable(
+                "Data",
+                hasHeaderRow: true,
+                CancellationToken.None);
+
+            Assert.True(reader.Read());
+            Assert.Equal(42, reader.GetInt32(0));
+            Assert.True(reader.Read());
+            Assert.Equal(43, reader.GetInt32(0));
+            Assert.False(reader.Read());
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void XlsxTabularWorkbook_PreservesGetCharsAndGetBytesAcrossSchemaReplay() {
+        string path = Path.Combine(
+            Path.GetTempPath(),
+            $"OfficeIMO.Excel.XlsxNativeSchemaGetters.{Guid.NewGuid():N}.xlsx");
+        try {
+            using (var document = ExcelDocument.Create(path)) {
+                ExcelSheet sheet = document.AddWorksheet("Data");
+                sheet.CellValue(1, 1, "Value");
+                sheet.CellValue(1, 2, "Optional");
+                sheet.CellValue(2, 1, "Sampled");
+                sheet.CellValue(3, 1, "Streamed");
+                document.Save();
+            }
+
+            var options = new ExcelReadOptions {
+                InferSchema = true,
+                SchemaSampleRows = 1
+            };
+            using var workbook = XlsxTabularWorkbook.Open(path, options);
+            using DbDataReader reader = workbook.OpenTable(
+                "Data",
+                hasHeaderRow: true,
+                CancellationToken.None);
+
+            Assert.True(reader.Read());
+            Assert.Equal(0, reader.GetChars(1, 0, null, 0, 0));
+            Assert.Throws<NotSupportedException>(() => reader.GetBytes(0, 0, null, 0, 0));
+
+            Assert.True(reader.Read());
+            Assert.Equal(0, reader.GetChars(1, 0, null, 0, 0));
+            Assert.Throws<NotSupportedException>(() => reader.GetBytes(0, 0, null, 0, 0));
+            Assert.False(reader.Read());
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
     public void OpenDataReader_ReusesValidatedSharedStringIndexForCachedFormula() {
         string path = Path.Combine(
             Path.GetTempPath(),

--- a/OfficeIMO.Excel/Read/ExcelSchemaInferenceDataReader.cs
+++ b/OfficeIMO.Excel/Read/ExcelSchemaInferenceDataReader.cs
@@ -1,0 +1,277 @@
+#nullable enable
+
+using System.Collections;
+using System.Data;
+using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Threading;
+
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Adds bounded schema inference and sampled-row replay to a forward-only Excel reader.
+    /// </summary>
+    internal sealed class ExcelSchemaInferenceDataReader : DbDataReader {
+        private readonly DbDataReader _inner;
+        private readonly List<object[]> _sampledRows;
+        private readonly Type[] _columnTypes;
+        private readonly CultureInfo _culture;
+        private int _sampleIndex;
+        private object[]? _sampledCurrentRow;
+        private bool _closed;
+        private bool _disposed;
+
+        private ExcelSchemaInferenceDataReader(
+            DbDataReader inner,
+            int schemaSampleRows,
+            int maximumSchemaSampleRows,
+            long maximumBufferedCells,
+            CultureInfo culture,
+            CancellationToken cancellationToken) {
+            _inner = inner;
+            _culture = culture;
+
+            int fieldCount = inner.FieldCount;
+            if (maximumSchemaSampleRows < 0 || maximumBufferedCells <= 0L) {
+                throw new InvalidOperationException("Excel data-reader safety limits must be positive.");
+            }
+            if (schemaSampleRows > maximumSchemaSampleRows) {
+                throw new ArgumentOutOfRangeException(
+                    nameof(schemaSampleRows),
+                    $"Schema sample row count exceeds {maximumSchemaSampleRows}.");
+            }
+
+            _sampledRows = new List<object[]>(Math.Min(schemaSampleRows, 1024));
+            while (_sampledRows.Count < schemaSampleRows && inner.Read()) {
+                cancellationToken.ThrowIfCancellationRequested();
+                long bufferedCells = checked((long)(_sampledRows.Count + 1) * fieldCount);
+                if (bufferedCells > maximumBufferedCells) {
+                    throw new InvalidDataException(
+                        $"Range data-reader buffering exceeds {nameof(ExcelReadOptions.MaxDataReaderBufferedCells)}.");
+                }
+
+                var values = new object[fieldCount];
+                inner.GetValues(values);
+                _sampledRows.Add(values);
+            }
+
+            _columnTypes = InferColumnTypes(_sampledRows, fieldCount);
+        }
+
+        internal static DbDataReader Create(
+            DbDataReader inner,
+            int schemaSampleRows,
+            int maximumSchemaSampleRows,
+            long maximumBufferedCells,
+            CultureInfo culture,
+            CancellationToken cancellationToken) {
+            try {
+                return new ExcelSchemaInferenceDataReader(
+                    inner,
+                    schemaSampleRows,
+                    maximumSchemaSampleRows,
+                    maximumBufferedCells,
+                    culture,
+                    cancellationToken);
+            } catch {
+                inner.Dispose();
+                throw;
+            }
+        }
+
+        public override object this[int ordinal] => GetValue(ordinal);
+
+        public override object this[string name] => GetValue(GetOrdinal(name));
+
+        public override int Depth => 0;
+
+        public override int FieldCount => _inner.FieldCount;
+
+        public override bool HasRows => !_closed && (_sampledRows.Count > 0 || _inner.HasRows);
+
+        public override bool IsClosed => _closed;
+
+        public override int RecordsAffected => -1;
+
+        public override bool GetBoolean(int ordinal) => IsSampledRow
+            ? Convert.ToBoolean(GetNonDbNullValue(ordinal), _culture)
+            : _inner.GetBoolean(ordinal);
+
+        public override byte GetByte(int ordinal) => IsSampledRow
+            ? Convert.ToByte(GetNonDbNullValue(ordinal), _culture)
+            : _inner.GetByte(ordinal);
+
+        public override long GetBytes(
+            int ordinal,
+            long dataOffset,
+            byte[]? buffer,
+            int bufferOffset,
+            int length) =>
+            throw new NotSupportedException("Excel range fields are exposed as scalar values.");
+
+        public override char GetChar(int ordinal) => IsSampledRow
+            ? Convert.ToChar(GetNonDbNullValue(ordinal), _culture)
+            : _inner.GetChar(ordinal);
+
+        public override long GetChars(
+            int ordinal,
+            long dataOffset,
+            char[]? buffer,
+            int bufferOffset,
+            int length) {
+            string value = Convert.ToString(GetValue(ordinal), _culture) ?? string.Empty;
+            if (buffer == null) {
+                return value.Length;
+            }
+            if (dataOffset >= value.Length || length == 0) {
+                return 0;
+            }
+
+            int count = Math.Min(length, value.Length - checked((int)dataOffset));
+            value.CopyTo(checked((int)dataOffset), buffer, bufferOffset, count);
+            return count;
+        }
+
+        public override string GetDataTypeName(int ordinal) => GetFieldType(ordinal).Name;
+
+        public override DateTime GetDateTime(int ordinal) => IsSampledRow
+            ? Convert.ToDateTime(GetNonDbNullValue(ordinal), _culture)
+            : _inner.GetDateTime(ordinal);
+
+        public override decimal GetDecimal(int ordinal) => IsSampledRow
+            ? Convert.ToDecimal(GetNonDbNullValue(ordinal), _culture)
+            : _inner.GetDecimal(ordinal);
+
+        public override double GetDouble(int ordinal) => IsSampledRow
+            ? Convert.ToDouble(GetNonDbNullValue(ordinal), _culture)
+            : _inner.GetDouble(ordinal);
+
+        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]
+        public override Type GetFieldType(int ordinal) => _columnTypes[ordinal];
+
+        public override float GetFloat(int ordinal) => IsSampledRow
+            ? Convert.ToSingle(GetNonDbNullValue(ordinal), _culture)
+            : _inner.GetFloat(ordinal);
+
+        public override Guid GetGuid(int ordinal) {
+            if (!IsSampledRow) {
+                return _inner.GetGuid(ordinal);
+            }
+
+            object value = GetNonDbNullValue(ordinal);
+            return value is Guid guid ? guid : Guid.Parse(Convert.ToString(value, _culture)!);
+        }
+
+        public override short GetInt16(int ordinal) => IsSampledRow
+            ? Convert.ToInt16(GetNonDbNullValue(ordinal), _culture)
+            : _inner.GetInt16(ordinal);
+
+        public override int GetInt32(int ordinal) => IsSampledRow
+            ? Convert.ToInt32(GetNonDbNullValue(ordinal), _culture)
+            : _inner.GetInt32(ordinal);
+
+        public override long GetInt64(int ordinal) => IsSampledRow
+            ? Convert.ToInt64(GetNonDbNullValue(ordinal), _culture)
+            : _inner.GetInt64(ordinal);
+
+        public override string GetName(int ordinal) => _inner.GetName(ordinal);
+
+        public override int GetOrdinal(string name) => _inner.GetOrdinal(name);
+
+        public override string GetString(int ordinal) => IsSampledRow
+            ? Convert.ToString(GetNonDbNullValue(ordinal), _culture) ?? string.Empty
+            : _inner.GetString(ordinal);
+
+        public override object GetValue(int ordinal) => IsSampledRow
+            ? _sampledCurrentRow![ordinal]
+            : _inner.GetValue(ordinal);
+
+        public override int GetValues(object[] values) {
+            if (!IsSampledRow) {
+                return _inner.GetValues(values);
+            }
+
+            int count = Math.Min(values.Length, FieldCount);
+            Array.Copy(_sampledCurrentRow!, values, count);
+            return count;
+        }
+
+        public override bool IsDBNull(int ordinal) {
+            object value = GetValue(ordinal);
+            return value == null || ReferenceEquals(value, DBNull.Value);
+        }
+
+        public override bool NextResult() => false;
+
+        public override bool Read() {
+            if (_closed) {
+                return false;
+            }
+            if (_sampleIndex < _sampledRows.Count) {
+                _sampledCurrentRow = _sampledRows[_sampleIndex++];
+                return true;
+            }
+
+            _sampledCurrentRow = null;
+            return _inner.Read();
+        }
+
+        public override void Close() {
+            if (_closed) {
+                return;
+            }
+
+            _closed = true;
+            _sampledCurrentRow = null;
+            _inner.Close();
+        }
+
+        [UnconditionalSuppressMessage("Trimming", "IL2111", Justification = "The schema table stores Type values as data and does not reflect over Type.TypeInitializer or other Type members.")]
+        public override DataTable GetSchemaTable() =>
+            ExcelDataReaderSchemaTable.Create(FieldCount, GetName, GetFieldType);
+
+        public override IEnumerator GetEnumerator() {
+            while (Read()) {
+                yield return this;
+            }
+        }
+
+        protected override void Dispose(bool disposing) {
+            if (disposing && !_disposed) {
+                _disposed = true;
+                Close();
+                _inner.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        private bool IsSampledRow => _sampledCurrentRow != null;
+
+        private object GetNonDbNullValue(int ordinal) {
+            object value = GetValue(ordinal);
+            if (value == null || ReferenceEquals(value, DBNull.Value)) {
+                throw new InvalidCastException($"Column '{GetName(ordinal)}' contains DBNull.");
+            }
+
+            return value;
+        }
+
+        private static Type[] InferColumnTypes(IReadOnlyList<object[]> rows, int fieldCount) {
+            var types = new Type[fieldCount];
+            for (int column = 0; column < fieldCount; column++) {
+                Type? inferred = null;
+                for (int row = 0; row < rows.Count; row++) {
+                    inferred = ExcelSheetReader.MergeDataTableColumnType(inferred, rows[row][column]);
+                    if (inferred == typeof(object)) {
+                        break;
+                    }
+                }
+
+                types[column] = inferred ?? typeof(object);
+            }
+
+            return types;
+        }
+    }
+}

--- a/OfficeIMO.Excel/Read/ExcelSchemaInferenceDataReader.cs
+++ b/OfficeIMO.Excel/Read/ExcelSchemaInferenceDataReader.cs
@@ -146,6 +146,7 @@ namespace OfficeIMO.Excel {
             ? Convert.ToDouble(GetNonDbNullValue(ordinal), _culture)
             : _inner.GetDouble(ordinal);
 
+        [UnconditionalSuppressMessage("Trimming", "IL2063", Justification = "Inferred Excel column types are closed scalar conversion tokens; OfficeIMO never activates or reflects over their public members.")]
         [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]
         public override Type GetFieldType(int ordinal) => _columnTypes[ordinal];
 

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Xml.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.Xml.cs
@@ -89,6 +89,9 @@ namespace OfficeIMO.Excel {
                     _utf8SourceOrdinalOffset = firstColumn - utf8SourceFirstColumn;
                 } else if (ExcelUtf8RangeRowSource.TryCreate(owner, firstRow, lastRow, firstColumn, fieldCount, ct, out var utf8Source)) {
                     _utf8Source = utf8Source;
+                } else if (!owner._hasSdkWorksheetPart) {
+                    throw new XlsxTabularFastPathNotSupportedException(
+                        $"Worksheet '{owner._sheetName}' requires the Open XML SDK fallback path.");
                 } else {
                     _stream = owner._wsPart.GetStream(FileMode.Open, FileAccess.Read);
                     RewindWorksheetStream(_stream);

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.cs
@@ -146,7 +146,7 @@ namespace OfficeIMO.Excel {
                 throw new InvalidDataException($"Range data-reader buffering exceeds {nameof(ExcelReadOptions.MaxDataReaderBufferedCells)}.");
             }
             if (schemaSampleRows == 0
-                && rows > BufferedRangeStreamRowLimit
+                && (!_hasSdkWorksheetPart || rows > BufferedRangeStreamRowLimit)
                 && CanUseRangeStreamXmlReader()) {
                 if (cols > _opt.MaxDataReaderBufferedCells) {
                     throw new InvalidDataException($"Range data-reader buffering exceeds {nameof(ExcelReadOptions.MaxDataReaderBufferedCells)}.");

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.Snapshot.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.Snapshot.cs
@@ -125,7 +125,7 @@ namespace OfficeIMO.Excel {
             return types;
         }
 
-        private static Type? MergeDataTableColumnType(Type? current, object? value) {
+        internal static Type? MergeDataTableColumnType(Type? current, object? value) {
             if (value == null || value == DBNull.Value) {
                 return current;
             }

--- a/OfficeIMO.Excel/Read/ExcelWorkbookDataReader.cs
+++ b/OfficeIMO.Excel/Read/ExcelWorkbookDataReader.cs
@@ -339,9 +339,8 @@ namespace OfficeIMO.Excel {
         }
 
         private static bool CanUseNativeOpenXmlPath(ExcelReadOptions options) =>
-            !options.InferSchema
-            && string.IsNullOrWhiteSpace(options.A1Range)
-            && options.CellValueConverter == null;
+            options.CellValueConverter == null
+            && (options.InferSchema || string.IsNullOrWhiteSpace(options.A1Range));
 
         private static DbDataReader OpenOpenXmlSheet(
             ExcelDocumentReader owner,

--- a/OfficeIMO.Excel/Read/XlsxTabularWorkbook.cs
+++ b/OfficeIMO.Excel/Read/XlsxTabularWorkbook.cs
@@ -192,10 +192,27 @@ namespace OfficeIMO.Excel {
                 _options,
                 DateSystem,
                 _parts);
-            return (DbDataReader)reader.ReadUsedRangeAsDataReader(
-                hasHeaderRow,
-                schemaSampleRows: 0,
-                cancellationToken);
+            DbDataReader dataReader = string.IsNullOrWhiteSpace(_options.A1Range)
+                ? (DbDataReader)reader.ReadUsedRangeAsDataReader(
+                    hasHeaderRow,
+                    schemaSampleRows: 0,
+                    cancellationToken)
+                : (DbDataReader)reader.ReadRangeAsDataReader(
+                    _options.A1Range!,
+                    hasHeaderRow,
+                    chunkRows: Math.Min(1024, _options.MaxDataReaderChunkRows),
+                    schemaSampleRows: 0,
+                    ct: cancellationToken);
+
+            return _options.InferSchema && _options.SchemaSampleRows > 0
+                ? ExcelSchemaInferenceDataReader.Create(
+                    dataReader,
+                    _options.SchemaSampleRows,
+                    _options.MaxDataReaderSchemaSampleRows,
+                    _options.MaxDataReaderBufferedCells,
+                    _options.Culture,
+                    cancellationToken)
+                : dataReader;
         }
 
         private string ReadWorkbookPartName() {


### PR DESCRIPTION
## Summary

- add bounded schema inference over the native forward-only XLSX reader
- route inferred-schema full-sheet and ranged reads through the native path while preserving existing non-schema routes
- enforce schema-sampling and buffered-cell limits across sampled and live rows
- keep getter, close-state, and lifetime behavior consistent across the replay boundary

## Performance

Measurements were serialized and pinned separately to one logical processor in each LLC domain on a Ryzen 9 9950X3D2. Results are compared only within the same domain.

- full-sheet `DataTable` reads: 54.1% faster on LLC 0 and 51.7% faster on LLC 16
- ranged `DataTable` reads: 19.3% faster on LLC 0 and 15.8% faster on LLC 16

Existing full-sheet native reads keep their current path. Explicit-range reads without schema inference also keep their previous route.

## Validation

- OfficeIMO.Excel builds on .NET 8 and .NET 10
- 168 focused reader tests pass on each target framework
- broader .NET 8 suite passes with host-dependent visual and desktop Excel checks excluded
- independent read-only review completed; schema limits, buffered-cell accounting, getter parity, and close-state findings were fixed and confirmed