### PR TITLE
Fix AES protection for PDFs with embedded fonts

### DIFF
--- a/OfficeIMO.Pdf.Tests/Pdf/PdfAdapterSecurityComplianceTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfAdapterSecurityComplianceTests.cs
@@ -143,6 +143,28 @@ public class PdfAdapterSecurityComplianceTests {
         Assert.Contains("encryption", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Theory]
+    [InlineData(PdfCore.PdfStandardEncryptionAlgorithm.Aes128)]
+    [InlineData(PdfCore.PdfStandardEncryptionAlgorithm.Aes256)]
+    public void GeneratedPdfA2BArtifactCanBeProtectedAndUnlockedAfterCreation(PdfCore.PdfStandardEncryptionAlgorithm algorithm) {
+        byte[] archivalPdf = Convert("html", CreatePdfA2BOptions());
+        var encryption = new PdfCore.PdfStandardEncryptionOptions("open") {
+            OwnerPassword = "owner",
+            Algorithm = algorithm,
+            AesCryptographyProvider = OfficeIMO.Security.OfficeManagedAesCryptographyProvider.Default
+        };
+
+        PdfCore.PdfSecurityMutationResult protectedPdf = PdfCore.PdfDocument.Open(archivalPdf).Security.Encrypt(encryption);
+        PdfCore.PdfSecurityMutationResult unlockedPdf = protectedPdf.ToDocument().Security.Decrypt("owner");
+
+        Assert.True(PdfCore.PdfInspector.Probe(protectedPdf.Pdf).HasEncryption);
+        Assert.False(PdfCore.PdfInspector.Probe(unlockedPdf.Pdf).HasEncryption);
+        Assert.Contains(
+            Marker("html"),
+            PdfCore.PdfReadDocument.Open(unlockedPdf.Pdf).ExtractText(),
+            StringComparison.Ordinal);
+    }
+
     private static PdfCore.PdfOptions CreatePdfA2BOptions() {
         string? fontPath = PdfComplianceTestFonts.FindBundledOpenTypeCffFont();
         Assert.NotNull(fontPath);

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfStandardSecurityWriter.Aes128.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfStandardSecurityWriter.Aes128.cs
@@ -181,7 +181,22 @@ internal static partial class PdfStandardSecurityWriter {
 
     private static byte[] ReplaceDirectStreamLength(byte[] prefix, int encryptedLength) {
         byte[] marker = PdfEncoding.Latin1GetBytes("/Length");
-        int markerIndex = IndexOf(prefix, marker, 0);
+        int markerIndex = -1;
+        int searchStart = 0;
+        while (searchStart < prefix.Length) {
+            int candidate = IndexOf(prefix, marker, searchStart);
+            if (candidate < 0) {
+                break;
+            }
+
+            int afterMarker = candidate + marker.Length;
+            if (afterMarker < prefix.Length && IsWhiteSpace(prefix[afterMarker])) {
+                markerIndex = candidate;
+            }
+
+            searchStart = afterMarker;
+        }
+
         if (markerIndex < 0) {
             throw new InvalidOperationException("AES-encrypted PDF streams require a direct /Length entry.");
         }

--- a/Website/Apps/OfficeIMO.Web.Converter.Tests/BrowserPdfToolServiceTests.cs
+++ b/Website/Apps/OfficeIMO.Web.Converter.Tests/BrowserPdfToolServiceTests.cs
@@ -108,6 +108,36 @@ public sealed class BrowserPdfToolServiceTests {
     }
 
     [Fact]
+    public void ProtectAndUnlock_RoundTripJapaneseArchivalArtifact() {
+        const string japanese = "日本語の保存版を東京都で確認します。";
+        var conversions = new BrowserConversionService();
+        ConversionResult archival = conversions.ConvertText(
+            ConversionRouteCatalog.Find("html-pdf"),
+            $"<article lang='ja'><h1>日本語の保存版</h1><p>{japanese}</p></article>",
+            BrowserPdfProfileCatalog.Archival);
+
+        PdfToolResult protectedPdf = _service.Execute(Request(
+            "protect",
+            [Document(archival.Bytes, archival.FileName)],
+            userPassword: "reader-2026",
+            ownerPassword: "owner-2026"));
+        PdfToolResult unlocked = _service.Execute(Request(
+            "unlock",
+            [Document(protectedPdf.Artifact.Bytes, protectedPdf.Artifact.FileName)],
+            ownerPassword: "owner-2026"));
+
+        PdfDocumentPreflight protectedPreflight = PdfDocument.Preflight(protectedPdf.Artifact.Bytes, new PdfReadOptions {
+            Password = "reader-2026",
+            AesCryptographyProvider = OfficeManagedAesCryptographyProvider.Default
+        });
+        Assert.True(protectedPreflight.Probe.Security.HasEncryption);
+        Assert.Equal(6, protectedPreflight.Probe.Security.EncryptionRevision);
+        Assert.Equal(256, protectedPreflight.Probe.Security.EncryptionLengthBits);
+        Assert.False(PdfDocument.Preflight(unlocked.Artifact.Bytes).Probe.Security.HasEncryption);
+        Assert.Contains(japanese, PdfReadDocument.Open(unlocked.Artifact.Bytes).ExtractText(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Redact_RemovesAndVerifiesLiteralMarker() {
         const string marker = "PAY-SECRET-2026";
         PdfToolResult result = _service.Execute(Request(


### PR DESCRIPTION
## Summary

- targets the real PDF stream `/Length` entry without mistaking embedded-font `/Length1` metadata for it
- restores AES-128 and AES-256 protection and owner-password removal for PDFs with embedded OpenType/CFF fonts
- covers the deployed browser workflow from Japanese archival PDF/A-2B generation through AES-256 protection and owner-password removal

## Why

AES protection rewrites stream lengths after adding the IV and CBC padding. Embedded font dictionaries carry both `/Length1` and `/Length`; matching the prefix inside `/Length1` left the real encrypted stream length stale, so protected archival PDFs could not be read back.

## Validation

- focused encryption, security editor, adapter, and provider tests: 79/79 on .NET 8, .NET 10, and .NET Framework 4.7.2
- browser PDF workbench tests: 11/11 on .NET 10
- exact Japanese archival PDF/A-2B to AES-256 protect and owner-password removal regression: passed
- independent read-only review: no P0-P3 findings

The website consumes repository source and will receive this fix through its deployment after merge. Public NuGet consumers will receive the shared engine fix in the next normal OfficeIMO package release.