### PR TITLE
Add atomic email save conflict policy

### DIFF
--- a/OfficeIMO.Email.Tests/Usage/EmailDocumentUsageTests.cs
+++ b/OfficeIMO.Email.Tests/Usage/EmailDocumentUsageTests.cs
@@ -54,6 +54,79 @@ public sealed class EmailDocumentUsageTests {
     }
 
     [Fact]
+    public async Task PathSaveConflictPolicyPreservesOrReplacesAnExistingDestination() {
+        string directory = CreateTempDirectory();
+        try {
+            string synchronousPath = Path.Combine(directory, "synchronous.eml");
+            string asynchronousPath = Path.Combine(directory, "asynchronous.eml");
+            byte[] existingContent = Encoding.UTF8.GetBytes("existing destination");
+            File.WriteAllBytes(synchronousPath, existingContent);
+            File.WriteAllBytes(asynchronousPath, existingContent);
+            var document = new EmailDocument { Subject = "Conflict policy" };
+
+            Assert.Throws<IOException>(() =>
+                document.SaveWithConflictPolicy(synchronousPath, EmailFileConflictPolicy.FailIfExists));
+            await Assert.ThrowsAsync<IOException>(() =>
+                document.SaveWithConflictPolicyAsync(asynchronousPath, EmailFileConflictPolicy.FailIfExists));
+
+            Assert.Equal(existingContent, File.ReadAllBytes(synchronousPath));
+            Assert.Equal(existingContent, File.ReadAllBytes(asynchronousPath));
+
+            document.SaveWithConflictPolicy(synchronousPath, EmailFileConflictPolicy.Replace);
+            await document.SaveWithConflictPolicyAsync(asynchronousPath, EmailFileConflictPolicy.Replace);
+
+            Assert.False(existingContent.SequenceEqual(File.ReadAllBytes(synchronousPath)));
+            Assert.False(existingContent.SequenceEqual(File.ReadAllBytes(asynchronousPath)));
+            Assert.Equal("Conflict policy", EmailDocument.Load(synchronousPath).Subject);
+            Assert.Equal("Conflict policy", EmailDocument.Load(asynchronousPath).Subject);
+        } finally {
+            Directory.Delete(directory, true);
+        }
+    }
+
+    [Fact]
+    public void PathSaveRejectsUnknownConflictPolicyBeforeOpeningTheDestination() {
+        string directory = CreateTempDirectory();
+        try {
+            string outputPath = Path.Combine(directory, "message.eml");
+            var document = new EmailDocument { Subject = "Invalid conflict policy" };
+
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                document.SaveWithConflictPolicy(outputPath, (EmailFileConflictPolicy)42));
+
+            Assert.False(File.Exists(outputPath));
+        } finally {
+            Directory.Delete(directory, true);
+        }
+    }
+
+    [Fact]
+    public async Task ExistingDefaultLiteralSaveCallsRemainSourceCompatible() {
+        string directory = CreateTempDirectory();
+        try {
+            var document = new EmailDocument { Subject = "Source compatibility" };
+            var options = new EmailWriterOptions();
+            CancellationToken cancellationToken = default;
+
+            Assert.Throws<NotSupportedException>(() =>
+                document.Save(Path.Combine(directory, "sync-all-defaults.bin"), default, default));
+            Assert.Throws<NotSupportedException>(() =>
+                document.Save(Path.Combine(directory, "sync-default-format.bin"), default, options));
+            document.Save(Path.Combine(directory, "sync-default-options.bin"), EmailFileFormat.Eml, default);
+            await Assert.ThrowsAsync<NotSupportedException>(() =>
+                document.SaveAsync(Path.Combine(directory, "async-all-defaults.bin"),
+                    default, default, default));
+            await Assert.ThrowsAsync<NotSupportedException>(() =>
+                document.SaveAsync(Path.Combine(directory, "async-default-format.bin"),
+                    default, options, cancellationToken));
+            await document.SaveAsync(Path.Combine(directory, "async-default-options.bin"),
+                EmailFileFormat.Eml, default, cancellationToken);
+        } finally {
+            Directory.Delete(directory, true);
+        }
+    }
+
+    [Fact]
     public void LoadFailsClearlyWhileTheAdvancedReaderRetainsDiagnostics() {
         byte[] invalid = Encoding.UTF8.GetBytes("This is not an email artifact.");
 

--- a/OfficeIMO.Email/Model/EmailDocument.IO.cs
+++ b/OfficeIMO.Email/Model/EmailDocument.IO.cs
@@ -53,9 +53,34 @@ public sealed partial class EmailDocument {
     public EmailWriteResult Save(string filePath, EmailWriterOptions? options = null) =>
         Save(filePath, InferOutputFormat(filePath), options);
 
+    /// <summary>
+    /// Saves the document as EML, MSG, OFT, or TNEF, inferred from the destination filename,
+    /// using a strict atomic destination conflict policy.
+    /// </summary>
+    public EmailWriteResult SaveWithConflictPolicy(string filePath, EmailFileConflictPolicy conflictPolicy,
+        EmailWriterOptions? options = null) =>
+        SaveWithConflictPolicy(filePath, InferOutputFormat(filePath), conflictPolicy, options);
+
     /// <summary>Saves the document in the explicitly selected artifact format.</summary>
     public EmailWriteResult Save(string filePath, EmailFileFormat format, EmailWriterOptions? options = null) {
         if (filePath == null) throw new ArgumentNullException(nameof(filePath));
+        return SaveToPath(filePath, format, OfficeFileCommit.ConflictPolicy.Replace, options,
+            requireAtomicCommit: false);
+    }
+
+    /// <summary>
+    /// Saves the document in the explicitly selected artifact format using a strict atomic destination conflict policy.
+    /// </summary>
+    public EmailWriteResult SaveWithConflictPolicy(string filePath, EmailFileFormat format,
+        EmailFileConflictPolicy conflictPolicy, EmailWriterOptions? options = null) {
+        if (filePath == null) throw new ArgumentNullException(nameof(filePath));
+        OfficeFileCommit.ConflictPolicy commitPolicy = GetCommitConflictPolicy(conflictPolicy);
+        return SaveToPath(filePath, format, commitPolicy, options, requireAtomicCommit: true);
+    }
+
+    private EmailWriteResult SaveToPath(string filePath, EmailFileFormat format,
+        OfficeFileCommit.ConflictPolicy commitPolicy, EmailWriterOptions? options,
+        bool requireAtomicCommit) {
         EmailDocumentWriter writer = new EmailDocumentWriter(options ?? EmailWriterOptions.Default);
         string stagingPath = string.Empty;
         try {
@@ -65,7 +90,11 @@ public sealed partial class EmailDocument {
                 result = writer.Write(this, staging, format);
                 EnsureWriteSucceeded(result);
             }
-            OfficeFileCommit.CommitTemporaryFile(stagingPath, filePath);
+            if (requireAtomicCommit) {
+                OfficeFileCommit.CommitTemporaryFileAtomically(stagingPath, filePath, commitPolicy);
+            } else {
+                OfficeFileCommit.CommitTemporaryFile(stagingPath, filePath, commitPolicy);
+            }
             stagingPath = string.Empty;
             return result;
         } finally {
@@ -92,10 +121,40 @@ public sealed partial class EmailDocument {
         CancellationToken cancellationToken = default) =>
         SaveAsync(filePath, InferOutputFormat(filePath), options, cancellationToken);
 
+    /// <summary>
+    /// Asynchronously saves the document, inferring the format from the destination filename and using the requested
+    /// strict atomic destination conflict policy.
+    /// </summary>
+    public Task<EmailWriteResult> SaveWithConflictPolicyAsync(string filePath,
+        EmailFileConflictPolicy conflictPolicy, EmailWriterOptions? options = null,
+        CancellationToken cancellationToken = default) =>
+        SaveWithConflictPolicyAsync(filePath, InferOutputFormat(filePath), conflictPolicy, options,
+            cancellationToken);
+
     /// <summary>Asynchronously saves the document in the explicitly selected artifact format.</summary>
     public async Task<EmailWriteResult> SaveAsync(string filePath, EmailFileFormat format,
         EmailWriterOptions? options = null, CancellationToken cancellationToken = default) {
         if (filePath == null) throw new ArgumentNullException(nameof(filePath));
+        return await SaveToPathAsync(filePath, format, OfficeFileCommit.ConflictPolicy.Replace, options,
+            requireAtomicCommit: false, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Asynchronously saves the document in the explicitly selected artifact format using the requested destination
+    /// conflict policy.
+    /// </summary>
+    public async Task<EmailWriteResult> SaveWithConflictPolicyAsync(string filePath, EmailFileFormat format,
+        EmailFileConflictPolicy conflictPolicy, EmailWriterOptions? options = null,
+        CancellationToken cancellationToken = default) {
+        if (filePath == null) throw new ArgumentNullException(nameof(filePath));
+        OfficeFileCommit.ConflictPolicy commitPolicy = GetCommitConflictPolicy(conflictPolicy);
+        return await SaveToPathAsync(filePath, format, commitPolicy, options,
+            requireAtomicCommit: true, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<EmailWriteResult> SaveToPathAsync(string filePath, EmailFileFormat format,
+        OfficeFileCommit.ConflictPolicy commitPolicy, EmailWriterOptions? options,
+        bool requireAtomicCommit, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
         EmailDocumentWriter writer = new EmailDocumentWriter(options ?? EmailWriterOptions.Default);
         string stagingPath = string.Empty;
@@ -108,7 +167,11 @@ public sealed partial class EmailDocument {
                 EnsureWriteSucceeded(result);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            OfficeFileCommit.CommitTemporaryFile(stagingPath, filePath);
+            if (requireAtomicCommit) {
+                OfficeFileCommit.CommitTemporaryFileAtomically(stagingPath, filePath, commitPolicy);
+            } else {
+                OfficeFileCommit.CommitTemporaryFile(stagingPath, filePath, commitPolicy);
+            }
             stagingPath = string.Empty;
             return result;
         } finally {
@@ -182,6 +245,19 @@ public sealed partial class EmailDocument {
             int read = source.Read(buffer, 0, buffer.Length);
             if (read == 0) return;
             destination.Write(buffer, 0, read);
+        }
+    }
+
+    private static OfficeFileCommit.ConflictPolicy GetCommitConflictPolicy(
+        EmailFileConflictPolicy conflictPolicy) {
+        switch (conflictPolicy) {
+            case EmailFileConflictPolicy.FailIfExists:
+                return OfficeFileCommit.ConflictPolicy.FailIfExists;
+            case EmailFileConflictPolicy.Replace:
+                return OfficeFileCommit.ConflictPolicy.Replace;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(conflictPolicy), conflictPolicy,
+                    "The email file conflict policy is not supported.");
         }
     }
 

--- a/OfficeIMO.Email/README.md
+++ b/OfficeIMO.Email/README.md
@@ -66,6 +66,16 @@ EmailDocument message = await EmailDocument.LoadAsync("message.msg", cancellatio
 await message.SaveAsync("message.eml", cancellationToken: cancellationToken);
 ```
 
+Path-based saves replace an existing destination by default. Use `FailIfExists` when exporting into a shared or
+user-managed directory where claiming a new filename must be atomic and an existing artifact must remain unchanged:
+
+```csharp
+await message.SaveWithConflictPolicyAsync(
+    "message.eml",
+    EmailFileConflictPolicy.FailIfExists,
+    cancellationToken: cancellationToken);
+```
+
 Use `EmailDocumentReader` when the host needs custom limits, raw-source preservation, or structured diagnostics:
 
 ```csharp

--- a/OfficeIMO.Email/Writing/EmailFileConflictPolicy.cs
+++ b/OfficeIMO.Email/Writing/EmailFileConflictPolicy.cs
@@ -1,0 +1,11 @@
+namespace OfficeIMO.Email;
+
+/// <summary>
+/// Controls how a path-based email save handles an existing destination.
+/// </summary>
+public enum EmailFileConflictPolicy {
+    /// <summary>Fails without modifying the existing destination.</summary>
+    FailIfExists,
+    /// <summary>Replaces the existing destination after the new artifact has been written successfully.</summary>
+    Replace
+}


### PR DESCRIPTION
## Summary

Adds an explicit, source-compatible conflict policy for path-based email artifact saves.

- adds `EmailFileConflictPolicy` with `FailIfExists` and `Replace`
- adds distinctly named `SaveWithConflictPolicy` and `SaveWithConflictPolicyAsync` entry points without changing the existing `Save` overload set
- commits both conflict-policy modes atomically or fails without using the non-atomic replacement fallback
- preserves existing path save behavior for callers that do not opt into the new policy
- documents safe file-claim usage for shared and user-managed export directories

## Compatibility

Existing `Save` and `SaveAsync` source call shapes remain unchanged, including positional `default` literals. The new policy API is additive and separately named to avoid overload-resolution ambiguity.

## Validation

- OfficeIMO.Email tests: .NET 8 — 1,332 passed, 11 skipped
- OfficeIMO.Email tests: .NET Framework — 1,292 passed, 11 skipped
- focused usage tests: 8 passed on each target
- `dotnet pack OfficeIMO.Email` succeeded