### PR TITLE
Improve image correctness and performance evidence

### DIFF
--- a/Build/Run-LibraryComparisonBenchmarks.ps1
+++ b/Build/Run-LibraryComparisonBenchmarks.ps1
@@ -11,6 +11,10 @@ param(
         'xlsx',
         'xlsxwrite',
         'xlsb',
+        'imagepngdecode',
+        'imagejpegdecode',
+        'imagepngencode',
+        'imageresize',
         'word',
         'wordcreate',
         'wordreport',
@@ -123,6 +127,38 @@ $definitions = [ordered]@{
         Suite = 'OfficeIMO.Excel.Xlsb.MarkPflug65K'
         IdentityVariables = @()
         ExpectedCases = @('OfficeIMO', 'Sylvan', 'ExcelDataReader')
+    }
+    imagepngdecode = [pscustomobject]@{
+        Project = 'OfficeIMO.Drawing.Benchmarks.Comparisons\OfficeIMO.Drawing.Benchmarks.Comparisons.csproj'
+        Filter = '*ImagePngDecodeBenchmarks*'
+        ComparisonId = "image-png-decode-$Framework"
+        Suite = 'OfficeIMO.Drawing.PngDecode'
+        IdentityVariables = @()
+        ExpectedCases = @('OfficeIMO', 'SkiaSharp', 'MagickNET', 'StbImageSharp')
+    }
+    imagejpegdecode = [pscustomobject]@{
+        Project = 'OfficeIMO.Drawing.Benchmarks.Comparisons\OfficeIMO.Drawing.Benchmarks.Comparisons.csproj'
+        Filter = '*ImageJpegDecodeBenchmarks*'
+        ComparisonId = "image-jpeg-decode-$Framework"
+        Suite = 'OfficeIMO.Drawing.JpegDecode'
+        IdentityVariables = @()
+        ExpectedCases = @('OfficeIMO', 'SkiaSharp', 'MagickNET', 'StbImageSharp')
+    }
+    imagepngencode = [pscustomobject]@{
+        Project = 'OfficeIMO.Drawing.Benchmarks.Comparisons\OfficeIMO.Drawing.Benchmarks.Comparisons.csproj'
+        Filter = '*ImagePngEncodeBenchmarks*'
+        ComparisonId = "image-png-encode-$Framework"
+        Suite = 'OfficeIMO.Drawing.PngEncode'
+        IdentityVariables = @()
+        ExpectedCases = @('OfficeIMO', 'SkiaSharp', 'MagickNET')
+    }
+    imageresize = [pscustomobject]@{
+        Project = 'OfficeIMO.Drawing.Benchmarks.Comparisons\OfficeIMO.Drawing.Benchmarks.Comparisons.csproj'
+        Filter = '*ImageResizeBenchmarks*'
+        ComparisonId = "image-resize-$Framework"
+        Suite = 'OfficeIMO.Drawing.Resize'
+        IdentityVariables = @()
+        ExpectedCases = @('OfficeIMO', 'SkiaSharp', 'MagickNET')
     }
     pdfgenerate = [pscustomobject]@{
         Project = 'OfficeIMO.Pdf.Benchmarks.Comparisons\OfficeIMO.Pdf.Benchmarks.Comparisons.csproj'

--- a/Build/Run-LibraryComparisonBenchmarks.ps1
+++ b/Build/Run-LibraryComparisonBenchmarks.ps1
@@ -36,6 +36,7 @@ param(
     [string] $PowerForgeRoot = $env:POWERFORGE_ROOT,
     [ValidateSet('net8.0', 'net10.0')]
     [string] $PowerForgeFramework = 'net8.0',
+    [UInt64] $AffinityMask = 0,
     [switch] $AcceptNPOIOSMFLicense,
     [switch] $Publish,
     [switch] $PlanOnly
@@ -50,6 +51,7 @@ if ($Publish -and $RunMode -ne 'full') {
 . (Join-Path $PSScriptRoot 'BenchmarkEvidence.ps1')
 
 $repositoryRoot = Split-Path -Parent $PSScriptRoot
+$affinityLabel = if ($AffinityMask -ne 0) { '0x{0:X}' -f $AffinityMask } else { $null }
 $OutputRoot = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath(
     $OutputRoot)
 $platform = if ([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform(
@@ -498,6 +500,9 @@ foreach ($name in $selected) {
         'benchmark.workload.sourceCommit' = $gitSha
         'benchmark.workload.framework' = $Framework
     }
+    if ($null -ne $affinityLabel) {
+        $provenanceMetadata['benchmark.workload.affinityMask'] = $affinityLabel
+    }
     $provenanceCapture = Start-BenchmarkProvenanceCapture `
         -SourceRoot $repositoryRoot `
         -ArtifactRoot $artifactsPath `
@@ -520,6 +525,9 @@ foreach ($name in $selected) {
     )
     if ($RunMode -eq 'quick') {
         $arguments += @('--job', 'Dry')
+    }
+    if ($AffinityMask -ne 0) {
+        $arguments += @('--affinity', $AffinityMask.ToString([Globalization.CultureInfo]::InvariantCulture))
     }
 
     Push-Location -LiteralPath $repositoryRoot
@@ -619,6 +627,7 @@ $outputs = foreach ($measurement in $measurements) {
         Platform = $platform
         RunMode = $RunMode
         Publish = $executionPlanByWorkload[$measurement.Workload].Publish
+        AffinityMask = $affinityLabel
         SourceCommit = $gitSha
         ArtifactsPath = $measurement.ArtifactsPath
         NormalizedResult = if ($measurement.CatalogEligible) {

--- a/Docs/README.md
+++ b/Docs/README.md
@@ -13,6 +13,7 @@ Use this index to find package guides, cross-package contracts, generated eviden
 - [Website search and answer-engine operations](officeimo.website-seo-geo-operations.md) — publication and discovery checks.
 - [CI and test strategy](officeimo.ci-test-strategy.md) — test ownership and validation lanes.
 - [Excel benchmark notes](officeimo.excel.benchmark-notes.md) — reproducible comparison-suite execution and provenance.
+- [Image engine benchmarks](../OfficeIMO.Drawing.Benchmarks/README.md) — validated identification, decode, encode, resize, and placement-optimization workloads, with isolated opt-in library comparisons.
 
 ## Current product contracts
 

--- a/OfficeIMO.Core/Internal/Compression/OfficeZlibCodec.cs
+++ b/OfficeIMO.Core/Internal/Compression/OfficeZlibCodec.cs
@@ -44,7 +44,60 @@ namespace OfficeIMO.Core.Internal {
 
             using var source = new MemoryStream(bytes, 2, bytes.Length - 6, writable: false);
             using var deflate = new DeflateStream(source, CompressionMode.Decompress);
-            using var output = new MemoryStream(expectedOutputBytes.GetValueOrDefault());
+            byte[] result = expectedOutputBytes.HasValue
+                ? DecompressExact(deflate, expectedOutputBytes.Value, maximumOutputBytes)
+                : DecompressBounded(deflate, maximumOutputBytes);
+            uint expectedChecksum = ReadBigEndianUInt32(bytes, bytes.Length - 4);
+            if (Adler32(result) != expectedChecksum) {
+                throw new InvalidDataException("The zlib stream Adler-32 checksum is invalid.");
+            }
+            return result;
+        }
+
+        private static uint Adler32(byte[] data) {
+            const uint Modulus = 65521;
+            const int MaximumChunk = 5552;
+            uint a = 1;
+            uint b = 0;
+            int offset = 0;
+            while (offset < data.Length) {
+                int end = Math.Min(offset + MaximumChunk, data.Length);
+                while (offset < end) {
+                    a += data[offset++];
+                    b += a;
+                }
+                a %= Modulus;
+                b %= Modulus;
+            }
+            return (b << 16) | a;
+        }
+
+        private static byte[] DecompressExact(DeflateStream deflate, int expectedOutputBytes, int maximumOutputBytes) {
+            if (expectedOutputBytes < 0) throw new ArgumentOutOfRangeException(nameof(expectedOutputBytes));
+            if (expectedOutputBytes > maximumOutputBytes) {
+                throw new OfficeDecompressionSizeLimitException(
+                    $"The decompressed zlib stream exceeds {maximumOutputBytes} bytes.");
+            }
+
+            var result = new byte[expectedOutputBytes];
+            int offset = 0;
+            while (offset < result.Length) {
+                int read = deflate.Read(result, offset, result.Length - offset);
+                if (read == 0) {
+                    throw new InvalidDataException(
+                        $"The zlib stream expanded to {offset} bytes instead of {expectedOutputBytes} bytes.");
+                }
+                offset += read;
+            }
+            if (deflate.ReadByte() != -1) {
+                throw new InvalidDataException(
+                    $"The zlib stream expanded beyond the expected {expectedOutputBytes} bytes.");
+            }
+            return result;
+        }
+
+        private static byte[] DecompressBounded(DeflateStream deflate, int maximumOutputBytes) {
+            using var output = new MemoryStream();
             var buffer = new byte[8192];
             while (true) {
                 int read = deflate.Read(buffer, 0, buffer.Length);
@@ -55,28 +108,7 @@ namespace OfficeIMO.Core.Internal {
                 }
                 output.Write(buffer, 0, read);
             }
-
-            byte[] result = output.ToArray();
-            if (expectedOutputBytes.HasValue && result.Length != expectedOutputBytes.Value) {
-                throw new InvalidDataException(
-                    $"The zlib stream expanded to {result.Length} bytes instead of {expectedOutputBytes.Value} bytes.");
-            }
-            uint expectedChecksum = ReadBigEndianUInt32(bytes, bytes.Length - 4);
-            if (Adler32(result) != expectedChecksum) {
-                throw new InvalidDataException("The zlib stream Adler-32 checksum is invalid.");
-            }
-            return result;
-        }
-
-        private static uint Adler32(byte[] data) {
-            const uint Modulus = 65521;
-            uint a = 1;
-            uint b = 0;
-            for (int index = 0; index < data.Length; index++) {
-                a = (a + data[index]) % Modulus;
-                b = (b + a) % Modulus;
-            }
-            return (b << 16) | a;
+            return output.ToArray();
         }
 
         private static uint ReadBigEndianUInt32(byte[] bytes, int offset) =>

--- a/OfficeIMO.Core/Jpeg/OfficeJpegCodec.cs
+++ b/OfficeIMO.Core/Jpeg/OfficeJpegCodec.cs
@@ -14,7 +14,7 @@ public static class OfficeJpegCodec {
         if (!IsJpeg(encodedBytes)) return false;
         try {
             byte[] pixels = OfficeJpegReader.DecodeRgba32(encodedBytes!, out int width, out int height, options);
-            image = OfficeRasterImage.FromRgba32(width, height, pixels);
+            image = OfficeRasterImage.FromOwnedRgba32(width, height, pixels);
             return true;
         } catch (Exception ex) when (ex is FormatException || ex is ArgumentException || ex is IndexOutOfRangeException || ex is OverflowException) {
             return false;
@@ -25,7 +25,7 @@ public static class OfficeJpegCodec {
     public static OfficeRasterImage Decode(byte[] encodedBytes, OfficeJpegDecodeOptions options = default) {
         if (encodedBytes == null) throw new ArgumentNullException(nameof(encodedBytes));
         byte[] pixels = OfficeJpegReader.DecodeRgba32(encodedBytes, out int width, out int height, options);
-        return OfficeRasterImage.FromRgba32(width, height, pixels);
+        return OfficeRasterImage.FromOwnedRgba32(width, height, pixels);
     }
 
     internal static bool TryDecodeColorComponents(
@@ -65,9 +65,19 @@ public static class OfficeJpegCodec {
     public static byte[] Encode(OfficeRasterImage image, OfficeJpegEncodeOptions? options = null) {
         if (image == null) throw new ArgumentNullException(nameof(image));
         OfficeJpegEncodeOptions effectiveOptions = options ?? new OfficeJpegEncodeOptions();
-        byte[] rgba = image.GetPixels();
-        FlattenAlpha(rgba, effectiveOptions.Background);
+        byte[] rgba = image.PixelBuffer;
+        if (HasTransparency(rgba)) {
+            rgba = (byte[])rgba.Clone();
+            FlattenAlpha(rgba, effectiveOptions.Background);
+        }
         return OfficeJpegWriter.WriteRgba(image.Width, image.Height, rgba, checked(image.Width * 4), effectiveOptions);
+    }
+
+    private static bool HasTransparency(byte[] rgba) {
+        for (int index = 3; index < rgba.Length; index += 4) {
+            if (rgba[index] != byte.MaxValue) return true;
+        }
+        return false;
     }
 
     private static void FlattenAlpha(byte[] rgba, OfficeColor background) {

--- a/OfficeIMO.Core/Jpeg/OfficeJpegReader.Decode.Helpers.cs
+++ b/OfficeIMO.Core/Jpeg/OfficeJpegReader.Decode.Helpers.cs
@@ -1262,8 +1262,18 @@ internal static partial class OfficeJpegReader {
         public bool AllowTruncated => _allowTruncated;
 
         public bool TryPeekBits(int count, out int value) {
+            int originalPosition = _pos;
+            int originalBitBuffer = _bitBuffer;
+            int originalBitCount = _bitCount;
+            bool originalRestartMarkerSeen = RestartMarkerSeen;
             while (_bitCount < count) {
                 if (!TryReadByte(out int next)) {
+                    RestorePeekState(originalPosition, originalBitBuffer, originalBitCount, originalRestartMarkerSeen);
+                    value = 0;
+                    return false;
+                }
+                if (RestartMarkerSeen != originalRestartMarkerSeen) {
+                    RestorePeekState(originalPosition, originalBitBuffer, originalBitCount, originalRestartMarkerSeen);
                     value = 0;
                     return false;
                 }
@@ -1272,6 +1282,13 @@ internal static partial class OfficeJpegReader {
             }
             value = (_bitBuffer >> (_bitCount - count)) & ((1 << count) - 1);
             return true;
+        }
+
+        private void RestorePeekState(int position, int bitBuffer, int bitCount, bool restartMarkerSeen) {
+            _pos = position;
+            _bitBuffer = bitBuffer;
+            _bitCount = bitCount;
+            RestartMarkerSeen = restartMarkerSeen;
         }
 
         public void SkipBits(int count) {

--- a/OfficeIMO.Core/Jpeg/OfficeJpegReader.Decode.Helpers.cs
+++ b/OfficeIMO.Core/Jpeg/OfficeJpegReader.Decode.Helpers.cs
@@ -166,12 +166,33 @@ internal static partial class OfficeJpegReader {
                 : usePdfColorTransformDefault || !hasRgbComponentIds;
 
         var yIndex2 = FindComponentIndex(frame.Components, 1);
-        if (yIndex2 < 0) yIndex2 = 0;
         var cbIndex = frame.ComponentCount > 1 ? FindComponentIndex(frame.Components, 2) : -1;
         var crIndex = frame.ComponentCount > 1 ? FindComponentIndex(frame.Components, 3) : -1;
         if (frame.ComponentCount == 3) {
-            if (cbIndex < 0) cbIndex = yIndex2 == 0 ? 1 : 0;
-            if (crIndex < 0) crIndex = yIndex2 == 2 ? 1 : 2;
+            bool hasConventionalYccIds = yIndex2 >= 0 && cbIndex >= 0 && crIndex >= 0;
+            if (!hasConventionalYccIds) {
+                yIndex2 = 0;
+                cbIndex = 1;
+                crIndex = 2;
+            }
+
+            if (!highQualityChroma) {
+                int firstIndex = transformToRgb ? yIndex2 : hasRgbComponentIds ? rIndex : 0;
+                int secondIndex = transformToRgb ? cbIndex : hasRgbComponentIds ? gIndex : 1;
+                int thirdIndex = transformToRgb ? crIndex : hasRgbComponentIds ? bIndex : 2;
+                ComposeThreeComponentNearest(
+                    components,
+                    frame.Width,
+                    frame.Height,
+                    states[firstIndex],
+                    states[secondIndex],
+                    states[thirdIndex],
+                    maxH,
+                    maxV,
+                    transformToRgb,
+                    outputRgba);
+                return components;
+            }
         }
 
         for (var y = 0; y < frame.Height; y++) {
@@ -214,6 +235,89 @@ internal static partial class OfficeJpegReader {
         }
 
         return components;
+    }
+
+    private static void ComposeThreeComponentNearest(
+        byte[] output,
+        int width,
+        int height,
+        BaselineComponentState first,
+        BaselineComponentState second,
+        BaselineComponentState third,
+        int maximumHorizontalSampling,
+        int maximumVerticalSampling,
+        bool transformYccToRgb,
+        bool outputRgba) {
+        int firstY = 0;
+        int secondY = 0;
+        int thirdY = 0;
+        int firstYAccumulator = 0;
+        int secondYAccumulator = 0;
+        int thirdYAccumulator = 0;
+        int target = 0;
+
+        for (int y = 0; y < height; y++) {
+            int firstRow = firstY * first.Stride;
+            int secondRow = secondY * second.Stride;
+            int thirdRow = thirdY * third.Stride;
+            int firstX = 0;
+            int secondX = 0;
+            int thirdX = 0;
+            int firstXAccumulator = 0;
+            int secondXAccumulator = 0;
+            int thirdXAccumulator = 0;
+
+            for (int x = 0; x < width; x++) {
+                byte firstValue = first.Buffer[firstRow + firstX];
+                byte secondValue = second.Buffer[secondRow + secondX];
+                byte thirdValue = third.Buffer[thirdRow + thirdX];
+                if (transformYccToRgb) {
+                    int red = firstValue + CrToR[thirdValue];
+                    int green = firstValue - CbToG[secondValue] - CrToG[thirdValue];
+                    int blue = firstValue + CbToB[secondValue];
+                    output[target++] = ClampToByte(red);
+                    output[target++] = ClampToByte(green);
+                    output[target++] = ClampToByte(blue);
+                } else {
+                    output[target++] = firstValue;
+                    output[target++] = secondValue;
+                    output[target++] = thirdValue;
+                }
+                if (outputRgba) output[target++] = byte.MaxValue;
+
+                firstXAccumulator += first.Component.H;
+                if (firstXAccumulator >= maximumHorizontalSampling) {
+                    firstX++;
+                    firstXAccumulator -= maximumHorizontalSampling;
+                }
+                secondXAccumulator += second.Component.H;
+                if (secondXAccumulator >= maximumHorizontalSampling) {
+                    secondX++;
+                    secondXAccumulator -= maximumHorizontalSampling;
+                }
+                thirdXAccumulator += third.Component.H;
+                if (thirdXAccumulator >= maximumHorizontalSampling) {
+                    thirdX++;
+                    thirdXAccumulator -= maximumHorizontalSampling;
+                }
+            }
+
+            firstYAccumulator += first.Component.V;
+            if (firstYAccumulator >= maximumVerticalSampling) {
+                firstY++;
+                firstYAccumulator -= maximumVerticalSampling;
+            }
+            secondYAccumulator += second.Component.V;
+            if (secondYAccumulator >= maximumVerticalSampling) {
+                secondY++;
+                secondYAccumulator -= maximumVerticalSampling;
+            }
+            thirdYAccumulator += third.Component.V;
+            if (thirdYAccumulator >= maximumVerticalSampling) {
+                thirdY++;
+                thirdYAccumulator -= maximumVerticalSampling;
+            }
+        }
     }
 
     private static void WriteGrayPixel(byte[] output, int pixel, byte gray, bool outputRgba) {
@@ -316,7 +420,8 @@ internal static partial class OfficeJpegReader {
         int[] quant,
         ref int prevDc,
         int[] coeffs,
-        int[] pixels) {
+        byte[] pixels,
+        int[] workspace) {
         Array.Clear(coeffs, 0, 64);
 
         var t = DecodeHuffman(ref reader, dcTable, useFast: true);
@@ -347,12 +452,11 @@ internal static partial class OfficeJpegReader {
             k++;
         }
 
-        InverseDct(coeffs, pixels);
+        InverseDct(coeffs, pixels, workspace);
     }
 
     private static int DecodeHuffman(ref JpegBitReader reader, HuffmanTable table, bool useFast) {
-        if (useFast && table.Fast is not null && reader.HasBits(HuffmanFastBits)) {
-            var peek = reader.PeekBits(HuffmanFastBits);
+        if (useFast && table.Fast is not null && reader.TryPeekBits(HuffmanFastBits, out int peek)) {
             var entry = table.Fast[peek];
             if (entry >= 0) {
                 var size = entry >> 8;
@@ -381,20 +485,17 @@ internal static partial class OfficeJpegReader {
         return value;
     }
 
-    private static void WriteBlock(int[] buffer, int stride, int blockX, int blockY, int[] pixels) {
+    private static void WriteBlock(byte[] buffer, int stride, int blockX, int blockY, byte[] pixels) {
         var baseX = blockX * 8;
         var baseY = blockY * 8;
         for (var y = 0; y < 8; y++) {
             var row = (baseY + y) * stride + baseX;
             var src = y * 8;
-            for (var x = 0; x < 8; x++) {
-                buffer[row + x] = pixels[src + x];
-            }
+            Buffer.BlockCopy(pixels, src, buffer, row, 8);
         }
     }
 
-    private static void InverseDct(int[] input, int[] output) {
-        int[] workspace = new int[64];
+    private static void InverseDct(int[] input, byte[] output, int[] workspace) {
 
         // Pass 1: process columns into the workspace (scaled by Pass1Bits).
         for (var ctr = 0; ctr < 8; ctr++) {
@@ -890,9 +991,10 @@ internal static partial class OfficeJpegReader {
 
     private sealed class BaselineComponentState {
         public Component Component;
-        public int[] Buffer;
+        public byte[] Buffer;
         public int[] BlockCoeffs;
-        public int[] BlockPixels;
+        public byte[] BlockPixels;
+        public int[] BlockWorkspace;
         public int Stride;
         public int BlocksPerRow;
         public int BlocksPerCol;
@@ -903,10 +1005,11 @@ internal static partial class OfficeJpegReader {
             BlocksPerRow = blocksPerRow;
             BlocksPerCol = blocksPerCol;
             Stride = OfficeRasterGuards.EnsureByteCount((long)blocksPerRow * 8, JpegDimensionsLimitMessage);
-            var bufferLength = OfficeRasterGuards.EnsureInt32ArrayLength((long)Stride * blocksPerCol * 8, ref aggregateBytes, JpegDimensionsLimitMessage);
-            Buffer = new int[bufferLength];
+            var bufferLength = OfficeRasterGuards.EnsureByteArrayLength((long)Stride * blocksPerCol * 8, ref aggregateBytes, JpegDimensionsLimitMessage);
+            Buffer = new byte[bufferLength];
             BlockCoeffs = new int[OfficeRasterGuards.EnsureInt32ArrayLength(64, ref aggregateBytes, JpegDimensionsLimitMessage)];
-            BlockPixels = new int[OfficeRasterGuards.EnsureInt32ArrayLength(64, ref aggregateBytes, JpegDimensionsLimitMessage)];
+            BlockPixels = new byte[OfficeRasterGuards.EnsureByteArrayLength(64, ref aggregateBytes, JpegDimensionsLimitMessage)];
+            BlockWorkspace = new int[OfficeRasterGuards.EnsureInt32ArrayLength(64, ref aggregateBytes, JpegDimensionsLimitMessage)];
             PrevDc = 0;
         }
 
@@ -915,7 +1018,7 @@ internal static partial class OfficeJpegReader {
             int blocksPerRow,
             int blocksPerCol,
             int stride,
-            int[] buffer) {
+            byte[] buffer) {
             return new BaselineComponentState {
                 Component = component,
                 BlocksPerRow = blocksPerRow,
@@ -923,14 +1026,16 @@ internal static partial class OfficeJpegReader {
                 Stride = stride,
                 Buffer = buffer,
                 BlockCoeffs = Array.Empty<int>(),
-                BlockPixels = Array.Empty<int>()
+                BlockPixels = Array.Empty<byte>(),
+                BlockWorkspace = Array.Empty<int>()
             };
         }
 
         private BaselineComponentState() {
-            Buffer = Array.Empty<int>();
+            Buffer = Array.Empty<byte>();
             BlockCoeffs = Array.Empty<int>();
-            BlockPixels = Array.Empty<int>();
+            BlockPixels = Array.Empty<byte>();
+            BlockWorkspace = Array.Empty<int>();
         }
     }
 
@@ -960,7 +1065,12 @@ internal static partial class OfficeJpegReader {
                 }
                 var blocksPerRow = OfficeRasterGuards.EnsureByteCount((long)mcuCols * comp.H, JpegDimensionsLimitMessage);
                 var blocksPerCol = OfficeRasterGuards.EnsureByteCount((long)mcuRows * comp.V, JpegDimensionsLimitMessage);
-                components[i] = new ProgressiveComponentState(comp, blocksPerRow, blocksPerCol, ref aggregateBytes);
+                components[i] = new ProgressiveComponentState(
+                    comp,
+                    blocksPerRow,
+                    blocksPerCol,
+                    quantTables[comp.QuantId],
+                    ref aggregateBytes);
             }
 
             return new ProgressiveState {
@@ -1000,8 +1110,11 @@ internal static partial class OfficeJpegReader {
                 for (var by = 0; by < compState.BlocksPerCol; by++) {
                     for (var bx = 0; bx < compState.BlocksPerRow; bx++) {
                         var baseIndex = (by * compState.BlocksPerRow + bx) * 64;
-                        Array.Copy(compState.Coeffs, baseIndex, compState.BlockCoeffs, 0, 64);
-                        InverseDct(compState.BlockCoeffs, compState.BlockPixels);
+                        for (int coefficient = 0; coefficient < 64; coefficient++) {
+                            compState.BlockCoeffs[coefficient] =
+                                compState.Coeffs[baseIndex + coefficient] * compState.Quantization[coefficient];
+                        }
+                        InverseDct(compState.BlockCoeffs, compState.BlockPixels, compState.BlockWorkspace);
                         WriteBlock(compState.Buffer, compState.Stride, bx, by, compState.BlockPixels);
                     }
                 }
@@ -1032,24 +1145,33 @@ internal static partial class OfficeJpegReader {
         public Component Component;
         public int BlocksPerRow;
         public int BlocksPerCol;
-        public int[] Coeffs;
-        public int[] Buffer;
+        public short[] Coeffs;
+        public int[] Quantization;
+        public byte[] Buffer;
         public int[] BlockCoeffs;
-        public int[] BlockPixels;
+        public byte[] BlockPixels;
+        public int[] BlockWorkspace;
         public int Stride;
         public int PrevDc;
 
-        public ProgressiveComponentState(Component component, int blocksPerRow, int blocksPerCol, ref long aggregateBytes) {
+        public ProgressiveComponentState(
+            Component component,
+            int blocksPerRow,
+            int blocksPerCol,
+            int[] quantization,
+            ref long aggregateBytes) {
             Component = component;
             BlocksPerRow = blocksPerRow;
             BlocksPerCol = blocksPerCol;
+            Quantization = quantization;
             Stride = OfficeRasterGuards.EnsureByteCount((long)blocksPerRow * 8, JpegDimensionsLimitMessage);
-            var coeffLength = OfficeRasterGuards.EnsureInt32ArrayLength((long)BlocksPerRow * BlocksPerCol * 64, ref aggregateBytes, JpegDimensionsLimitMessage);
-            var bufferLength = OfficeRasterGuards.EnsureInt32ArrayLength((long)Stride * blocksPerCol * 8, ref aggregateBytes, JpegDimensionsLimitMessage);
-            Coeffs = new int[coeffLength];
-            Buffer = new int[bufferLength];
+            var coeffLength = OfficeRasterGuards.EnsureInt16ArrayLength((long)BlocksPerRow * BlocksPerCol * 64, ref aggregateBytes, JpegDimensionsLimitMessage);
+            var bufferLength = OfficeRasterGuards.EnsureByteArrayLength((long)Stride * blocksPerCol * 8, ref aggregateBytes, JpegDimensionsLimitMessage);
+            Coeffs = new short[coeffLength];
+            Buffer = new byte[bufferLength];
             BlockCoeffs = new int[OfficeRasterGuards.EnsureInt32ArrayLength(64, ref aggregateBytes, JpegDimensionsLimitMessage)];
-            BlockPixels = new int[OfficeRasterGuards.EnsureInt32ArrayLength(64, ref aggregateBytes, JpegDimensionsLimitMessage)];
+            BlockPixels = new byte[OfficeRasterGuards.EnsureByteArrayLength(64, ref aggregateBytes, JpegDimensionsLimitMessage)];
+            BlockWorkspace = new int[OfficeRasterGuards.EnsureInt32ArrayLength(64, ref aggregateBytes, JpegDimensionsLimitMessage)];
             PrevDc = 0;
         }
     }
@@ -1139,14 +1261,17 @@ internal static partial class OfficeJpegReader {
 
         public bool AllowTruncated => _allowTruncated;
 
-        public bool HasBits(int count) {
-            return _bitCount >= count;
-        }
-
-        public int PeekBits(int count) {
-            if (count == 0) return 0;
-            EnsureBits(count);
-            return (_bitBuffer >> (_bitCount - count)) & ((1 << count) - 1);
+        public bool TryPeekBits(int count, out int value) {
+            while (_bitCount < count) {
+                if (!TryReadByte(out int next)) {
+                    value = 0;
+                    return false;
+                }
+                _bitBuffer = (_bitBuffer << 8) | next;
+                _bitCount += 8;
+            }
+            value = (_bitBuffer >> (_bitCount - count)) & ((1 << count) - 1);
+            return true;
         }
 
         public void SkipBits(int count) {
@@ -1214,24 +1339,43 @@ internal static partial class OfficeJpegReader {
         }
 
         private int ReadByte() {
+            if (TryReadByte(out int value)) return value;
+            throw new FormatException("Unexpected JPEG end.");
+        }
+
+        private bool TryReadByte(out int value) {
             while (_pos < _data.Length) {
                 var b = _data[_pos++];
-                if (b != 0xFF) return b;
+                if (b != 0xFF) {
+                    value = b;
+                    return true;
+                }
                 while (_pos < _data.Length && _data[_pos] == 0xFF) _pos++;
                 if (_pos >= _data.Length) {
-                    if (_allowTruncated) return 0;
-                    throw new FormatException("Unexpected JPEG end.");
+                    if (_allowTruncated) {
+                        value = 0;
+                        return true;
+                    }
+                    value = 0;
+                    return false;
                 }
                 var marker = _data[_pos++];
-                if (marker == 0x00) return 0xFF;
+                if (marker == 0x00) {
+                    value = 0xFF;
+                    return true;
+                }
                 if (marker >= 0xD0 && marker <= 0xD7) {
                     RestartMarkerSeen = true;
                     continue;
                 }
                 throw new FormatException("Unexpected JPEG marker in scan.");
             }
-            if (_allowTruncated) return 0;
-            throw new FormatException("Unexpected JPEG end.");
+            if (_allowTruncated) {
+                value = 0;
+                return true;
+            }
+            value = 0;
+            return false;
         }
     }
 

--- a/OfficeIMO.Core/Jpeg/OfficeJpegReader.Decode.Scan.cs
+++ b/OfficeIMO.Core/Jpeg/OfficeJpegReader.Decode.Scan.cs
@@ -49,7 +49,8 @@ internal static partial class OfficeJpegReader {
                         quantTables[componentState.Component.QuantId],
                         ref componentState.PrevDc,
                         componentState.BlockCoeffs,
-                        componentState.BlockPixels);
+                        componentState.BlockPixels,
+                        componentState.BlockWorkspace);
                     WriteBlock(componentState.Buffer, componentState.Stride, mx, my, componentState.BlockPixels);
                 } else {
                     for (var ci = 0; ci < scan.ComponentIndices.Length; ci++) {
@@ -64,7 +65,8 @@ internal static partial class OfficeJpegReader {
                                 quantTables[componentState.Component.QuantId],
                                 ref componentState.PrevDc,
                                 componentState.BlockCoeffs,
-                                componentState.BlockPixels);
+                                componentState.BlockPixels,
+                                componentState.BlockWorkspace);
 
                             var blockX = mx * componentState.Component.H + (b % componentState.Component.H);
                             var blockY = my * componentState.Component.V + (b / componentState.Component.H);
@@ -239,8 +241,7 @@ internal static partial class OfficeJpegReader {
         int blockX,
         int blockY,
         ref int eobRun) {
-        var quant = quantTables[state.Component.QuantId];
-        if (quant is null) throw new FormatException("Missing JPEG quantization table.");
+        if (quantTables[state.Component.QuantId] is null) throw new FormatException("Missing JPEG quantization table.");
         var baseIndex = (blockY * state.BlocksPerRow + blockX) * 64;
 
         if (scan.Ss == 0 && scan.Se == 0) {
@@ -251,13 +252,13 @@ internal static partial class OfficeJpegReader {
                 var diff = t == 0 ? 0 : Extend(reader.ReadBits(t), t);
                 var dc = state.PrevDc + (diff << scan.Al);
                 state.PrevDc = dc;
-                state.Coeffs[baseIndex] = dc * quant[0];
+                SetProgressiveCoefficient(state.Coeffs, baseIndex, dc);
             } else {
                 var bit = reader.ReadBit();
                 if (bit != 0) {
-                    var delta = (1 << scan.Al) * quant[0];
-                    var sign = state.Coeffs[baseIndex] >= 0 ? 1 : -1;
-                    state.Coeffs[baseIndex] += sign * delta;
+                    var delta = 1 << scan.Al;
+                    int refined = unchecked((short)((ushort)state.Coeffs[baseIndex] | (ushort)delta));
+                    SetProgressiveCoefficient(state.Coeffs, baseIndex, refined);
                 }
             }
             return;
@@ -268,9 +269,9 @@ internal static partial class OfficeJpegReader {
         if (!acTable.IsValid) throw new FormatException("Missing JPEG AC Huffman table.");
 
         if (scan.Ah == 0) {
-            DecodeProgressiveAcFirst(ref reader, scan, state, acTable, quant, baseIndex, ref eobRun);
+            DecodeProgressiveAcFirst(ref reader, scan, state, acTable, baseIndex, ref eobRun);
         } else {
-            DecodeProgressiveAcRefine(ref reader, scan, state, acTable, quant, baseIndex, ref eobRun);
+            DecodeProgressiveAcRefine(ref reader, scan, state, acTable, baseIndex, ref eobRun);
         }
     }
 
@@ -282,7 +283,6 @@ internal static partial class OfficeJpegReader {
         ScanHeader scan,
         ProgressiveComponentState state,
         HuffmanTable acTable,
-        int[] quant,
         int baseIndex,
         ref int eobRun) {
         if (eobRun > 0) {
@@ -313,7 +313,7 @@ internal static partial class OfficeJpegReader {
             if (k > scan.Se) break;
             var ac = Extend(reader.ReadBits(s), s);
             var zig = ZigZag[k];
-            state.Coeffs[baseIndex + zig] = (ac << scan.Al) * quant[zig];
+            SetProgressiveCoefficient(state.Coeffs, baseIndex + zig, ac << scan.Al);
             k++;
         }
     }
@@ -323,13 +323,12 @@ internal static partial class OfficeJpegReader {
         ScanHeader scan,
         ProgressiveComponentState state,
         HuffmanTable acTable,
-        int[] quant,
         int baseIndex,
         ref int eobRun) {
         var k = (int)scan.Ss;
         if (eobRun > 0) {
             for (; k <= scan.Se; k++) {
-                RefineCoefficient(ref reader, state.Coeffs, baseIndex + ZigZag[k], scan.Al, quant[ZigZag[k]]);
+                RefineCoefficient(ref reader, state.Coeffs, baseIndex + ZigZag[k], scan.Al);
             }
             eobRun--;
             return;
@@ -345,7 +344,7 @@ internal static partial class OfficeJpegReader {
                     var zeros = 16;
                     while (zeros > 0 && k <= scan.Se) {
                         var index = baseIndex + ZigZag[k];
-                        RefineCoefficient(ref reader, state.Coeffs, index, scan.Al, quant[ZigZag[k]]);
+                        RefineCoefficient(ref reader, state.Coeffs, index, scan.Al);
                         if (state.Coeffs[index] == 0) zeros--;
                         k++;
                     }
@@ -355,7 +354,7 @@ internal static partial class OfficeJpegReader {
                 eobRun = (1 << r) - 1;
                 if (r > 0) eobRun += reader.ReadBits(r);
                 for (; k <= scan.Se; k++) {
-                    RefineCoefficient(ref reader, state.Coeffs, baseIndex + ZigZag[k], scan.Al, quant[ZigZag[k]]);
+                    RefineCoefficient(ref reader, state.Coeffs, baseIndex + ZigZag[k], scan.Al);
                 }
                 break;
             }
@@ -366,7 +365,7 @@ internal static partial class OfficeJpegReader {
                 var zig = ZigZag[k];
                 var index = baseIndex + zig;
                 if (state.Coeffs[index] != 0) {
-                    RefineCoefficient(ref reader, state.Coeffs, index, scan.Al, quant[zig]);
+                    RefineCoefficient(ref reader, state.Coeffs, index, scan.Al);
                     k++;
                     continue;
                 }
@@ -377,19 +376,27 @@ internal static partial class OfficeJpegReader {
                     continue;
                 }
 
-                state.Coeffs[index] = (ac << scan.Al) * quant[zig];
+                SetProgressiveCoefficient(state.Coeffs, index, ac << scan.Al);
                 k++;
                 break;
             }
         }
     }
 
-    private static void RefineCoefficient(ref JpegBitReader reader, int[] coeffs, int index, int al, int quant) {
+    private static void RefineCoefficient(ref JpegBitReader reader, short[] coeffs, int index, int al) {
         if (coeffs[index] == 0) return;
         var bit = reader.ReadBit();
         if (bit == 0) return;
-        var delta = (1 << al) * quant;
-        coeffs[index] += coeffs[index] > 0 ? delta : -delta;
+        var delta = 1 << al;
+        if (((ushort)coeffs[index] & (ushort)delta) != 0) return;
+        SetProgressiveCoefficient(coeffs, index, coeffs[index] + (coeffs[index] > 0 ? delta : -delta));
+    }
+
+    private static void SetProgressiveCoefficient(short[] coefficients, int index, int value) {
+        if (value < short.MinValue || value > short.MaxValue) {
+            throw new FormatException("Progressive JPEG coefficient exceeds the supported 8-bit sample range.");
+        }
+        coefficients[index] = (short)value;
     }
 
 }

--- a/OfficeIMO.Core/Png/OfficePngReader.cs
+++ b/OfficeIMO.Core/Png/OfficePngReader.cs
@@ -324,6 +324,11 @@ public static class OfficePngReader {
     }
 
     private static void ExpandScanline(byte[] current, int width, int y, int colorType, int bitDepth, byte[]? palette, byte[]? transparency, OfficeRasterImage image) {
+        if (colorType == 6 && bitDepth == 8) {
+            Buffer.BlockCopy(current, 0, image.PixelBuffer, checked(y * width * 4), checked(width * 4));
+            return;
+        }
+
         for (int x = 0; x < width; x++) {
             OfficeColor color;
             switch (colorType) {
@@ -433,31 +438,42 @@ public static class OfficePngReader {
         blue == ((transparency[4] << 8) | transparency[5]);
 
     private static void Unfilter(byte[] current, byte[] previous, int bytesPerPixel, int filter) {
-        for (int i = 0; i < current.Length; i++) {
-            int left = i >= bytesPerPixel ? current[i - bytesPerPixel] : 0;
-            int up = previous[i];
-            int upLeft = i >= bytesPerPixel ? previous[i - bytesPerPixel] : 0;
-            int value = current[i];
-            switch (filter) {
-                case 0:
-                    break;
-                case 1:
-                    value += left;
-                    break;
-                case 2:
-                    value += up;
-                    break;
-                case 3:
-                    value += (left + up) / 2;
-                    break;
-                case 4:
-                    value += Paeth(left, up, upLeft);
-                    break;
-                default:
-                    throw new InvalidDataException("Unsupported PNG filter.");
-            }
-
-            current[i] = (byte)(value & 0xFF);
+        switch (filter) {
+            case 0:
+                return;
+            case 1:
+                for (int index = bytesPerPixel; index < current.Length; index++) {
+                    current[index] = unchecked((byte)(current[index] + current[index - bytesPerPixel]));
+                }
+                return;
+            case 2:
+                for (int index = 0; index < current.Length; index++) {
+                    current[index] = unchecked((byte)(current[index] + previous[index]));
+                }
+                return;
+            case 3:
+                int prefixLength = Math.Min(bytesPerPixel, current.Length);
+                for (int index = 0; index < prefixLength; index++) {
+                    current[index] = unchecked((byte)(current[index] + (previous[index] / 2)));
+                }
+                for (int index = bytesPerPixel; index < current.Length; index++) {
+                    current[index] = unchecked((byte)(current[index] + ((current[index - bytesPerPixel] + previous[index]) / 2)));
+                }
+                return;
+            case 4:
+                int firstPixelBytes = Math.Min(bytesPerPixel, current.Length);
+                for (int index = 0; index < firstPixelBytes; index++) {
+                    current[index] = unchecked((byte)(current[index] + previous[index]));
+                }
+                for (int index = bytesPerPixel; index < current.Length; index++) {
+                    current[index] = unchecked((byte)(current[index] + Paeth(
+                        current[index - bytesPerPixel],
+                        previous[index],
+                        previous[index - bytesPerPixel])));
+                }
+                return;
+            default:
+                throw new InvalidDataException("Unsupported PNG filter.");
         }
     }
 

--- a/OfficeIMO.Core/Png/OfficePngWriter.cs
+++ b/OfficeIMO.Core/Png/OfficePngWriter.cs
@@ -25,6 +25,7 @@ public enum OfficePngCompression {
 /// </summary>
 public static class OfficePngWriter {
     private static readonly byte[] PngSignature = { 137, 80, 78, 71, 13, 10, 26, 10 };
+    private static readonly uint[] CrcTable = CreateCrcTable();
 
     /// <summary>
     /// Encodes an RGBA image as PNG bytes.
@@ -34,7 +35,7 @@ public static class OfficePngWriter {
             throw new ArgumentNullException(nameof(image));
         }
 
-        return EncodeRgba(image.Width, image.Height, image.GetPixels(), compression);
+        return EncodeRgba(image.Width, image.Height, image.PixelBuffer, compression);
     }
 
     /// <summary>Encodes an RGBA image with explicit compression and physical-resolution metadata.</summary>
@@ -43,7 +44,7 @@ public static class OfficePngWriter {
         if (options == null) throw new ArgumentNullException(nameof(options));
         ValidateDpi(options.DpiX, nameof(options.DpiX));
         ValidateDpi(options.DpiY, nameof(options.DpiY));
-        return EncodeRgba(image.Width, image.Height, image.GetPixels(), options);
+        return EncodeRgba(image.Width, image.Height, image.PixelBuffer, options);
     }
 
     /// <summary>
@@ -66,15 +67,7 @@ public static class OfficePngWriter {
             throw new ArgumentException("RGBA buffer length does not match image dimensions.", nameof(rgba));
         }
 
-        byte[] scanlines = new byte[height * (1 + width * 4)];
-        int source = 0;
-        int target = 0;
-        for (int y = 0; y < height; y++) {
-            scanlines[target++] = 0;
-            Buffer.BlockCopy(rgba, source, scanlines, target, width * 4);
-            source += width * 4;
-            target += width * 4;
-        }
+        byte[] scanlines = CreateRgbaScanlines(width, height, rgba, compression == OfficePngCompression.Optimal);
 
         return EncodeScanlines(width, height, 8, 6, scanlines, compression);
     }
@@ -86,7 +79,7 @@ public static class OfficePngWriter {
         ValidateDpi(options.DpiY, nameof(options.DpiY));
         ValidateRgba(width, height, rgba);
 
-        byte[] scanlines = CreateRgbaScanlines(width, height, rgba);
+        byte[] scanlines = CreateRgbaScanlines(width, height, rgba, options.Compression == OfficePngCompression.Optimal);
         byte[] compressed = options.Compression switch {
             OfficePngCompression.Optimal => DeflateZlib(scanlines),
             OfficePngCompression.Stored => DeflateZlibStored(scanlines),
@@ -178,17 +171,84 @@ public static class OfficePngWriter {
         }
     }
 
-    private static byte[] CreateRgbaScanlines(int width, int height, byte[] rgba) {
-        byte[] scanlines = new byte[height * (1 + width * 4)];
-        int source = 0;
-        int target = 0;
+    private static byte[] CreateRgbaScanlines(int width, int height, byte[] rgba, bool adaptiveFiltering) {
+        int stride = checked(width * 4);
+        byte[] scanlines = new byte[checked(height * (1 + stride))];
+        if (!adaptiveFiltering) {
+            int source = 0;
+            int target = 0;
+            for (int y = 0; y < height; y++) {
+                scanlines[target++] = 0;
+                Buffer.BlockCopy(rgba, source, scanlines, target, stride);
+                source += stride;
+                target += stride;
+            }
+            return scanlines;
+        }
+
+        byte[] candidate = new byte[stride];
         for (int y = 0; y < height; y++) {
-            scanlines[target++] = 0;
-            Buffer.BlockCopy(rgba, source, scanlines, target, width * 4);
-            source += width * 4;
-            target += width * 4;
+            int rowOffset = y * stride;
+            int previousRowOffset = rowOffset - stride;
+            int target = y * (stride + 1);
+            if (y == 0) {
+                scanlines[target] = 1;
+                FilterFirstRowSub(rgba, rowOffset, stride, scanlines, target + 1);
+                continue;
+            }
+
+            long upScore = FilterUp(rgba, rowOffset, previousRowOffset, stride, scanlines, target + 1);
+            long paethScore = FilterPaeth(rgba, rowOffset, previousRowOffset, stride, candidate);
+            if (paethScore < upScore) {
+                scanlines[target] = 4;
+                Buffer.BlockCopy(candidate, 0, scanlines, target + 1, stride);
+            } else {
+                scanlines[target] = 2;
+            }
         }
         return scanlines;
+    }
+
+    private static void FilterFirstRowSub(byte[] rgba, int rowOffset, int stride, byte[] destination, int destinationOffset) {
+        for (int index = 0; index < 4 && index < stride; index++) {
+            destination[destinationOffset + index] = rgba[rowOffset + index];
+        }
+        for (int index = 4; index < stride; index++) {
+            destination[destinationOffset + index] = unchecked((byte)(rgba[rowOffset + index] - rgba[rowOffset + index - 4]));
+        }
+    }
+
+    private static long FilterUp(byte[] rgba, int rowOffset, int previousRowOffset, int stride, byte[] destination, int destinationOffset) {
+        long score = 0L;
+        for (int index = 0; index < stride; index++) {
+            byte filtered = unchecked((byte)(rgba[rowOffset + index] - rgba[previousRowOffset + index]));
+            destination[destinationOffset + index] = filtered;
+            score += Math.Abs((int)(sbyte)filtered);
+        }
+        return score;
+    }
+
+    private static long FilterPaeth(byte[] rgba, int rowOffset, int previousRowOffset, int stride, byte[] destination) {
+        long score = 0L;
+        for (int index = 0; index < stride; index++) {
+            int left = index >= 4 ? rgba[rowOffset + index - 4] : 0;
+            int above = rgba[previousRowOffset + index];
+            int upperLeft = index >= 4 ? rgba[previousRowOffset + index - 4] : 0;
+            byte filtered = unchecked((byte)(rgba[rowOffset + index] - PaethPredictor(left, above, upperLeft)));
+            destination[index] = filtered;
+            score += Math.Abs((int)(sbyte)filtered);
+        }
+        return score;
+    }
+
+    private static int PaethPredictor(int left, int above, int upperLeft) {
+        int prediction = left + above - upperLeft;
+        int distanceLeft = Math.Abs(prediction - left);
+        int distanceAbove = Math.Abs(prediction - above);
+        int distanceUpperLeft = Math.Abs(prediction - upperLeft);
+        return distanceLeft <= distanceAbove && distanceLeft <= distanceUpperLeft
+            ? left
+            : distanceAbove <= distanceUpperLeft ? above : upperLeft;
     }
 
     private static byte[] BuildPhysicalResolution(double dpiX, double dpiY) {
@@ -324,11 +384,18 @@ public static class OfficePngWriter {
 
     private static uint Adler32(byte[] data) {
         const uint mod = 65521;
+        const int maximumChunk = 5552;
         uint a = 1;
         uint b = 0;
-        for (int i = 0; i < data.Length; i++) {
-            a = (a + data[i]) % mod;
-            b = (b + a) % mod;
+        int offset = 0;
+        while (offset < data.Length) {
+            int end = Math.Min(offset + maximumChunk, data.Length);
+            while (offset < end) {
+                a += data[offset++];
+                b += a;
+            }
+            a %= mod;
+            b %= mod;
         }
 
         return (b << 16) | a;
@@ -362,12 +429,19 @@ public static class OfficePngWriter {
     }
 
     private static uint UpdateCrc(uint crc, byte value) {
-        crc ^= value;
-        for (int i = 0; i < 8; i++) {
-            crc = (crc & 1) != 0 ? 0xEDB88320 ^ (crc >> 1) : crc >> 1;
-        }
+        return CrcTable[(crc ^ value) & 0xFF] ^ (crc >> 8);
+    }
 
-        return crc;
+    private static uint[] CreateCrcTable() {
+        var table = new uint[256];
+        for (uint index = 0; index < table.Length; index++) {
+            uint value = index;
+            for (int bit = 0; bit < 8; bit++) {
+                value = (value & 1) != 0 ? 0xEDB88320 ^ (value >> 1) : value >> 1;
+            }
+            table[index] = value;
+        }
+        return table;
     }
 
     private static void WriteBigEndianInt32(byte[] bytes, int offset, int value) {

--- a/OfficeIMO.Core/Raster/OfficeGifReader.cs
+++ b/OfficeIMO.Core/Raster/OfficeGifReader.cs
@@ -156,7 +156,7 @@ public static class OfficeGifReader {
                     }
                     ApplyDisposal(canvas, previousFrame, previousDisposalMethod, backgroundColor, restoreCanvas);
                     restoreCanvas = disposalMethod == 3
-                        ? OfficeRasterImage.FromRgba32(canvas.Width, canvas.Height, canvas.GetPixels())
+                        ? OfficeRasterImage.FromRgba32(canvas.Width, canvas.Height, canvas.PixelBuffer)
                         : null;
                     if (!TryReadImageFrame(
                         bytes,
@@ -172,7 +172,7 @@ public static class OfficeGifReader {
                     }
 
                     if (frameCount == frameIndex) {
-                        image = OfficeRasterImage.FromRgba32(canvas.Width, canvas.Height, canvas.GetPixels());
+                        image = OfficeRasterImage.FromRgba32(canvas.Width, canvas.Height, canvas.PixelBuffer);
                     }
                     previousFrame = frame;
                     previousDisposalMethod = disposalMethod;

--- a/OfficeIMO.Core/Raster/OfficeRasterGuards.cs
+++ b/OfficeIMO.Core/Raster/OfficeRasterGuards.cs
@@ -37,10 +37,22 @@ internal static class OfficeRasterGuards {
     }
 
     public static int EnsureInt32ArrayLength(long elements, ref long aggregateBytes, string message) {
+        return EnsureArrayLength(elements, sizeof(int), ref aggregateBytes, message);
+    }
+
+    public static int EnsureInt16ArrayLength(long elements, ref long aggregateBytes, string message) {
+        return EnsureArrayLength(elements, sizeof(short), ref aggregateBytes, message);
+    }
+
+    public static int EnsureByteArrayLength(long elements, ref long aggregateBytes, string message) {
+        return EnsureArrayLength(elements, sizeof(byte), ref aggregateBytes, message);
+    }
+
+    private static int EnsureArrayLength(long elements, int elementSize, ref long aggregateBytes, string message) {
         if (elements <= 0 || elements > int.MaxValue) throw new FormatException(message);
         long bytes;
         try {
-            bytes = checked(elements * sizeof(int));
+            bytes = checked(elements * elementSize);
             aggregateBytes = checked(aggregateBytes + bytes);
         } catch (OverflowException) {
             throw new FormatException(message);

--- a/OfficeIMO.Core/Raster/OfficeRasterImage.cs
+++ b/OfficeIMO.Core/Raster/OfficeRasterImage.cs
@@ -44,14 +44,20 @@ public sealed class OfficeRasterImage {
     }
 
     internal static OfficeRasterImage FromRgba32(int width, int height, byte[] pixels) {
-        if (pixels == null) throw new ArgumentNullException(nameof(pixels));
-        if (pixels.Length != checked(width * height * 4)) {
-            throw new ArgumentException("RGBA buffer length does not match image dimensions.", nameof(pixels));
-        }
+        ValidateRgba32Buffer(width, height, pixels);
+        return new OfficeRasterImage(width, height, (byte[])pixels.Clone());
+    }
 
-        var image = new OfficeRasterImage(width, height);
-        Buffer.BlockCopy(pixels, 0, image._pixels, 0, pixels.Length);
-        return image;
+    /// <summary>Creates an image by taking ownership of a newly allocated decoder buffer.</summary>
+    internal static OfficeRasterImage FromOwnedRgba32(int width, int height, byte[] pixels) {
+        ValidateRgba32Buffer(width, height, pixels);
+        return new OfficeRasterImage(width, height, pixels);
+    }
+
+    private OfficeRasterImage(int width, int height, byte[] ownedPixels) {
+        Width = width;
+        Height = height;
+        _pixels = ownedPixels;
     }
 
     /// <summary>Gets the color of a pixel.</summary>
@@ -120,6 +126,15 @@ public sealed class OfficeRasterImage {
 
         if ((uint)y >= (uint)Height) {
             throw new ArgumentOutOfRangeException(nameof(y));
+        }
+    }
+
+    private static void ValidateRgba32Buffer(int width, int height, byte[] pixels) {
+        if (width <= 0) throw new ArgumentOutOfRangeException(nameof(width));
+        if (height <= 0) throw new ArgumentOutOfRangeException(nameof(height));
+        if (pixels == null) throw new ArgumentNullException(nameof(pixels));
+        if (pixels.Length != checked(width * height * 4)) {
+            throw new ArgumentException("RGBA buffer length does not match image dimensions.", nameof(pixels));
         }
     }
 

--- a/OfficeIMO.Core/Raster/OfficeRasterResampler.cs
+++ b/OfficeIMO.Core/Raster/OfficeRasterResampler.cs
@@ -21,7 +21,7 @@ public static class OfficeRasterResampler {
         OfficeRasterGuards.EnsureOutputPixels(width, height, "Raster resize dimensions exceed the managed image limit.");
 
         if (source.Width == width && source.Height == height) {
-            return OfficeRasterImage.FromRgba32(width, height, source.GetPixels());
+            return OfficeRasterImage.FromRgba32(width, height, source.PixelBuffer);
         }
 
         var result = new OfficeRasterImage(width, height);

--- a/OfficeIMO.Core/Raster/OfficeTiffCodec.cs
+++ b/OfficeIMO.Core/Raster/OfficeTiffCodec.cs
@@ -47,7 +47,7 @@ public static partial class OfficeTiffCodec {
         OfficeTiffEncodeOptions effective = options ?? new OfficeTiffEncodeOptions();
         ValidateOptions(effective);
 
-        byte[] pixels = image.GetPixels();
+        byte[] pixels = image.PixelBuffer;
         byte[] strip = effective.Compression switch {
             OfficeTiffCompression.PackBits => EncodePackBits(pixels),
             OfficeTiffCompression.Deflate => OfficeZlibCodec.Compress(pixels),
@@ -271,7 +271,7 @@ public static partial class OfficeTiffCodec {
                 }
 
                 if (isFirstIfd && rgba != null) {
-                    firstImage = OfficeRasterImage.FromRgba32(orientedWidth, orientedHeight, rgba);
+                    firstImage = OfficeRasterImage.FromOwnedRgba32(orientedWidth, orientedHeight, rgba);
                 }
                 int nextIfdPointerOffset = checked(ifdOffset + 2 + entryCount * 12);
                 ifdOffset = ReadOffset(encodedBytes, nextIfdPointerOffset, littleEndian);

--- a/OfficeIMO.Core/Raster/OfficeWebpCodec.cs
+++ b/OfficeIMO.Core/Raster/OfficeWebpCodec.cs
@@ -39,7 +39,7 @@ public static class OfficeWebpCodec {
         if (image.Width > OfficeRasterImageEncoder.WebpMaximumDimension) throw new ArgumentOutOfRangeException(nameof(image), "WebP width cannot exceed 16,384 pixels.");
         if (image.Height > OfficeRasterImageEncoder.WebpMaximumDimension) throw new ArgumentOutOfRangeException(nameof(image), "WebP height cannot exceed 16,384 pixels.");
 
-        byte[] pixels = image.GetPixels();
+        byte[] pixels = image.PixelBuffer;
         bool hasAlpha = HasTransparency(pixels);
         byte[] payload;
         using (var stream = new MemoryStream()) {
@@ -221,7 +221,7 @@ public static class OfficeWebpCodec {
             if (!reader.HasOnlyZeroPadding()) {
                 return false;
             }
-            image = OfficeRasterImage.FromRgba32(width, height, rgba);
+            image = OfficeRasterImage.FromOwnedRgba32(width, height, rgba);
             return true;
         } catch (FormatException) {
             return false;

--- a/OfficeIMO.Drawing.Benchmarks.Comparisons/ImageComparisonAdapters.cs
+++ b/OfficeIMO.Drawing.Benchmarks.Comparisons/ImageComparisonAdapters.cs
@@ -11,14 +11,16 @@ internal static class ImageComparisonAdapters {
     }
 
     internal static int DecodeSkia(byte[] encoded) {
-        using SKBitmap bitmap = SKBitmap.Decode(encoded)
-            ?? throw new InvalidOperationException("SkiaSharp could not decode the image.");
+        using SKBitmap bitmap = DecodeSkiaBitmap(encoded);
         return checked(bitmap.Width * bitmap.Height);
     }
 
     internal static int DecodeMagick(byte[] encoded) {
         using var image = new MagickImage(encoded);
-        return checked((int)(image.Width * image.Height));
+        using IPixelCollection<byte> pixels = image.GetPixels();
+        byte[] rgba = pixels.ToByteArray(PixelMapping.RGBA)
+            ?? throw new InvalidOperationException("Magick.NET did not expose decoded RGBA pixels.");
+        return checked(rgba.Length / 4);
     }
 
     internal static int DecodeStb(byte[] encoded) {
@@ -87,18 +89,22 @@ internal static class ImageComparisonAdapters {
     }
 
     internal static byte[] DecodeSkiaRgba(byte[] encoded) {
+        using SKBitmap decoded = DecodeSkiaBitmap(encoded);
+        var rgba = new byte[checked(decoded.Width * decoded.Height * 4)];
+        System.Runtime.InteropServices.Marshal.Copy(decoded.GetPixels(), rgba, 0, rgba.Length);
+        return rgba;
+    }
+
+    private static SKBitmap DecodeSkiaBitmap(byte[] encoded) {
         using SKData data = SKData.CreateCopy(encoded);
         using SKCodec codec = SKCodec.Create(data)
             ?? throw new InvalidOperationException("SkiaSharp could not create a decoder.");
         var info = new SKImageInfo(codec.Info.Width, codec.Info.Height, SKColorType.Rgba8888, SKAlphaType.Unpremul);
-        using var decoded = new SKBitmap(info);
+        var decoded = new SKBitmap(info);
         SKCodecResult result = codec.GetPixels(info, decoded.GetPixels());
-        if (result != SKCodecResult.Success) {
-            throw new InvalidOperationException("SkiaSharp did not decode a complete RGBA image: " + result + ".");
-        }
-        var rgba = new byte[checked(decoded.Width * decoded.Height * 4)];
-        System.Runtime.InteropServices.Marshal.Copy(decoded.GetPixels(), rgba, 0, rgba.Length);
-        return rgba;
+        if (result == SKCodecResult.Success) return decoded;
+        decoded.Dispose();
+        throw new InvalidOperationException("SkiaSharp did not decode a complete RGBA image: " + result + ".");
     }
 
     internal static byte[] DecodeMagickRgba(byte[] encoded) {

--- a/OfficeIMO.Drawing.Benchmarks.Comparisons/ImageComparisonAdapters.cs
+++ b/OfficeIMO.Drawing.Benchmarks.Comparisons/ImageComparisonAdapters.cs
@@ -1,0 +1,110 @@
+using ImageMagick;
+using SkiaSharp;
+using StbImageSharp;
+
+namespace OfficeIMO.Drawing.Benchmarks.Comparisons;
+
+internal static class ImageComparisonAdapters {
+    internal static int DecodeOfficeImo(byte[] encoded) {
+        OfficeRasterImage image = ImageBenchmarkCorpus.Decode(encoded, "OfficeIMO decode");
+        return checked(image.Width * image.Height);
+    }
+
+    internal static int DecodeSkia(byte[] encoded) {
+        using SKBitmap bitmap = SKBitmap.Decode(encoded)
+            ?? throw new InvalidOperationException("SkiaSharp could not decode the image.");
+        return checked(bitmap.Width * bitmap.Height);
+    }
+
+    internal static int DecodeMagick(byte[] encoded) {
+        using var image = new MagickImage(encoded);
+        return checked((int)(image.Width * image.Height));
+    }
+
+    internal static int DecodeStb(byte[] encoded) {
+        ImageResult image = ImageResult.FromMemory(encoded, ColorComponents.RedGreenBlueAlpha);
+        return checked(image.Width * image.Height);
+    }
+
+    internal static byte[] EncodeOfficeImo(OfficeRasterImage image) =>
+        OfficeRasterImageEncoder.Encode(image, OfficeImageExportFormat.Png);
+
+    internal static byte[] EncodeSkia(SKBitmap bitmap) {
+        using SKImage image = SKImage.FromBitmap(bitmap);
+        using SKData data = image.Encode(SKEncodedImageFormat.Png, 100);
+        return data.ToArray();
+    }
+
+    internal static byte[] EncodeMagick(MagickImage image) {
+        image.Format = MagickFormat.Png;
+        return image.ToByteArray();
+    }
+
+    internal static SKBitmap CreateSkiaBitmap(byte[] rgba, int width, int height) {
+        var bitmap = new SKBitmap(new SKImageInfo(width, height, SKColorType.Rgba8888, SKAlphaType.Unpremul));
+        System.Runtime.InteropServices.Marshal.Copy(rgba, 0, bitmap.GetPixels(), rgba.Length);
+        return bitmap;
+    }
+
+    internal static MagickImage CreateMagickImage(byte[] rgba, int width, int height) =>
+        new(rgba, new PixelReadSettings((uint)width, (uint)height, StorageType.Char, PixelMapping.RGBA));
+
+    internal static int ResizeOfficeImo(OfficeRasterImage image, int width, int height) {
+        OfficeRasterImage resized = OfficeRasterResampler.Resize(image, width, height, OfficeRasterResamplingMode.Bilinear);
+        return checked(resized.Width * resized.Height);
+    }
+
+    internal static int ResizeSkia(SKBitmap image, int width, int height) {
+        using SKBitmap resized = image.Resize(
+            new SKImageInfo(width, height, SKColorType.Rgba8888, SKAlphaType.Unpremul),
+            new SKSamplingOptions(SKFilterMode.Linear, SKMipmapMode.None))
+            ?? throw new InvalidOperationException("SkiaSharp could not resize the image.");
+        return checked(resized.Width * resized.Height);
+    }
+
+    internal static int ResizeMagick(MagickImage image, int width, int height) {
+        using IMagickImage<byte> resized = image.Clone();
+        resized.FilterType = FilterType.Triangle;
+        resized.Resize(new MagickGeometry((uint)width, (uint)height) { IgnoreAspectRatio = true });
+        return checked((int)(resized.Width * resized.Height));
+    }
+
+    internal static byte[] ResizeSkiaRgba(SKBitmap image, int width, int height) {
+        using SKBitmap resized = image.Resize(
+            new SKImageInfo(width, height, SKColorType.Rgba8888, SKAlphaType.Unpremul),
+            new SKSamplingOptions(SKFilterMode.Linear, SKMipmapMode.None))
+            ?? throw new InvalidOperationException("SkiaSharp could not resize the image.");
+        var rgba = new byte[checked(width * height * 4)];
+        System.Runtime.InteropServices.Marshal.Copy(resized.GetPixels(), rgba, 0, rgba.Length);
+        return rgba;
+    }
+
+    internal static byte[] ResizeMagickRgba(MagickImage image, int width, int height) {
+        using IMagickImage<byte> resized = image.Clone();
+        resized.FilterType = FilterType.Triangle;
+        resized.Resize(new MagickGeometry((uint)width, (uint)height) { IgnoreAspectRatio = true });
+        return resized.ToByteArray(MagickFormat.Rgba);
+    }
+
+    internal static byte[] DecodeSkiaRgba(byte[] encoded) {
+        using SKData data = SKData.CreateCopy(encoded);
+        using SKCodec codec = SKCodec.Create(data)
+            ?? throw new InvalidOperationException("SkiaSharp could not create a decoder.");
+        var info = new SKImageInfo(codec.Info.Width, codec.Info.Height, SKColorType.Rgba8888, SKAlphaType.Unpremul);
+        using var decoded = new SKBitmap(info);
+        SKCodecResult result = codec.GetPixels(info, decoded.GetPixels());
+        if (result != SKCodecResult.Success) {
+            throw new InvalidOperationException("SkiaSharp did not decode a complete RGBA image: " + result + ".");
+        }
+        var rgba = new byte[checked(decoded.Width * decoded.Height * 4)];
+        System.Runtime.InteropServices.Marshal.Copy(decoded.GetPixels(), rgba, 0, rgba.Length);
+        return rgba;
+    }
+
+    internal static byte[] DecodeMagickRgba(byte[] encoded) {
+        using var image = new MagickImage(encoded);
+        using IPixelCollection<byte> pixels = image.GetPixels();
+        return pixels.ToByteArray(PixelMapping.RGBA)
+            ?? throw new InvalidOperationException("Magick.NET did not expose decoded RGBA pixels.");
+    }
+}

--- a/OfficeIMO.Drawing.Benchmarks.Comparisons/ImageComparisonValidation.cs
+++ b/OfficeIMO.Drawing.Benchmarks.Comparisons/ImageComparisonValidation.cs
@@ -1,0 +1,112 @@
+using StbImageSharp;
+
+namespace OfficeIMO.Drawing.Benchmarks.Comparisons;
+
+internal static class ImageComparisonValidation {
+    internal static void Validate(TextWriter writer) {
+        byte[] logo = ImageBenchmarkCorpus.Logo.ReadBytes();
+        ValidatePngDecode(logo);
+        writer.WriteLine("PNG decode: OfficeIMO, SkiaSharp, Magick.NET, and StbImageSharp produced identical 512x512 RGBA pixels.");
+
+        byte[] photo = ImageBenchmarkCorpus.Photo.ReadBytes();
+        (double skiaError, double magickError, double stbError) = MeasureJpegDecodeError(photo, 2048, 1619);
+        writer.WriteLine(
+            $"JPEG decode: expected 2048x1619 dimensions; RGBA mean absolute error versus OfficeIMO was " +
+            $"SkiaSharp {skiaError:F3}, Magick.NET {magickError:F3}, StbImageSharp {stbError:F3}.");
+
+        OfficeRasterImage source = ImageBenchmarkCorpus.CreatePattern();
+        byte[] rgba = source.GetPixels();
+        using var skia = ImageComparisonAdapters.CreateSkiaBitmap(rgba, source.Width, source.Height);
+        using var magick = ImageComparisonAdapters.CreateMagickImage(rgba, source.Width, source.Height);
+        byte[] officePng = ImageComparisonAdapters.EncodeOfficeImo(source);
+        byte[] skiaPng = ImageComparisonAdapters.EncodeSkia(skia);
+        byte[] magickPng = ImageComparisonAdapters.EncodeMagick(magick);
+        ValidatePngEncode(source, officePng, skiaPng, magickPng);
+        writer.WriteLine($"PNG encode: exact RGBA round-trip; OfficeIMO {officePng.Length:N0}, SkiaSharp {skiaPng.Length:N0}, Magick.NET {magickPng.Length:N0} bytes.");
+
+        OfficeRasterImage photoImage = ImageBenchmarkCorpus.Decode(photo, "resize validation");
+        byte[] photoRgba = photoImage.GetPixels();
+        using var photoSkia = ImageComparisonAdapters.CreateSkiaBitmap(photoRgba, 2048, 1619);
+        using var photoMagick = ImageComparisonAdapters.CreateMagickImage(photoRgba, 2048, 1619);
+        byte[] officeResize = OfficeRasterResampler.Resize(photoImage, 800, 632).GetPixels();
+        AssertSimilarPixels("SkiaSharp resize", officeResize, ImageComparisonAdapters.ResizeSkiaRgba(photoSkia, 800, 632), 3D);
+        AssertSimilarPixels("Magick.NET resize", officeResize, ImageComparisonAdapters.ResizeMagickRgba(photoMagick, 800, 632), 3D);
+        writer.WriteLine("Resize: all engines produced 800x632 RGBA output within the declared mean absolute error tolerance.");
+    }
+
+    internal static void ValidatePngDecode(byte[] encoded) {
+        OfficeRasterImage office = ImageBenchmarkCorpus.Decode(encoded, "OfficeIMO PNG validation");
+        byte[] expected = office.GetPixels();
+        AssertPixels("SkiaSharp", expected, ImageComparisonAdapters.DecodeSkiaRgba(encoded));
+        AssertPixels("Magick.NET", expected, ImageComparisonAdapters.DecodeMagickRgba(encoded));
+        ImageResult stb = ImageResult.FromMemory(encoded, ColorComponents.RedGreenBlueAlpha);
+        AssertPixels("StbImageSharp", expected, stb.Data);
+    }
+
+    internal static void ValidateDimensions(byte[] encoded, int width, int height) {
+        int expected = checked(width * height);
+        if (ImageComparisonAdapters.DecodeOfficeImo(encoded) != expected ||
+            ImageComparisonAdapters.DecodeSkia(encoded) != expected ||
+            ImageComparisonAdapters.DecodeMagick(encoded) != expected ||
+            ImageComparisonAdapters.DecodeStb(encoded) != expected) {
+            throw new InvalidOperationException("A JPEG decoder did not produce the expected dimensions.");
+        }
+    }
+
+    internal static (double SkiaError, double MagickError, double StbError) MeasureJpegDecodeError(
+        byte[] encoded,
+        int width,
+        int height) {
+        ValidateDimensions(encoded, width, height);
+        OfficeRasterImage office = ImageBenchmarkCorpus.Decode(encoded, "OfficeIMO JPEG validation");
+        byte[] expected = office.GetPixels();
+        ImageResult stb = ImageResult.FromMemory(encoded, ColorComponents.RedGreenBlueAlpha);
+        var errors = (
+            SkiaError: CalculateMeanAbsoluteError(expected, ImageComparisonAdapters.DecodeSkiaRgba(encoded)),
+            MagickError: CalculateMeanAbsoluteError(expected, ImageComparisonAdapters.DecodeMagickRgba(encoded)),
+            StbError: CalculateMeanAbsoluteError(expected, stb.Data));
+        const double maximumMeanAbsoluteError = 1.5D;
+        if (errors.SkiaError > maximumMeanAbsoluteError ||
+            errors.MagickError > maximumMeanAbsoluteError ||
+            errors.StbError > maximumMeanAbsoluteError) {
+            throw new InvalidOperationException(
+                $"JPEG decoder output exceeded the {maximumMeanAbsoluteError:F1} mean absolute channel error limit: " +
+                $"SkiaSharp {errors.SkiaError:F3}, Magick.NET {errors.MagickError:F3}, StbImageSharp {errors.StbError:F3}.");
+        }
+        return errors;
+    }
+
+    internal static void ValidatePngEncode(OfficeRasterImage source, params byte[][] encodedImages) {
+        byte[] expected = source.GetPixels();
+        foreach (byte[] encoded in encodedImages) {
+            ImageBenchmarkCorpus.AssertIdentified(encoded, OfficeImageFormat.Png, source.Width, source.Height, "PNG comparison encode");
+            OfficeRasterImage decoded = ImageBenchmarkCorpus.Decode(encoded, "PNG comparison encode");
+            AssertPixels("PNG encoder", expected, decoded.GetPixels());
+        }
+    }
+
+    private static void AssertPixels(string engine, byte[] expected, byte[] actual) {
+        if (!expected.AsSpan().SequenceEqual(actual)) {
+            throw new InvalidOperationException(engine + " did not produce the expected RGBA pixels.");
+        }
+    }
+
+    internal static void AssertSimilarPixels(string engine, byte[] expected, byte[] actual, double maximumMeanAbsoluteError) {
+        double meanAbsoluteError = CalculateMeanAbsoluteError(expected, actual);
+        if (meanAbsoluteError > maximumMeanAbsoluteError) {
+            throw new InvalidOperationException(
+                $"{engine} mean absolute channel error {meanAbsoluteError:F3} exceeded {maximumMeanAbsoluteError:F3}.");
+        }
+    }
+
+    private static double CalculateMeanAbsoluteError(byte[] expected, byte[] actual) {
+        if (expected.Length != actual.Length) {
+            throw new InvalidOperationException("The image decoder did not produce the expected pixel count.");
+        }
+        long absoluteError = 0L;
+        for (int index = 0; index < expected.Length; index++) {
+            absoluteError += Math.Abs(expected[index] - actual[index]);
+        }
+        return absoluteError / (double)expected.Length;
+    }
+}

--- a/OfficeIMO.Drawing.Benchmarks.Comparisons/ImageJpegDecodeBenchmarks.cs
+++ b/OfficeIMO.Drawing.Benchmarks.Comparisons/ImageJpegDecodeBenchmarks.cs
@@ -1,0 +1,27 @@
+using BenchmarkDotNet.Attributes;
+
+namespace OfficeIMO.Drawing.Benchmarks.Comparisons;
+
+/// <summary>Decodes one identical photographic JPEG completely in every engine.</summary>
+[MemoryDiagnoser]
+public class ImageJpegDecodeBenchmarks {
+    private byte[] _encoded = null!;
+
+    [GlobalSetup]
+    public void Setup() {
+        _encoded = ImageBenchmarkCorpus.Photo.ReadBytes();
+        ImageComparisonValidation.MeasureJpegDecodeError(_encoded, 2048, 1619);
+    }
+
+    [Benchmark(Baseline = true)]
+    public int OfficeIMO() => ImageComparisonAdapters.DecodeOfficeImo(_encoded);
+
+    [Benchmark]
+    public int SkiaSharp() => ImageComparisonAdapters.DecodeSkia(_encoded);
+
+    [Benchmark]
+    public int MagickNET() => ImageComparisonAdapters.DecodeMagick(_encoded);
+
+    [Benchmark]
+    public int StbImageSharp() => ImageComparisonAdapters.DecodeStb(_encoded);
+}

--- a/OfficeIMO.Drawing.Benchmarks.Comparisons/ImagePngDecodeBenchmarks.cs
+++ b/OfficeIMO.Drawing.Benchmarks.Comparisons/ImagePngDecodeBenchmarks.cs
@@ -1,0 +1,27 @@
+using BenchmarkDotNet.Attributes;
+
+namespace OfficeIMO.Drawing.Benchmarks.Comparisons;
+
+/// <summary>Decodes one identical PNG completely in every engine.</summary>
+[MemoryDiagnoser]
+public class ImagePngDecodeBenchmarks {
+    private byte[] _encoded = null!;
+
+    [GlobalSetup]
+    public void Setup() {
+        _encoded = ImageBenchmarkCorpus.Logo.ReadBytes();
+        ImageComparisonValidation.ValidatePngDecode(_encoded);
+    }
+
+    [Benchmark(Baseline = true)]
+    public int OfficeIMO() => ImageComparisonAdapters.DecodeOfficeImo(_encoded);
+
+    [Benchmark]
+    public int SkiaSharp() => ImageComparisonAdapters.DecodeSkia(_encoded);
+
+    [Benchmark]
+    public int MagickNET() => ImageComparisonAdapters.DecodeMagick(_encoded);
+
+    [Benchmark]
+    public int StbImageSharp() => ImageComparisonAdapters.DecodeStb(_encoded);
+}

--- a/OfficeIMO.Drawing.Benchmarks.Comparisons/ImagePngEncodeBenchmarks.cs
+++ b/OfficeIMO.Drawing.Benchmarks.Comparisons/ImagePngEncodeBenchmarks.cs
@@ -1,0 +1,37 @@
+using BenchmarkDotNet.Attributes;
+using ImageMagick;
+using SkiaSharp;
+
+namespace OfficeIMO.Drawing.Benchmarks.Comparisons;
+
+/// <summary>Encodes one identical 512x512 RGBA buffer as lossless PNG.</summary>
+[MemoryDiagnoser]
+public class ImagePngEncodeBenchmarks {
+    private OfficeRasterImage _officeImage = null!;
+    private SKBitmap _skiaImage = null!;
+    private MagickImage _magickImage = null!;
+
+    [GlobalSetup]
+    public void Setup() {
+        _officeImage = ImageBenchmarkCorpus.CreatePattern();
+        byte[] rgba = _officeImage.GetPixels();
+        _skiaImage = ImageComparisonAdapters.CreateSkiaBitmap(rgba, _officeImage.Width, _officeImage.Height);
+        _magickImage = ImageComparisonAdapters.CreateMagickImage(rgba, _officeImage.Width, _officeImage.Height);
+        ImageComparisonValidation.ValidatePngEncode(_officeImage, OfficeIMO(), SkiaSharp(), MagickNET());
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() {
+        _skiaImage.Dispose();
+        _magickImage.Dispose();
+    }
+
+    [Benchmark(Baseline = true)]
+    public byte[] OfficeIMO() => ImageComparisonAdapters.EncodeOfficeImo(_officeImage);
+
+    [Benchmark]
+    public byte[] SkiaSharp() => ImageComparisonAdapters.EncodeSkia(_skiaImage);
+
+    [Benchmark]
+    public byte[] MagickNET() => ImageComparisonAdapters.EncodeMagick(_magickImage);
+}

--- a/OfficeIMO.Drawing.Benchmarks.Comparisons/ImageResizeBenchmarks.cs
+++ b/OfficeIMO.Drawing.Benchmarks.Comparisons/ImageResizeBenchmarks.cs
@@ -1,0 +1,50 @@
+using BenchmarkDotNet.Attributes;
+using ImageMagick;
+using SkiaSharp;
+
+namespace OfficeIMO.Drawing.Benchmarks.Comparisons;
+
+/// <summary>Resizes one identical opaque RGBA photo using linear/bilinear sampling.</summary>
+[MemoryDiagnoser]
+public class ImageResizeBenchmarks {
+    private const int TargetWidth = 800;
+    private const int TargetHeight = 632;
+    private OfficeRasterImage _officeImage = null!;
+    private SKBitmap _skiaImage = null!;
+    private MagickImage _magickImage = null!;
+
+    [GlobalSetup]
+    public void Setup() {
+        _officeImage = ImageBenchmarkCorpus.Decode(ImageBenchmarkCorpus.Photo.ReadBytes(), "resize source");
+        byte[] rgba = _officeImage.GetPixels();
+        _skiaImage = ImageComparisonAdapters.CreateSkiaBitmap(rgba, _officeImage.Width, _officeImage.Height);
+        _magickImage = ImageComparisonAdapters.CreateMagickImage(rgba, _officeImage.Width, _officeImage.Height);
+
+        byte[] office = OfficeRasterResampler.Resize(_officeImage, TargetWidth, TargetHeight).GetPixels();
+        ImageComparisonValidation.AssertSimilarPixels(
+            "SkiaSharp resize",
+            office,
+            ImageComparisonAdapters.ResizeSkiaRgba(_skiaImage, TargetWidth, TargetHeight),
+            maximumMeanAbsoluteError: 3D);
+        ImageComparisonValidation.AssertSimilarPixels(
+            "Magick.NET resize",
+            office,
+            ImageComparisonAdapters.ResizeMagickRgba(_magickImage, TargetWidth, TargetHeight),
+            maximumMeanAbsoluteError: 3D);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() {
+        _skiaImage.Dispose();
+        _magickImage.Dispose();
+    }
+
+    [Benchmark(Baseline = true)]
+    public int OfficeIMO() => ImageComparisonAdapters.ResizeOfficeImo(_officeImage, TargetWidth, TargetHeight);
+
+    [Benchmark]
+    public int SkiaSharp() => ImageComparisonAdapters.ResizeSkia(_skiaImage, TargetWidth, TargetHeight);
+
+    [Benchmark]
+    public int MagickNET() => ImageComparisonAdapters.ResizeMagick(_magickImage, TargetWidth, TargetHeight);
+}

--- a/OfficeIMO.Drawing.Benchmarks.Comparisons/OfficeIMO.Drawing.Benchmarks.Comparisons.csproj
+++ b/OfficeIMO.Drawing.Benchmarks.Comparisons/OfficeIMO.Drawing.Benchmarks.Comparisons.csproj
@@ -1,0 +1,40 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>Latest</LangVersion>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.16.0" />
+    <PackageReference Include="SkiaSharp" Version="4.151.1" />
+    <PackageReference Include="StbImageSharp" Version="2.30.16" />
+    <ProjectReference Include="..\OfficeIMO.Core\OfficeIMO.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\OfficeIMO.Drawing.Benchmarks\ImageBenchmarkCorpus.cs"
+             Link="Shared\ImageBenchmarkCorpus.cs" />
+    <None Include="..\Assets\Images\Others\Logo-evotec.png"
+          Link="Corpus\logo.png"
+          CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\OfficeIMO.Examples\Images\Kulek.jpg"
+          Link="Corpus\photo.jpg"
+          CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\OfficeIMO.Examples\Images\example.gif"
+          Link="Corpus\animation.gif"
+          CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\OfficeIMO.Examples\Images\saturn.tif"
+          Link="Corpus\saturn.tif"
+          CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\OfficeIMO.Examples\Images\snail.bmp"
+          Link="Corpus\snail.bmp"
+          CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+</Project>

--- a/OfficeIMO.Drawing.Benchmarks.Comparisons/Program.cs
+++ b/OfficeIMO.Drawing.Benchmarks.Comparisons/Program.cs
@@ -1,0 +1,9 @@
+using BenchmarkDotNet.Running;
+using OfficeIMO.Drawing.Benchmarks.Comparisons;
+
+if (args.Length == 1 && args[0].Equals("--validate", StringComparison.OrdinalIgnoreCase)) {
+    ImageComparisonValidation.Validate(Console.Out);
+    return;
+}
+
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

--- a/OfficeIMO.Drawing.Benchmarks.Comparisons/README.md
+++ b/OfficeIMO.Drawing.Benchmarks.Comparisons/README.md
@@ -13,4 +13,12 @@ dotnet run --project OfficeIMO.Drawing.Benchmarks.Comparisons -c Release -f net1
 dotnet run --project OfficeIMO.Drawing.Benchmarks.Comparisons -c Release -f net10.0 -- --job Dry --filter '*ImagePng*Benchmarks*'
 ```
 
+On heterogeneous or multi-CCD processors, collect comparative evidence through the repository runner with a reviewed affinity mask that keeps the benchmark on one representative processor region. For example, this host exposes one CCD as logical processors 0-15:
+
+```powershell
+./Build/Run-LibraryComparisonBenchmarks.ps1 -RunMode full -Workload imagepngdecode -AffinityMask 0xFFFF
+```
+
+The runner records the mask in benchmark provenance. Affinity reduces scheduler noise; it does not make small differences meaningful, so conclusions should still favor effect sizes that clearly exceed run-to-run variation.
+
 BenchmarkDotNet's allocation column reports managed allocations only. SkiaSharp and Magick.NET perform material work in native code, so their managed allocation numbers are not total-memory comparisons; use process/native-memory profiling before drawing memory-efficiency conclusions across engines.

--- a/OfficeIMO.Drawing.Benchmarks.Comparisons/README.md
+++ b/OfficeIMO.Drawing.Benchmarks.Comparisons/README.md
@@ -1,0 +1,16 @@
+# OfficeIMO image library comparisons
+
+This opt-in project compares equivalent image work without adding third-party dependencies to the OfficeIMO product or normal solution. The initial lanes cover full PNG and photographic JPEG decode, lossless PNG encode from one identical RGBA buffer, and 2048x1619-to-800x632 linear/bilinear resize from identical RGBA pixels.
+
+Metadata identification remains in the first-party benchmark project, not the comparison table. OfficeIMO performs bounded container-structure validation during identification, while the candidate libraries' lightweight information APIs do not all validate the same structure; timing those unlike contracts as peers would be misleading.
+
+The comparison uses SkiaSharp, Magick.NET, and StbImageSharp. ImageSharp 4 is intentionally excluded because its build now requires a Six Labors license key; benchmark restore/build must remain reproducible without secrets. StbImageSharp participates only in decode because it does not provide an encoder.
+
+Correctness comes before timing. PNG decode and encode require exact full-buffer RGBA equality. The JPEG lane requires complete decode, equal dimensions, and a full-buffer mean absolute channel error no greater than 1.5 against every independent decoder so normal color-conversion and rounding differences remain distinguishable from material output defects.
+
+```powershell
+dotnet run --project OfficeIMO.Drawing.Benchmarks.Comparisons -c Release -f net10.0 -- --validate
+dotnet run --project OfficeIMO.Drawing.Benchmarks.Comparisons -c Release -f net10.0 -- --job Dry --filter '*ImagePng*Benchmarks*'
+```
+
+BenchmarkDotNet's allocation column reports managed allocations only. SkiaSharp and Magick.NET perform material work in native code, so their managed allocation numbers are not total-memory comparisons; use process/native-memory profiling before drawing memory-efficiency conclusions across engines.

--- a/OfficeIMO.Drawing.Benchmarks/ImageBenchmarkCorpus.cs
+++ b/OfficeIMO.Drawing.Benchmarks/ImageBenchmarkCorpus.cs
@@ -1,0 +1,93 @@
+using System.Security.Cryptography;
+
+namespace OfficeIMO.Drawing.Benchmarks;
+
+internal sealed record ImageBenchmarkAsset(
+    string Id,
+    string FileName,
+    OfficeImageFormat Format,
+    int Width,
+    int Height) {
+    internal byte[] ReadBytes() => File.ReadAllBytes(ImageBenchmarkCorpus.GetPath(FileName));
+}
+
+internal static class ImageBenchmarkCorpus {
+    internal static readonly ImageBenchmarkAsset Logo = new("LogoPng", "logo.png", OfficeImageFormat.Png, 512, 512);
+    internal static readonly ImageBenchmarkAsset Photo = new("PhotoJpeg", "photo.jpg", OfficeImageFormat.Jpeg, 2048, 1619);
+    internal static readonly ImageBenchmarkAsset Animation = new("AnimationGif", "animation.gif", OfficeImageFormat.Gif, 220, 137);
+    internal static readonly ImageBenchmarkAsset Tiff = new("SaturnTiff", "saturn.tif", OfficeImageFormat.Tiff, 640, 480);
+    internal static readonly ImageBenchmarkAsset Bitmap = new("SnailBmp", "snail.bmp", OfficeImageFormat.Bmp, 256, 256);
+
+    internal static IReadOnlyList<ImageBenchmarkAsset> All { get; } = [Logo, Photo, Animation, Tiff, Bitmap];
+
+    internal static ImageBenchmarkAsset Get(string id) => All.Single(asset => asset.Id == id);
+
+    internal static string GetPath(string fileName) => Path.Combine(AppContext.BaseDirectory, "Corpus", fileName);
+
+    internal static OfficeRasterImage CreatePattern(int width = 512, int height = 512) {
+        var image = new OfficeRasterImage(width, height);
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                byte red = (byte)((x * 13 + y * 3) & 255);
+                byte green = (byte)((x * 5 + y * 11) & 255);
+                byte blue = (byte)(((x ^ y) * 7) & 255);
+                byte alpha = (byte)(96 + ((x + y) & 159));
+                image.SetPixel(x, y, OfficeColor.FromRgba(red, green, blue, alpha));
+            }
+        }
+        return image;
+    }
+
+    internal static byte[] CreateBmp24(int width = 256, int height = 256) {
+        int rowStride = checked(((width * 24) + 31) / 32 * 4);
+        int pixelOffset = 54;
+        var bytes = new byte[checked(pixelOffset + (rowStride * height))];
+        bytes[0] = (byte)'B';
+        bytes[1] = (byte)'M';
+        WriteInt32LittleEndian(bytes, 2, bytes.Length);
+        WriteInt32LittleEndian(bytes, 10, pixelOffset);
+        WriteInt32LittleEndian(bytes, 14, 40);
+        WriteInt32LittleEndian(bytes, 18, width);
+        WriteInt32LittleEndian(bytes, 22, height);
+        bytes[26] = 1;
+        bytes[28] = 24;
+        WriteInt32LittleEndian(bytes, 34, rowStride * height);
+        for (int y = 0; y < height; y++) {
+            int row = pixelOffset + ((height - 1 - y) * rowStride);
+            for (int x = 0; x < width; x++) {
+                int pixel = row + (x * 3);
+                bytes[pixel] = (byte)(((x ^ y) * 7) & 255);
+                bytes[pixel + 1] = (byte)((x * 5 + y * 11) & 255);
+                bytes[pixel + 2] = (byte)((x * 13 + y * 3) & 255);
+            }
+        }
+        return bytes;
+    }
+
+    internal static string PixelHash(OfficeRasterImage image) =>
+        Convert.ToHexString(SHA256.HashData(image.GetPixels()));
+
+    internal static void AssertIdentified(byte[] encoded, OfficeImageFormat format, int width, int height, string operation) {
+        if (!OfficeImageReader.TryIdentify(encoded, fileName: null, out OfficeImageInfo info)) {
+            throw new InvalidOperationException(operation + " did not produce identifiable image bytes.");
+        }
+        if (info.Format != format || info.Width != width || info.Height != height) {
+            throw new InvalidOperationException(
+                $"{operation} produced {info.Format} {info.Width}x{info.Height}; expected {format} {width}x{height}.");
+        }
+    }
+
+    internal static OfficeRasterImage Decode(byte[] encoded, string operation) {
+        if (!OfficeRasterImageDecoder.TryDecode(encoded, out OfficeRasterImage? image) || image == null) {
+            throw new InvalidOperationException(operation + " could not be decoded by the managed image engine.");
+        }
+        return image;
+    }
+
+    private static void WriteInt32LittleEndian(byte[] bytes, int offset, int value) {
+        bytes[offset] = (byte)value;
+        bytes[offset + 1] = (byte)(value >> 8);
+        bytes[offset + 2] = (byte)(value >> 16);
+        bytes[offset + 3] = (byte)(value >> 24);
+    }
+}

--- a/OfficeIMO.Drawing.Benchmarks/ImageBenchmarkValidator.cs
+++ b/OfficeIMO.Drawing.Benchmarks/ImageBenchmarkValidator.cs
@@ -1,0 +1,35 @@
+namespace OfficeIMO.Drawing.Benchmarks;
+
+internal static class ImageBenchmarkValidator {
+    internal static void Validate(TextWriter writer) {
+        foreach (ImageBenchmarkAsset asset in ImageBenchmarkCorpus.All) {
+            byte[] encoded = asset.ReadBytes();
+            ImageBenchmarkCorpus.AssertIdentified(encoded, asset.Format, asset.Width, asset.Height, asset.Id);
+            if (ReferenceEquals(asset, ImageBenchmarkCorpus.Bitmap)) {
+                writer.WriteLine($"{asset.Id,-14} {asset.Format,-5} {asset.Width,4}x{asset.Height,-4} {encoded.Length,10:N0} bytes metadata-only (trailing payload)");
+                continue;
+            }
+            OfficeRasterImage decoded = ImageBenchmarkCorpus.Decode(encoded, asset.Id);
+            if (decoded.Width != asset.Width || decoded.Height != asset.Height) {
+                throw new InvalidOperationException($"{asset.Id} decoded to {decoded.Width}x{decoded.Height}.");
+            }
+            writer.WriteLine($"{asset.Id,-14} {asset.Format,-5} {asset.Width,4}x{asset.Height,-4} {encoded.Length,10:N0} bytes {ImageBenchmarkCorpus.PixelHash(decoded)[..16]}");
+        }
+
+        byte[] bmp = ImageBenchmarkCorpus.CreateBmp24();
+        OfficeRasterImage decodedBmp = ImageBenchmarkCorpus.Decode(bmp, "GeneratedBmp24");
+        writer.WriteLine($"{"GeneratedBmp24",-14} {OfficeImageFormat.Bmp,-5} {decodedBmp.Width,4}x{decodedBmp.Height,-4} {bmp.Length,10:N0} bytes {ImageBenchmarkCorpus.PixelHash(decodedBmp)[..16]}");
+
+        var encode = new ImageEncodeBenchmarks();
+        encode.Setup();
+        writer.WriteLine($"Encode PNG     {encode.Png().Length,10:N0} bytes");
+        writer.WriteLine($"Encode JPEG    {encode.Jpeg().Length,10:N0} bytes");
+        writer.WriteLine($"Encode TIFF    {encode.Tiff().Length,10:N0} bytes");
+        writer.WriteLine($"Encode WebP    {encode.Webp().Length,10:N0} bytes");
+
+        var transform = new ImageTransformBenchmarks();
+        transform.Setup();
+        OfficeImageOptimizationResult optimized = transform.OptimizeForPlacement();
+        writer.WriteLine($"Optimize JPEG  {optimized.Final.Width,4}x{optimized.Final.Height,-4} {optimized.FinalEncodedLength,10:N0} bytes {optimized.Status}");
+    }
+}

--- a/OfficeIMO.Drawing.Benchmarks/ImageDecodeBenchmarks.cs
+++ b/OfficeIMO.Drawing.Benchmarks/ImageDecodeBenchmarks.cs
@@ -1,0 +1,27 @@
+using BenchmarkDotNet.Attributes;
+
+namespace OfficeIMO.Drawing.Benchmarks;
+
+/// <summary>Measures full managed decode into OfficeIMO's RGBA raster contract.</summary>
+[MemoryDiagnoser]
+public class ImageDecodeBenchmarks {
+    private byte[] _encoded = null!;
+
+    [Params("LogoPng", "PhotoJpeg", "AnimationGif", "SaturnTiff", "GeneratedBmp24")]
+    public string Asset { get; set; } = string.Empty;
+
+    [GlobalSetup]
+    public void Setup() {
+        ImageBenchmarkAsset? asset = ImageBenchmarkCorpus.All.SingleOrDefault(candidate => candidate.Id == Asset);
+        _encoded = Asset == "GeneratedBmp24" ? ImageBenchmarkCorpus.CreateBmp24() : asset!.ReadBytes();
+        OfficeRasterImage decoded = ImageBenchmarkCorpus.Decode(_encoded, Asset);
+        int expectedWidth = asset?.Width ?? 256;
+        int expectedHeight = asset?.Height ?? 256;
+        if (decoded.Width != expectedWidth || decoded.Height != expectedHeight) {
+            throw new InvalidOperationException($"{Asset} decoded to {decoded.Width}x{decoded.Height}.");
+        }
+    }
+
+    [Benchmark]
+    public OfficeRasterImage Decode() => ImageBenchmarkCorpus.Decode(_encoded, Asset);
+}

--- a/OfficeIMO.Drawing.Benchmarks/ImageEncodeBenchmarks.cs
+++ b/OfficeIMO.Drawing.Benchmarks/ImageEncodeBenchmarks.cs
@@ -1,0 +1,38 @@
+using BenchmarkDotNet.Attributes;
+
+namespace OfficeIMO.Drawing.Benchmarks;
+
+/// <summary>Measures encoders from one identical deterministic RGBA source.</summary>
+[MemoryDiagnoser]
+public class ImageEncodeBenchmarks {
+    private OfficeRasterImage _image = null!;
+
+    [GlobalSetup]
+    public void Setup() {
+        _image = ImageBenchmarkCorpus.CreatePattern();
+        ValidateLossless(Png(), OfficeImageFormat.Png, nameof(Png));
+        ValidateLossless(Tiff(), OfficeImageFormat.Tiff, nameof(Tiff));
+        ValidateLossless(Webp(), OfficeImageFormat.Webp, nameof(Webp));
+        ImageBenchmarkCorpus.AssertIdentified(Jpeg(), OfficeImageFormat.Jpeg, _image.Width, _image.Height, nameof(Jpeg));
+    }
+
+    [Benchmark(Baseline = true)]
+    public byte[] Png() => OfficeRasterImageEncoder.Encode(_image, OfficeImageExportFormat.Png);
+
+    [Benchmark]
+    public byte[] Jpeg() => OfficeRasterImageEncoder.Encode(_image, OfficeImageExportFormat.Jpeg);
+
+    [Benchmark]
+    public byte[] Tiff() => OfficeRasterImageEncoder.Encode(_image, OfficeImageExportFormat.Tiff);
+
+    [Benchmark]
+    public byte[] Webp() => OfficeRasterImageEncoder.Encode(_image, OfficeImageExportFormat.Webp);
+
+    private void ValidateLossless(byte[] encoded, OfficeImageFormat format, string operation) {
+        ImageBenchmarkCorpus.AssertIdentified(encoded, format, _image.Width, _image.Height, operation);
+        OfficeRasterImage decoded = ImageBenchmarkCorpus.Decode(encoded, operation);
+        if (!string.Equals(ImageBenchmarkCorpus.PixelHash(decoded), ImageBenchmarkCorpus.PixelHash(_image), StringComparison.Ordinal)) {
+            throw new InvalidOperationException(operation + " did not preserve the RGBA pixels.");
+        }
+    }
+}

--- a/OfficeIMO.Drawing.Benchmarks/ImageIdentifyBenchmarks.cs
+++ b/OfficeIMO.Drawing.Benchmarks/ImageIdentifyBenchmarks.cs
@@ -1,0 +1,31 @@
+using BenchmarkDotNet.Attributes;
+
+namespace OfficeIMO.Drawing.Benchmarks;
+
+/// <summary>Measures metadata identification separately from full raster decoding.</summary>
+[MemoryDiagnoser]
+public class ImageIdentifyBenchmarks {
+    private byte[] _encoded = null!;
+
+    [Params("LogoPng", "PhotoJpeg", "AnimationGif", "SaturnTiff", "SnailBmp")]
+    public string Asset { get; set; } = string.Empty;
+
+    [GlobalSetup]
+    public void Setup() {
+        ImageBenchmarkAsset asset = ImageBenchmarkCorpus.Get(Asset);
+        _encoded = asset.ReadBytes();
+        ImageBenchmarkCorpus.AssertIdentified(_encoded, asset.Format, asset.Width, asset.Height, Asset);
+    }
+
+    [Benchmark(Baseline = true)]
+    public OfficeImageInfo IdentifyBytes() => OfficeImageReader.Identify(_encoded);
+
+    [Benchmark]
+    public OfficeImageInfo IdentifySeekableStream() {
+        using var stream = new MemoryStream(_encoded, writable: false);
+        if (!OfficeImageReader.TryIdentify(stream, fileName: null, out OfficeImageInfo info)) {
+            throw new InvalidOperationException("The benchmark image could not be identified.");
+        }
+        return info;
+    }
+}

--- a/OfficeIMO.Drawing.Benchmarks/ImageTransformBenchmarks.cs
+++ b/OfficeIMO.Drawing.Benchmarks/ImageTransformBenchmarks.cs
@@ -1,0 +1,38 @@
+using BenchmarkDotNet.Attributes;
+
+namespace OfficeIMO.Drawing.Benchmarks;
+
+/// <summary>Measures shared resize and encoded-image optimization workflows.</summary>
+[MemoryDiagnoser]
+public class ImageTransformBenchmarks {
+    private OfficeRasterImage _photo = null!;
+    private byte[] _photoBytes = null!;
+    private OfficeImageOptimizationRequest _optimization = null!;
+
+    [GlobalSetup]
+    public void Setup() {
+        _photoBytes = ImageBenchmarkCorpus.Photo.ReadBytes();
+        _photo = ImageBenchmarkCorpus.Decode(_photoBytes, "photo setup");
+        _optimization = new OfficeImageOptimizationRequest(800, 800) {
+            PreserveAspectRatio = true,
+            ResamplingMode = OfficeRasterResamplingMode.Bilinear,
+            JpegQuality = 85,
+            KeepOriginalWhenNotSmaller = false
+        };
+
+        OfficeRasterImage resized = ResizeBilinear();
+        if (resized.Width != 800 || resized.Height != 632) {
+            throw new InvalidOperationException($"Resize produced {resized.Width}x{resized.Height}; expected 800x632.");
+        }
+        OfficeImageOptimizationResult optimized = OptimizeForPlacement();
+        ImageBenchmarkCorpus.AssertIdentified(optimized.Bytes, OfficeImageFormat.Jpeg, 800, 632, nameof(OptimizeForPlacement));
+    }
+
+    [Benchmark(Baseline = true)]
+    public OfficeRasterImage ResizeBilinear() =>
+        OfficeRasterResampler.Resize(_photo, 800, 632, OfficeRasterResamplingMode.Bilinear);
+
+    [Benchmark]
+    public OfficeImageOptimizationResult OptimizeForPlacement() =>
+        OfficeImageOptimizer.Optimize(_photoBytes, _optimization, "photo.jpg");
+}

--- a/OfficeIMO.Drawing.Benchmarks/OfficeIMO.Drawing.Benchmarks.csproj
+++ b/OfficeIMO.Drawing.Benchmarks/OfficeIMO.Drawing.Benchmarks.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>Latest</LangVersion>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+    <ProjectReference Include="..\OfficeIMO.Core\OfficeIMO.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\Assets\Images\Others\Logo-evotec.png"
+          Link="Corpus\logo.png"
+          CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\OfficeIMO.Examples\Images\Kulek.jpg"
+          Link="Corpus\photo.jpg"
+          CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\OfficeIMO.Examples\Images\example.gif"
+          Link="Corpus\animation.gif"
+          CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\OfficeIMO.Examples\Images\saturn.tif"
+          Link="Corpus\saturn.tif"
+          CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\OfficeIMO.Examples\Images\snail.bmp"
+          Link="Corpus\snail.bmp"
+          CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+</Project>

--- a/OfficeIMO.Drawing.Benchmarks/Program.cs
+++ b/OfficeIMO.Drawing.Benchmarks/Program.cs
@@ -1,0 +1,9 @@
+using BenchmarkDotNet.Running;
+using OfficeIMO.Drawing.Benchmarks;
+
+if (args.Length == 1 && args[0].Equals("--validate", StringComparison.OrdinalIgnoreCase)) {
+    ImageBenchmarkValidator.Validate(Console.Out);
+    return;
+}
+
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

--- a/OfficeIMO.Drawing.Benchmarks/README.md
+++ b/OfficeIMO.Drawing.Benchmarks/README.md
@@ -1,0 +1,17 @@
+# OfficeIMO image benchmarks
+
+This project measures the first-party `OfficeIMO.Core` image engine without adding image-library dependencies to the product. The corpus covers PNG, JPEG, GIF, TIFF, and BMP metadata and decode paths, deterministic RGBA encoding to PNG/JPEG/TIFF/WebP, bilinear resize, and placement-aware optimization. The repository's `snail.bmp` has four trailing bytes beyond its declared BMP file size, so it remains a metadata fixture; decode measurements use a generated canonical 24-bit BMP instead of weakening the decoder's strict container contract.
+
+Every timed workload is validated in global setup. Run the complete validation pass before collecting measurements:
+
+```powershell
+dotnet run --project OfficeIMO.Drawing.Benchmarks -c Release -f net10.0 -- --validate
+```
+
+Start benchmark work with a short diagnostic run:
+
+```powershell
+dotnet run --project OfficeIMO.Drawing.Benchmarks -c Release -f net10.0 -- --job Dry --filter '*ImageEncodeBenchmarks*'
+```
+
+Use a normal BenchmarkDotNet job only after the workload, output dimensions, format, and pixel-preservation contract have been validated. Benchmark artifacts belong in an ignored or temporary output directory and should not be committed.

--- a/OfficeIMO.Drawing.Tests/Drawing.ImageOptimization.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.ImageOptimization.cs
@@ -1,4 +1,5 @@
 using OfficeIMO.Drawing;
+using System.Security.Cryptography;
 using Xunit;
 
 namespace OfficeIMO.Tests {
@@ -244,6 +245,11 @@ namespace OfficeIMO.Tests {
             Assert.Equal(identified.Height, decoded.Height);
             Assert.True(decoded.Width > 100);
             Assert.True(decoded.Height > 100);
+            using (SHA256 sha256 = SHA256.Create()) {
+                Assert.Equal(
+                    "EA87164A1FF1B2CE978E3C007382CD90AAAC5269078CBA79306FD35972231E0D",
+                    BitConverter.ToString(sha256.ComputeHash(decoded.GetPixels())).Replace("-", string.Empty));
+            }
         }
 
         [Fact]

--- a/OfficeIMO.Drawing.Tests/Drawing.ImageOptimization.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.ImageOptimization.cs
@@ -253,6 +253,22 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void OfficeJpegCodec_DecodesBaselineRestartIntervalsWithoutFastPeekCrossingMarkers() {
+            byte[] jpeg = Convert.FromBase64String(
+                "/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRT/" +
+                "2wBDAQMEBAUEBQkFBQkUDQsNFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBT/wAARCAAQACADAREAAhEBAxEB/" +
+                "8QAFAABAAAAAAAAAAAAAAAAAAAACP/EABQQAQAAAAAAAAAAAAAAAAAAAAD/xAAVAQEBAAAAAAAAAAAAAAAAAAAHCf/EABQRAQAAAAAAAAAAAAAAAAAAAAD/" +
+                "3QAEAAH/2gAMAwEAAhEDEQA/ADoDFU3/0DoDFU3/0ToDFU3/0joDFU3/0zoDFU3/1DoDFU3/1ToDFU3/1joDFU3/2Q==");
+
+            OfficeRasterImage decoded = OfficeJpegCodec.Decode(jpeg);
+
+            Assert.Equal(32, decoded.Width);
+            Assert.Equal(16, decoded.Height);
+            AssertColorNear(decoded.GetPixel(0, 0), OfficeColor.Red, 8);
+            AssertColorNear(decoded.GetPixel(31, 15), OfficeColor.Red, 8);
+        }
+
+        [Fact]
         public void OfficeJpegCodec_FlattensTransparencyAgainstConfiguredBackground() {
             var source = new OfficeRasterImage(8, 8, OfficeColor.FromRgba(255, 0, 0, 128));
 

--- a/OfficeIMO.Drawing.Tests/Drawing.PngWriter.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.PngWriter.cs
@@ -36,6 +36,27 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void OfficePngWriter_AdaptiveFilteringPreservesPixelsAndCompressesStructuredRows() {
+            var image = new OfficeRasterImage(128, 64);
+            for (int y = 0; y < image.Height; y++) {
+                for (int x = 0; x < image.Width; x++) {
+                    image.SetPixel(
+                        x,
+                        y,
+                        OfficeColor.FromRgba((byte)x, (byte)(x + y), (byte)(y * 3), (byte)(128 + (x & 127))));
+                }
+            }
+
+            byte[] optimal = OfficePngWriter.Encode(image, OfficePngCompression.Optimal);
+            byte[] stored = OfficePngWriter.Encode(image, OfficePngCompression.Stored);
+
+            Assert.True(OfficePngReader.TryDecode(optimal, out OfficeRasterImage? decoded));
+            Assert.NotNull(decoded);
+            Assert.Equal(image.GetPixels(), decoded!.GetPixels());
+            Assert.True(optimal.Length < stored.Length / 4, $"Expected adaptive PNG ({optimal.Length}) to be materially smaller than stored PNG ({stored.Length}).");
+        }
+
+        [Fact]
         public void OfficePngWriter_RejectsIndexedColorWithoutPalette() {
             byte[] scanlines = { 0, 0 };
 

--- a/OfficeIMO.sln
+++ b/OfficeIMO.sln
@@ -354,6 +354,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Latex.Pdf", "Offi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Pdf.Benchmarks", "OfficeIMO.Pdf.Benchmarks\OfficeIMO.Pdf.Benchmarks.csproj", "{F0ABCF0D-01C1-4D74-B840-78D0D67E7158}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Drawing.Benchmarks", "OfficeIMO.Drawing.Benchmarks\OfficeIMO.Drawing.Benchmarks.csproj", "{2F621DD7-97BB-4B48-911D-6D0B39A1839B}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.PowerPoint.Benchmarks", "OfficeIMO.PowerPoint.Benchmarks\OfficeIMO.PowerPoint.Benchmarks.csproj", "{E98A2407-9B37-429F-B9DD-9E4CEE696148}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Reader.Email", "OfficeIMO.Reader.Email\OfficeIMO.Reader.Email.csproj", "{827DCC08-592F-464E-989D-0E2122B045B0}"
@@ -1858,6 +1860,18 @@ Global
 		{F0ABCF0D-01C1-4D74-B840-78D0D67E7158}.Release|x64.Build.0 = Release|Any CPU
 		{F0ABCF0D-01C1-4D74-B840-78D0D67E7158}.Release|x86.ActiveCfg = Release|Any CPU
 		{F0ABCF0D-01C1-4D74-B840-78D0D67E7158}.Release|x86.Build.0 = Release|Any CPU
+		{2F621DD7-97BB-4B48-911D-6D0B39A1839B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2F621DD7-97BB-4B48-911D-6D0B39A1839B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2F621DD7-97BB-4B48-911D-6D0B39A1839B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2F621DD7-97BB-4B48-911D-6D0B39A1839B}.Debug|x64.Build.0 = Debug|Any CPU
+		{2F621DD7-97BB-4B48-911D-6D0B39A1839B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2F621DD7-97BB-4B48-911D-6D0B39A1839B}.Debug|x86.Build.0 = Debug|Any CPU
+		{2F621DD7-97BB-4B48-911D-6D0B39A1839B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2F621DD7-97BB-4B48-911D-6D0B39A1839B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2F621DD7-97BB-4B48-911D-6D0B39A1839B}.Release|x64.ActiveCfg = Release|Any CPU
+		{2F621DD7-97BB-4B48-911D-6D0B39A1839B}.Release|x64.Build.0 = Release|Any CPU
+		{2F621DD7-97BB-4B48-911D-6D0B39A1839B}.Release|x86.ActiveCfg = Release|Any CPU
+		{2F621DD7-97BB-4B48-911D-6D0B39A1839B}.Release|x86.Build.0 = Release|Any CPU
 		{E98A2407-9B37-429F-B9DD-9E4CEE696148}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E98A2407-9B37-429F-B9DD-9E4CEE696148}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E98A2407-9B37-429F-B9DD-9E4CEE696148}.Debug|x64.ActiveCfg = Debug|Any CPU

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Every checked item below is implemented today. Detailed behavior, examples, and 
 - [x] Dependency-free TIFF output with uncompressed, PackBits, or Deflate strips and deterministic lossless WebP encoding with common raster export options
 - [x] Shared SVG primitive writing and scalable drawing export
 - [x] Single and batch image-export builders with dimensions, source metadata, and diagnostics
+- [x] Reproducible, output-validated identification, decode, encode, resize, and placement-optimization benchmarks with opt-in library comparisons isolated from runtime packages
 
 _Dependency footprint:_ zero third-party runtime dependencies.
 


### PR DESCRIPTION
## Summary

- Correct progressive JPEG component routing, refinement, restart-marker handling, and decoder buffer ownership.
- Reduce avoidable image buffer copies and improve PNG decoding, filtering, CRC, and compression paths in the shared `OfficeIMO.Core` engine.
- Add first-party image benchmarks plus opt-in comparison lanes for equivalent PNG/JPEG decode, PNG encode, and resize work.
- Validate comparison output before timing it: exact RGBA for PNG, bounded JPEG/resize error, and equivalent materialized output.

## Correctness and compatibility

- Covers PNG, JPEG, GIF, TIFF, BMP, and WebP read/write or metadata paths already owned by the image engine.
- Adds independent progressive and restart-coded JPEG regression fixtures, including legal non-conventional component identifiers.
- Keeps comparison-only dependencies outside the normal solution/runtime dependency graph.
- Documents why ImageSharp is not part of the reproducible comparison runner without a build-license key.

## Performance evidence

A full local BenchmarkDotNet comparison was pinned to logical processors 0-15 (`0xFFFF`) on an AMD Ryzen 9 9950X3D2. This host still showed multimodal behavior, so these figures are directional effect-size evidence rather than claims about small differences.

| Equivalent workload | OfficeIMO | SkiaSharp | Magick.NET | StbImageSharp |
| --- | ---: | ---: | ---: | ---: |
| PNG decode | 6.27 ms | 0.87 ms | 3.61 ms | 2.00 ms |
| JPEG decode | 54.19 ms | 25.59 ms | 37.87 ms | 57.66 ms |
| PNG encode | 9.18 ms | 10.71 ms | 15.72 ms | n/a |
| Resize | 8.46 ms | 3.45 ms | 72.62 ms | n/a |

The broad result is useful: PNG encode is competitive, while decode throughput, resize throughput, and managed decode allocations remain the clearest future optimization targets. Native-library allocations are not visible to BenchmarkDotNet's managed allocation column and are not compared as if they were equivalent.

These timing artifacts were recorded immediately before the dependency-only rebase onto the latest #2381 head; the image implementation was unchanged by that rebase, and all correctness tests and validators were rerun afterward.

## Validation

- 1,470/1,470 `OfficeIMO.Drawing.Tests` passed on .NET 10, .NET 8, and .NET Framework 4.7.2.
- First-party corpus validation passed on .NET 10 and .NET 8.
- Comparison validation passed on .NET 10 and .NET 8: exact PNG RGBA, JPEG mean absolute error below 0.15 against OfficeIMO, exact PNG round-trip, and resize within the declared tolerance.
- Benchmark runner plan/affinity integration and `git diff --check` passed on the rebased head.
- A full solution build still encounters the existing `OfficeIMO.OneNote.Tests` net472 `Encoding.Latin1` compile error; that file and failure are outside this image layer.

## Dependency

This PR is intentionally based on #2381 and should be reviewed and merged after that lower layer settles.