### PR TITLE
Preserve Word layout overflow in PDF exports

### DIFF
--- a/OfficeIMO.Excel.Tests/Pdf/Excel.SaveAsPdf.OptionsWarningTests.cs
+++ b/OfficeIMO.Excel.Tests/Pdf/Excel.SaveAsPdf.OptionsWarningTests.cs
@@ -87,7 +87,6 @@ public partial class Excel {
         Assert.Contains(result.Warnings, warning => warning.Source == "Warnings" && warning.Code == "WorksheetHeaderFooterFormatting");
         Assert.Contains(result.Warnings, warning => warning.Source == "Warnings" && warning.Code == "WorksheetRows");
         Assert.Contains(result.Warnings, warning => warning.Source == "Warnings" && warning.Code == "WorksheetChart" && warning.Message.Contains("Surface", StringComparison.Ordinal));
-        Assert.All(result.Warnings, warning => Assert.Equal("Warnings", warning.Source));
         Assert.True(saveResult.Succeeded);
         Assert.Contains(saveResult.Warnings, warning => warning.Source == "Warnings" && warning.Code == "WorksheetHeaderFooterFormatting");
         Assert.Contains(saveResult.Warnings, warning => warning.Source == "Warnings" && warning.Code == "WorksheetRows");

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfComposePageHeaderFooterRenderingTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfComposePageHeaderFooterRenderingTests.cs
@@ -754,6 +754,134 @@ namespace OfficeIMO.Tests.Pdf {
         }
 
         [Fact]
+        public void HeaderFooterShapeShadowUsesVisibleBoundsForClippingDiagnostics() {
+            OfficeShape shape = OfficeShape.Rectangle(24, 12);
+            shape.FillColor = OfficeColor.Blue;
+            shape.Shadow = new OfficeShadow(OfficeColor.Black, 0.5D, 45D, 0D);
+            var report = new PdfConversionReport();
+            var options = new PdfOptions {
+                PageWidth = 260,
+                PageHeight = 220,
+                MarginLeft = 40,
+                MarginRight = 40,
+                MarginTop = 50,
+                MarginBottom = 50
+            }.ReportDiagnosticsTo(report, "OfficeIMO.Tests");
+
+            byte[] bytes = PdfDocument.Create(options)
+                .Header(header => header.Shape(shape, PdfAlign.Right))
+                .Paragraph(paragraph => paragraph.Text("Header shape shadow diagnostic body"))
+                .ToBytes();
+
+            Assert.NotEmpty(bytes);
+            PdfConversionWarning warning = Assert.Single(report.Warnings, warning =>
+                warning.Code == "HeaderFooterPageBoundsClipped" &&
+                warning.Source == "Header");
+            Assert.Equal(PdfLayoutDiagnosticKind.ClippedContent, warning.LayoutDiagnostic?.Kind);
+            Assert.InRange(warning.LayoutDiagnostic?.X ?? 0D, 195.999D, 196.001D);
+            Assert.InRange(warning.LayoutDiagnostic?.Width ?? 0D, 68.999D, 69.001D);
+            Assert.True(report.HasLoss);
+        }
+
+        [Fact]
+        public void HeaderFooterShapeStrokeUsesVisibleBoundsForClippingDiagnostics() {
+            OfficeShape shape = OfficeShape.Rectangle(24, 12);
+            shape.FillColor = OfficeColor.Blue;
+            shape.StrokeColor = OfficeColor.Black;
+            shape.StrokeWidth = 4;
+            var report = new PdfConversionReport();
+            var options = new PdfOptions {
+                PageWidth = 260,
+                PageHeight = 220,
+                MarginLeft = 1,
+                MarginRight = 40,
+                MarginTop = 50,
+                MarginBottom = 50
+            }.ReportDiagnosticsTo(report, "OfficeIMO.Tests");
+
+            byte[] bytes = PdfDocument.Create(options)
+                .Header(header => header.Shape(shape, PdfAlign.Left))
+                .Paragraph(paragraph => paragraph.Text("Header shape stroke diagnostic body"))
+                .ToBytes();
+
+            Assert.NotEmpty(bytes);
+            PdfConversionWarning warning = Assert.Single(report.Warnings, warning =>
+                warning.Code == "HeaderFooterPageBoundsClipped" &&
+                warning.Source == "Header");
+            Assert.Equal(PdfLayoutDiagnosticKind.ClippedContent, warning.LayoutDiagnostic?.Kind);
+            Assert.InRange(warning.LayoutDiagnostic?.X ?? 0D, -1.001D, -0.999D);
+            Assert.InRange(warning.LayoutDiagnostic?.Width ?? 0D, 27.999D, 28.001D);
+            Assert.True(report.HasLoss);
+        }
+
+        [Fact]
+        public void HeaderFooterShapeMiterAndShadowUseVisibleBoundsForClippingDiagnostics() {
+            OfficeShape shape = OfficeShape.Polygon(
+                new OfficePoint(0, 0),
+                new OfficePoint(100, 1),
+                new OfficePoint(0, 2));
+            shape.StrokeColor = OfficeColor.Black;
+            shape.StrokeWidth = 4;
+            shape.StrokeLineJoin = OfficeStrokeLineJoin.Miter;
+            shape.Shadow = new OfficeShadow(OfficeColor.Black, 0.5D, 30D, 0D);
+            var report = new PdfConversionReport();
+            var options = new PdfOptions {
+                PageWidth = 260,
+                PageHeight = 220,
+                MarginLeft = 40,
+                MarginRight = 40,
+                MarginTop = 50,
+                MarginBottom = 50
+            }.ReportDiagnosticsTo(report, "OfficeIMO.Tests");
+
+            byte[] bytes = PdfDocument.Create(options)
+                .Header(header => header.Shape(shape, PdfAlign.Right))
+                .Paragraph(paragraph => paragraph.Text("Header miter shadow diagnostic body"))
+                .ToBytes();
+
+            Assert.NotEmpty(bytes);
+            PdfConversionWarning warning = Assert.Single(report.Warnings, warning =>
+                warning.Code == "HeaderFooterPageBoundsClipped" &&
+                warning.Source == "Header");
+            Assert.Equal(PdfLayoutDiagnosticKind.ClippedContent, warning.LayoutDiagnostic?.Kind);
+            Assert.True((warning.LayoutDiagnostic?.X ?? 0D) + (warning.LayoutDiagnostic?.Width ?? 0D) > options.PageWidth);
+            Assert.True(report.HasLoss);
+        }
+
+        [Fact]
+        public void HeaderFooterUnpaintedAndEmptyClippedShapesDoNotReportVisibleBounds() {
+            OfficeShape unpaintedLine = OfficeShape.Line(0, 0, 24, 12);
+            unpaintedLine.Transform = OfficeTransform.Translate(300D, 0D);
+            OfficeShape emptyClippedShape = OfficeShape.Rectangle(24, 12);
+            emptyClippedShape.FillColor = OfficeColor.Blue;
+            emptyClippedShape.ClipPath = OfficeClipPath.Empty();
+            emptyClippedShape.Shadow = new OfficeShadow(OfficeColor.Black, 0.5D, 300D, 0D);
+            var report = new PdfConversionReport();
+            var options = new PdfOptions {
+                PageWidth = 260,
+                PageHeight = 220,
+                MarginLeft = 40,
+                MarginRight = 40,
+                MarginTop = 50,
+                MarginBottom = 50
+            }.ReportDiagnosticsTo(report, "OfficeIMO.Tests");
+
+            byte[] bytes = PdfDocument.Create(options)
+                .Header(header => header
+                    .Shape(unpaintedLine, PdfAlign.Left)
+                    .Shape(emptyClippedShape, PdfAlign.Right))
+                .Paragraph(paragraph => paragraph.Text("Header invisible shape diagnostic body"))
+                .ToBytes();
+
+            Assert.NotEmpty(bytes);
+            Assert.DoesNotContain(report.Warnings, warning =>
+                warning.Code == "HeaderFooterPageBoundsClipped" ||
+                warning.Code == "HeaderFooterContentOverflow" ||
+                warning.Code == "HeaderFooterZoneOverlap");
+            Assert.False(report.HasLoss);
+        }
+
+        [Fact]
         public void HeaderFooterImageBeyondPhysicalPageReportsClipping() {
             byte[] png = CreateMinimalRgbPng();
             var report = new PdfConversionReport();
@@ -800,6 +928,59 @@ namespace OfficeIMO.Tests.Pdf {
             Assert.NotEmpty(bytes);
             Assert.DoesNotContain(report.Warnings, warning => warning.Code == "HeaderFooterContentOverflow");
             Assert.DoesNotContain(report.Warnings, warning => warning.Code == "HeaderFooterPageBoundsClipped");
+            Assert.False(report.HasLoss);
+        }
+
+        [Fact]
+        public void HeaderFooterZonedContainedImageUsesVisibleBoundsForClippingDiagnostics() {
+            byte[] portraitPng = PdfPngTestImages.CreateRgbPng(1, 4);
+            var report = new PdfConversionReport();
+            var options = new PdfOptions {
+                PageWidth = 260,
+                PageHeight = 220,
+                MarginLeft = 80,
+                MarginRight = 80,
+                MarginTop = 50,
+                MarginBottom = 50
+            }.ReportDiagnosticsTo(report, "OfficeIMO.Tests");
+
+            byte[] bytes = PdfDocument.Create(options)
+                .Header(header => header
+                    .Zones("H", null, null)
+                    .Image(portraitPng, 300, 20, PdfAlign.Left, OfficeImageFit.Contain))
+                .Paragraph(paragraph => paragraph.Text("Contained zoned header image body"))
+                .ToBytes();
+
+            Assert.NotEmpty(bytes);
+            Assert.DoesNotContain(report.Warnings, warning => warning.Code == "HeaderFooterPageBoundsClipped");
+            Assert.False(report.HasLoss);
+        }
+
+        [Fact]
+        public void HeaderFooterVisualOnlyGroupsReportOverlap() {
+            byte[] png = CreateMinimalRgbPng();
+            var report = new PdfConversionReport();
+            var options = new PdfOptions {
+                PageWidth = 260,
+                PageHeight = 220,
+                MarginLeft = 40,
+                MarginRight = 40,
+                MarginTop = 50,
+                MarginBottom = 50
+            }.ReportDiagnosticsTo(report, "OfficeIMO.Tests");
+
+            byte[] bytes = PdfDocument.Create(options)
+                .Header(header => header
+                    .Image(png, 120, 14, PdfAlign.Left)
+                    .Image(png, 120, 14, PdfAlign.Center))
+                .Paragraph(paragraph => paragraph.Text("Visual-only header overlap body"))
+                .ToBytes();
+
+            Assert.NotEmpty(bytes);
+            Assert.Contains(report.Warnings, warning =>
+                warning.Code == "HeaderFooterZoneOverlap" &&
+                warning.Source == "Header" &&
+                warning.Severity == PdfConversionWarningSeverity.Information);
             Assert.False(report.HasLoss);
         }
 

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfComposePageHeaderFooterRenderingTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfComposePageHeaderFooterRenderingTests.cs
@@ -562,6 +562,60 @@ namespace OfficeIMO.Tests.Pdf {
         }
 
         [Fact]
+        public void HeaderFooterRichTextDecorationsUsePaintedVerticalBoundsForClippingDiagnostics() {
+            var backgroundReport = new PdfConversionReport();
+            var backgroundOptions = new PdfOptions {
+                PageWidth = 260,
+                PageHeight = 220,
+                MarginLeft = 40,
+                MarginRight = 40,
+                MarginTop = 10,
+                MarginBottom = 40,
+                HeaderOffsetY = 1,
+                HeaderFontSize = 12
+            }.ReportDiagnosticsTo(backgroundReport, "OfficeIMO.Tests");
+
+            byte[] backgroundBytes = PdfDocument.Create(backgroundOptions)
+                .Header(header => header.Text(text => text.Run(PdfTextRun.Normal(
+                    "HeaderBackgroundClip",
+                    fontSize: 12,
+                    backgroundColor: PdfColor.FromRgb(255, 255, 0)))))
+                .Paragraph(paragraph => paragraph.Text("Header decoration diagnostic body"))
+                .ToBytes();
+
+            var underlineReport = new PdfConversionReport();
+            var underlineOptions = new PdfOptions {
+                PageWidth = 260,
+                PageHeight = 220,
+                MarginLeft = 40,
+                MarginRight = 40,
+                MarginTop = 40,
+                MarginBottom = 1,
+                FooterOffsetY = 0,
+                FooterFontSize = 1
+            }.ReportDiagnosticsTo(underlineReport, "OfficeIMO.Tests");
+
+            byte[] underlineBytes = PdfDocument.Create(underlineOptions)
+                .Footer(footer => footer.Text(text => text.Run(PdfTextRun.Underlined("FooterUnderlineClip", fontSize: 1))))
+                .Paragraph(paragraph => paragraph.Text("Footer decoration diagnostic body"))
+                .ToBytes();
+
+            Assert.NotEmpty(backgroundBytes);
+            Assert.Contains(backgroundReport.Warnings, warning =>
+                warning.Code == "HeaderFooterPageBoundsClipped" &&
+                warning.Source == "Header" &&
+                (warning.LayoutDiagnostic?.Y ?? 0D) + (warning.LayoutDiagnostic?.Height ?? 0D) > backgroundOptions.PageHeight);
+            Assert.True(backgroundReport.HasLoss);
+
+            Assert.NotEmpty(underlineBytes);
+            Assert.Contains(underlineReport.Warnings, warning =>
+                warning.Code == "HeaderFooterPageBoundsClipped" &&
+                warning.Source == "Footer" &&
+                warning.LayoutDiagnostic?.Y < 0D);
+            Assert.True(underlineReport.HasLoss);
+        }
+
+        [Fact]
         public void HeaderFooterZones_CanConfigureFirstAndEvenPageVariants() {
             var doc = PdfDocument.Create(new PdfOptions {
                     HeaderFont = PdfStandardFont.Helvetica,
@@ -753,13 +807,47 @@ namespace OfficeIMO.Tests.Pdf {
             Assert.True(report.HasLoss);
         }
 
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void HeaderFooterShapeClipBoundsConstrainBaseGeometryDiagnostics(bool transformed) {
+            OfficeShape shape = OfficeShape.Rectangle(300, 12);
+            shape.FillColor = OfficeColor.Blue;
+            shape.ClipPath = OfficeClipPath.Rectangle(20, 12);
+            if (transformed) {
+                shape.Transform = OfficeTransform.Translate(5D, 0D);
+            }
+
+            var report = new PdfConversionReport();
+            var options = new PdfOptions {
+                PageWidth = 260,
+                PageHeight = 220,
+                MarginLeft = 40,
+                MarginRight = 40,
+                MarginTop = 50,
+                MarginBottom = 50
+            }.ReportDiagnosticsTo(report, "OfficeIMO.Tests");
+
+            byte[] bytes = PdfDocument.Create(options)
+                .Header(header => header.Shape(shape, PdfAlign.Left))
+                .Paragraph(paragraph => paragraph.Text("Header shape clip diagnostic body"))
+                .ToBytes();
+
+            Assert.NotEmpty(bytes);
+            Assert.DoesNotContain(report.Warnings, warning => warning.Code == "HeaderFooterPageBoundsClipped");
+            Assert.False(report.HasLoss);
+        }
+
         [Fact]
         public void HeaderFooterShapeShadowUsesVisibleBoundsForClippingDiagnostics() {
             OfficeShape shape = OfficeShape.Rectangle(24, 12);
             shape.FillColor = OfficeColor.Blue;
+            shape.ClipPath = OfficeClipPath.Rectangle(12, 12);
+            shape.Transform = OfficeTransform.Identity;
             shape.Shadow = new OfficeShadow(OfficeColor.Black, 0.5D, 45D, 0D);
             var report = new PdfConversionReport();
             var options = new PdfOptions {
+                CompressContentStreams = false,
                 PageWidth = 260,
                 PageHeight = 220,
                 MarginLeft = 40,
@@ -774,6 +862,8 @@ namespace OfficeIMO.Tests.Pdf {
                 .ToBytes();
 
             Assert.NotEmpty(bytes);
+            string rawPdf = Encoding.ASCII.GetString(bytes);
+            Assert.Equal(1, CountOccurrences(rawPdf, "0 0 12 12 re W n"));
             PdfConversionWarning warning = Assert.Single(report.Warnings, warning =>
                 warning.Code == "HeaderFooterPageBoundsClipped" &&
                 warning.Source == "Header");

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfComposePageHeaderFooterRenderingTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfComposePageHeaderFooterRenderingTests.cs
@@ -430,38 +430,87 @@ namespace OfficeIMO.Tests.Pdf {
         }
 
         [Fact]
-        public void HeaderFooterZones_RejectTextThatWouldOverlap() {
-            var headerException = Assert.Throws<ArgumentException>(() =>
-                PdfDocument.Create(new PdfOptions {
-                        HeaderFont = PdfStandardFont.Helvetica,
-                        HeaderFontSize = 12
-                    })
-                    .Size(260, 260)
-                    .Margin(72)
-                    .Header(header => header.Zones(
-                        "Very long left header zone",
-                        "Very long center header zone",
-                        "Very long right header zone"))
-                    .Paragraph(p => p.Text("Header zone overlap body."))
-                    .ToBytes());
+        public void HeaderFooterZones_PreserveOverflowAndReportLayoutDiagnostics() {
+            var report = new PdfConversionReport();
+            var options = new PdfOptions {
+                HeaderFont = PdfStandardFont.Helvetica,
+                HeaderFontSize = 12,
+                FooterFont = PdfStandardFont.Helvetica,
+                FooterFontSize = 12
+            }.ReportDiagnosticsTo(report, "OfficeIMO.Tests");
 
-            Assert.Contains("PDF header zone content", headerException.Message, StringComparison.Ordinal);
+            byte[] bytes = PdfDocument.Create(options)
+                .Size(260, 260)
+                .Margin(72)
+                .Header(header => header.Zones(
+                    "LeftHeaderOverflowMarker",
+                    "CenterHeaderOverflowMarker",
+                    "RightHeaderOverflowMarker"))
+                .Footer(footer => footer.Zones(
+                    "LeftFooterOverflowMarker",
+                    "CenterFooterOverflowMarker",
+                    "RightFooterOverflowMarker"))
+                .Paragraph(p => p.Text("Header footer overflow body."))
+                .ToBytes();
 
-            var footerException = Assert.Throws<ArgumentException>(() =>
-                PdfDocument.Create(new PdfOptions {
-                        FooterFont = PdfStandardFont.Helvetica,
-                        FooterFontSize = 12
-                    })
-                    .Size(260, 260)
-                    .Margin(72)
-                    .Footer(footer => footer.Zones(
-                        "Very long left footer zone",
-                        "Very long center footer zone",
-                        "Very long right footer zone"))
-                    .Paragraph(p => p.Text("Footer zone overlap body."))
-                    .ToBytes());
+            using var pdf = PdfPigDocument.Open(new MemoryStream(bytes));
+            string pageText = Normalize(pdf.GetPage(1).Text);
+            Assert.Contains("LeftHeaderOverflowMarker", pageText, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("CenterHeaderOverflowMarker", pageText, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("RightHeaderOverflowMarker", pageText, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("LeftFooterOverflowMarker", pageText, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("CenterFooterOverflowMarker", pageText, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("RightFooterOverflowMarker", pageText, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(report.Warnings, warning =>
+                warning.Code == "HeaderFooterContentOverflow" &&
+                warning.Source == "Header" &&
+                warning.Severity == PdfConversionWarningSeverity.Information &&
+                warning.LayoutDiagnostic?.Kind == PdfLayoutDiagnosticKind.Overflow);
+            Assert.Contains(report.Warnings, warning =>
+                warning.Code == "HeaderFooterContentOverflow" &&
+                warning.Source == "Footer" &&
+                warning.Severity == PdfConversionWarningSeverity.Information &&
+                warning.LayoutDiagnostic?.Kind == PdfLayoutDiagnosticKind.Overflow);
+            Assert.Contains(report.Warnings, warning =>
+                warning.Code == "HeaderFooterZoneOverlap" &&
+                warning.Source == "Header");
+            Assert.Contains(report.Warnings, warning =>
+                warning.Code == "HeaderFooterZoneOverlap" &&
+                warning.Source == "Footer");
+            Assert.False(report.HasLoss);
+        }
 
-            Assert.Contains("PDF footer zone content", footerException.Message, StringComparison.Ordinal);
+        [Fact]
+        public void HeaderFooterSingleText_PreservesOverflowWithInformationalDiagnostics() {
+            var report = new PdfConversionReport();
+            var options = new PdfOptions {
+                HeaderFont = PdfStandardFont.Helvetica,
+                HeaderFontSize = 12,
+                FooterFont = PdfStandardFont.Helvetica,
+                FooterFontSize = 12
+            }.ReportDiagnosticsTo(report, "OfficeIMO.Tests");
+
+            byte[] bytes = PdfDocument.Create(options)
+                .Size(260, 260)
+                .Margin(72)
+                .Header(header => header.AlignCenter().Text("SingleHeaderOverflowMarker"))
+                .Footer(footer => footer.AlignRight().Text(text => text.Text("SingleFooterOverflowMarker")))
+                .Paragraph(p => p.Text("Single text overflow body."))
+                .ToBytes();
+
+            using var pdf = PdfPigDocument.Open(new MemoryStream(bytes));
+            string pageText = Normalize(pdf.GetPage(1).Text);
+            Assert.Contains("SingleHeaderOverflowMarker", pageText, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("SingleFooterOverflowMarker", pageText, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(report.Warnings, warning =>
+                warning.Code == "HeaderFooterContentOverflow" &&
+                warning.Source == "Header" &&
+                warning.Severity == PdfConversionWarningSeverity.Information);
+            Assert.Contains(report.Warnings, warning =>
+                warning.Code == "HeaderFooterContentOverflow" &&
+                warning.Source == "Footer" &&
+                warning.Severity == PdfConversionWarningSeverity.Information);
+            Assert.False(report.HasLoss);
         }
 
         [Fact]
@@ -584,6 +633,96 @@ namespace OfficeIMO.Tests.Pdf {
             double textRight = headerLetters.Max(letter => letter.EndBaseLine.X);
             Assert.True(imageX >= textRight + 3.9D, "Aligned header text and images must not overlap.");
             Assert.InRange(Math.Abs((textLeft + imageX + 24D) / 2D - 150D), 0D, 0.1D);
+        }
+
+        [Fact]
+        public void HeaderFooterImagesAndShapes_PreserveMarginOverflowWithDiagnostics() {
+            byte[] png = CreateMinimalRgbPng();
+            OfficeShape footerShape = OfficeShape.Rectangle(160, 12);
+            footerShape.FillColor = OfficeColor.Blue;
+            var report = new PdfConversionReport();
+            var options = new PdfOptions {
+                PageWidth = 260,
+                PageHeight = 220,
+                MarginLeft = 80,
+                MarginRight = 80,
+                MarginTop = 50,
+                MarginBottom = 50,
+                DefaultFont = PdfStandardFont.Helvetica,
+                DefaultFontSize = 10
+            }.ReportDiagnosticsTo(report, "OfficeIMO.Tests");
+
+            byte[] bytes = PdfDocument.Create(options)
+                .Header(header => header.Image(png, 150, 14, PdfAlign.Center))
+                .Footer(footer => footer.Shape(footerShape, PdfAlign.Right))
+                .Paragraph(paragraph => paragraph.Text("Header footer visual overflow body"))
+                .ToBytes();
+
+            string rawPdf = Encoding.ASCII.GetString(bytes);
+            Assert.Contains("150 0 0 14 55 174 cm", rawPdf, StringComparison.Ordinal);
+            Assert.Contains("20 32 160 12 re", rawPdf, StringComparison.Ordinal);
+            Assert.Contains(report.Warnings, warning =>
+                warning.Code == "HeaderFooterContentOverflow" &&
+                warning.Source == "Header" &&
+                warning.Severity == PdfConversionWarningSeverity.Information &&
+                warning.LayoutDiagnostic?.Kind == PdfLayoutDiagnosticKind.Overflow);
+            Assert.Contains(report.Warnings, warning =>
+                warning.Code == "HeaderFooterContentOverflow" &&
+                warning.Source == "Footer" &&
+                warning.Severity == PdfConversionWarningSeverity.Information &&
+                warning.LayoutDiagnostic?.Kind == PdfLayoutDiagnosticKind.Overflow);
+            Assert.DoesNotContain(report.Warnings, warning => warning.Code == "HeaderFooterPageBoundsClipped");
+            Assert.False(report.HasLoss);
+        }
+
+        [Fact]
+        public void HeaderFooterImageBeyondPhysicalPageReportsClipping() {
+            byte[] png = CreateMinimalRgbPng();
+            var report = new PdfConversionReport();
+            var options = new PdfOptions {
+                PageWidth = 260,
+                PageHeight = 220,
+                MarginLeft = 80,
+                MarginRight = 80,
+                MarginTop = 50,
+                MarginBottom = 50
+            }.ReportDiagnosticsTo(report, "OfficeIMO.Tests");
+
+            byte[] bytes = PdfDocument.Create(options)
+                .Header(header => header.Image(png, 300, 14, PdfAlign.Center))
+                .Paragraph(paragraph => paragraph.Text("Physical page clipping diagnostic body"))
+                .ToBytes();
+
+            Assert.NotEmpty(bytes);
+            Assert.Contains(report.Warnings, warning =>
+                warning.Code == "HeaderFooterPageBoundsClipped" &&
+                warning.Source == "Header" &&
+                warning.LayoutDiagnostic?.Kind == PdfLayoutDiagnosticKind.ClippedContent);
+            Assert.True(report.HasLoss);
+        }
+
+        [Fact]
+        public void HeaderFooterContainedImageUsesVisibleBoundsForClippingDiagnostics() {
+            byte[] portraitPng = PdfPngTestImages.CreateRgbPng(1, 4);
+            var report = new PdfConversionReport();
+            var options = new PdfOptions {
+                PageWidth = 260,
+                PageHeight = 220,
+                MarginLeft = 80,
+                MarginRight = 80,
+                MarginTop = 50,
+                MarginBottom = 50
+            }.ReportDiagnosticsTo(report, "OfficeIMO.Tests");
+
+            byte[] bytes = PdfDocument.Create(options)
+                .Header(header => header.Image(portraitPng, 300, 20, PdfAlign.Center, OfficeImageFit.Contain))
+                .Paragraph(paragraph => paragraph.Text("Contained header image body"))
+                .ToBytes();
+
+            Assert.NotEmpty(bytes);
+            Assert.DoesNotContain(report.Warnings, warning => warning.Code == "HeaderFooterContentOverflow");
+            Assert.DoesNotContain(report.Warnings, warning => warning.Code == "HeaderFooterPageBoundsClipped");
+            Assert.False(report.HasLoss);
         }
 
         [Fact]

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfComposePageHeaderFooterRenderingTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfComposePageHeaderFooterRenderingTests.cs
@@ -513,6 +513,54 @@ namespace OfficeIMO.Tests.Pdf {
             Assert.False(report.HasLoss);
         }
 
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void HeaderFooterTextBeyondPhysicalPageReportsVerticalClipping(bool useZones) {
+            var report = new PdfConversionReport();
+            var options = new PdfOptions {
+                PageWidth = 260,
+                PageHeight = 220,
+                MarginLeft = 40,
+                MarginRight = 40,
+                MarginTop = 40,
+                MarginBottom = 40,
+                HeaderOffsetY = 40,
+                FooterOffsetY = 40,
+                HeaderFontSize = 12,
+                FooterFontSize = 12
+            }.ReportDiagnosticsTo(report, "OfficeIMO.Tests");
+
+            PdfDocument document = PdfDocument.Create(options);
+            if (useZones) {
+                document
+                    .Header(header => header.Zones("HeaderVerticalClip", null, null))
+                    .Footer(footer => footer.Zones("FooterVerticalClip", null, null));
+            } else {
+                document
+                    .Header(header => header.Text("HeaderVerticalClip"))
+                    .Footer(footer => footer.Text("FooterVerticalClip"));
+            }
+
+            byte[] bytes = document
+                .Paragraph(paragraph => paragraph.Text("Vertical clipping diagnostic body"))
+                .ToBytes();
+
+            Assert.NotEmpty(bytes);
+            PdfConversionWarning[] clippingWarnings = report.Warnings
+                .Where(warning => warning.Code == "HeaderFooterPageBoundsClipped")
+                .ToArray();
+            Assert.Contains(clippingWarnings, warning =>
+                warning.Source == "Header" &&
+                (warning.LayoutDiagnostic?.Y ?? 0D) + (warning.LayoutDiagnostic?.Height ?? 0D) > options.PageHeight &&
+                warning.LayoutDiagnostic?.Height > 0D);
+            Assert.Contains(clippingWarnings, warning =>
+                warning.Source == "Footer" &&
+                warning.LayoutDiagnostic?.Y < 0D &&
+                warning.LayoutDiagnostic.Height > 0D);
+            Assert.True(report.HasLoss);
+        }
+
         [Fact]
         public void HeaderFooterZones_CanConfigureFirstAndEvenPageVariants() {
             var doc = PdfDocument.Create(new PdfOptions {
@@ -673,6 +721,36 @@ namespace OfficeIMO.Tests.Pdf {
                 warning.LayoutDiagnostic?.Kind == PdfLayoutDiagnosticKind.Overflow);
             Assert.DoesNotContain(report.Warnings, warning => warning.Code == "HeaderFooterPageBoundsClipped");
             Assert.False(report.HasLoss);
+        }
+
+        [Fact]
+        public void HeaderFooterTransformedShapeUsesVisibleBoundsForClippingDiagnostics() {
+            OfficeShape shape = OfficeShape.Rectangle(24, 12);
+            shape.FillColor = OfficeColor.Blue;
+            shape.Transform = OfficeTransform.Scale(1.5D, 1D).Then(OfficeTransform.Translate(220D, 0D));
+            var report = new PdfConversionReport();
+            var options = new PdfOptions {
+                PageWidth = 260,
+                PageHeight = 220,
+                MarginLeft = 40,
+                MarginRight = 40,
+                MarginTop = 50,
+                MarginBottom = 50
+            }.ReportDiagnosticsTo(report, "OfficeIMO.Tests");
+
+            byte[] bytes = PdfDocument.Create(options)
+                .Header(header => header.Shape(shape, PdfAlign.Left))
+                .Paragraph(paragraph => paragraph.Text("Transformed header shape diagnostic body"))
+                .ToBytes();
+
+            Assert.NotEmpty(bytes);
+            PdfConversionWarning warning = Assert.Single(report.Warnings, warning =>
+                warning.Code == "HeaderFooterPageBoundsClipped" &&
+                warning.Source == "Header");
+            Assert.Equal(PdfLayoutDiagnosticKind.ClippedContent, warning.LayoutDiagnostic?.Kind);
+            Assert.True((warning.LayoutDiagnostic?.X ?? 0D) + (warning.LayoutDiagnostic?.Width ?? 0D) > options.PageWidth);
+            Assert.InRange(warning.LayoutDiagnostic?.Width ?? 0D, 35.999D, 36.001D);
+            Assert.True(report.HasLoss);
         }
 
         [Fact]

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfDocumentVisualQualityParagraphLayoutTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfDocumentVisualQualityParagraphLayoutTests.cs
@@ -277,6 +277,40 @@ public partial class PdfDocumentVisualQualityTests {
     }
 
     [Fact]
+    public void Paragraph_NegativeIndentsExtendTextIntoMargins() {
+        var options = new PdfOptions {
+            PageWidth = 300,
+            PageHeight = 280,
+            MarginLeft = 30,
+            MarginRight = 30,
+            MarginTop = 30,
+            MarginBottom = 30,
+            DefaultFont = PdfStandardFont.Helvetica,
+            DefaultFontSize = 10
+        };
+
+        byte[] defaultBytes = CreateParagraphIndentProbe(options, null);
+        byte[] extendedBytes = CreateParagraphIndentProbe(options, new PdfParagraphStyle {
+            LeftIndent = -18,
+            RightIndent = -30,
+            SpacingAfter = 0
+        });
+
+        using var defaultPdf = PdfPigDocument.Open(new MemoryStream(defaultBytes));
+        using var extendedPdf = PdfPigDocument.Open(new MemoryStream(extendedBytes));
+        var defaultPage = defaultPdf.GetPage(1);
+        var extendedPage = extendedPdf.GetPage(1);
+
+        double defaultX = FindWordStartX(defaultPage, "IndentedMarker");
+        double extendedX = FindWordStartX(extendedPage, "IndentedMarker");
+        int defaultLineCount = CountTextLines(defaultPage);
+        int extendedLineCount = CountTextLines(extendedPage);
+
+        Assert.True(defaultX - extendedX >= 17D, $"Expected a negative left indent to extend paragraph text into the left margin. Default x: {defaultX:0.##}, extended x: {extendedX:0.##}.");
+        Assert.True(extendedLineCount < defaultLineCount, $"Expected a negative right indent to widen the text frame and reduce wrapping. Default lines: {defaultLineCount}, extended lines: {extendedLineCount}.");
+    }
+
+    [Fact]
     public void Paragraph_UsesConfiguredFirstLineIndent() {
         var options = new PdfOptions {
             PageWidth = 300,

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfDocumentVisualQualityRowStylePrimitiveValidationTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfDocumentVisualQualityRowStylePrimitiveValidationTests.cs
@@ -213,17 +213,17 @@ public partial class PdfDocumentVisualQualityTests {
 
         var leftIndentException = Assert.Throws<ArgumentException>(() =>
             new PdfParagraphStyle {
-                LeftIndent = -1
+                LeftIndent = double.NegativeInfinity
             });
 
-        Assert.Contains("Paragraph left indent must be a non-negative finite value.", leftIndentException.Message, StringComparison.Ordinal);
+        Assert.Contains("Paragraph left indent must be a finite value.", leftIndentException.Message, StringComparison.Ordinal);
 
         var rightIndentException = Assert.Throws<ArgumentException>(() =>
             new PdfParagraphStyle {
                 RightIndent = double.NaN
             });
 
-        Assert.Contains("Paragraph right indent must be a non-negative finite value.", rightIndentException.Message, StringComparison.Ordinal);
+        Assert.Contains("Paragraph right indent must be a finite value.", rightIndentException.Message, StringComparison.Ordinal);
 
         var firstLineIndentException = Assert.Throws<ArgumentException>(() =>
             new PdfParagraphStyle {
@@ -238,20 +238,6 @@ public partial class PdfDocumentVisualQualityTests {
             });
 
         Assert.Contains("Paragraph default tab stop width must be a positive finite value.", tabStopException.Message, StringComparison.Ordinal);
-
-        var hangingOutsideFrameException = Assert.Throws<ArgumentException>(() =>
-            PdfDocument.Create(new PdfOptions {
-                    PageWidth = 160,
-                    MarginLeft = 20,
-                    MarginRight = 20
-                })
-                .Paragraph(p => p.Text("Invalid hanging indent"), style: new PdfParagraphStyle {
-                    LeftIndent = 10,
-                    FirstLineIndent = -12
-                })
-                .ToBytes());
-
-        Assert.Contains("Paragraph first line indent must not move text outside the left content frame.", hangingOutsideFrameException.Message, StringComparison.Ordinal);
 
         var firstLineWidthException = Assert.Throws<ArgumentException>(() =>
             PdfDocument.Create(new PdfOptions {

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfDocumentVisualQualityTableSecurityTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfDocumentVisualQualityTableSecurityTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using OfficeIMO.Drawing;
 using OfficeIMO.Pdf;
 using PdfPigDocument = UglyToad.PdfPig.PdfDocument;
 using Xunit;
@@ -99,5 +100,60 @@ public partial class PdfDocumentVisualQualityTests {
 
         Assert.InRange(link.X1, 29.5D, 31D);
         Assert.InRange(link.X2, 30D, 112.5D);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void NoWrapTableParagraphTextDoesNotPaintAcrossAdjacentCells(bool rowColumn) {
+        var options = new PdfOptions {
+            PageWidth = 260,
+            PageHeight = 180,
+            MarginLeft = 30,
+            MarginRight = 30,
+            MarginTop = 30,
+            MarginBottom = 30,
+            DefaultFont = PdfStandardFont.Helvetica,
+            DefaultFontSize = 12
+        };
+        var style = TableStyles.Minimal();
+        style.HeaderRowCount = 0;
+        style.BorderColor = null;
+        style.BorderWidth = 0D;
+        style.CellPaddingX = 0D;
+        style.CellPaddingY = 0D;
+        style.ColumnWidthPoints = new List<double?> { 60, 60 };
+        PdfTextRun[] runs = { PdfTextRun.Normal(new string('M', 80)) };
+        PdfTableCell[][] rows = {
+            new[] {
+                new PdfTableCell(runs, new[] { new PdfTableCellParagraph(runs) }, noWrap: true),
+                PdfTableCell.TextCell(string.Empty)
+            }
+        };
+
+        PdfDocument document = PdfDocument.Create(options);
+        if (rowColumn) {
+            document.Compose(compose =>
+                compose.Page(page =>
+                    page.Content(content =>
+                        content.Row(row =>
+                            row.Column(100, column => column.Table(rows, style: style))))));
+        } else {
+            document.Table(rows, style: style);
+        }
+
+        OfficeRasterImage raster = OfficeDrawingRasterRenderer.Render(PdfPageImageRenderer.RenderPage(document.ToBytes()));
+        bool paintedInAdjacentCell = false;
+        for (int y = 28; y < 55 && !paintedInAdjacentCell; y++) {
+            for (int x = 96; x < 145; x++) {
+                OfficeColor pixel = raster.GetPixel(x, y);
+                if (pixel.A > 0 && pixel.R < 96 && pixel.G < 96 && pixel.B < 96) {
+                    paintedInAdjacentCell = true;
+                    break;
+                }
+            }
+        }
+
+        Assert.False(paintedInAdjacentCell, "No-wrap paragraph text must remain clipped before the adjacent table cell.");
     }
 }

--- a/OfficeIMO.Pdf/Model/PdfParagraphStyle.cs
+++ b/OfficeIMO.Pdf/Model/PdfParagraphStyle.cs
@@ -23,19 +23,19 @@ public class PdfParagraphStyle {
             _lineHeight = value;
         }
     }
-    /// <summary>Horizontal inset from the left edge of the paragraph frame, in points.</summary>
+    /// <summary>Horizontal offset from the left edge of the paragraph frame, in points. Negative values extend text into the left margin.</summary>
     public double LeftIndent {
         get => _leftIndent;
         set {
-            ValidateNonNegativeFiniteValue(value, nameof(LeftIndent), "Paragraph left indent must be a non-negative finite value.");
+            ValidateFiniteValue(value, nameof(LeftIndent), "Paragraph left indent must be a finite value.");
             _leftIndent = value;
         }
     }
-    /// <summary>Horizontal inset from the right edge of the paragraph frame, in points.</summary>
+    /// <summary>Horizontal offset from the right edge of the paragraph frame, in points. Negative values extend text into the right margin.</summary>
     public double RightIndent {
         get => _rightIndent;
         set {
-            ValidateNonNegativeFiniteValue(value, nameof(RightIndent), "Paragraph right indent must be a non-negative finite value.");
+            ValidateFiniteValue(value, nameof(RightIndent), "Paragraph right indent must be a finite value.");
             _rightIndent = value;
         }
     }

--- a/OfficeIMO.Pdf/Model/PdfTableCell.cs
+++ b/OfficeIMO.Pdf/Model/PdfTableCell.cs
@@ -277,12 +277,12 @@ internal sealed class PdfTableCellParagraph {
             throw new System.ArgumentOutOfRangeException(nameof(spacingAfter), "Table cell paragraph spacing must be a non-negative finite value.");
         }
 
-        if (leftIndent < 0 || double.IsNaN(leftIndent) || double.IsInfinity(leftIndent)) {
-            throw new System.ArgumentOutOfRangeException(nameof(leftIndent), "Table cell paragraph left indent must be a non-negative finite value.");
+        if (double.IsNaN(leftIndent) || double.IsInfinity(leftIndent)) {
+            throw new System.ArgumentOutOfRangeException(nameof(leftIndent), "Table cell paragraph left indent must be a finite value.");
         }
 
-        if (rightIndent < 0 || double.IsNaN(rightIndent) || double.IsInfinity(rightIndent)) {
-            throw new System.ArgumentOutOfRangeException(nameof(rightIndent), "Table cell paragraph right indent must be a non-negative finite value.");
+        if (double.IsNaN(rightIndent) || double.IsInfinity(rightIndent)) {
+            throw new System.ArgumentOutOfRangeException(nameof(rightIndent), "Table cell paragraph right indent must be a finite value.");
         }
 
         if (double.IsNaN(firstLineIndent) || double.IsInfinity(firstLineIndent)) {

--- a/OfficeIMO.Pdf/Options/PdfOptions.Diagnostics.cs
+++ b/OfficeIMO.Pdf/Options/PdfOptions.Diagnostics.cs
@@ -1,0 +1,32 @@
+namespace OfficeIMO.Pdf;
+
+public sealed partial class PdfOptions {
+    internal void AddLayoutDiagnostic(
+        string code,
+        string source,
+        string message,
+        PdfLayoutDiagnosticKind kind,
+        PdfConversionWarningSeverity severity = PdfConversionWarningSeverity.Warning,
+        double? x = null,
+        double? y = null,
+        double? width = null,
+        double? height = null) {
+        if (_diagnosticsReport == null) {
+            return;
+        }
+
+        string key = code + "|" + source + "|" + message;
+        if (!(_reportedLayoutDiagnostics ??= new HashSet<string>()).Add(key)) {
+            return;
+        }
+
+        var layoutDiagnostic = new PdfLayoutDiagnostic(kind, source, message, x, y, width, height);
+        _diagnosticsReport.Add(new PdfConversionWarning(
+            _diagnosticsConverter,
+            code,
+            source,
+            message,
+            severity,
+            layoutDiagnostic));
+    }
+}

--- a/OfficeIMO.Pdf/Options/PdfOptions.Text.cs
+++ b/OfficeIMO.Pdf/Options/PdfOptions.Text.cs
@@ -182,18 +182,19 @@ public sealed partial class PdfOptions {
     }
 
     /// <summary>
-    /// Records generated text diagnostics encountered while writing PDF content.
+    /// Records generated text and layout diagnostics encountered while writing PDF content.
     /// </summary>
-    /// <param name="report">Mutable conversion report that receives text encoding, missing-glyph, shaping, and embedded-font diagnostics.</param>
+    /// <param name="report">Mutable conversion report that receives text encoding, missing-glyph, shaping, embedded-font, and layout diagnostics.</param>
     /// <param name="converter">Converter or adapter name to place on recorded warnings.</param>
     /// <returns>The current options instance for fluent configuration.</returns>
-    /// <remarks>Diagnostics are reported in addition to the existing fail-closed exceptions.</remarks>
+    /// <remarks>Invalid input can still fail closed; renderable fidelity risks are recorded without suppressing the output.</remarks>
     public PdfOptions ReportDiagnosticsTo(PdfConversionReport report, string converter = "OfficeIMO.Pdf") {
         Guard.NotNull(report, nameof(report));
         _diagnosticsReport = report;
         _diagnosticsConverter = string.IsNullOrWhiteSpace(converter) ? "OfficeIMO.Pdf" : converter;
         _reportedEmbeddedFontProgramFailures?.Clear();
         _reportedTextShapingDiagnostics?.Clear();
+        _reportedLayoutDiagnostics?.Clear();
         _providerShapedTextRuns?.Clear();
         return this;
     }

--- a/OfficeIMO.Pdf/Options/PdfOptions.cs
+++ b/OfficeIMO.Pdf/Options/PdfOptions.cs
@@ -112,6 +112,7 @@ public sealed partial class PdfOptions {
     private System.Collections.Generic.HashSet<PdfStandardFont>? _embeddedFontProgramFailures;
     private System.Collections.Generic.HashSet<string>? _reportedEmbeddedFontProgramFailures;
     private System.Collections.Generic.HashSet<string>? _reportedTextShapingDiagnostics;
+    private System.Collections.Generic.HashSet<string>? _reportedLayoutDiagnostics;
     private System.Collections.Generic.HashSet<string>? _providerShapedTextRuns;
     private Func<string, IReadOnlyList<int>>? _textLineBreakCallback;
     private PdfTextHyphenationCallback? _textHyphenationCallback;

--- a/OfficeIMO.Pdf/README.md
+++ b/OfficeIMO.Pdf/README.md
@@ -290,7 +290,7 @@ PdfDocument.Create(pdf => pdf.Page(page => page
     .Save("styled-header.pdf");
 ```
 
-Styled header/footer runs support fonts, size, color, highlighting, underline, strike, and baseline changes. Use the existing header/footer image and shape methods for visuals; interactive links and inline elements are intentionally kept out of text runs.
+Styled header/footer runs support fonts, size, color, highlighting, underline, strike, and baseline changes. Use the existing header/footer image and shape methods for visuals; interactive links and inline elements are intentionally kept out of text runs. Authored header/footer content that enters margins or overlaps another zone is preserved instead of rejected; attach a `PdfConversionReport` with `ReportDiagnosticsTo(...)` when the host needs structured overflow or clipping warnings.
 
 ### Rich report layout
 

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Drawing.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Drawing.cs
@@ -175,6 +175,7 @@ internal static partial class PdfWriter {
         if (source.Transform.HasValue) {
             shape = source.Clone();
             shape.StrokeWidth = strokeWidth;
+            shape.ClipPath = null;
             DrawTransformedShape(sb, shape, hasFill ? color : (PdfColor?)null, hasStroke ? color : (PdfColor?)null, null, x, bottomY);
         } else if (shape.Kind == OfficeIMO.Drawing.OfficeShapeKind.Line) {
             DrawLine(sb, hasStroke ? color : (PdfColor?)null, strokeWidth, OfficeIMO.Drawing.OfficeStrokeDashStyle.Solid, shape.StrokeLineCap, shape.StrokeLineJoin, shape.Points, x, bottomY, shape.Height);

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Row.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Row.cs
@@ -857,6 +857,9 @@ internal static partial class PdfWriter {
                                         var visibleAlignments = SliceTableCellLineAlignments(lines, sourceStartLine, visibleLineCount);
                                         var visibleXOffsets = SliceTableCellLineXOffsets(lines, sourceStartLine, visibleLineCount);
                                         var visibleWidths = SliceTableCellLineWidths(lines, sourceStartLine, visibleLineCount, innerW);
+                                        double textClipX = xi - TableCellClipBleed;
+                                        double textClipWidth = cellWidth + (TableCellClipBleed * 2D);
+                                        ExpandTableCellTextClip(xi + cellPadLeft, visibleXOffsets, visibleWidths, ref textClipX, ref textClipWidth);
                                         var paragraph = new RichParagraphBlock(StripRunLinksWhenCellLinked(cell.Runs, linkUri, linkDestinationName), MapTableCellAlignment(align), textColor);
                                         string structureType = renderAsHeader ? "TH" : "TD";
                                         int tableColumnSpan = cell.ColumnSpan > 1 ? cell.ColumnSpan : 1;
@@ -873,7 +876,7 @@ internal static partial class PdfWriter {
                                             markedContentId = RegisterTextStructureElement(structureType, rowStructureElementIndex, renderAsHeader ? "Column" : string.Empty, tableColumnSpan, tableRowSpan);
                                         }
 
-                                        WriteClippedRichParagraph(sb, paragraph, visibleLines, visibleHeights, currentOpts, firstBaseline, rowSize, rowLeading, currentPage!.Annotations, xi - TableCellClipBleed, cellBottom - TableCellClipBleed, cellWidth + (TableCellClipBleed * 2D), cellHeight + (TableCellClipBleed * 2D), xi + cellPadLeft, innerW, structureType: markedStructureType, markedContentId: markedContentId, structurePage: currentPage, lineAlignments: visibleAlignments, lineXOffsets: visibleXOffsets, lineWidths: visibleWidths);
+                                        WriteClippedRichParagraph(sb, paragraph, visibleLines, visibleHeights, currentOpts, firstBaseline, rowSize, rowLeading, currentPage!.Annotations, textClipX, cellBottom - TableCellClipBleed, textClipWidth, cellHeight + (TableCellClipBleed * 2D), xi + cellPadLeft, innerW, structureType: markedStructureType, markedContentId: markedContentId, structurePage: currentPage, lineAlignments: visibleAlignments, lineXOffsets: visibleXOffsets, lineWidths: visibleWidths);
                                     }
                                     if (!suppressCellObjects && (cell.Images.Count > 0 || cell.CheckBoxes.Count > 0 || cell.FormFields.Count > 0) && sourceStartLine == 0) {
                                         if (CanRenderTableCellCheckBoxInline(cell, lines, sourceStartLine, visibleLineCount)) {

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Row.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Row.cs
@@ -859,7 +859,7 @@ internal static partial class PdfWriter {
                                         var visibleWidths = SliceTableCellLineWidths(lines, sourceStartLine, visibleLineCount, innerW);
                                         double textClipX = xi - TableCellClipBleed;
                                         double textClipWidth = cellWidth + (TableCellClipBleed * 2D);
-                                        ExpandTableCellTextClip(xi + cellPadLeft, visibleXOffsets, visibleWidths, ref textClipX, ref textClipWidth);
+                                        ExpandTableCellTextClip(xi + cellPadLeft, innerW, cell.NoWrap, visibleXOffsets, visibleWidths, ref textClipX, ref textClipWidth);
                                         var paragraph = new RichParagraphBlock(StripRunLinksWhenCellLinked(cell.Runs, linkUri, linkDestinationName), MapTableCellAlignment(align), textColor);
                                         string structureType = renderAsHeader ? "TH" : "TD";
                                         int tableColumnSpan = cell.ColumnSpan > 1 ? cell.ColumnSpan : 1;

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Table.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Table.cs
@@ -597,7 +597,7 @@ internal static partial class PdfWriter {
                         var visibleWidths = SliceTableCellLineWidths(lines, sourceStartLine, visibleLineCount, innerW);
                         double textClipX = xi - TableCellClipBleed;
                         double textClipWidth = cellWidth + (TableCellClipBleed * 2D);
-                        ExpandTableCellTextClip(xi + cellPadLeft, visibleXOffsets, visibleWidths, ref textClipX, ref textClipWidth);
+                        ExpandTableCellTextClip(xi + cellPadLeft, innerW, cell.NoWrap, visibleXOffsets, visibleWidths, ref textClipX, ref textClipWidth);
                         var paragraph = new RichParagraphBlock(StripRunLinksWhenCellLinked(cell.Runs, linkUri, linkDestinationName), MapTableCellAlignment(align), textColor);
                         string structureType = renderAsHeader ? "TH" : "TD";
                         int tableColumnSpan = cell.ColumnSpan > 1 ? cell.ColumnSpan : 1;

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Table.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Table.cs
@@ -595,6 +595,9 @@ internal static partial class PdfWriter {
                         var visibleAlignments = SliceTableCellLineAlignments(lines, sourceStartLine, visibleLineCount);
                         var visibleXOffsets = SliceTableCellLineXOffsets(lines, sourceStartLine, visibleLineCount);
                         var visibleWidths = SliceTableCellLineWidths(lines, sourceStartLine, visibleLineCount, innerW);
+                        double textClipX = xi - TableCellClipBleed;
+                        double textClipWidth = cellWidth + (TableCellClipBleed * 2D);
+                        ExpandTableCellTextClip(xi + cellPadLeft, visibleXOffsets, visibleWidths, ref textClipX, ref textClipWidth);
                         var paragraph = new RichParagraphBlock(StripRunLinksWhenCellLinked(cell.Runs, linkUri, linkDestinationName), MapTableCellAlignment(align), textColor);
                         string structureType = renderAsHeader ? "TH" : "TD";
                         int tableColumnSpan = cell.ColumnSpan > 1 ? cell.ColumnSpan : 1;
@@ -620,7 +623,7 @@ internal static partial class PdfWriter {
                                 : RegisterTextStructureElement(structureType, rowStructureElement, renderAsHeader ? "Column" : string.Empty, tableColumnSpan, tableRowSpan);
                         }
 
-                        WriteClippedRichParagraph(sb, paragraph, visibleLines, visibleHeights, currentOpts, firstBaseline, rowSize, rowLeading, currentPage!.Annotations, xi - TableCellClipBleed, cellBottom - TableCellClipBleed, cellWidth + (TableCellClipBleed * 2D), cellHeight + (TableCellClipBleed * 2D), xi + cellPadLeft, innerW, structureType: markedStructureType, markedContentId: markedContentId, structurePage: currentPage, lineAlignments: visibleAlignments, lineXOffsets: visibleXOffsets, lineWidths: visibleWidths);
+                        WriteClippedRichParagraph(sb, paragraph, visibleLines, visibleHeights, currentOpts, firstBaseline, rowSize, rowLeading, currentPage!.Annotations, textClipX, cellBottom - TableCellClipBleed, textClipWidth, cellHeight + (TableCellClipBleed * 2D), xi + cellPadLeft, innerW, structureType: markedStructureType, markedContentId: markedContentId, structurePage: currentPage, lineAlignments: visibleAlignments, lineXOffsets: visibleXOffsets, lineWidths: visibleWidths);
                     }
                     if (!suppressCellObjects && (cell.Images.Count > 0 || cell.CheckBoxes.Count > 0 || cell.FormFields.Count > 0) && sourceStartLine == 0) {
                         if (CanRenderTableCellCheckBoxInline(cell, lines, sourceStartLine, visibleLineCount)) {

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.HeaderFooter.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.HeaderFooter.cs
@@ -66,6 +66,8 @@ internal static partial class PdfWriter {
         int pageNumber,
         int totalPages,
         int documentPages) {
+        ValidateHeaderFooterGroupLayouts(options, variantPageNumber, pageNumber, totalPages, documentPages, isHeader: true);
+        ValidateHeaderFooterGroupLayouts(options, variantPageNumber, pageNumber, totalPages, documentPages, isHeader: false);
         AddHeaderFooterImages(
             page,
             options,
@@ -279,13 +281,14 @@ internal static partial class PdfWriter {
         double bottomY = isHeader
             ? options.PageHeight - options.MarginTop + options.HeaderOffsetY - block.Shape.Height
             : options.MarginBottom - options.FooterOffsetY;
-        GetHeaderFooterShapeBounds(block.Shape, x, bottomY, out double visibleX, out double visibleY, out double visibleWidth, out double visibleHeight);
-        ReportHeaderFooterBounds(options, source, "shape", visibleX, visibleY, visibleWidth, visibleHeight);
+        if (TryGetHeaderFooterShapeBounds(block.Shape, x, bottomY, out double visibleX, out double visibleY, out double visibleWidth, out double visibleHeight)) {
+            ReportHeaderFooterBounds(options, source, "shape", visibleX, visibleY, visibleWidth, visibleHeight);
+        }
 
         DrawHeaderFooterShapeGeometryAt(sb, page, block.Shape, x, bottomY);
     }
 
-    private static void GetHeaderFooterShapeBounds(
+    private static bool TryGetHeaderFooterShapeBounds(
         OfficeShape shape,
         double x,
         double bottomY,
@@ -293,20 +296,141 @@ internal static partial class PdfWriter {
         out double boundsY,
         out double boundsWidth,
         out double boundsHeight) {
-        if (!shape.Transform.HasValue) {
+        boundsX = boundsY = boundsWidth = boundsHeight = 0D;
+        if (shape.ClipPath?.Kind == OfficeClipPathKind.Empty) {
+            return false;
+        }
+
+        ResolveHeaderFooterBaseGeometry(shape, out bool baseHasFill, out bool baseHasStroke);
+        bool hasBounds = false;
+        if (baseHasFill || baseHasStroke) {
+            GetHeaderFooterShapeLayerBounds(
+                shape,
+                x,
+                bottomY,
+                baseHasStroke ? shape.StrokeWidth : 0D,
+                out boundsX,
+                out boundsY,
+                out boundsWidth,
+                out boundsHeight);
+            hasBounds = true;
+        }
+
+        OfficeShadow? shadow = shape.Shadow;
+        if (shadow == null || shadow.Opacity <= 0D || shadow.Color.A == 0) {
+            return hasBounds;
+        }
+
+        double coreOpacity = shadow.Opacity * shadow.Color.A / 255D;
+        ResolveShadowGeometry(shape, out bool shadowHasFill, out bool shadowHasStroke);
+        IReadOnlyList<OfficeShadowLayer> layers = OfficeShadowLayerPlanner.Create(
+            coreOpacity,
+            shadow.BlurRadius,
+            shape.StrokeWidth,
+            shadowHasFill,
+            shadowHasStroke,
+            OfficeShadowLayerPlanner.CanExpand(shape));
+        double shadowX = x + shadow.OffsetX;
+        double shadowBottomY = bottomY - shadow.OffsetY;
+        for (int index = 0; index < layers.Count; index++) {
+            OfficeShadowLayer layer = layers[index];
+            OfficeShape layerShape = layer.Expansion > 0D
+                ? OfficeShadowLayerPlanner.CreateExpandedShape(shape, layer.Expansion)
+                : shape;
+            GetHeaderFooterShapeLayerBounds(
+                layerShape,
+                shadowX - layer.Expansion,
+                shadowBottomY - layer.Expansion,
+                layer.HasStroke ? layer.StrokeWidth : 0D,
+                out double layerX,
+                out double layerY,
+                out double layerWidth,
+                out double layerHeight);
+            IncludeShapeBounds(
+                layerX,
+                layerY,
+                layerWidth,
+                layerHeight,
+                ref hasBounds,
+                ref boundsX,
+                ref boundsY,
+                ref boundsWidth,
+                ref boundsHeight);
+        }
+
+        return hasBounds;
+    }
+
+    private static void ResolveHeaderFooterBaseGeometry(OfficeShape shape, out bool hasFill, out bool hasStroke) {
+        hasFill = shape.Kind != OfficeShapeKind.Line
+            && (shape.FillOpacity ?? 1D) > 0D
+            && ((shape.FillColor.HasValue && shape.FillColor.Value.A > 0) || shape.FillGradient != null || shape.FillRadialGradient != null);
+        hasStroke = shape.StrokeWidth > 0D
+            && (shape.StrokeOpacity ?? 1D) > 0D
+            && shape.StrokeColor.HasValue
+            && shape.StrokeColor.Value.A > 0;
+    }
+
+    private static void IncludeShapeBounds(
+        double x,
+        double y,
+        double width,
+        double height,
+        ref bool hasBounds,
+        ref double boundsX,
+        ref double boundsY,
+        ref double boundsWidth,
+        ref double boundsHeight) {
+        if (!hasBounds) {
             boundsX = x;
-            boundsY = bottomY;
-            boundsWidth = shape.Width;
-            boundsHeight = shape.Height;
+            boundsY = y;
+            boundsWidth = width;
+            boundsHeight = height;
+            hasBounds = true;
             return;
         }
 
-        (double left, double top, double right, double bottom) = shape.Transform.Value.TransformRectangleBounds(0D, 0D, shape.Width, shape.Height);
-        boundsX = x + left;
-        boundsY = bottomY + shape.Height - bottom;
-        boundsWidth = right - left;
-        boundsHeight = bottom - top;
+        double right = System.Math.Max(boundsX + boundsWidth, x + width);
+        double top = System.Math.Max(boundsY + boundsHeight, y + height);
+        boundsX = System.Math.Min(boundsX, x);
+        boundsY = System.Math.Min(boundsY, y);
+        boundsWidth = right - boundsX;
+        boundsHeight = top - boundsY;
     }
+
+    private static void GetHeaderFooterShapeLayerBounds(
+        OfficeShape shape,
+        double x,
+        double bottomY,
+        double strokeWidth,
+        out double boundsX,
+        out double boundsY,
+        out double boundsWidth,
+        out double boundsHeight) {
+        double strokeExpansionFactor = UsesPdfMiterJoinEnvelope(shape) ? 10D : 1D;
+        if (!shape.Transform.HasValue) {
+            double strokeExpansion = strokeWidth * 0.5D * strokeExpansionFactor;
+            boundsX = x - strokeExpansion;
+            boundsY = bottomY - strokeExpansion;
+            boundsWidth = shape.Width + (strokeExpansion * 2D);
+            boundsHeight = shape.Height + (strokeExpansion * 2D);
+            return;
+        }
+
+        OfficeTransform transform = shape.Transform.Value;
+        (double left, double top, double right, double bottom) = transform.TransformRectangleBounds(0D, 0D, shape.Width, shape.Height);
+        double halfStroke = strokeWidth * 0.5D * strokeExpansionFactor;
+        double strokeExpansionX = halfStroke * System.Math.Sqrt((transform.M11 * transform.M11) + (transform.M21 * transform.M21));
+        double strokeExpansionY = halfStroke * System.Math.Sqrt((transform.M12 * transform.M12) + (transform.M22 * transform.M22));
+        boundsX = x + left - strokeExpansionX;
+        boundsY = bottomY + shape.Height - bottom - strokeExpansionY;
+        boundsWidth = right - left + (strokeExpansionX * 2D);
+        boundsHeight = bottom - top + (strokeExpansionY * 2D);
+    }
+
+    private static bool UsesPdfMiterJoinEnvelope(OfficeShape shape) =>
+        (shape.Kind == OfficeShapeKind.Polygon || shape.Kind == OfficeShapeKind.Path)
+        && (!shape.StrokeLineJoin.HasValue || shape.StrokeLineJoin.Value == OfficeStrokeLineJoin.Miter);
 
     private static void ReportHeaderFooterBounds(
         PdfOptions options,
@@ -317,21 +441,6 @@ internal static partial class PdfWriter {
         double width,
         double? height) {
         const double tolerance = 0.001D;
-        double contentLeft = options.MarginLeft;
-        double contentRight = options.PageWidth - options.MarginRight;
-        if (x < contentLeft - tolerance || x + width > contentRight + tolerance) {
-            options.AddLayoutDiagnostic(
-                "HeaderFooterContentOverflow",
-                source,
-                source + " " + contentKind + " content exceeds the page content frame and was preserved as authored.",
-                PdfLayoutDiagnosticKind.Overflow,
-                PdfConversionWarningSeverity.Information,
-                x,
-                y,
-                width,
-                height);
-        }
-
         bool outsideVerticalBounds = y.HasValue && height.HasValue &&
             (y.Value < -tolerance || y.Value + height.Value > options.PageHeight + tolerance);
         if (x < -tolerance || x + width > options.PageWidth + tolerance || outsideVerticalBounds) {

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.HeaderFooter.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.HeaderFooter.cs
@@ -279,9 +279,33 @@ internal static partial class PdfWriter {
         double bottomY = isHeader
             ? options.PageHeight - options.MarginTop + options.HeaderOffsetY - block.Shape.Height
             : options.MarginBottom - options.FooterOffsetY;
-        ReportHeaderFooterBounds(options, source, "shape", x, bottomY, block.Shape.Width, block.Shape.Height);
+        GetHeaderFooterShapeBounds(block.Shape, x, bottomY, out double visibleX, out double visibleY, out double visibleWidth, out double visibleHeight);
+        ReportHeaderFooterBounds(options, source, "shape", visibleX, visibleY, visibleWidth, visibleHeight);
 
         DrawHeaderFooterShapeGeometryAt(sb, page, block.Shape, x, bottomY);
+    }
+
+    private static void GetHeaderFooterShapeBounds(
+        OfficeShape shape,
+        double x,
+        double bottomY,
+        out double boundsX,
+        out double boundsY,
+        out double boundsWidth,
+        out double boundsHeight) {
+        if (!shape.Transform.HasValue) {
+            boundsX = x;
+            boundsY = bottomY;
+            boundsWidth = shape.Width;
+            boundsHeight = shape.Height;
+            return;
+        }
+
+        (double left, double top, double right, double bottom) = shape.Transform.Value.TransformRectangleBounds(0D, 0D, shape.Width, shape.Height);
+        boundsX = x + left;
+        boundsY = bottomY + shape.Height - bottom;
+        boundsWidth = right - left;
+        boundsHeight = bottom - top;
     }
 
     private static void ReportHeaderFooterBounds(

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.HeaderFooter.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.HeaderFooter.cs
@@ -123,25 +123,22 @@ internal static partial class PdfWriter {
     }
 
     private static void AddHeaderFooterImage(LayoutResult.Page page, PdfOptions options, PdfHeaderFooterImage image, double x, bool isHeader) {
-        double contentLeft = options.MarginLeft;
-        double contentWidth = options.PageWidth - options.MarginLeft - options.MarginRight;
-        if (image.Width > contentWidth + 0.001D) {
-            throw new ArgumentException("PDF " + (isHeader ? "header" : "footer") + " image must fit inside the page content width.");
-        }
-
-        if (x < contentLeft - 0.001D || x + image.Width > contentLeft + contentWidth + 0.001D) {
-            throw new ArgumentException("Combined PDF " + (isHeader ? "header" : "footer") + " text and images must fit inside the page content width.");
-        }
-
+        string source = isHeader ? "Header" : "Footer";
         double y = isHeader
             ? options.PageHeight - options.MarginTop + options.HeaderOffsetY - image.Height
             : options.MarginBottom - options.FooterOffsetY;
-        if (y < -0.001D || y + image.Height > options.PageHeight + 0.001D) {
-            throw new ArgumentException("PDF " + (isHeader ? "header" : "footer") + " image must fit inside the page bounds.");
-        }
-
         ImageBlock block = image.ToImageBlock();
-        PageImage pageImage = CreatePageImage(block, block.Style ?? new PdfImageStyle(), x, y);
+        PdfImageStyle style = block.Style ?? new PdfImageStyle();
+        PageImage pageImage = CreatePageImage(block, style, x, y);
+        GetImageAnnotationBounds(style, pageImage, x, y, image.Width, image.Height, out double visibleX1, out double visibleY1, out double visibleX2, out double visibleY2);
+        ReportHeaderFooterBounds(
+            options,
+            source,
+            "image",
+            visibleX1,
+            visibleY1,
+            visibleX2 - visibleX1,
+            visibleY2 - visibleY1);
         pageImage.IsBackgroundDecoration = string.IsNullOrWhiteSpace(pageImage.AlternativeText);
         page.Images.Add(pageImage);
     }
@@ -194,10 +191,6 @@ internal static partial class PdfWriter {
     private static double AlignHeaderFooterGroup(PdfOptions options, double groupWidth, PdfAlign align) {
         double contentLeft = options.MarginLeft;
         double contentWidth = options.PageWidth - options.MarginLeft - options.MarginRight;
-        if (groupWidth > contentWidth + 0.001D) {
-            throw new ArgumentException("Combined PDF header/footer content must fit inside the page content width.");
-        }
-
         return GetHeaderFooterAlignedObjectX(contentLeft, contentWidth, groupWidth, align);
     }
 
@@ -282,29 +275,57 @@ internal static partial class PdfWriter {
         PdfDrawingStyle style = block.Style ?? new PdfDrawingStyle();
         PdfDocument.ValidateDrawingStyle(style, isHeader ? "Header shape" : "Footer shape");
 
-        double contentLeft = options.MarginLeft;
-        double contentWidth = options.PageWidth - options.MarginLeft - options.MarginRight;
-        if (block.Shape.Width > contentWidth + 0.001D) {
-            throw new ArgumentException("PDF " + (isHeader ? "header" : "footer") + " shape must fit inside the page content width.");
-        }
-
-        if (x < contentLeft - 0.001D || x + block.Shape.Width > contentLeft + contentWidth + 0.001D) {
-            throw new ArgumentException("Combined PDF " + (isHeader ? "header" : "footer") + " text, images, and shapes must fit inside the page content width.");
-        }
-
+        string source = isHeader ? "Header" : "Footer";
         double bottomY = isHeader
             ? options.PageHeight - options.MarginTop + options.HeaderOffsetY - block.Shape.Height
             : options.MarginBottom - options.FooterOffsetY;
-        if (bottomY < -0.001D || bottomY + block.Shape.Height > options.PageHeight + 0.001D) {
-            throw new ArgumentException("PDF " + (isHeader ? "header" : "footer") + " shape must fit inside the page bounds.");
-        }
+        ReportHeaderFooterBounds(options, source, "shape", x, bottomY, block.Shape.Width, block.Shape.Height);
 
         DrawHeaderFooterShapeGeometryAt(sb, page, block.Shape, x, bottomY);
     }
 
+    private static void ReportHeaderFooterBounds(
+        PdfOptions options,
+        string source,
+        string contentKind,
+        double x,
+        double? y,
+        double width,
+        double? height) {
+        const double tolerance = 0.001D;
+        double contentLeft = options.MarginLeft;
+        double contentRight = options.PageWidth - options.MarginRight;
+        if (x < contentLeft - tolerance || x + width > contentRight + tolerance) {
+            options.AddLayoutDiagnostic(
+                "HeaderFooterContentOverflow",
+                source,
+                source + " " + contentKind + " content exceeds the page content frame and was preserved as authored.",
+                PdfLayoutDiagnosticKind.Overflow,
+                PdfConversionWarningSeverity.Information,
+                x,
+                y,
+                width,
+                height);
+        }
+
+        bool outsideVerticalBounds = y.HasValue && height.HasValue &&
+            (y.Value < -tolerance || y.Value + height.Value > options.PageHeight + tolerance);
+        if (x < -tolerance || x + width > options.PageWidth + tolerance || outsideVerticalBounds) {
+            options.AddLayoutDiagnostic(
+                "HeaderFooterPageBoundsClipped",
+                source,
+                source + " " + contentKind + " extends beyond the physical page bounds and may be clipped by the PDF page.",
+                PdfLayoutDiagnosticKind.ClippedContent,
+                x: x,
+                y: y,
+                width: width,
+                height: height);
+        }
+    }
+
     private static double GetHeaderFooterAlignedObjectX(double containerX, double containerWidth, double objectWidth, PdfAlign align) {
-        if (align == PdfAlign.Center) return containerX + Math.Max(0, (containerWidth - objectWidth) / 2);
-        if (align == PdfAlign.Right) return containerX + Math.Max(0, containerWidth - objectWidth);
+        if (align == PdfAlign.Center) return containerX + ((containerWidth - objectWidth) / 2);
+        if (align == PdfAlign.Right) return containerX + containerWidth - objectWidth;
         return containerX;
     }
 

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.HeaderFooter.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.HeaderFooter.cs
@@ -309,11 +309,29 @@ internal static partial class PdfWriter {
                 x,
                 bottomY,
                 baseHasStroke ? shape.StrokeWidth : 0D,
-                out boundsX,
-                out boundsY,
-                out boundsWidth,
-                out boundsHeight);
-            hasBounds = true;
+                out double baseX,
+                out double baseY,
+                out double baseWidth,
+                out double baseHeight);
+            if (shape.ClipPath == null || TryIntersectHeaderFooterShapeClipBounds(
+                    shape,
+                    x,
+                    bottomY,
+                    ref baseX,
+                    ref baseY,
+                    ref baseWidth,
+                    ref baseHeight)) {
+                IncludeShapeBounds(
+                    baseX,
+                    baseY,
+                    baseWidth,
+                    baseHeight,
+                    ref hasBounds,
+                    ref boundsX,
+                    ref boundsY,
+                    ref boundsWidth,
+                    ref boundsHeight);
+            }
         }
 
         OfficeShadow? shadow = shape.Shadow;
@@ -359,6 +377,51 @@ internal static partial class PdfWriter {
         }
 
         return hasBounds;
+    }
+
+    private static bool TryIntersectHeaderFooterShapeClipBounds(
+        OfficeShape shape,
+        double x,
+        double bottomY,
+        ref double boundsX,
+        ref double boundsY,
+        ref double boundsWidth,
+        ref double boundsHeight) {
+        OfficeClipPath clipPath = shape.ClipPath!;
+        double clipX;
+        double clipY;
+        double clipWidth;
+        double clipHeight;
+        if (!shape.Transform.HasValue) {
+            clipX = x;
+            clipY = bottomY + shape.Height - clipPath.Height;
+            clipWidth = clipPath.Width;
+            clipHeight = clipPath.Height;
+        } else {
+            (double left, double top, double right, double bottom) = shape.Transform.Value.TransformRectangleBounds(
+                0D,
+                0D,
+                clipPath.Width,
+                clipPath.Height);
+            clipX = x + left;
+            clipY = bottomY + shape.Height - bottom;
+            clipWidth = right - left;
+            clipHeight = bottom - top;
+        }
+
+        double intersectionX = System.Math.Max(boundsX, clipX);
+        double intersectionY = System.Math.Max(boundsY, clipY);
+        double intersectionRight = System.Math.Min(boundsX + boundsWidth, clipX + clipWidth);
+        double intersectionTop = System.Math.Min(boundsY + boundsHeight, clipY + clipHeight);
+        if (intersectionRight <= intersectionX || intersectionTop <= intersectionY) {
+            return false;
+        }
+
+        boundsX = intersectionX;
+        boundsY = intersectionY;
+        boundsWidth = intersectionRight - intersectionX;
+        boundsHeight = intersectionTop - intersectionY;
+        return true;
     }
 
     private static void ResolveHeaderFooterBaseGeometry(OfficeShape shape, out bool hasFill, out bool hasStroke) {

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.PageText.Rich.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.PageText.Rich.cs
@@ -1,6 +1,55 @@
 namespace OfficeIMO.Pdf;
 
 internal static partial class PdfWriter {
+    private static void GetPageTextVerticalBoundsOrBaseline(
+        System.Collections.Generic.IReadOnlyList<PdfTextRun> runs,
+        PdfStandardFont baseFont,
+        double defaultFontSize,
+        PdfOptions options,
+        double firstBaseline,
+        out double bottom,
+        out double top) {
+        if (!TryGetPageTextVerticalBounds(runs, baseFont, defaultFontSize, options, firstBaseline, out bottom, out top)) {
+            bottom = firstBaseline;
+            top = firstBaseline;
+        }
+    }
+
+    private static bool TryGetPageTextVerticalBounds(
+        System.Collections.Generic.IReadOnlyList<PdfTextRun> runs,
+        PdfStandardFont baseFont,
+        double defaultFontSize,
+        PdfOptions options,
+        double firstBaseline,
+        out double bottom,
+        out double top) {
+        var lines = BuildPageTextLineRuns(runs);
+        double[] baselines = BuildPageTextLineBaselines(lines, firstBaseline, defaultFontSize);
+        bottom = double.PositiveInfinity;
+        top = double.NegativeInfinity;
+
+        for (int lineIndex = 0; lineIndex < lines.Count; lineIndex++) {
+            foreach (PdfTextRun run in lines[lineIndex]) {
+                if (string.IsNullOrEmpty(run.Text)) {
+                    continue;
+                }
+
+                PdfStandardFont runFont = ResolvePageTextRunFont(run, baseFont);
+                PdfNamedFontFace? namedFont = options.TryResolveNamedFontFace(run.FontFamily, run.Bold, run.Italic, out PdfNamedFontFace resolvedNamedFont)
+                    ? resolvedNamedFont
+                    : null;
+                double requestedFontSize = run.FontSize ?? defaultFontSize;
+                double effectiveFontSize = EffectiveRichFontSize(requestedFontSize, run.Baseline);
+                double textRise = TextRiseForBaseline(requestedFontSize, run.Baseline);
+                double runBaseline = baselines[lineIndex] + textRise;
+                bottom = System.Math.Min(bottom, runBaseline - GetDescenderForOptions(runFont, namedFont, effectiveFontSize, options));
+                top = System.Math.Max(top, runBaseline + GetAscenderForOptions(runFont, namedFont, effectiveFontSize, options));
+            }
+        }
+
+        return !double.IsPositiveInfinity(bottom) && !double.IsNegativeInfinity(top);
+    }
+
     private static double[] BuildPageTextLineBaselines(
         System.Collections.Generic.List<System.Collections.Generic.IReadOnlyList<PdfTextRun>> lines,
         double firstBaseline,

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.PageText.Rich.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.PageText.Rich.cs
@@ -42,8 +42,34 @@ internal static partial class PdfWriter {
                 double effectiveFontSize = EffectiveRichFontSize(requestedFontSize, run.Baseline);
                 double textRise = TextRiseForBaseline(requestedFontSize, run.Baseline);
                 double runBaseline = baselines[lineIndex] + textRise;
-                bottom = System.Math.Min(bottom, runBaseline - GetDescenderForOptions(runFont, namedFont, effectiveFontSize, options));
-                top = System.Math.Max(top, runBaseline + GetAscenderForOptions(runFont, namedFont, effectiveFontSize, options));
+                double ascender = GetAscenderForOptions(runFont, namedFont, effectiveFontSize, options);
+                double descender = GetDescenderForOptions(runFont, namedFont, effectiveFontSize, options);
+                double runBottom = runBaseline - descender;
+                double runTop = runBaseline + ascender;
+                double width = MeasureRichText(run.Text, runFont, namedFont, requestedFontSize, run.Baseline, options);
+                if (width > 0D && run.BackgroundColor.HasValue) {
+                    double paddingY = System.Math.Max(0.35D, effectiveFontSize * 0.04D);
+                    runBottom -= paddingY;
+                    runTop += paddingY;
+                }
+
+                if (width > 0D && (run.Underline || run.Strike)) {
+                    double halfDecorationWidth = System.Math.Max(0.45D, effectiveFontSize * 0.055D) / 2D;
+                    if (run.Underline) {
+                        double underlineY = runBaseline - System.Math.Max(0.8D, effectiveFontSize * 0.1D);
+                        runBottom = System.Math.Min(runBottom, underlineY - halfDecorationWidth);
+                        runTop = System.Math.Max(runTop, underlineY + halfDecorationWidth);
+                    }
+
+                    if (run.Strike) {
+                        double strikeY = runBaseline + (effectiveFontSize * 0.28D);
+                        runBottom = System.Math.Min(runBottom, strikeY - halfDecorationWidth);
+                        runTop = System.Math.Max(runTop, strikeY + halfDecorationWidth);
+                    }
+                }
+
+                bottom = System.Math.Min(bottom, runBottom);
+                top = System.Math.Max(top, runTop);
             }
         }
 

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.PageText.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.PageText.cs
@@ -149,6 +149,10 @@ internal static partial class PdfWriter {
         var sb = new StringBuilder();
         var zoneLayouts = BuildPageTextZoneLayouts(opts, zones, variantPage, page, pages, documentPages, font, fontSize, isHeader);
         foreach (var zone in zoneLayouts) {
+            if (string.IsNullOrEmpty(zone.Text)) {
+                continue;
+            }
+
             string? fontFamily = isHeader ? opts.HeaderFontFamily : opts.FooterFontFamily;
             System.Collections.Generic.IReadOnlyList<PdfTextRun> runs = BuildPageTextRuns(zone.Text, font, fontSize, color, opts, fontFamily);
             PdfNamedFontFace? namedFont = TryResolvePageTextNamedFont(opts, fontFamily, font, out PdfNamedFontFace resolvedNamedFont)
@@ -193,7 +197,7 @@ internal static partial class PdfWriter {
             double imagesWidth = MeasureHeaderFooterImagesWidth(images, PdfAlign.Left);
             double shapesWidth = MeasureHeaderFooterShapesWidth(shapes, PdfAlign.Left);
             double occupiedWidth = CombineHeaderFooterInlineWidths(textWidth, imagesWidth, shapesWidth);
-            layouts.Add(new PageTextZoneLayout(text, contentLeft, textWidth, PdfAlign.Left, contentLeft, occupiedWidth, textBottom, textTop - textBottom));
+            layouts.Add(new PageTextZoneLayout(text, contentLeft, textWidth, PdfAlign.Left, textBottom, textTop - textBottom));
         }
 
         if (!string.IsNullOrEmpty(zones.Center)) {
@@ -205,7 +209,7 @@ internal static partial class PdfWriter {
             double shapesWidth = MeasureHeaderFooterShapesWidth(shapes, PdfAlign.Center);
             double occupiedWidth = CombineHeaderFooterInlineWidths(textWidth, imagesWidth, shapesWidth);
             double occupiedX = contentLeft + ((contentWidth - occupiedWidth) / 2);
-            layouts.Add(new PageTextZoneLayout(text, occupiedX, textWidth, PdfAlign.Center, occupiedX, occupiedWidth, textBottom, textTop - textBottom));
+            layouts.Add(new PageTextZoneLayout(text, occupiedX, textWidth, PdfAlign.Center, textBottom, textTop - textBottom));
         }
 
         if (!string.IsNullOrEmpty(zones.Right)) {
@@ -217,48 +221,69 @@ internal static partial class PdfWriter {
             double shapesWidth = MeasureHeaderFooterShapesWidth(shapes, PdfAlign.Right);
             double occupiedWidth = CombineHeaderFooterInlineWidths(textWidth, imagesWidth, shapesWidth);
             double occupiedX = contentLeft + contentWidth - occupiedWidth;
-            layouts.Add(new PageTextZoneLayout(text, occupiedX, textWidth, PdfAlign.Right, occupiedX, occupiedWidth, textBottom, textTop - textBottom));
+            layouts.Add(new PageTextZoneLayout(text, occupiedX, textWidth, PdfAlign.Right, textBottom, textTop - textBottom));
         }
 
-        ValidatePageTextZoneLayouts(opts, layouts, contentLeft, contentLeft + contentWidth, isHeader);
+        ValidatePageTextZoneLayouts(opts, layouts, isHeader);
         return layouts;
     }
 
-    private static void ValidatePageTextZoneLayouts(PdfOptions options, System.Collections.Generic.List<PageTextZoneLayout> layouts, double contentLeft, double contentRight, bool isHeader) {
-        const double tolerance = 0.01D;
-        const double minimumGap = 2D;
+    private static void ValidatePageTextZoneLayouts(PdfOptions options, System.Collections.Generic.List<PageTextZoneLayout> layouts, bool isHeader) {
         string source = isHeader ? "Header" : "Footer";
         foreach (var zone in layouts) {
-            if (zone.OccupiedX < contentLeft - tolerance || zone.OccupiedX + zone.OccupiedWidth > contentRight + tolerance) {
+            if (zone.TextWidth > 0D) {
+                ReportHeaderFooterBounds(options, source, "text", zone.X, zone.TextBottom, zone.TextWidth, zone.TextHeight);
+            }
+        }
+    }
+
+    private static void ValidateHeaderFooterGroupLayouts(
+        PdfOptions options,
+        int variantPage,
+        int page,
+        int pages,
+        int documentPages,
+        bool isHeader) {
+        const double tolerance = 0.01D;
+        const double minimumGap = 2D;
+        double contentLeft = options.MarginLeft;
+        double contentRight = options.PageWidth - options.MarginRight;
+        string source = isHeader ? "Header" : "Footer";
+        var layouts = new System.Collections.Generic.List<HeaderFooterGroupLayout>(3);
+
+        foreach (PdfAlign align in new[] { PdfAlign.Left, PdfAlign.Center, PdfAlign.Right }) {
+            if (!TryGetHeaderFooterGroupVisibleHorizontalBounds(
+                    options,
+                    variantPage,
+                    page,
+                    pages,
+                    documentPages,
+                    align,
+                    isHeader,
+                    out double visibleLeft,
+                    out double visibleRight)) {
+                continue;
+            }
+
+            var layout = new HeaderFooterGroupLayout(visibleLeft, visibleRight - visibleLeft);
+            layouts.Add(layout);
+            if (layout.X < contentLeft - tolerance || layout.X + layout.Width > contentRight + tolerance) {
                 options.AddLayoutDiagnostic(
                     "HeaderFooterContentOverflow",
                     source,
                     source + " zone content exceeds the page content frame and was preserved as authored.",
                     PdfLayoutDiagnosticKind.Overflow,
                     PdfConversionWarningSeverity.Information,
-                    x: zone.OccupiedX,
-                    width: zone.OccupiedWidth);
-            }
-
-            bool outsideVerticalBounds = zone.TextBottom < -tolerance || zone.TextBottom + zone.TextHeight > options.PageHeight + tolerance;
-            if (zone.OccupiedX < -tolerance || zone.OccupiedX + zone.OccupiedWidth > options.PageWidth + tolerance || outsideVerticalBounds) {
-                options.AddLayoutDiagnostic(
-                    "HeaderFooterPageBoundsClipped",
-                    source,
-                    source + " zone content extends beyond the physical page bounds and may be clipped by the PDF page.",
-                    PdfLayoutDiagnosticKind.ClippedContent,
-                    x: zone.OccupiedX,
-                    y: zone.TextBottom,
-                    width: zone.OccupiedWidth,
-                    height: zone.TextHeight);
+                    x: layout.X,
+                    width: layout.Width);
             }
         }
 
-        var ordered = layouts.OrderBy(zone => zone.OccupiedX).ToList();
+        var ordered = layouts.OrderBy(zone => zone.X).ToList();
         for (int i = 1; i < ordered.Count; i++) {
             var previous = ordered[i - 1];
             var current = ordered[i];
-            if (previous.OccupiedX + previous.OccupiedWidth + minimumGap > current.OccupiedX + tolerance) {
+            if (previous.X + previous.Width + minimumGap > current.X + tolerance) {
                 options.AddLayoutDiagnostic(
                     "HeaderFooterZoneOverlap",
                     source,
@@ -267,6 +292,82 @@ internal static partial class PdfWriter {
                     PdfConversionWarningSeverity.Information);
             }
         }
+    }
+
+    private static bool TryGetHeaderFooterGroupVisibleHorizontalBounds(
+        PdfOptions options,
+        int variantPage,
+        int page,
+        int pages,
+        int documentPages,
+        PdfAlign align,
+        bool isHeader,
+        out double visibleLeft,
+        out double visibleRight) {
+        double textWidth = MeasureHeaderFooterTextWidth(options, variantPage, page, pages, documentPages, align, isHeader);
+        System.Collections.Generic.IReadOnlyList<PdfHeaderFooterImage> images = isHeader
+            ? options.GetHeaderImagesForPage(variantPage)
+            : options.GetFooterImagesForPage(variantPage);
+        System.Collections.Generic.IReadOnlyList<PdfHeaderFooterShape> shapes = isHeader
+            ? options.GetHeaderShapesForPage(variantPage)
+            : options.GetFooterShapesForPage(variantPage);
+        double imagesWidth = MeasureHeaderFooterImagesWidth(images, align);
+        double shapesWidth = MeasureHeaderFooterShapesWidth(shapes, align);
+        double groupWidth = CombineHeaderFooterInlineWidths(textWidth, imagesWidth, shapesWidth);
+        double groupX = AlignHeaderFooterGroup(options, groupWidth, align);
+        visibleLeft = double.PositiveInfinity;
+        visibleRight = double.NegativeInfinity;
+
+        if (textWidth > 0D) {
+            IncludeHorizontalBounds(groupX, groupX + textWidth, ref visibleLeft, ref visibleRight);
+        }
+
+        double imageConsumedWidth = 0D;
+        foreach (PdfHeaderFooterImage image in images) {
+            if (image.Align != align) {
+                continue;
+            }
+
+            double imageX = groupX +
+                (textWidth > 0D ? textWidth + HeaderFooterInlineGap : 0D) +
+                imageConsumedWidth;
+            double imageBottomY = isHeader
+                ? options.PageHeight - options.MarginTop + options.HeaderOffsetY - image.Height
+                : options.MarginBottom - options.FooterOffsetY;
+            ImageBlock block = image.ToImageBlock();
+            PdfImageStyle style = block.Style ?? new PdfImageStyle();
+            PageImage pageImage = CreatePageImage(block, style, imageX, imageBottomY);
+            GetImageAnnotationBounds(style, pageImage, imageX, imageBottomY, image.Width, image.Height, out double imageLeft, out _, out double imageRight, out _);
+            IncludeHorizontalBounds(imageLeft, imageRight, ref visibleLeft, ref visibleRight);
+            imageConsumedWidth += image.Width + HeaderFooterInlineGap;
+        }
+
+        double shapeConsumedWidth = 0D;
+        foreach (PdfHeaderFooterShape headerFooterShape in shapes) {
+            if (headerFooterShape.Align != align) {
+                continue;
+            }
+
+            double shapeX = groupX +
+                (textWidth > 0D ? textWidth + HeaderFooterInlineGap : 0D) +
+                (imagesWidth > 0D ? imagesWidth + HeaderFooterInlineGap : 0D) +
+                shapeConsumedWidth;
+            ShapeBlock shapeBlock = headerFooterShape.ToShapeBlock();
+            double shapeBottomY = isHeader
+                ? options.PageHeight - options.MarginTop + options.HeaderOffsetY - shapeBlock.Shape.Height
+                : options.MarginBottom - options.FooterOffsetY;
+            if (TryGetHeaderFooterShapeBounds(shapeBlock.Shape, shapeX, shapeBottomY, out double shapeLeft, out _, out double shapeWidth, out _)) {
+                IncludeHorizontalBounds(shapeLeft, shapeLeft + shapeWidth, ref visibleLeft, ref visibleRight);
+            }
+            shapeConsumedWidth += headerFooterShape.Width + HeaderFooterInlineGap;
+        }
+
+        return !double.IsPositiveInfinity(visibleLeft) && !double.IsNegativeInfinity(visibleRight);
+    }
+
+    private static void IncludeHorizontalBounds(double left, double right, ref double visibleLeft, ref double visibleRight) {
+        visibleLeft = System.Math.Min(visibleLeft, left);
+        visibleRight = System.Math.Max(visibleRight, right);
     }
 
     private static double MeasureHeaderFooterTextWidth(
@@ -325,10 +426,10 @@ internal static partial class PdfWriter {
         double X,
         double TextWidth,
         PdfAlign Align,
-        double OccupiedX,
-        double OccupiedWidth,
         double TextBottom,
         double TextHeight);
+
+    private readonly record struct HeaderFooterGroupLayout(double X, double Width);
 
     private static System.Collections.Generic.IReadOnlyList<PdfTextRun> BuildPageTextRuns(string text, PdfStandardFont font, double fontSize, PdfColor? color, PdfOptions opts, string? fontFamily = null) {
         (bool bold, bool italic) = GetPageTextFontStyle(font);

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.PageText.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.PageText.cs
@@ -21,6 +21,9 @@ internal static partial class PdfWriter {
         double shapesWidth = MeasureHeaderFooterShapesWidth(opts.GetFooterShapesForPage(variantPage), opts.FooterAlign);
         double groupWidth = CombineHeaderFooterInlineWidths(textWidth, imagesWidth, shapesWidth);
         double x = AlignHeaderFooterGroup(opts, groupWidth, opts.FooterAlign);
+        if (textWidth > 0D) {
+            ReportHeaderFooterBounds(opts, "Footer", "text", x, y: null, width: textWidth, height: null);
+        }
         double y = opts.MarginBottom - opts.FooterOffsetY;
         PdfColor? footerColor = opts.FooterTextColor;
         var sb = new StringBuilder();
@@ -46,6 +49,9 @@ internal static partial class PdfWriter {
         double shapesWidth = MeasureHeaderFooterShapesWidth(opts.GetHeaderShapesForPage(variantPage), opts.HeaderAlign);
         double groupWidth = CombineHeaderFooterInlineWidths(textWidth, imagesWidth, shapesWidth);
         double x = AlignHeaderFooterGroup(opts, groupWidth, opts.HeaderAlign);
+        if (textWidth > 0D) {
+            ReportHeaderFooterBounds(opts, "Header", "text", x, y: null, width: textWidth, height: null);
+        }
         double y = opts.PageHeight - opts.MarginTop + opts.HeaderOffsetY;
         PdfColor? headerColor = opts.HeaderTextColor;
 
@@ -205,17 +211,34 @@ internal static partial class PdfWriter {
             layouts.Add(new PageTextZoneLayout(text, occupiedX, textWidth, PdfAlign.Right, occupiedX, occupiedWidth));
         }
 
-        ValidatePageTextZoneLayouts(layouts, contentLeft, contentLeft + contentWidth, isHeader);
+        ValidatePageTextZoneLayouts(opts, layouts, contentLeft, contentLeft + contentWidth, isHeader);
         return layouts;
     }
 
-    private static void ValidatePageTextZoneLayouts(System.Collections.Generic.List<PageTextZoneLayout> layouts, double contentLeft, double contentRight, bool isHeader) {
+    private static void ValidatePageTextZoneLayouts(PdfOptions options, System.Collections.Generic.List<PageTextZoneLayout> layouts, double contentLeft, double contentRight, bool isHeader) {
         const double tolerance = 0.01D;
         const double minimumGap = 2D;
-        string scope = isHeader ? "header" : "footer";
+        string source = isHeader ? "Header" : "Footer";
         foreach (var zone in layouts) {
             if (zone.OccupiedX < contentLeft - tolerance || zone.OccupiedX + zone.OccupiedWidth > contentRight + tolerance) {
-                throw new ArgumentException("PDF " + scope + " zone content must fit inside the page content width.");
+                options.AddLayoutDiagnostic(
+                    "HeaderFooterContentOverflow",
+                    source,
+                    source + " zone content exceeds the page content frame and was preserved as authored.",
+                    PdfLayoutDiagnosticKind.Overflow,
+                    PdfConversionWarningSeverity.Information,
+                    x: zone.OccupiedX,
+                    width: zone.OccupiedWidth);
+            }
+
+            if (zone.OccupiedX < -tolerance || zone.OccupiedX + zone.OccupiedWidth > options.PageWidth + tolerance) {
+                options.AddLayoutDiagnostic(
+                    "HeaderFooterPageBoundsClipped",
+                    source,
+                    source + " zone content extends beyond the physical page bounds and may be clipped by the PDF page.",
+                    PdfLayoutDiagnosticKind.ClippedContent,
+                    x: zone.OccupiedX,
+                    width: zone.OccupiedWidth);
             }
         }
 
@@ -224,7 +247,12 @@ internal static partial class PdfWriter {
             var previous = ordered[i - 1];
             var current = ordered[i];
             if (previous.OccupiedX + previous.OccupiedWidth + minimumGap > current.OccupiedX + tolerance) {
-                throw new ArgumentException("PDF " + scope + " zones must not overlap.");
+                options.AddLayoutDiagnostic(
+                    "HeaderFooterZoneOverlap",
+                    source,
+                    source + " zones overlap and were preserved as authored.",
+                    PdfLayoutDiagnosticKind.Overflow,
+                    PdfConversionWarningSeverity.Information);
             }
         }
     }

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.PageText.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.PageText.cs
@@ -21,10 +21,10 @@ internal static partial class PdfWriter {
         double shapesWidth = MeasureHeaderFooterShapesWidth(opts.GetFooterShapesForPage(variantPage), opts.FooterAlign);
         double groupWidth = CombineHeaderFooterInlineWidths(textWidth, imagesWidth, shapesWidth);
         double x = AlignHeaderFooterGroup(opts, groupWidth, opts.FooterAlign);
-        if (textWidth > 0D) {
-            ReportHeaderFooterBounds(opts, "Footer", "text", x, y: null, width: textWidth, height: null);
-        }
         double y = opts.MarginBottom - opts.FooterOffsetY;
+        if (textWidth > 0D && TryGetPageTextVerticalBounds(runs, footerFont, opts.FooterFontSize, opts, y, out double textBottom, out double textTop)) {
+            ReportHeaderFooterBounds(opts, "Footer", "text", x, textBottom, textWidth, textTop - textBottom);
+        }
         PdfColor? footerColor = opts.FooterTextColor;
         var sb = new StringBuilder();
         AppendPageTextRuns(sb, runs, footerFont, footerFontResource, fontResources, namedFontResources, opts.FooterFontSize, footerColor, x, y, opts, textWidth, opts.FooterAlign);
@@ -49,10 +49,10 @@ internal static partial class PdfWriter {
         double shapesWidth = MeasureHeaderFooterShapesWidth(opts.GetHeaderShapesForPage(variantPage), opts.HeaderAlign);
         double groupWidth = CombineHeaderFooterInlineWidths(textWidth, imagesWidth, shapesWidth);
         double x = AlignHeaderFooterGroup(opts, groupWidth, opts.HeaderAlign);
-        if (textWidth > 0D) {
-            ReportHeaderFooterBounds(opts, "Header", "text", x, y: null, width: textWidth, height: null);
-        }
         double y = opts.PageHeight - opts.MarginTop + opts.HeaderOffsetY;
+        if (textWidth > 0D && TryGetPageTextVerticalBounds(runs, headerFont, opts.HeaderFontSize, opts, y, out double textBottom, out double textTop)) {
+            ReportHeaderFooterBounds(opts, "Header", "text", x, textBottom, textWidth, textTop - textBottom);
+        }
         PdfColor? headerColor = opts.HeaderTextColor;
 
         var sb = new StringBuilder();
@@ -173,6 +173,9 @@ internal static partial class PdfWriter {
         bool isHeader) {
         double contentLeft = opts.MarginLeft;
         double contentWidth = opts.PageWidth - opts.MarginLeft - opts.MarginRight;
+        double textBaseline = isHeader
+            ? opts.PageHeight - opts.MarginTop + opts.HeaderOffsetY
+            : opts.MarginBottom - opts.FooterOffsetY;
         var layouts = new System.Collections.Generic.List<PageTextZoneLayout>();
         System.Collections.Generic.IReadOnlyList<PdfHeaderFooterImage> images = isHeader
             ? opts.GetHeaderImagesForPage(variantPage)
@@ -184,31 +187,37 @@ internal static partial class PdfWriter {
 
         if (!string.IsNullOrEmpty(zones.Left)) {
             string text = FormatPageText(zones.Left!, page, pages, documentPages, opts.PageNumberStyle);
-            double textWidth = MeasurePageTextRuns(BuildPageTextRuns(text, font, fontSize, color: null, opts, fontFamily), font, fontSize, opts);
+            System.Collections.Generic.IReadOnlyList<PdfTextRun> runs = BuildPageTextRuns(text, font, fontSize, color: null, opts, fontFamily);
+            double textWidth = MeasurePageTextRuns(runs, font, fontSize, opts);
+            GetPageTextVerticalBoundsOrBaseline(runs, font, fontSize, opts, textBaseline, out double textBottom, out double textTop);
             double imagesWidth = MeasureHeaderFooterImagesWidth(images, PdfAlign.Left);
             double shapesWidth = MeasureHeaderFooterShapesWidth(shapes, PdfAlign.Left);
             double occupiedWidth = CombineHeaderFooterInlineWidths(textWidth, imagesWidth, shapesWidth);
-            layouts.Add(new PageTextZoneLayout(text, contentLeft, textWidth, PdfAlign.Left, contentLeft, occupiedWidth));
+            layouts.Add(new PageTextZoneLayout(text, contentLeft, textWidth, PdfAlign.Left, contentLeft, occupiedWidth, textBottom, textTop - textBottom));
         }
 
         if (!string.IsNullOrEmpty(zones.Center)) {
             string text = FormatPageText(zones.Center!, page, pages, documentPages, opts.PageNumberStyle);
-            double textWidth = MeasurePageTextRuns(BuildPageTextRuns(text, font, fontSize, color: null, opts, fontFamily), font, fontSize, opts);
+            System.Collections.Generic.IReadOnlyList<PdfTextRun> runs = BuildPageTextRuns(text, font, fontSize, color: null, opts, fontFamily);
+            double textWidth = MeasurePageTextRuns(runs, font, fontSize, opts);
+            GetPageTextVerticalBoundsOrBaseline(runs, font, fontSize, opts, textBaseline, out double textBottom, out double textTop);
             double imagesWidth = MeasureHeaderFooterImagesWidth(images, PdfAlign.Center);
             double shapesWidth = MeasureHeaderFooterShapesWidth(shapes, PdfAlign.Center);
             double occupiedWidth = CombineHeaderFooterInlineWidths(textWidth, imagesWidth, shapesWidth);
             double occupiedX = contentLeft + ((contentWidth - occupiedWidth) / 2);
-            layouts.Add(new PageTextZoneLayout(text, occupiedX, textWidth, PdfAlign.Center, occupiedX, occupiedWidth));
+            layouts.Add(new PageTextZoneLayout(text, occupiedX, textWidth, PdfAlign.Center, occupiedX, occupiedWidth, textBottom, textTop - textBottom));
         }
 
         if (!string.IsNullOrEmpty(zones.Right)) {
             string text = FormatPageText(zones.Right!, page, pages, documentPages, opts.PageNumberStyle);
-            double textWidth = MeasurePageTextRuns(BuildPageTextRuns(text, font, fontSize, color: null, opts, fontFamily), font, fontSize, opts);
+            System.Collections.Generic.IReadOnlyList<PdfTextRun> runs = BuildPageTextRuns(text, font, fontSize, color: null, opts, fontFamily);
+            double textWidth = MeasurePageTextRuns(runs, font, fontSize, opts);
+            GetPageTextVerticalBoundsOrBaseline(runs, font, fontSize, opts, textBaseline, out double textBottom, out double textTop);
             double imagesWidth = MeasureHeaderFooterImagesWidth(images, PdfAlign.Right);
             double shapesWidth = MeasureHeaderFooterShapesWidth(shapes, PdfAlign.Right);
             double occupiedWidth = CombineHeaderFooterInlineWidths(textWidth, imagesWidth, shapesWidth);
             double occupiedX = contentLeft + contentWidth - occupiedWidth;
-            layouts.Add(new PageTextZoneLayout(text, occupiedX, textWidth, PdfAlign.Right, occupiedX, occupiedWidth));
+            layouts.Add(new PageTextZoneLayout(text, occupiedX, textWidth, PdfAlign.Right, occupiedX, occupiedWidth, textBottom, textTop - textBottom));
         }
 
         ValidatePageTextZoneLayouts(opts, layouts, contentLeft, contentLeft + contentWidth, isHeader);
@@ -231,14 +240,17 @@ internal static partial class PdfWriter {
                     width: zone.OccupiedWidth);
             }
 
-            if (zone.OccupiedX < -tolerance || zone.OccupiedX + zone.OccupiedWidth > options.PageWidth + tolerance) {
+            bool outsideVerticalBounds = zone.TextBottom < -tolerance || zone.TextBottom + zone.TextHeight > options.PageHeight + tolerance;
+            if (zone.OccupiedX < -tolerance || zone.OccupiedX + zone.OccupiedWidth > options.PageWidth + tolerance || outsideVerticalBounds) {
                 options.AddLayoutDiagnostic(
                     "HeaderFooterPageBoundsClipped",
                     source,
                     source + " zone content extends beyond the physical page bounds and may be clipped by the PDF page.",
                     PdfLayoutDiagnosticKind.ClippedContent,
                     x: zone.OccupiedX,
-                    width: zone.OccupiedWidth);
+                    y: zone.TextBottom,
+                    width: zone.OccupiedWidth,
+                    height: zone.TextHeight);
             }
         }
 
@@ -314,7 +326,9 @@ internal static partial class PdfWriter {
         double TextWidth,
         PdfAlign Align,
         double OccupiedX,
-        double OccupiedWidth);
+        double OccupiedWidth,
+        double TextBottom,
+        double TextHeight);
 
     private static System.Collections.Generic.IReadOnlyList<PdfTextRun> BuildPageTextRuns(string text, PdfStandardFont font, double fontSize, PdfColor? color, PdfOptions opts, string? fontFamily = null) {
         (bool bold, bool italic) = GetPageTextFontStyle(font);

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.TableCells.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.TableCells.cs
@@ -849,13 +849,14 @@ internal static partial class PdfWriter {
 
     private static PdfParagraphStyle CreateTableCellParagraphStyle(PdfTableCellParagraph paragraph, double availableWidth) {
         const double minimumTextWidth = 0.001D;
+        const double maximumSafeIndentMagnitude = double.MaxValue / 8D;
         double safeWidth = double.IsNaN(availableWidth) || double.IsInfinity(availableWidth)
             ? minimumTextWidth
-            : System.Math.Max(minimumTextWidth, availableWidth);
-        double leftIndent = System.Math.Max(-safeWidth, System.Math.Min(paragraph.LeftIndent, safeWidth - minimumTextWidth));
-        double rightIndent = System.Math.Max(-safeWidth, System.Math.Min(paragraph.RightIndent, safeWidth - leftIndent - minimumTextWidth));
+            : System.Math.Min(maximumSafeIndentMagnitude, System.Math.Max(minimumTextWidth, availableWidth));
+        double leftIndent = System.Math.Max(-maximumSafeIndentMagnitude, System.Math.Min(paragraph.LeftIndent, safeWidth - minimumTextWidth));
+        double rightIndent = System.Math.Max(-maximumSafeIndentMagnitude, System.Math.Min(paragraph.RightIndent, safeWidth - leftIndent - minimumTextWidth));
         double textWidth = System.Math.Max(minimumTextWidth, safeWidth - leftIndent - rightIndent);
-        double firstLineIndent = System.Math.Max(-safeWidth - leftIndent, System.Math.Min(paragraph.FirstLineIndent, textWidth - minimumTextWidth));
+        double firstLineIndent = System.Math.Max(-maximumSafeIndentMagnitude, System.Math.Min(paragraph.FirstLineIndent, textWidth - minimumTextWidth));
         var style = new PdfParagraphStyle {
             LineHeight = paragraph.LineHeight,
             LeftIndent = leftIndent,

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.TableCells.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.TableCells.cs
@@ -852,10 +852,10 @@ internal static partial class PdfWriter {
         double safeWidth = double.IsNaN(availableWidth) || double.IsInfinity(availableWidth)
             ? minimumTextWidth
             : System.Math.Max(minimumTextWidth, availableWidth);
-        double leftIndent = System.Math.Min(paragraph.LeftIndent, System.Math.Max(0D, safeWidth - minimumTextWidth));
-        double rightIndent = System.Math.Min(paragraph.RightIndent, System.Math.Max(0D, safeWidth - leftIndent - minimumTextWidth));
+        double leftIndent = System.Math.Max(-safeWidth, System.Math.Min(paragraph.LeftIndent, safeWidth - minimumTextWidth));
+        double rightIndent = System.Math.Max(-safeWidth, System.Math.Min(paragraph.RightIndent, safeWidth - leftIndent - minimumTextWidth));
         double textWidth = System.Math.Max(minimumTextWidth, safeWidth - leftIndent - rightIndent);
-        double firstLineIndent = System.Math.Max(-leftIndent, System.Math.Min(paragraph.FirstLineIndent, textWidth - minimumTextWidth));
+        double firstLineIndent = System.Math.Max(-safeWidth - leftIndent, System.Math.Min(paragraph.FirstLineIndent, textWidth - minimumTextWidth));
         var style = new PdfParagraphStyle {
             LineHeight = paragraph.LineHeight,
             LeftIndent = leftIndent,

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.TableRendering.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.TableRendering.cs
@@ -256,6 +256,28 @@ internal static partial class PdfWriter {
         return widths;
     }
 
+    private static void ExpandTableCellTextClip(
+        double textOriginX,
+        System.Collections.Generic.IReadOnlyList<double>? lineXOffsets,
+        System.Collections.Generic.IReadOnlyList<double>? lineWidths,
+        ref double clipX,
+        ref double clipWidth) {
+        if (lineXOffsets == null || lineWidths == null) {
+            return;
+        }
+
+        double clipRight = clipX + clipWidth;
+        int lineCount = System.Math.Min(lineXOffsets.Count, lineWidths.Count);
+        for (int index = 0; index < lineCount; index++) {
+            double lineX = textOriginX + lineXOffsets[index];
+            double lineRight = lineX + System.Math.Max(0D, lineWidths[index]);
+            clipX = System.Math.Min(clipX, lineX - TableCellClipBleed);
+            clipRight = System.Math.Max(clipRight, lineRight + TableCellClipBleed);
+        }
+
+        clipWidth = clipRight - clipX;
+    }
+
     private static PdfAlign MapTableCellAlignment(PdfColumnAlign align) => align switch {
         PdfColumnAlign.Center => PdfAlign.Center,
         PdfColumnAlign.Right => PdfAlign.Right,

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.TableRendering.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.TableRendering.cs
@@ -258,6 +258,8 @@ internal static partial class PdfWriter {
 
     private static void ExpandTableCellTextClip(
         double textOriginX,
+        double cellInnerWidth,
+        bool noWrap,
         System.Collections.Generic.IReadOnlyList<double>? lineXOffsets,
         System.Collections.Generic.IReadOnlyList<double>? lineWidths,
         ref double clipX,
@@ -270,7 +272,12 @@ internal static partial class PdfWriter {
         int lineCount = System.Math.Min(lineXOffsets.Count, lineWidths.Count);
         for (int index = 0; index < lineCount; index++) {
             double lineX = textOriginX + lineXOffsets[index];
-            double lineRight = lineX + System.Math.Max(0D, lineWidths[index]);
+            double relativeLineRight = lineXOffsets[index] + System.Math.Max(0D, lineWidths[index]);
+            if (noWrap) {
+                relativeLineRight = cellInnerWidth + (relativeLineRight - TableCellNoWrapWidth);
+            }
+
+            double lineRight = textOriginX + relativeLineRight;
             clipX = System.Math.Min(clipX, lineX - TableCellClipBleed);
             clipRight = System.Math.Max(clipRight, lineRight + TableCellClipBleed);
         }

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.TextStyles.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.TextStyles.cs
@@ -201,20 +201,16 @@ internal static partial class PdfWriter {
         double leftIndent = style?.LeftIndent ?? 0;
         double rightIndent = style?.RightIndent ?? 0;
         double firstLineIndent = style?.FirstLineIndent ?? 0;
-        if (leftIndent < 0 || double.IsNaN(leftIndent) || double.IsInfinity(leftIndent)) {
-            throw new ArgumentException("Paragraph left indent must be a non-negative finite value.");
+        if (double.IsNaN(leftIndent) || double.IsInfinity(leftIndent)) {
+            throw new ArgumentException("Paragraph left indent must be a finite value.");
         }
 
-        if (rightIndent < 0 || double.IsNaN(rightIndent) || double.IsInfinity(rightIndent)) {
-            throw new ArgumentException("Paragraph right indent must be a non-negative finite value.");
+        if (double.IsNaN(rightIndent) || double.IsInfinity(rightIndent)) {
+            throw new ArgumentException("Paragraph right indent must be a finite value.");
         }
 
         if (double.IsNaN(firstLineIndent) || double.IsInfinity(firstLineIndent)) {
             throw new ArgumentException("Paragraph first line indent must be a finite value.");
-        }
-
-        if (leftIndent + firstLineIndent < 0) {
-            throw new ArgumentException("Paragraph first line indent must not move text outside the left content frame.");
         }
 
         double textWidth = width - leftIndent - rightIndent;

--- a/OfficeIMO.Word.Pdf/README.md
+++ b/OfficeIMO.Word.Pdf/README.md
@@ -125,7 +125,7 @@ pdf.SaveAsWord(
 
 ## What it exports
 
-- Paragraphs, headings, rich runs, links, bookmarks, page breaks, lists, and common spacing/indentation settings.
+- Paragraphs, headings, rich runs, links, bookmarks, page breaks, lists, and common spacing/indentation settings, including hanging and legal negative left/right indents.
 - Word sections, page size, orientation, margins, columns, headers, footers, page numbers, and document background color.
 - Tables with common Word table styling, repeated headers, cell fills, borders, alignment, merged cells, and rich text in cells.
 - Paragraph-aligned images, selected shapes, text boxes, content controls, simple form controls, footnote/endnote markers, and table-of-contents links where supported by the first-party PDF path.
@@ -143,7 +143,7 @@ pdf.SaveAsWord(
 
 ## Options and diagnostics
 
-Use `WordPdfSaveOptions` when callers need to override page geometry, metadata, page-number behavior, font family, table-border fallback, profile presets, or text fallback policy. `TextFallbacks` uses the shared `PdfTextFallbackFeatures` enum. The balanced resource default enables installed fonts but denies arbitrary local and remote reads; use `PdfResourcePolicy.CreatePortableDeterministic()` for reproducible or untrusted conversion and `CreateTrustedHost()` only when local or remote resource access is intentional. Profiles do not inject page numbers; set `IncludePageNumbers = true` explicitly when generated numbering is desired. Request `ToPdfDocumentResult()` or `TrySaveAsPdf()` when diagnostics matter; unsupported Word features should become actionable operation results instead of mutable option state. Available embeddable Word families use shared named PDF resources and are not limited to three compatibility slots. Unavailable or non-embeddable families fall back to a mapped PDF font with an explicit warning.
+Use `WordPdfSaveOptions` when callers need to override page geometry, metadata, page-number behavior, font family, table-border fallback, profile presets, or text fallback policy. `TextFallbacks` uses the shared `PdfTextFallbackFeatures` enum. The balanced resource default enables installed fonts but denies arbitrary local and remote reads; use `PdfResourcePolicy.CreatePortableDeterministic()` for reproducible or untrusted conversion and `CreateTrustedHost()` only when local or remote resource access is intentional. Profiles do not inject page numbers; set `IncludePageNumbers = true` explicitly when generated numbering is desired. Request `ToPdfDocumentResult()` or `TrySaveAsPdf()` when diagnostics matter; unsupported Word features and preserved header/footer overflow become actionable operation results instead of mutable option state. Available embeddable Word families use shared named PDF resources and are not limited to three compatibility slots. Unavailable or non-embeddable families fall back to a mapped PDF font with an explicit warning.
 
 ## Current limits
 

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.ParagraphStyles.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.ParagraphStyles.cs
@@ -68,13 +68,7 @@ namespace OfficeIMO.Word.Pdf {
 
             if (paragraph.IndentationHangingPoints.HasValue) {
                 double hangingIndent = paragraph.IndentationHangingPoints.Value;
-                if (style.LeftIndent < hangingIndent) {
-                    style.LeftIndent = hangingIndent;
-                }
-
                 style.FirstLineIndent = -hangingIndent;
-            } else if (style.FirstLineIndent < 0D && style.LeftIndent < -style.FirstLineIndent) {
-                style.LeftIndent = -style.FirstLineIndent;
             }
 
             style.LineHeight = lineHeight;

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.TableCells.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.TableCells.cs
@@ -386,20 +386,14 @@ namespace OfficeIMO.Word.Pdf {
 
             if (paragraph.IndentationHangingPoints.HasValue) {
                 double hangingIndent = paragraph.IndentationHangingPoints.Value;
-                if (leftIndent < hangingIndent) {
-                    leftIndent = hangingIndent;
-                }
-
                 firstLineIndent = -hangingIndent;
-            } else if (firstLineIndent < 0D && leftIndent < -firstLineIndent) {
-                leftIndent = -firstLineIndent;
             }
 
             return (leftIndent, rightIndent, firstLineIndent);
         }
 
         private static double NormalizeNativeTableCellIndent(double value) =>
-            value < 0D || double.IsNaN(value) || double.IsInfinity(value) ? 0D : value;
+            double.IsNaN(value) || double.IsInfinity(value) ? 0D : value;
 
         private static double? ResolveNativeTableCellParagraphLineHeight(
             WordParagraph paragraph,

--- a/OfficeIMO.Word.Tests/Pdf/Word.SaveAsPdf.HeaderFooterContent.cs
+++ b/OfficeIMO.Word.Tests/Pdf/Word.SaveAsPdf.HeaderFooterContent.cs
@@ -15,6 +15,64 @@ namespace OfficeIMO.Tests;
 
 public partial class Word {
     [Fact]
+    public void SaveAsPdf_OfficeIMOEngine_Preserves_Wide_HeaderFooter_Zones_With_Diagnostics() {
+        string docPath = Path.Combine(_directoryWithFiles, "PdfNativeWideHeaderFooterZones.docx");
+        string pdfPath = Path.Combine(_directoryWithFiles, "PdfNativeWideHeaderFooterZones.pdf");
+
+        using (WordDocument document = WordDocument.Create(docPath)) {
+            document.AddHeadersAndFooters();
+            WordHeader header = RequireSectionHeader(document, 0, HeaderFooterValues.Default);
+            header.AddParagraph("LeftHeaderOverflowMarker");
+            WordParagraph centeredHeader = header.AddParagraph("CenterHeaderOverflowMarker");
+            centeredHeader.ParagraphAlignment = WordParagraphAlignment.Center;
+            WordParagraph rightHeader = header.AddParagraph("RightHeaderOverflowMarker");
+            rightHeader.ParagraphAlignment = WordParagraphAlignment.Right;
+
+            WordFooter footer = RequireSectionFooter(document, 0, HeaderFooterValues.Default);
+            footer.AddParagraph("LeftFooterOverflowMarker");
+            WordParagraph centeredFooter = footer.AddParagraph("CenterFooterOverflowMarker");
+            centeredFooter.ParagraphAlignment = WordParagraphAlignment.Center;
+            WordParagraph rightFooter = footer.AddParagraph("RightFooterOverflowMarker");
+            rightFooter.ParagraphAlignment = WordParagraphAlignment.Right;
+
+            document.AddParagraph("Wide header footer body");
+            document.Save();
+
+            PdfCore.PdfDocumentConversionResult result = document.ToPdfDocumentResult(new WordPdfSaveOptions {
+                IncludePageNumbers = false,
+                PageSize = new PdfCore.PageSize(260, 300),
+                Margins = PdfCore.PageMargins.Uniform(72)
+            });
+            result.Save(pdfPath);
+
+            Assert.Contains(result.Warnings, warning =>
+                warning.Code == "HeaderFooterContentOverflow" &&
+                warning.Source == "Header" &&
+                warning.Severity == PdfCore.PdfConversionWarningSeverity.Information &&
+                warning.Converter == "OfficeIMO.Word.Pdf");
+            Assert.Contains(result.Warnings, warning =>
+                warning.Code == "HeaderFooterZoneOverlap" &&
+                warning.Source == "Footer" &&
+                warning.Severity == PdfCore.PdfConversionWarningSeverity.Information &&
+                warning.Converter == "OfficeIMO.Word.Pdf");
+            Assert.DoesNotContain(result.Warnings, warning =>
+                (warning.Code == "HeaderFooterContentOverflow" || warning.Code == "HeaderFooterZoneOverlap") &&
+                warning.Severity != PdfCore.PdfConversionWarningSeverity.Information);
+            Assert.DoesNotContain(result.Warnings, warning => warning.Code == "HeaderFooterPageBoundsClipped");
+        }
+
+        using PdfPigDocument pdf = PdfPigDocument.Open(pdfPath);
+        string text = pdf.GetPage(1).Text;
+        Assert.Contains("LeftHeaderOverflowMarker", text, StringComparison.Ordinal);
+        Assert.Contains("CenterHeaderOverflowMarker", text, StringComparison.Ordinal);
+        Assert.Contains("RightHeaderOverflowMarker", text, StringComparison.Ordinal);
+        Assert.Contains("LeftFooterOverflowMarker", text, StringComparison.Ordinal);
+        Assert.Contains("CenterFooterOverflowMarker", text, StringComparison.Ordinal);
+        Assert.Contains("RightFooterOverflowMarker", text, StringComparison.Ordinal);
+        Assert.Contains("Wide header footer body", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void SaveAsPdf_OfficeIMOEngine_Records_Warnings_For_Unsupported_HeaderFooter_Content() {
         string docPath = Path.Combine(_directoryWithFiles, "PdfNativeHeaderFooterWarnings.docx");
         string pdfPath = Path.Combine(_directoryWithFiles, "PdfNativeHeaderFooterWarnings.pdf");

--- a/OfficeIMO.Word.Tests/Pdf/Word.SaveAsPdf.ParagraphFormatting.cs
+++ b/OfficeIMO.Word.Tests/Pdf/Word.SaveAsPdf.ParagraphFormatting.cs
@@ -1964,6 +1964,36 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void SaveAsPdf_OfficeIMOEngine_Preserves_Negative_Paragraph_Indents() {
+            string docPath = Path.Combine(_directoryWithFiles, "PdfNativeNegativeParagraphIndents.docx");
+            string pdfPath = Path.Combine(_directoryWithFiles, "PdfNativeNegativeParagraphIndents.pdf");
+
+            using (WordDocument document = WordDocument.Create(docPath)) {
+                WordParagraph normal = document.AddParagraph("NormalIndentMarker alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi omicron pi rho sigma tau");
+                normal.LineSpacingAfterPoints = 0;
+                WordParagraph extended = document.AddParagraph("NegativeIndentMarker alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi omicron pi rho sigma tau");
+                extended.IndentationBeforePoints = -18;
+                extended.IndentationAfterPoints = -30;
+                extended.LineSpacingAfterPoints = 0;
+
+                document.Save();
+                document.SaveAsPdf(pdfPath, new WordPdfSaveOptions {
+                    IncludePageNumbers = false,
+                    PageSize = new OfficeIMO.Pdf.PageSize(300, 320),
+                    Margins = PageMargins.Uniform(30)
+                });
+            }
+
+            using PdfPigDocument pdf = PdfPigDocument.Open(pdfPath);
+            var page = pdf.GetPage(1);
+            double normalX = FindWordStartX(page, "NormalIndentMarker");
+            double negativeX = FindWordStartX(page, "NegativeIndentMarker");
+
+            Assert.True(normalX - negativeX >= 17D, $"Expected the negative Word indent to extend text into the left margin. Normal x: {normalX:0.##}; negative x: {negativeX:0.##}.");
+            Assert.Contains("NegativeIndentMarker", page.Text, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void SaveAsPdf_OfficeIMOEngine_Renders_Paragraph_Hanging_Indent_Without_Left_Indent() {
             string docPath = Path.Combine(_directoryWithFiles, "PdfNativeHangingIndentNoLeft.docx");
             string pdfPath = Path.Combine(_directoryWithFiles, "PdfNativeHangingIndentNoLeft.pdf");
@@ -1973,12 +2003,28 @@ namespace OfficeIMO.Tests {
                 paragraph.IndentationHangingPoints = 36;
 
                 document.Save();
-                document.SaveAsPdf(pdfPath);
+                document.SaveAsPdf(pdfPath, new WordPdfSaveOptions {
+                    IncludePageNumbers = false,
+                    PageSize = new OfficeIMO.Pdf.PageSize(260, 260),
+                    Margins = PageMargins.Uniform(36)
+                });
             }
 
             Assert.True(File.Exists(pdfPath));
             using PdfPigDocument pdf = PdfPigDocument.Open(pdfPath);
-            Assert.Contains("HangingOnly", pdf.GetPage(1).Text);
+            var page = pdf.GetPage(1);
+            Assert.Contains("HangingOnly", page.Text);
+
+            var lineLefts = page
+                .GetWords()
+                .GroupBy(word => Math.Round(word.BoundingBox.Bottom, 1))
+                .OrderByDescending(group => group.Key)
+                .Take(2)
+                .Select(group => group.Min(word => word.BoundingBox.Left))
+                .ToList();
+
+            Assert.Equal(2, lineLefts.Count);
+            Assert.True(lineLefts[1] > lineLefts[0] + 30D, $"Expected a hanging indent without a left indent to preserve the authored first-line margin extension. First line x: {lineLefts[0]:0.##}; second line x: {lineLefts[1]:0.##}.");
         }
 
         [Fact]

--- a/OfficeIMO.Word.Tests/Pdf/Word.SaveAsPdf.TableRowsAndCells.cs
+++ b/OfficeIMO.Word.Tests/Pdf/Word.SaveAsPdf.TableRowsAndCells.cs
@@ -1142,22 +1142,22 @@ public partial class Word {
 
         using (WordDocument document = WordDocument.Create(docPath)) {
             WordTable table = document.AddTable(3, 1);
-            table.Width = 3000;
+            table.Width = 600;
             table.WidthType = WordTableWidthUnit.Dxa;
             table.LayoutMode = WordTableLayoutMode.Fixed;
             foreach (WordTableRow row in table.Rows) {
-                row.Cells[0].Width = 3000;
+                row.Cells[0].Width = 600;
                 row.Cells[0].WidthType = WordTableWidthUnit.Dxa;
             }
 
-            table.Rows[0].Cells[0].Paragraphs[0].Text = "PlainCellMarker";
+            table.Rows[0].Cells[0].Paragraphs[0].Text = "P0";
             WordParagraph negative = table.Rows[1].Cells[0].Paragraphs[0];
-            negative.Text = "NegativeCellMarker";
-            negative.IndentationBeforePoints = -18D;
-            negative.IndentationAfterPoints = -18D;
+            negative.Text = "N0";
+            negative.IndentationBeforePoints = -30D;
+            negative.IndentationAfterPoints = -30D;
 
             WordParagraph hanging = table.Rows[2].Cells[0].Paragraphs[0];
-            hanging.Text = "CellHangingStart alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu";
+            hanging.Text = "H0 a b c d e f g h i j k l m";
             hanging.IndentationHangingPoints = 36D;
 
             document.Save();
@@ -1172,16 +1172,16 @@ public partial class Word {
         using PdfPigDocument pdf = PdfPigDocument.Open(pdfPath);
         var page = pdf.GetPage(1);
         var words = page.GetWords().ToList();
-        var plain = Assert.Single(words, word => word.Text == "PlainCellMarker");
-        var negativeWord = Assert.Single(words, word => word.Text == "NegativeCellMarker");
-        Assert.True(plain.BoundingBox.Left - negativeWord.BoundingBox.Left >= 17D,
+        var plain = Assert.Single(words, word => word.Text == "P0");
+        var negativeWord = Assert.Single(words, word => word.Text == "N0");
+        Assert.True(plain.BoundingBox.Left - negativeWord.BoundingBox.Left >= 29D,
             $"Expected the negative table-cell paragraph indent to extend text left. Plain x: {plain.BoundingBox.Left:0.##}; negative x: {negativeWord.BoundingBox.Left:0.##}.");
 
         var hangingLines = words
             .GroupBy(word => Math.Round(word.BoundingBox.Bottom, 1))
             .OrderByDescending(group => group.Key)
             .ToList();
-        int firstHangingLine = hangingLines.FindIndex(group => group.Any(word => word.Text == "CellHangingStart"));
+        int firstHangingLine = hangingLines.FindIndex(group => group.Any(word => word.Text == "H0"));
         Assert.InRange(firstHangingLine, 0, hangingLines.Count - 2);
         double firstLineX = hangingLines[firstHangingLine].Min(word => word.BoundingBox.Left);
         double continuationLineX = hangingLines[firstHangingLine + 1].Min(word => word.BoundingBox.Left);

--- a/OfficeIMO.Word.Tests/Pdf/Word.SaveAsPdf.TableRowsAndCells.cs
+++ b/OfficeIMO.Word.Tests/Pdf/Word.SaveAsPdf.TableRowsAndCells.cs
@@ -1136,6 +1136,60 @@ public partial class Word {
     }
 
     [Fact]
+    public void SaveAsPdf_OfficeIMOEngine_Preserves_Negative_And_Hanging_Table_Cell_Paragraph_Indents() {
+        string docPath = Path.Combine(_directoryWithFiles, "PdfNativeNegativeTableCellParagraphIndents.docx");
+        string pdfPath = Path.Combine(_directoryWithFiles, "PdfNativeNegativeTableCellParagraphIndents.pdf");
+
+        using (WordDocument document = WordDocument.Create(docPath)) {
+            WordTable table = document.AddTable(3, 1);
+            table.Width = 3000;
+            table.WidthType = WordTableWidthUnit.Dxa;
+            table.LayoutMode = WordTableLayoutMode.Fixed;
+            foreach (WordTableRow row in table.Rows) {
+                row.Cells[0].Width = 3000;
+                row.Cells[0].WidthType = WordTableWidthUnit.Dxa;
+            }
+
+            table.Rows[0].Cells[0].Paragraphs[0].Text = "PlainCellMarker";
+            WordParagraph negative = table.Rows[1].Cells[0].Paragraphs[0];
+            negative.Text = "NegativeCellMarker";
+            negative.IndentationBeforePoints = -18D;
+            negative.IndentationAfterPoints = -18D;
+
+            WordParagraph hanging = table.Rows[2].Cells[0].Paragraphs[0];
+            hanging.Text = "CellHangingStart alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu";
+            hanging.IndentationHangingPoints = 36D;
+
+            document.Save();
+            document.SaveAsPdf(pdfPath, new WordPdfSaveOptions {
+                IncludePageNumbers = false,
+                PageSize = new PdfCore.PageSize(360, 300),
+                Margins = PdfCore.PageMargins.Uniform(40),
+                FontFamily = "Helvetica"
+            });
+        }
+
+        using PdfPigDocument pdf = PdfPigDocument.Open(pdfPath);
+        var page = pdf.GetPage(1);
+        var words = page.GetWords().ToList();
+        var plain = Assert.Single(words, word => word.Text == "PlainCellMarker");
+        var negativeWord = Assert.Single(words, word => word.Text == "NegativeCellMarker");
+        Assert.True(plain.BoundingBox.Left - negativeWord.BoundingBox.Left >= 17D,
+            $"Expected the negative table-cell paragraph indent to extend text left. Plain x: {plain.BoundingBox.Left:0.##}; negative x: {negativeWord.BoundingBox.Left:0.##}.");
+
+        var hangingLines = words
+            .GroupBy(word => Math.Round(word.BoundingBox.Bottom, 1))
+            .OrderByDescending(group => group.Key)
+            .ToList();
+        int firstHangingLine = hangingLines.FindIndex(group => group.Any(word => word.Text == "CellHangingStart"));
+        Assert.InRange(firstHangingLine, 0, hangingLines.Count - 2);
+        double firstLineX = hangingLines[firstHangingLine].Min(word => word.BoundingBox.Left);
+        double continuationLineX = hangingLines[firstHangingLine + 1].Min(word => word.BoundingBox.Left);
+        Assert.True(continuationLineX > firstLineX + 30D,
+            $"Expected a table-cell hanging indent without a left indent to preserve the authored first-line extension. First line x: {firstLineX:0.##}; continuation x: {continuationLineX:0.##}.");
+    }
+
+    [Fact]
     public void SaveAsPdf_OfficeIMOEngine_Renders_Table_Cell_Paragraph_Tab_Leaders() {
         string docPath = Path.Combine(_directoryWithFiles, "PdfNativeTableCellParagraphTabs.docx");
         string pdfPath = Path.Combine(_directoryWithFiles, "PdfNativeTableCellParagraphTabs.pdf");

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ OfficeIMO is a family of COM-free .NET libraries for creating, reading, editing,
 
 This is not one facade over a collection of unrelated document libraries. OfficeIMO owns its OneNote, PDF, Markdown, RTF, OpenDocument, AsciiDoc, LaTeX, CSV, EPUB, ZIP, drawing, legacy Word `.doc`, legacy Excel `.xls`, and legacy PowerPoint `.ppt`/`.pot`/`.pps` implementations. Word, Excel, and PowerPoint use the Open XML SDK for package mechanics; HTML uses AngleSharp for DOM and CSS parsing. Converters compose the same first-party object models used by the native packages and return diagnostics when a target format cannot carry everything from the source.
 
-The current source line is `3.1.x`; the latest NuGet release is `3.0.3`. Applications should keep OfficeIMO packages on the same coordinated version. The 3.1 source API keeps CSV and Excel behavior package-owned, uses one document lifecycle vocabulary, and keeps converters explicit about fidelity and diagnostics.
+The current source line is `3.2.x`; the latest coordinated NuGet release is `3.2.6`. Applications should keep OfficeIMO packages on the same coordinated version. Converters compose package-owned document models and expose result-bearing APIs when callers need fidelity diagnostics.
 
 Upgrading an existing application? Most `OfficeIMO.Word` users can begin with the [short Word-first 3.1 path](MIGRATION.md#start-here-most-officeimoword-applications); the full [OfficeIMO migration guide](MIGRATION.md) covers package, API, and behavior changes across every format. Release history and downloadable artifacts are published through [GitHub Releases](https://github.com/EvotecIT/OfficeIMO/releases).
 
@@ -1099,37 +1099,37 @@ Fixed-layout PDF import is necessarily semantic rather than visually lossless. R
 
 ## Install
 
-Install only the native packages and adapters an application needs. The commands below use the current `3.0.3` NuGet release.
+Install only the native packages and adapters an application needs. The commands below use the current `3.2.6` NuGet release.
 
 ```powershell
-dotnet add package OfficeIMO.Word --version 3.0.3
-dotnet add package OfficeIMO.Word.Pdf --version 3.0.3
+dotnet add package OfficeIMO.Word --version 3.2.6
+dotnet add package OfficeIMO.Word.Pdf --version 3.2.6
 
-dotnet add package OfficeIMO.Excel --version 3.0.3
-dotnet add package OfficeIMO.Excel.Html --version 3.0.3
-dotnet add package OfficeIMO.Excel.Pdf --version 3.0.3
+dotnet add package OfficeIMO.Excel --version 3.2.6
+dotnet add package OfficeIMO.Excel.Html --version 3.2.6
+dotnet add package OfficeIMO.Excel.Pdf --version 3.2.6
 
-dotnet add package OfficeIMO.Epub --version 3.0.3
-dotnet add package OfficeIMO.Epub.Image --version 3.0.3
+dotnet add package OfficeIMO.Epub --version 3.2.6
+dotnet add package OfficeIMO.Epub.Image --version 3.2.6
 
-dotnet add package OfficeIMO.Adf --version 3.0.3
-dotnet add package OfficeIMO.Confluence --version 3.0.3
+dotnet add package OfficeIMO.Adf --version 3.2.6
+dotnet add package OfficeIMO.Confluence --version 3.2.6
 
-dotnet add package OfficeIMO.Reader.Pdf --version 3.0.3
+dotnet add package OfficeIMO.Reader.Pdf --version 3.2.6
 
 # Add every Reader adapter only when a broad ingestion host genuinely needs all formats.
-dotnet add package OfficeIMO.Reader.All --version 3.0.3
+dotnet add package OfficeIMO.Reader.All --version 3.2.6
 
-dotnet add package OfficeIMO.OneNote --version 3.0.3
-dotnet add package OfficeIMO.OneNote.Markdown --version 3.0.3
-dotnet add package OfficeIMO.OneNote.Html --version 3.0.3
-dotnet add package OfficeIMO.OneNote.Pdf --version 3.0.3
-dotnet add package OfficeIMO.Reader.OneNote --version 3.0.3
+dotnet add package OfficeIMO.OneNote --version 3.2.6
+dotnet add package OfficeIMO.OneNote.Markdown --version 3.2.6
+dotnet add package OfficeIMO.OneNote.Html --version 3.2.6
+dotnet add package OfficeIMO.OneNote.Pdf --version 3.2.6
+dotnet add package OfficeIMO.Reader.OneNote --version 3.2.6
 ```
 
-Keep OfficeIMO package references in one application on the same published version. The repository source is already on the coordinated `3.1.x` line.
+Keep OfficeIMO package references in one application on the same published version. The repository source is on the coordinated `3.2.x` line.
 
-The unified `OfficeIMO.Tool` CLI documented in this repository is the `3.1.x` source-tree surface, not part of the published `3.0.3` package block above. In this checkout, run it directly with `dotnet run --project OfficeIMO.Tool/OfficeIMO.Tool.csproj --framework net8.0 -- <command>`.
+Install the unified CLI with `dotnet tool install --global OfficeIMO.Tool --version 3.2.6`. Contributors can run the current checkout directly with `dotnet run --project OfficeIMO.Tool/OfficeIMO.Tool.csproj --framework net8.0 -- <command>`.
 
 ## Common workflows
 


### PR DESCRIPTION
## Summary

- preserve legal negative and hanging paragraph indents in direct PDF composition and Word-to-PDF conversion, including table cells
- preserve renderable header/footer text, image, and shape overflow instead of rejecting the document
- keep no-wrap table text clipped to its cell while still honoring authored negative-indent overflow
- report physical clipping from visible text, fitted-image, and transformed-shape bounds while treating content-frame overflow and zone overlap as informational diagnostics
- keep current package installation examples aligned with the published 3.2.6 release

## Validation

- `OfficeIMO.Pdf.Tests` on .NET 10: 5,344 passed
- `OfficeIMO.Word.Tests` on .NET 10: 2,814 passed, 11 expected opt-in skips
- focused PDF contracts: 12 passed on each of .NET Framework 4.7.2, .NET 8, and .NET 10
- focused Word conversion contracts: 4 passed on each of .NET Framework 4.7.2, .NET 8, and .NET 10
- rendered negative-indent, header/footer, and no-wrap table-cell artifacts visually inspected
- published 3.2.6 package restore/build and `OfficeIMO.Tool` installation verified