### PR TITLE
Improve image correctness, conversions, and allocation efficiency

### DIFF
--- a/Build/Run-LibraryComparisonBenchmarks.ps1
+++ b/Build/Run-LibraryComparisonBenchmarks.ps1
@@ -11,6 +11,10 @@ param(
         'xlsx',
         'xlsxwrite',
         'xlsb',
+        'imagepngdecode',
+        'imagejpegdecode',
+        'imagepngencode',
+        'imageresize',
         'word',
         'wordcreate',
         'wordreport',
@@ -123,6 +127,38 @@ $definitions = [ordered]@{
         Suite = 'OfficeIMO.Excel.Xlsb.MarkPflug65K'
         IdentityVariables = @()
         ExpectedCases = @('OfficeIMO', 'Sylvan', 'ExcelDataReader')
+    }
+    imagepngdecode = [pscustomobject]@{
+        Project = 'OfficeIMO.Drawing.Benchmarks.Comparisons\OfficeIMO.Drawing.Benchmarks.Comparisons.csproj'
+        Filter = '*ImagePngDecodeBenchmarks*'
+        ComparisonId = "image-png-decode-$Framework"
+        Suite = 'OfficeIMO.Drawing.PngDecode'
+        IdentityVariables = @()
+        ExpectedCases = @('OfficeIMO', 'SkiaSharp', 'MagickNET', 'StbImageSharp')
+    }
+    imagejpegdecode = [pscustomobject]@{
+        Project = 'OfficeIMO.Drawing.Benchmarks.Comparisons\OfficeIMO.Drawing.Benchmarks.Comparisons.csproj'
+        Filter = '*ImageJpegDecodeBenchmarks*'
+        ComparisonId = "image-jpeg-decode-$Framework"
+        Suite = 'OfficeIMO.Drawing.JpegDecode'
+        IdentityVariables = @()
+        ExpectedCases = @('OfficeIMO', 'SkiaSharp', 'MagickNET', 'StbImageSharp')
+    }
+    imagepngencode = [pscustomobject]@{
+        Project = 'OfficeIMO.Drawing.Benchmarks.Comparisons\OfficeIMO.Drawing.Benchmarks.Comparisons.csproj'
+        Filter = '*ImagePngEncodeBenchmarks*'
+        ComparisonId = "image-png-encode-$Framework"
+        Suite = 'OfficeIMO.Drawing.PngEncode'
+        IdentityVariables = @()
+        ExpectedCases = @('OfficeIMO', 'SkiaSharp', 'MagickNET')
+    }
+    imageresize = [pscustomobject]@{
+        Project = 'OfficeIMO.Drawing.Benchmarks.Comparisons\OfficeIMO.Drawing.Benchmarks.Comparisons.csproj'
+        Filter = '*ImageResizeBenchmarks*'
+        ComparisonId = "image-resize-$Framework"
+        Suite = 'OfficeIMO.Drawing.Resize'
+        IdentityVariables = @()
+        ExpectedCases = @('OfficeIMO', 'SkiaSharp', 'MagickNET')
     }
     pdfgenerate = [pscustomobject]@{
         Project = 'OfficeIMO.Pdf.Benchmarks.Comparisons\OfficeIMO.Pdf.Benchmarks.Comparisons.csproj'

--- a/Build/Run-LibraryComparisonBenchmarks.ps1
+++ b/Build/Run-LibraryComparisonBenchmarks.ps1
@@ -36,6 +36,7 @@ param(
     [string] $PowerForgeRoot = $env:POWERFORGE_ROOT,
     [ValidateSet('net8.0', 'net10.0')]
     [string] $PowerForgeFramework = 'net8.0',
+    [UInt64] $AffinityMask = 0,
     [switch] $AcceptNPOIOSMFLicense,
     [switch] $Publish,
     [switch] $PlanOnly
@@ -50,6 +51,7 @@ if ($Publish -and $RunMode -ne 'full') {
 . (Join-Path $PSScriptRoot 'BenchmarkEvidence.ps1')
 
 $repositoryRoot = Split-Path -Parent $PSScriptRoot
+$affinityLabel = if ($AffinityMask -ne 0) { '0x{0:X}' -f $AffinityMask } else { $null }
 $OutputRoot = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath(
     $OutputRoot)
 $platform = if ([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform(
@@ -498,6 +500,9 @@ foreach ($name in $selected) {
         'benchmark.workload.sourceCommit' = $gitSha
         'benchmark.workload.framework' = $Framework
     }
+    if ($null -ne $affinityLabel) {
+        $provenanceMetadata['benchmark.workload.affinityMask'] = $affinityLabel
+    }
     $provenanceCapture = Start-BenchmarkProvenanceCapture `
         -SourceRoot $repositoryRoot `
         -ArtifactRoot $artifactsPath `
@@ -520,6 +525,9 @@ foreach ($name in $selected) {
     )
     if ($RunMode -eq 'quick') {
         $arguments += @('--job', 'Dry')
+    }
+    if ($AffinityMask -ne 0) {
+        $arguments += @('--affinity', $AffinityMask.ToString([Globalization.CultureInfo]::InvariantCulture))
     }
 
     Push-Location -LiteralPath $repositoryRoot
@@ -619,6 +627,7 @@ $outputs = foreach ($measurement in $measurements) {
         Platform = $platform
         RunMode = $RunMode
         Publish = $executionPlanByWorkload[$measurement.Workload].Publish
+        AffinityMask = $affinityLabel
         SourceCommit = $gitSha
         ArtifactsPath = $measurement.ArtifactsPath
         NormalizedResult = if ($measurement.CatalogEligible) {

--- a/Docs/README.md
+++ b/Docs/README.md
@@ -13,6 +13,7 @@ Use this index to find package guides, cross-package contracts, generated eviden
 - [Website search and answer-engine operations](officeimo.website-seo-geo-operations.md) — publication and discovery checks.
 - [CI and test strategy](officeimo.ci-test-strategy.md) — test ownership and validation lanes.
 - [Excel benchmark notes](officeimo.excel.benchmark-notes.md) — reproducible comparison-suite execution and provenance.
+- [Image engine benchmarks](../OfficeIMO.Drawing.Benchmarks/README.md) — validated identification, decode, encode, resize, and placement-optimization workloads, with isolated opt-in library comparisons.
 
 ## Current product contracts
 

--- a/OfficeIMO.Core/Internal/Compression/OfficeZlibCodec.cs
+++ b/OfficeIMO.Core/Internal/Compression/OfficeZlibCodec.cs
@@ -44,7 +44,60 @@ namespace OfficeIMO.Core.Internal {
 
             using var source = new MemoryStream(bytes, 2, bytes.Length - 6, writable: false);
             using var deflate = new DeflateStream(source, CompressionMode.Decompress);
-            using var output = new MemoryStream(expectedOutputBytes.GetValueOrDefault());
+            byte[] result = expectedOutputBytes.HasValue
+                ? DecompressExact(deflate, expectedOutputBytes.Value, maximumOutputBytes)
+                : DecompressBounded(deflate, maximumOutputBytes);
+            uint expectedChecksum = ReadBigEndianUInt32(bytes, bytes.Length - 4);
+            if (Adler32(result) != expectedChecksum) {
+                throw new InvalidDataException("The zlib stream Adler-32 checksum is invalid.");
+            }
+            return result;
+        }
+
+        private static uint Adler32(byte[] data) {
+            const uint Modulus = 65521;
+            const int MaximumChunk = 5552;
+            uint a = 1;
+            uint b = 0;
+            int offset = 0;
+            while (offset < data.Length) {
+                int end = Math.Min(offset + MaximumChunk, data.Length);
+                while (offset < end) {
+                    a += data[offset++];
+                    b += a;
+                }
+                a %= Modulus;
+                b %= Modulus;
+            }
+            return (b << 16) | a;
+        }
+
+        private static byte[] DecompressExact(DeflateStream deflate, int expectedOutputBytes, int maximumOutputBytes) {
+            if (expectedOutputBytes < 0) throw new ArgumentOutOfRangeException(nameof(expectedOutputBytes));
+            if (expectedOutputBytes > maximumOutputBytes) {
+                throw new OfficeDecompressionSizeLimitException(
+                    $"The decompressed zlib stream exceeds {maximumOutputBytes} bytes.");
+            }
+
+            var result = new byte[expectedOutputBytes];
+            int offset = 0;
+            while (offset < result.Length) {
+                int read = deflate.Read(result, offset, result.Length - offset);
+                if (read == 0) {
+                    throw new InvalidDataException(
+                        $"The zlib stream expanded to {offset} bytes instead of {expectedOutputBytes} bytes.");
+                }
+                offset += read;
+            }
+            if (deflate.ReadByte() != -1) {
+                throw new InvalidDataException(
+                    $"The zlib stream expanded beyond the expected {expectedOutputBytes} bytes.");
+            }
+            return result;
+        }
+
+        private static byte[] DecompressBounded(DeflateStream deflate, int maximumOutputBytes) {
+            using var output = new MemoryStream();
             var buffer = new byte[8192];
             while (true) {
                 int read = deflate.Read(buffer, 0, buffer.Length);
@@ -55,28 +108,7 @@ namespace OfficeIMO.Core.Internal {
                 }
                 output.Write(buffer, 0, read);
             }
-
-            byte[] result = output.ToArray();
-            if (expectedOutputBytes.HasValue && result.Length != expectedOutputBytes.Value) {
-                throw new InvalidDataException(
-                    $"The zlib stream expanded to {result.Length} bytes instead of {expectedOutputBytes.Value} bytes.");
-            }
-            uint expectedChecksum = ReadBigEndianUInt32(bytes, bytes.Length - 4);
-            if (Adler32(result) != expectedChecksum) {
-                throw new InvalidDataException("The zlib stream Adler-32 checksum is invalid.");
-            }
-            return result;
-        }
-
-        private static uint Adler32(byte[] data) {
-            const uint Modulus = 65521;
-            uint a = 1;
-            uint b = 0;
-            for (int index = 0; index < data.Length; index++) {
-                a = (a + data[index]) % Modulus;
-                b = (b + a) % Modulus;
-            }
-            return (b << 16) | a;
+            return output.ToArray();
         }
 
         private static uint ReadBigEndianUInt32(byte[] bytes, int offset) =>

--- a/OfficeIMO.Core/Jpeg/OfficeJpegCodec.cs
+++ b/OfficeIMO.Core/Jpeg/OfficeJpegCodec.cs
@@ -14,7 +14,7 @@ public static class OfficeJpegCodec {
         if (!IsJpeg(encodedBytes)) return false;
         try {
             byte[] pixels = OfficeJpegReader.DecodeRgba32(encodedBytes!, out int width, out int height, options);
-            image = OfficeRasterImage.FromRgba32(width, height, pixels);
+            image = OfficeRasterImage.FromOwnedRgba32(width, height, pixels);
             return true;
         } catch (Exception ex) when (ex is FormatException || ex is ArgumentException || ex is IndexOutOfRangeException || ex is OverflowException) {
             return false;
@@ -25,7 +25,7 @@ public static class OfficeJpegCodec {
     public static OfficeRasterImage Decode(byte[] encodedBytes, OfficeJpegDecodeOptions options = default) {
         if (encodedBytes == null) throw new ArgumentNullException(nameof(encodedBytes));
         byte[] pixels = OfficeJpegReader.DecodeRgba32(encodedBytes, out int width, out int height, options);
-        return OfficeRasterImage.FromRgba32(width, height, pixels);
+        return OfficeRasterImage.FromOwnedRgba32(width, height, pixels);
     }
 
     internal static bool TryDecodeColorComponents(
@@ -65,9 +65,19 @@ public static class OfficeJpegCodec {
     public static byte[] Encode(OfficeRasterImage image, OfficeJpegEncodeOptions? options = null) {
         if (image == null) throw new ArgumentNullException(nameof(image));
         OfficeJpegEncodeOptions effectiveOptions = options ?? new OfficeJpegEncodeOptions();
-        byte[] rgba = image.GetPixels();
-        FlattenAlpha(rgba, effectiveOptions.Background);
+        byte[] rgba = image.PixelBuffer;
+        if (HasTransparency(rgba)) {
+            rgba = (byte[])rgba.Clone();
+            FlattenAlpha(rgba, effectiveOptions.Background);
+        }
         return OfficeJpegWriter.WriteRgba(image.Width, image.Height, rgba, checked(image.Width * 4), effectiveOptions);
+    }
+
+    private static bool HasTransparency(byte[] rgba) {
+        for (int index = 3; index < rgba.Length; index += 4) {
+            if (rgba[index] != byte.MaxValue) return true;
+        }
+        return false;
     }
 
     private static void FlattenAlpha(byte[] rgba, OfficeColor background) {

--- a/OfficeIMO.Core/Jpeg/OfficeJpegReader.Decode.Helpers.cs
+++ b/OfficeIMO.Core/Jpeg/OfficeJpegReader.Decode.Helpers.cs
@@ -1262,8 +1262,18 @@ internal static partial class OfficeJpegReader {
         public bool AllowTruncated => _allowTruncated;
 
         public bool TryPeekBits(int count, out int value) {
+            int originalPosition = _pos;
+            int originalBitBuffer = _bitBuffer;
+            int originalBitCount = _bitCount;
+            bool originalRestartMarkerSeen = RestartMarkerSeen;
             while (_bitCount < count) {
                 if (!TryReadByte(out int next)) {
+                    RestorePeekState(originalPosition, originalBitBuffer, originalBitCount, originalRestartMarkerSeen);
+                    value = 0;
+                    return false;
+                }
+                if (RestartMarkerSeen != originalRestartMarkerSeen) {
+                    RestorePeekState(originalPosition, originalBitBuffer, originalBitCount, originalRestartMarkerSeen);
                     value = 0;
                     return false;
                 }
@@ -1272,6 +1282,13 @@ internal static partial class OfficeJpegReader {
             }
             value = (_bitBuffer >> (_bitCount - count)) & ((1 << count) - 1);
             return true;
+        }
+
+        private void RestorePeekState(int position, int bitBuffer, int bitCount, bool restartMarkerSeen) {
+            _pos = position;
+            _bitBuffer = bitBuffer;
+            _bitCount = bitCount;
+            RestartMarkerSeen = restartMarkerSeen;
         }
 
         public void SkipBits(int count) {

--- a/OfficeIMO.Core/Jpeg/OfficeJpegReader.Decode.Helpers.cs
+++ b/OfficeIMO.Core/Jpeg/OfficeJpegReader.Decode.Helpers.cs
@@ -166,12 +166,33 @@ internal static partial class OfficeJpegReader {
                 : usePdfColorTransformDefault || !hasRgbComponentIds;
 
         var yIndex2 = FindComponentIndex(frame.Components, 1);
-        if (yIndex2 < 0) yIndex2 = 0;
         var cbIndex = frame.ComponentCount > 1 ? FindComponentIndex(frame.Components, 2) : -1;
         var crIndex = frame.ComponentCount > 1 ? FindComponentIndex(frame.Components, 3) : -1;
         if (frame.ComponentCount == 3) {
-            if (cbIndex < 0) cbIndex = yIndex2 == 0 ? 1 : 0;
-            if (crIndex < 0) crIndex = yIndex2 == 2 ? 1 : 2;
+            bool hasConventionalYccIds = yIndex2 >= 0 && cbIndex >= 0 && crIndex >= 0;
+            if (!hasConventionalYccIds) {
+                yIndex2 = 0;
+                cbIndex = 1;
+                crIndex = 2;
+            }
+
+            if (!highQualityChroma) {
+                int firstIndex = transformToRgb ? yIndex2 : hasRgbComponentIds ? rIndex : 0;
+                int secondIndex = transformToRgb ? cbIndex : hasRgbComponentIds ? gIndex : 1;
+                int thirdIndex = transformToRgb ? crIndex : hasRgbComponentIds ? bIndex : 2;
+                ComposeThreeComponentNearest(
+                    components,
+                    frame.Width,
+                    frame.Height,
+                    states[firstIndex],
+                    states[secondIndex],
+                    states[thirdIndex],
+                    maxH,
+                    maxV,
+                    transformToRgb,
+                    outputRgba);
+                return components;
+            }
         }
 
         for (var y = 0; y < frame.Height; y++) {
@@ -214,6 +235,89 @@ internal static partial class OfficeJpegReader {
         }
 
         return components;
+    }
+
+    private static void ComposeThreeComponentNearest(
+        byte[] output,
+        int width,
+        int height,
+        BaselineComponentState first,
+        BaselineComponentState second,
+        BaselineComponentState third,
+        int maximumHorizontalSampling,
+        int maximumVerticalSampling,
+        bool transformYccToRgb,
+        bool outputRgba) {
+        int firstY = 0;
+        int secondY = 0;
+        int thirdY = 0;
+        int firstYAccumulator = 0;
+        int secondYAccumulator = 0;
+        int thirdYAccumulator = 0;
+        int target = 0;
+
+        for (int y = 0; y < height; y++) {
+            int firstRow = firstY * first.Stride;
+            int secondRow = secondY * second.Stride;
+            int thirdRow = thirdY * third.Stride;
+            int firstX = 0;
+            int secondX = 0;
+            int thirdX = 0;
+            int firstXAccumulator = 0;
+            int secondXAccumulator = 0;
+            int thirdXAccumulator = 0;
+
+            for (int x = 0; x < width; x++) {
+                byte firstValue = first.Buffer[firstRow + firstX];
+                byte secondValue = second.Buffer[secondRow + secondX];
+                byte thirdValue = third.Buffer[thirdRow + thirdX];
+                if (transformYccToRgb) {
+                    int red = firstValue + CrToR[thirdValue];
+                    int green = firstValue - CbToG[secondValue] - CrToG[thirdValue];
+                    int blue = firstValue + CbToB[secondValue];
+                    output[target++] = ClampToByte(red);
+                    output[target++] = ClampToByte(green);
+                    output[target++] = ClampToByte(blue);
+                } else {
+                    output[target++] = firstValue;
+                    output[target++] = secondValue;
+                    output[target++] = thirdValue;
+                }
+                if (outputRgba) output[target++] = byte.MaxValue;
+
+                firstXAccumulator += first.Component.H;
+                if (firstXAccumulator >= maximumHorizontalSampling) {
+                    firstX++;
+                    firstXAccumulator -= maximumHorizontalSampling;
+                }
+                secondXAccumulator += second.Component.H;
+                if (secondXAccumulator >= maximumHorizontalSampling) {
+                    secondX++;
+                    secondXAccumulator -= maximumHorizontalSampling;
+                }
+                thirdXAccumulator += third.Component.H;
+                if (thirdXAccumulator >= maximumHorizontalSampling) {
+                    thirdX++;
+                    thirdXAccumulator -= maximumHorizontalSampling;
+                }
+            }
+
+            firstYAccumulator += first.Component.V;
+            if (firstYAccumulator >= maximumVerticalSampling) {
+                firstY++;
+                firstYAccumulator -= maximumVerticalSampling;
+            }
+            secondYAccumulator += second.Component.V;
+            if (secondYAccumulator >= maximumVerticalSampling) {
+                secondY++;
+                secondYAccumulator -= maximumVerticalSampling;
+            }
+            thirdYAccumulator += third.Component.V;
+            if (thirdYAccumulator >= maximumVerticalSampling) {
+                thirdY++;
+                thirdYAccumulator -= maximumVerticalSampling;
+            }
+        }
     }
 
     private static void WriteGrayPixel(byte[] output, int pixel, byte gray, bool outputRgba) {
@@ -316,7 +420,8 @@ internal static partial class OfficeJpegReader {
         int[] quant,
         ref int prevDc,
         int[] coeffs,
-        int[] pixels) {
+        byte[] pixels,
+        int[] workspace) {
         Array.Clear(coeffs, 0, 64);
 
         var t = DecodeHuffman(ref reader, dcTable, useFast: true);
@@ -347,12 +452,11 @@ internal static partial class OfficeJpegReader {
             k++;
         }
 
-        InverseDct(coeffs, pixels);
+        InverseDct(coeffs, pixels, workspace);
     }
 
     private static int DecodeHuffman(ref JpegBitReader reader, HuffmanTable table, bool useFast) {
-        if (useFast && table.Fast is not null && reader.HasBits(HuffmanFastBits)) {
-            var peek = reader.PeekBits(HuffmanFastBits);
+        if (useFast && table.Fast is not null && reader.TryPeekBits(HuffmanFastBits, out int peek)) {
             var entry = table.Fast[peek];
             if (entry >= 0) {
                 var size = entry >> 8;
@@ -381,20 +485,17 @@ internal static partial class OfficeJpegReader {
         return value;
     }
 
-    private static void WriteBlock(int[] buffer, int stride, int blockX, int blockY, int[] pixels) {
+    private static void WriteBlock(byte[] buffer, int stride, int blockX, int blockY, byte[] pixels) {
         var baseX = blockX * 8;
         var baseY = blockY * 8;
         for (var y = 0; y < 8; y++) {
             var row = (baseY + y) * stride + baseX;
             var src = y * 8;
-            for (var x = 0; x < 8; x++) {
-                buffer[row + x] = pixels[src + x];
-            }
+            Buffer.BlockCopy(pixels, src, buffer, row, 8);
         }
     }
 
-    private static void InverseDct(int[] input, int[] output) {
-        int[] workspace = new int[64];
+    private static void InverseDct(int[] input, byte[] output, int[] workspace) {
 
         // Pass 1: process columns into the workspace (scaled by Pass1Bits).
         for (var ctr = 0; ctr < 8; ctr++) {
@@ -890,9 +991,10 @@ internal static partial class OfficeJpegReader {
 
     private sealed class BaselineComponentState {
         public Component Component;
-        public int[] Buffer;
+        public byte[] Buffer;
         public int[] BlockCoeffs;
-        public int[] BlockPixels;
+        public byte[] BlockPixels;
+        public int[] BlockWorkspace;
         public int Stride;
         public int BlocksPerRow;
         public int BlocksPerCol;
@@ -903,10 +1005,11 @@ internal static partial class OfficeJpegReader {
             BlocksPerRow = blocksPerRow;
             BlocksPerCol = blocksPerCol;
             Stride = OfficeRasterGuards.EnsureByteCount((long)blocksPerRow * 8, JpegDimensionsLimitMessage);
-            var bufferLength = OfficeRasterGuards.EnsureInt32ArrayLength((long)Stride * blocksPerCol * 8, ref aggregateBytes, JpegDimensionsLimitMessage);
-            Buffer = new int[bufferLength];
+            var bufferLength = OfficeRasterGuards.EnsureByteArrayLength((long)Stride * blocksPerCol * 8, ref aggregateBytes, JpegDimensionsLimitMessage);
+            Buffer = new byte[bufferLength];
             BlockCoeffs = new int[OfficeRasterGuards.EnsureInt32ArrayLength(64, ref aggregateBytes, JpegDimensionsLimitMessage)];
-            BlockPixels = new int[OfficeRasterGuards.EnsureInt32ArrayLength(64, ref aggregateBytes, JpegDimensionsLimitMessage)];
+            BlockPixels = new byte[OfficeRasterGuards.EnsureByteArrayLength(64, ref aggregateBytes, JpegDimensionsLimitMessage)];
+            BlockWorkspace = new int[OfficeRasterGuards.EnsureInt32ArrayLength(64, ref aggregateBytes, JpegDimensionsLimitMessage)];
             PrevDc = 0;
         }
 
@@ -915,7 +1018,7 @@ internal static partial class OfficeJpegReader {
             int blocksPerRow,
             int blocksPerCol,
             int stride,
-            int[] buffer) {
+            byte[] buffer) {
             return new BaselineComponentState {
                 Component = component,
                 BlocksPerRow = blocksPerRow,
@@ -923,14 +1026,16 @@ internal static partial class OfficeJpegReader {
                 Stride = stride,
                 Buffer = buffer,
                 BlockCoeffs = Array.Empty<int>(),
-                BlockPixels = Array.Empty<int>()
+                BlockPixels = Array.Empty<byte>(),
+                BlockWorkspace = Array.Empty<int>()
             };
         }
 
         private BaselineComponentState() {
-            Buffer = Array.Empty<int>();
+            Buffer = Array.Empty<byte>();
             BlockCoeffs = Array.Empty<int>();
-            BlockPixels = Array.Empty<int>();
+            BlockPixels = Array.Empty<byte>();
+            BlockWorkspace = Array.Empty<int>();
         }
     }
 
@@ -960,7 +1065,12 @@ internal static partial class OfficeJpegReader {
                 }
                 var blocksPerRow = OfficeRasterGuards.EnsureByteCount((long)mcuCols * comp.H, JpegDimensionsLimitMessage);
                 var blocksPerCol = OfficeRasterGuards.EnsureByteCount((long)mcuRows * comp.V, JpegDimensionsLimitMessage);
-                components[i] = new ProgressiveComponentState(comp, blocksPerRow, blocksPerCol, ref aggregateBytes);
+                components[i] = new ProgressiveComponentState(
+                    comp,
+                    blocksPerRow,
+                    blocksPerCol,
+                    quantTables[comp.QuantId],
+                    ref aggregateBytes);
             }
 
             return new ProgressiveState {
@@ -1000,8 +1110,11 @@ internal static partial class OfficeJpegReader {
                 for (var by = 0; by < compState.BlocksPerCol; by++) {
                     for (var bx = 0; bx < compState.BlocksPerRow; bx++) {
                         var baseIndex = (by * compState.BlocksPerRow + bx) * 64;
-                        Array.Copy(compState.Coeffs, baseIndex, compState.BlockCoeffs, 0, 64);
-                        InverseDct(compState.BlockCoeffs, compState.BlockPixels);
+                        for (int coefficient = 0; coefficient < 64; coefficient++) {
+                            compState.BlockCoeffs[coefficient] =
+                                compState.Coeffs[baseIndex + coefficient] * compState.Quantization[coefficient];
+                        }
+                        InverseDct(compState.BlockCoeffs, compState.BlockPixels, compState.BlockWorkspace);
                         WriteBlock(compState.Buffer, compState.Stride, bx, by, compState.BlockPixels);
                     }
                 }
@@ -1032,24 +1145,33 @@ internal static partial class OfficeJpegReader {
         public Component Component;
         public int BlocksPerRow;
         public int BlocksPerCol;
-        public int[] Coeffs;
-        public int[] Buffer;
+        public short[] Coeffs;
+        public int[] Quantization;
+        public byte[] Buffer;
         public int[] BlockCoeffs;
-        public int[] BlockPixels;
+        public byte[] BlockPixels;
+        public int[] BlockWorkspace;
         public int Stride;
         public int PrevDc;
 
-        public ProgressiveComponentState(Component component, int blocksPerRow, int blocksPerCol, ref long aggregateBytes) {
+        public ProgressiveComponentState(
+            Component component,
+            int blocksPerRow,
+            int blocksPerCol,
+            int[] quantization,
+            ref long aggregateBytes) {
             Component = component;
             BlocksPerRow = blocksPerRow;
             BlocksPerCol = blocksPerCol;
+            Quantization = quantization;
             Stride = OfficeRasterGuards.EnsureByteCount((long)blocksPerRow * 8, JpegDimensionsLimitMessage);
-            var coeffLength = OfficeRasterGuards.EnsureInt32ArrayLength((long)BlocksPerRow * BlocksPerCol * 64, ref aggregateBytes, JpegDimensionsLimitMessage);
-            var bufferLength = OfficeRasterGuards.EnsureInt32ArrayLength((long)Stride * blocksPerCol * 8, ref aggregateBytes, JpegDimensionsLimitMessage);
-            Coeffs = new int[coeffLength];
-            Buffer = new int[bufferLength];
+            var coeffLength = OfficeRasterGuards.EnsureInt16ArrayLength((long)BlocksPerRow * BlocksPerCol * 64, ref aggregateBytes, JpegDimensionsLimitMessage);
+            var bufferLength = OfficeRasterGuards.EnsureByteArrayLength((long)Stride * blocksPerCol * 8, ref aggregateBytes, JpegDimensionsLimitMessage);
+            Coeffs = new short[coeffLength];
+            Buffer = new byte[bufferLength];
             BlockCoeffs = new int[OfficeRasterGuards.EnsureInt32ArrayLength(64, ref aggregateBytes, JpegDimensionsLimitMessage)];
-            BlockPixels = new int[OfficeRasterGuards.EnsureInt32ArrayLength(64, ref aggregateBytes, JpegDimensionsLimitMessage)];
+            BlockPixels = new byte[OfficeRasterGuards.EnsureByteArrayLength(64, ref aggregateBytes, JpegDimensionsLimitMessage)];
+            BlockWorkspace = new int[OfficeRasterGuards.EnsureInt32ArrayLength(64, ref aggregateBytes, JpegDimensionsLimitMessage)];
             PrevDc = 0;
         }
     }
@@ -1139,14 +1261,17 @@ internal static partial class OfficeJpegReader {
 
         public bool AllowTruncated => _allowTruncated;
 
-        public bool HasBits(int count) {
-            return _bitCount >= count;
-        }
-
-        public int PeekBits(int count) {
-            if (count == 0) return 0;
-            EnsureBits(count);
-            return (_bitBuffer >> (_bitCount - count)) & ((1 << count) - 1);
+        public bool TryPeekBits(int count, out int value) {
+            while (_bitCount < count) {
+                if (!TryReadByte(out int next)) {
+                    value = 0;
+                    return false;
+                }
+                _bitBuffer = (_bitBuffer << 8) | next;
+                _bitCount += 8;
+            }
+            value = (_bitBuffer >> (_bitCount - count)) & ((1 << count) - 1);
+            return true;
         }
 
         public void SkipBits(int count) {
@@ -1214,24 +1339,43 @@ internal static partial class OfficeJpegReader {
         }
 
         private int ReadByte() {
+            if (TryReadByte(out int value)) return value;
+            throw new FormatException("Unexpected JPEG end.");
+        }
+
+        private bool TryReadByte(out int value) {
             while (_pos < _data.Length) {
                 var b = _data[_pos++];
-                if (b != 0xFF) return b;
+                if (b != 0xFF) {
+                    value = b;
+                    return true;
+                }
                 while (_pos < _data.Length && _data[_pos] == 0xFF) _pos++;
                 if (_pos >= _data.Length) {
-                    if (_allowTruncated) return 0;
-                    throw new FormatException("Unexpected JPEG end.");
+                    if (_allowTruncated) {
+                        value = 0;
+                        return true;
+                    }
+                    value = 0;
+                    return false;
                 }
                 var marker = _data[_pos++];
-                if (marker == 0x00) return 0xFF;
+                if (marker == 0x00) {
+                    value = 0xFF;
+                    return true;
+                }
                 if (marker >= 0xD0 && marker <= 0xD7) {
                     RestartMarkerSeen = true;
                     continue;
                 }
                 throw new FormatException("Unexpected JPEG marker in scan.");
             }
-            if (_allowTruncated) return 0;
-            throw new FormatException("Unexpected JPEG end.");
+            if (_allowTruncated) {
+                value = 0;
+                return true;
+            }
+            value = 0;
+            return false;
         }
     }
 

--- a/OfficeIMO.Core/Jpeg/OfficeJpegReader.Decode.Scan.cs
+++ b/OfficeIMO.Core/Jpeg/OfficeJpegReader.Decode.Scan.cs
@@ -49,7 +49,8 @@ internal static partial class OfficeJpegReader {
                         quantTables[componentState.Component.QuantId],
                         ref componentState.PrevDc,
                         componentState.BlockCoeffs,
-                        componentState.BlockPixels);
+                        componentState.BlockPixels,
+                        componentState.BlockWorkspace);
                     WriteBlock(componentState.Buffer, componentState.Stride, mx, my, componentState.BlockPixels);
                 } else {
                     for (var ci = 0; ci < scan.ComponentIndices.Length; ci++) {
@@ -64,7 +65,8 @@ internal static partial class OfficeJpegReader {
                                 quantTables[componentState.Component.QuantId],
                                 ref componentState.PrevDc,
                                 componentState.BlockCoeffs,
-                                componentState.BlockPixels);
+                                componentState.BlockPixels,
+                                componentState.BlockWorkspace);
 
                             var blockX = mx * componentState.Component.H + (b % componentState.Component.H);
                             var blockY = my * componentState.Component.V + (b / componentState.Component.H);
@@ -239,8 +241,7 @@ internal static partial class OfficeJpegReader {
         int blockX,
         int blockY,
         ref int eobRun) {
-        var quant = quantTables[state.Component.QuantId];
-        if (quant is null) throw new FormatException("Missing JPEG quantization table.");
+        if (quantTables[state.Component.QuantId] is null) throw new FormatException("Missing JPEG quantization table.");
         var baseIndex = (blockY * state.BlocksPerRow + blockX) * 64;
 
         if (scan.Ss == 0 && scan.Se == 0) {
@@ -251,13 +252,13 @@ internal static partial class OfficeJpegReader {
                 var diff = t == 0 ? 0 : Extend(reader.ReadBits(t), t);
                 var dc = state.PrevDc + (diff << scan.Al);
                 state.PrevDc = dc;
-                state.Coeffs[baseIndex] = dc * quant[0];
+                SetProgressiveCoefficient(state.Coeffs, baseIndex, dc);
             } else {
                 var bit = reader.ReadBit();
                 if (bit != 0) {
-                    var delta = (1 << scan.Al) * quant[0];
-                    var sign = state.Coeffs[baseIndex] >= 0 ? 1 : -1;
-                    state.Coeffs[baseIndex] += sign * delta;
+                    var delta = 1 << scan.Al;
+                    int refined = unchecked((short)((ushort)state.Coeffs[baseIndex] | (ushort)delta));
+                    SetProgressiveCoefficient(state.Coeffs, baseIndex, refined);
                 }
             }
             return;
@@ -268,9 +269,9 @@ internal static partial class OfficeJpegReader {
         if (!acTable.IsValid) throw new FormatException("Missing JPEG AC Huffman table.");
 
         if (scan.Ah == 0) {
-            DecodeProgressiveAcFirst(ref reader, scan, state, acTable, quant, baseIndex, ref eobRun);
+            DecodeProgressiveAcFirst(ref reader, scan, state, acTable, baseIndex, ref eobRun);
         } else {
-            DecodeProgressiveAcRefine(ref reader, scan, state, acTable, quant, baseIndex, ref eobRun);
+            DecodeProgressiveAcRefine(ref reader, scan, state, acTable, baseIndex, ref eobRun);
         }
     }
 
@@ -282,7 +283,6 @@ internal static partial class OfficeJpegReader {
         ScanHeader scan,
         ProgressiveComponentState state,
         HuffmanTable acTable,
-        int[] quant,
         int baseIndex,
         ref int eobRun) {
         if (eobRun > 0) {
@@ -313,7 +313,7 @@ internal static partial class OfficeJpegReader {
             if (k > scan.Se) break;
             var ac = Extend(reader.ReadBits(s), s);
             var zig = ZigZag[k];
-            state.Coeffs[baseIndex + zig] = (ac << scan.Al) * quant[zig];
+            SetProgressiveCoefficient(state.Coeffs, baseIndex + zig, ac << scan.Al);
             k++;
         }
     }
@@ -323,13 +323,12 @@ internal static partial class OfficeJpegReader {
         ScanHeader scan,
         ProgressiveComponentState state,
         HuffmanTable acTable,
-        int[] quant,
         int baseIndex,
         ref int eobRun) {
         var k = (int)scan.Ss;
         if (eobRun > 0) {
             for (; k <= scan.Se; k++) {
-                RefineCoefficient(ref reader, state.Coeffs, baseIndex + ZigZag[k], scan.Al, quant[ZigZag[k]]);
+                RefineCoefficient(ref reader, state.Coeffs, baseIndex + ZigZag[k], scan.Al);
             }
             eobRun--;
             return;
@@ -345,7 +344,7 @@ internal static partial class OfficeJpegReader {
                     var zeros = 16;
                     while (zeros > 0 && k <= scan.Se) {
                         var index = baseIndex + ZigZag[k];
-                        RefineCoefficient(ref reader, state.Coeffs, index, scan.Al, quant[ZigZag[k]]);
+                        RefineCoefficient(ref reader, state.Coeffs, index, scan.Al);
                         if (state.Coeffs[index] == 0) zeros--;
                         k++;
                     }
@@ -355,7 +354,7 @@ internal static partial class OfficeJpegReader {
                 eobRun = (1 << r) - 1;
                 if (r > 0) eobRun += reader.ReadBits(r);
                 for (; k <= scan.Se; k++) {
-                    RefineCoefficient(ref reader, state.Coeffs, baseIndex + ZigZag[k], scan.Al, quant[ZigZag[k]]);
+                    RefineCoefficient(ref reader, state.Coeffs, baseIndex + ZigZag[k], scan.Al);
                 }
                 break;
             }
@@ -366,7 +365,7 @@ internal static partial class OfficeJpegReader {
                 var zig = ZigZag[k];
                 var index = baseIndex + zig;
                 if (state.Coeffs[index] != 0) {
-                    RefineCoefficient(ref reader, state.Coeffs, index, scan.Al, quant[zig]);
+                    RefineCoefficient(ref reader, state.Coeffs, index, scan.Al);
                     k++;
                     continue;
                 }
@@ -377,19 +376,27 @@ internal static partial class OfficeJpegReader {
                     continue;
                 }
 
-                state.Coeffs[index] = (ac << scan.Al) * quant[zig];
+                SetProgressiveCoefficient(state.Coeffs, index, ac << scan.Al);
                 k++;
                 break;
             }
         }
     }
 
-    private static void RefineCoefficient(ref JpegBitReader reader, int[] coeffs, int index, int al, int quant) {
+    private static void RefineCoefficient(ref JpegBitReader reader, short[] coeffs, int index, int al) {
         if (coeffs[index] == 0) return;
         var bit = reader.ReadBit();
         if (bit == 0) return;
-        var delta = (1 << al) * quant;
-        coeffs[index] += coeffs[index] > 0 ? delta : -delta;
+        var delta = 1 << al;
+        if (((ushort)coeffs[index] & (ushort)delta) != 0) return;
+        SetProgressiveCoefficient(coeffs, index, coeffs[index] + (coeffs[index] > 0 ? delta : -delta));
+    }
+
+    private static void SetProgressiveCoefficient(short[] coefficients, int index, int value) {
+        if (value < short.MinValue || value > short.MaxValue) {
+            throw new FormatException("Progressive JPEG coefficient exceeds the supported 8-bit sample range.");
+        }
+        coefficients[index] = (short)value;
     }
 
 }

--- a/OfficeIMO.Core/Jpeg/OfficeJpegWriter.cs
+++ b/OfficeIMO.Core/Jpeg/OfficeJpegWriter.cs
@@ -746,13 +746,13 @@ internal static class OfficeJpegWriter {
         if (dpiX < OfficeRasterImageEncoder.JpegMinimumDpi ||
             double.IsNaN(dpiX) ||
             double.IsInfinity(dpiX) ||
-            dpiX > ushort.MaxValue) {
+            dpiX > OfficeRasterImageEncoder.JpegMaximumDpi) {
             throw new ArgumentOutOfRangeException(nameof(dpiX));
         }
         if (dpiY < OfficeRasterImageEncoder.JpegMinimumDpi ||
             double.IsNaN(dpiY) ||
             double.IsInfinity(dpiY) ||
-            dpiY > ushort.MaxValue) {
+            dpiY > OfficeRasterImageEncoder.JpegMaximumDpi) {
             throw new ArgumentOutOfRangeException(nameof(dpiY));
         }
         WriteMarker(s, 0xFFE0);

--- a/OfficeIMO.Core/Png/OfficePngReader.cs
+++ b/OfficeIMO.Core/Png/OfficePngReader.cs
@@ -324,6 +324,11 @@ public static class OfficePngReader {
     }
 
     private static void ExpandScanline(byte[] current, int width, int y, int colorType, int bitDepth, byte[]? palette, byte[]? transparency, OfficeRasterImage image) {
+        if (colorType == 6 && bitDepth == 8) {
+            Buffer.BlockCopy(current, 0, image.PixelBuffer, checked(y * width * 4), checked(width * 4));
+            return;
+        }
+
         for (int x = 0; x < width; x++) {
             OfficeColor color;
             switch (colorType) {
@@ -433,31 +438,42 @@ public static class OfficePngReader {
         blue == ((transparency[4] << 8) | transparency[5]);
 
     private static void Unfilter(byte[] current, byte[] previous, int bytesPerPixel, int filter) {
-        for (int i = 0; i < current.Length; i++) {
-            int left = i >= bytesPerPixel ? current[i - bytesPerPixel] : 0;
-            int up = previous[i];
-            int upLeft = i >= bytesPerPixel ? previous[i - bytesPerPixel] : 0;
-            int value = current[i];
-            switch (filter) {
-                case 0:
-                    break;
-                case 1:
-                    value += left;
-                    break;
-                case 2:
-                    value += up;
-                    break;
-                case 3:
-                    value += (left + up) / 2;
-                    break;
-                case 4:
-                    value += Paeth(left, up, upLeft);
-                    break;
-                default:
-                    throw new InvalidDataException("Unsupported PNG filter.");
-            }
-
-            current[i] = (byte)(value & 0xFF);
+        switch (filter) {
+            case 0:
+                return;
+            case 1:
+                for (int index = bytesPerPixel; index < current.Length; index++) {
+                    current[index] = unchecked((byte)(current[index] + current[index - bytesPerPixel]));
+                }
+                return;
+            case 2:
+                for (int index = 0; index < current.Length; index++) {
+                    current[index] = unchecked((byte)(current[index] + previous[index]));
+                }
+                return;
+            case 3:
+                int prefixLength = Math.Min(bytesPerPixel, current.Length);
+                for (int index = 0; index < prefixLength; index++) {
+                    current[index] = unchecked((byte)(current[index] + (previous[index] / 2)));
+                }
+                for (int index = bytesPerPixel; index < current.Length; index++) {
+                    current[index] = unchecked((byte)(current[index] + ((current[index - bytesPerPixel] + previous[index]) / 2)));
+                }
+                return;
+            case 4:
+                int firstPixelBytes = Math.Min(bytesPerPixel, current.Length);
+                for (int index = 0; index < firstPixelBytes; index++) {
+                    current[index] = unchecked((byte)(current[index] + previous[index]));
+                }
+                for (int index = bytesPerPixel; index < current.Length; index++) {
+                    current[index] = unchecked((byte)(current[index] + Paeth(
+                        current[index - bytesPerPixel],
+                        previous[index],
+                        previous[index - bytesPerPixel])));
+                }
+                return;
+            default:
+                throw new InvalidDataException("Unsupported PNG filter.");
         }
     }
 

--- a/OfficeIMO.Core/Png/OfficePngWriter.cs
+++ b/OfficeIMO.Core/Png/OfficePngWriter.cs
@@ -67,9 +67,18 @@ public static class OfficePngWriter {
             throw new ArgumentException("RGBA buffer length does not match image dimensions.", nameof(rgba));
         }
 
-        byte[] scanlines = CreateRgbaScanlines(width, height, rgba, compression == OfficePngCompression.Optimal);
-
-        return EncodeScanlines(width, height, 8, 6, scanlines, compression);
+        byte[] compressed;
+        switch (compression) {
+            case OfficePngCompression.Optimal:
+                compressed = DeflateRgbaScanlines(width, height, rgba);
+                break;
+            case OfficePngCompression.Stored:
+                compressed = DeflateZlibStored(CreateRgbaScanlines(width, height, rgba, adaptiveFiltering: false));
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(compression));
+        }
+        return CreateFromCompressedScanlines(width, height, 8, 6, compressed);
     }
 
     /// <summary>Encodes raw RGBA pixels with explicit compression and physical-resolution metadata.</summary>
@@ -79,12 +88,17 @@ public static class OfficePngWriter {
         ValidateDpi(options.DpiY, nameof(options.DpiY));
         ValidateRgba(width, height, rgba);
 
-        byte[] scanlines = CreateRgbaScanlines(width, height, rgba, options.Compression == OfficePngCompression.Optimal);
-        byte[] compressed = options.Compression switch {
-            OfficePngCompression.Optimal => DeflateZlib(scanlines),
-            OfficePngCompression.Stored => DeflateZlibStored(scanlines),
-            _ => throw new ArgumentOutOfRangeException(nameof(options.Compression))
-        };
+        byte[] compressed;
+        switch (options.Compression) {
+            case OfficePngCompression.Optimal:
+                compressed = DeflateRgbaScanlines(width, height, rgba);
+                break;
+            case OfficePngCompression.Stored:
+                compressed = DeflateZlibStored(CreateRgbaScanlines(width, height, rgba, adaptiveFiltering: false));
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(options.Compression));
+        }
         return CreateFromCompressedScanlines(
             width,
             height,
@@ -267,11 +281,11 @@ public static class OfficePngWriter {
         if (dpi < OfficeRasterImageEncoder.PngMinimumDpi ||
             double.IsNaN(dpi) ||
             double.IsInfinity(dpi) ||
-            dpi > uint.MaxValue * 0.0254D) {
+            dpi > OfficeRasterImageEncoder.PngMaximumDpi) {
             throw new ArgumentOutOfRangeException(
                 paramName,
                 "PNG DPI must be finite and between 0.0127 and " +
-                (uint.MaxValue * 0.0254D).ToString(System.Globalization.CultureInfo.InvariantCulture) +
+                OfficeRasterImageEncoder.PngMaximumDpi.ToString(System.Globalization.CultureInfo.InvariantCulture) +
                 ".");
         }
     }
@@ -355,6 +369,54 @@ public static class OfficePngWriter {
         return stream.ToArray();
     }
 
+    private static byte[] DeflateRgbaScanlines(int width, int height, byte[] rgba) {
+        int stride = checked(width * 4);
+        var filteredRow = new byte[checked(stride + 1)];
+        var paethCandidate = new byte[stride];
+        var compressionBatch = new byte[Math.Max(filteredRow.Length, 64 * 1024)];
+        int batchLength = 0;
+        uint adlerA = 1;
+        uint adlerB = 0;
+        using MemoryStream stream = new MemoryStream();
+        stream.WriteByte(0x78);
+        stream.WriteByte(0x9C);
+        using (var deflate = new DeflateStream(stream, CompressionLevel.Optimal, leaveOpen: true)) {
+            for (int y = 0; y < height; y++) {
+                int rowOffset = y * stride;
+                if (y == 0) {
+                    filteredRow[0] = 1;
+                    FilterFirstRowSub(rgba, rowOffset, stride, filteredRow, 1);
+                } else {
+                    int previousRowOffset = rowOffset - stride;
+                    long upScore = FilterUp(rgba, rowOffset, previousRowOffset, stride, filteredRow, 1);
+                    long paethScore = FilterPaeth(rgba, rowOffset, previousRowOffset, stride, paethCandidate);
+                    if (paethScore < upScore) {
+                        filteredRow[0] = 4;
+                        Buffer.BlockCopy(paethCandidate, 0, filteredRow, 1, stride);
+                    } else {
+                        filteredRow[0] = 2;
+                    }
+                }
+
+                if (filteredRow.Length > compressionBatch.Length - batchLength) {
+                    deflate.Write(compressionBatch, 0, batchLength);
+                    batchLength = 0;
+                }
+                Buffer.BlockCopy(filteredRow, 0, compressionBatch, batchLength, filteredRow.Length);
+                batchLength += filteredRow.Length;
+                UpdateAdler32(filteredRow, 0, filteredRow.Length, ref adlerA, ref adlerB);
+            }
+            if (batchLength > 0) deflate.Write(compressionBatch, 0, batchLength);
+        }
+
+        uint adler = (adlerB << 16) | adlerA;
+        stream.WriteByte((byte)((adler >> 24) & 0xFF));
+        stream.WriteByte((byte)((adler >> 16) & 0xFF));
+        stream.WriteByte((byte)((adler >> 8) & 0xFF));
+        stream.WriteByte((byte)(adler & 0xFF));
+        return stream.ToArray();
+    }
+
     private static byte[] DeflateZlibStored(byte[] data) {
         using MemoryStream stream = new MemoryStream();
         stream.WriteByte(0x78);
@@ -383,22 +445,27 @@ public static class OfficePngWriter {
     }
 
     private static uint Adler32(byte[] data) {
-        const uint mod = 65521;
-        const int maximumChunk = 5552;
         uint a = 1;
         uint b = 0;
-        int offset = 0;
-        while (offset < data.Length) {
-            int end = Math.Min(offset + maximumChunk, data.Length);
+        UpdateAdler32(data, 0, data.Length, ref a, ref b);
+        return (b << 16) | a;
+    }
+
+    private static void UpdateAdler32(byte[] data, int offset, int count, ref uint a, ref uint b) {
+        const uint mod = 65521;
+        const int maximumChunk = 5552;
+        int remaining = count;
+        while (remaining > 0) {
+            int chunk = Math.Min(maximumChunk, remaining);
+            int end = offset + chunk;
             while (offset < end) {
                 a += data[offset++];
                 b += a;
             }
             a %= mod;
             b %= mod;
+            remaining -= chunk;
         }
-
-        return (b << 16) | a;
     }
 
     private static void WriteChunk(Stream stream, string type, byte[] data) {

--- a/OfficeIMO.Core/Png/OfficePngWriter.cs
+++ b/OfficeIMO.Core/Png/OfficePngWriter.cs
@@ -25,6 +25,7 @@ public enum OfficePngCompression {
 /// </summary>
 public static class OfficePngWriter {
     private static readonly byte[] PngSignature = { 137, 80, 78, 71, 13, 10, 26, 10 };
+    private static readonly uint[] CrcTable = CreateCrcTable();
 
     /// <summary>
     /// Encodes an RGBA image as PNG bytes.
@@ -34,7 +35,7 @@ public static class OfficePngWriter {
             throw new ArgumentNullException(nameof(image));
         }
 
-        return EncodeRgba(image.Width, image.Height, image.GetPixels(), compression);
+        return EncodeRgba(image.Width, image.Height, image.PixelBuffer, compression);
     }
 
     /// <summary>Encodes an RGBA image with explicit compression and physical-resolution metadata.</summary>
@@ -43,7 +44,7 @@ public static class OfficePngWriter {
         if (options == null) throw new ArgumentNullException(nameof(options));
         ValidateDpi(options.DpiX, nameof(options.DpiX));
         ValidateDpi(options.DpiY, nameof(options.DpiY));
-        return EncodeRgba(image.Width, image.Height, image.GetPixels(), options);
+        return EncodeRgba(image.Width, image.Height, image.PixelBuffer, options);
     }
 
     /// <summary>
@@ -66,15 +67,7 @@ public static class OfficePngWriter {
             throw new ArgumentException("RGBA buffer length does not match image dimensions.", nameof(rgba));
         }
 
-        byte[] scanlines = new byte[height * (1 + width * 4)];
-        int source = 0;
-        int target = 0;
-        for (int y = 0; y < height; y++) {
-            scanlines[target++] = 0;
-            Buffer.BlockCopy(rgba, source, scanlines, target, width * 4);
-            source += width * 4;
-            target += width * 4;
-        }
+        byte[] scanlines = CreateRgbaScanlines(width, height, rgba, compression == OfficePngCompression.Optimal);
 
         return EncodeScanlines(width, height, 8, 6, scanlines, compression);
     }
@@ -86,7 +79,7 @@ public static class OfficePngWriter {
         ValidateDpi(options.DpiY, nameof(options.DpiY));
         ValidateRgba(width, height, rgba);
 
-        byte[] scanlines = CreateRgbaScanlines(width, height, rgba);
+        byte[] scanlines = CreateRgbaScanlines(width, height, rgba, options.Compression == OfficePngCompression.Optimal);
         byte[] compressed = options.Compression switch {
             OfficePngCompression.Optimal => DeflateZlib(scanlines),
             OfficePngCompression.Stored => DeflateZlibStored(scanlines),
@@ -178,17 +171,84 @@ public static class OfficePngWriter {
         }
     }
 
-    private static byte[] CreateRgbaScanlines(int width, int height, byte[] rgba) {
-        byte[] scanlines = new byte[height * (1 + width * 4)];
-        int source = 0;
-        int target = 0;
+    private static byte[] CreateRgbaScanlines(int width, int height, byte[] rgba, bool adaptiveFiltering) {
+        int stride = checked(width * 4);
+        byte[] scanlines = new byte[checked(height * (1 + stride))];
+        if (!adaptiveFiltering) {
+            int source = 0;
+            int target = 0;
+            for (int y = 0; y < height; y++) {
+                scanlines[target++] = 0;
+                Buffer.BlockCopy(rgba, source, scanlines, target, stride);
+                source += stride;
+                target += stride;
+            }
+            return scanlines;
+        }
+
+        byte[] candidate = new byte[stride];
         for (int y = 0; y < height; y++) {
-            scanlines[target++] = 0;
-            Buffer.BlockCopy(rgba, source, scanlines, target, width * 4);
-            source += width * 4;
-            target += width * 4;
+            int rowOffset = y * stride;
+            int previousRowOffset = rowOffset - stride;
+            int target = y * (stride + 1);
+            if (y == 0) {
+                scanlines[target] = 1;
+                FilterFirstRowSub(rgba, rowOffset, stride, scanlines, target + 1);
+                continue;
+            }
+
+            long upScore = FilterUp(rgba, rowOffset, previousRowOffset, stride, scanlines, target + 1);
+            long paethScore = FilterPaeth(rgba, rowOffset, previousRowOffset, stride, candidate);
+            if (paethScore < upScore) {
+                scanlines[target] = 4;
+                Buffer.BlockCopy(candidate, 0, scanlines, target + 1, stride);
+            } else {
+                scanlines[target] = 2;
+            }
         }
         return scanlines;
+    }
+
+    private static void FilterFirstRowSub(byte[] rgba, int rowOffset, int stride, byte[] destination, int destinationOffset) {
+        for (int index = 0; index < 4 && index < stride; index++) {
+            destination[destinationOffset + index] = rgba[rowOffset + index];
+        }
+        for (int index = 4; index < stride; index++) {
+            destination[destinationOffset + index] = unchecked((byte)(rgba[rowOffset + index] - rgba[rowOffset + index - 4]));
+        }
+    }
+
+    private static long FilterUp(byte[] rgba, int rowOffset, int previousRowOffset, int stride, byte[] destination, int destinationOffset) {
+        long score = 0L;
+        for (int index = 0; index < stride; index++) {
+            byte filtered = unchecked((byte)(rgba[rowOffset + index] - rgba[previousRowOffset + index]));
+            destination[destinationOffset + index] = filtered;
+            score += Math.Abs((int)(sbyte)filtered);
+        }
+        return score;
+    }
+
+    private static long FilterPaeth(byte[] rgba, int rowOffset, int previousRowOffset, int stride, byte[] destination) {
+        long score = 0L;
+        for (int index = 0; index < stride; index++) {
+            int left = index >= 4 ? rgba[rowOffset + index - 4] : 0;
+            int above = rgba[previousRowOffset + index];
+            int upperLeft = index >= 4 ? rgba[previousRowOffset + index - 4] : 0;
+            byte filtered = unchecked((byte)(rgba[rowOffset + index] - PaethPredictor(left, above, upperLeft)));
+            destination[index] = filtered;
+            score += Math.Abs((int)(sbyte)filtered);
+        }
+        return score;
+    }
+
+    private static int PaethPredictor(int left, int above, int upperLeft) {
+        int prediction = left + above - upperLeft;
+        int distanceLeft = Math.Abs(prediction - left);
+        int distanceAbove = Math.Abs(prediction - above);
+        int distanceUpperLeft = Math.Abs(prediction - upperLeft);
+        return distanceLeft <= distanceAbove && distanceLeft <= distanceUpperLeft
+            ? left
+            : distanceAbove <= distanceUpperLeft ? above : upperLeft;
     }
 
     private static byte[] BuildPhysicalResolution(double dpiX, double dpiY) {
@@ -324,11 +384,18 @@ public static class OfficePngWriter {
 
     private static uint Adler32(byte[] data) {
         const uint mod = 65521;
+        const int maximumChunk = 5552;
         uint a = 1;
         uint b = 0;
-        for (int i = 0; i < data.Length; i++) {
-            a = (a + data[i]) % mod;
-            b = (b + a) % mod;
+        int offset = 0;
+        while (offset < data.Length) {
+            int end = Math.Min(offset + maximumChunk, data.Length);
+            while (offset < end) {
+                a += data[offset++];
+                b += a;
+            }
+            a %= mod;
+            b %= mod;
         }
 
         return (b << 16) | a;
@@ -362,12 +429,19 @@ public static class OfficePngWriter {
     }
 
     private static uint UpdateCrc(uint crc, byte value) {
-        crc ^= value;
-        for (int i = 0; i < 8; i++) {
-            crc = (crc & 1) != 0 ? 0xEDB88320 ^ (crc >> 1) : crc >> 1;
-        }
+        return CrcTable[(crc ^ value) & 0xFF] ^ (crc >> 8);
+    }
 
-        return crc;
+    private static uint[] CreateCrcTable() {
+        var table = new uint[256];
+        for (uint index = 0; index < table.Length; index++) {
+            uint value = index;
+            for (int bit = 0; bit < 8; bit++) {
+                value = (value & 1) != 0 ? 0xEDB88320 ^ (value >> 1) : value >> 1;
+            }
+            table[index] = value;
+        }
+        return table;
     }
 
     private static void WriteBigEndianInt32(byte[] bytes, int offset, int value) {

--- a/OfficeIMO.Core/README.md
+++ b/OfficeIMO.Core/README.md
@@ -234,7 +234,30 @@ byte[] webp = OfficeRasterImageEncoder.Encode(image, OfficeImageExportFormat.Web
 
 WebP output is deterministic, lossless VP8L. TIFF output is a single-page classic RGBA image with uncompressed, PackBits, or Deflate strips. JPEG uses the existing managed quality, subsampling, progressive, metadata, and transparency-flattening settings.
 
-`OfficeRasterExportPlanner` is the shared pre-allocation owner for image export. It combines the caller's `MaximumRasterPixels` with renderer and encoder dimension/pixel limits, then either reduces scale with `IMAGE_RASTER_SCALE_REDUCED` or throws `OfficeImageExportLimitException`, according to `RasterOverflowBehavior`. The returned plan also owns the effective encoding settings: `CreateEncodingOptions()` reduces encoded density with the raster scale so safety limits preserve the document's physical size. Explicit top-level `DpiX`/`DpiY` values apply across formats; when those values are not assigned, format-specific PNG, JPEG, and TIFF density remains authoritative. Drawing's managed PNG, JPEG, classic 8-bit chunky grayscale/palette/RGB/RGBA/DeviceCMYK TIFF, uncompressed BMP, explicitly selected composited GIF frame, and OfficeIMO literal-lossless WebP decoders enforce encoded-payload and source-pixel guards. `OfficeRasterDecodeOptions` selects a GIF frame or rejects animated input, while `OfficeRasterDecodeInfo` reports the detected format, frame count, selected frame, success, and any discarded animation. TIFF accepts uncompressed, PackBits, and Deflate strips with horizontal prediction; LZW/JPEG, tiled, planar, floating-point, BigTIFF pixel data, and multi-page images remain outside the bounded profile. `OfficeRasterImageFallbackCodec` can wrap an application codec at the final raster boundary. It reports `IMAGE_SOURCE_DECODED_BY_CALLER_CODEC` when that codec succeeds; if neither Drawing nor the application can decode a source image, it returns a visible placeholder and `IMAGE_SOURCE_DECODE_FALLBACK` instead of allowing the renderer to omit the image silently.
+### Optimize encoded images for a placement
+
+`OfficeImageOptimizer` resizes and re-encodes a static raster image for the pixel bounds where it will be used:
+
+```csharp
+using OfficeIMO.Drawing;
+
+byte[] source = File.ReadAllBytes("photo.jpg");
+var request = new OfficeImageOptimizationRequest(1200, 800) {
+    OutputFormat = OfficeImageFormat.Jpeg,
+    JpegQuality = 82,
+    JpegSubsampling = OfficeJpegSubsampling.Y420,
+    JpegProgressive = true,
+    JpegOptimizeHuffman = true
+};
+
+OfficeImageOptimizationResult result = OfficeImageOptimizer.Optimize(source, request, "photo.jpg");
+File.WriteAllBytes("photo.optimized.jpg", result.Bytes);
+Console.WriteLine($"{result.Status}: {result.BytesSaved} bytes saved");
+```
+
+The request preserves aspect ratio, avoids upscaling, keeps the original when re-encoding is not smaller, and retains source DPI by default. Set `OutputDpiX` and `OutputDpiY` to override density. Output can be PNG, JPEG, TIFF, or WebP; use `PngCompression`, the JPEG quality/subsampling/progressive/Huffman settings, or `TiffCompression` for the selected format. The result reports whether bytes changed and exposes both original and final image metadata. Animated and multi-page input is rejected so optimization never silently drops frames or pages.
+
+`OfficeRasterExportPlanner` is the shared pre-allocation owner for image export. It combines the caller's `MaximumRasterPixels` with renderer and encoder dimension/pixel limits, then either reduces scale with `IMAGE_RASTER_SCALE_REDUCED` or throws `OfficeImageExportLimitException`, according to `RasterOverflowBehavior`. The returned plan also owns the effective encoding settings: `CreateEncodingOptions()` reduces encoded density with the raster scale so safety limits preserve the document's physical size. Explicit top-level `DpiX`/`DpiY` values apply across formats; when those values are not assigned, format-specific PNG, JPEG, and TIFF density remains authoritative. Drawing's managed PNG, JPEG, classic 8-bit chunky grayscale/palette/RGB/RGBA/DeviceCMYK TIFF, uncompressed BMP, explicitly selected composited GIF frame, and OfficeIMO literal-lossless WebP decoders enforce encoded-payload and source-pixel guards. `OfficeRasterDecodeOptions` selects a GIF frame or rejects multi-frame input, while `OfficeRasterDecodeInfo` reports the detected format, frame count, selected frame, success, and any discarded frames or pages. TIFF accepts uncompressed, PackBits, and Deflate strips with horizontal prediction. For a supported multi-page classic TIFF, the default frame-loss policy decodes the first page and reports the discarded pages; `RejectAnimated` rejects the container instead. LZW/JPEG, tiled, planar, floating-point, and BigTIFF pixel data remain outside the bounded profile. `OfficeRasterImageFallbackCodec` can wrap an application codec at the final raster boundary. It reports `IMAGE_SOURCE_DECODED_BY_CALLER_CODEC` when that codec succeeds; if neither Drawing nor the application can decode a source image, it returns a visible placeholder and `IMAGE_SOURCE_DECODE_FALLBACK` instead of allowing the renderer to omit the image silently.
 
 Every format package builds on the same fluent export contract. `FitWithin(width, height)`, `FitWithinWidth(...)`, and `FitWithinHeight(...)` cap both raster and SVG output without enlarging smaller content. `ConfigureOptions(...)` exposes the complete provider-specific option object when no dedicated fluent shortcut exists. Batch limits, cancellation, progress, and `WithRenderTimeout(...)` apply to the complete operation, including streaming saves. Each batch result reports its zero-based `SequenceIndex`; `SequenceCount` is populated when the total is known before streaming or after a fluent builder materializes the complete result list.
 

--- a/OfficeIMO.Core/Raster/OfficeGifReader.cs
+++ b/OfficeIMO.Core/Raster/OfficeGifReader.cs
@@ -156,7 +156,7 @@ public static class OfficeGifReader {
                     }
                     ApplyDisposal(canvas, previousFrame, previousDisposalMethod, backgroundColor, restoreCanvas);
                     restoreCanvas = disposalMethod == 3
-                        ? OfficeRasterImage.FromRgba32(canvas.Width, canvas.Height, canvas.GetPixels())
+                        ? OfficeRasterImage.FromRgba32(canvas.Width, canvas.Height, canvas.PixelBuffer)
                         : null;
                     if (!TryReadImageFrame(
                         bytes,
@@ -172,7 +172,7 @@ public static class OfficeGifReader {
                     }
 
                     if (frameCount == frameIndex) {
-                        image = OfficeRasterImage.FromRgba32(canvas.Width, canvas.Height, canvas.GetPixels());
+                        image = OfficeRasterImage.FromRgba32(canvas.Width, canvas.Height, canvas.PixelBuffer);
                     }
                     previousFrame = frame;
                     previousDisposalMethod = disposalMethod;

--- a/OfficeIMO.Core/Raster/OfficeImageOptimizer.cs
+++ b/OfficeIMO.Core/Raster/OfficeImageOptimizer.cs
@@ -21,6 +21,8 @@ public sealed class OfficeImageOptimizationRequest {
     private int _targetPixelWidth;
     private int _targetPixelHeight;
     private int _jpegQuality = 85;
+    private double? _outputDpiX;
+    private double? _outputDpiY;
 
     /// <summary>Creates an optimization request for a target pixel bounding box.</summary>
     public OfficeImageOptimizationRequest(int targetPixelWidth, int targetPixelHeight) {
@@ -55,8 +57,35 @@ public sealed class OfficeImageOptimizationRequest {
     /// <summary>Sampling mode used when dimensions change.</summary>
     public OfficeRasterResamplingMode ResamplingMode { get; set; } = OfficeRasterResamplingMode.Bilinear;
 
-    /// <summary>Optional PNG or JPEG output override. Null preserves JPEG and otherwise emits PNG.</summary>
+    /// <summary>Optional PNG, JPEG, TIFF, or WebP output override. Null preserves JPEG and otherwise emits PNG.</summary>
     public OfficeImageFormat? OutputFormat { get; set; }
+
+    /// <summary>
+    /// Optional horizontal output resolution. Null preserves source DPI. Values outside the selected
+    /// destination format's metadata range are clamped to its nearest representable limit.
+    /// </summary>
+    public double? OutputDpiX {
+        get => _outputDpiX;
+        set {
+            ValidateOutputDpi(value, nameof(OutputDpiX));
+            _outputDpiX = value;
+        }
+    }
+
+    /// <summary>
+    /// Optional vertical output resolution. Null preserves source DPI. Values outside the selected
+    /// destination format's metadata range are clamped to its nearest representable limit.
+    /// </summary>
+    public double? OutputDpiY {
+        get => _outputDpiY;
+        set {
+            ValidateOutputDpi(value, nameof(OutputDpiY));
+            _outputDpiY = value;
+        }
+    }
+
+    /// <summary>PNG compression used when optimized output is PNG.</summary>
+    public OfficePngCompression PngCompression { get; set; } = OfficePngCompression.Optimal;
 
     /// <summary>JPEG quality from 1 through 100.</summary>
     public int JpegQuality {
@@ -70,19 +99,39 @@ public sealed class OfficeImageOptimizationRequest {
     /// <summary>JPEG chroma subsampling used for optimized output.</summary>
     public OfficeJpegSubsampling JpegSubsampling { get; set; } = OfficeJpegSubsampling.Y420;
 
+    /// <summary>Writes progressive JPEG scans when optimized output is JPEG.</summary>
+    public bool JpegProgressive { get; set; }
+
+    /// <summary>Builds image-specific Huffman tables when optimized output is JPEG.</summary>
+    public bool JpegOptimizeHuffman { get; set; }
+
     /// <summary>Background used when explicit JPEG output flattens alpha.</summary>
     public OfficeColor JpegBackground { get; set; } = OfficeColor.White;
 
+    /// <summary>TIFF strip compression used when optimized output is TIFF.</summary>
+    public OfficeTiffCompression TiffCompression { get; set; } = OfficeTiffCompression.PackBits;
+
     /// <summary>Keeps original bytes when the candidate would be the same size or larger.</summary>
     public bool KeepOriginalWhenNotSmaller { get; set; } = true;
+
+    private static void ValidateOutputDpi(double? value, string paramName) {
+        if (value.HasValue && (value.Value <= 0D || double.IsNaN(value.Value) || double.IsInfinity(value.Value))) {
+            throw new ArgumentOutOfRangeException(paramName, "Output DPI must be finite and greater than zero.");
+        }
+    }
 }
 
 /// <summary>Immutable result of encoded-image optimization.</summary>
 public sealed class OfficeImageOptimizationResult {
     private readonly byte[] _bytes;
 
-    internal OfficeImageOptimizationResult(byte[] bytes, OfficeImageOptimizationStatus status, OfficeImageInfo original, OfficeImageInfo final) {
-        _bytes = (byte[])bytes.Clone();
+    internal OfficeImageOptimizationResult(
+        byte[] bytes,
+        OfficeImageOptimizationStatus status,
+        OfficeImageInfo original,
+        OfficeImageInfo final,
+        bool takeOwnership) {
+        _bytes = takeOwnership ? bytes : (byte[])bytes.Clone();
         Status = status;
         Original = original;
         Final = final;
@@ -108,7 +157,10 @@ public sealed class OfficeImageOptimizationResult {
 
 /// <summary>Shared dependency-free placement-aware encoded-image optimizer.</summary>
 public static class OfficeImageOptimizer {
-    /// <summary>Resizes PNG, JPEG, or uncompressed BMP bytes for a known placement and emits PNG or JPEG.</summary>
+    /// <summary>
+    /// Resizes managed static raster input for a known placement and emits PNG, JPEG, TIFF, or WebP.
+    /// Animated input is rejected so optimization never silently discards frames.
+    /// </summary>
     public static OfficeImageOptimizationResult Optimize(byte[] encodedBytes, OfficeImageOptimizationRequest request, string? fileName = null) {
         if (encodedBytes == null) throw new ArgumentNullException(nameof(encodedBytes));
         if (request == null) throw new ArgumentNullException(nameof(request));
@@ -116,34 +168,54 @@ public static class OfficeImageOptimizer {
             return Result(encodedBytes, OfficeImageOptimizationStatus.UnsupportedFormat, new OfficeImageInfo(OfficeImageFormat.Unknown, 0, 0), new OfficeImageInfo(OfficeImageFormat.Unknown, 0, 0));
         }
 
-        if (original.Format != OfficeImageFormat.Png && original.Format != OfficeImageFormat.Jpeg && original.Format != OfficeImageFormat.Bmp) {
+        if (!IsSupportedInputFormat(original.Format)) {
             return Result(encodedBytes, OfficeImageOptimizationStatus.UnsupportedFormat, original, original);
         }
 
-        if (!OfficeRasterImageDecoder.TryDecode(encodedBytes, out OfficeRasterImage? decoded) || decoded == null) {
+        var decodeOptions = new OfficeRasterDecodeOptions {
+            AnimationPolicy = OfficeRasterAnimationPolicy.RejectAnimated
+        };
+        if (!OfficeRasterImageDecoder.TryDecode(encodedBytes, decodeOptions, out OfficeRasterImage? decoded, out _) || decoded == null) {
             return Result(encodedBytes, OfficeImageOptimizationStatus.DecodeFailed, original, original);
         }
 
         ResolveDimensions(decoded.Width, decoded.Height, request, out int width, out int height);
         OfficeImageFormat outputFormat = ResolveOutputFormat(original.Format, request.OutputFormat);
-        if (width == decoded.Width && height == decoded.Height && outputFormat == original.Format) {
+        if (width == decoded.Width && height == decoded.Height && outputFormat == original.Format &&
+            !request.OutputDpiX.HasValue && !request.OutputDpiY.HasValue) {
             return Result(encodedBytes, OfficeImageOptimizationStatus.AlreadySuitable, original, original);
         }
 
         OfficeRasterImage candidateImage = width == decoded.Width && height == decoded.Height
             ? decoded
             : OfficeRasterResampler.Resize(decoded, width, height, request.ResamplingMode);
-        byte[] candidate = Encode(candidateImage, outputFormat, request);
-        OfficeImageInfo final = new OfficeImageInfo(outputFormat, width, height, original.DpiX, original.DpiY);
+        byte[] candidate = Encode(candidateImage, outputFormat, original, request);
+        OfficeImageInfo final = OfficeImageReader.Identify(candidate);
         if (request.KeepOriginalWhenNotSmaller && candidate.LongLength >= encodedBytes.LongLength) {
             return Result(encodedBytes, OfficeImageOptimizationStatus.OriginalWasSmaller, original, original);
         }
 
-        return Result(candidate, OfficeImageOptimizationStatus.Optimized, original, final, encodedBytes.LongLength);
+        return Result(candidate, OfficeImageOptimizationStatus.Optimized, original, final, encodedBytes.LongLength, takeOwnership: true);
     }
 
-    private static OfficeImageOptimizationResult Result(byte[] bytes, OfficeImageOptimizationStatus status, OfficeImageInfo original, OfficeImageInfo final, long? originalLength = null) =>
-        new OfficeImageOptimizationResult(bytes, status, original, final) { OriginalEncodedLength = originalLength ?? bytes.LongLength };
+    private static OfficeImageOptimizationResult Result(
+        byte[] bytes,
+        OfficeImageOptimizationStatus status,
+        OfficeImageInfo original,
+        OfficeImageInfo final,
+        long? originalLength = null,
+        bool takeOwnership = false) =>
+        new OfficeImageOptimizationResult(bytes, status, original, final, takeOwnership) {
+            OriginalEncodedLength = originalLength ?? bytes.LongLength
+        };
+
+    private static bool IsSupportedInputFormat(OfficeImageFormat format) =>
+        format == OfficeImageFormat.Png ||
+        format == OfficeImageFormat.Jpeg ||
+        format == OfficeImageFormat.Gif ||
+        format == OfficeImageFormat.Bmp ||
+        format == OfficeImageFormat.Tiff ||
+        format == OfficeImageFormat.Webp;
 
     private static void ResolveDimensions(int sourceWidth, int sourceHeight, OfficeImageOptimizationRequest request, out int width, out int height) {
         if (!request.PreserveAspectRatio) {
@@ -160,18 +232,48 @@ public static class OfficeImageOptimizer {
 
     private static OfficeImageFormat ResolveOutputFormat(OfficeImageFormat source, OfficeImageFormat? requested) {
         OfficeImageFormat format = requested ?? (source == OfficeImageFormat.Jpeg ? OfficeImageFormat.Jpeg : OfficeImageFormat.Png);
-        if (format != OfficeImageFormat.Png && format != OfficeImageFormat.Jpeg) {
-            throw new ArgumentOutOfRangeException(nameof(requested), "Managed optimization output must be PNG or JPEG.");
+        if (format != OfficeImageFormat.Png &&
+            format != OfficeImageFormat.Jpeg &&
+            format != OfficeImageFormat.Tiff &&
+            format != OfficeImageFormat.Webp) {
+            throw new ArgumentOutOfRangeException(nameof(requested), "Managed optimization output must be PNG, JPEG, TIFF, or WebP.");
         }
         return format;
     }
 
-    private static byte[] Encode(OfficeRasterImage image, OfficeImageFormat format, OfficeImageOptimizationRequest request) {
-        if (format == OfficeImageFormat.Png) return OfficePngWriter.Encode(image);
-        return OfficeJpegCodec.Encode(image, new OfficeJpegEncodeOptions {
-            Quality = request.JpegQuality,
-            Subsampling = request.JpegSubsampling,
-            Background = request.JpegBackground
-        });
+    private static byte[] Encode(
+        OfficeRasterImage image,
+        OfficeImageFormat format,
+        OfficeImageInfo original,
+        OfficeImageOptimizationRequest request) {
+        OfficeImageExportFormat exportFormat = ToExportFormat(format);
+        double dpiX = OfficeRasterImageEncoder.NormalizeDpi(exportFormat, request.OutputDpiX ?? original.DpiX);
+        double dpiY = OfficeRasterImageEncoder.NormalizeDpi(exportFormat, request.OutputDpiY ?? original.DpiY);
+        var options = new OfficeRasterEncodingOptions {
+            DpiX = dpiX,
+            DpiY = dpiY,
+            Png = new OfficePngEncodeOptions {
+                Compression = request.PngCompression
+            },
+            Jpeg = new OfficeJpegEncodeOptions {
+                Quality = request.JpegQuality,
+                Subsampling = request.JpegSubsampling,
+                Progressive = request.JpegProgressive,
+                OptimizeHuffman = request.JpegOptimizeHuffman,
+                Background = request.JpegBackground
+            },
+            Tiff = new OfficeTiffEncodeOptions {
+                Compression = request.TiffCompression
+            }
+        };
+        return OfficeRasterImageEncoder.Encode(image, exportFormat, options);
     }
+
+    private static OfficeImageExportFormat ToExportFormat(OfficeImageFormat format) => format switch {
+        OfficeImageFormat.Png => OfficeImageExportFormat.Png,
+        OfficeImageFormat.Jpeg => OfficeImageExportFormat.Jpeg,
+        OfficeImageFormat.Tiff => OfficeImageExportFormat.Tiff,
+        OfficeImageFormat.Webp => OfficeImageExportFormat.Webp,
+        _ => throw new ArgumentOutOfRangeException(nameof(format))
+    };
 }

--- a/OfficeIMO.Core/Raster/OfficeRasterGuards.cs
+++ b/OfficeIMO.Core/Raster/OfficeRasterGuards.cs
@@ -37,10 +37,22 @@ internal static class OfficeRasterGuards {
     }
 
     public static int EnsureInt32ArrayLength(long elements, ref long aggregateBytes, string message) {
+        return EnsureArrayLength(elements, sizeof(int), ref aggregateBytes, message);
+    }
+
+    public static int EnsureInt16ArrayLength(long elements, ref long aggregateBytes, string message) {
+        return EnsureArrayLength(elements, sizeof(short), ref aggregateBytes, message);
+    }
+
+    public static int EnsureByteArrayLength(long elements, ref long aggregateBytes, string message) {
+        return EnsureArrayLength(elements, sizeof(byte), ref aggregateBytes, message);
+    }
+
+    private static int EnsureArrayLength(long elements, int elementSize, ref long aggregateBytes, string message) {
         if (elements <= 0 || elements > int.MaxValue) throw new FormatException(message);
         long bytes;
         try {
-            bytes = checked(elements * sizeof(int));
+            bytes = checked(elements * elementSize);
             aggregateBytes = checked(aggregateBytes + bytes);
         } catch (OverflowException) {
             throw new FormatException(message);

--- a/OfficeIMO.Core/Raster/OfficeRasterImage.cs
+++ b/OfficeIMO.Core/Raster/OfficeRasterImage.cs
@@ -44,14 +44,20 @@ public sealed class OfficeRasterImage {
     }
 
     internal static OfficeRasterImage FromRgba32(int width, int height, byte[] pixels) {
-        if (pixels == null) throw new ArgumentNullException(nameof(pixels));
-        if (pixels.Length != checked(width * height * 4)) {
-            throw new ArgumentException("RGBA buffer length does not match image dimensions.", nameof(pixels));
-        }
+        ValidateRgba32Buffer(width, height, pixels);
+        return new OfficeRasterImage(width, height, (byte[])pixels.Clone());
+    }
 
-        var image = new OfficeRasterImage(width, height);
-        Buffer.BlockCopy(pixels, 0, image._pixels, 0, pixels.Length);
-        return image;
+    /// <summary>Creates an image by taking ownership of a newly allocated decoder buffer.</summary>
+    internal static OfficeRasterImage FromOwnedRgba32(int width, int height, byte[] pixels) {
+        ValidateRgba32Buffer(width, height, pixels);
+        return new OfficeRasterImage(width, height, pixels);
+    }
+
+    private OfficeRasterImage(int width, int height, byte[] ownedPixels) {
+        Width = width;
+        Height = height;
+        _pixels = ownedPixels;
     }
 
     /// <summary>Gets the color of a pixel.</summary>
@@ -120,6 +126,15 @@ public sealed class OfficeRasterImage {
 
         if ((uint)y >= (uint)Height) {
             throw new ArgumentOutOfRangeException(nameof(y));
+        }
+    }
+
+    private static void ValidateRgba32Buffer(int width, int height, byte[] pixels) {
+        if (width <= 0) throw new ArgumentOutOfRangeException(nameof(width));
+        if (height <= 0) throw new ArgumentOutOfRangeException(nameof(height));
+        if (pixels == null) throw new ArgumentNullException(nameof(pixels));
+        if (pixels.Length != checked(width * height * 4)) {
+            throw new ArgumentException("RGBA buffer length does not match image dimensions.", nameof(pixels));
         }
     }
 

--- a/OfficeIMO.Core/Raster/OfficeRasterImageDecoder.cs
+++ b/OfficeIMO.Core/Raster/OfficeRasterImageDecoder.cs
@@ -90,6 +90,30 @@ public static class OfficeRasterImageDecoder {
             }
         }
 
+        if (format == OfficeImageFormat.Tiff) {
+            if (!OfficeTiffCodec.TryGetPageCount(bytes, out int tiffPageCount)) {
+                info = new OfficeRasterDecodeInfo(format, 0, effective.FrameIndex, succeeded: false, diagnostic: "The TIFF container is malformed or outside the managed decoder subset.");
+                return false;
+            }
+            if (tiffPageCount > 1) {
+                if (effective.AnimationPolicy == OfficeRasterAnimationPolicy.RejectAnimated) {
+                    info = new OfficeRasterDecodeInfo(format, tiffPageCount, effective.FrameIndex, succeeded: false, diagnostic: "Multi-page TIFF input was rejected by the configured frame-loss policy.");
+                    return false;
+                }
+                if (effective.FrameIndex != 0) {
+                    info = new OfficeRasterDecodeInfo(format, tiffPageCount, effective.FrameIndex, succeeded: false, diagnostic: "Managed TIFF decoding currently exposes only the first page.");
+                    return false;
+                }
+
+                bool decoded = OfficeTiffCodec.TryDecode(bytes, out image);
+                info = new OfficeRasterDecodeInfo(format, tiffPageCount, effective.FrameIndex, decoded,
+                    decoded
+                        ? "The first TIFF page was decoded; remaining pages were not retained in the static raster result."
+                        : "The first TIFF page could not be decoded.");
+                return decoded;
+            }
+        }
+
         int webpFrameCount = format == OfficeImageFormat.Webp ? CountWebpAnimationFrames(bytes) : 1;
         if (webpFrameCount > 1) {
             info = new OfficeRasterDecodeInfo(format, webpFrameCount, effective.FrameIndex, succeeded: false,

--- a/OfficeIMO.Core/Raster/OfficeRasterImageEncoder.cs
+++ b/OfficeIMO.Core/Raster/OfficeRasterImageEncoder.cs
@@ -10,6 +10,10 @@ public static class OfficeRasterImageEncoder {
     internal const double JpegMinimumDpi = 0.5D;
     internal const double TiffMinimumDpi = 0.001D;
     internal const double WebpMinimumDpi = 0.0001D;
+    internal const double PngMaximumDpi = uint.MaxValue * 0.0254D;
+    internal const double JpegMaximumDpi = ushort.MaxValue;
+    internal const double TiffMaximumDpi = 1000000D;
+    internal const double WebpMaximumDpi = 1000000D;
     internal const int JpegMaximumDimension = ushort.MaxValue;
     internal const int WebpMaximumDimension = 16384;
 
@@ -41,6 +45,22 @@ public static class OfficeRasterImageEncoder {
         OfficeImageExportFormat.Svg => throw new ArgumentException("SVG output does not encode raster density.", nameof(format)),
         _ => throw new ArgumentOutOfRangeException(nameof(format))
     };
+
+    internal static double GetMaximumDpi(OfficeImageExportFormat format) => format switch {
+        OfficeImageExportFormat.Png => PngMaximumDpi,
+        OfficeImageExportFormat.Jpeg => JpegMaximumDpi,
+        OfficeImageExportFormat.Tiff => TiffMaximumDpi,
+        OfficeImageExportFormat.Webp => WebpMaximumDpi,
+        OfficeImageExportFormat.Svg => throw new ArgumentException("SVG output does not encode raster density.", nameof(format)),
+        _ => throw new ArgumentOutOfRangeException(nameof(format))
+    };
+
+    internal static double NormalizeDpi(OfficeImageExportFormat format, double dpi) {
+        if (double.IsNaN(dpi) || double.IsInfinity(dpi) || dpi <= 0D) {
+            throw new ArgumentOutOfRangeException(nameof(dpi), "Raster DPI must be finite and greater than zero.");
+        }
+        return Math.Min(GetMaximumDpi(format), Math.Max(GetMinimumDpi(format), dpi));
+    }
 
     /// <summary>Encodes an RGBA image using the requested raster format.</summary>
     public static byte[] Encode(

--- a/OfficeIMO.Core/Raster/OfficeRasterResampler.cs
+++ b/OfficeIMO.Core/Raster/OfficeRasterResampler.cs
@@ -21,7 +21,7 @@ public static class OfficeRasterResampler {
         OfficeRasterGuards.EnsureOutputPixels(width, height, "Raster resize dimensions exceed the managed image limit.");
 
         if (source.Width == width && source.Height == height) {
-            return OfficeRasterImage.FromRgba32(width, height, source.GetPixels());
+            return OfficeRasterImage.FromRgba32(width, height, source.PixelBuffer);
         }
 
         var result = new OfficeRasterImage(width, height);

--- a/OfficeIMO.Core/Raster/OfficeTiffCodec.cs
+++ b/OfficeIMO.Core/Raster/OfficeTiffCodec.cs
@@ -47,7 +47,7 @@ public static partial class OfficeTiffCodec {
         OfficeTiffEncodeOptions effective = options ?? new OfficeTiffEncodeOptions();
         ValidateOptions(effective);
 
-        byte[] pixels = image.GetPixels();
+        byte[] pixels = image.PixelBuffer;
         byte[] strip = effective.Compression switch {
             OfficeTiffCompression.PackBits => EncodePackBits(pixels),
             OfficeTiffCompression.Deflate => OfficeZlibCodec.Compress(pixels),
@@ -271,7 +271,7 @@ public static partial class OfficeTiffCodec {
                 }
 
                 if (isFirstIfd && rgba != null) {
-                    firstImage = OfficeRasterImage.FromRgba32(orientedWidth, orientedHeight, rgba);
+                    firstImage = OfficeRasterImage.FromOwnedRgba32(orientedWidth, orientedHeight, rgba);
                 }
                 int nextIfdPointerOffset = checked(ifdOffset + 2 + entryCount * 12);
                 ifdOffset = ReadOffset(encodedBytes, nextIfdPointerOffset, littleEndian);

--- a/OfficeIMO.Core/Raster/OfficeTiffCodec.cs
+++ b/OfficeIMO.Core/Raster/OfficeTiffCodec.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using OfficeIMO.Core.Internal;
 
 namespace OfficeIMO.Drawing;
@@ -48,11 +47,12 @@ public static partial class OfficeTiffCodec {
         ValidateOptions(effective);
 
         byte[] pixels = image.PixelBuffer;
-        byte[] strip = effective.Compression switch {
-            OfficeTiffCompression.PackBits => EncodePackBits(pixels),
-            OfficeTiffCompression.Deflate => OfficeZlibCodec.Compress(pixels),
-            _ => pixels
-        };
+        byte[]? strip = effective.Compression == OfficeTiffCompression.Deflate
+            ? OfficeZlibCodec.Compress(pixels)
+            : effective.Compression == OfficeTiffCompression.None ? pixels : null;
+        int stripLength = effective.Compression == OfficeTiffCompression.PackBits
+            ? EncodePackBits(pixels, output: null, outputOffset: 0)
+            : strip!.Length;
 
         const int ifdOffset = 8;
         int ifdLength = 2 + (EntryCount * 12) + 4;
@@ -60,7 +60,7 @@ public static partial class OfficeTiffCodec {
         int xResolutionOffset = checked(bitsPerSampleOffset + 8);
         int yResolutionOffset = checked(xResolutionOffset + 8);
         int stripOffset = checked(yResolutionOffset + 8);
-        int fileLength = checked(stripOffset + strip.Length);
+        int fileLength = checked(stripOffset + stripLength);
         byte[] output = new byte[fileLength];
 
         output[0] = (byte)'I';
@@ -79,7 +79,7 @@ public static partial class OfficeTiffCodec {
         WriteShortEntry(output, ref entry, 274, 1);
         WriteShortEntry(output, ref entry, 277, 4);
         WriteEntry(output, ref entry, 278, 4, 1, image.Height);
-        WriteEntry(output, ref entry, 279, 4, 1, strip.Length);
+        WriteEntry(output, ref entry, 279, 4, 1, stripLength);
         WriteEntry(output, ref entry, 282, 5, 1, xResolutionOffset);
         WriteEntry(output, ref entry, 283, 5, 1, yResolutionOffset);
         WriteShortEntry(output, ref entry, 284, 1);
@@ -93,8 +93,63 @@ public static partial class OfficeTiffCodec {
         WriteUInt16(output, bitsPerSampleOffset + 6, 8);
         WriteRational(output, xResolutionOffset, effective.DpiX);
         WriteRational(output, yResolutionOffset, effective.DpiY);
-        Buffer.BlockCopy(strip, 0, output, stripOffset, strip.Length);
+        if (effective.Compression == OfficeTiffCompression.PackBits) {
+            int written = EncodePackBits(pixels, output, stripOffset);
+            if (written != stripLength) {
+                throw new InvalidOperationException("The TIFF PackBits length calculation is inconsistent.");
+            }
+        } else {
+            Buffer.BlockCopy(strip!, 0, output, stripOffset, stripLength);
+        }
         return output;
+    }
+
+    /// <summary>Reads the number of top-level images from a bounded classic TIFF IFD chain.</summary>
+    public static bool TryGetPageCount(byte[]? encodedBytes, out int pageCount) {
+        pageCount = 0;
+        if (!IsTiff(encodedBytes) || encodedBytes == null ||
+            encodedBytes.Length > OfficeRasterGuards.MaximumEncodedBytes) {
+            return false;
+        }
+
+        try {
+            bool littleEndian = encodedBytes[0] == (byte)'I';
+            if (ReadUInt16(encodedBytes, 2, littleEndian) != 42) return false;
+            int ifdOffset = ReadOffset(encodedBytes, 4, littleEndian);
+            int firstIfdOffset = ifdOffset;
+            System.Collections.Generic.HashSet<int>? visitedIfds = null;
+            while (ifdOffset != 0) {
+                if (pageCount >= MaximumIfdCount || ifdOffset < 8 || !HasBytes(encodedBytes, ifdOffset, 2)) {
+                    pageCount = 0;
+                    return false;
+                }
+                if (pageCount > 0) {
+                    visitedIfds ??= new System.Collections.Generic.HashSet<int> { firstIfdOffset };
+                    if (!visitedIfds.Add(ifdOffset)) {
+                        pageCount = 0;
+                        return false;
+                    }
+                }
+                int entryCount = ReadUInt16(encodedBytes, ifdOffset, littleEndian);
+                if (entryCount <= 0 || !HasBytes(encodedBytes, ifdOffset + 2, checked(entryCount * 12 + 4))) {
+                    pageCount = 0;
+                    return false;
+                }
+                pageCount++;
+                int nextIfdPointerOffset = checked(ifdOffset + 2 + entryCount * 12);
+                ifdOffset = ReadOffset(encodedBytes, nextIfdPointerOffset, littleEndian);
+            }
+            return pageCount > 0;
+        } catch (ArgumentException) {
+            pageCount = 0;
+            return false;
+        } catch (FormatException) {
+            pageCount = 0;
+            return false;
+        } catch (OverflowException) {
+            pageCount = 0;
+            return false;
+        }
     }
 
     /// <summary>
@@ -347,19 +402,22 @@ public static partial class OfficeTiffCodec {
         if (dpi < OfficeRasterImageEncoder.TiffMinimumDpi ||
             double.IsNaN(dpi) ||
             double.IsInfinity(dpi) ||
-            dpi > 1000000D) {
+            dpi > OfficeRasterImageEncoder.TiffMaximumDpi) {
             throw new ArgumentOutOfRangeException(name, "TIFF DPI must be finite and between 0.001 and 1,000,000.");
         }
     }
 
-    private static byte[] EncodePackBits(byte[] input) {
-        using var output = new MemoryStream(input.Length);
+    private static int EncodePackBits(byte[] input, byte[]? output, int outputOffset) {
         int index = 0;
+        int target = outputOffset;
         while (index < input.Length) {
             int runLength = CountRun(input, index);
             if (runLength >= 3) {
-                output.WriteByte(unchecked((byte)(257 - runLength)));
-                output.WriteByte(input[index]);
+                if (output != null) {
+                    output[target] = unchecked((byte)(257 - runLength));
+                    output[target + 1] = input[index];
+                }
+                target += 2;
                 index += runLength;
                 continue;
             }
@@ -374,11 +432,14 @@ public static partial class OfficeTiffCodec {
                 literalLength += take;
             }
 
-            output.WriteByte((byte)(literalLength - 1));
-            output.Write(input, literalStart, literalLength);
+            if (output != null) {
+                output[target] = (byte)(literalLength - 1);
+                Buffer.BlockCopy(input, literalStart, output, target + 1, literalLength);
+            }
+            target += literalLength + 1;
         }
 
-        return output.ToArray();
+        return checked(target - outputOffset);
     }
 
     private static int CountRun(byte[] input, int index) {

--- a/OfficeIMO.Core/Raster/OfficeWebpCodec.cs
+++ b/OfficeIMO.Core/Raster/OfficeWebpCodec.cs
@@ -39,7 +39,7 @@ public static class OfficeWebpCodec {
         if (image.Width > OfficeRasterImageEncoder.WebpMaximumDimension) throw new ArgumentOutOfRangeException(nameof(image), "WebP width cannot exceed 16,384 pixels.");
         if (image.Height > OfficeRasterImageEncoder.WebpMaximumDimension) throw new ArgumentOutOfRangeException(nameof(image), "WebP height cannot exceed 16,384 pixels.");
 
-        byte[] pixels = image.GetPixels();
+        byte[] pixels = image.PixelBuffer;
         bool hasAlpha = HasTransparency(pixels);
         byte[] payload;
         using (var stream = new MemoryStream()) {
@@ -221,7 +221,7 @@ public static class OfficeWebpCodec {
             if (!reader.HasOnlyZeroPadding()) {
                 return false;
             }
-            image = OfficeRasterImage.FromRgba32(width, height, rgba);
+            image = OfficeRasterImage.FromOwnedRgba32(width, height, rgba);
             return true;
         } catch (FormatException) {
             return false;

--- a/OfficeIMO.Core/Raster/OfficeWebpCodec.cs
+++ b/OfficeIMO.Core/Raster/OfficeWebpCodec.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 
 namespace OfficeIMO.Drawing;
 
@@ -11,7 +10,7 @@ namespace OfficeIMO.Drawing;
 /// auditable implementation over compression efficiency while producing standards-compatible WebP.
 /// </remarks>
 public static class OfficeWebpCodec {
-    private const double MaximumDpi = 1000000D;
+    private const int LiteralHeaderBitCount = 1239;
 
     /// <summary>Returns whether the payload is a RIFF WebP container.</summary>
     public static bool IsWebp(byte[]? encodedBytes) =>
@@ -41,86 +40,85 @@ public static class OfficeWebpCodec {
 
         byte[] pixels = image.PixelBuffer;
         bool hasAlpha = HasTransparency(pixels);
-        byte[] payload;
-        using (var stream = new MemoryStream()) {
-            stream.WriteByte(0x2F);
-            var writer = new LsbBitWriter(stream);
-            writer.WriteBits((uint)(image.Width - 1), 14);
-            writer.WriteBits((uint)(image.Height - 1), 14);
-            writer.WriteBits(hasAlpha ? 1U : 0U, 1);
-            writer.WriteBits(0, 3);
+        int payloadLength = checked(1 + (int)((LiteralHeaderBitCount + pixels.LongLength * 8L + 7L) / 8L));
+        byte[]? exif = includeResolutionMetadata
+            ? CreateResolutionExif(image.Width, image.Height, dpiX, dpiY)
+            : null;
+        int paddedPayloadLength = checked(payloadLength + (payloadLength & 1));
+        int payloadOffset;
+        byte[] output;
+        if (exif == null) {
+            int fileLength = checked(20 + paddedPayloadLength);
+            output = new byte[fileLength];
+            WriteAscii(output, 0, "RIFF");
+            WriteUInt32(output, 4, fileLength - 8);
+            WriteAscii(output, 8, "WEBP");
+            WriteAscii(output, 12, "VP8L");
+            WriteUInt32(output, 16, payloadLength);
+            payloadOffset = 20;
+        } else {
+            int paddedExifLength = checked(exif.Length + (exif.Length & 1));
+            int fileLength = checked(12 + 18 + 8 + paddedPayloadLength + 8 + paddedExifLength);
+            output = new byte[fileLength];
+            WriteAscii(output, 0, "RIFF");
+            WriteUInt32(output, 4, fileLength - 8);
+            WriteAscii(output, 8, "WEBP");
+            WriteAscii(output, 12, "VP8X");
+            WriteUInt32(output, 16, 10);
+            output[20] = (byte)(0x08 | (hasAlpha ? 0x10 : 0x00));
+            WriteUInt24(output, 24, image.Width - 1);
+            WriteUInt24(output, 27, image.Height - 1);
 
-            writer.WriteBits(0, 1); // no transforms
-            writer.WriteBits(0, 1); // no color cache
-            writer.WriteBits(0, 1); // one Huffman code group for the whole image
+            const int vp8lChunkOffset = 30;
+            WriteAscii(output, vp8lChunkOffset, "VP8L");
+            WriteUInt32(output, vp8lChunkOffset + 4, payloadLength);
+            payloadOffset = vp8lChunkOffset + 8;
 
-            WriteLiteralTree(writer, 280);
-            WriteLiteralTree(writer, 256);
-            WriteLiteralTree(writer, 256);
-            WriteLiteralTree(writer, 256);
-            WriteSingleSymbolTree(writer);
-
-            for (int offset = 0; offset < pixels.Length; offset += 4) {
-                writer.WriteBits(ReverseByte(pixels[offset + 1]), 8); // green
-                writer.WriteBits(ReverseByte(pixels[offset]), 8);     // red
-                writer.WriteBits(ReverseByte(pixels[offset + 2]), 8); // blue
-                writer.WriteBits(ReverseByte(pixels[offset + 3]), 8); // alpha
-            }
-
-            writer.Flush();
-            payload = stream.ToArray();
+            int exifChunkOffset = payloadOffset + paddedPayloadLength;
+            WriteAscii(output, exifChunkOffset, "EXIF");
+            WriteUInt32(output, exifChunkOffset + 4, exif.Length);
+            Buffer.BlockCopy(exif, 0, output, exifChunkOffset + 8, exif.Length);
         }
 
-        return includeResolutionMetadata
-            ? BuildExtendedContainer(image.Width, image.Height, hasAlpha, payload, dpiX, dpiY)
-            : BuildSimpleContainer(payload);
-    }
-
-    private static byte[] BuildSimpleContainer(byte[] payload) {
-        int paddedPayloadLength = checked(payload.Length + (payload.Length & 1));
-        int fileLength = checked(20 + paddedPayloadLength);
-        byte[] output = new byte[fileLength];
-        WriteAscii(output, 0, "RIFF");
-        WriteUInt32(output, 4, fileLength - 8);
-        WriteAscii(output, 8, "WEBP");
-        WriteAscii(output, 12, "VP8L");
-        WriteUInt32(output, 16, payload.Length);
-        Buffer.BlockCopy(payload, 0, output, 20, payload.Length);
+        WriteLiteralPayload(output, payloadOffset, payloadLength, image.Width, image.Height, hasAlpha, pixels);
         return output;
     }
 
-    private static byte[] BuildExtendedContainer(
+    private static void WriteLiteralPayload(
+        byte[] output,
+        int payloadOffset,
+        int payloadLength,
         int width,
         int height,
         bool hasAlpha,
-        byte[] payload,
-        double dpiX,
-        double dpiY) {
-        byte[] exif = CreateResolutionExif(width, height, dpiX, dpiY);
-        int paddedPayloadLength = checked(payload.Length + (payload.Length & 1));
-        int paddedExifLength = checked(exif.Length + (exif.Length & 1));
-        int fileLength = checked(12 + 18 + 8 + paddedPayloadLength + 8 + paddedExifLength);
-        byte[] output = new byte[fileLength];
-        WriteAscii(output, 0, "RIFF");
-        WriteUInt32(output, 4, fileLength - 8);
-        WriteAscii(output, 8, "WEBP");
+        byte[] pixels) {
+        output[payloadOffset] = 0x2F;
+        var writer = new LsbBitWriter(output, payloadOffset + 1);
+        writer.WriteBits((uint)(width - 1), 14);
+        writer.WriteBits((uint)(height - 1), 14);
+        writer.WriteBits(hasAlpha ? 1U : 0U, 1);
+        writer.WriteBits(0, 3);
 
-        WriteAscii(output, 12, "VP8X");
-        WriteUInt32(output, 16, 10);
-        output[20] = (byte)(0x08 | (hasAlpha ? 0x10 : 0x00));
-        WriteUInt24(output, 24, width - 1);
-        WriteUInt24(output, 27, height - 1);
+        writer.WriteBits(0, 1); // no transforms
+        writer.WriteBits(0, 1); // no color cache
+        writer.WriteBits(0, 1); // one Huffman code group for the whole image
 
-        const int vp8lChunkOffset = 30;
-        WriteAscii(output, vp8lChunkOffset, "VP8L");
-        WriteUInt32(output, vp8lChunkOffset + 4, payload.Length);
-        Buffer.BlockCopy(payload, 0, output, vp8lChunkOffset + 8, payload.Length);
+        WriteLiteralTree(writer, 280);
+        WriteLiteralTree(writer, 256);
+        WriteLiteralTree(writer, 256);
+        WriteLiteralTree(writer, 256);
+        WriteSingleSymbolTree(writer);
 
-        int exifChunkOffset = vp8lChunkOffset + 8 + paddedPayloadLength;
-        WriteAscii(output, exifChunkOffset, "EXIF");
-        WriteUInt32(output, exifChunkOffset + 4, exif.Length);
-        Buffer.BlockCopy(exif, 0, output, exifChunkOffset + 8, exif.Length);
-        return output;
+        for (int offset = 0; offset < pixels.Length; offset += 4) {
+            writer.WriteBits(ReverseByte(pixels[offset + 1]), 8); // green
+            writer.WriteBits(ReverseByte(pixels[offset]), 8);     // red
+            writer.WriteBits(ReverseByte(pixels[offset + 2]), 8); // blue
+            writer.WriteBits(ReverseByte(pixels[offset + 3]), 8); // alpha
+        }
+        writer.Flush();
+        if (writer.BytesWritten != payloadOffset + payloadLength) {
+            throw new InvalidOperationException("The literal WebP payload length calculation is inconsistent.");
+        }
     }
 
     private static byte[] CreateResolutionExif(int width, int height, double dpiX, double dpiY) {
@@ -366,7 +364,7 @@ public static class OfficeWebpCodec {
         if (dpi < OfficeRasterImageEncoder.WebpMinimumDpi ||
             double.IsNaN(dpi) ||
             double.IsInfinity(dpi) ||
-            dpi > MaximumDpi) {
+            dpi > OfficeRasterImageEncoder.WebpMaximumDpi) {
             throw new ArgumentOutOfRangeException(name, "WebP DPI must be finite and between 0.0001 and 1,000,000.");
         }
     }
@@ -382,13 +380,17 @@ public static class OfficeWebpCodec {
     }
 
     private sealed class LsbBitWriter {
-        private readonly Stream _stream;
+        private readonly byte[] _output;
+        private int _offset;
         private ulong _buffer;
         private int _bitCount;
 
-        public LsbBitWriter(Stream stream) {
-            _stream = stream;
+        public LsbBitWriter(byte[] output, int offset) {
+            _output = output;
+            _offset = offset;
         }
+
+        public int BytesWritten => _offset;
 
         public void WriteBits(uint value, int count) {
             if (count < 0 || count > 32) throw new ArgumentOutOfRangeException(nameof(count));
@@ -396,7 +398,7 @@ public static class OfficeWebpCodec {
             _buffer |= ((ulong)value & mask) << _bitCount;
             _bitCount += count;
             while (_bitCount >= 8) {
-                _stream.WriteByte((byte)_buffer);
+                WriteByte((byte)_buffer);
                 _buffer >>= 8;
                 _bitCount -= 8;
             }
@@ -404,10 +406,17 @@ public static class OfficeWebpCodec {
 
         public void Flush() {
             if (_bitCount > 0) {
-                _stream.WriteByte((byte)_buffer);
+                WriteByte((byte)_buffer);
                 _buffer = 0;
                 _bitCount = 0;
             }
+        }
+
+        private void WriteByte(byte value) {
+            if (_offset >= _output.Length) {
+                throw new InvalidOperationException("The literal WebP payload exceeded its computed length.");
+            }
+            _output[_offset++] = value;
         }
     }
 

--- a/OfficeIMO.Drawing.Benchmarks.Comparisons/ImageComparisonAdapters.cs
+++ b/OfficeIMO.Drawing.Benchmarks.Comparisons/ImageComparisonAdapters.cs
@@ -11,14 +11,16 @@ internal static class ImageComparisonAdapters {
     }
 
     internal static int DecodeSkia(byte[] encoded) {
-        using SKBitmap bitmap = SKBitmap.Decode(encoded)
-            ?? throw new InvalidOperationException("SkiaSharp could not decode the image.");
+        using SKBitmap bitmap = DecodeSkiaBitmap(encoded);
         return checked(bitmap.Width * bitmap.Height);
     }
 
     internal static int DecodeMagick(byte[] encoded) {
         using var image = new MagickImage(encoded);
-        return checked((int)(image.Width * image.Height));
+        using IPixelCollection<byte> pixels = image.GetPixels();
+        byte[] rgba = pixels.ToByteArray(PixelMapping.RGBA)
+            ?? throw new InvalidOperationException("Magick.NET did not expose decoded RGBA pixels.");
+        return checked(rgba.Length / 4);
     }
 
     internal static int DecodeStb(byte[] encoded) {
@@ -87,18 +89,22 @@ internal static class ImageComparisonAdapters {
     }
 
     internal static byte[] DecodeSkiaRgba(byte[] encoded) {
+        using SKBitmap decoded = DecodeSkiaBitmap(encoded);
+        var rgba = new byte[checked(decoded.Width * decoded.Height * 4)];
+        System.Runtime.InteropServices.Marshal.Copy(decoded.GetPixels(), rgba, 0, rgba.Length);
+        return rgba;
+    }
+
+    private static SKBitmap DecodeSkiaBitmap(byte[] encoded) {
         using SKData data = SKData.CreateCopy(encoded);
         using SKCodec codec = SKCodec.Create(data)
             ?? throw new InvalidOperationException("SkiaSharp could not create a decoder.");
         var info = new SKImageInfo(codec.Info.Width, codec.Info.Height, SKColorType.Rgba8888, SKAlphaType.Unpremul);
-        using var decoded = new SKBitmap(info);
+        var decoded = new SKBitmap(info);
         SKCodecResult result = codec.GetPixels(info, decoded.GetPixels());
-        if (result != SKCodecResult.Success) {
-            throw new InvalidOperationException("SkiaSharp did not decode a complete RGBA image: " + result + ".");
-        }
-        var rgba = new byte[checked(decoded.Width * decoded.Height * 4)];
-        System.Runtime.InteropServices.Marshal.Copy(decoded.GetPixels(), rgba, 0, rgba.Length);
-        return rgba;
+        if (result == SKCodecResult.Success) return decoded;
+        decoded.Dispose();
+        throw new InvalidOperationException("SkiaSharp did not decode a complete RGBA image: " + result + ".");
     }
 
     internal static byte[] DecodeMagickRgba(byte[] encoded) {

--- a/OfficeIMO.Drawing.Benchmarks.Comparisons/ImageComparisonAdapters.cs
+++ b/OfficeIMO.Drawing.Benchmarks.Comparisons/ImageComparisonAdapters.cs
@@ -1,0 +1,110 @@
+using ImageMagick;
+using SkiaSharp;
+using StbImageSharp;
+
+namespace OfficeIMO.Drawing.Benchmarks.Comparisons;
+
+internal static class ImageComparisonAdapters {
+    internal static int DecodeOfficeImo(byte[] encoded) {
+        OfficeRasterImage image = ImageBenchmarkCorpus.Decode(encoded, "OfficeIMO decode");
+        return checked(image.Width * image.Height);
+    }
+
+    internal static int DecodeSkia(byte[] encoded) {
+        using SKBitmap bitmap = SKBitmap.Decode(encoded)
+            ?? throw new InvalidOperationException("SkiaSharp could not decode the image.");
+        return checked(bitmap.Width * bitmap.Height);
+    }
+
+    internal static int DecodeMagick(byte[] encoded) {
+        using var image = new MagickImage(encoded);
+        return checked((int)(image.Width * image.Height));
+    }
+
+    internal static int DecodeStb(byte[] encoded) {
+        ImageResult image = ImageResult.FromMemory(encoded, ColorComponents.RedGreenBlueAlpha);
+        return checked(image.Width * image.Height);
+    }
+
+    internal static byte[] EncodeOfficeImo(OfficeRasterImage image) =>
+        OfficeRasterImageEncoder.Encode(image, OfficeImageExportFormat.Png);
+
+    internal static byte[] EncodeSkia(SKBitmap bitmap) {
+        using SKImage image = SKImage.FromBitmap(bitmap);
+        using SKData data = image.Encode(SKEncodedImageFormat.Png, 100);
+        return data.ToArray();
+    }
+
+    internal static byte[] EncodeMagick(MagickImage image) {
+        image.Format = MagickFormat.Png;
+        return image.ToByteArray();
+    }
+
+    internal static SKBitmap CreateSkiaBitmap(byte[] rgba, int width, int height) {
+        var bitmap = new SKBitmap(new SKImageInfo(width, height, SKColorType.Rgba8888, SKAlphaType.Unpremul));
+        System.Runtime.InteropServices.Marshal.Copy(rgba, 0, bitmap.GetPixels(), rgba.Length);
+        return bitmap;
+    }
+
+    internal static MagickImage CreateMagickImage(byte[] rgba, int width, int height) =>
+        new(rgba, new PixelReadSettings((uint)width, (uint)height, StorageType.Char, PixelMapping.RGBA));
+
+    internal static int ResizeOfficeImo(OfficeRasterImage image, int width, int height) {
+        OfficeRasterImage resized = OfficeRasterResampler.Resize(image, width, height, OfficeRasterResamplingMode.Bilinear);
+        return checked(resized.Width * resized.Height);
+    }
+
+    internal static int ResizeSkia(SKBitmap image, int width, int height) {
+        using SKBitmap resized = image.Resize(
+            new SKImageInfo(width, height, SKColorType.Rgba8888, SKAlphaType.Unpremul),
+            new SKSamplingOptions(SKFilterMode.Linear, SKMipmapMode.None))
+            ?? throw new InvalidOperationException("SkiaSharp could not resize the image.");
+        return checked(resized.Width * resized.Height);
+    }
+
+    internal static int ResizeMagick(MagickImage image, int width, int height) {
+        using IMagickImage<byte> resized = image.Clone();
+        resized.FilterType = FilterType.Triangle;
+        resized.Resize(new MagickGeometry((uint)width, (uint)height) { IgnoreAspectRatio = true });
+        return checked((int)(resized.Width * resized.Height));
+    }
+
+    internal static byte[] ResizeSkiaRgba(SKBitmap image, int width, int height) {
+        using SKBitmap resized = image.Resize(
+            new SKImageInfo(width, height, SKColorType.Rgba8888, SKAlphaType.Unpremul),
+            new SKSamplingOptions(SKFilterMode.Linear, SKMipmapMode.None))
+            ?? throw new InvalidOperationException("SkiaSharp could not resize the image.");
+        var rgba = new byte[checked(width * height * 4)];
+        System.Runtime.InteropServices.Marshal.Copy(resized.GetPixels(), rgba, 0, rgba.Length);
+        return rgba;
+    }
+
+    internal static byte[] ResizeMagickRgba(MagickImage image, int width, int height) {
+        using IMagickImage<byte> resized = image.Clone();
+        resized.FilterType = FilterType.Triangle;
+        resized.Resize(new MagickGeometry((uint)width, (uint)height) { IgnoreAspectRatio = true });
+        return resized.ToByteArray(MagickFormat.Rgba);
+    }
+
+    internal static byte[] DecodeSkiaRgba(byte[] encoded) {
+        using SKData data = SKData.CreateCopy(encoded);
+        using SKCodec codec = SKCodec.Create(data)
+            ?? throw new InvalidOperationException("SkiaSharp could not create a decoder.");
+        var info = new SKImageInfo(codec.Info.Width, codec.Info.Height, SKColorType.Rgba8888, SKAlphaType.Unpremul);
+        using var decoded = new SKBitmap(info);
+        SKCodecResult result = codec.GetPixels(info, decoded.GetPixels());
+        if (result != SKCodecResult.Success) {
+            throw new InvalidOperationException("SkiaSharp did not decode a complete RGBA image: " + result + ".");
+        }
+        var rgba = new byte[checked(decoded.Width * decoded.Height * 4)];
+        System.Runtime.InteropServices.Marshal.Copy(decoded.GetPixels(), rgba, 0, rgba.Length);
+        return rgba;
+    }
+
+    internal static byte[] DecodeMagickRgba(byte[] encoded) {
+        using var image = new MagickImage(encoded);
+        using IPixelCollection<byte> pixels = image.GetPixels();
+        return pixels.ToByteArray(PixelMapping.RGBA)
+            ?? throw new InvalidOperationException("Magick.NET did not expose decoded RGBA pixels.");
+    }
+}

--- a/OfficeIMO.Drawing.Benchmarks.Comparisons/ImageComparisonAdapters.cs
+++ b/OfficeIMO.Drawing.Benchmarks.Comparisons/ImageComparisonAdapters.cs
@@ -5,27 +5,28 @@ using StbImageSharp;
 namespace OfficeIMO.Drawing.Benchmarks.Comparisons;
 
 internal static class ImageComparisonAdapters {
-    internal static int DecodeOfficeImo(byte[] encoded) {
+    internal static byte[] DecodeOfficeImoRgba(byte[] encoded) {
         OfficeRasterImage image = ImageBenchmarkCorpus.Decode(encoded, "OfficeIMO decode");
-        return checked(image.Width * image.Height);
+        return image.GetPixels();
     }
 
-    internal static int DecodeSkia(byte[] encoded) {
-        using SKBitmap bitmap = DecodeSkiaBitmap(encoded);
-        return checked(bitmap.Width * bitmap.Height);
+    internal static byte[] DecodeSkiaRgba(byte[] encoded) {
+        using SKBitmap decoded = DecodeSkiaBitmap(encoded);
+        var rgba = new byte[checked(decoded.Width * decoded.Height * 4)];
+        System.Runtime.InteropServices.Marshal.Copy(decoded.GetPixels(), rgba, 0, rgba.Length);
+        return rgba;
     }
 
-    internal static int DecodeMagick(byte[] encoded) {
+    internal static byte[] DecodeMagickRgba(byte[] encoded) {
         using var image = new MagickImage(encoded);
         using IPixelCollection<byte> pixels = image.GetPixels();
-        byte[] rgba = pixels.ToByteArray(PixelMapping.RGBA)
+        return pixels.ToByteArray(PixelMapping.RGBA)
             ?? throw new InvalidOperationException("Magick.NET did not expose decoded RGBA pixels.");
-        return checked(rgba.Length / 4);
     }
 
-    internal static int DecodeStb(byte[] encoded) {
+    internal static byte[] DecodeStbRgba(byte[] encoded) {
         ImageResult image = ImageResult.FromMemory(encoded, ColorComponents.RedGreenBlueAlpha);
-        return checked(image.Width * image.Height);
+        return image.Data;
     }
 
     internal static byte[] EncodeOfficeImo(OfficeRasterImage image) =>
@@ -88,13 +89,6 @@ internal static class ImageComparisonAdapters {
         return resized.ToByteArray(MagickFormat.Rgba);
     }
 
-    internal static byte[] DecodeSkiaRgba(byte[] encoded) {
-        using SKBitmap decoded = DecodeSkiaBitmap(encoded);
-        var rgba = new byte[checked(decoded.Width * decoded.Height * 4)];
-        System.Runtime.InteropServices.Marshal.Copy(decoded.GetPixels(), rgba, 0, rgba.Length);
-        return rgba;
-    }
-
     private static SKBitmap DecodeSkiaBitmap(byte[] encoded) {
         using SKData data = SKData.CreateCopy(encoded);
         using SKCodec codec = SKCodec.Create(data)
@@ -107,10 +101,4 @@ internal static class ImageComparisonAdapters {
         throw new InvalidOperationException("SkiaSharp did not decode a complete RGBA image: " + result + ".");
     }
 
-    internal static byte[] DecodeMagickRgba(byte[] encoded) {
-        using var image = new MagickImage(encoded);
-        using IPixelCollection<byte> pixels = image.GetPixels();
-        return pixels.ToByteArray(PixelMapping.RGBA)
-            ?? throw new InvalidOperationException("Magick.NET did not expose decoded RGBA pixels.");
-    }
 }

--- a/OfficeIMO.Drawing.Benchmarks.Comparisons/ImageComparisonValidation.cs
+++ b/OfficeIMO.Drawing.Benchmarks.Comparisons/ImageComparisonValidation.cs
@@ -1,0 +1,112 @@
+using StbImageSharp;
+
+namespace OfficeIMO.Drawing.Benchmarks.Comparisons;
+
+internal static class ImageComparisonValidation {
+    internal static void Validate(TextWriter writer) {
+        byte[] logo = ImageBenchmarkCorpus.Logo.ReadBytes();
+        ValidatePngDecode(logo);
+        writer.WriteLine("PNG decode: OfficeIMO, SkiaSharp, Magick.NET, and StbImageSharp produced identical 512x512 RGBA pixels.");
+
+        byte[] photo = ImageBenchmarkCorpus.Photo.ReadBytes();
+        (double skiaError, double magickError, double stbError) = MeasureJpegDecodeError(photo, 2048, 1619);
+        writer.WriteLine(
+            $"JPEG decode: expected 2048x1619 dimensions; RGBA mean absolute error versus OfficeIMO was " +
+            $"SkiaSharp {skiaError:F3}, Magick.NET {magickError:F3}, StbImageSharp {stbError:F3}.");
+
+        OfficeRasterImage source = ImageBenchmarkCorpus.CreatePattern();
+        byte[] rgba = source.GetPixels();
+        using var skia = ImageComparisonAdapters.CreateSkiaBitmap(rgba, source.Width, source.Height);
+        using var magick = ImageComparisonAdapters.CreateMagickImage(rgba, source.Width, source.Height);
+        byte[] officePng = ImageComparisonAdapters.EncodeOfficeImo(source);
+        byte[] skiaPng = ImageComparisonAdapters.EncodeSkia(skia);
+        byte[] magickPng = ImageComparisonAdapters.EncodeMagick(magick);
+        ValidatePngEncode(source, officePng, skiaPng, magickPng);
+        writer.WriteLine($"PNG encode: exact RGBA round-trip; OfficeIMO {officePng.Length:N0}, SkiaSharp {skiaPng.Length:N0}, Magick.NET {magickPng.Length:N0} bytes.");
+
+        OfficeRasterImage photoImage = ImageBenchmarkCorpus.Decode(photo, "resize validation");
+        byte[] photoRgba = photoImage.GetPixels();
+        using var photoSkia = ImageComparisonAdapters.CreateSkiaBitmap(photoRgba, 2048, 1619);
+        using var photoMagick = ImageComparisonAdapters.CreateMagickImage(photoRgba, 2048, 1619);
+        byte[] officeResize = OfficeRasterResampler.Resize(photoImage, 800, 632).GetPixels();
+        AssertSimilarPixels("SkiaSharp resize", officeResize, ImageComparisonAdapters.ResizeSkiaRgba(photoSkia, 800, 632), 3D);
+        AssertSimilarPixels("Magick.NET resize", officeResize, ImageComparisonAdapters.ResizeMagickRgba(photoMagick, 800, 632), 3D);
+        writer.WriteLine("Resize: all engines produced 800x632 RGBA output within the declared mean absolute error tolerance.");
+    }
+
+    internal static void ValidatePngDecode(byte[] encoded) {
+        OfficeRasterImage office = ImageBenchmarkCorpus.Decode(encoded, "OfficeIMO PNG validation");
+        byte[] expected = office.GetPixels();
+        AssertPixels("SkiaSharp", expected, ImageComparisonAdapters.DecodeSkiaRgba(encoded));
+        AssertPixels("Magick.NET", expected, ImageComparisonAdapters.DecodeMagickRgba(encoded));
+        ImageResult stb = ImageResult.FromMemory(encoded, ColorComponents.RedGreenBlueAlpha);
+        AssertPixels("StbImageSharp", expected, stb.Data);
+    }
+
+    internal static void ValidateDimensions(byte[] encoded, int width, int height) {
+        int expected = checked(width * height);
+        if (ImageComparisonAdapters.DecodeOfficeImo(encoded) != expected ||
+            ImageComparisonAdapters.DecodeSkia(encoded) != expected ||
+            ImageComparisonAdapters.DecodeMagick(encoded) != expected ||
+            ImageComparisonAdapters.DecodeStb(encoded) != expected) {
+            throw new InvalidOperationException("A JPEG decoder did not produce the expected dimensions.");
+        }
+    }
+
+    internal static (double SkiaError, double MagickError, double StbError) MeasureJpegDecodeError(
+        byte[] encoded,
+        int width,
+        int height) {
+        ValidateDimensions(encoded, width, height);
+        OfficeRasterImage office = ImageBenchmarkCorpus.Decode(encoded, "OfficeIMO JPEG validation");
+        byte[] expected = office.GetPixels();
+        ImageResult stb = ImageResult.FromMemory(encoded, ColorComponents.RedGreenBlueAlpha);
+        var errors = (
+            SkiaError: CalculateMeanAbsoluteError(expected, ImageComparisonAdapters.DecodeSkiaRgba(encoded)),
+            MagickError: CalculateMeanAbsoluteError(expected, ImageComparisonAdapters.DecodeMagickRgba(encoded)),
+            StbError: CalculateMeanAbsoluteError(expected, stb.Data));
+        const double maximumMeanAbsoluteError = 1.5D;
+        if (errors.SkiaError > maximumMeanAbsoluteError ||
+            errors.MagickError > maximumMeanAbsoluteError ||
+            errors.StbError > maximumMeanAbsoluteError) {
+            throw new InvalidOperationException(
+                $"JPEG decoder output exceeded the {maximumMeanAbsoluteError:F1} mean absolute channel error limit: " +
+                $"SkiaSharp {errors.SkiaError:F3}, Magick.NET {errors.MagickError:F3}, StbImageSharp {errors.StbError:F3}.");
+        }
+        return errors;
+    }
+
+    internal static void ValidatePngEncode(OfficeRasterImage source, params byte[][] encodedImages) {
+        byte[] expected = source.GetPixels();
+        foreach (byte[] encoded in encodedImages) {
+            ImageBenchmarkCorpus.AssertIdentified(encoded, OfficeImageFormat.Png, source.Width, source.Height, "PNG comparison encode");
+            OfficeRasterImage decoded = ImageBenchmarkCorpus.Decode(encoded, "PNG comparison encode");
+            AssertPixels("PNG encoder", expected, decoded.GetPixels());
+        }
+    }
+
+    private static void AssertPixels(string engine, byte[] expected, byte[] actual) {
+        if (!expected.AsSpan().SequenceEqual(actual)) {
+            throw new InvalidOperationException(engine + " did not produce the expected RGBA pixels.");
+        }
+    }
+
+    internal static void AssertSimilarPixels(string engine, byte[] expected, byte[] actual, double maximumMeanAbsoluteError) {
+        double meanAbsoluteError = CalculateMeanAbsoluteError(expected, actual);
+        if (meanAbsoluteError > maximumMeanAbsoluteError) {
+            throw new InvalidOperationException(
+                $"{engine} mean absolute channel error {meanAbsoluteError:F3} exceeded {maximumMeanAbsoluteError:F3}.");
+        }
+    }
+
+    private static double CalculateMeanAbsoluteError(byte[] expected, byte[] actual) {
+        if (expected.Length != actual.Length) {
+            throw new InvalidOperationException("The image decoder did not produce the expected pixel count.");
+        }
+        long absoluteError = 0L;
+        for (int index = 0; index < expected.Length; index++) {
+            absoluteError += Math.Abs(expected[index] - actual[index]);
+        }
+        return absoluteError / (double)expected.Length;
+    }
+}

--- a/OfficeIMO.Drawing.Benchmarks.Comparisons/ImageComparisonValidation.cs
+++ b/OfficeIMO.Drawing.Benchmarks.Comparisons/ImageComparisonValidation.cs
@@ -44,11 +44,11 @@ internal static class ImageComparisonValidation {
     }
 
     internal static void ValidateDimensions(byte[] encoded, int width, int height) {
-        int expected = checked(width * height);
-        if (ImageComparisonAdapters.DecodeOfficeImo(encoded) != expected ||
-            ImageComparisonAdapters.DecodeSkia(encoded) != expected ||
-            ImageComparisonAdapters.DecodeMagick(encoded) != expected ||
-            ImageComparisonAdapters.DecodeStb(encoded) != expected) {
+        int expected = checked(width * height * 4);
+        if (ImageComparisonAdapters.DecodeOfficeImoRgba(encoded).Length != expected ||
+            ImageComparisonAdapters.DecodeSkiaRgba(encoded).Length != expected ||
+            ImageComparisonAdapters.DecodeMagickRgba(encoded).Length != expected ||
+            ImageComparisonAdapters.DecodeStbRgba(encoded).Length != expected) {
             throw new InvalidOperationException("A JPEG decoder did not produce the expected dimensions.");
         }
     }

--- a/OfficeIMO.Drawing.Benchmarks.Comparisons/ImageJpegDecodeBenchmarks.cs
+++ b/OfficeIMO.Drawing.Benchmarks.Comparisons/ImageJpegDecodeBenchmarks.cs
@@ -2,7 +2,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace OfficeIMO.Drawing.Benchmarks.Comparisons;
 
-/// <summary>Decodes one identical photographic JPEG completely in every engine.</summary>
+/// <summary>Decodes one identical photographic JPEG into a managed RGBA buffer in every engine.</summary>
 [MemoryDiagnoser]
 public class ImageJpegDecodeBenchmarks {
     private byte[] _encoded = null!;
@@ -14,14 +14,14 @@ public class ImageJpegDecodeBenchmarks {
     }
 
     [Benchmark(Baseline = true)]
-    public int OfficeIMO() => ImageComparisonAdapters.DecodeOfficeImo(_encoded);
+    public byte[] OfficeIMO() => ImageComparisonAdapters.DecodeOfficeImoRgba(_encoded);
 
     [Benchmark]
-    public int SkiaSharp() => ImageComparisonAdapters.DecodeSkia(_encoded);
+    public byte[] SkiaSharp() => ImageComparisonAdapters.DecodeSkiaRgba(_encoded);
 
     [Benchmark]
-    public int MagickNET() => ImageComparisonAdapters.DecodeMagick(_encoded);
+    public byte[] MagickNET() => ImageComparisonAdapters.DecodeMagickRgba(_encoded);
 
     [Benchmark]
-    public int StbImageSharp() => ImageComparisonAdapters.DecodeStb(_encoded);
+    public byte[] StbImageSharp() => ImageComparisonAdapters.DecodeStbRgba(_encoded);
 }

--- a/OfficeIMO.Drawing.Benchmarks.Comparisons/ImageJpegDecodeBenchmarks.cs
+++ b/OfficeIMO.Drawing.Benchmarks.Comparisons/ImageJpegDecodeBenchmarks.cs
@@ -1,0 +1,27 @@
+using BenchmarkDotNet.Attributes;
+
+namespace OfficeIMO.Drawing.Benchmarks.Comparisons;
+
+/// <summary>Decodes one identical photographic JPEG completely in every engine.</summary>
+[MemoryDiagnoser]
+public class ImageJpegDecodeBenchmarks {
+    private byte[] _encoded = null!;
+
+    [GlobalSetup]
+    public void Setup() {
+        _encoded = ImageBenchmarkCorpus.Photo.ReadBytes();
+        ImageComparisonValidation.MeasureJpegDecodeError(_encoded, 2048, 1619);
+    }
+
+    [Benchmark(Baseline = true)]
+    public int OfficeIMO() => ImageComparisonAdapters.DecodeOfficeImo(_encoded);
+
+    [Benchmark]
+    public int SkiaSharp() => ImageComparisonAdapters.DecodeSkia(_encoded);
+
+    [Benchmark]
+    public int MagickNET() => ImageComparisonAdapters.DecodeMagick(_encoded);
+
+    [Benchmark]
+    public int StbImageSharp() => ImageComparisonAdapters.DecodeStb(_encoded);
+}

--- a/OfficeIMO.Drawing.Benchmarks.Comparisons/ImagePngDecodeBenchmarks.cs
+++ b/OfficeIMO.Drawing.Benchmarks.Comparisons/ImagePngDecodeBenchmarks.cs
@@ -2,7 +2,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace OfficeIMO.Drawing.Benchmarks.Comparisons;
 
-/// <summary>Decodes one identical PNG completely in every engine.</summary>
+/// <summary>Decodes one identical PNG into a managed RGBA buffer in every engine.</summary>
 [MemoryDiagnoser]
 public class ImagePngDecodeBenchmarks {
     private byte[] _encoded = null!;
@@ -14,14 +14,14 @@ public class ImagePngDecodeBenchmarks {
     }
 
     [Benchmark(Baseline = true)]
-    public int OfficeIMO() => ImageComparisonAdapters.DecodeOfficeImo(_encoded);
+    public byte[] OfficeIMO() => ImageComparisonAdapters.DecodeOfficeImoRgba(_encoded);
 
     [Benchmark]
-    public int SkiaSharp() => ImageComparisonAdapters.DecodeSkia(_encoded);
+    public byte[] SkiaSharp() => ImageComparisonAdapters.DecodeSkiaRgba(_encoded);
 
     [Benchmark]
-    public int MagickNET() => ImageComparisonAdapters.DecodeMagick(_encoded);
+    public byte[] MagickNET() => ImageComparisonAdapters.DecodeMagickRgba(_encoded);
 
     [Benchmark]
-    public int StbImageSharp() => ImageComparisonAdapters.DecodeStb(_encoded);
+    public byte[] StbImageSharp() => ImageComparisonAdapters.DecodeStbRgba(_encoded);
 }

--- a/OfficeIMO.Drawing.Benchmarks.Comparisons/ImagePngDecodeBenchmarks.cs
+++ b/OfficeIMO.Drawing.Benchmarks.Comparisons/ImagePngDecodeBenchmarks.cs
@@ -1,0 +1,27 @@
+using BenchmarkDotNet.Attributes;
+
+namespace OfficeIMO.Drawing.Benchmarks.Comparisons;
+
+/// <summary>Decodes one identical PNG completely in every engine.</summary>
+[MemoryDiagnoser]
+public class ImagePngDecodeBenchmarks {
+    private byte[] _encoded = null!;
+
+    [GlobalSetup]
+    public void Setup() {
+        _encoded = ImageBenchmarkCorpus.Logo.ReadBytes();
+        ImageComparisonValidation.ValidatePngDecode(_encoded);
+    }
+
+    [Benchmark(Baseline = true)]
+    public int OfficeIMO() => ImageComparisonAdapters.DecodeOfficeImo(_encoded);
+
+    [Benchmark]
+    public int SkiaSharp() => ImageComparisonAdapters.DecodeSkia(_encoded);
+
+    [Benchmark]
+    public int MagickNET() => ImageComparisonAdapters.DecodeMagick(_encoded);
+
+    [Benchmark]
+    public int StbImageSharp() => ImageComparisonAdapters.DecodeStb(_encoded);
+}

--- a/OfficeIMO.Drawing.Benchmarks.Comparisons/ImagePngEncodeBenchmarks.cs
+++ b/OfficeIMO.Drawing.Benchmarks.Comparisons/ImagePngEncodeBenchmarks.cs
@@ -1,0 +1,37 @@
+using BenchmarkDotNet.Attributes;
+using ImageMagick;
+using SkiaSharp;
+
+namespace OfficeIMO.Drawing.Benchmarks.Comparisons;
+
+/// <summary>Encodes one identical 512x512 RGBA buffer as lossless PNG.</summary>
+[MemoryDiagnoser]
+public class ImagePngEncodeBenchmarks {
+    private OfficeRasterImage _officeImage = null!;
+    private SKBitmap _skiaImage = null!;
+    private MagickImage _magickImage = null!;
+
+    [GlobalSetup]
+    public void Setup() {
+        _officeImage = ImageBenchmarkCorpus.CreatePattern();
+        byte[] rgba = _officeImage.GetPixels();
+        _skiaImage = ImageComparisonAdapters.CreateSkiaBitmap(rgba, _officeImage.Width, _officeImage.Height);
+        _magickImage = ImageComparisonAdapters.CreateMagickImage(rgba, _officeImage.Width, _officeImage.Height);
+        ImageComparisonValidation.ValidatePngEncode(_officeImage, OfficeIMO(), SkiaSharp(), MagickNET());
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() {
+        _skiaImage.Dispose();
+        _magickImage.Dispose();
+    }
+
+    [Benchmark(Baseline = true)]
+    public byte[] OfficeIMO() => ImageComparisonAdapters.EncodeOfficeImo(_officeImage);
+
+    [Benchmark]
+    public byte[] SkiaSharp() => ImageComparisonAdapters.EncodeSkia(_skiaImage);
+
+    [Benchmark]
+    public byte[] MagickNET() => ImageComparisonAdapters.EncodeMagick(_magickImage);
+}

--- a/OfficeIMO.Drawing.Benchmarks.Comparisons/ImageResizeBenchmarks.cs
+++ b/OfficeIMO.Drawing.Benchmarks.Comparisons/ImageResizeBenchmarks.cs
@@ -1,0 +1,50 @@
+using BenchmarkDotNet.Attributes;
+using ImageMagick;
+using SkiaSharp;
+
+namespace OfficeIMO.Drawing.Benchmarks.Comparisons;
+
+/// <summary>Resizes one identical opaque RGBA photo using linear/bilinear sampling.</summary>
+[MemoryDiagnoser]
+public class ImageResizeBenchmarks {
+    private const int TargetWidth = 800;
+    private const int TargetHeight = 632;
+    private OfficeRasterImage _officeImage = null!;
+    private SKBitmap _skiaImage = null!;
+    private MagickImage _magickImage = null!;
+
+    [GlobalSetup]
+    public void Setup() {
+        _officeImage = ImageBenchmarkCorpus.Decode(ImageBenchmarkCorpus.Photo.ReadBytes(), "resize source");
+        byte[] rgba = _officeImage.GetPixels();
+        _skiaImage = ImageComparisonAdapters.CreateSkiaBitmap(rgba, _officeImage.Width, _officeImage.Height);
+        _magickImage = ImageComparisonAdapters.CreateMagickImage(rgba, _officeImage.Width, _officeImage.Height);
+
+        byte[] office = OfficeRasterResampler.Resize(_officeImage, TargetWidth, TargetHeight).GetPixels();
+        ImageComparisonValidation.AssertSimilarPixels(
+            "SkiaSharp resize",
+            office,
+            ImageComparisonAdapters.ResizeSkiaRgba(_skiaImage, TargetWidth, TargetHeight),
+            maximumMeanAbsoluteError: 3D);
+        ImageComparisonValidation.AssertSimilarPixels(
+            "Magick.NET resize",
+            office,
+            ImageComparisonAdapters.ResizeMagickRgba(_magickImage, TargetWidth, TargetHeight),
+            maximumMeanAbsoluteError: 3D);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() {
+        _skiaImage.Dispose();
+        _magickImage.Dispose();
+    }
+
+    [Benchmark(Baseline = true)]
+    public int OfficeIMO() => ImageComparisonAdapters.ResizeOfficeImo(_officeImage, TargetWidth, TargetHeight);
+
+    [Benchmark]
+    public int SkiaSharp() => ImageComparisonAdapters.ResizeSkia(_skiaImage, TargetWidth, TargetHeight);
+
+    [Benchmark]
+    public int MagickNET() => ImageComparisonAdapters.ResizeMagick(_magickImage, TargetWidth, TargetHeight);
+}

--- a/OfficeIMO.Drawing.Benchmarks.Comparisons/OfficeIMO.Drawing.Benchmarks.Comparisons.csproj
+++ b/OfficeIMO.Drawing.Benchmarks.Comparisons/OfficeIMO.Drawing.Benchmarks.Comparisons.csproj
@@ -1,0 +1,40 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>Latest</LangVersion>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.16.0" />
+    <PackageReference Include="SkiaSharp" Version="4.151.1" />
+    <PackageReference Include="StbImageSharp" Version="2.30.16" />
+    <ProjectReference Include="..\OfficeIMO.Core\OfficeIMO.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\OfficeIMO.Drawing.Benchmarks\ImageBenchmarkCorpus.cs"
+             Link="Shared\ImageBenchmarkCorpus.cs" />
+    <None Include="..\Assets\Images\Others\Logo-evotec.png"
+          Link="Corpus\logo.png"
+          CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\OfficeIMO.Examples\Images\Kulek.jpg"
+          Link="Corpus\photo.jpg"
+          CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\OfficeIMO.Examples\Images\example.gif"
+          Link="Corpus\animation.gif"
+          CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\OfficeIMO.Examples\Images\saturn.tif"
+          Link="Corpus\saturn.tif"
+          CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\OfficeIMO.Examples\Images\snail.bmp"
+          Link="Corpus\snail.bmp"
+          CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+</Project>

--- a/OfficeIMO.Drawing.Benchmarks.Comparisons/Program.cs
+++ b/OfficeIMO.Drawing.Benchmarks.Comparisons/Program.cs
@@ -1,0 +1,9 @@
+using BenchmarkDotNet.Running;
+using OfficeIMO.Drawing.Benchmarks.Comparisons;
+
+if (args.Length == 1 && args[0].Equals("--validate", StringComparison.OrdinalIgnoreCase)) {
+    ImageComparisonValidation.Validate(Console.Out);
+    return;
+}
+
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

--- a/OfficeIMO.Drawing.Benchmarks.Comparisons/README.md
+++ b/OfficeIMO.Drawing.Benchmarks.Comparisons/README.md
@@ -1,6 +1,6 @@
 # OfficeIMO image library comparisons
 
-This opt-in project compares equivalent image work without adding third-party dependencies to the OfficeIMO product or normal solution. The initial lanes cover full PNG and photographic JPEG decode, lossless PNG encode from one identical RGBA buffer, and 2048x1619-to-800x632 linear/bilinear resize from identical RGBA pixels.
+This opt-in project compares equivalent image work without adding third-party dependencies to the OfficeIMO product or normal solution. The initial lanes cover PNG and photographic JPEG decode into a managed RGBA byte array, lossless PNG encode from one identical RGBA buffer, and 2048x1619-to-800x632 linear/bilinear resize from identical RGBA pixels.
 
 Metadata identification remains in the first-party benchmark project, not the comparison table. OfficeIMO performs bounded container-structure validation during identification, while the candidate libraries' lightweight information APIs do not all validate the same structure; timing those unlike contracts as peers would be misleading.
 
@@ -21,4 +21,4 @@ On heterogeneous or multi-CCD processors, collect comparative evidence through t
 
 The runner records the mask in benchmark provenance. Affinity reduces scheduler noise; it does not make small differences meaningful, so conclusions should still favor effect sizes that clearly exceed run-to-run variation.
 
-BenchmarkDotNet's allocation column reports managed allocations only. SkiaSharp and Magick.NET perform material work in native code, so their managed allocation numbers are not total-memory comparisons; use process/native-memory profiling before drawing memory-efficiency conclusions across engines.
+Every timed decode returns the same managed RGBA output shape. BenchmarkDotNet's allocation column still reports managed allocations only. SkiaSharp and Magick.NET perform material work in native code, so their managed allocation numbers are not total-memory comparisons; use process/native-memory profiling before drawing memory-efficiency conclusions across engines.

--- a/OfficeIMO.Drawing.Benchmarks.Comparisons/README.md
+++ b/OfficeIMO.Drawing.Benchmarks.Comparisons/README.md
@@ -13,4 +13,12 @@ dotnet run --project OfficeIMO.Drawing.Benchmarks.Comparisons -c Release -f net1
 dotnet run --project OfficeIMO.Drawing.Benchmarks.Comparisons -c Release -f net10.0 -- --job Dry --filter '*ImagePng*Benchmarks*'
 ```
 
+On heterogeneous or multi-CCD processors, collect comparative evidence through the repository runner with a reviewed affinity mask that keeps the benchmark on one representative processor region. For example, this host exposes one CCD as logical processors 0-15:
+
+```powershell
+./Build/Run-LibraryComparisonBenchmarks.ps1 -RunMode full -Workload imagepngdecode -AffinityMask 0xFFFF
+```
+
+The runner records the mask in benchmark provenance. Affinity reduces scheduler noise; it does not make small differences meaningful, so conclusions should still favor effect sizes that clearly exceed run-to-run variation.
+
 BenchmarkDotNet's allocation column reports managed allocations only. SkiaSharp and Magick.NET perform material work in native code, so their managed allocation numbers are not total-memory comparisons; use process/native-memory profiling before drawing memory-efficiency conclusions across engines.

--- a/OfficeIMO.Drawing.Benchmarks.Comparisons/README.md
+++ b/OfficeIMO.Drawing.Benchmarks.Comparisons/README.md
@@ -1,0 +1,16 @@
+# OfficeIMO image library comparisons
+
+This opt-in project compares equivalent image work without adding third-party dependencies to the OfficeIMO product or normal solution. The initial lanes cover full PNG and photographic JPEG decode, lossless PNG encode from one identical RGBA buffer, and 2048x1619-to-800x632 linear/bilinear resize from identical RGBA pixels.
+
+Metadata identification remains in the first-party benchmark project, not the comparison table. OfficeIMO performs bounded container-structure validation during identification, while the candidate libraries' lightweight information APIs do not all validate the same structure; timing those unlike contracts as peers would be misleading.
+
+The comparison uses SkiaSharp, Magick.NET, and StbImageSharp. ImageSharp 4 is intentionally excluded because its build now requires a Six Labors license key; benchmark restore/build must remain reproducible without secrets. StbImageSharp participates only in decode because it does not provide an encoder.
+
+Correctness comes before timing. PNG decode and encode require exact full-buffer RGBA equality. The JPEG lane requires complete decode, equal dimensions, and a full-buffer mean absolute channel error no greater than 1.5 against every independent decoder so normal color-conversion and rounding differences remain distinguishable from material output defects.
+
+```powershell
+dotnet run --project OfficeIMO.Drawing.Benchmarks.Comparisons -c Release -f net10.0 -- --validate
+dotnet run --project OfficeIMO.Drawing.Benchmarks.Comparisons -c Release -f net10.0 -- --job Dry --filter '*ImagePng*Benchmarks*'
+```
+
+BenchmarkDotNet's allocation column reports managed allocations only. SkiaSharp and Magick.NET perform material work in native code, so their managed allocation numbers are not total-memory comparisons; use process/native-memory profiling before drawing memory-efficiency conclusions across engines.

--- a/OfficeIMO.Drawing.Benchmarks/ImageBenchmarkCorpus.cs
+++ b/OfficeIMO.Drawing.Benchmarks/ImageBenchmarkCorpus.cs
@@ -1,0 +1,93 @@
+using System.Security.Cryptography;
+
+namespace OfficeIMO.Drawing.Benchmarks;
+
+internal sealed record ImageBenchmarkAsset(
+    string Id,
+    string FileName,
+    OfficeImageFormat Format,
+    int Width,
+    int Height) {
+    internal byte[] ReadBytes() => File.ReadAllBytes(ImageBenchmarkCorpus.GetPath(FileName));
+}
+
+internal static class ImageBenchmarkCorpus {
+    internal static readonly ImageBenchmarkAsset Logo = new("LogoPng", "logo.png", OfficeImageFormat.Png, 512, 512);
+    internal static readonly ImageBenchmarkAsset Photo = new("PhotoJpeg", "photo.jpg", OfficeImageFormat.Jpeg, 2048, 1619);
+    internal static readonly ImageBenchmarkAsset Animation = new("AnimationGif", "animation.gif", OfficeImageFormat.Gif, 220, 137);
+    internal static readonly ImageBenchmarkAsset Tiff = new("SaturnTiff", "saturn.tif", OfficeImageFormat.Tiff, 640, 480);
+    internal static readonly ImageBenchmarkAsset Bitmap = new("SnailBmp", "snail.bmp", OfficeImageFormat.Bmp, 256, 256);
+
+    internal static IReadOnlyList<ImageBenchmarkAsset> All { get; } = [Logo, Photo, Animation, Tiff, Bitmap];
+
+    internal static ImageBenchmarkAsset Get(string id) => All.Single(asset => asset.Id == id);
+
+    internal static string GetPath(string fileName) => Path.Combine(AppContext.BaseDirectory, "Corpus", fileName);
+
+    internal static OfficeRasterImage CreatePattern(int width = 512, int height = 512) {
+        var image = new OfficeRasterImage(width, height);
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                byte red = (byte)((x * 13 + y * 3) & 255);
+                byte green = (byte)((x * 5 + y * 11) & 255);
+                byte blue = (byte)(((x ^ y) * 7) & 255);
+                byte alpha = (byte)(96 + ((x + y) & 159));
+                image.SetPixel(x, y, OfficeColor.FromRgba(red, green, blue, alpha));
+            }
+        }
+        return image;
+    }
+
+    internal static byte[] CreateBmp24(int width = 256, int height = 256) {
+        int rowStride = checked(((width * 24) + 31) / 32 * 4);
+        int pixelOffset = 54;
+        var bytes = new byte[checked(pixelOffset + (rowStride * height))];
+        bytes[0] = (byte)'B';
+        bytes[1] = (byte)'M';
+        WriteInt32LittleEndian(bytes, 2, bytes.Length);
+        WriteInt32LittleEndian(bytes, 10, pixelOffset);
+        WriteInt32LittleEndian(bytes, 14, 40);
+        WriteInt32LittleEndian(bytes, 18, width);
+        WriteInt32LittleEndian(bytes, 22, height);
+        bytes[26] = 1;
+        bytes[28] = 24;
+        WriteInt32LittleEndian(bytes, 34, rowStride * height);
+        for (int y = 0; y < height; y++) {
+            int row = pixelOffset + ((height - 1 - y) * rowStride);
+            for (int x = 0; x < width; x++) {
+                int pixel = row + (x * 3);
+                bytes[pixel] = (byte)(((x ^ y) * 7) & 255);
+                bytes[pixel + 1] = (byte)((x * 5 + y * 11) & 255);
+                bytes[pixel + 2] = (byte)((x * 13 + y * 3) & 255);
+            }
+        }
+        return bytes;
+    }
+
+    internal static string PixelHash(OfficeRasterImage image) =>
+        Convert.ToHexString(SHA256.HashData(image.GetPixels()));
+
+    internal static void AssertIdentified(byte[] encoded, OfficeImageFormat format, int width, int height, string operation) {
+        if (!OfficeImageReader.TryIdentify(encoded, fileName: null, out OfficeImageInfo info)) {
+            throw new InvalidOperationException(operation + " did not produce identifiable image bytes.");
+        }
+        if (info.Format != format || info.Width != width || info.Height != height) {
+            throw new InvalidOperationException(
+                $"{operation} produced {info.Format} {info.Width}x{info.Height}; expected {format} {width}x{height}.");
+        }
+    }
+
+    internal static OfficeRasterImage Decode(byte[] encoded, string operation) {
+        if (!OfficeRasterImageDecoder.TryDecode(encoded, out OfficeRasterImage? image) || image == null) {
+            throw new InvalidOperationException(operation + " could not be decoded by the managed image engine.");
+        }
+        return image;
+    }
+
+    private static void WriteInt32LittleEndian(byte[] bytes, int offset, int value) {
+        bytes[offset] = (byte)value;
+        bytes[offset + 1] = (byte)(value >> 8);
+        bytes[offset + 2] = (byte)(value >> 16);
+        bytes[offset + 3] = (byte)(value >> 24);
+    }
+}

--- a/OfficeIMO.Drawing.Benchmarks/ImageBenchmarkValidator.cs
+++ b/OfficeIMO.Drawing.Benchmarks/ImageBenchmarkValidator.cs
@@ -1,0 +1,35 @@
+namespace OfficeIMO.Drawing.Benchmarks;
+
+internal static class ImageBenchmarkValidator {
+    internal static void Validate(TextWriter writer) {
+        foreach (ImageBenchmarkAsset asset in ImageBenchmarkCorpus.All) {
+            byte[] encoded = asset.ReadBytes();
+            ImageBenchmarkCorpus.AssertIdentified(encoded, asset.Format, asset.Width, asset.Height, asset.Id);
+            if (ReferenceEquals(asset, ImageBenchmarkCorpus.Bitmap)) {
+                writer.WriteLine($"{asset.Id,-14} {asset.Format,-5} {asset.Width,4}x{asset.Height,-4} {encoded.Length,10:N0} bytes metadata-only (trailing payload)");
+                continue;
+            }
+            OfficeRasterImage decoded = ImageBenchmarkCorpus.Decode(encoded, asset.Id);
+            if (decoded.Width != asset.Width || decoded.Height != asset.Height) {
+                throw new InvalidOperationException($"{asset.Id} decoded to {decoded.Width}x{decoded.Height}.");
+            }
+            writer.WriteLine($"{asset.Id,-14} {asset.Format,-5} {asset.Width,4}x{asset.Height,-4} {encoded.Length,10:N0} bytes {ImageBenchmarkCorpus.PixelHash(decoded)[..16]}");
+        }
+
+        byte[] bmp = ImageBenchmarkCorpus.CreateBmp24();
+        OfficeRasterImage decodedBmp = ImageBenchmarkCorpus.Decode(bmp, "GeneratedBmp24");
+        writer.WriteLine($"{"GeneratedBmp24",-14} {OfficeImageFormat.Bmp,-5} {decodedBmp.Width,4}x{decodedBmp.Height,-4} {bmp.Length,10:N0} bytes {ImageBenchmarkCorpus.PixelHash(decodedBmp)[..16]}");
+
+        var encode = new ImageEncodeBenchmarks();
+        encode.Setup();
+        writer.WriteLine($"Encode PNG     {encode.Png().Length,10:N0} bytes");
+        writer.WriteLine($"Encode JPEG    {encode.Jpeg().Length,10:N0} bytes");
+        writer.WriteLine($"Encode TIFF    {encode.Tiff().Length,10:N0} bytes");
+        writer.WriteLine($"Encode WebP    {encode.Webp().Length,10:N0} bytes");
+
+        var transform = new ImageTransformBenchmarks();
+        transform.Setup();
+        OfficeImageOptimizationResult optimized = transform.OptimizeForPlacement();
+        writer.WriteLine($"Optimize JPEG  {optimized.Final.Width,4}x{optimized.Final.Height,-4} {optimized.FinalEncodedLength,10:N0} bytes {optimized.Status}");
+    }
+}

--- a/OfficeIMO.Drawing.Benchmarks/ImageBenchmarkValidator.cs
+++ b/OfficeIMO.Drawing.Benchmarks/ImageBenchmarkValidator.cs
@@ -24,12 +24,18 @@ internal static class ImageBenchmarkValidator {
         encode.Setup();
         writer.WriteLine($"Encode PNG     {encode.Png().Length,10:N0} bytes");
         writer.WriteLine($"Encode JPEG    {encode.Jpeg().Length,10:N0} bytes");
+        writer.WriteLine($"Encode JPEG420 {encode.Jpeg420().Length,10:N0} bytes");
+        writer.WriteLine($"JPEG420 prog   {encode.Jpeg420ProgressiveOptimized().Length,10:N0} bytes");
         writer.WriteLine($"Encode TIFF    {encode.Tiff().Length,10:N0} bytes");
+        writer.WriteLine($"TIFF Deflate   {encode.TiffDeflate().Length,10:N0} bytes");
         writer.WriteLine($"Encode WebP    {encode.Webp().Length,10:N0} bytes");
 
         var transform = new ImageTransformBenchmarks();
         transform.Setup();
         OfficeImageOptimizationResult optimized = transform.OptimizeForPlacement();
         writer.WriteLine($"Optimize JPEG  {optimized.Final.Width,4}x{optimized.Final.Height,-4} {optimized.FinalEncodedLength,10:N0} bytes {optimized.Status}");
+
+        ImageEncodingEvidence.Validate(writer);
+        ImageConversionEvidence.Validate(writer);
     }
 }

--- a/OfficeIMO.Drawing.Benchmarks/ImageConversionEvidence.cs
+++ b/OfficeIMO.Drawing.Benchmarks/ImageConversionEvidence.cs
@@ -1,0 +1,104 @@
+namespace OfficeIMO.Drawing.Benchmarks;
+
+/// <summary>Validates the supported static raster conversion matrix and animation-loss boundary.</summary>
+internal static class ImageConversionEvidence {
+    private sealed record ConversionSource(string Name, byte[] Bytes);
+
+    private static readonly OfficeImageFormat[] OutputFormats = {
+        OfficeImageFormat.Png,
+        OfficeImageFormat.Jpeg,
+        OfficeImageFormat.Tiff,
+        OfficeImageFormat.Webp
+    };
+
+    internal static void Validate(TextWriter writer) {
+        OfficeRasterImage pattern = ImageBenchmarkCorpus.CreatePattern(64, 48);
+        var sourceOptions = new OfficeRasterEncodingOptions {
+            DpiX = 144D,
+            DpiY = 120D
+        };
+        var sources = new[] {
+            new ConversionSource("PNG", OfficeRasterImageEncoder.Encode(pattern, OfficeImageExportFormat.Png, sourceOptions)),
+            new ConversionSource("JPEG", OfficeRasterImageEncoder.Encode(pattern, OfficeImageExportFormat.Jpeg, sourceOptions)),
+            new ConversionSource("TIFF", OfficeRasterImageEncoder.Encode(pattern, OfficeImageExportFormat.Tiff, sourceOptions)),
+            new ConversionSource("WebP", OfficeRasterImageEncoder.Encode(pattern, OfficeImageExportFormat.Webp, sourceOptions)),
+            new ConversionSource("BMP", ImageBenchmarkCorpus.CreateBmp24(64, 48)),
+            new ConversionSource("GIF", Convert.FromBase64String("R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=="))
+        };
+
+        writer.WriteLine();
+        writer.WriteLine("Static conversion matrix (source -> output, validated dimensions/DPI/pixels):");
+        writer.WriteLine("Source     Output       Dimensions      Bytes       MAE");
+        foreach (ConversionSource source in sources) {
+            OfficeImageInfo sourceInfo = OfficeImageReader.Identify(source.Bytes);
+            OfficeRasterImage decodedSource = ImageBenchmarkCorpus.Decode(source.Bytes, source.Name + " conversion source");
+            int targetWidth = Math.Max(1, decodedSource.Width / 2);
+            int targetHeight = Math.Max(1, decodedSource.Height / 2);
+            OfficeRasterImage expected = targetWidth == decodedSource.Width && targetHeight == decodedSource.Height
+                ? decodedSource
+                : OfficeRasterResampler.Resize(decodedSource, targetWidth, targetHeight);
+
+            foreach (OfficeImageFormat outputFormat in OutputFormats) {
+                OfficeImageOptimizationResult result = OfficeImageOptimizer.Optimize(
+                    source.Bytes,
+                    new OfficeImageOptimizationRequest(targetWidth, targetHeight) {
+                        PreserveAspectRatio = false,
+                        OutputFormat = outputFormat,
+                        KeepOriginalWhenNotSmaller = false,
+                        JpegSubsampling = OfficeJpegSubsampling.Y420,
+                        JpegOptimizeHuffman = true,
+                        TiffCompression = OfficeTiffCompression.Deflate
+                    });
+                if (result.Status != OfficeImageOptimizationStatus.Optimized) {
+                    throw new InvalidOperationException(
+                        $"{source.Name} to {outputFormat} returned {result.Status} instead of Optimized.");
+                }
+
+                byte[] resultBytes = result.Bytes;
+                OfficeImageInfo actualInfo = OfficeImageReader.Identify(resultBytes);
+                if (actualInfo.Format != outputFormat ||
+                    actualInfo.Width != targetWidth ||
+                    actualInfo.Height != targetHeight ||
+                    Math.Abs(actualInfo.DpiX - sourceInfo.DpiX) > 0.05D ||
+                    Math.Abs(actualInfo.DpiY - sourceInfo.DpiY) > 0.05D ||
+                    actualInfo.DpiX != result.Final.DpiX ||
+                    actualInfo.DpiY != result.Final.DpiY) {
+                    throw new InvalidOperationException(
+                        $"{source.Name} to {outputFormat} did not preserve its encoded format, dimensions, or physical resolution contract.");
+                }
+
+                OfficeRasterImage actual = ImageBenchmarkCorpus.Decode(resultBytes, source.Name + " to " + outputFormat);
+                double meanAbsoluteError;
+                if (outputFormat == OfficeImageFormat.Jpeg) {
+                    byte[] flattened = ImageEncodingEvidence.FlattenAgainstWhite(expected.GetPixels());
+                    (meanAbsoluteError, double psnr) = ImageEncodingEvidence.MeasureRgbFidelity(flattened, actual.GetPixels());
+                    if (meanAbsoluteError > 40D || psnr < 15D) {
+                        throw new InvalidOperationException(
+                            $"{source.Name} to JPEG fidelity was outside the validation envelope: MAE {meanAbsoluteError:F3}, PSNR {psnr:F2} dB.");
+                    }
+                } else {
+                    byte[] expectedPixels = expected.GetPixels();
+                    byte[] actualPixels = actual.GetPixels();
+                    if (!expectedPixels.AsSpan().SequenceEqual(actualPixels)) {
+                        throw new InvalidOperationException(source.Name + " to " + outputFormat + " was not lossless.");
+                    }
+                    meanAbsoluteError = 0D;
+                }
+
+                writer.WriteLine(
+                    $"{source.Name,-10} {outputFormat,-10} {targetWidth,4}x{targetHeight,-4} {resultBytes.Length,10:N0} {meanAbsoluteError,9:F3}");
+            }
+        }
+
+        byte[] animation = ImageBenchmarkCorpus.Animation.ReadBytes();
+        OfficeImageOptimizationResult animated = OfficeImageOptimizer.Optimize(
+            animation,
+            new OfficeImageOptimizationRequest(110, 69) {
+                KeepOriginalWhenNotSmaller = false
+            });
+        if (animated.Status != OfficeImageOptimizationStatus.DecodeFailed || animated.Changed) {
+            throw new InvalidOperationException("Animated GIF optimization did not preserve the no-implicit-frame-loss boundary.");
+        }
+        writer.WriteLine("Animated GIF input was rejected without silently selecting one frame.");
+    }
+}

--- a/OfficeIMO.Drawing.Benchmarks/ImageDecodeBenchmarks.cs
+++ b/OfficeIMO.Drawing.Benchmarks/ImageDecodeBenchmarks.cs
@@ -1,0 +1,27 @@
+using BenchmarkDotNet.Attributes;
+
+namespace OfficeIMO.Drawing.Benchmarks;
+
+/// <summary>Measures full managed decode into OfficeIMO's RGBA raster contract.</summary>
+[MemoryDiagnoser]
+public class ImageDecodeBenchmarks {
+    private byte[] _encoded = null!;
+
+    [Params("LogoPng", "PhotoJpeg", "AnimationGif", "SaturnTiff", "GeneratedBmp24")]
+    public string Asset { get; set; } = string.Empty;
+
+    [GlobalSetup]
+    public void Setup() {
+        ImageBenchmarkAsset? asset = ImageBenchmarkCorpus.All.SingleOrDefault(candidate => candidate.Id == Asset);
+        _encoded = Asset == "GeneratedBmp24" ? ImageBenchmarkCorpus.CreateBmp24() : asset!.ReadBytes();
+        OfficeRasterImage decoded = ImageBenchmarkCorpus.Decode(_encoded, Asset);
+        int expectedWidth = asset?.Width ?? 256;
+        int expectedHeight = asset?.Height ?? 256;
+        if (decoded.Width != expectedWidth || decoded.Height != expectedHeight) {
+            throw new InvalidOperationException($"{Asset} decoded to {decoded.Width}x{decoded.Height}.");
+        }
+    }
+
+    [Benchmark]
+    public OfficeRasterImage Decode() => ImageBenchmarkCorpus.Decode(_encoded, Asset);
+}

--- a/OfficeIMO.Drawing.Benchmarks/ImageEncodeBenchmarks.cs
+++ b/OfficeIMO.Drawing.Benchmarks/ImageEncodeBenchmarks.cs
@@ -1,0 +1,38 @@
+using BenchmarkDotNet.Attributes;
+
+namespace OfficeIMO.Drawing.Benchmarks;
+
+/// <summary>Measures encoders from one identical deterministic RGBA source.</summary>
+[MemoryDiagnoser]
+public class ImageEncodeBenchmarks {
+    private OfficeRasterImage _image = null!;
+
+    [GlobalSetup]
+    public void Setup() {
+        _image = ImageBenchmarkCorpus.CreatePattern();
+        ValidateLossless(Png(), OfficeImageFormat.Png, nameof(Png));
+        ValidateLossless(Tiff(), OfficeImageFormat.Tiff, nameof(Tiff));
+        ValidateLossless(Webp(), OfficeImageFormat.Webp, nameof(Webp));
+        ImageBenchmarkCorpus.AssertIdentified(Jpeg(), OfficeImageFormat.Jpeg, _image.Width, _image.Height, nameof(Jpeg));
+    }
+
+    [Benchmark(Baseline = true)]
+    public byte[] Png() => OfficeRasterImageEncoder.Encode(_image, OfficeImageExportFormat.Png);
+
+    [Benchmark]
+    public byte[] Jpeg() => OfficeRasterImageEncoder.Encode(_image, OfficeImageExportFormat.Jpeg);
+
+    [Benchmark]
+    public byte[] Tiff() => OfficeRasterImageEncoder.Encode(_image, OfficeImageExportFormat.Tiff);
+
+    [Benchmark]
+    public byte[] Webp() => OfficeRasterImageEncoder.Encode(_image, OfficeImageExportFormat.Webp);
+
+    private void ValidateLossless(byte[] encoded, OfficeImageFormat format, string operation) {
+        ImageBenchmarkCorpus.AssertIdentified(encoded, format, _image.Width, _image.Height, operation);
+        OfficeRasterImage decoded = ImageBenchmarkCorpus.Decode(encoded, operation);
+        if (!string.Equals(ImageBenchmarkCorpus.PixelHash(decoded), ImageBenchmarkCorpus.PixelHash(_image), StringComparison.Ordinal)) {
+            throw new InvalidOperationException(operation + " did not preserve the RGBA pixels.");
+        }
+    }
+}

--- a/OfficeIMO.Drawing.Benchmarks/ImageEncodeBenchmarks.cs
+++ b/OfficeIMO.Drawing.Benchmarks/ImageEncodeBenchmarks.cs
@@ -2,18 +2,29 @@ using BenchmarkDotNet.Attributes;
 
 namespace OfficeIMO.Drawing.Benchmarks;
 
-/// <summary>Measures encoders from one identical deterministic RGBA source.</summary>
+/// <summary>Measures encoder time and managed allocation growth from identical deterministic RGBA sources.</summary>
 [MemoryDiagnoser]
 public class ImageEncodeBenchmarks {
     private OfficeRasterImage _image = null!;
 
+    [Params(256, 512, 1024)]
+    public int Size { get; set; } = 512;
+
     [GlobalSetup]
     public void Setup() {
-        _image = ImageBenchmarkCorpus.CreatePattern();
+        _image = ImageBenchmarkCorpus.CreatePattern(Size, Size);
         ValidateLossless(Png(), OfficeImageFormat.Png, nameof(Png));
         ValidateLossless(Tiff(), OfficeImageFormat.Tiff, nameof(Tiff));
+        ValidateLossless(TiffDeflate(), OfficeImageFormat.Tiff, nameof(TiffDeflate));
         ValidateLossless(Webp(), OfficeImageFormat.Webp, nameof(Webp));
         ImageBenchmarkCorpus.AssertIdentified(Jpeg(), OfficeImageFormat.Jpeg, _image.Width, _image.Height, nameof(Jpeg));
+        ImageBenchmarkCorpus.AssertIdentified(Jpeg420(), OfficeImageFormat.Jpeg, _image.Width, _image.Height, nameof(Jpeg420));
+        ImageBenchmarkCorpus.AssertIdentified(
+            Jpeg420ProgressiveOptimized(),
+            OfficeImageFormat.Jpeg,
+            _image.Width,
+            _image.Height,
+            nameof(Jpeg420ProgressiveOptimized));
     }
 
     [Benchmark(Baseline = true)]
@@ -23,7 +34,26 @@ public class ImageEncodeBenchmarks {
     public byte[] Jpeg() => OfficeRasterImageEncoder.Encode(_image, OfficeImageExportFormat.Jpeg);
 
     [Benchmark]
+    public byte[] Jpeg420() => OfficeJpegCodec.Encode(_image, new OfficeJpegEncodeOptions {
+        Quality = 85,
+        Subsampling = OfficeJpegSubsampling.Y420
+    });
+
+    [Benchmark]
+    public byte[] Jpeg420ProgressiveOptimized() => OfficeJpegCodec.Encode(_image, new OfficeJpegEncodeOptions {
+        Quality = 85,
+        Subsampling = OfficeJpegSubsampling.Y420,
+        Progressive = true,
+        OptimizeHuffman = true
+    });
+
+    [Benchmark]
     public byte[] Tiff() => OfficeRasterImageEncoder.Encode(_image, OfficeImageExportFormat.Tiff);
+
+    [Benchmark]
+    public byte[] TiffDeflate() => OfficeTiffCodec.Encode(_image, new OfficeTiffEncodeOptions {
+        Compression = OfficeTiffCompression.Deflate
+    });
 
     [Benchmark]
     public byte[] Webp() => OfficeRasterImageEncoder.Encode(_image, OfficeImageExportFormat.Webp);

--- a/OfficeIMO.Drawing.Benchmarks/ImageEncodingEvidence.cs
+++ b/OfficeIMO.Drawing.Benchmarks/ImageEncodingEvidence.cs
@@ -1,0 +1,125 @@
+namespace OfficeIMO.Drawing.Benchmarks;
+
+/// <summary>Validates output size and fidelity separately from timed benchmark measurements.</summary>
+internal static class ImageEncodingEvidence {
+    private static readonly int[] Sizes = { 256, 512, 1024 };
+
+    internal static void Validate(TextWriter writer) {
+        writer.WriteLine();
+        writer.WriteLine("Encoding size and fidelity matrix (encoded bytes versus source RGBA bytes):");
+        writer.WriteLine("Size       Format/options                  Bytes    Ratio       MAE     PSNR");
+
+        foreach (int size in Sizes) {
+            OfficeRasterImage source = ImageBenchmarkCorpus.CreatePattern(size, size);
+            WriteLossless(writer, size, source, "PNG optimal", OfficePngWriter.Encode(source, new OfficePngEncodeOptions {
+                Compression = OfficePngCompression.Optimal
+            }));
+            WriteLossless(writer, size, source, "PNG stored", OfficePngWriter.Encode(source, new OfficePngEncodeOptions {
+                Compression = OfficePngCompression.Stored
+            }));
+            WriteJpeg(writer, size, source, quality: 60, OfficeJpegSubsampling.Y420, progressive: false, optimizeHuffman: false);
+            WriteJpeg(writer, size, source, quality: 85, OfficeJpegSubsampling.Y420, progressive: false, optimizeHuffman: false);
+            WriteJpeg(writer, size, source, quality: 95, OfficeJpegSubsampling.Y420, progressive: false, optimizeHuffman: false);
+            WriteJpeg(writer, size, source, quality: 85, OfficeJpegSubsampling.Y444, progressive: false, optimizeHuffman: false);
+            WriteJpeg(writer, size, source, quality: 85, OfficeJpegSubsampling.Y420, progressive: true, optimizeHuffman: true);
+            WriteLossless(writer, size, source, "TIFF none", OfficeTiffCodec.Encode(source, new OfficeTiffEncodeOptions {
+                Compression = OfficeTiffCompression.None
+            }));
+            WriteLossless(writer, size, source, "TIFF PackBits", OfficeTiffCodec.Encode(source, new OfficeTiffEncodeOptions {
+                Compression = OfficeTiffCompression.PackBits
+            }));
+            WriteLossless(writer, size, source, "TIFF Deflate", OfficeTiffCodec.Encode(source, new OfficeTiffEncodeOptions {
+                Compression = OfficeTiffCompression.Deflate
+            }));
+            WriteLossless(writer, size, source, "WebP literal lossless", OfficeWebpCodec.Encode(source));
+        }
+    }
+
+    private static void WriteLossless(TextWriter writer, int size, OfficeRasterImage source, string label, byte[] encoded) {
+        OfficeRasterImage decoded = ImageBenchmarkCorpus.Decode(encoded, label);
+        byte[] expected = source.GetPixels();
+        byte[] actual = decoded.GetPixels();
+        if (!expected.AsSpan().SequenceEqual(actual)) {
+            throw new InvalidOperationException(label + " did not preserve the source RGBA pixels.");
+        }
+        WriteRow(writer, size, label, encoded.Length, expected.Length, meanAbsoluteError: 0D, psnr: double.PositiveInfinity);
+    }
+
+    private static void WriteJpeg(
+        TextWriter writer,
+        int size,
+        OfficeRasterImage source,
+        int quality,
+        OfficeJpegSubsampling subsampling,
+        bool progressive,
+        bool optimizeHuffman) {
+        byte[] encoded = OfficeJpegCodec.Encode(source, new OfficeJpegEncodeOptions {
+            Quality = quality,
+            Subsampling = subsampling,
+            Progressive = progressive,
+            OptimizeHuffman = optimizeHuffman,
+            Background = OfficeColor.White
+        });
+        OfficeRasterImage decoded = ImageBenchmarkCorpus.Decode(encoded, "JPEG evidence");
+        byte[] expected = FlattenAgainstWhite(source.GetPixels());
+        (double mae, double psnr) = MeasureRgbFidelity(expected, decoded.GetPixels());
+        if (mae > 40D || psnr < 15D) {
+            throw new InvalidOperationException(
+                $"JPEG Q{quality} {subsampling} fidelity was outside the validation envelope: MAE {mae:F3}, PSNR {psnr:F2} dB.");
+        }
+
+        string mode = progressive ? " progressive+huffman" : string.Empty;
+        WriteRow(writer, size, $"JPEG Q{quality} {subsampling}{mode}", encoded.Length, expected.Length, mae, psnr);
+    }
+
+    internal static byte[] FlattenAgainstWhite(byte[] rgba) {
+        var flattened = new byte[rgba.Length];
+        for (int offset = 0; offset < rgba.Length; offset += 4) {
+            int alpha = rgba[offset + 3];
+            int inverse = 255 - alpha;
+            flattened[offset] = (byte)((rgba[offset] * alpha + 255 * inverse + 127) / 255);
+            flattened[offset + 1] = (byte)((rgba[offset + 1] * alpha + 255 * inverse + 127) / 255);
+            flattened[offset + 2] = (byte)((rgba[offset + 2] * alpha + 255 * inverse + 127) / 255);
+            flattened[offset + 3] = 255;
+        }
+        return flattened;
+    }
+
+    internal static (double MeanAbsoluteError, double Psnr) MeasureRgbFidelity(byte[] expected, byte[] actual) {
+        if (expected.Length != actual.Length || expected.Length % 4 != 0) {
+            throw new InvalidOperationException("JPEG evidence did not preserve the expected pixel dimensions.");
+        }
+
+        long absoluteError = 0L;
+        double squaredError = 0D;
+        long channelCount = expected.LongLength / 4L * 3L;
+        for (int offset = 0; offset < expected.Length; offset += 4) {
+            for (int channel = 0; channel < 3; channel++) {
+                int difference = expected[offset + channel] - actual[offset + channel];
+                absoluteError += Math.Abs(difference);
+                squaredError += difference * difference;
+            }
+        }
+
+        double meanAbsoluteError = absoluteError / (double)channelCount;
+        double meanSquaredError = squaredError / channelCount;
+        double psnr = meanSquaredError == 0D
+            ? double.PositiveInfinity
+            : 10D * Math.Log10(255D * 255D / meanSquaredError);
+        return (meanAbsoluteError, psnr);
+    }
+
+    private static void WriteRow(
+        TextWriter writer,
+        int size,
+        string label,
+        int encodedLength,
+        int rgbaLength,
+        double meanAbsoluteError,
+        double psnr) {
+        string psnrText = double.IsPositiveInfinity(psnr) ? "lossless" : psnr.ToString("F2");
+        writer.WriteLine(
+            $"{size,4}x{size,-4} {label,-31} {encodedLength,10:N0} {encodedLength / (double)rgbaLength,8:P1} " +
+            $"{meanAbsoluteError,9:F3} {psnrText,8}");
+    }
+}

--- a/OfficeIMO.Drawing.Benchmarks/ImageIdentifyBenchmarks.cs
+++ b/OfficeIMO.Drawing.Benchmarks/ImageIdentifyBenchmarks.cs
@@ -1,0 +1,31 @@
+using BenchmarkDotNet.Attributes;
+
+namespace OfficeIMO.Drawing.Benchmarks;
+
+/// <summary>Measures metadata identification separately from full raster decoding.</summary>
+[MemoryDiagnoser]
+public class ImageIdentifyBenchmarks {
+    private byte[] _encoded = null!;
+
+    [Params("LogoPng", "PhotoJpeg", "AnimationGif", "SaturnTiff", "SnailBmp")]
+    public string Asset { get; set; } = string.Empty;
+
+    [GlobalSetup]
+    public void Setup() {
+        ImageBenchmarkAsset asset = ImageBenchmarkCorpus.Get(Asset);
+        _encoded = asset.ReadBytes();
+        ImageBenchmarkCorpus.AssertIdentified(_encoded, asset.Format, asset.Width, asset.Height, Asset);
+    }
+
+    [Benchmark(Baseline = true)]
+    public OfficeImageInfo IdentifyBytes() => OfficeImageReader.Identify(_encoded);
+
+    [Benchmark]
+    public OfficeImageInfo IdentifySeekableStream() {
+        using var stream = new MemoryStream(_encoded, writable: false);
+        if (!OfficeImageReader.TryIdentify(stream, fileName: null, out OfficeImageInfo info)) {
+            throw new InvalidOperationException("The benchmark image could not be identified.");
+        }
+        return info;
+    }
+}

--- a/OfficeIMO.Drawing.Benchmarks/ImageTransformBenchmarks.cs
+++ b/OfficeIMO.Drawing.Benchmarks/ImageTransformBenchmarks.cs
@@ -8,12 +8,17 @@ public class ImageTransformBenchmarks {
     private OfficeRasterImage _photo = null!;
     private byte[] _photoBytes = null!;
     private OfficeImageOptimizationRequest _optimization = null!;
+    private int _targetHeight;
+
+    [Params(400, 800, 1600)]
+    public int TargetWidth { get; set; } = 800;
 
     [GlobalSetup]
     public void Setup() {
         _photoBytes = ImageBenchmarkCorpus.Photo.ReadBytes();
         _photo = ImageBenchmarkCorpus.Decode(_photoBytes, "photo setup");
-        _optimization = new OfficeImageOptimizationRequest(800, 800) {
+        _targetHeight = Math.Max(1, (int)Math.Round(_photo.Height * (TargetWidth / (double)_photo.Width)));
+        _optimization = new OfficeImageOptimizationRequest(TargetWidth, TargetWidth) {
             PreserveAspectRatio = true,
             ResamplingMode = OfficeRasterResamplingMode.Bilinear,
             JpegQuality = 85,
@@ -21,16 +26,22 @@ public class ImageTransformBenchmarks {
         };
 
         OfficeRasterImage resized = ResizeBilinear();
-        if (resized.Width != 800 || resized.Height != 632) {
-            throw new InvalidOperationException($"Resize produced {resized.Width}x{resized.Height}; expected 800x632.");
+        if (resized.Width != TargetWidth || resized.Height != _targetHeight) {
+            throw new InvalidOperationException(
+                $"Resize produced {resized.Width}x{resized.Height}; expected {TargetWidth}x{_targetHeight}.");
         }
         OfficeImageOptimizationResult optimized = OptimizeForPlacement();
-        ImageBenchmarkCorpus.AssertIdentified(optimized.Bytes, OfficeImageFormat.Jpeg, 800, 632, nameof(OptimizeForPlacement));
+        ImageBenchmarkCorpus.AssertIdentified(
+            optimized.Bytes,
+            OfficeImageFormat.Jpeg,
+            TargetWidth,
+            _targetHeight,
+            nameof(OptimizeForPlacement));
     }
 
     [Benchmark(Baseline = true)]
     public OfficeRasterImage ResizeBilinear() =>
-        OfficeRasterResampler.Resize(_photo, 800, 632, OfficeRasterResamplingMode.Bilinear);
+        OfficeRasterResampler.Resize(_photo, TargetWidth, _targetHeight, OfficeRasterResamplingMode.Bilinear);
 
     [Benchmark]
     public OfficeImageOptimizationResult OptimizeForPlacement() =>

--- a/OfficeIMO.Drawing.Benchmarks/ImageTransformBenchmarks.cs
+++ b/OfficeIMO.Drawing.Benchmarks/ImageTransformBenchmarks.cs
@@ -1,0 +1,38 @@
+using BenchmarkDotNet.Attributes;
+
+namespace OfficeIMO.Drawing.Benchmarks;
+
+/// <summary>Measures shared resize and encoded-image optimization workflows.</summary>
+[MemoryDiagnoser]
+public class ImageTransformBenchmarks {
+    private OfficeRasterImage _photo = null!;
+    private byte[] _photoBytes = null!;
+    private OfficeImageOptimizationRequest _optimization = null!;
+
+    [GlobalSetup]
+    public void Setup() {
+        _photoBytes = ImageBenchmarkCorpus.Photo.ReadBytes();
+        _photo = ImageBenchmarkCorpus.Decode(_photoBytes, "photo setup");
+        _optimization = new OfficeImageOptimizationRequest(800, 800) {
+            PreserveAspectRatio = true,
+            ResamplingMode = OfficeRasterResamplingMode.Bilinear,
+            JpegQuality = 85,
+            KeepOriginalWhenNotSmaller = false
+        };
+
+        OfficeRasterImage resized = ResizeBilinear();
+        if (resized.Width != 800 || resized.Height != 632) {
+            throw new InvalidOperationException($"Resize produced {resized.Width}x{resized.Height}; expected 800x632.");
+        }
+        OfficeImageOptimizationResult optimized = OptimizeForPlacement();
+        ImageBenchmarkCorpus.AssertIdentified(optimized.Bytes, OfficeImageFormat.Jpeg, 800, 632, nameof(OptimizeForPlacement));
+    }
+
+    [Benchmark(Baseline = true)]
+    public OfficeRasterImage ResizeBilinear() =>
+        OfficeRasterResampler.Resize(_photo, 800, 632, OfficeRasterResamplingMode.Bilinear);
+
+    [Benchmark]
+    public OfficeImageOptimizationResult OptimizeForPlacement() =>
+        OfficeImageOptimizer.Optimize(_photoBytes, _optimization, "photo.jpg");
+}

--- a/OfficeIMO.Drawing.Benchmarks/OfficeIMO.Drawing.Benchmarks.csproj
+++ b/OfficeIMO.Drawing.Benchmarks/OfficeIMO.Drawing.Benchmarks.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>Latest</LangVersion>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+    <ProjectReference Include="..\OfficeIMO.Core\OfficeIMO.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\Assets\Images\Others\Logo-evotec.png"
+          Link="Corpus\logo.png"
+          CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\OfficeIMO.Examples\Images\Kulek.jpg"
+          Link="Corpus\photo.jpg"
+          CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\OfficeIMO.Examples\Images\example.gif"
+          Link="Corpus\animation.gif"
+          CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\OfficeIMO.Examples\Images\saturn.tif"
+          Link="Corpus\saturn.tif"
+          CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\OfficeIMO.Examples\Images\snail.bmp"
+          Link="Corpus\snail.bmp"
+          CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+</Project>

--- a/OfficeIMO.Drawing.Benchmarks/Program.cs
+++ b/OfficeIMO.Drawing.Benchmarks/Program.cs
@@ -1,0 +1,9 @@
+using BenchmarkDotNet.Running;
+using OfficeIMO.Drawing.Benchmarks;
+
+if (args.Length == 1 && args[0].Equals("--validate", StringComparison.OrdinalIgnoreCase)) {
+    ImageBenchmarkValidator.Validate(Console.Out);
+    return;
+}
+
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

--- a/OfficeIMO.Drawing.Benchmarks/README.md
+++ b/OfficeIMO.Drawing.Benchmarks/README.md
@@ -1,0 +1,17 @@
+# OfficeIMO image benchmarks
+
+This project measures the first-party `OfficeIMO.Core` image engine without adding image-library dependencies to the product. The corpus covers PNG, JPEG, GIF, TIFF, and BMP metadata and decode paths, deterministic RGBA encoding to PNG/JPEG/TIFF/WebP, bilinear resize, and placement-aware optimization. The repository's `snail.bmp` has four trailing bytes beyond its declared BMP file size, so it remains a metadata fixture; decode measurements use a generated canonical 24-bit BMP instead of weakening the decoder's strict container contract.
+
+Every timed workload is validated in global setup. Run the complete validation pass before collecting measurements:
+
+```powershell
+dotnet run --project OfficeIMO.Drawing.Benchmarks -c Release -f net10.0 -- --validate
+```
+
+Start benchmark work with a short diagnostic run:
+
+```powershell
+dotnet run --project OfficeIMO.Drawing.Benchmarks -c Release -f net10.0 -- --job Dry --filter '*ImageEncodeBenchmarks*'
+```
+
+Use a normal BenchmarkDotNet job only after the workload, output dimensions, format, and pixel-preservation contract have been validated. Benchmark artifacts belong in an ignored or temporary output directory and should not be committed.

--- a/OfficeIMO.Drawing.Benchmarks/README.md
+++ b/OfficeIMO.Drawing.Benchmarks/README.md
@@ -1,6 +1,10 @@
 # OfficeIMO image benchmarks
 
-This project measures the first-party `OfficeIMO.Core` image engine without adding image-library dependencies to the product. The corpus covers PNG, JPEG, GIF, TIFF, and BMP metadata and decode paths, deterministic RGBA encoding to PNG/JPEG/TIFF/WebP, bilinear resize, and placement-aware optimization. The repository's `snail.bmp` has four trailing bytes beyond its declared BMP file size, so it remains a metadata fixture; decode measurements use a generated canonical 24-bit BMP instead of weakening the decoder's strict container contract.
+This project measures the first-party `OfficeIMO.Core` image engine without adding image-library dependencies to the product. The corpus covers PNG, JPEG, GIF, TIFF, and BMP metadata and decode paths, deterministic RGBA encoding to PNG/JPEG/TIFF/WebP, bilinear resize, and placement-aware optimization. Encode and transform workloads run at several image or target sizes so managed-allocation growth remains visible instead of being inferred from one small sample.
+
+The validation pass reports encoded bytes separately from benchmark time. It includes PNG compression, JPEG quality/subsampling/progressive modes with MAE and PSNR, TIFF compression, literal-lossless WebP, and every supported static source-to-output conversion. Lossless rows require exact RGBA equality. JPEG rows compare against the alpha-flattened source. Animated input is rejected by the optimization matrix rather than silently reduced to one frame.
+
+The repository's `snail.bmp` has four trailing bytes beyond its declared BMP file size, so it remains a metadata fixture; decode measurements use a generated canonical 24-bit BMP instead of weakening the decoder's strict container contract.
 
 Every timed workload is validated in global setup. Run the complete validation pass before collecting measurements:
 
@@ -15,3 +19,17 @@ dotnet run --project OfficeIMO.Drawing.Benchmarks -c Release -f net10.0 -- --job
 ```
 
 Use a normal BenchmarkDotNet job only after the workload, output dimensions, format, and pixel-preservation contract have been validated. Benchmark artifacts belong in an ignored or temporary output directory and should not be committed.
+
+For a heterogeneous or multi-CCD processor, pin the run to a reviewed processor region. For example, use this mask when logical processors 0-15 form one representative region:
+
+```powershell
+dotnet run --project OfficeIMO.Drawing.Benchmarks -c Release -f net10.0 -- --job Short --filter '*ImageEncodeBenchmarks*' --affinity 65535
+```
+
+Interpret the columns as separate tradeoffs:
+
+- `Allocated` is managed allocation per operation. It does not include native allocations from comparison libraries.
+- Encoded byte length and JPEG fidelity come from deterministic validation, not timed iterations.
+- Small timing differences are not decisions on their own, even with affinity. Prefer changes that also remove whole image-sized buffers, reduce output materially, or improve a correctness contract.
+- JPEG 4:2:0, optimized Huffman tables, progressive scans, TIFF Deflate, and TIFF PackBits have different CPU, fidelity, allocation, and file-size profiles. Keep them explicit when no one policy wins every axis.
+- OfficeIMO WebP currently emits a standards-compatible literal-only lossless VP8L subset. It is fast and auditable, but its output size is close to raw RGBA; do not interpret it as a general-purpose WebP compression comparison.

--- a/OfficeIMO.Drawing.Tests/Drawing.ImageOptimization.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.ImageOptimization.cs
@@ -325,18 +325,169 @@ namespace OfficeIMO.Tests {
             Assert.InRange(decoded!.GetPixel(10, 5).A, 95, 97);
         }
 
+        [Theory]
+        [InlineData(OfficeImageFormat.Png)]
+        [InlineData(OfficeImageFormat.Jpeg)]
+        [InlineData(OfficeImageFormat.Tiff)]
+        [InlineData(OfficeImageFormat.Webp)]
+        public void OfficeImageOptimizer_EncodesRequestedFormatWithSourceResolution(OfficeImageFormat outputFormat) {
+            var source = new OfficeRasterImage(16, 12, OfficeColor.SteelBlue);
+            byte[] png = OfficePngWriter.Encode(source, new OfficePngEncodeOptions {
+                DpiX = 144D,
+                DpiY = 120D
+            });
+
+            OfficeImageOptimizationResult result = OfficeImageOptimizer.Optimize(
+                png,
+                new OfficeImageOptimizationRequest(8, 6) {
+                    OutputFormat = outputFormat,
+                    KeepOriginalWhenNotSmaller = false,
+                    TiffCompression = OfficeTiffCompression.Deflate,
+                    JpegOptimizeHuffman = true
+                });
+
+            OfficeImageInfo encodedInfo = OfficeImageReader.Identify(result.Bytes);
+            Assert.Equal(OfficeImageOptimizationStatus.Optimized, result.Status);
+            Assert.Equal(outputFormat, result.Final.Format);
+            Assert.Equal(outputFormat, encodedInfo.Format);
+            Assert.Equal((8, 6), (encodedInfo.Width, encodedInfo.Height));
+            Assert.InRange(encodedInfo.DpiX, 143.98D, 144.02D);
+            Assert.InRange(encodedInfo.DpiY, 119.98D, 120.02D);
+            Assert.Equal(encodedInfo.DpiX, result.Final.DpiX);
+            Assert.Equal(encodedInfo.DpiY, result.Final.DpiY);
+        }
+
+        [Theory]
+        [InlineData(OfficeImageFormat.Jpeg, 65535D)]
+        [InlineData(OfficeImageFormat.Tiff, 1000000D)]
+        [InlineData(OfficeImageFormat.Webp, 1000000D)]
+        public void OfficeImageOptimizer_ClampsSourceResolutionToDestinationMaximum(
+            OfficeImageFormat outputFormat,
+            double expectedMaximumDpi) {
+            var source = new OfficeRasterImage(4, 4, OfficeColor.SteelBlue);
+            byte[] png = OfficePngWriter.Encode(source, new OfficePngEncodeOptions {
+                DpiX = 60000000D,
+                DpiY = 60000000D
+            });
+
+            OfficeImageOptimizationResult result = OfficeImageOptimizer.Optimize(
+                png,
+                new OfficeImageOptimizationRequest(4, 4) {
+                    OutputFormat = outputFormat,
+                    KeepOriginalWhenNotSmaller = false
+                });
+
+            OfficeImageInfo encodedInfo = OfficeImageReader.Identify(result.Bytes);
+            Assert.Equal(OfficeImageOptimizationStatus.Optimized, result.Status);
+            Assert.InRange(encodedInfo.DpiX, expectedMaximumDpi - 0.01D, expectedMaximumDpi + 0.01D);
+            Assert.InRange(encodedInfo.DpiY, expectedMaximumDpi - 0.01D, expectedMaximumDpi + 0.01D);
+            Assert.Equal(encodedInfo.DpiX, result.Final.DpiX);
+            Assert.Equal(encodedInfo.DpiY, result.Final.DpiY);
+        }
+
+        [Theory]
+        [InlineData(OfficeImageFormat.Png, 0.0127D)]
+        [InlineData(OfficeImageFormat.Jpeg, 0.5D)]
+        public void OfficeImageOptimizer_ClampsSourceResolutionToDestinationMinimum(
+            OfficeImageFormat outputFormat,
+            double expectedMinimumDpi) {
+            var source = new OfficeRasterImage(4, 4, OfficeColor.SteelBlue);
+            byte[] webp = OfficeWebpCodec.Encode(source, 0.0001D, 0.0001D);
+
+            OfficeImageOptimizationResult result = OfficeImageOptimizer.Optimize(
+                webp,
+                new OfficeImageOptimizationRequest(4, 4) {
+                    OutputFormat = outputFormat,
+                    KeepOriginalWhenNotSmaller = false
+                });
+
+            OfficeImageInfo encodedInfo = OfficeImageReader.Identify(result.Bytes);
+            Assert.Equal(OfficeImageOptimizationStatus.Optimized, result.Status);
+            Assert.True(encodedInfo.DpiX >= expectedMinimumDpi);
+            Assert.True(encodedInfo.DpiY >= expectedMinimumDpi);
+            Assert.Equal(encodedInfo.DpiX, result.Final.DpiX);
+            Assert.Equal(encodedInfo.DpiY, result.Final.DpiY);
+        }
+
         [Fact]
-        public void OfficeImageOptimizer_DoesNotRewriteAnimationCapableFormats() {
-            byte[] gif = {
-                (byte)'G', (byte)'I', (byte)'F', (byte)'8', (byte)'9', (byte)'a',
-                1, 0, 1, 0, 0, 0, 0
+        public void OfficeImageOptimizer_UsesExplicitOutputResolutionWhenNoResizeIsNeeded() {
+            byte[] png = OfficePngWriter.Encode(new OfficeRasterImage(4, 4, OfficeColor.SteelBlue));
+            var request = new OfficeImageOptimizationRequest(4, 4) {
+                OutputDpiX = 300D,
+                OutputDpiY = 150D,
+                KeepOriginalWhenNotSmaller = false
             };
 
-            OfficeImageOptimizationResult result = OfficeImageOptimizer.Optimize(gif, new OfficeImageOptimizationRequest(1, 1));
+            OfficeImageOptimizationResult result = OfficeImageOptimizer.Optimize(png, request);
 
-            Assert.Equal(OfficeImageOptimizationStatus.UnsupportedFormat, result.Status);
-            Assert.False(result.Changed);
-            Assert.Equal(gif, result.Bytes);
+            Assert.Equal(OfficeImageOptimizationStatus.Optimized, result.Status);
+            Assert.InRange(result.Final.DpiX, 299.98D, 300.02D);
+            Assert.InRange(result.Final.DpiY, 149.98D, 150.02D);
+        }
+
+        [Fact]
+        public void OfficeImageOptimizationRequest_RejectsInvalidOutputResolution() {
+            var request = new OfficeImageOptimizationRequest(4, 4);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => request.OutputDpiX = 0D);
+            Assert.Throws<ArgumentOutOfRangeException>(() => request.OutputDpiX = double.NaN);
+            Assert.Throws<ArgumentOutOfRangeException>(() => request.OutputDpiY = double.PositiveInfinity);
+        }
+
+        [Theory]
+        [InlineData(OfficeImageFormat.Tiff)]
+        [InlineData(OfficeImageFormat.Webp)]
+        public void OfficeImageOptimizer_ConvertsManagedStaticInputsToPng(OfficeImageFormat sourceFormat) {
+            OfficeRasterImage source = CreateQuadrantImage(16, 12);
+            OfficeImageExportFormat exportFormat = sourceFormat == OfficeImageFormat.Tiff
+                ? OfficeImageExportFormat.Tiff
+                : OfficeImageExportFormat.Webp;
+            byte[] encoded = OfficeRasterImageEncoder.Encode(source, exportFormat);
+
+            OfficeImageOptimizationResult result = OfficeImageOptimizer.Optimize(
+                encoded,
+                new OfficeImageOptimizationRequest(8, 6) {
+                    KeepOriginalWhenNotSmaller = false
+                });
+
+            Assert.Equal(OfficeImageOptimizationStatus.Optimized, result.Status);
+            Assert.Equal(sourceFormat, result.Original.Format);
+            Assert.Equal(OfficeImageFormat.Png, result.Final.Format);
+            Assert.True(OfficeRasterImageDecoder.TryDecode(result.Bytes, out OfficeRasterImage? decoded));
+            Assert.Equal((8, 6), (decoded!.Width, decoded.Height));
+        }
+
+        [Fact]
+        public void OfficeImageOptimizer_ConvertsStaticGifWithoutImplicitAnimationLoss() {
+            byte[] gif = Convert.FromBase64String("R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==");
+
+            OfficeImageOptimizationResult result = OfficeImageOptimizer.Optimize(
+                gif,
+                new OfficeImageOptimizationRequest(1, 1) {
+                    KeepOriginalWhenNotSmaller = false
+                });
+
+            Assert.Equal(OfficeImageOptimizationStatus.Optimized, result.Status);
+            Assert.Equal(OfficeImageFormat.Gif, result.Original.Format);
+            Assert.Equal(OfficeImageFormat.Png, result.Final.Format);
+            Assert.True(OfficePngReader.TryDecode(result.Bytes, out OfficeRasterImage? decoded));
+            Assert.Equal((1, 1), (decoded!.Width, decoded.Height));
+        }
+
+        [Fact]
+        public void OfficeImageOptimizer_ResultKeepsEncodedBytesImmutable() {
+            byte[] source = OfficePngWriter.Encode(new OfficeRasterImage(8, 8, OfficeColor.SteelBlue));
+            OfficeImageOptimizationResult result = OfficeImageOptimizer.Optimize(
+                source,
+                new OfficeImageOptimizationRequest(4, 4) {
+                    KeepOriginalWhenNotSmaller = false
+                });
+            byte[] first = result.Bytes;
+            byte expected = first[0];
+
+            first[0] ^= 0xFF;
+
+            Assert.Equal(expected, result.Bytes[0]);
         }
 
         private static OfficeRasterImage CreateQuadrantImage(int width, int height) {

--- a/OfficeIMO.Drawing.Tests/Drawing.ImageOptimization.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.ImageOptimization.cs
@@ -1,4 +1,5 @@
 using OfficeIMO.Drawing;
+using System.Security.Cryptography;
 using Xunit;
 
 namespace OfficeIMO.Tests {
@@ -244,6 +245,11 @@ namespace OfficeIMO.Tests {
             Assert.Equal(identified.Height, decoded.Height);
             Assert.True(decoded.Width > 100);
             Assert.True(decoded.Height > 100);
+            using (SHA256 sha256 = SHA256.Create()) {
+                Assert.Equal(
+                    "EA87164A1FF1B2CE978E3C007382CD90AAAC5269078CBA79306FD35972231E0D",
+                    BitConverter.ToString(sha256.ComputeHash(decoded.GetPixels())).Replace("-", string.Empty));
+            }
         }
 
         [Fact]

--- a/OfficeIMO.Drawing.Tests/Drawing.ImageOptimization.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.ImageOptimization.cs
@@ -253,6 +253,22 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void OfficeJpegCodec_DecodesBaselineRestartIntervalsWithoutFastPeekCrossingMarkers() {
+            byte[] jpeg = Convert.FromBase64String(
+                "/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRT/" +
+                "2wBDAQMEBAUEBQkFBQkUDQsNFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBT/wAARCAAQACADAREAAhEBAxEB/" +
+                "8QAFAABAAAAAAAAAAAAAAAAAAAACP/EABQQAQAAAAAAAAAAAAAAAAAAAAD/xAAVAQEBAAAAAAAAAAAAAAAAAAAHCf/EABQRAQAAAAAAAAAAAAAAAAAAAAD/" +
+                "3QAEAAH/2gAMAwEAAhEDEQA/ADoDFU3/0DoDFU3/0ToDFU3/0joDFU3/0zoDFU3/1DoDFU3/1ToDFU3/1joDFU3/2Q==");
+
+            OfficeRasterImage decoded = OfficeJpegCodec.Decode(jpeg);
+
+            Assert.Equal(32, decoded.Width);
+            Assert.Equal(16, decoded.Height);
+            AssertColorNear(decoded.GetPixel(0, 0), OfficeColor.Red, 8);
+            AssertColorNear(decoded.GetPixel(31, 15), OfficeColor.Red, 8);
+        }
+
+        [Fact]
         public void OfficeJpegCodec_FlattensTransparencyAgainstConfiguredBackground() {
             var source = new OfficeRasterImage(8, 8, OfficeColor.FromRgba(255, 0, 0, 128));
 

--- a/OfficeIMO.Drawing.Tests/Drawing.PngWriter.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.PngWriter.cs
@@ -36,6 +36,27 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void OfficePngWriter_AdaptiveFilteringPreservesPixelsAndCompressesStructuredRows() {
+            var image = new OfficeRasterImage(128, 64);
+            for (int y = 0; y < image.Height; y++) {
+                for (int x = 0; x < image.Width; x++) {
+                    image.SetPixel(
+                        x,
+                        y,
+                        OfficeColor.FromRgba((byte)x, (byte)(x + y), (byte)(y * 3), (byte)(128 + (x & 127))));
+                }
+            }
+
+            byte[] optimal = OfficePngWriter.Encode(image, OfficePngCompression.Optimal);
+            byte[] stored = OfficePngWriter.Encode(image, OfficePngCompression.Stored);
+
+            Assert.True(OfficePngReader.TryDecode(optimal, out OfficeRasterImage? decoded));
+            Assert.NotNull(decoded);
+            Assert.Equal(image.GetPixels(), decoded!.GetPixels());
+            Assert.True(optimal.Length < stored.Length / 4, $"Expected adaptive PNG ({optimal.Length}) to be materially smaller than stored PNG ({stored.Length}).");
+        }
+
+        [Fact]
         public void OfficePngWriter_RejectsIndexedColorWithoutPalette() {
             byte[] scanlines = { 0, 0 };
 

--- a/OfficeIMO.Drawing.Tests/Drawing.Raster.Encoding.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.Raster.Encoding.cs
@@ -304,10 +304,38 @@ public sealed class DrawingRasterEncodingTests {
 
         Assert.True(OfficeTiffCodec.TryDecode(chained, out OfficeRasterImage? firstPage));
         Assert.NotNull(firstPage);
+        Assert.True(OfficeTiffCodec.TryGetPageCount(chained, out int pageCount));
+        Assert.Equal(2, pageCount);
+
+        Assert.True(OfficeRasterImageDecoder.TryDecode(
+            chained,
+            options: null,
+            out OfficeRasterImage? selectedPage,
+            out OfficeRasterDecodeInfo selectedInfo));
+        Assert.NotNull(selectedPage);
+        Assert.Equal(2, selectedInfo.FrameCount);
+        Assert.True(selectedInfo.AnimationDiscarded);
+
+        var rejectFrameLoss = new OfficeRasterDecodeOptions {
+            AnimationPolicy = OfficeRasterAnimationPolicy.RejectAnimated
+        };
+        Assert.False(OfficeRasterImageDecoder.TryDecode(
+            chained,
+            rejectFrameLoss,
+            out OfficeRasterImage? rejectedPage,
+            out OfficeRasterDecodeInfo rejectedInfo));
+        Assert.Null(rejectedPage);
+        Assert.Equal(2, rejectedInfo.FrameCount);
+
+        OfficeImageOptimizationResult optimization = OfficeImageOptimizer.Optimize(
+            chained,
+            new OfficeImageOptimizationRequest(1, 1) { KeepOriginalWhenNotSmaller = false });
+        Assert.Equal(OfficeImageOptimizationStatus.DecodeFailed, optimization.Status);
 
         byte[] cyclic = (byte[])first.Clone();
         WriteLittleEndian(cyclic, firstNextIfdPointerOffset, firstIfdOffset);
         Assert.False(OfficeTiffCodec.TryDecode(cyclic, out _));
+        Assert.False(OfficeTiffCodec.TryGetPageCount(cyclic, out _));
 
         byte[] truncated = chained.Take(chained.Length - 1).ToArray();
         Assert.False(OfficeTiffCodec.TryDecode(truncated, out OfficeRasterImage? partial));

--- a/OfficeIMO.Visio.Tests/Visio.PngExport.cs
+++ b/OfficeIMO.Visio.Tests/Visio.PngExport.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.IO.Compression;
 using System.Xml.Linq;
 using OfficeIMO.Drawing;
 using OfficeIMO.Visio;
@@ -2513,46 +2512,9 @@ namespace OfficeIMO.Tests {
             (bytes[offset] << 24) | (bytes[offset + 1] << 16) | (bytes[offset + 2] << 8) | bytes[offset + 3];
 
         private static RgbaPng DecodeRgbaPng(byte[] bytes) {
-            AssertPngSignature(bytes);
-            int width = 0;
-            int height = 0;
-            using MemoryStream idat = new();
-            int offset = 8;
-            while (offset < bytes.Length) {
-                int length = ReadBigEndianInt32(bytes, offset);
-                string type = System.Text.Encoding.ASCII.GetString(bytes, offset + 4, 4);
-                int dataOffset = offset + 8;
-                if (type == "IHDR") {
-                    width = ReadBigEndianInt32(bytes, dataOffset);
-                    height = ReadBigEndianInt32(bytes, dataOffset + 4);
-                    Assert.Equal(8, bytes[dataOffset + 8]);
-                    Assert.Equal(6, bytes[dataOffset + 9]);
-                } else if (type == "IDAT") {
-                    idat.Write(bytes, dataOffset, length);
-                } else if (type == "IEND") {
-                    break;
-                }
-
-                offset = dataOffset + length + 4;
-            }
-
-            byte[] compressed = idat.ToArray();
-            using MemoryStream source = new(compressed, 2, compressed.Length - 6);
-            using DeflateStream deflate = new(source, CompressionMode.Decompress);
-            using MemoryStream inflated = new();
-            deflate.CopyTo(inflated);
-            byte[] scanlines = inflated.ToArray();
-            byte[] rgba = new byte[width * height * 4];
-            int sourceOffset = 0;
-            int targetOffset = 0;
-            for (int y = 0; y < height; y++) {
-                Assert.Equal(0, scanlines[sourceOffset++]);
-                Buffer.BlockCopy(scanlines, sourceOffset, rgba, targetOffset, width * 4);
-                sourceOffset += width * 4;
-                targetOffset += width * 4;
-            }
-
-            return new RgbaPng(width, height, rgba);
+            Assert.True(OfficePngReader.TryDecode(bytes, out OfficeRasterImage? decoded));
+            Assert.NotNull(decoded);
+            return new RgbaPng(decoded!.Width, decoded.Height, decoded.GetPixels());
         }
 
         private static byte[] RenderStyledItalicText(bool italic) {

--- a/OfficeIMO.sln
+++ b/OfficeIMO.sln
@@ -354,6 +354,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Latex.Pdf", "Offi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Pdf.Benchmarks", "OfficeIMO.Pdf.Benchmarks\OfficeIMO.Pdf.Benchmarks.csproj", "{F0ABCF0D-01C1-4D74-B840-78D0D67E7158}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Drawing.Benchmarks", "OfficeIMO.Drawing.Benchmarks\OfficeIMO.Drawing.Benchmarks.csproj", "{2F621DD7-97BB-4B48-911D-6D0B39A1839B}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.PowerPoint.Benchmarks", "OfficeIMO.PowerPoint.Benchmarks\OfficeIMO.PowerPoint.Benchmarks.csproj", "{E98A2407-9B37-429F-B9DD-9E4CEE696148}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Reader.Email", "OfficeIMO.Reader.Email\OfficeIMO.Reader.Email.csproj", "{827DCC08-592F-464E-989D-0E2122B045B0}"
@@ -1858,6 +1860,18 @@ Global
 		{F0ABCF0D-01C1-4D74-B840-78D0D67E7158}.Release|x64.Build.0 = Release|Any CPU
 		{F0ABCF0D-01C1-4D74-B840-78D0D67E7158}.Release|x86.ActiveCfg = Release|Any CPU
 		{F0ABCF0D-01C1-4D74-B840-78D0D67E7158}.Release|x86.Build.0 = Release|Any CPU
+		{2F621DD7-97BB-4B48-911D-6D0B39A1839B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2F621DD7-97BB-4B48-911D-6D0B39A1839B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2F621DD7-97BB-4B48-911D-6D0B39A1839B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2F621DD7-97BB-4B48-911D-6D0B39A1839B}.Debug|x64.Build.0 = Debug|Any CPU
+		{2F621DD7-97BB-4B48-911D-6D0B39A1839B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2F621DD7-97BB-4B48-911D-6D0B39A1839B}.Debug|x86.Build.0 = Debug|Any CPU
+		{2F621DD7-97BB-4B48-911D-6D0B39A1839B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2F621DD7-97BB-4B48-911D-6D0B39A1839B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2F621DD7-97BB-4B48-911D-6D0B39A1839B}.Release|x64.ActiveCfg = Release|Any CPU
+		{2F621DD7-97BB-4B48-911D-6D0B39A1839B}.Release|x64.Build.0 = Release|Any CPU
+		{2F621DD7-97BB-4B48-911D-6D0B39A1839B}.Release|x86.ActiveCfg = Release|Any CPU
+		{2F621DD7-97BB-4B48-911D-6D0B39A1839B}.Release|x86.Build.0 = Release|Any CPU
 		{E98A2407-9B37-429F-B9DD-9E4CEE696148}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E98A2407-9B37-429F-B9DD-9E4CEE696148}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E98A2407-9B37-429F-B9DD-9E4CEE696148}.Debug|x64.ActiveCfg = Debug|Any CPU

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Every checked item below is implemented today. Detailed behavior, examples, and 
 - [x] Dependency-free TIFF output with uncompressed, PackBits, or Deflate strips and deterministic lossless WebP encoding with common raster export options
 - [x] Shared SVG primitive writing and scalable drawing export
 - [x] Single and batch image-export builders with dimensions, source metadata, and diagnostics
+- [x] Reproducible, output-validated identification, decode, encode, resize, and placement-optimization benchmarks with opt-in library comparisons isolated from runtime packages
 
 _Dependency footprint:_ zero third-party runtime dependencies.
 


### PR DESCRIPTION
## Summary

- Expand the managed optimizer across static PNG, JPEG, GIF, BMP, TIFF, and WebP input, with PNG, JPEG, TIFF, and WebP output.
- Preserve correctness through explicit frame-loss policy, destination-safe DPI handling, immutable results, and re-identification of encoded candidates.
- Reduce large transient allocations in PNG, TIFF PackBits, and literal-lossless WebP encoding.
- Add validated size, fidelity, allocation, conversion, and opt-in library-comparison evidence at representative image sizes.

## Correctness and conversions

- Validates all 24 static routes from PNG/JPEG/TIFF/WebP/BMP/GIF input to PNG/JPEG/TIFF/WebP output.
- Requires exact pixels for lossless routes and reports JPEG MAE/PSNR for lossy routes.
- Rejects animated input and multi-page TIFF when optimization would silently discard frames or pages.
- Preserves source DPI when representable, clamps it to destination metadata limits otherwise, and supports explicit output-DPI overrides.
- Exposes PNG compression, JPEG subsampling/progressive/Huffman options, and TIFF compression without forcing one quality/size policy as the universal default.
- Documents the public optimizer workflow and multi-page TIFF frame-loss boundary in the owning package README.

## Allocation and size evidence

BenchmarkDotNet managed allocations at 1024x1024 showed these coarse improvements:

| Encoder | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| PNG optimal | 4,779 KB | 750 KB | ~84% |
| TIFF PackBits | 20,542 KB | 4,127 KB | ~80% |
| WebP literal lossless | 24,578 KB | 4,097 KB | ~83% |

Representative encoded-size validation at 1024x1024:

| Policy | Bytes | Fidelity |
| --- | ---: | --- |
| PNG optimal | 87,668 | exact |
| JPEG Q85 4:4:4 | 784,272 | MAE 6.320 / PSNR 29.07 |
| JPEG Q85 4:2:0 | 474,093 | MAE 11.523 / PSNR 22.44 |
| JPEG Q85 4:2:0 progressive + optimized Huffman | 454,448 | MAE 11.523 / PSNR 22.44 |
| TIFF PackBits | 4,225,370 | exact |
| TIFF Deflate | 1,074,156 | exact |
| WebP literal lossless | 4,194,480 | exact |

Literal WebP remains deliberately simple and near raw size; it is a correctness-oriented managed baseline, not yet a compression-efficiency claim.

## Timing interpretation

Comparative workloads remain pinned to logical processors 0-15 (`0xFFFF`) on the Ryzen 9 9950X3D2. The host still exhibits multimodal timing, so only large, repeatable effect sizes are treated as actionable. Managed allocation columns are not presented as total-memory comparisons against native engines.

## Validation

- 1,484/1,484 `OfficeIMO.Drawing.Tests` passed on .NET 10, .NET 8, and .NET Framework 4.7.2 after the final rebase.
- First-party corpus, encoding-size/fidelity, and static-conversion validation passed on .NET 10 and .NET 8.
- Opt-in comparison validation passed on .NET 10 and .NET 8: decode lanes materialize the same managed RGBA output shape, PNG pixels/round-trip are exact, JPEG decoder differences are bounded, and resize output is equivalent.
- Independent review confirmed the multi-page TIFF and destination-DPI fixes; the adjacent single-page TIFF preflight allocation regression was also removed and revalidated.

## Dependency and predecessor

PR #2381 is merged, and this branch is rebased onto its merge result. This PR supersedes #2382, which GitHub automatically closed when #2381's head branch was deleted and would not allow to be retargeted or reopened.
