### PR TITLE
Harden email resources and HTML image rewriting

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -9,6 +9,12 @@ This guide contains version-to-version changes that require application code, pa
 
 OfficeIMO 3.2 is a coordinated package-ownership cleanup. Upgrade every OfficeIMO package in an application to the same `3.2.x` version and perform a clean restore after changing versions.
 
+## OfficeIMO 3.2: bounded email body resource projections
+
+`EmailBodyProjection.Create(...)` now indexes at most 128 resources, accepts at most 128 MiB from one resource, and reads or declares at most 256 MiB across one projection by default. Older versions had no resource-count or projection-wide byte ceiling. Exceeding a ceiling throws `EmailLimitExceededException`; repeated and parallel reads share the same projection-wide budget.
+
+Trusted applications that must process larger messages can set explicit, application-owned values through `EmailBodyProjectionOptions.MaxResourceCount`, `MaxResourceBytes`, and `MaxTotalResourceBytes`. Body-only consumers should set `IncludeResources = false` so attachments are not indexed. Prefer `OpenReadStream`, `CopyTo`, or their asynchronous counterparts when content does not need to be materialized as a byte array.
+
 ## OfficeIMO 3.2: deterministic Reader export destinations
 
 `WriteAssetsToDirectory`, `WriteTableExportsToDirectory`, and `WriteVisualExportsToDirectory` now reject duplicate destination filenames before creating or replacing any output. The comparison uses the destination filesystem's case and Unicode-normalization behavior after applying the materializer's filename sanitization. It also treats trailing dots and spaces as aliases when the destination filesystem applies Windows filename semantics, so names such as `report`, `report.`, and `report ` cannot target one output. Older versions could write or skip colliding entries according to `Overwrite`, making the surviving payload depend on enumeration order.

--- a/OfficeIMO.Email.Html/EmailBodyProjection.cs
+++ b/OfficeIMO.Email.Html/EmailBodyProjection.cs
@@ -159,8 +159,15 @@ public static class EmailBodyProjection {
                 resourceAttachments.Length, effective.MaxResourceCount);
         }
 
+        var resourceBudget = new EmailBodyResourceBudget(effective.MaxTotalResourceBytes);
+        EmailBodyResource[] projectedResources = resourceAttachments
+            .Select(attachment => new EmailBodyResource(
+                attachment,
+                effective.MaxResourceBytes,
+                resourceBudget))
+            .ToArray();
+        var resourceIdentity = new EmailBodyResourceIdentityIndex(projectedResources);
         Uri? baseUri = effective.BaseUri ?? ResolveBaseUri(source.Body.HtmlContentLocation);
-        var resourceIdentity = new EmailBodyResourceIdentityIndex(resourceAttachments);
         HtmlConversionDocumentOptions htmlOptions = effective.HtmlOptions?.Clone() ??
             HtmlConversionDocumentOptions.CreateUntrustedProfile();
         htmlOptions.BaseUri ??= baseUri;
@@ -180,24 +187,17 @@ public static class EmailBodyProjection {
         string safeHtml = CreateSafeEmailHtml(sourceDocument);
         HtmlConversionDocument document = HtmlConversionDocument.Parse(safeHtml, htmlOptions);
         long declaredResourceBytes = 0;
-        foreach (EmailAttachment attachment in resourceAttachments) {
-            if (attachment.Length <= 0) continue;
-            if (attachment.Length > effective.MaxTotalResourceBytes - declaredResourceBytes) {
-                long actual = attachment.Length > long.MaxValue - declaredResourceBytes
+        foreach (EmailBodyResource resource in projectedResources) {
+            if (resource.Length <= 0) continue;
+            if (resource.Length > effective.MaxTotalResourceBytes - declaredResourceBytes) {
+                long actual = resource.Length > long.MaxValue - declaredResourceBytes
                     ? long.MaxValue
-                    : declaredResourceBytes + attachment.Length;
+                    : declaredResourceBytes + resource.Length;
                 throw new EmailLimitExceededException("EmailBodyProjectionOptions.MaxTotalResourceBytes",
                     actual, effective.MaxTotalResourceBytes);
             }
-            declaredResourceBytes += attachment.Length;
+            declaredResourceBytes += resource.Length;
         }
-        var resourceBudget = new EmailBodyResourceBudget(effective.MaxTotalResourceBytes);
-        EmailBodyResource[] projectedResources = resourceAttachments
-            .Select(attachment => new EmailBodyResource(
-                attachment,
-                effective.MaxResourceBytes,
-                resourceBudget))
-            .ToArray();
         return new EmailBodyProjectionResult(sourceKind, safeHtml, source.Body.Text,
             document, projectedResources, diagnostics.AsReadOnly(), baseUri, resourceIdentity);
     }

--- a/OfficeIMO.Email.Html/EmailBodyProjection.cs
+++ b/OfficeIMO.Email.Html/EmailBodyProjection.cs
@@ -32,6 +32,8 @@ public enum EmailRemoteResourcePolicy {
 
 /// <summary>Options for the dependency-isolated email body projection.</summary>
 public sealed class EmailBodyProjectionOptions {
+    /// <summary>Controls whether inline attachment resources are indexed.</summary>
+    public bool IncludeResources { get; set; } = true;
     /// <summary>Body preference.</summary>
     public EmailBodySelectionPolicy SelectionPolicy { get; set; } = EmailBodySelectionPolicy.Richest;
     /// <summary>Remote resource policy. Network access is never performed by this package.</summary>
@@ -58,6 +60,7 @@ public sealed class EmailBodyProjectionOptions {
         if (MaxResourceCount <= 0) throw new ArgumentOutOfRangeException(nameof(MaxResourceCount));
         if (MaxTotalResourceBytes <= 0) throw new ArgumentOutOfRangeException(nameof(MaxTotalResourceBytes));
         return new EmailBodyProjectionOptions {
+            IncludeResources = IncludeResources,
             SelectionPolicy = SelectionPolicy,
             RemoteResourcePolicy = RemoteResourcePolicy,
             MaxResourceBytes = MaxResourceBytes,
@@ -172,11 +175,13 @@ public static class EmailBodyProjection {
         HtmlConversionDocument sourceDocument = HtmlConversionDocument.Parse(selectedHtml, htmlOptions);
         string safeHtml = CreateSafeEmailHtml(sourceDocument);
         HtmlConversionDocument document = HtmlConversionDocument.Parse(safeHtml, htmlOptions);
-        EmailAttachment[] resourceAttachments = source.Attachments
-            .Where(attachment => attachment.IsInline ||
-                !string.IsNullOrWhiteSpace(attachment.ContentId) ||
-                !string.IsNullOrWhiteSpace(attachment.ContentLocation))
-            .ToArray();
+        EmailAttachment[] resourceAttachments = effective.IncludeResources
+            ? source.Attachments
+                .Where(attachment => attachment.IsInline ||
+                    !string.IsNullOrWhiteSpace(attachment.ContentId) ||
+                    !string.IsNullOrWhiteSpace(attachment.ContentLocation))
+                .ToArray()
+            : Array.Empty<EmailAttachment>();
         if (resourceAttachments.Length > effective.MaxResourceCount) {
             throw new EmailLimitExceededException("EmailBodyProjectionOptions.MaxResourceCount",
                 resourceAttachments.Length, effective.MaxResourceCount);

--- a/OfficeIMO.Email.Html/EmailBodyProjection.cs
+++ b/OfficeIMO.Email.Html/EmailBodyProjection.cs
@@ -36,8 +36,12 @@ public sealed class EmailBodyProjectionOptions {
     public EmailBodySelectionPolicy SelectionPolicy { get; set; } = EmailBodySelectionPolicy.Richest;
     /// <summary>Remote resource policy. Network access is never performed by this package.</summary>
     public EmailRemoteResourcePolicy RemoteResourcePolicy { get; set; } = EmailRemoteResourcePolicy.Block;
-    /// <summary>Maximum bytes one inline resource may materialize.</summary>
+    /// <summary>Maximum bytes read from one inline resource.</summary>
     public long MaxResourceBytes { get; set; } = 128L * 1024 * 1024;
+    /// <summary>Maximum inline resources indexed by one projection.</summary>
+    public int MaxResourceCount { get; set; } = 128;
+    /// <summary>Maximum bytes read across all inline resources in one projection.</summary>
+    public long MaxTotalResourceBytes { get; set; } = 256L * 1024 * 1024;
     /// <summary>Optional base URI used for content-location resolution.</summary>
     public Uri? BaseUri { get; set; }
     /// <summary>Optional shared HTML policy. An untrusted profile is used when null.</summary>
@@ -51,90 +55,18 @@ public sealed class EmailBodyProjectionOptions {
             throw new ArgumentOutOfRangeException(nameof(RemoteResourcePolicy));
         }
         if (MaxResourceBytes <= 0) throw new ArgumentOutOfRangeException(nameof(MaxResourceBytes));
+        if (MaxResourceCount <= 0) throw new ArgumentOutOfRangeException(nameof(MaxResourceCount));
+        if (MaxTotalResourceBytes <= 0) throw new ArgumentOutOfRangeException(nameof(MaxTotalResourceBytes));
         return new EmailBodyProjectionOptions {
             SelectionPolicy = SelectionPolicy,
             RemoteResourcePolicy = RemoteResourcePolicy,
             MaxResourceBytes = MaxResourceBytes,
+            MaxResourceCount = MaxResourceCount,
+            MaxTotalResourceBytes = MaxTotalResourceBytes,
             BaseUri = BaseUri,
             HtmlOptions = HtmlOptions?.Clone()
         };
     }
-}
-
-/// <summary>Operation-scoped attachment resource resolved by CID, content location, or filename.</summary>
-public sealed class EmailBodyResource {
-    private readonly EmailAttachment _attachment;
-    private readonly long _maximumBytes;
-
-    internal EmailBodyResource(EmailAttachment attachment, long maximumBytes) {
-        _attachment = attachment;
-        _maximumBytes = maximumBytes;
-    }
-
-    /// <summary>Content type declared by the artifact.</summary>
-    public string ContentType => _attachment.ContentType ?? "application/octet-stream";
-    /// <summary>Declared decoded length.</summary>
-    public long Length => _attachment.Length;
-    /// <summary>Normalized Content-ID without angle brackets.</summary>
-    public string? ContentId => NormalizeContentId(_attachment.ContentId);
-    /// <summary>Content-Location retained by the artifact.</summary>
-    public string? ContentLocation => _attachment.ContentLocation;
-    /// <summary>Safe filename retained by the artifact.</summary>
-    public string? FileName => _attachment.FileName;
-
-    /// <summary>Reads this resource within the configured bound. Each call opens a fresh operation-scoped source.</summary>
-    public byte[] ReadAllBytes(CancellationToken cancellationToken = default) {
-        if (Length > _maximumBytes) {
-            throw new EmailLimitExceededException("EmailBodyProjectionOptions.MaxResourceBytes",
-                Length, _maximumBytes);
-        }
-        using Stream source = _attachment.OpenContentStream();
-        using (var output = new MemoryStream()) {
-            var buffer = new byte[64 * 1024];
-            long total = 0;
-            int read;
-            while ((read = source.Read(buffer, 0, buffer.Length)) != 0) {
-                cancellationToken.ThrowIfCancellationRequested();
-                total = checked(total + read);
-                if (total > _maximumBytes) {
-                    throw new EmailLimitExceededException("EmailBodyProjectionOptions.MaxResourceBytes",
-                        total, _maximumBytes);
-                }
-                output.Write(buffer, 0, read);
-            }
-            return output.ToArray();
-        }
-    }
-
-    /// <summary>Asynchronously reads this resource within the configured bound.</summary>
-    public async Task<byte[]> ReadAllBytesAsync(CancellationToken cancellationToken = default) {
-        if (Length > _maximumBytes) {
-            throw new EmailLimitExceededException("EmailBodyProjectionOptions.MaxResourceBytes",
-                Length, _maximumBytes);
-        }
-        using Stream source = await _attachment.OpenContentStreamAsync(cancellationToken)
-            .ConfigureAwait(false);
-        using (var output = new MemoryStream()) {
-            var buffer = new byte[64 * 1024];
-            long total = 0;
-            while (true) {
-                int read = await source.ReadAsync(buffer, 0, buffer.Length, cancellationToken)
-                    .ConfigureAwait(false);
-                if (read == 0) break;
-                total = checked(total + read);
-                if (total > _maximumBytes) {
-                    throw new EmailLimitExceededException("EmailBodyProjectionOptions.MaxResourceBytes",
-                        total, _maximumBytes);
-                }
-                output.Write(buffer, 0, read);
-            }
-            return output.ToArray();
-        }
-    }
-
-    internal static string? NormalizeContentId(string? value) => string.IsNullOrWhiteSpace(value)
-        ? null
-        : value!.Trim().Trim('<', '>');
 }
 
 /// <summary>One safe, reusable body/resource projection shared by transport consumers.</summary>
@@ -240,11 +172,30 @@ public static class EmailBodyProjection {
         HtmlConversionDocument sourceDocument = HtmlConversionDocument.Parse(selectedHtml, htmlOptions);
         string safeHtml = CreateSafeEmailHtml(sourceDocument);
         HtmlConversionDocument document = HtmlConversionDocument.Parse(safeHtml, htmlOptions);
-        var projectedResources = source.Attachments
+        EmailAttachment[] resourceAttachments = source.Attachments
             .Where(attachment => attachment.IsInline ||
                 !string.IsNullOrWhiteSpace(attachment.ContentId) ||
                 !string.IsNullOrWhiteSpace(attachment.ContentLocation))
-            .Select(attachment => new EmailBodyResource(attachment, effective.MaxResourceBytes))
+            .ToArray();
+        if (resourceAttachments.Length > effective.MaxResourceCount) {
+            throw new EmailLimitExceededException("EmailBodyProjectionOptions.MaxResourceCount",
+                resourceAttachments.Length, effective.MaxResourceCount);
+        }
+        long declaredResourceBytes = 0;
+        foreach (EmailAttachment attachment in resourceAttachments) {
+            if (attachment.Length <= 0) continue;
+            declaredResourceBytes = checked(declaredResourceBytes + attachment.Length);
+            if (declaredResourceBytes > effective.MaxTotalResourceBytes) {
+                throw new EmailLimitExceededException("EmailBodyProjectionOptions.MaxTotalResourceBytes",
+                    declaredResourceBytes, effective.MaxTotalResourceBytes);
+            }
+        }
+        var resourceBudget = new EmailBodyResourceBudget(effective.MaxTotalResourceBytes);
+        EmailBodyResource[] projectedResources = resourceAttachments
+            .Select(attachment => new EmailBodyResource(
+                attachment,
+                effective.MaxResourceBytes,
+                resourceBudget))
             .ToArray();
         return new EmailBodyProjectionResult(sourceKind, safeHtml, source.Body.Text,
             document, projectedResources, diagnostics.AsReadOnly(), baseUri);

--- a/OfficeIMO.Email.Html/EmailBodyProjection.cs
+++ b/OfficeIMO.Email.Html/EmailBodyProjection.cs
@@ -76,10 +76,12 @@ public sealed class EmailBodyProjectionOptions {
 public sealed class EmailBodyProjectionResult {
     private readonly IReadOnlyList<EmailBodyResource> _resources;
     private readonly Uri? _baseUri;
+    private readonly EmailBodyResourceIdentityIndex _resourceIdentity;
 
     internal EmailBodyProjectionResult(EmailBodySourceKind sourceKind, string html,
         string? text, HtmlConversionDocument document, IReadOnlyList<EmailBodyResource> resources,
-        IReadOnlyList<EmailDiagnostic> diagnostics, Uri? baseUri) {
+        IReadOnlyList<EmailDiagnostic> diagnostics, Uri? baseUri,
+        EmailBodyResourceIdentityIndex resourceIdentity) {
         SourceKind = sourceKind;
         Html = html;
         Text = text;
@@ -87,6 +89,7 @@ public sealed class EmailBodyProjectionResult {
         _resources = resources;
         Diagnostics = diagnostics;
         _baseUri = baseUri;
+        _resourceIdentity = resourceIdentity ?? throw new ArgumentNullException(nameof(resourceIdentity));
     }
 
     /// <summary>Selected source body.</summary>
@@ -103,23 +106,8 @@ public sealed class EmailBodyProjectionResult {
     public IReadOnlyList<EmailDiagnostic> Diagnostics { get; }
 
     /// <summary>Resolves CID, content-location, resolved absolute URI, or filename without opening content.</summary>
-    public EmailBodyResource? ResolveResource(string? reference, Uri? resolvedUri = null) {
-        if (string.IsNullOrWhiteSpace(reference) && resolvedUri == null) return null;
-        string value = (reference ?? resolvedUri!.OriginalString).Trim();
-        if (value.StartsWith("cid:", StringComparison.OrdinalIgnoreCase)) {
-            string id = Uri.UnescapeDataString(value.Substring(4)).Trim().Trim('<', '>');
-            return _resources.FirstOrDefault(resource => resource.MatchesContentId(id));
-        }
-        foreach (EmailBodyResource resource in _resources) {
-            if (string.Equals(resource.ContentLocation, value, StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(resource.FileName, value, StringComparison.OrdinalIgnoreCase)) return resource;
-            if (!string.IsNullOrWhiteSpace(resource.ContentLocation) && _baseUri != null &&
-                Uri.TryCreate(_baseUri, resource.ContentLocation, out Uri? resourceUri) &&
-                resolvedUri != null && string.Equals(resourceUri.AbsoluteUri, resolvedUri.AbsoluteUri,
-                    StringComparison.OrdinalIgnoreCase)) return resource;
-        }
-        return null;
-    }
+    public EmailBodyResource? ResolveResource(string? reference, Uri? resolvedUri = null) =>
+        _resourceIdentity.Resolve(_resources, _baseUri, reference, resolvedUri);
 }
 
 /// <summary>Builds the canonical dependency-isolated safe email body projection.</summary>
@@ -172,7 +160,7 @@ public static class EmailBodyProjection {
         }
 
         Uri? baseUri = effective.BaseUri ?? ResolveBaseUri(source.Body.HtmlContentLocation);
-        string[] projectionContentIds = CreateProjectionContentIds(resourceAttachments);
+        var resourceIdentity = new EmailBodyResourceIdentityIndex(resourceAttachments);
         HtmlConversionDocumentOptions htmlOptions = effective.HtmlOptions?.Clone() ??
             HtmlConversionDocumentOptions.CreateUntrustedProfile();
         htmlOptions.BaseUri ??= baseUri;
@@ -183,35 +171,35 @@ public static class EmailBodyProjection {
         resources.AllowedUrlSchemes.Add("data");
         resources.AllowedUrlSchemes.Add("cid");
         if (effective.RemoteResourcePolicy == EmailRemoteResourcePolicy.Block) {
-            resources.ResolvedUrlTransform = value => ResolveEmbeddedResourceUrl(
-                value,
-                baseUri,
-                resourceAttachments,
-                projectionContentIds);
+            resources.ResolvedUrlTransform = value => resourceIdentity.Rewrite(value, baseUri);
         }
         htmlOptions.ResourceUrlPolicy = resources;
         HtmlConversionDocument sourceDocument = HtmlConversionDocument.Parse(selectedHtml, htmlOptions);
+        baseUri = sourceDocument.BaseUri;
+        htmlOptions.BaseUri = baseUri;
         string safeHtml = CreateSafeEmailHtml(sourceDocument);
         HtmlConversionDocument document = HtmlConversionDocument.Parse(safeHtml, htmlOptions);
         long declaredResourceBytes = 0;
         foreach (EmailAttachment attachment in resourceAttachments) {
             if (attachment.Length <= 0) continue;
-            declaredResourceBytes = checked(declaredResourceBytes + attachment.Length);
-            if (declaredResourceBytes > effective.MaxTotalResourceBytes) {
+            if (attachment.Length > effective.MaxTotalResourceBytes - declaredResourceBytes) {
+                long actual = attachment.Length > long.MaxValue - declaredResourceBytes
+                    ? long.MaxValue
+                    : declaredResourceBytes + attachment.Length;
                 throw new EmailLimitExceededException("EmailBodyProjectionOptions.MaxTotalResourceBytes",
-                    declaredResourceBytes, effective.MaxTotalResourceBytes);
+                    actual, effective.MaxTotalResourceBytes);
             }
+            declaredResourceBytes += attachment.Length;
         }
         var resourceBudget = new EmailBodyResourceBudget(effective.MaxTotalResourceBytes);
         EmailBodyResource[] projectedResources = resourceAttachments
-            .Select((attachment, index) => new EmailBodyResource(
+            .Select(attachment => new EmailBodyResource(
                 attachment,
                 effective.MaxResourceBytes,
-                resourceBudget,
-                projectionContentIds[index]))
+                resourceBudget))
             .ToArray();
         return new EmailBodyProjectionResult(sourceKind, safeHtml, source.Body.Text,
-            document, projectedResources, diagnostics.AsReadOnly(), baseUri);
+            document, projectedResources, diagnostics.AsReadOnly(), baseUri, resourceIdentity);
     }
 
     private static string PlainTextHtml(string text) =>
@@ -245,60 +233,6 @@ public static class EmailBodyProjection {
 
     private static Uri? ResolveBaseUri(string? value) =>
         Uri.TryCreate(value, UriKind.Absolute, out Uri? uri) ? uri : null;
-
-    private static string[] CreateProjectionContentIds(IReadOnlyList<EmailAttachment> attachments) {
-        var used = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (EmailAttachment attachment in attachments) {
-            string? contentId = EmailBodyResource.NormalizeContentId(attachment.ContentId);
-            if (!string.IsNullOrWhiteSpace(contentId)) used.Add(contentId!);
-        }
-
-        var aliases = new string[attachments.Count];
-        for (int index = 0; index < attachments.Count; index++) {
-            string? contentId = EmailBodyResource.NormalizeContentId(attachments[index].ContentId);
-            if (!string.IsNullOrWhiteSpace(contentId)) {
-                aliases[index] = contentId!;
-                continue;
-            }
-
-            string candidate = "officeimo-resource-" + index + "@officeimo.invalid";
-            int suffix = 1;
-            while (!used.Add(candidate)) {
-                candidate = "officeimo-resource-" + index + "-" + suffix++ + "@officeimo.invalid";
-            }
-            aliases[index] = candidate;
-        }
-        return aliases;
-    }
-
-    private static string? ResolveEmbeddedResourceUrl(
-        string value,
-        Uri? baseUri,
-        IReadOnlyList<EmailAttachment> attachments,
-        IReadOnlyList<string> projectionContentIds) {
-        if (value.StartsWith("cid:", StringComparison.OrdinalIgnoreCase) ||
-            value.StartsWith("data:", StringComparison.OrdinalIgnoreCase)) return value;
-
-        for (int index = 0; index < attachments.Count; index++) {
-            EmailAttachment attachment = attachments[index];
-            if (MatchesResourceLocation(value, attachment.ContentLocation, baseUri) ||
-                MatchesResourceLocation(value, attachment.FileName, baseUri)) {
-                return "cid:" + projectionContentIds[index];
-            }
-        }
-        return null;
-    }
-
-    private static bool MatchesResourceLocation(string candidate, string? resourceLocation, Uri? baseUri) {
-        if (string.IsNullOrWhiteSpace(resourceLocation)) return false;
-        string location = resourceLocation!.Trim();
-        if (string.Equals(candidate, location, StringComparison.OrdinalIgnoreCase)) return true;
-        if (baseUri == null ||
-            !Uri.TryCreate(baseUri, candidate, out Uri? candidateUri) ||
-            !Uri.TryCreate(baseUri, location, out Uri? resourceUri)) return false;
-        return string.Equals(candidateUri.AbsoluteUri, resourceUri.AbsoluteUri,
-            StringComparison.OrdinalIgnoreCase);
-    }
 
     private static string CreateSafeEmailHtml(HtmlConversionDocument document) {
         AngleSharp.Html.Dom.IHtmlDocument safe = document.CreateDocumentForConversion();

--- a/OfficeIMO.Email.Html/EmailBodyProjection.cs
+++ b/OfficeIMO.Email.Html/EmailBodyProjection.cs
@@ -108,8 +108,7 @@ public sealed class EmailBodyProjectionResult {
         string value = (reference ?? resolvedUri!.OriginalString).Trim();
         if (value.StartsWith("cid:", StringComparison.OrdinalIgnoreCase)) {
             string id = Uri.UnescapeDataString(value.Substring(4)).Trim().Trim('<', '>');
-            return _resources.FirstOrDefault(resource => string.Equals(resource.ContentId, id,
-                StringComparison.OrdinalIgnoreCase));
+            return _resources.FirstOrDefault(resource => resource.MatchesContentId(id));
         }
         foreach (EmailBodyResource resource in _resources) {
             if (string.Equals(resource.ContentLocation, value, StringComparison.OrdinalIgnoreCase) ||
@@ -160,21 +159,6 @@ public static class EmailBodyProjection {
                 EmailDiagnosticSeverity.Warning, "message/body"));
         }
 
-        Uri? baseUri = effective.BaseUri ?? ResolveBaseUri(source.Body.HtmlContentLocation);
-        HtmlConversionDocumentOptions htmlOptions = effective.HtmlOptions?.Clone() ??
-            HtmlConversionDocumentOptions.CreateUntrustedProfile();
-        htmlOptions.BaseUri ??= baseUri;
-        htmlOptions.UseBodyContentsOnly = true;
-        HtmlUrlPolicy resources = effective.RemoteResourcePolicy == EmailRemoteResourcePolicy.Block
-            ? HtmlUrlPolicy.CreateEmbeddedResourceProfile()
-            : HtmlUrlPolicy.CreateWebOnlyProfile();
-        resources.AllowDataUrls = true;
-        resources.AllowedUrlSchemes.Add("data");
-        resources.AllowedUrlSchemes.Add("cid");
-        htmlOptions.ResourceUrlPolicy = resources;
-        HtmlConversionDocument sourceDocument = HtmlConversionDocument.Parse(selectedHtml, htmlOptions);
-        string safeHtml = CreateSafeEmailHtml(sourceDocument);
-        HtmlConversionDocument document = HtmlConversionDocument.Parse(safeHtml, htmlOptions);
         EmailAttachment[] resourceAttachments = effective.IncludeResources
             ? source.Attachments
                 .Where(attachment => attachment.IsInline ||
@@ -186,6 +170,29 @@ public static class EmailBodyProjection {
             throw new EmailLimitExceededException("EmailBodyProjectionOptions.MaxResourceCount",
                 resourceAttachments.Length, effective.MaxResourceCount);
         }
+
+        Uri? baseUri = effective.BaseUri ?? ResolveBaseUri(source.Body.HtmlContentLocation);
+        string[] projectionContentIds = CreateProjectionContentIds(resourceAttachments);
+        HtmlConversionDocumentOptions htmlOptions = effective.HtmlOptions?.Clone() ??
+            HtmlConversionDocumentOptions.CreateUntrustedProfile();
+        htmlOptions.BaseUri ??= baseUri;
+        baseUri = htmlOptions.BaseUri;
+        htmlOptions.UseBodyContentsOnly = true;
+        HtmlUrlPolicy resources = HtmlUrlPolicy.CreateWebResourceProfile();
+        resources.AllowDataUrls = true;
+        resources.AllowedUrlSchemes.Add("data");
+        resources.AllowedUrlSchemes.Add("cid");
+        if (effective.RemoteResourcePolicy == EmailRemoteResourcePolicy.Block) {
+            resources.ResolvedUrlTransform = value => ResolveEmbeddedResourceUrl(
+                value,
+                baseUri,
+                resourceAttachments,
+                projectionContentIds);
+        }
+        htmlOptions.ResourceUrlPolicy = resources;
+        HtmlConversionDocument sourceDocument = HtmlConversionDocument.Parse(selectedHtml, htmlOptions);
+        string safeHtml = CreateSafeEmailHtml(sourceDocument);
+        HtmlConversionDocument document = HtmlConversionDocument.Parse(safeHtml, htmlOptions);
         long declaredResourceBytes = 0;
         foreach (EmailAttachment attachment in resourceAttachments) {
             if (attachment.Length <= 0) continue;
@@ -197,10 +204,11 @@ public static class EmailBodyProjection {
         }
         var resourceBudget = new EmailBodyResourceBudget(effective.MaxTotalResourceBytes);
         EmailBodyResource[] projectedResources = resourceAttachments
-            .Select(attachment => new EmailBodyResource(
+            .Select((attachment, index) => new EmailBodyResource(
                 attachment,
                 effective.MaxResourceBytes,
-                resourceBudget))
+                resourceBudget,
+                projectionContentIds[index]))
             .ToArray();
         return new EmailBodyProjectionResult(sourceKind, safeHtml, source.Body.Text,
             document, projectedResources, diagnostics.AsReadOnly(), baseUri);
@@ -237,6 +245,60 @@ public static class EmailBodyProjection {
 
     private static Uri? ResolveBaseUri(string? value) =>
         Uri.TryCreate(value, UriKind.Absolute, out Uri? uri) ? uri : null;
+
+    private static string[] CreateProjectionContentIds(IReadOnlyList<EmailAttachment> attachments) {
+        var used = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (EmailAttachment attachment in attachments) {
+            string? contentId = EmailBodyResource.NormalizeContentId(attachment.ContentId);
+            if (!string.IsNullOrWhiteSpace(contentId)) used.Add(contentId!);
+        }
+
+        var aliases = new string[attachments.Count];
+        for (int index = 0; index < attachments.Count; index++) {
+            string? contentId = EmailBodyResource.NormalizeContentId(attachments[index].ContentId);
+            if (!string.IsNullOrWhiteSpace(contentId)) {
+                aliases[index] = contentId!;
+                continue;
+            }
+
+            string candidate = "officeimo-resource-" + index + "@officeimo.invalid";
+            int suffix = 1;
+            while (!used.Add(candidate)) {
+                candidate = "officeimo-resource-" + index + "-" + suffix++ + "@officeimo.invalid";
+            }
+            aliases[index] = candidate;
+        }
+        return aliases;
+    }
+
+    private static string? ResolveEmbeddedResourceUrl(
+        string value,
+        Uri? baseUri,
+        IReadOnlyList<EmailAttachment> attachments,
+        IReadOnlyList<string> projectionContentIds) {
+        if (value.StartsWith("cid:", StringComparison.OrdinalIgnoreCase) ||
+            value.StartsWith("data:", StringComparison.OrdinalIgnoreCase)) return value;
+
+        for (int index = 0; index < attachments.Count; index++) {
+            EmailAttachment attachment = attachments[index];
+            if (MatchesResourceLocation(value, attachment.ContentLocation, baseUri) ||
+                MatchesResourceLocation(value, attachment.FileName, baseUri)) {
+                return "cid:" + projectionContentIds[index];
+            }
+        }
+        return null;
+    }
+
+    private static bool MatchesResourceLocation(string candidate, string? resourceLocation, Uri? baseUri) {
+        if (string.IsNullOrWhiteSpace(resourceLocation)) return false;
+        string location = resourceLocation!.Trim();
+        if (string.Equals(candidate, location, StringComparison.OrdinalIgnoreCase)) return true;
+        if (baseUri == null ||
+            !Uri.TryCreate(baseUri, candidate, out Uri? candidateUri) ||
+            !Uri.TryCreate(baseUri, location, out Uri? resourceUri)) return false;
+        return string.Equals(candidateUri.AbsoluteUri, resourceUri.AbsoluteUri,
+            StringComparison.OrdinalIgnoreCase);
+    }
 
     private static string CreateSafeEmailHtml(HtmlConversionDocument document) {
         AngleSharp.Html.Dom.IHtmlDocument safe = document.CreateDocumentForConversion();

--- a/OfficeIMO.Email.Html/EmailBodyResource.cs
+++ b/OfficeIMO.Email.Html/EmailBodyResource.cs
@@ -111,8 +111,9 @@ public sealed class EmailBodyResource {
 
     private MemoryStream CreateOutputBuffer() {
         EnsureDeclaredLengthAllowed();
-        int capacity = Length > 0 && Length <= int.MaxValue ? checked((int)Length) : 0;
-        return capacity > 0 ? new MemoryStream(capacity) : new MemoryStream();
+        _limitState.ThrowIfExceeded();
+        _budget.ThrowIfExceeded();
+        return new MemoryStream();
     }
 
     private void EnsureDeclaredLengthAllowed() {
@@ -360,6 +361,9 @@ internal sealed class EmailBodyResourceReadStream : Stream {
             _bytesRead += read;
             if (read == 0) _endOfStream = true;
             return read;
+        } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+            _budget.Release(reserved);
+            throw;
         } catch {
             _budget.Release(reserved);
             _sourceFailed = true;
@@ -394,6 +398,9 @@ internal sealed class EmailBodyResourceReadStream : Stream {
         int read;
         try {
             read = await _source.ReadAsync(probe, 0, 1, cancellationToken).ConfigureAwait(false);
+        } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+            _budget.Release(1);
+            throw;
         } catch {
             _budget.Release(1);
             _sourceFailed = true;
@@ -431,6 +438,8 @@ internal sealed class EmailBodyResourceReadStream : Stream {
                 return 0;
             }
             return FailAggregateLimit();
+        } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+            throw;
         } catch {
             _sourceFailed = true;
             throw;

--- a/OfficeIMO.Email.Html/EmailBodyResource.cs
+++ b/OfficeIMO.Email.Html/EmailBodyResource.cs
@@ -129,6 +129,7 @@ public sealed class EmailBodyResource {
 
 internal sealed class EmailBodyResourceBudget {
     private readonly object _gate = new object();
+    private readonly SemaphoreSlim _readGate = new SemaphoreSlim(1, 1);
     private readonly long _maximumBytes;
     private long _consumedBytes;
     private long _reservedBytes;
@@ -149,6 +150,14 @@ internal sealed class EmailBodyResourceBudget {
             return reserved;
         }
     }
+
+    internal void EnterRead(CancellationToken cancellationToken) =>
+        _readGate.Wait(cancellationToken);
+
+    internal Task EnterReadAsync(CancellationToken cancellationToken) =>
+        _readGate.WaitAsync(cancellationToken);
+
+    internal void ExitRead() => _readGate.Release();
 
     internal void Commit(int reservedCount, int consumedCount) {
         lock (_gate) {
@@ -254,7 +263,12 @@ internal sealed class EmailBodyResourceReadStream : Stream {
         ThrowIfUnavailable();
         _operationCancellationToken.ThrowIfCancellationRequested();
         if (count == 0 || _endOfStream) return 0;
-        return ReadCore(buffer, offset, count);
+        _budget.EnterRead(_operationCancellationToken);
+        try {
+            return ReadCore(buffer, offset, count);
+        } finally {
+            _budget.ExitRead();
+        }
     }
 
     public override async Task<int> ReadAsync(
@@ -281,11 +295,16 @@ internal sealed class EmailBodyResourceReadStream : Stream {
             effectiveCancellationToken = linkedCancellation.Token;
         }
         try {
-            return await ReadCoreAsync(
-                buffer,
-                offset,
-                count,
-                effectiveCancellationToken).ConfigureAwait(false);
+            await _budget.EnterReadAsync(effectiveCancellationToken).ConfigureAwait(false);
+            try {
+                return await ReadCoreAsync(
+                    buffer,
+                    offset,
+                    count,
+                    effectiveCancellationToken).ConfigureAwait(false);
+            } finally {
+                _budget.ExitRead();
+            }
         } finally {
             linkedCancellation?.Dispose();
         }

--- a/OfficeIMO.Email.Html/EmailBodyResource.cs
+++ b/OfficeIMO.Email.Html/EmailBodyResource.cs
@@ -2,7 +2,13 @@ namespace OfficeIMO.Email;
 
 /// <summary>Operation-scoped attachment resource resolved by CID, content location, or filename.</summary>
 public sealed class EmailBodyResource {
-    private readonly EmailAttachment _attachment;
+    private readonly byte[]? _content;
+    private readonly IEmailContentSource? _contentSource;
+    private readonly string _contentType;
+    private readonly long _length;
+    private readonly string? _contentId;
+    private readonly string? _contentLocation;
+    private readonly string? _fileName;
     private readonly long _maximumBytes;
     private readonly EmailBodyResourceBudget _budget;
     private readonly EmailBodyResourceLimitState _limitState;
@@ -11,22 +17,29 @@ public sealed class EmailBodyResource {
         EmailAttachment attachment,
         long maximumBytes,
         EmailBodyResourceBudget budget) {
-        _attachment = attachment ?? throw new ArgumentNullException(nameof(attachment));
+        if (attachment == null) throw new ArgumentNullException(nameof(attachment));
+        _content = attachment.Content;
+        _contentSource = attachment.ContentSource;
+        _contentType = attachment.ContentType ?? "application/octet-stream";
+        _length = attachment.Length;
+        _contentId = NormalizeContentId(attachment.ContentId);
+        _contentLocation = attachment.ContentLocation;
+        _fileName = attachment.FileName;
         _maximumBytes = maximumBytes;
         _budget = budget ?? throw new ArgumentNullException(nameof(budget));
         _limitState = new EmailBodyResourceLimitState(maximumBytes);
     }
 
     /// <summary>Content type declared by the artifact.</summary>
-    public string ContentType => _attachment.ContentType ?? "application/octet-stream";
+    public string ContentType => _contentType;
     /// <summary>Declared decoded length.</summary>
-    public long Length => _attachment.Length;
+    public long Length => _length;
     /// <summary>Normalized Content-ID without angle brackets.</summary>
-    public string? ContentId => NormalizeContentId(_attachment.ContentId);
+    public string? ContentId => _contentId;
     /// <summary>Content-Location retained by the artifact.</summary>
-    public string? ContentLocation => _attachment.ContentLocation;
+    public string? ContentLocation => _contentLocation;
     /// <summary>Safe filename retained by the artifact.</summary>
-    public string? FileName => _attachment.FileName;
+    public string? FileName => _fileName;
 
     /// <summary>Opens a fresh sequential stream governed by the per-resource and projection-wide budgets.</summary>
     public Stream OpenReadStream(CancellationToken cancellationToken = default) {
@@ -34,7 +47,7 @@ public sealed class EmailBodyResource {
         _limitState.ThrowIfUnavailable();
         _budget.ThrowIfExceeded();
         cancellationToken.ThrowIfCancellationRequested();
-        Stream source = _attachment.OpenContentStream();
+        Stream source = OpenContentStream();
         try {
             return new EmailBodyResourceReadStream(
                 source,
@@ -54,7 +67,7 @@ public sealed class EmailBodyResource {
         _limitState.ThrowIfUnavailable();
         _budget.ThrowIfExceeded();
         cancellationToken.ThrowIfCancellationRequested();
-        Stream source = await _attachment.OpenContentStreamAsync(cancellationToken).ConfigureAwait(false);
+        Stream source = await OpenContentStreamAsync(cancellationToken).ConfigureAwait(false);
         try {
             return new EmailBodyResourceReadStream(
                 source,
@@ -114,6 +127,25 @@ public sealed class EmailBodyResource {
         _limitState.ThrowIfUnavailable();
         _budget.ThrowIfExceeded();
         return new MemoryStream();
+    }
+
+    private Stream OpenContentStream() {
+        if (_content != null) return new MemoryStream(_content, writable: false);
+        if (_contentSource == null) return new MemoryStream(Array.Empty<byte>(), writable: false);
+        Stream source = _contentSource.OpenRead();
+        if (source != null && source.CanRead) return source;
+        source?.Dispose();
+        throw new InvalidDataException("The attachment content source did not return a readable stream.");
+    }
+
+    private async Task<Stream> OpenContentStreamAsync(CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (_content != null) return new MemoryStream(_content, writable: false);
+        if (_contentSource == null) return new MemoryStream(Array.Empty<byte>(), writable: false);
+        Stream source = await _contentSource.OpenReadAsync(cancellationToken).ConfigureAwait(false);
+        if (source != null && source.CanRead) return source;
+        source?.Dispose();
+        throw new InvalidDataException("The attachment content source did not return a readable stream.");
     }
 
     private void EnsureDeclaredLengthAllowed() {

--- a/OfficeIMO.Email.Html/EmailBodyResource.cs
+++ b/OfficeIMO.Email.Html/EmailBodyResource.cs
@@ -6,14 +6,17 @@ public sealed class EmailBodyResource {
     private readonly long _maximumBytes;
     private readonly EmailBodyResourceBudget _budget;
     private readonly EmailBodyResourceLimitState _limitState;
+    private readonly string _projectionContentId;
 
     internal EmailBodyResource(
         EmailAttachment attachment,
         long maximumBytes,
-        EmailBodyResourceBudget budget) {
+        EmailBodyResourceBudget budget,
+        string projectionContentId) {
         _attachment = attachment ?? throw new ArgumentNullException(nameof(attachment));
         _maximumBytes = maximumBytes;
         _budget = budget ?? throw new ArgumentNullException(nameof(budget));
+        _projectionContentId = projectionContentId ?? throw new ArgumentNullException(nameof(projectionContentId));
         _limitState = new EmailBodyResourceLimitState(maximumBytes);
     }
 
@@ -126,12 +129,17 @@ public sealed class EmailBodyResource {
     internal static string? NormalizeContentId(string? value) => string.IsNullOrWhiteSpace(value)
         ? null
         : value!.Trim().Trim('<', '>');
+
+    internal bool MatchesContentId(string value) =>
+        string.Equals(ContentId, value, StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(_projectionContentId, value, StringComparison.OrdinalIgnoreCase);
 }
 
 internal sealed class EmailBodyResourceBudget {
     private readonly object _gate = new object();
-    private readonly SemaphoreSlim _readGate = new SemaphoreSlim(1, 1);
+    private readonly SemaphoreSlim _aggregateProbeGate = new SemaphoreSlim(1, 1);
     private readonly long _maximumBytes;
+    private TaskCompletionSource<bool> _reservationChanged = CreateReservationSignal();
     private long _consumedBytes;
     private long _reservedBytes;
     private long? _exceededActualValue;
@@ -140,30 +148,57 @@ internal sealed class EmailBodyResourceBudget {
         _maximumBytes = maximumBytes;
     }
 
-    internal int Reserve(int requestedCount) {
+    internal int Reserve(int requestedCount, CancellationToken cancellationToken) {
         if (requestedCount <= 0) return 0;
-        lock (_gate) {
-            ThrowIfExceededLocked();
-            long available = _maximumBytes - _consumedBytes - _reservedBytes;
-            if (available <= 0) return 0;
-            int reserved = (int)Math.Min(requestedCount, available);
-            _reservedBytes += reserved;
-            return reserved;
+        while (true) {
+            Task reservationChanged;
+            lock (_gate) {
+                ThrowIfExceededLocked();
+                long available = _maximumBytes - _consumedBytes - _reservedBytes;
+                if (available > 0) {
+                    int reserved = (int)Math.Min(requestedCount, available);
+                    _reservedBytes += reserved;
+                    return reserved;
+                }
+                if (_reservedBytes == 0) return 0;
+                reservationChanged = _reservationChanged.Task;
+            }
+            reservationChanged.Wait(cancellationToken);
         }
     }
 
-    internal void EnterRead(CancellationToken cancellationToken) =>
-        _readGate.Wait(cancellationToken);
+    internal async Task<int> ReserveAsync(int requestedCount, CancellationToken cancellationToken) {
+        if (requestedCount <= 0) return 0;
+        while (true) {
+            Task reservationChanged;
+            lock (_gate) {
+                ThrowIfExceededLocked();
+                long available = _maximumBytes - _consumedBytes - _reservedBytes;
+                if (available > 0) {
+                    int reserved = (int)Math.Min(requestedCount, available);
+                    _reservedBytes += reserved;
+                    return reserved;
+                }
+                if (_reservedBytes == 0) return 0;
+                reservationChanged = _reservationChanged.Task;
+            }
+            await WaitWithCancellationAsync(reservationChanged, cancellationToken).ConfigureAwait(false);
+        }
+    }
 
-    internal Task EnterReadAsync(CancellationToken cancellationToken) =>
-        _readGate.WaitAsync(cancellationToken);
+    internal void EnterAggregateProbe(CancellationToken cancellationToken) =>
+        _aggregateProbeGate.Wait(cancellationToken);
 
-    internal void ExitRead() => _readGate.Release();
+    internal Task EnterAggregateProbeAsync(CancellationToken cancellationToken) =>
+        _aggregateProbeGate.WaitAsync(cancellationToken);
+
+    internal void ExitAggregateProbe() => _aggregateProbeGate.Release();
 
     internal void Commit(int reservedCount, int consumedCount) {
         lock (_gate) {
             _reservedBytes -= reservedCount;
             _consumedBytes += consumedCount;
+            SignalReservationChangedLocked();
         }
     }
 
@@ -171,6 +206,7 @@ internal sealed class EmailBodyResourceBudget {
         if (reservedCount <= 0) return;
         lock (_gate) {
             _reservedBytes -= reservedCount;
+            SignalReservationChangedLocked();
         }
     }
 
@@ -196,10 +232,31 @@ internal sealed class EmailBodyResourceBudget {
                 _maximumBytes);
         }
     }
+
+    private void SignalReservationChangedLocked() {
+        TaskCompletionSource<bool> signal = _reservationChanged;
+        _reservationChanged = CreateReservationSignal();
+        signal.TrySetResult(true);
+    }
+
+    private static TaskCompletionSource<bool> CreateReservationSignal() =>
+        new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private static async Task WaitWithCancellationAsync(Task operation, CancellationToken cancellationToken) {
+        if (!cancellationToken.CanBeCanceled) {
+            await operation.ConfigureAwait(false);
+            return;
+        }
+        var canceled = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using (cancellationToken.Register(() => canceled.TrySetCanceled())) {
+            await await Task.WhenAny(operation, canceled.Task).ConfigureAwait(false);
+        }
+    }
 }
 
 internal sealed class EmailBodyResourceLimitState {
     private readonly object _gate = new object();
+    private readonly SemaphoreSlim _readGate = new SemaphoreSlim(1, 1);
     private readonly long _maximumBytes;
     private long? _exceededActualValue;
 
@@ -223,6 +280,14 @@ internal sealed class EmailBodyResourceLimitState {
             }
         }
     }
+
+    internal void EnterRead(CancellationToken cancellationToken) =>
+        _readGate.Wait(cancellationToken);
+
+    internal Task EnterReadAsync(CancellationToken cancellationToken) =>
+        _readGate.WaitAsync(cancellationToken);
+
+    internal void ExitRead() => _readGate.Release();
 }
 
 internal sealed class EmailBodyResourceReadStream : Stream {
@@ -264,11 +329,12 @@ internal sealed class EmailBodyResourceReadStream : Stream {
         ThrowIfUnavailable();
         _operationCancellationToken.ThrowIfCancellationRequested();
         if (count == 0 || _endOfStream) return 0;
-        _budget.EnterRead(_operationCancellationToken);
+        _limitState.EnterRead(_operationCancellationToken);
         try {
+            ThrowIfUnavailable();
             return ReadCore(buffer, offset, count);
         } finally {
-            _budget.ExitRead();
+            _limitState.ExitRead();
         }
     }
 
@@ -296,15 +362,16 @@ internal sealed class EmailBodyResourceReadStream : Stream {
             effectiveCancellationToken = linkedCancellation.Token;
         }
         try {
-            await _budget.EnterReadAsync(effectiveCancellationToken).ConfigureAwait(false);
+            await _limitState.EnterReadAsync(effectiveCancellationToken).ConfigureAwait(false);
             try {
+                ThrowIfUnavailable();
                 return await ReadCoreAsync(
                     buffer,
                     offset,
                     count,
                     effectiveCancellationToken).ConfigureAwait(false);
             } finally {
-                _budget.ExitRead();
+                _limitState.ExitRead();
             }
         } finally {
             linkedCancellation?.Dispose();
@@ -327,7 +394,7 @@ internal sealed class EmailBodyResourceReadStream : Stream {
     private int ReadCore(byte[] buffer, int offset, int count) {
         int allowed = GetAllowedReadCount(count);
         if (allowed == 0) return ProbeBoundary();
-        int reserved = _budget.Reserve(allowed);
+        int reserved = _budget.Reserve(allowed, _operationCancellationToken);
         if (reserved == 0) return ProbeAggregateBoundary();
         try {
             int read = _source.Read(buffer, offset, reserved);
@@ -349,7 +416,7 @@ internal sealed class EmailBodyResourceReadStream : Stream {
         CancellationToken cancellationToken) {
         int allowed = GetAllowedReadCount(count);
         if (allowed == 0) return await ProbeBoundaryAsync(cancellationToken).ConfigureAwait(false);
-        int reserved = _budget.Reserve(allowed);
+        int reserved = await _budget.ReserveAsync(allowed, cancellationToken).ConfigureAwait(false);
         if (reserved == 0) return await ProbeAggregateBoundaryAsync(cancellationToken).ConfigureAwait(false);
         try {
             int read = await _source.ReadAsync(
@@ -372,7 +439,7 @@ internal sealed class EmailBodyResourceReadStream : Stream {
     }
 
     private int ProbeBoundary() {
-        int reserved = _budget.Reserve(1);
+        int reserved = _budget.Reserve(1, _operationCancellationToken);
         if (reserved == 0) return ProbeAggregateBoundary();
         var probe = new byte[1];
         int read;
@@ -392,7 +459,7 @@ internal sealed class EmailBodyResourceReadStream : Stream {
     }
 
     private async Task<int> ProbeBoundaryAsync(CancellationToken cancellationToken) {
-        int reserved = _budget.Reserve(1);
+        int reserved = await _budget.ReserveAsync(1, cancellationToken).ConfigureAwait(false);
         if (reserved == 0) return await ProbeAggregateBoundaryAsync(cancellationToken).ConfigureAwait(false);
         var probe = new byte[1];
         int read;
@@ -415,8 +482,10 @@ internal sealed class EmailBodyResourceReadStream : Stream {
     }
 
     private int ProbeAggregateBoundary() {
-        var probe = new byte[1];
+        _budget.EnterAggregateProbe(_operationCancellationToken);
         try {
+            _budget.ThrowIfExceeded();
+            var probe = new byte[1];
             int read = _source.Read(probe, 0, 1);
             if (read == 0) {
                 _endOfStream = true;
@@ -426,12 +495,16 @@ internal sealed class EmailBodyResourceReadStream : Stream {
         } catch {
             _sourceFailed = true;
             throw;
+        } finally {
+            _budget.ExitAggregateProbe();
         }
     }
 
     private async Task<int> ProbeAggregateBoundaryAsync(CancellationToken cancellationToken) {
-        var probe = new byte[1];
+        await _budget.EnterAggregateProbeAsync(cancellationToken).ConfigureAwait(false);
         try {
+            _budget.ThrowIfExceeded();
+            var probe = new byte[1];
             int read = await _source.ReadAsync(probe, 0, 1, cancellationToken).ConfigureAwait(false);
             if (read == 0) {
                 _endOfStream = true;
@@ -443,6 +516,8 @@ internal sealed class EmailBodyResourceReadStream : Stream {
         } catch {
             _sourceFailed = true;
             throw;
+        } finally {
+            _budget.ExitAggregateProbe();
         }
     }
 

--- a/OfficeIMO.Email.Html/EmailBodyResource.cs
+++ b/OfficeIMO.Email.Html/EmailBodyResource.cs
@@ -5,6 +5,7 @@ public sealed class EmailBodyResource {
     private readonly EmailAttachment _attachment;
     private readonly long _maximumBytes;
     private readonly EmailBodyResourceBudget _budget;
+    private readonly EmailBodyResourceLimitState _limitState;
 
     internal EmailBodyResource(
         EmailAttachment attachment,
@@ -13,6 +14,7 @@ public sealed class EmailBodyResource {
         _attachment = attachment ?? throw new ArgumentNullException(nameof(attachment));
         _maximumBytes = maximumBytes;
         _budget = budget ?? throw new ArgumentNullException(nameof(budget));
+        _limitState = new EmailBodyResourceLimitState(maximumBytes);
     }
 
     /// <summary>Content type declared by the artifact.</summary>
@@ -29,10 +31,17 @@ public sealed class EmailBodyResource {
     /// <summary>Opens a fresh sequential stream governed by the per-resource and projection-wide budgets.</summary>
     public Stream OpenReadStream(CancellationToken cancellationToken = default) {
         EnsureDeclaredLengthAllowed();
+        _limitState.ThrowIfExceeded();
+        _budget.ThrowIfExceeded();
         cancellationToken.ThrowIfCancellationRequested();
         Stream source = _attachment.OpenContentStream();
         try {
-            return new EmailBodyResourceReadStream(source, _maximumBytes, _budget, cancellationToken);
+            return new EmailBodyResourceReadStream(
+                source,
+                _maximumBytes,
+                _budget,
+                _limitState,
+                cancellationToken);
         } catch {
             source.Dispose();
             throw;
@@ -42,10 +51,17 @@ public sealed class EmailBodyResource {
     /// <summary>Asynchronously opens a fresh sequential stream governed by the configured budgets.</summary>
     public async Task<Stream> OpenReadStreamAsync(CancellationToken cancellationToken = default) {
         EnsureDeclaredLengthAllowed();
+        _limitState.ThrowIfExceeded();
+        _budget.ThrowIfExceeded();
         cancellationToken.ThrowIfCancellationRequested();
         Stream source = await _attachment.OpenContentStreamAsync(cancellationToken).ConfigureAwait(false);
         try {
-            return new EmailBodyResourceReadStream(source, _maximumBytes, _budget, cancellationToken);
+            return new EmailBodyResourceReadStream(
+                source,
+                _maximumBytes,
+                _budget,
+                _limitState,
+                cancellationToken);
         } catch {
             source.Dispose();
             throw;
@@ -115,20 +131,86 @@ internal sealed class EmailBodyResourceBudget {
     private readonly object _gate = new object();
     private readonly long _maximumBytes;
     private long _consumedBytes;
+    private long _reservedBytes;
+    private long? _exceededActualValue;
 
     internal EmailBodyResourceBudget(long maximumBytes) {
         _maximumBytes = maximumBytes;
     }
 
-    internal void Consume(int count) {
-        if (count <= 0) return;
+    internal int Reserve(int requestedCount) {
+        if (requestedCount <= 0) return 0;
         lock (_gate) {
-            long next = checked(_consumedBytes + count);
-            if (next > _maximumBytes) {
-                throw new EmailLimitExceededException("EmailBodyProjectionOptions.MaxTotalResourceBytes",
-                    next, _maximumBytes);
+            ThrowIfExceededLocked();
+            long available = _maximumBytes - _consumedBytes - _reservedBytes;
+            if (available <= 0) return 0;
+            int reserved = (int)Math.Min(requestedCount, available);
+            _reservedBytes += reserved;
+            return reserved;
+        }
+    }
+
+    internal void Commit(int reservedCount, int consumedCount) {
+        lock (_gate) {
+            _reservedBytes -= reservedCount;
+            _consumedBytes += consumedCount;
+        }
+    }
+
+    internal void Release(int reservedCount) {
+        if (reservedCount <= 0) return;
+        lock (_gate) {
+            _reservedBytes -= reservedCount;
+        }
+    }
+
+    internal void MarkExceeded() {
+        lock (_gate) {
+            _exceededActualValue ??= _maximumBytes == long.MaxValue
+                ? long.MaxValue
+                : _maximumBytes + 1L;
+        }
+    }
+
+    internal void ThrowIfExceeded() {
+        lock (_gate) {
+            ThrowIfExceededLocked();
+        }
+    }
+
+    private void ThrowIfExceededLocked() {
+        if (_exceededActualValue.HasValue) {
+            throw new EmailLimitExceededException(
+                "EmailBodyProjectionOptions.MaxTotalResourceBytes",
+                _exceededActualValue.Value,
+                _maximumBytes);
+        }
+    }
+}
+
+internal sealed class EmailBodyResourceLimitState {
+    private readonly object _gate = new object();
+    private readonly long _maximumBytes;
+    private long? _exceededActualValue;
+
+    internal EmailBodyResourceLimitState(long maximumBytes) {
+        _maximumBytes = maximumBytes;
+    }
+
+    internal void MarkExceeded(long actualValue) {
+        lock (_gate) {
+            _exceededActualValue ??= actualValue;
+        }
+    }
+
+    internal void ThrowIfExceeded() {
+        lock (_gate) {
+            if (_exceededActualValue.HasValue) {
+                throw new EmailLimitExceededException(
+                    "EmailBodyProjectionOptions.MaxResourceBytes",
+                    _exceededActualValue.Value,
+                    _maximumBytes);
             }
-            _consumedBytes = next;
         }
     }
 }
@@ -137,19 +219,24 @@ internal sealed class EmailBodyResourceReadStream : Stream {
     private readonly Stream _source;
     private readonly long _maximumBytes;
     private readonly EmailBodyResourceBudget _budget;
+    private readonly EmailBodyResourceLimitState _limitState;
     private readonly CancellationToken _operationCancellationToken;
     private long _bytesRead;
     private bool _disposed;
+    private bool _endOfStream;
+    private bool _sourceFailed;
 
     internal EmailBodyResourceReadStream(
         Stream source,
         long maximumBytes,
         EmailBodyResourceBudget budget,
+        EmailBodyResourceLimitState limitState,
         CancellationToken operationCancellationToken) {
         _source = source ?? throw new ArgumentNullException(nameof(source));
         if (!source.CanRead) throw new ArgumentException("Source stream must be readable.", nameof(source));
         _maximumBytes = maximumBytes;
         _budget = budget ?? throw new ArgumentNullException(nameof(budget));
+        _limitState = limitState ?? throw new ArgumentNullException(nameof(limitState));
         _operationCancellationToken = operationCancellationToken;
     }
 
@@ -163,11 +250,11 @@ internal sealed class EmailBodyResourceReadStream : Stream {
     }
 
     public override int Read(byte[] buffer, int offset, int count) {
-        ThrowIfDisposed();
+        ValidateReadArguments(buffer, offset, count);
+        ThrowIfUnavailable();
         _operationCancellationToken.ThrowIfCancellationRequested();
-        int read = _source.Read(buffer, offset, count);
-        Account(read);
-        return read;
+        if (count == 0 || _endOfStream) return 0;
+        return ReadCore(buffer, offset, count);
     }
 
     public override async Task<int> ReadAsync(
@@ -175,12 +262,33 @@ internal sealed class EmailBodyResourceReadStream : Stream {
         int offset,
         int count,
         CancellationToken cancellationToken) {
-        ThrowIfDisposed();
+        ValidateReadArguments(buffer, offset, count);
+        ThrowIfUnavailable();
         _operationCancellationToken.ThrowIfCancellationRequested();
         cancellationToken.ThrowIfCancellationRequested();
-        int read = await _source.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
-        Account(read);
-        return read;
+        if (count == 0 || _endOfStream) return 0;
+        CancellationTokenSource? linkedCancellation = null;
+        CancellationToken effectiveCancellationToken;
+        if (!_operationCancellationToken.CanBeCanceled ||
+            _operationCancellationToken == cancellationToken) {
+            effectiveCancellationToken = cancellationToken;
+        } else if (!cancellationToken.CanBeCanceled) {
+            effectiveCancellationToken = _operationCancellationToken;
+        } else {
+            linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+                _operationCancellationToken,
+                cancellationToken);
+            effectiveCancellationToken = linkedCancellation.Token;
+        }
+        try {
+            return await ReadCoreAsync(
+                buffer,
+                offset,
+                count,
+                effectiveCancellationToken).ConfigureAwait(false);
+        } finally {
+            linkedCancellation?.Dispose();
+        }
     }
 
     public override void Flush() => throw new NotSupportedException();
@@ -196,18 +304,157 @@ internal sealed class EmailBodyResourceReadStream : Stream {
         base.Dispose(disposing);
     }
 
-    private void Account(int count) {
-        if (count <= 0) return;
-        long next = checked(_bytesRead + count);
-        if (next > _maximumBytes) {
-            throw new EmailLimitExceededException("EmailBodyProjectionOptions.MaxResourceBytes",
-                next, _maximumBytes);
+    private int ReadCore(byte[] buffer, int offset, int count) {
+        int allowed = GetAllowedReadCount(count);
+        if (allowed == 0) return ProbeBoundary();
+        int reserved = _budget.Reserve(allowed);
+        if (reserved == 0) return ProbeAggregateBoundary();
+        try {
+            int read = _source.Read(buffer, offset, reserved);
+            _budget.Commit(reserved, read);
+            _bytesRead += read;
+            if (read == 0) _endOfStream = true;
+            return read;
+        } catch {
+            _budget.Release(reserved);
+            _sourceFailed = true;
+            throw;
         }
-        _budget.Consume(count);
-        _bytesRead = next;
     }
 
-    private void ThrowIfDisposed() {
+    private async Task<int> ReadCoreAsync(
+        byte[] buffer,
+        int offset,
+        int count,
+        CancellationToken cancellationToken) {
+        int allowed = GetAllowedReadCount(count);
+        if (allowed == 0) return await ProbeBoundaryAsync(cancellationToken).ConfigureAwait(false);
+        int reserved = _budget.Reserve(allowed);
+        if (reserved == 0) return await ProbeAggregateBoundaryAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            int read = await _source.ReadAsync(
+                buffer,
+                offset,
+                reserved,
+                cancellationToken).ConfigureAwait(false);
+            _budget.Commit(reserved, read);
+            _bytesRead += read;
+            if (read == 0) _endOfStream = true;
+            return read;
+        } catch {
+            _budget.Release(reserved);
+            _sourceFailed = true;
+            throw;
+        }
+    }
+
+    private int ProbeBoundary() {
+        int reserved = _budget.Reserve(1);
+        if (reserved == 0) return ProbeAggregateBoundary();
+        var probe = new byte[1];
+        int read;
+        try {
+            read = _source.Read(probe, 0, 1);
+        } catch {
+            _budget.Release(1);
+            _sourceFailed = true;
+            throw;
+        }
+        _budget.Commit(1, read);
+        if (read == 0) {
+            _endOfStream = true;
+            return 0;
+        }
+        return FailResourceLimit();
+    }
+
+    private async Task<int> ProbeBoundaryAsync(CancellationToken cancellationToken) {
+        int reserved = _budget.Reserve(1);
+        if (reserved == 0) return await ProbeAggregateBoundaryAsync(cancellationToken).ConfigureAwait(false);
+        var probe = new byte[1];
+        int read;
+        try {
+            read = await _source.ReadAsync(probe, 0, 1, cancellationToken).ConfigureAwait(false);
+        } catch {
+            _budget.Release(1);
+            _sourceFailed = true;
+            throw;
+        }
+        _budget.Commit(1, read);
+        if (read == 0) {
+            _endOfStream = true;
+            return 0;
+        }
+        return FailResourceLimit();
+    }
+
+    private int ProbeAggregateBoundary() {
+        var probe = new byte[1];
+        try {
+            int read = _source.Read(probe, 0, 1);
+            if (read == 0) {
+                _endOfStream = true;
+                return 0;
+            }
+            return FailAggregateLimit();
+        } catch {
+            _sourceFailed = true;
+            throw;
+        }
+    }
+
+    private async Task<int> ProbeAggregateBoundaryAsync(CancellationToken cancellationToken) {
+        var probe = new byte[1];
+        try {
+            int read = await _source.ReadAsync(probe, 0, 1, cancellationToken).ConfigureAwait(false);
+            if (read == 0) {
+                _endOfStream = true;
+                return 0;
+            }
+            return FailAggregateLimit();
+        } catch {
+            _sourceFailed = true;
+            throw;
+        }
+    }
+
+    private int FailResourceLimit() {
+        long actual = _maximumBytes == long.MaxValue ? long.MaxValue : _maximumBytes + 1L;
+        _limitState.MarkExceeded(actual);
+        _sourceFailed = true;
+        throw new EmailLimitExceededException(
+            "EmailBodyProjectionOptions.MaxResourceBytes",
+            actual,
+            _maximumBytes);
+    }
+
+    private int FailAggregateLimit() {
+        _budget.MarkExceeded();
+        _sourceFailed = true;
+        _budget.ThrowIfExceeded();
+        throw new InvalidOperationException("The aggregate resource limit failure was not recorded.");
+    }
+
+    private int GetAllowedReadCount(int requestedCount) {
+        long remaining = _maximumBytes - _bytesRead;
+        return remaining <= 0
+            ? 0
+            : (int)Math.Min(requestedCount, remaining);
+    }
+
+    private void ThrowIfUnavailable() {
         if (_disposed) throw new ObjectDisposedException(nameof(EmailBodyResourceReadStream));
+        _limitState.ThrowIfExceeded();
+        _budget.ThrowIfExceeded();
+        if (_sourceFailed) {
+            throw new InvalidOperationException("The resource stream cannot continue after a failed source read.");
+        }
+    }
+
+    private static void ValidateReadArguments(byte[] buffer, int offset, int count) {
+        if (buffer == null) throw new ArgumentNullException(nameof(buffer));
+        if (offset < 0 || offset > buffer.Length) throw new ArgumentOutOfRangeException(nameof(offset));
+        if (count < 0) throw new ArgumentOutOfRangeException(nameof(count));
+        if (buffer.Length - offset < count) throw new ArgumentException("Offset and count exceed the buffer length.");
     }
 }

--- a/OfficeIMO.Email.Html/EmailBodyResource.cs
+++ b/OfficeIMO.Email.Html/EmailBodyResource.cs
@@ -1,0 +1,213 @@
+namespace OfficeIMO.Email;
+
+/// <summary>Operation-scoped attachment resource resolved by CID, content location, or filename.</summary>
+public sealed class EmailBodyResource {
+    private readonly EmailAttachment _attachment;
+    private readonly long _maximumBytes;
+    private readonly EmailBodyResourceBudget _budget;
+
+    internal EmailBodyResource(
+        EmailAttachment attachment,
+        long maximumBytes,
+        EmailBodyResourceBudget budget) {
+        _attachment = attachment ?? throw new ArgumentNullException(nameof(attachment));
+        _maximumBytes = maximumBytes;
+        _budget = budget ?? throw new ArgumentNullException(nameof(budget));
+    }
+
+    /// <summary>Content type declared by the artifact.</summary>
+    public string ContentType => _attachment.ContentType ?? "application/octet-stream";
+    /// <summary>Declared decoded length.</summary>
+    public long Length => _attachment.Length;
+    /// <summary>Normalized Content-ID without angle brackets.</summary>
+    public string? ContentId => NormalizeContentId(_attachment.ContentId);
+    /// <summary>Content-Location retained by the artifact.</summary>
+    public string? ContentLocation => _attachment.ContentLocation;
+    /// <summary>Safe filename retained by the artifact.</summary>
+    public string? FileName => _attachment.FileName;
+
+    /// <summary>Opens a fresh sequential stream governed by the per-resource and projection-wide budgets.</summary>
+    public Stream OpenReadStream(CancellationToken cancellationToken = default) {
+        EnsureDeclaredLengthAllowed();
+        cancellationToken.ThrowIfCancellationRequested();
+        Stream source = _attachment.OpenContentStream();
+        try {
+            return new EmailBodyResourceReadStream(source, _maximumBytes, _budget, cancellationToken);
+        } catch {
+            source.Dispose();
+            throw;
+        }
+    }
+
+    /// <summary>Asynchronously opens a fresh sequential stream governed by the configured budgets.</summary>
+    public async Task<Stream> OpenReadStreamAsync(CancellationToken cancellationToken = default) {
+        EnsureDeclaredLengthAllowed();
+        cancellationToken.ThrowIfCancellationRequested();
+        Stream source = await _attachment.OpenContentStreamAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            return new EmailBodyResourceReadStream(source, _maximumBytes, _budget, cancellationToken);
+        } catch {
+            source.Dispose();
+            throw;
+        }
+    }
+
+    /// <summary>Copies this resource to a caller-owned destination without materializing another byte array.</summary>
+    public void CopyTo(Stream destination, CancellationToken cancellationToken = default) {
+        if (destination == null) throw new ArgumentNullException(nameof(destination));
+        if (!destination.CanWrite) throw new ArgumentException("Destination stream must be writable.", nameof(destination));
+        using Stream source = OpenReadStream(cancellationToken);
+        var buffer = new byte[64 * 1024];
+        while (true) {
+            cancellationToken.ThrowIfCancellationRequested();
+            int read = source.Read(buffer, 0, buffer.Length);
+            if (read == 0) break;
+            destination.Write(buffer, 0, read);
+        }
+    }
+
+    /// <summary>Asynchronously copies this resource to a caller-owned destination.</summary>
+    public async Task CopyToAsync(Stream destination, CancellationToken cancellationToken = default) {
+        if (destination == null) throw new ArgumentNullException(nameof(destination));
+        if (!destination.CanWrite) throw new ArgumentException("Destination stream must be writable.", nameof(destination));
+        using Stream source = await OpenReadStreamAsync(cancellationToken).ConfigureAwait(false);
+        var buffer = new byte[64 * 1024];
+        while (true) {
+            int read = await source.ReadAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
+            if (read == 0) break;
+            await destination.WriteAsync(buffer, 0, read, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>Reads this resource within the configured budgets.</summary>
+    public byte[] ReadAllBytes(CancellationToken cancellationToken = default) {
+        using var output = CreateOutputBuffer();
+        CopyTo(output, cancellationToken);
+        return output.ToArray();
+    }
+
+    /// <summary>Asynchronously reads this resource within the configured budgets.</summary>
+    public async Task<byte[]> ReadAllBytesAsync(CancellationToken cancellationToken = default) {
+        using var output = CreateOutputBuffer();
+        await CopyToAsync(output, cancellationToken).ConfigureAwait(false);
+        return output.ToArray();
+    }
+
+    private MemoryStream CreateOutputBuffer() {
+        EnsureDeclaredLengthAllowed();
+        int capacity = Length > 0 && Length <= int.MaxValue ? checked((int)Length) : 0;
+        return capacity > 0 ? new MemoryStream(capacity) : new MemoryStream();
+    }
+
+    private void EnsureDeclaredLengthAllowed() {
+        if (Length > _maximumBytes) {
+            throw new EmailLimitExceededException("EmailBodyProjectionOptions.MaxResourceBytes",
+                Length, _maximumBytes);
+        }
+    }
+
+    internal static string? NormalizeContentId(string? value) => string.IsNullOrWhiteSpace(value)
+        ? null
+        : value!.Trim().Trim('<', '>');
+}
+
+internal sealed class EmailBodyResourceBudget {
+    private readonly object _gate = new object();
+    private readonly long _maximumBytes;
+    private long _consumedBytes;
+
+    internal EmailBodyResourceBudget(long maximumBytes) {
+        _maximumBytes = maximumBytes;
+    }
+
+    internal void Consume(int count) {
+        if (count <= 0) return;
+        lock (_gate) {
+            long next = checked(_consumedBytes + count);
+            if (next > _maximumBytes) {
+                throw new EmailLimitExceededException("EmailBodyProjectionOptions.MaxTotalResourceBytes",
+                    next, _maximumBytes);
+            }
+            _consumedBytes = next;
+        }
+    }
+}
+
+internal sealed class EmailBodyResourceReadStream : Stream {
+    private readonly Stream _source;
+    private readonly long _maximumBytes;
+    private readonly EmailBodyResourceBudget _budget;
+    private readonly CancellationToken _operationCancellationToken;
+    private long _bytesRead;
+    private bool _disposed;
+
+    internal EmailBodyResourceReadStream(
+        Stream source,
+        long maximumBytes,
+        EmailBodyResourceBudget budget,
+        CancellationToken operationCancellationToken) {
+        _source = source ?? throw new ArgumentNullException(nameof(source));
+        if (!source.CanRead) throw new ArgumentException("Source stream must be readable.", nameof(source));
+        _maximumBytes = maximumBytes;
+        _budget = budget ?? throw new ArgumentNullException(nameof(budget));
+        _operationCancellationToken = operationCancellationToken;
+    }
+
+    public override bool CanRead => !_disposed && _source.CanRead;
+    public override bool CanSeek => false;
+    public override bool CanWrite => false;
+    public override long Length => throw new NotSupportedException();
+    public override long Position {
+        get => throw new NotSupportedException();
+        set => throw new NotSupportedException();
+    }
+
+    public override int Read(byte[] buffer, int offset, int count) {
+        ThrowIfDisposed();
+        _operationCancellationToken.ThrowIfCancellationRequested();
+        int read = _source.Read(buffer, offset, count);
+        Account(read);
+        return read;
+    }
+
+    public override async Task<int> ReadAsync(
+        byte[] buffer,
+        int offset,
+        int count,
+        CancellationToken cancellationToken) {
+        ThrowIfDisposed();
+        _operationCancellationToken.ThrowIfCancellationRequested();
+        cancellationToken.ThrowIfCancellationRequested();
+        int read = await _source.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+        Account(read);
+        return read;
+    }
+
+    public override void Flush() => throw new NotSupportedException();
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+    public override void SetLength(long value) => throw new NotSupportedException();
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    protected override void Dispose(bool disposing) {
+        if (!_disposed) {
+            _disposed = true;
+            if (disposing) _source.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+
+    private void Account(int count) {
+        if (count <= 0) return;
+        long next = checked(_bytesRead + count);
+        if (next > _maximumBytes) {
+            throw new EmailLimitExceededException("EmailBodyProjectionOptions.MaxResourceBytes",
+                next, _maximumBytes);
+        }
+        _budget.Consume(count);
+        _bytesRead = next;
+    }
+
+    private void ThrowIfDisposed() {
+        if (_disposed) throw new ObjectDisposedException(nameof(EmailBodyResourceReadStream));
+    }
+}

--- a/OfficeIMO.Email.Html/EmailBodyResource.cs
+++ b/OfficeIMO.Email.Html/EmailBodyResource.cs
@@ -6,17 +6,14 @@ public sealed class EmailBodyResource {
     private readonly long _maximumBytes;
     private readonly EmailBodyResourceBudget _budget;
     private readonly EmailBodyResourceLimitState _limitState;
-    private readonly string _projectionContentId;
 
     internal EmailBodyResource(
         EmailAttachment attachment,
         long maximumBytes,
-        EmailBodyResourceBudget budget,
-        string projectionContentId) {
+        EmailBodyResourceBudget budget) {
         _attachment = attachment ?? throw new ArgumentNullException(nameof(attachment));
         _maximumBytes = maximumBytes;
         _budget = budget ?? throw new ArgumentNullException(nameof(budget));
-        _projectionContentId = projectionContentId ?? throw new ArgumentNullException(nameof(projectionContentId));
         _limitState = new EmailBodyResourceLimitState(maximumBytes);
     }
 
@@ -34,7 +31,7 @@ public sealed class EmailBodyResource {
     /// <summary>Opens a fresh sequential stream governed by the per-resource and projection-wide budgets.</summary>
     public Stream OpenReadStream(CancellationToken cancellationToken = default) {
         EnsureDeclaredLengthAllowed();
-        _limitState.ThrowIfExceeded();
+        _limitState.ThrowIfUnavailable();
         _budget.ThrowIfExceeded();
         cancellationToken.ThrowIfCancellationRequested();
         Stream source = _attachment.OpenContentStream();
@@ -54,7 +51,7 @@ public sealed class EmailBodyResource {
     /// <summary>Asynchronously opens a fresh sequential stream governed by the configured budgets.</summary>
     public async Task<Stream> OpenReadStreamAsync(CancellationToken cancellationToken = default) {
         EnsureDeclaredLengthAllowed();
-        _limitState.ThrowIfExceeded();
+        _limitState.ThrowIfUnavailable();
         _budget.ThrowIfExceeded();
         cancellationToken.ThrowIfCancellationRequested();
         Stream source = await _attachment.OpenContentStreamAsync(cancellationToken).ConfigureAwait(false);
@@ -114,7 +111,7 @@ public sealed class EmailBodyResource {
 
     private MemoryStream CreateOutputBuffer() {
         EnsureDeclaredLengthAllowed();
-        _limitState.ThrowIfExceeded();
+        _limitState.ThrowIfUnavailable();
         _budget.ThrowIfExceeded();
         return new MemoryStream();
     }
@@ -130,9 +127,6 @@ public sealed class EmailBodyResource {
         ? null
         : value!.Trim().Trim('<', '>');
 
-    internal bool MatchesContentId(string value) =>
-        string.Equals(ContentId, value, StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(_projectionContentId, value, StringComparison.OrdinalIgnoreCase);
 }
 
 internal sealed class EmailBodyResourceBudget {
@@ -259,6 +253,7 @@ internal sealed class EmailBodyResourceLimitState {
     private readonly SemaphoreSlim _readGate = new SemaphoreSlim(1, 1);
     private readonly long _maximumBytes;
     private long? _exceededActualValue;
+    private bool _sourceFailed;
 
     internal EmailBodyResourceLimitState(long maximumBytes) {
         _maximumBytes = maximumBytes;
@@ -270,13 +265,23 @@ internal sealed class EmailBodyResourceLimitState {
         }
     }
 
-    internal void ThrowIfExceeded() {
+    internal void MarkSourceFailed() {
+        lock (_gate) {
+            _sourceFailed = true;
+        }
+    }
+
+    internal void ThrowIfUnavailable() {
         lock (_gate) {
             if (_exceededActualValue.HasValue) {
                 throw new EmailLimitExceededException(
                     "EmailBodyProjectionOptions.MaxResourceBytes",
                     _exceededActualValue.Value,
                     _maximumBytes);
+            }
+            if (_sourceFailed) {
+                throw new InvalidOperationException(
+                    "The resource cannot be reopened after a failed source read.");
             }
         }
     }
@@ -404,7 +409,7 @@ internal sealed class EmailBodyResourceReadStream : Stream {
             return read;
         } catch {
             _budget.Release(reserved);
-            _sourceFailed = true;
+            MarkSourceFailed();
             throw;
         }
     }
@@ -430,10 +435,11 @@ internal sealed class EmailBodyResourceReadStream : Stream {
             return read;
         } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
             _budget.Release(reserved);
+            MarkSourceFailed();
             throw;
         } catch {
             _budget.Release(reserved);
-            _sourceFailed = true;
+            MarkSourceFailed();
             throw;
         }
     }
@@ -447,7 +453,7 @@ internal sealed class EmailBodyResourceReadStream : Stream {
             read = _source.Read(probe, 0, 1);
         } catch {
             _budget.Release(1);
-            _sourceFailed = true;
+            MarkSourceFailed();
             throw;
         }
         _budget.Commit(1, read);
@@ -467,10 +473,11 @@ internal sealed class EmailBodyResourceReadStream : Stream {
             read = await _source.ReadAsync(probe, 0, 1, cancellationToken).ConfigureAwait(false);
         } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
             _budget.Release(1);
+            MarkSourceFailed();
             throw;
         } catch {
             _budget.Release(1);
-            _sourceFailed = true;
+            MarkSourceFailed();
             throw;
         }
         _budget.Commit(1, read);
@@ -486,15 +493,18 @@ internal sealed class EmailBodyResourceReadStream : Stream {
         try {
             _budget.ThrowIfExceeded();
             var probe = new byte[1];
-            int read = _source.Read(probe, 0, 1);
+            int read;
+            try {
+                read = _source.Read(probe, 0, 1);
+            } catch {
+                MarkSourceFailed();
+                throw;
+            }
             if (read == 0) {
                 _endOfStream = true;
                 return 0;
             }
             return FailAggregateLimit();
-        } catch {
-            _sourceFailed = true;
-            throw;
         } finally {
             _budget.ExitAggregateProbe();
         }
@@ -505,17 +515,18 @@ internal sealed class EmailBodyResourceReadStream : Stream {
         try {
             _budget.ThrowIfExceeded();
             var probe = new byte[1];
-            int read = await _source.ReadAsync(probe, 0, 1, cancellationToken).ConfigureAwait(false);
+            int read;
+            try {
+                read = await _source.ReadAsync(probe, 0, 1, cancellationToken).ConfigureAwait(false);
+            } catch {
+                MarkSourceFailed();
+                throw;
+            }
             if (read == 0) {
                 _endOfStream = true;
                 return 0;
             }
             return FailAggregateLimit();
-        } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
-            throw;
-        } catch {
-            _sourceFailed = true;
-            throw;
         } finally {
             _budget.ExitAggregateProbe();
         }
@@ -547,11 +558,16 @@ internal sealed class EmailBodyResourceReadStream : Stream {
 
     private void ThrowIfUnavailable() {
         if (_disposed) throw new ObjectDisposedException(nameof(EmailBodyResourceReadStream));
-        _limitState.ThrowIfExceeded();
+        _limitState.ThrowIfUnavailable();
         _budget.ThrowIfExceeded();
         if (_sourceFailed) {
             throw new InvalidOperationException("The resource stream cannot continue after a failed source read.");
         }
+    }
+
+    private void MarkSourceFailed() {
+        _sourceFailed = true;
+        _limitState.MarkSourceFailed();
     }
 
     private static void ValidateReadArguments(byte[] buffer, int offset, int count) {

--- a/OfficeIMO.Email.Html/EmailBodyResourceIdentityIndex.cs
+++ b/OfficeIMO.Email.Html/EmailBodyResourceIdentityIndex.cs
@@ -1,0 +1,148 @@
+namespace OfficeIMO.Email;
+
+/// <summary>
+/// Owns the immutable, ambiguity-aware identity policy used by HTML rewrites and resource resolution.
+/// </summary>
+internal sealed class EmailBodyResourceIdentityIndex {
+    private const int NotFound = -1;
+    private const int Ambiguous = -2;
+    private readonly Entry[] _entries;
+
+    internal EmailBodyResourceIdentityIndex(IReadOnlyList<EmailAttachment> attachments) {
+        if (attachments == null) throw new ArgumentNullException(nameof(attachments));
+        string?[] contentIds = attachments
+            .Select(attachment => EmailBodyResource.NormalizeContentId(attachment.ContentId))
+            .ToArray();
+        var contentIdCounts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        var usedAliases = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (string? contentId in contentIds) {
+            if (string.IsNullOrWhiteSpace(contentId)) continue;
+            usedAliases.Add(contentId!);
+            contentIdCounts.TryGetValue(contentId!, out int count);
+            contentIdCounts[contentId!] = count + 1;
+        }
+
+        _entries = new Entry[attachments.Count];
+        for (int index = 0; index < attachments.Count; index++) {
+            string? contentId = contentIds[index];
+            string projectionContentId = !string.IsNullOrWhiteSpace(contentId) &&
+                                         contentIdCounts[contentId!] == 1
+                ? contentId!
+                : CreateUniqueAlias(index, usedAliases);
+            EmailAttachment attachment = attachments[index];
+            _entries[index] = new Entry(
+                contentId,
+                NormalizeReference(attachment.ContentLocation),
+                NormalizeReference(attachment.FileName),
+                projectionContentId);
+        }
+    }
+
+    internal string? Rewrite(string value, Uri? baseUri) {
+        if (value.StartsWith("data:", StringComparison.OrdinalIgnoreCase)) return value;
+        int index;
+        if (value.StartsWith("cid:", StringComparison.OrdinalIgnoreCase)) {
+            string? contentId = DecodeContentId(value);
+            index = contentId == null
+                ? NotFound
+                : FindUnique(entry => entry.MatchesContentId(contentId));
+        } else {
+            index = FindUnique(entry => MatchesLocation(value, null, entry.ContentLocation, baseUri));
+            if (index == Ambiguous) return null;
+            if (index == NotFound) {
+                index = FindUnique(entry => MatchesLocation(value, null, entry.FileName, baseUri));
+            }
+        }
+        return index >= 0 ? "cid:" + _entries[index].ProjectionContentId : null;
+    }
+
+    internal EmailBodyResource? Resolve(
+        IReadOnlyList<EmailBodyResource> resources,
+        Uri? baseUri,
+        string? reference,
+        Uri? resolvedUri) {
+        if (resources == null) throw new ArgumentNullException(nameof(resources));
+        if (string.IsNullOrWhiteSpace(reference) && resolvedUri == null) return null;
+        string value = (reference ?? resolvedUri!.OriginalString).Trim();
+        int index;
+        if (value.StartsWith("cid:", StringComparison.OrdinalIgnoreCase)) {
+            string? contentId = DecodeContentId(value);
+            index = contentId == null
+                ? NotFound
+                : FindUnique(entry => entry.MatchesContentId(contentId));
+        } else {
+            index = FindUnique(entry => MatchesLocation(value, resolvedUri, entry.ContentLocation, baseUri));
+            if (index == Ambiguous) return null;
+            if (index == NotFound) {
+                index = FindUnique(entry => MatchesLocation(value, resolvedUri, entry.FileName, baseUri));
+            }
+        }
+        return index >= 0 && index < resources.Count ? resources[index] : null;
+    }
+
+    private int FindUnique(Func<Entry, bool> predicate) {
+        int match = NotFound;
+        for (int index = 0; index < _entries.Length; index++) {
+            if (!predicate(_entries[index])) continue;
+            if (match != NotFound) return Ambiguous;
+            match = index;
+        }
+        return match;
+    }
+
+    private static bool MatchesLocation(
+        string candidate,
+        Uri? resolvedUri,
+        string? location,
+        Uri? baseUri) {
+        if (location == null) return false;
+        if (string.Equals(candidate, location, StringComparison.Ordinal)) return true;
+        Uri? candidateUri = resolvedUri;
+        if (candidateUri == null && !TryResolveUri(candidate, baseUri, out candidateUri)) return false;
+        return TryResolveUri(location, baseUri, out Uri? locationUri) && candidateUri!.Equals(locationUri);
+    }
+
+    private static bool TryResolveUri(string value, Uri? baseUri, out Uri? uri) {
+        if (baseUri != null && Uri.TryCreate(baseUri, value, out uri)) return true;
+        return Uri.TryCreate(value, UriKind.Absolute, out uri);
+    }
+
+    private static string CreateUniqueAlias(int index, ISet<string> usedAliases) {
+        string candidate = "officeimo-resource-" + index + "@officeimo.invalid";
+        int suffix = 1;
+        while (!usedAliases.Add(candidate)) {
+            candidate = "officeimo-resource-" + index + "-" + suffix++ + "@officeimo.invalid";
+        }
+        return candidate;
+    }
+
+    private static string? DecodeContentId(string value) {
+        try {
+            return EmailBodyResource.NormalizeContentId(Uri.UnescapeDataString(value.Substring(4)));
+        } catch (UriFormatException) {
+            return null;
+        }
+    }
+
+    private static string? NormalizeReference(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value!.Trim();
+
+    private sealed class Entry {
+        internal Entry(string? contentId, string? contentLocation, string? fileName,
+            string projectionContentId) {
+            ContentId = contentId;
+            ContentLocation = contentLocation;
+            FileName = fileName;
+            ProjectionContentId = projectionContentId;
+        }
+
+        internal string? ContentId { get; }
+        internal string? ContentLocation { get; }
+        internal string? FileName { get; }
+        internal string ProjectionContentId { get; }
+
+        internal bool MatchesContentId(string value) =>
+            string.Equals(ContentId, value, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(ProjectionContentId, value, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/OfficeIMO.Email.Html/EmailBodyResourceIdentityIndex.cs
+++ b/OfficeIMO.Email.Html/EmailBodyResourceIdentityIndex.cs
@@ -8,10 +8,10 @@ internal sealed class EmailBodyResourceIdentityIndex {
     private const int Ambiguous = -2;
     private readonly Entry[] _entries;
 
-    internal EmailBodyResourceIdentityIndex(IReadOnlyList<EmailAttachment> attachments) {
-        if (attachments == null) throw new ArgumentNullException(nameof(attachments));
-        string?[] contentIds = attachments
-            .Select(attachment => EmailBodyResource.NormalizeContentId(attachment.ContentId))
+    internal EmailBodyResourceIdentityIndex(IReadOnlyList<EmailBodyResource> resources) {
+        if (resources == null) throw new ArgumentNullException(nameof(resources));
+        string?[] contentIds = resources
+            .Select(resource => resource.ContentId)
             .ToArray();
         var contentIdCounts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
         var usedAliases = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -22,18 +22,18 @@ internal sealed class EmailBodyResourceIdentityIndex {
             contentIdCounts[contentId!] = count + 1;
         }
 
-        _entries = new Entry[attachments.Count];
-        for (int index = 0; index < attachments.Count; index++) {
+        _entries = new Entry[resources.Count];
+        for (int index = 0; index < resources.Count; index++) {
             string? contentId = contentIds[index];
             string projectionContentId = !string.IsNullOrWhiteSpace(contentId) &&
                                          contentIdCounts[contentId!] == 1
                 ? contentId!
                 : CreateUniqueAlias(index, usedAliases);
-            EmailAttachment attachment = attachments[index];
+            EmailBodyResource resource = resources[index];
             _entries[index] = new Entry(
                 contentId,
-                NormalizeReference(attachment.ContentLocation),
-                NormalizeReference(attachment.FileName),
+                NormalizeReference(resource.ContentLocation),
+                NormalizeReference(resource.FileName),
                 projectionContentId);
         }
     }
@@ -50,7 +50,8 @@ internal sealed class EmailBodyResourceIdentityIndex {
             index = FindUnique(entry => MatchesLocation(value, null, entry.ContentLocation, baseUri));
             if (index == Ambiguous) return null;
             if (index == NotFound) {
-                index = FindUnique(entry => MatchesLocation(value, null, entry.FileName, baseUri));
+                index = FindUnique(entry => MatchesFileName(
+                    value, null, entry.FileName, baseUri));
             }
         }
         return index >= 0 ? "cid:" + _entries[index].ProjectionContentId : null;
@@ -74,7 +75,8 @@ internal sealed class EmailBodyResourceIdentityIndex {
             index = FindUnique(entry => MatchesLocation(value, resolvedUri, entry.ContentLocation, baseUri));
             if (index == Ambiguous) return null;
             if (index == NotFound) {
-                index = FindUnique(entry => MatchesLocation(value, resolvedUri, entry.FileName, baseUri));
+                index = FindUnique(entry => MatchesFileName(
+                    value, resolvedUri, entry.FileName, baseUri));
             }
         }
         return index >= 0 && index < resources.Count ? resources[index] : null;
@@ -100,6 +102,20 @@ internal sealed class EmailBodyResourceIdentityIndex {
         Uri? candidateUri = resolvedUri;
         if (candidateUri == null && !TryResolveUri(candidate, baseUri, out candidateUri)) return false;
         return TryResolveUri(location, baseUri, out Uri? locationUri) && candidateUri!.Equals(locationUri);
+    }
+
+    private static bool MatchesFileName(
+        string candidate,
+        Uri? resolvedUri,
+        string? fileName,
+        Uri? baseUri) {
+        if (fileName == null) return false;
+        if (string.Equals(candidate, fileName, StringComparison.OrdinalIgnoreCase)) return true;
+        Uri? candidateUri = resolvedUri;
+        if (candidateUri == null && !TryResolveUri(candidate, baseUri, out candidateUri)) return false;
+        return TryResolveUri(fileName, baseUri, out Uri? fileNameUri) &&
+            string.Equals(candidateUri!.AbsoluteUri, fileNameUri!.AbsoluteUri,
+                StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool TryResolveUri(string value, Uri? baseUri, out Uri? uri) {

--- a/OfficeIMO.Email.Html/EmailHtmlImageDocument.cs
+++ b/OfficeIMO.Email.Html/EmailHtmlImageDocument.cs
@@ -1,0 +1,82 @@
+using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
+
+namespace OfficeIMO.Email;
+
+/// <summary>One image source discovered in an email HTML body.</summary>
+public sealed class EmailHtmlImageReference {
+    internal EmailHtmlImageReference(int index, string source) {
+        Index = index;
+        Source = source;
+    }
+
+    /// <summary>Zero-based image index in document order.</summary>
+    public int Index { get; }
+
+    /// <summary>Decoded value of the image's <c>src</c> attribute.</summary>
+    public string Source { get; }
+}
+
+/// <summary>
+/// Bounded, network-free DOM view used to discover and rewrite image sources in email HTML.
+/// </summary>
+/// <remarks>
+/// Parsing and HTML recovery are owned by OfficeIMO.Html. This type never resolves or downloads a
+/// resource; callers remain responsible for authorizing local files and remote network access.
+/// </remarks>
+public sealed class EmailHtmlImageDocument {
+    private readonly IHtmlDocument _document;
+    private readonly IElement[] _images;
+    private readonly bool _preserveDocumentEnvelope;
+
+    private EmailHtmlImageDocument(IHtmlDocument document, bool preserveDocumentEnvelope) {
+        _document = document;
+        _images = document.QuerySelectorAll("img[src]").ToArray();
+        _preserveDocumentEnvelope = preserveDocumentEnvelope;
+        Images = _images
+            .Select((image, index) => new EmailHtmlImageReference(index, image.GetAttribute("src") ?? string.Empty))
+            .ToArray();
+    }
+
+    /// <summary>Images with explicit <c>src</c> attributes in document order.</summary>
+    public IReadOnlyList<EmailHtmlImageReference> Images { get; }
+
+    /// <summary>
+    /// Parses an HTML fragment or document under the shared OfficeIMO limits without performing network access.
+    /// </summary>
+    /// <param name="html">HTML fragment or document to inspect.</param>
+    public static EmailHtmlImageDocument Parse(string html) {
+        if (html == null) throw new ArgumentNullException(nameof(html));
+
+        HtmlUrlPolicy compatibleResources = HtmlUrlPolicy.CreateOfficeIMOProfile();
+        var options = HtmlConversionDocumentOptions.CreateUntrustedProfile();
+        options.IncludeNormalizedHtml = false;
+        options.UseBodyContentsOnly = false;
+        options.ResourceUrlPolicy = compatibleResources;
+        HtmlConversionDocument conversion = HtmlConversionDocument.Parse(html, options);
+        IHtmlDocument document = conversion.CreateDocumentForConversion();
+        bool preserveEnvelope = ContainsDocumentEnvelope(html);
+        return new EmailHtmlImageDocument(document, preserveEnvelope);
+    }
+
+    /// <summary>Rewrites one image source selected by its stable document-order index.</summary>
+    /// <param name="imageIndex">Index from <see cref="EmailHtmlImageReference.Index"/>.</param>
+    /// <param name="source">Replacement source, such as a <c>cid:</c> reference.</param>
+    public void SetImageSource(int imageIndex, string source) {
+        if (imageIndex < 0 || imageIndex >= _images.Length) throw new ArgumentOutOfRangeException(nameof(imageIndex));
+        if (string.IsNullOrWhiteSpace(source)) throw new ArgumentException("An image source is required.", nameof(source));
+        _images[imageIndex].SetAttribute("src", source);
+    }
+
+    /// <summary>Serializes the current DOM while retaining fragment versus document shape.</summary>
+    public string ToHtml() {
+        if (_preserveDocumentEnvelope) return _document.DocumentElement?.OuterHtml ?? string.Empty;
+        return _document.Body?.InnerHtml ?? _document.DocumentElement?.InnerHtml ?? string.Empty;
+    }
+
+    private static bool ContainsDocumentEnvelope(string html) =>
+        html.IndexOf("<!doctype", StringComparison.OrdinalIgnoreCase) >= 0 ||
+        html.IndexOf("<html", StringComparison.OrdinalIgnoreCase) >= 0 ||
+        html.IndexOf("<head", StringComparison.OrdinalIgnoreCase) >= 0 ||
+        html.IndexOf("<body", StringComparison.OrdinalIgnoreCase) >= 0;
+}

--- a/OfficeIMO.Email.Html/EmailHtmlImageDocument.cs
+++ b/OfficeIMO.Email.Html/EmailHtmlImageDocument.cs
@@ -1,3 +1,4 @@
+using AngleSharp;
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 
@@ -28,11 +29,19 @@ public sealed class EmailHtmlImageDocument {
     private readonly IHtmlDocument _document;
     private readonly IElement[] _images;
     private readonly bool _preserveDocumentEnvelope;
+    private readonly string[] _leadingDocumentNodes;
+    private readonly string[] _trailingDocumentNodes;
 
-    private EmailHtmlImageDocument(IHtmlDocument document, bool preserveDocumentEnvelope) {
+    private EmailHtmlImageDocument(
+        IHtmlDocument document,
+        bool preserveDocumentEnvelope,
+        string[] leadingDocumentNodes,
+        string[] trailingDocumentNodes) {
         _document = document;
         _images = document.QuerySelectorAll("img[src]").ToArray();
         _preserveDocumentEnvelope = preserveDocumentEnvelope;
+        _leadingDocumentNodes = leadingDocumentNodes;
+        _trailingDocumentNodes = trailingDocumentNodes;
         Images = _images
             .Select((image, index) => new EmailHtmlImageReference(index, image.GetAttribute("src") ?? string.Empty))
             .ToArray();
@@ -55,8 +64,23 @@ public sealed class EmailHtmlImageDocument {
         options.ResourceUrlPolicy = compatibleResources;
         HtmlConversionDocument conversion = HtmlConversionDocument.Parse(html, options);
         IHtmlDocument document = conversion.CreateDocumentForConversion();
+        IHtmlDocument sourceDocument = conversion.CreateSourceDocumentForConversion();
+        var leadingNodes = new List<string>();
+        var trailingNodes = new List<string>();
+        bool passedDocumentElement = false;
+        foreach (INode node in sourceDocument.ChildNodes) {
+            if (ReferenceEquals(node, sourceDocument.DocumentElement)) {
+                passedDocumentElement = true;
+            } else {
+                (passedDocumentElement ? trailingNodes : leadingNodes).Add(node.ToHtml());
+            }
+        }
         bool preserveEnvelope = conversion.HasExplicitDocumentEnvelope;
-        return new EmailHtmlImageDocument(document, preserveEnvelope);
+        return new EmailHtmlImageDocument(
+            document,
+            preserveEnvelope,
+            leadingNodes.ToArray(),
+            trailingNodes.ToArray());
     }
 
     /// <summary>Rewrites one image source selected by its stable document-order index.</summary>
@@ -70,8 +94,27 @@ public sealed class EmailHtmlImageDocument {
 
     /// <summary>Serializes the current DOM while retaining fragment versus document shape.</summary>
     public string ToHtml() {
-        if (_preserveDocumentEnvelope) return _document.DocumentElement?.OuterHtml ?? string.Empty;
-        return _document.Body?.InnerHtml ?? _document.DocumentElement?.InnerHtml ?? string.Empty;
+        if (_preserveDocumentEnvelope) {
+            return string.Concat(_leadingDocumentNodes) +
+                (_document.DocumentElement?.OuterHtml ?? string.Empty) +
+                string.Concat(_trailingDocumentNodes);
+        }
+
+        var output = new StringBuilder();
+        foreach (string node in _leadingDocumentNodes) output.Append(node);
+        foreach (INode node in _document.ChildNodes) {
+            if (!ReferenceEquals(node, _document.DocumentElement)) {
+                continue;
+            }
+            if (_document.Head != null) {
+                foreach (INode headNode in _document.Head.ChildNodes) output.Append(headNode.ToHtml());
+            }
+            if (_document.Body != null) {
+                foreach (INode bodyNode in _document.Body.ChildNodes) output.Append(bodyNode.ToHtml());
+            }
+        }
+        foreach (string node in _trailingDocumentNodes) output.Append(node);
+        return output.ToString();
     }
 
 }

--- a/OfficeIMO.Email.Html/EmailHtmlImageDocument.cs
+++ b/OfficeIMO.Email.Html/EmailHtmlImageDocument.cs
@@ -55,7 +55,7 @@ public sealed class EmailHtmlImageDocument {
         options.ResourceUrlPolicy = compatibleResources;
         HtmlConversionDocument conversion = HtmlConversionDocument.Parse(html, options);
         IHtmlDocument document = conversion.CreateDocumentForConversion();
-        bool preserveEnvelope = ContainsDocumentEnvelope(html);
+        bool preserveEnvelope = conversion.HasExplicitDocumentEnvelope;
         return new EmailHtmlImageDocument(document, preserveEnvelope);
     }
 
@@ -74,9 +74,4 @@ public sealed class EmailHtmlImageDocument {
         return _document.Body?.InnerHtml ?? _document.DocumentElement?.InnerHtml ?? string.Empty;
     }
 
-    private static bool ContainsDocumentEnvelope(string html) =>
-        html.IndexOf("<!doctype", StringComparison.OrdinalIgnoreCase) >= 0 ||
-        html.IndexOf("<html", StringComparison.OrdinalIgnoreCase) >= 0 ||
-        html.IndexOf("<head", StringComparison.OrdinalIgnoreCase) >= 0 ||
-        html.IndexOf("<body", StringComparison.OrdinalIgnoreCase) >= 0;
 }

--- a/OfficeIMO.Email.Html/README.md
+++ b/OfficeIMO.Email.Html/README.md
@@ -12,9 +12,16 @@ using OfficeIMO.Email;
 EmailBodyProjectionResult projection = EmailBodyProjection.Create(message);
 string safeHtml = projection.Html;
 EmailBodyResource? logo = projection.ResolveResource("cid:logo@example.test");
+
+if (logo is not null) {
+    await using FileStream output = File.Create("logo.bin");
+    await logo.CopyToAsync(output);
+}
 ```
 
 Remote resources are blocked by default. Selecting `AllowByConsumerResolver` only retains eligible HTTP(S) references; this package never downloads them. Attachment content remains operation-scoped and is opened only through bounded resource reads.
+
+`EmailBodyProjectionOptions` bounds each projection by resource count, bytes per resource, and total bytes read across all resources. The defaults are 128 resources, 128 MiB per resource, and 256 MiB per projection. `OpenReadStream`, `CopyTo`, and their asynchronous counterparts let consumers process content without first allocating another full byte array. Repeated reads share the projection-wide budget.
 
 `OfficeIMO.Email.Image` uses the prepared HTML and resource index for rendering. `OfficeIMO.Reader.Email` uses the same projection before producing safe text or Markdown, so those adapters do not choose bodies, sanitize markup, or resolve embedded resources independently.
 

--- a/OfficeIMO.Email.Html/README.md
+++ b/OfficeIMO.Email.Html/README.md
@@ -14,14 +14,14 @@ string safeHtml = projection.Html;
 EmailBodyResource? logo = projection.ResolveResource("cid:logo@example.test");
 
 if (logo is not null) {
-    await using FileStream output = File.Create("logo.bin");
+    using FileStream output = File.Create("logo.bin");
     await logo.CopyToAsync(output);
 }
 ```
 
 Remote resources are blocked by default. Selecting `AllowByConsumerResolver` only retains eligible HTTP(S) references; this package never downloads them. Attachment content remains operation-scoped and is opened only through bounded resource reads.
 
-`EmailBodyProjectionOptions` bounds each projection by resource count, bytes per resource, and total bytes read across all resources. The defaults are 128 resources, 128 MiB per resource, and 256 MiB per projection. `OpenReadStream`, `CopyTo`, and their asynchronous counterparts let consumers process content without first allocating another full byte array. Repeated reads share the projection-wide budget.
+`EmailBodyProjectionOptions` bounds each projection by indexed resource count, bytes per resource, and declared or read bytes across all resources. The defaults are 128 resources, 128 MiB per resource, and 256 MiB per projection. `OpenReadStream`, `CopyTo`, and their asynchronous counterparts let consumers process content without first allocating another full byte array. Repeated reads share the projection-wide budget. Body-only consumers can set `IncludeResources` to `false` to avoid indexing attachments.
 
 `OfficeIMO.Email.Image` uses the prepared HTML and resource index for rendering. `OfficeIMO.Reader.Email` uses the same projection before producing safe text or Markdown, so those adapters do not choose bodies, sanitize markup, or resolve embedded resources independently.
 

--- a/OfficeIMO.Email.Html/README.md
+++ b/OfficeIMO.Email.Html/README.md
@@ -19,6 +19,22 @@ if (logo is not null) {
 }
 ```
 
+For targeted image inspection and rewriting without creating a full body projection, use the bounded, network-free DOM view:
+
+```csharp
+EmailHtmlImageDocument images = EmailHtmlImageDocument.Parse(message.Body.Html ?? string.Empty);
+
+foreach (EmailHtmlImageReference image in images.Images) {
+    if (image.Source == "logo.png") {
+        images.SetImageSource(image.Index, "cid:logo@example.test");
+    }
+}
+
+string rewrittenHtml = images.ToHtml();
+```
+
+`Parse` accepts either an HTML fragment or a complete document. `Images` reports explicit `img[src]` attributes in document order, `SetImageSource` rewrites one stable index, and `ToHtml` preserves fragment-versus-document shape. This workflow does not open local files or download remote resources.
+
 Remote resources are blocked by default. Selecting `AllowByConsumerResolver` only retains eligible HTTP(S) references; this package never downloads them. Attachment content remains operation-scoped and is opened only through bounded resource reads.
 
 `EmailBodyProjectionOptions` bounds each projection by indexed resource count, bytes per resource, and declared or read bytes across all resources. The defaults are 128 resources, 128 MiB per resource, and 256 MiB per projection. `OpenReadStream`, `CopyTo`, and their asynchronous counterparts let consumers process content without first allocating another full byte array. Repeated reads share the projection-wide budget. Body-only consumers can set `IncludeResources` to `false` to avoid indexing attachments.

--- a/OfficeIMO.Email.Image/EmailImageExportExtensions.cs
+++ b/OfficeIMO.Email.Image/EmailImageExportExtensions.cs
@@ -328,6 +328,12 @@ public static class EmailImageExportExtensions {
                         bytes,
                         attachment.ContentType);
                 }
+                return null;
+            }
+            if (request.Uri.Scheme.Equals(
+                    "cid",
+                    StringComparison.OrdinalIgnoreCase)) {
+                return null;
             }
             if (fallback == null ||
                 !HtmlUrlPolicyEvaluator.IsAllowed(

--- a/OfficeIMO.Email.Image/EmailImageExportExtensions.cs
+++ b/OfficeIMO.Email.Image/EmailImageExportExtensions.cs
@@ -124,6 +124,7 @@ public static class EmailImageExportExtensions {
             options?.CloneEmail() ?? new EmailImageExportOptions();
         EmailBodyProjectionResult bodyProjection = EmailBodyProjection.Create(source,
             new EmailBodyProjectionOptions {
+                IncludeResources = effective.IncludeInlineResources,
                 SelectionPolicy = effective.PreferHtmlBody
                     ? EmailBodySelectionPolicy.Richest
                     : EmailBodySelectionPolicy.RtfFirst,
@@ -284,7 +285,7 @@ public static class EmailImageExportExtensions {
                 try {
                     bytes = attachment.ReadAllBytes(cancellationToken);
                 } catch (EmailLimitExceededException exception) {
-                    throw new HtmlRenderResourceByteLimitException(exception.ActualValue);
+                    throw MapResourceLimit(exception);
                 }
                 resource = bytes.Length > 0
                     ? new HtmlResolvedResource(
@@ -320,7 +321,7 @@ public static class EmailImageExportExtensions {
                 try {
                     bytes = await attachment.ReadAllBytesAsync(cancellationToken).ConfigureAwait(false);
                 } catch (EmailLimitExceededException exception) {
-                    throw new HtmlRenderResourceByteLimitException(exception.ActualValue);
+                    throw MapResourceLimit(exception);
                 }
                 if (bytes.Length > 0) {
                     return new HtmlResolvedResource(
@@ -338,6 +339,14 @@ public static class EmailImageExportExtensions {
                 .ConfigureAwait(false);
         };
     }
+
+    private static Exception MapResourceLimit(EmailLimitExceededException exception) =>
+        string.Equals(
+            exception.LimitName,
+            "EmailBodyProjectionOptions.MaxTotalResourceBytes",
+            StringComparison.Ordinal)
+            ? new HtmlRenderTotalResourceByteLimitException(exception.ActualValue)
+            : new HtmlRenderResourceByteLimitException(exception.ActualValue);
 
     private static OfficeImageExportDiagnostic MapBodyDiagnostic(EmailDiagnostic diagnostic) {
         string code;

--- a/OfficeIMO.Email.Image/EmailImageExportExtensions.cs
+++ b/OfficeIMO.Email.Image/EmailImageExportExtensions.cs
@@ -129,6 +129,8 @@ public static class EmailImageExportExtensions {
                     : EmailBodySelectionPolicy.RtfFirst,
                 RemoteResourcePolicy = effective.RemoteResourcePolicy,
                 MaxResourceBytes = effective.MaxResourceBytes,
+                MaxResourceCount = effective.MaxInlineResourceCount,
+                MaxTotalResourceBytes = effective.MaxTotalInlineResourceBytes,
                 BaseUri = effective.BaseUri
             });
         var diagnostics = bodyProjection.Diagnostics.Select(MapBodyDiagnostic).ToList();

--- a/OfficeIMO.Email.Image/EmailImageExportOptions.cs
+++ b/OfficeIMO.Email.Image/EmailImageExportOptions.cs
@@ -16,6 +16,12 @@ public sealed class EmailImageExportOptions : HtmlRenderOptions {
     /// <summary>Controls whether network resources remain eligible for an explicitly configured resolver.</summary>
     public EmailRemoteResourcePolicy RemoteResourcePolicy { get; set; } = EmailRemoteResourcePolicy.Block;
 
+    /// <summary>Maximum inline resources indexed for one export.</summary>
+    public int MaxInlineResourceCount { get; set; } = 128;
+
+    /// <summary>Maximum bytes read across all inline resources for one export.</summary>
+    public long MaxTotalInlineResourceBytes { get; set; } = 256L * 1024 * 1024;
+
     /// <summary>Creates an independent email options snapshot.</summary>
     public EmailImageExportOptions CloneEmail() {
         EmailImageExportOptions clone = CopyTo(new EmailImageExportOptions());
@@ -23,6 +29,8 @@ public sealed class EmailImageExportOptions : HtmlRenderOptions {
         clone.PreferHtmlBody = PreferHtmlBody;
         clone.IncludeInlineResources = IncludeInlineResources;
         clone.RemoteResourcePolicy = RemoteResourcePolicy;
+        clone.MaxInlineResourceCount = MaxInlineResourceCount;
+        clone.MaxTotalInlineResourceBytes = MaxTotalInlineResourceBytes;
         return clone;
     }
 

--- a/OfficeIMO.Email.Image/README.md
+++ b/OfficeIMO.Email.Image/README.md
@@ -21,6 +21,8 @@ IReadOnlyList<OfficeImageExportResult> pages = message
 
 The renderer consumes `OfficeIMO.Email.Html` for the same body selection, untrusted sanitization, remote-resource policy, and CID/Content-Location resolution used by Reader. It can convert an RTF body when HTML is absent and safely encodes plain text as the final fallback. Rendering limits, page selection, and diagnostics come from the shared HTML renderer.
 
+`EmailImageExportOptions` also limits inline MIME resources before rendering. `MaxInlineResourceCount` defaults to 128, while `MaxResourceBytes` and `MaxTotalInlineResourceBytes` bound individual and aggregate resource reads.
+
 Keeping this capability separate prevents MIME-only applications from acquiring AngleSharp, CSS layout, and the RTF bridge.
 
 Dependency footprint: `OfficeIMO.Core`, `OfficeIMO.Email`, `OfficeIMO.Email.Html`, and `OfficeIMO.Html`.

--- a/OfficeIMO.Email.Tests/Projection/EmailBodyProjectionResourcePolicyTests.cs
+++ b/OfficeIMO.Email.Tests/Projection/EmailBodyProjectionResourcePolicyTests.cs
@@ -1,0 +1,125 @@
+using OfficeIMO.Email;
+using Xunit;
+
+namespace OfficeIMO.Email.Tests;
+
+public sealed class EmailBodyProjectionResourcePolicyTests {
+    [Fact]
+    public void Offline_projection_uses_the_document_base_for_relative_content_locations() {
+        var document = new EmailDocument();
+        document.Body.Html = "<base href='https://mail.example/message/'><img src='images/logo.png'>";
+        document.Attachments.Add(new EmailAttachment {
+            FileName = "logo.png",
+            ContentType = "image/png",
+            ContentLocation = "images/logo.png",
+            IsInline = true,
+            Content = new byte[] { 1 },
+            Length = 1
+        });
+
+        EmailBodyProjectionResult projection = EmailBodyProjection.Create(document);
+
+        Assert.Contains("src=\"cid:officeimo-resource-", projection.Html,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(new Uri("https://mail.example/message/"), projection.Document.BaseUri);
+        Assert.Same(projection.Resources[0], projection.ResolveResource(
+            "https://mail.example/message/images/logo.png",
+            new Uri("https://mail.example/message/images/logo.png")));
+    }
+
+    [Fact]
+    public void Declared_aggregate_overflow_is_reported_as_a_limit_violation() {
+        var document = new EmailDocument { Body = { Html = "<p>resources</p>" } };
+        document.Attachments.Add(CreateInlineAttachment("first", long.MaxValue));
+        document.Attachments.Add(CreateInlineAttachment("second", 1));
+
+        EmailLimitExceededException exception = Assert.Throws<EmailLimitExceededException>(() =>
+            EmailBodyProjection.Create(document, new EmailBodyProjectionOptions {
+                MaxResourceBytes = long.MaxValue,
+                MaxTotalResourceBytes = long.MaxValue
+            }));
+
+        Assert.Equal("EmailBodyProjectionOptions.MaxTotalResourceBytes", exception.LimitName);
+        Assert.Equal(long.MaxValue, exception.ActualValue);
+        Assert.Equal(long.MaxValue, exception.MaximumValue);
+    }
+
+    [Fact]
+    public void Duplicate_content_ids_are_rewritten_to_unique_aliases_and_remain_ambiguous_by_original_id() {
+        var document = new EmailDocument();
+        document.Body.HtmlContentLocation = "https://mail.example/message/";
+        document.Body.Html = "<img src='images/second.png'>";
+        document.Attachments.Add(CreateInlineAttachment(
+            "duplicate@example.test", 1, "first.png", "images/first.png"));
+        document.Attachments.Add(CreateInlineAttachment(
+            "duplicate@example.test", 1, "second.png", "images/second.png"));
+
+        EmailBodyProjectionResult projection = EmailBodyProjection.Create(document);
+        string alias = projection.Document.CreateDocumentForConversion()
+            .QuerySelector("img")!.GetAttribute("src")!;
+
+        Assert.StartsWith("cid:officeimo-resource-", alias, StringComparison.OrdinalIgnoreCase);
+        Assert.Same(projection.Resources[1], projection.ResolveResource(alias));
+        Assert.Null(projection.ResolveResource("cid:duplicate@example.test"));
+    }
+
+    [Fact]
+    public void Content_location_matching_precedes_filename_fallback() {
+        var document = new EmailDocument { Body = { Html = "<img src='logo.png'>" } };
+        document.Attachments.Add(CreateInlineAttachment(
+            "filename@example.test", 1, "logo.png", null));
+        document.Attachments.Add(CreateInlineAttachment(
+            "location@example.test", 1, "other.png", "logo.png"));
+
+        EmailBodyProjectionResult projection = EmailBodyProjection.Create(document);
+
+        Assert.Contains("src=\"cid:location@example.test\"", projection.Html,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Absolute_resource_matching_preserves_path_case() {
+        var document = new EmailDocument();
+        document.Body.HtmlContentLocation = "https://assets.example/";
+        document.Body.Html = "<img src='images/logo.png'>";
+        document.Attachments.Add(CreateInlineAttachment(
+            "upper@example.test", 1, "upper.png", "Images/logo.png"));
+        document.Attachments.Add(CreateInlineAttachment(
+            "lower@example.test", 1, "lower.png", "images/logo.png"));
+
+        EmailBodyProjectionResult projection = EmailBodyProjection.Create(document);
+
+        Assert.Contains("src=\"cid:lower@example.test\"", projection.Html,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Ambiguous_content_locations_are_not_rewritten_or_resolved() {
+        var document = new EmailDocument { Body = { Html = "<img src='shared.png'>" } };
+        document.Attachments.Add(CreateInlineAttachment(
+            "first@example.test", 1, "first.png", "shared.png"));
+        document.Attachments.Add(CreateInlineAttachment(
+            "second@example.test", 1, "second.png", "shared.png"));
+
+        EmailBodyProjectionResult projection = EmailBodyProjection.Create(document);
+        AngleSharp.Dom.IElement image = projection.Document.CreateDocumentForConversion()
+            .QuerySelector("img")!;
+
+        Assert.False(image.HasAttribute("src"));
+        Assert.Null(projection.ResolveResource("shared.png"));
+    }
+
+    private static EmailAttachment CreateInlineAttachment(
+        string contentId,
+        long length,
+        string? fileName = null,
+        string? contentLocation = null) => new EmailAttachment {
+        FileName = fileName,
+        ContentLocation = contentLocation,
+        ContentId = contentId,
+        ContentType = "application/octet-stream",
+        IsInline = true,
+        Content = new byte[] { 1 },
+        Length = length
+    };
+}

--- a/OfficeIMO.Email.Tests/Projection/EmailBodyProjectionResourcePolicyTests.cs
+++ b/OfficeIMO.Email.Tests/Projection/EmailBodyProjectionResourcePolicyTests.cs
@@ -78,6 +78,49 @@ public sealed class EmailBodyProjectionResourcePolicyTests {
     }
 
     [Fact]
+    public void Filename_fallback_preserves_case_insensitive_compatibility() {
+        var document = new EmailDocument { Body = { Html = "<img src='LOGO.PNG'>" } };
+        document.Attachments.Add(CreateInlineAttachment(
+            "filename@example.test", 1, "logo.png", null));
+
+        EmailBodyProjectionResult projection = EmailBodyProjection.Create(document);
+
+        Assert.Contains("src=\"cid:filename@example.test\"", projection.Html,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.Same(projection.Resources[0], projection.ResolveResource("LOGO.PNG"));
+    }
+
+    [Fact]
+    public async Task Projection_snapshots_resource_identity_metadata_and_content_selection() {
+        var attachment = CreateInlineAttachment(
+            "old@example.test", 1, "old.png", "images/old.png");
+        attachment.ContentType = "image/png";
+        attachment.Content = new byte[] { 1 };
+        var document = new EmailDocument { Body = { Html = "<img src='cid:old@example.test'>" } };
+        document.Attachments.Add(attachment);
+
+        EmailBodyProjectionResult projection = EmailBodyProjection.Create(document);
+        EmailBodyResource resource = Assert.Single(projection.Resources);
+
+        attachment.ContentId = "new@example.test";
+        attachment.ContentLocation = "images/new.png";
+        attachment.FileName = "new.png";
+        attachment.ContentType = "image/jpeg";
+        attachment.Length = 2;
+        attachment.Content = new byte[] { 2, 3 };
+
+        Assert.Equal("old@example.test", resource.ContentId);
+        Assert.Equal("images/old.png", resource.ContentLocation);
+        Assert.Equal("old.png", resource.FileName);
+        Assert.Equal("image/png", resource.ContentType);
+        Assert.Equal(1, resource.Length);
+        Assert.Equal(new byte[] { 1 }, resource.ReadAllBytes());
+        Assert.Equal(new byte[] { 1 }, await resource.ReadAllBytesAsync());
+        Assert.Same(resource, projection.ResolveResource("cid:old@example.test"));
+        Assert.Null(projection.ResolveResource("cid:new@example.test"));
+    }
+
+    [Fact]
     public void Absolute_resource_matching_preserves_path_case() {
         var document = new EmailDocument();
         document.Body.HtmlContentLocation = "https://assets.example/";

--- a/OfficeIMO.Email.Tests/Projection/EmailBodyProjectionTests.cs
+++ b/OfficeIMO.Email.Tests/Projection/EmailBodyProjectionTests.cs
@@ -163,6 +163,92 @@ public sealed class EmailBodyProjectionTests {
             resource.OpenReadStreamAsync(cancellation.Token));
     }
 
+    [Fact]
+    public void Direct_reads_never_write_rejected_bytes_and_poison_an_oversized_resource() {
+        var content = new TrackingContentSource(new byte[] { 1, 2, 3, 4 });
+        EmailDocument document = CreateInlineResourceDocument(new byte[] { 0 });
+        document.Attachments[0].Content = null;
+        document.Attachments[0].ContentSource = content;
+        document.Attachments[0].Length = 0;
+        EmailBodyResource resource = EmailBodyProjection.Create(document,
+            new EmailBodyProjectionOptions { MaxResourceBytes = 3 }).Resources[0];
+        var buffer = new byte[] { 9, 9, 9, 9 };
+
+        using Stream source = resource.OpenReadStream();
+        Assert.Equal(3, source.Read(buffer, 0, buffer.Length));
+        Assert.Equal(new byte[] { 1, 2, 3, 9 }, buffer);
+        EmailLimitExceededException exception = Assert.Throws<EmailLimitExceededException>(() =>
+            source.Read(buffer, 0, buffer.Length));
+        int readsAfterFailure = content.ReadCount;
+
+        Assert.Equal("EmailBodyProjectionOptions.MaxResourceBytes", exception.LimitName);
+        Assert.Throws<EmailLimitExceededException>(() => source.Read(buffer, 0, buffer.Length));
+        Assert.Throws<EmailLimitExceededException>(() => resource.OpenReadStream());
+        Assert.Equal(readsAfterFailure, content.ReadCount);
+        source.Dispose();
+        Assert.Equal(1, content.DisposeCount);
+    }
+
+    [Fact]
+    public void Aggregate_failure_poisoning_prevents_reopening_other_resources() {
+        var firstContent = new TrackingContentSource(new byte[] { 1, 2, 3 });
+        var secondContent = new TrackingContentSource(new byte[] { 4, 5, 6 });
+        EmailDocument document = CreateInlineResourceDocument(new byte[] { 0 }, new byte[] { 0 });
+        document.Attachments[0].Content = null;
+        document.Attachments[0].ContentSource = firstContent;
+        document.Attachments[0].Length = 0;
+        document.Attachments[1].Content = null;
+        document.Attachments[1].ContentSource = secondContent;
+        document.Attachments[1].Length = 0;
+        EmailBodyProjectionResult projection = EmailBodyProjection.Create(document,
+            new EmailBodyProjectionOptions { MaxTotalResourceBytes = 3 });
+
+        Assert.Equal(new byte[] { 1, 2, 3 }, projection.Resources[0].ReadAllBytes());
+        EmailLimitExceededException exception = Assert.Throws<EmailLimitExceededException>(() =>
+            projection.Resources[1].ReadAllBytes());
+        int opensAfterFailure = secondContent.OpenCount;
+        int readsAfterFailure = secondContent.ReadCount;
+
+        Assert.Equal("EmailBodyProjectionOptions.MaxTotalResourceBytes", exception.LimitName);
+        Assert.Throws<EmailLimitExceededException>(() => projection.Resources[1].OpenReadStream());
+        Assert.Equal(opensAfterFailure, secondContent.OpenCount);
+        Assert.Equal(readsAfterFailure, secondContent.ReadCount);
+    }
+
+    [Fact]
+    public async Task Operation_cancellation_interrupts_an_active_async_source_read() {
+        var content = new BlockingContentSource();
+        EmailDocument document = CreateInlineResourceDocument(new byte[] { 0 });
+        document.Attachments[0].Content = null;
+        document.Attachments[0].ContentSource = content;
+        document.Attachments[0].Length = 0;
+        EmailBodyResource resource = EmailBodyProjection.Create(document).Resources[0];
+        using var cancellation = new CancellationTokenSource();
+        using Stream source = await resource.OpenReadStreamAsync(cancellation.Token);
+        Task<int> read = source.ReadAsync(new byte[1], 0, 1, CancellationToken.None);
+        await content.ReadStarted;
+
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => read);
+    }
+
+    [Fact]
+    public void Resource_indexing_can_be_disabled_for_body_only_consumers() {
+        EmailDocument document = CreateInlineResourceDocument(
+            new byte[] { 1, 2 },
+            new byte[] { 3, 4 });
+
+        EmailBodyProjectionResult projection = EmailBodyProjection.Create(document,
+            new EmailBodyProjectionOptions {
+                IncludeResources = false,
+                MaxResourceCount = 1,
+                MaxTotalResourceBytes = 1
+            });
+
+        Assert.Empty(projection.Resources);
+    }
+
     private static EmailDocument CreateInlineResourceDocument(params byte[][] resources) {
         var document = new EmailDocument { Body = { Html = "<p>inline resources</p>" } };
         for (int index = 0; index < resources.Length; index++) {
@@ -177,5 +263,122 @@ public sealed class EmailBodyProjectionTests {
             });
         }
         return document;
+    }
+
+    private sealed class TrackingContentSource : IEmailContentSource {
+        private readonly byte[] _content;
+
+        internal TrackingContentSource(byte[] content) {
+            _content = (byte[])content.Clone();
+        }
+
+        public long? Length => null;
+        internal int OpenCount { get; private set; }
+        internal int ReadCount { get; private set; }
+        internal int DisposeCount { get; private set; }
+
+        public Stream OpenRead() {
+            OpenCount++;
+            return new TrackingReadStream(
+                _content,
+                () => ReadCount++,
+                () => DisposeCount++);
+        }
+
+        public Task<Stream> OpenReadAsync(CancellationToken cancellationToken = default) {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(OpenRead());
+        }
+    }
+
+    private sealed class TrackingReadStream : Stream {
+        private readonly MemoryStream _inner;
+        private readonly Action _onRead;
+        private readonly Action _onDispose;
+        private bool _disposed;
+
+        internal TrackingReadStream(byte[] content, Action onRead, Action onDispose) {
+            _inner = new MemoryStream(content, writable: false);
+            _onRead = onRead;
+            _onDispose = onDispose;
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => _inner.Length;
+        public override long Position {
+            get => _inner.Position;
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) {
+            _onRead();
+            return _inner.Read(buffer, offset, count);
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count,
+            CancellationToken cancellationToken) {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(Read(buffer, offset, count));
+        }
+
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        protected override void Dispose(bool disposing) {
+            if (disposing && !_disposed) {
+                _disposed = true;
+                _inner.Dispose();
+                _onDispose();
+            }
+            base.Dispose(disposing);
+        }
+    }
+
+    private sealed class BlockingContentSource : IEmailContentSource {
+        private readonly TaskCompletionSource<bool> _readStarted =
+            new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public long? Length => null;
+        internal Task ReadStarted => _readStarted.Task;
+        public Stream OpenRead() => new BlockingReadStream(_readStarted);
+        public Task<Stream> OpenReadAsync(CancellationToken cancellationToken = default) {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(OpenRead());
+        }
+    }
+
+    private sealed class BlockingReadStream : Stream {
+        private readonly TaskCompletionSource<bool> _readStarted;
+
+        internal BlockingReadStream(TaskCompletionSource<bool> readStarted) {
+            _readStarted = readStarted;
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) =>
+            throw new NotSupportedException();
+
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count,
+            CancellationToken cancellationToken) {
+            _readStarted.TrySetResult(true);
+            await Task.Delay(Timeout.Infinite, cancellationToken);
+            return 0;
+        }
+
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
     }
 }

--- a/OfficeIMO.Email.Tests/Projection/EmailBodyProjectionTests.cs
+++ b/OfficeIMO.Email.Tests/Projection/EmailBodyProjectionTests.cs
@@ -234,6 +234,37 @@ public sealed class EmailBodyProjectionTests {
     }
 
     [Fact]
+    public async Task Concurrent_reads_wait_for_reservations_before_deciding_aggregate_exhaustion() {
+        var firstContent = new ControlledContentSource(new byte[] { 1 });
+        var secondContent = new TrackingContentSource(new byte[] { 2 });
+        EmailDocument document = CreateInlineResourceDocument(new byte[] { 0 }, new byte[] { 0 });
+        document.Attachments[0].Content = null;
+        document.Attachments[0].ContentSource = firstContent;
+        document.Attachments[0].Length = 0;
+        document.Attachments[1].Content = null;
+        document.Attachments[1].ContentSource = secondContent;
+        document.Attachments[1].Length = 0;
+        EmailBodyProjectionResult projection = EmailBodyProjection.Create(document,
+            new EmailBodyProjectionOptions { MaxTotalResourceBytes = 2 });
+        using Stream first = await projection.Resources[0].OpenReadStreamAsync();
+        using Stream second = await projection.Resources[1].OpenReadStreamAsync();
+        var firstBuffer = new byte[2];
+        var secondBuffer = new byte[1];
+
+        Task<int> firstRead = first.ReadAsync(firstBuffer, 0, firstBuffer.Length);
+        await firstContent.ReadStarted;
+        Task<int> secondRead = second.ReadAsync(secondBuffer, 0, secondBuffer.Length);
+        Assert.False(secondRead.IsCompleted);
+
+        firstContent.ReleaseRead();
+
+        Assert.Equal(1, await firstRead);
+        Assert.Equal(1, await secondRead);
+        Assert.Equal(1, firstBuffer[0]);
+        Assert.Equal(2, secondBuffer[0]);
+    }
+
+    [Fact]
     public void Resource_indexing_can_be_disabled_for_body_only_consumers() {
         EmailDocument document = CreateInlineResourceDocument(
             new byte[] { 1, 2 },
@@ -350,6 +381,30 @@ public sealed class EmailBodyProjectionTests {
         }
     }
 
+    private sealed class ControlledContentSource : IEmailContentSource {
+        private readonly byte[] _content;
+        private readonly TaskCompletionSource<bool> _readStarted =
+            new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<bool> _releaseRead =
+            new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        internal ControlledContentSource(byte[] content) {
+            _content = (byte[])content.Clone();
+        }
+
+        public long? Length => null;
+        internal Task ReadStarted => _readStarted.Task;
+        internal void ReleaseRead() => _releaseRead.TrySetResult(true);
+        public Stream OpenRead() => new ControlledReadStream(
+            _content,
+            _readStarted,
+            _releaseRead.Task);
+        public Task<Stream> OpenReadAsync(CancellationToken cancellationToken = default) {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(OpenRead());
+        }
+    }
+
     private sealed class BlockingReadStream : Stream {
         private readonly TaskCompletionSource<bool> _readStarted;
 
@@ -380,5 +435,62 @@ public sealed class EmailBodyProjectionTests {
         public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
         public override void SetLength(long value) => throw new NotSupportedException();
         public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    private sealed class ControlledReadStream : Stream {
+        private readonly MemoryStream _inner;
+        private readonly TaskCompletionSource<bool> _readStarted;
+        private readonly Task _releaseRead;
+
+        internal ControlledReadStream(
+            byte[] content,
+            TaskCompletionSource<bool> readStarted,
+            Task releaseRead) {
+            _inner = new MemoryStream(content, writable: false);
+            _readStarted = readStarted;
+            _releaseRead = releaseRead;
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => _inner.Length;
+        public override long Position {
+            get => _inner.Position;
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) =>
+            throw new NotSupportedException();
+
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count,
+            CancellationToken cancellationToken) {
+            _readStarted.TrySetResult(true);
+            await WaitWithCancellationAsync(_releaseRead, cancellationToken);
+            return _inner.Read(buffer, offset, count);
+        }
+
+        private static async Task WaitWithCancellationAsync(
+            Task operation,
+            CancellationToken cancellationToken) {
+            if (!cancellationToken.CanBeCanceled) {
+                await operation;
+                return;
+            }
+            var canceled = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            using (cancellationToken.Register(() => canceled.TrySetCanceled())) {
+                await await Task.WhenAny(operation, canceled.Task);
+            }
+        }
+
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        protected override void Dispose(bool disposing) {
+            if (disposing) _inner.Dispose();
+            base.Dispose(disposing);
+        }
     }
 }

--- a/OfficeIMO.Email.Tests/Projection/EmailBodyProjectionTests.cs
+++ b/OfficeIMO.Email.Tests/Projection/EmailBodyProjectionTests.cs
@@ -418,24 +418,27 @@ public sealed class EmailBodyProjectionTests {
     }
 
     [Fact]
-    public async Task Per_read_cancellation_does_not_poison_the_resource_stream() {
+    public async Task Cancellation_while_waiting_for_the_resource_gate_does_not_poison_the_resource() {
         var content = new ControlledContentSource(new byte[] { 7 });
         EmailDocument document = CreateInlineResourceDocument(new byte[] { 0 });
         document.Attachments[0].Content = null;
         document.Attachments[0].ContentSource = content;
         document.Attachments[0].Length = 0;
         EmailBodyResource resource = EmailBodyProjection.Create(document).Resources[0];
-        using Stream source = await resource.OpenReadStreamAsync();
+        using Stream first = await resource.OpenReadStreamAsync();
+        using Stream waiting = await resource.OpenReadStreamAsync();
         using var cancellation = new CancellationTokenSource();
 
-        Task<int> canceledRead = source.ReadAsync(new byte[1], 0, 1, cancellation.Token);
+        Task<int> firstRead = first.ReadAsync(new byte[1], 0, 1, CancellationToken.None);
         await content.ReadStarted;
+        Task<int> canceledRead = waiting.ReadAsync(new byte[1], 0, 1, cancellation.Token);
         cancellation.Cancel();
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => canceledRead);
 
         content.ReleaseRead();
+        Assert.Equal(1, await firstRead);
         var buffer = new byte[1];
-        Assert.Equal(1, await source.ReadAsync(buffer, 0, 1, CancellationToken.None));
+        Assert.Equal(1, await waiting.ReadAsync(buffer, 0, 1, CancellationToken.None));
         Assert.Equal(7, buffer[0]);
     }
 

--- a/OfficeIMO.Email.Tests/Projection/EmailBodyProjectionTests.cs
+++ b/OfficeIMO.Email.Tests/Projection/EmailBodyProjectionTests.cs
@@ -45,6 +45,32 @@ public sealed class EmailBodyProjectionTests {
         Assert.Contains("<body>", rendered, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public void ImageDocument_PreservesDoctypeForDocuments() {
+        EmailHtmlImageDocument document = EmailHtmlImageDocument.Parse(
+            "<!DOCTYPE html><html><head><title>Mail</title></head><body><img src='one.png'></body></html>");
+
+        document.SetImageSource(0, "cid:one.png");
+        string rendered = document.ToHtml();
+
+        Assert.StartsWith("<!DOCTYPE html>", rendered, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("src=\"cid:one.png\"", rendered, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ImageDocument_PreservesHeadAndDocumentLevelFragmentNodes() {
+        EmailHtmlImageDocument document = EmailHtmlImageDocument.Parse(
+            "<!--before--><style>.mail{color:red}</style><img class='mail' src='one.png'>");
+
+        document.SetImageSource(0, "cid:one.png");
+        string rendered = document.ToHtml();
+
+        Assert.DoesNotContain("<html", rendered, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("<!--before-->", rendered, StringComparison.Ordinal);
+        Assert.Contains("<style>.mail{color:red}</style>", rendered, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("src=\"cid:one.png\"", rendered, StringComparison.Ordinal);
+    }
+
     [Theory]
     [InlineData("<!-- <html><body>comment</body></html> --><img src='one.png'>")]
     [InlineData("<bodyguard><img src='one.png'></bodyguard>")]
@@ -56,7 +82,7 @@ public sealed class EmailBodyProjectionTests {
         document.SetImageSource(0, "cid:one.png");
         string rendered = document.ToHtml();
 
-        Assert.DoesNotContain("<html", rendered, StringComparison.OrdinalIgnoreCase);
+        Assert.False(rendered.TrimStart().StartsWith("<html", StringComparison.OrdinalIgnoreCase));
         Assert.Contains("src=\"cid:one.png\"", rendered, StringComparison.Ordinal);
     }
 
@@ -92,6 +118,108 @@ public sealed class EmailBodyProjectionTests {
         Assert.Same(cid, result.ResolveResource("images/logo.png"));
         Assert.Equal(new byte[] { 1, 2, 3 }, cid.ReadAllBytes());
         Assert.Equal(new byte[] { 1, 2, 3 }, cid.ReadAllBytes());
+    }
+
+    [Fact]
+    public void Offline_projection_rewrites_relative_content_location_before_blocking_network_urls() {
+        var document = new EmailDocument();
+        document.Body.HtmlContentLocation = "https://mail.example/messages/1/";
+        document.Body.Html = "<img src='images/logo.png'>" +
+            "<img src='https://assets.example/banner.png'>" +
+            "<img src='https://tracking.example/pixel'>";
+        document.Attachments.Add(new EmailAttachment {
+            FileName = "logo.png",
+            ContentType = "image/png",
+            ContentId = "logo@example.test",
+            ContentLocation = "images/logo.png",
+            IsInline = true,
+            Content = new byte[] { 1, 2, 3 },
+            Length = 3
+        });
+        document.Attachments.Add(new EmailAttachment {
+            FileName = "banner.png",
+            ContentType = "image/png",
+            ContentId = "banner@example.test",
+            ContentLocation = "https://assets.example/banner.png",
+            IsInline = true,
+            Content = new byte[] { 4, 5 },
+            Length = 2
+        });
+
+        EmailBodyProjectionResult result = EmailBodyProjection.Create(document);
+
+        Assert.Contains("src=\"cid:logo@example.test\"", result.Html, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("src=\"cid:banner@example.test\"", result.Html, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("tracking.example", result.Html, StringComparison.OrdinalIgnoreCase);
+        Assert.NotNull(result.ResolveResource("cid:logo@example.test"));
+        Assert.NotNull(result.ResolveResource("cid:banner@example.test"));
+        Assert.NotNull(result.ResolveResource("https://mail.example/messages/1/images/logo.png",
+            new Uri("https://mail.example/messages/1/images/logo.png")));
+    }
+
+    [Fact]
+    public void Offline_projection_assigns_a_safe_alias_to_content_location_only_resources() {
+        var document = new EmailDocument();
+        document.Body.HtmlContentLocation = "https://mail.example/messages/1/";
+        document.Body.Html = "<img src='images/logo.png'>";
+        document.Attachments.Add(new EmailAttachment {
+            FileName = "logo.png",
+            ContentType = "image/png",
+            ContentLocation = "images/logo.png",
+            IsInline = true,
+            Content = new byte[] { 1 },
+            Length = 1
+        });
+
+        EmailBodyProjectionResult result = EmailBodyProjection.Create(document);
+        string alias = Assert.Single(result.Document.CreateDocumentForConversion()
+            .QuerySelectorAll("img[src]")).GetAttribute("src")!;
+
+        Assert.StartsWith("cid:officeimo-resource-", alias, StringComparison.OrdinalIgnoreCase);
+        Assert.Same(result.Resources[0], result.ResolveResource(alias));
+    }
+
+    [Fact]
+    public void Offline_projection_rewrites_filename_only_resources_with_a_base_uri() {
+        var document = new EmailDocument();
+        document.Body.HtmlContentLocation = "https://mail.example/messages/1/";
+        document.Body.Html = "<img src='logo.png'>";
+        document.Attachments.Add(new EmailAttachment {
+            FileName = "logo.png",
+            ContentType = "image/png",
+            IsInline = true,
+            Content = new byte[] { 1 },
+            Length = 1
+        });
+
+        EmailBodyProjectionResult result = EmailBodyProjection.Create(document);
+        string alias = Assert.Single(result.Document.CreateDocumentForConversion()
+            .QuerySelectorAll("img[src]")).GetAttribute("src")!;
+
+        Assert.StartsWith("cid:officeimo-resource-", alias, StringComparison.OrdinalIgnoreCase);
+        Assert.Same(result.Resources[0], result.ResolveResource(alias));
+    }
+
+    [Fact]
+    public void Consumer_resolver_policy_allows_only_web_and_embedded_resource_schemes() {
+        var document = new EmailDocument();
+        document.Body.Html = "<img id='web' src='https://cdn.example/image.png'>" +
+            "<img id='mail' src='mailto:user@example.test'><img id='phone' src='tel:+123'>" +
+            "<img id='file' src='file:///tmp/image.png'><img id='cid' src='cid:logo'>" +
+            "<img id='data' src='data:image/png;base64,AQ=='>";
+
+        EmailBodyProjectionResult result = EmailBodyProjection.Create(document,
+            new EmailBodyProjectionOptions {
+                RemoteResourcePolicy = EmailRemoteResourcePolicy.AllowByConsumerResolver
+            });
+        AngleSharp.Html.Dom.IHtmlDocument html = result.Document.CreateDocumentForConversion();
+
+        Assert.Equal("https://cdn.example/image.png", html.QuerySelector("#web")!.GetAttribute("src"));
+        Assert.False(html.QuerySelector("#mail")!.HasAttribute("src"));
+        Assert.False(html.QuerySelector("#phone")!.HasAttribute("src"));
+        Assert.False(html.QuerySelector("#file")!.HasAttribute("src"));
+        Assert.Equal("cid:logo", html.QuerySelector("#cid")!.GetAttribute("src"));
+        Assert.Equal("data:image/png;base64,AQ==", html.QuerySelector("#data")!.GetAttribute("src"));
     }
 
     [Fact]

--- a/OfficeIMO.Email.Tests/Projection/EmailBodyProjectionTests.cs
+++ b/OfficeIMO.Email.Tests/Projection/EmailBodyProjectionTests.cs
@@ -84,4 +84,98 @@ public sealed class EmailBodyProjectionTests {
 
         Assert.Equal("EmailBodyProjectionOptions.MaxResourceBytes", exception.LimitName);
     }
+
+    [Fact]
+    public void Rejects_resource_count_before_opening_attachment_content() {
+        EmailDocument document = CreateInlineResourceDocument(
+            new byte[] { 1 },
+            new byte[] { 2 });
+
+        EmailLimitExceededException exception = Assert.Throws<EmailLimitExceededException>(() =>
+            EmailBodyProjection.Create(document,
+                new EmailBodyProjectionOptions { MaxResourceCount = 1 }));
+
+        Assert.Equal("EmailBodyProjectionOptions.MaxResourceCount", exception.LimitName);
+        Assert.Equal(2, exception.ActualValue);
+    }
+
+    [Fact]
+    public void Rejects_declared_aggregate_resource_size() {
+        EmailDocument document = CreateInlineResourceDocument(
+            new byte[] { 1, 2, 3 },
+            new byte[] { 4, 5, 6 });
+
+        EmailLimitExceededException exception = Assert.Throws<EmailLimitExceededException>(() =>
+            EmailBodyProjection.Create(document,
+                new EmailBodyProjectionOptions { MaxTotalResourceBytes = 5 }));
+
+        Assert.Equal("EmailBodyProjectionOptions.MaxTotalResourceBytes", exception.LimitName);
+        Assert.Equal(6, exception.ActualValue);
+    }
+
+    [Fact]
+    public void Open_stream_enforces_actual_size_when_declared_length_is_unknown() {
+        EmailDocument document = CreateInlineResourceDocument(new byte[] { 1, 2, 3, 4 });
+        document.Attachments[0].Length = 0;
+        EmailBodyResource resource = EmailBodyProjection.Create(document,
+            new EmailBodyProjectionOptions { MaxResourceBytes = 3 }).Resources[0];
+
+        using Stream source = resource.OpenReadStream();
+        using var output = new MemoryStream();
+        EmailLimitExceededException exception = Assert.Throws<EmailLimitExceededException>(() =>
+            source.CopyTo(output));
+
+        Assert.Equal("EmailBodyProjectionOptions.MaxResourceBytes", exception.LimitName);
+        Assert.Equal(4, exception.ActualValue);
+    }
+
+    [Fact]
+    public async Task Async_copies_share_one_projection_wide_resource_budget() {
+        EmailDocument document = CreateInlineResourceDocument(
+            new byte[] { 1, 2, 3 },
+            new byte[] { 4, 5, 6 });
+        document.Attachments[0].Length = 0;
+        document.Attachments[1].Length = 0;
+        EmailBodyProjectionResult projection = EmailBodyProjection.Create(document,
+            new EmailBodyProjectionOptions { MaxTotalResourceBytes = 5 });
+
+        using (var first = new MemoryStream()) {
+            await projection.Resources[0].CopyToAsync(first);
+            Assert.Equal(new byte[] { 1, 2, 3 }, first.ToArray());
+        }
+        using var second = new MemoryStream();
+        EmailLimitExceededException exception = await Assert.ThrowsAsync<EmailLimitExceededException>(() =>
+            projection.Resources[1].CopyToAsync(second));
+
+        Assert.Equal("EmailBodyProjectionOptions.MaxTotalResourceBytes", exception.LimitName);
+        Assert.Equal(6, exception.ActualValue);
+    }
+
+    [Fact]
+    public async Task Open_stream_honors_operation_and_read_cancellation() {
+        EmailDocument document = CreateInlineResourceDocument(new byte[] { 1, 2, 3 });
+        EmailBodyResource resource = EmailBodyProjection.Create(document).Resources[0];
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        Assert.Throws<OperationCanceledException>(() => resource.OpenReadStream(cancellation.Token));
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            resource.OpenReadStreamAsync(cancellation.Token));
+    }
+
+    private static EmailDocument CreateInlineResourceDocument(params byte[][] resources) {
+        var document = new EmailDocument { Body = { Html = "<p>inline resources</p>" } };
+        for (int index = 0; index < resources.Length; index++) {
+            byte[] content = resources[index];
+            document.Attachments.Add(new EmailAttachment {
+                FileName = $"resource-{index}.bin",
+                ContentId = $"resource-{index}",
+                ContentType = "application/octet-stream",
+                IsInline = true,
+                Content = content,
+                Length = content.LongLength
+            });
+        }
+        return document;
+    }
 }

--- a/OfficeIMO.Email.Tests/Projection/EmailBodyProjectionTests.cs
+++ b/OfficeIMO.Email.Tests/Projection/EmailBodyProjectionTests.cs
@@ -5,6 +5,47 @@ namespace OfficeIMO.Email.Tests;
 
 public sealed class EmailBodyProjectionTests {
     [Fact]
+    public void ImageDocument_DiscoversAndRewritesOnlyActualSrcAttributes() {
+        const string html = "<p data-src='not-an-image'>before</p><img data-src='lazy.png' SRC='one.png'><p>one.png</p>";
+
+        EmailHtmlImageDocument document = EmailHtmlImageDocument.Parse(html);
+
+        EmailHtmlImageReference image = Assert.Single(document.Images);
+        Assert.Equal("one.png", image.Source);
+        document.SetImageSource(image.Index, "cid:one.png");
+        string rendered = document.ToHtml();
+        Assert.Contains("data-src=\"lazy.png\"", rendered, StringComparison.Ordinal);
+        Assert.Contains("src=\"cid:one.png\"", rendered, StringComparison.Ordinal);
+        Assert.Contains(">one.png</p>", rendered, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ImageDocument_RewritesDuplicateSourcesIndependently() {
+        EmailHtmlImageDocument document = EmailHtmlImageDocument.Parse(
+            "<img src='same.png'><img src='same.png'>");
+
+        Assert.Equal(2, document.Images.Count);
+        document.SetImageSource(0, "cid:first.png");
+        document.SetImageSource(1, "cid:second.png");
+
+        string rendered = document.ToHtml();
+        Assert.Contains("src=\"cid:first.png\"", rendered, StringComparison.Ordinal);
+        Assert.Contains("src=\"cid:second.png\"", rendered, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ImageDocument_PreservesDocumentEnvelopeWhenPresent() {
+        EmailHtmlImageDocument document = EmailHtmlImageDocument.Parse(
+            "<html><head><title>Mail</title></head><body><img src='one.png'></body></html>");
+
+        string rendered = document.ToHtml();
+
+        Assert.StartsWith("<html", rendered, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("<head>", rendered, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("<body>", rendered, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void Sanitizes_html_blocks_remote_resources_and_resolves_embedded_content_once() {
         var document = new EmailDocument();
         document.Body.Html = "<html><body onload='alert(1)'><script>alert(2)</script>" +

--- a/OfficeIMO.Email.Tests/Projection/EmailBodyProjectionTests.cs
+++ b/OfficeIMO.Email.Tests/Projection/EmailBodyProjectionTests.cs
@@ -290,6 +290,28 @@ public sealed class EmailBodyProjectionTests {
     }
 
     [Fact]
+    public async Task Per_read_cancellation_does_not_poison_the_resource_stream() {
+        var content = new ControlledContentSource(new byte[] { 7 });
+        EmailDocument document = CreateInlineResourceDocument(new byte[] { 0 });
+        document.Attachments[0].Content = null;
+        document.Attachments[0].ContentSource = content;
+        document.Attachments[0].Length = 0;
+        EmailBodyResource resource = EmailBodyProjection.Create(document).Resources[0];
+        using Stream source = await resource.OpenReadStreamAsync();
+        using var cancellation = new CancellationTokenSource();
+
+        Task<int> canceledRead = source.ReadAsync(new byte[1], 0, 1, cancellation.Token);
+        await content.ReadStarted;
+        cancellation.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => canceledRead);
+
+        content.ReleaseRead();
+        var buffer = new byte[1];
+        Assert.Equal(1, await source.ReadAsync(buffer, 0, 1, CancellationToken.None));
+        Assert.Equal(7, buffer[0]);
+    }
+
+    [Fact]
     public async Task Concurrent_reads_wait_for_reservations_before_deciding_aggregate_exhaustion() {
         var firstContent = new ControlledContentSource(new byte[] { 1 });
         var secondContent = new TrackingContentSource(new byte[] { 2 });

--- a/OfficeIMO.Email.Tests/Projection/EmailBodyProjectionTests.cs
+++ b/OfficeIMO.Email.Tests/Projection/EmailBodyProjectionTests.cs
@@ -45,6 +45,21 @@ public sealed class EmailBodyProjectionTests {
         Assert.Contains("<body>", rendered, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Theory]
+    [InlineData("<!-- <html><body>comment</body></html> --><img src='one.png'>")]
+    [InlineData("<bodyguard><img src='one.png'></bodyguard>")]
+    [InlineData("prefix &lt;html without a tag <img src='one.png'>")]
+    [InlineData("<template><body>template text</body></template><img src='one.png'>")]
+    public void ImageDocument_DoesNotTreatEnvelopeLikeTextAsDocument(string html) {
+        EmailHtmlImageDocument document = EmailHtmlImageDocument.Parse(html);
+
+        document.SetImageSource(0, "cid:one.png");
+        string rendered = document.ToHtml();
+
+        Assert.DoesNotContain("<html", rendered, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("src=\"cid:one.png\"", rendered, StringComparison.Ordinal);
+    }
+
     [Fact]
     public void Sanitizes_html_blocks_remote_resources_and_resolves_embedded_content_once() {
         var document = new EmailDocument();

--- a/OfficeIMO.Email.Tests/Projection/EmailBodyResourceConcurrencyTests.cs
+++ b/OfficeIMO.Email.Tests/Projection/EmailBodyResourceConcurrencyTests.cs
@@ -83,6 +83,50 @@ public sealed class EmailBodyResourceConcurrencyTests {
     }
 
     [Fact]
+    public async Task Cancellation_from_an_advancing_source_poisons_the_shared_resource() {
+        using var cancellation = new CancellationTokenSource();
+        var content = new AdvancingCancellationContentSource(7, cancellation);
+        EmailBodyProjectionResult projection = CreateProjection(
+            maxResourceBytes: 2,
+            maxTotalResourceBytes: 2,
+            content);
+        EmailBodyResource resource = projection.Resources[0];
+        using Stream source = await resource.OpenReadStreamAsync();
+        var buffer = new byte[1];
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            source.ReadAsync(buffer, 0, 1, cancellation.Token));
+
+        Assert.Equal(7, buffer[0]);
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            source.ReadAsync(new byte[1], 0, 1, CancellationToken.None));
+        Assert.Throws<InvalidOperationException>(() => resource.OpenReadStream());
+        Assert.Equal(1, content.OpenCount);
+    }
+
+    [Fact]
+    public async Task Aggregate_probe_source_limit_failure_poisons_the_shared_resource() {
+        var content = new AdvancingLimitFailureContentSource(8);
+        EmailBodyProjectionResult projection = CreateProjection(
+            maxResourceBytes: 2,
+            maxTotalResourceBytes: 1,
+            new ImmediateContentSource(1),
+            content);
+        Assert.Equal(new byte[] { 1 }, projection.Resources[0].ReadAllBytes());
+        EmailBodyResource resource = projection.Resources[1];
+        using Stream source = await resource.OpenReadStreamAsync();
+        var buffer = new byte[1];
+
+        EmailLimitExceededException exception = await Assert.ThrowsAsync<EmailLimitExceededException>(() =>
+            source.ReadAsync(buffer, 0, 1, CancellationToken.None));
+
+        Assert.Equal("source-limit", exception.LimitName);
+        Assert.True(content.Advanced);
+        Assert.Throws<InvalidOperationException>(() => resource.OpenReadStream());
+        Assert.Equal(1, content.OpenCount);
+    }
+
+    [Fact]
     public async Task Concurrent_stream_does_not_read_after_same_resource_is_poisoned() {
         var content = new PoisoningContentSource();
         EmailBodyProjectionResult projection = CreateProjection(
@@ -191,6 +235,51 @@ public sealed class EmailBodyResourceConcurrencyTests {
         }
     }
 
+    private sealed class AdvancingCancellationContentSource : IEmailContentSource {
+        private readonly byte _value;
+        private readonly CancellationTokenSource _cancellation;
+
+        internal AdvancingCancellationContentSource(byte value, CancellationTokenSource cancellation) {
+            _value = value;
+            _cancellation = cancellation;
+        }
+
+        public long? Length => null;
+        internal int OpenCount { get; private set; }
+
+        public Stream OpenRead() {
+            OpenCount++;
+            return new AdvancingCancellationReadStream(_value, _cancellation);
+        }
+
+        public Task<Stream> OpenReadAsync(CancellationToken cancellationToken = default) {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(OpenRead());
+        }
+    }
+
+    private sealed class AdvancingLimitFailureContentSource : IEmailContentSource {
+        private readonly byte _value;
+
+        internal AdvancingLimitFailureContentSource(byte value) {
+            _value = value;
+        }
+
+        public long? Length => null;
+        internal int OpenCount { get; private set; }
+        internal bool Advanced { get; private set; }
+
+        public Stream OpenRead() {
+            OpenCount++;
+            return new AdvancingLimitFailureReadStream(_value, () => Advanced = true);
+        }
+
+        public Task<Stream> OpenReadAsync(CancellationToken cancellationToken = default) {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(OpenRead());
+        }
+    }
+
     private sealed class GateReadStream : Stream {
         private readonly byte _value;
         private readonly TaskCompletionSource<bool> _readStarted;
@@ -281,6 +370,66 @@ public sealed class EmailBodyResourceConcurrencyTests {
             _onRead();
             buffer[offset] = 9;
             return 1;
+        }
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count,
+            CancellationToken cancellationToken) {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(Read(buffer, offset, count));
+        }
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    private sealed class AdvancingCancellationReadStream : Stream {
+        private readonly byte _value;
+        private readonly CancellationTokenSource _cancellation;
+        private bool _read;
+
+        internal AdvancingCancellationReadStream(byte value, CancellationTokenSource cancellation) {
+            _value = value;
+            _cancellation = cancellation;
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => 1;
+        public override long Position { get => _read ? 1 : 0; set => throw new NotSupportedException(); }
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count,
+            CancellationToken cancellationToken) {
+            if (_read) return Task.FromResult(0);
+            buffer[offset] = _value;
+            _read = true;
+            _cancellation.Cancel();
+            throw new OperationCanceledException(cancellationToken);
+        }
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    private sealed class AdvancingLimitFailureReadStream : Stream {
+        private readonly byte _value;
+        private readonly Action _onAdvance;
+
+        internal AdvancingLimitFailureReadStream(byte value, Action onAdvance) {
+            _value = value;
+            _onAdvance = onAdvance;
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => 1;
+        public override long Position { get => 1; set => throw new NotSupportedException(); }
+        public override int Read(byte[] buffer, int offset, int count) {
+            buffer[offset] = _value;
+            _onAdvance();
+            throw new EmailLimitExceededException("source-limit", 2, 1);
         }
         public override Task<int> ReadAsync(byte[] buffer, int offset, int count,
             CancellationToken cancellationToken) {

--- a/OfficeIMO.Email.Tests/Projection/EmailBodyResourceConcurrencyTests.cs
+++ b/OfficeIMO.Email.Tests/Projection/EmailBodyResourceConcurrencyTests.cs
@@ -1,0 +1,306 @@
+using OfficeIMO.Email;
+using Xunit;
+
+namespace OfficeIMO.Email.Tests;
+
+public sealed class EmailBodyResourceConcurrencyTests {
+    [Fact]
+    public async Task Independent_resources_read_concurrently_through_the_sync_surface() {
+        var blockedContent = new GateContentSource(1);
+        var immediateContent = new ImmediateContentSource(2);
+        EmailBodyProjectionResult projection = CreateProjection(
+            maxResourceBytes: 2,
+            maxTotalResourceBytes: 2,
+            blockedContent,
+            immediateContent);
+        using Stream blocked = projection.Resources[0].OpenReadStream();
+        using Stream immediate = projection.Resources[1].OpenReadStream();
+        var blockedBuffer = new byte[1];
+        var immediateBuffer = new byte[1];
+
+        Task<int> blockedRead = Task.Run(() => blocked.Read(blockedBuffer, 0, 1));
+        await blockedContent.ReadStarted;
+        Task<int> immediateRead = Task.Run(() => immediate.Read(immediateBuffer, 0, 1));
+
+        Assert.Same(immediateRead, await Task.WhenAny(immediateRead, Task.Delay(TimeSpan.FromSeconds(5))));
+        Assert.Equal(1, await immediateRead);
+        Assert.Equal(2, immediateBuffer[0]);
+
+        blockedContent.ReleaseRead();
+        Assert.Equal(1, await blockedRead);
+        Assert.Equal(1, blockedBuffer[0]);
+    }
+
+    [Fact]
+    public async Task Independent_resources_read_concurrently_while_aggregate_capacity_remains() {
+        var blockedContent = new GateContentSource(1);
+        var immediateContent = new ImmediateContentSource(2);
+        EmailBodyProjectionResult projection = CreateProjection(
+            maxResourceBytes: 2,
+            maxTotalResourceBytes: 2,
+            blockedContent,
+            immediateContent);
+        using Stream blocked = await projection.Resources[0].OpenReadStreamAsync();
+        using Stream immediate = await projection.Resources[1].OpenReadStreamAsync();
+
+        Task<int> blockedRead = blocked.ReadAsync(new byte[1], 0, 1);
+        await blockedContent.ReadStarted;
+        var immediateBuffer = new byte[1];
+        Task<int> immediateRead = immediate.ReadAsync(immediateBuffer, 0, 1);
+
+        Assert.Same(immediateRead, await Task.WhenAny(immediateRead, Task.Delay(TimeSpan.FromSeconds(5))));
+        Assert.Equal(1, await immediateRead);
+        Assert.Equal(2, immediateBuffer[0]);
+
+        blockedContent.ReleaseRead();
+        Assert.Equal(1, await blockedRead);
+    }
+
+    [Fact]
+    public async Task Cancellation_while_waiting_for_an_aggregate_reservation_does_not_poison_the_stream() {
+        var blockedContent = new GateContentSource(1);
+        var immediateContent = new ImmediateContentSource(2);
+        EmailBodyProjectionResult projection = CreateProjection(
+            maxResourceBytes: 2,
+            maxTotalResourceBytes: 2,
+            blockedContent,
+            immediateContent);
+        using Stream blocked = await projection.Resources[0].OpenReadStreamAsync();
+        using Stream waiting = await projection.Resources[1].OpenReadStreamAsync();
+
+        Task<int> blockedRead = blocked.ReadAsync(new byte[2], 0, 2);
+        await blockedContent.ReadStarted;
+        using (var cancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(100))) {
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                waiting.ReadAsync(new byte[1], 0, 1, cancellation.Token));
+        }
+
+        blockedContent.ReleaseRead();
+        Assert.Equal(1, await blockedRead);
+        var buffer = new byte[1];
+        Assert.Equal(1, await waiting.ReadAsync(buffer, 0, 1));
+        Assert.Equal(2, buffer[0]);
+    }
+
+    [Fact]
+    public async Task Concurrent_stream_does_not_read_after_same_resource_is_poisoned() {
+        var content = new PoisoningContentSource();
+        EmailBodyProjectionResult projection = CreateProjection(
+            maxResourceBytes: 3,
+            maxTotalResourceBytes: 16,
+            content);
+        EmailBodyResource resource = projection.Resources[0];
+        using Stream first = await resource.OpenReadStreamAsync();
+        using Stream second = await resource.OpenReadStreamAsync();
+        Assert.Equal(3, await first.ReadAsync(new byte[3], 0, 3));
+
+        Task<int> poison = first.ReadAsync(new byte[1], 0, 1);
+        await content.ProbeStarted;
+        Task<int> waiting = second.ReadAsync(new byte[1], 0, 1);
+        Assert.False(waiting.IsCompleted);
+
+        content.ReleaseProbe();
+        EmailLimitExceededException firstFailure = await Assert.ThrowsAsync<EmailLimitExceededException>(
+            async () => await poison);
+        EmailLimitExceededException secondFailure = await Assert.ThrowsAsync<EmailLimitExceededException>(
+            async () => await waiting);
+
+        Assert.Equal("EmailBodyProjectionOptions.MaxResourceBytes", firstFailure.LimitName);
+        Assert.Equal("EmailBodyProjectionOptions.MaxResourceBytes", secondFailure.LimitName);
+        Assert.Equal(0, content.SecondStreamReadCount);
+    }
+
+    private static EmailBodyProjectionResult CreateProjection(
+        long maxResourceBytes,
+        long maxTotalResourceBytes,
+        params IEmailContentSource[] sources) {
+        var document = new EmailDocument { Body = { Html = "<p>resources</p>" } };
+        for (int index = 0; index < sources.Length; index++) {
+            document.Attachments.Add(new EmailAttachment {
+                ContentId = "resource-" + index,
+                IsInline = true,
+                ContentSource = sources[index],
+                Length = 0
+            });
+        }
+        return EmailBodyProjection.Create(document,
+            new EmailBodyProjectionOptions {
+                MaxResourceBytes = maxResourceBytes,
+                MaxTotalResourceBytes = maxTotalResourceBytes
+            });
+    }
+
+    private sealed class GateContentSource : IEmailContentSource {
+        private readonly byte _value;
+        private readonly TaskCompletionSource<bool> _readStarted =
+            new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<bool> _releaseRead =
+            new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        internal GateContentSource(byte value) {
+            _value = value;
+        }
+
+        public long? Length => null;
+        internal Task ReadStarted => _readStarted.Task;
+        internal void ReleaseRead() => _releaseRead.TrySetResult(true);
+        public Stream OpenRead() => new GateReadStream(_value, _readStarted, _releaseRead.Task);
+        public Task<Stream> OpenReadAsync(CancellationToken cancellationToken = default) {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(OpenRead());
+        }
+    }
+
+    private sealed class ImmediateContentSource : IEmailContentSource {
+        private readonly byte _value;
+
+        internal ImmediateContentSource(byte value) {
+            _value = value;
+        }
+
+        public long? Length => null;
+        public Stream OpenRead() => new MemoryStream(new[] { _value }, writable: false);
+        public Task<Stream> OpenReadAsync(CancellationToken cancellationToken = default) {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(OpenRead());
+        }
+    }
+
+    private sealed class PoisoningContentSource : IEmailContentSource {
+        private readonly TaskCompletionSource<bool> _probeStarted =
+            new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<bool> _releaseProbe =
+            new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _openCount;
+
+        public long? Length => null;
+        internal Task ProbeStarted => _probeStarted.Task;
+        internal int SecondStreamReadCount { get; private set; }
+        internal void ReleaseProbe() => _releaseProbe.TrySetResult(true);
+
+        public Stream OpenRead() {
+            int open = Interlocked.Increment(ref _openCount);
+            return open == 1
+                ? new PoisoningReadStream(_probeStarted, _releaseProbe.Task)
+                : new CountingReadStream(() => SecondStreamReadCount++);
+        }
+
+        public Task<Stream> OpenReadAsync(CancellationToken cancellationToken = default) {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(OpenRead());
+        }
+    }
+
+    private sealed class GateReadStream : Stream {
+        private readonly byte _value;
+        private readonly TaskCompletionSource<bool> _readStarted;
+        private readonly Task _releaseRead;
+        private bool _read;
+
+        internal GateReadStream(byte value, TaskCompletionSource<bool> readStarted, Task releaseRead) {
+            _value = value;
+            _readStarted = readStarted;
+            _releaseRead = releaseRead;
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+        public override int Read(byte[] buffer, int offset, int count) {
+            if (_read) return 0;
+            _readStarted.TrySetResult(true);
+            _releaseRead.GetAwaiter().GetResult();
+            buffer[offset] = _value;
+            _read = true;
+            return 1;
+        }
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count,
+            CancellationToken cancellationToken) {
+            if (_read) return 0;
+            _readStarted.TrySetResult(true);
+            await WaitWithCancellationAsync(_releaseRead, cancellationToken);
+            buffer[offset] = _value;
+            _read = true;
+            return 1;
+        }
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    private sealed class PoisoningReadStream : Stream {
+        private readonly MemoryStream _content = new MemoryStream(new byte[] { 1, 2, 3, 4 }, writable: false);
+        private readonly TaskCompletionSource<bool> _probeStarted;
+        private readonly Task _releaseProbe;
+
+        internal PoisoningReadStream(TaskCompletionSource<bool> probeStarted, Task releaseProbe) {
+            _probeStarted = probeStarted;
+            _releaseProbe = releaseProbe;
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => _content.Length;
+        public override long Position { get => _content.Position; set => throw new NotSupportedException(); }
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count,
+            CancellationToken cancellationToken) {
+            if (_content.Position >= 3) {
+                _probeStarted.TrySetResult(true);
+                await WaitWithCancellationAsync(_releaseProbe, cancellationToken);
+            }
+            return _content.Read(buffer, offset, count);
+        }
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        protected override void Dispose(bool disposing) {
+            if (disposing) _content.Dispose();
+            base.Dispose(disposing);
+        }
+    }
+
+    private sealed class CountingReadStream : Stream {
+        private readonly Action _onRead;
+
+        internal CountingReadStream(Action onRead) {
+            _onRead = onRead;
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => 1;
+        public override long Position { get => 0; set => throw new NotSupportedException(); }
+        public override int Read(byte[] buffer, int offset, int count) {
+            _onRead();
+            buffer[offset] = 9;
+            return 1;
+        }
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count,
+            CancellationToken cancellationToken) {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(Read(buffer, offset, count));
+        }
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    private static async Task WaitWithCancellationAsync(Task operation, CancellationToken cancellationToken) {
+        if (!cancellationToken.CanBeCanceled) {
+            await operation;
+            return;
+        }
+        var canceled = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using (cancellationToken.Register(() => canceled.TrySetCanceled())) {
+            await await Task.WhenAny(operation, canceled.Task);
+        }
+    }
+}

--- a/OfficeIMO.Html.Tests/Html.EmailImageExport.cs
+++ b/OfficeIMO.Html.Tests/Html.EmailImageExport.cs
@@ -313,6 +313,57 @@ public sealed class HtmlEmailImageExportTests {
     }
 
     [Fact]
+    public async Task EmptyRetainedHttpsResourceDoesNotFallThroughToTheAsyncFallback() {
+        var email = new EmailDocument { Subject = "Empty retained image" };
+        email.Body.Html = "<img src=\"https://assets.example/empty.png\" alt=\"empty\">";
+        email.Attachments.Add(new EmailAttachment {
+            FileName = "empty.png",
+            ContentType = "image/png",
+            ContentLocation = "https://assets.example/empty.png",
+            IsInline = true,
+            Content = Array.Empty<byte>(),
+            Length = 0
+        });
+        int fallbackCalls = 0;
+        var options = new EmailImageExportOptions {
+            RemoteResourcePolicy = EmailRemoteResourcePolicy.AllowByConsumerResolver,
+            ResourceResolver = (request, cancellationToken) => {
+                cancellationToken.ThrowIfCancellationRequested();
+                fallbackCalls++;
+                return Task.FromResult<HtmlResolvedResource?>(
+                    new HtmlResolvedResource(PixelPng, "image/png"));
+            }
+        };
+
+        await email.ExportImageAsync(OfficeImageExportFormat.Png, options);
+
+        Assert.Equal(0, fallbackCalls);
+    }
+
+    [Fact]
+    public async Task UnknownContentIdDoesNotFallThroughToAnExplicitCidFallback() {
+        var email = new EmailDocument { Subject = "Unknown CID" };
+        email.Body.Html = "<img src=\"cid:missing@example.test\" alt=\"missing\">";
+        int fallbackCalls = 0;
+        HtmlUrlPolicy fallbackPolicy = HtmlUrlPolicy.CreateWebResourceProfile();
+        fallbackPolicy.AllowedUrlSchemes.Add("cid");
+        var options = new EmailImageExportOptions {
+            RemoteResourcePolicy = EmailRemoteResourcePolicy.AllowByConsumerResolver,
+            ResourceUrlPolicy = fallbackPolicy,
+            ResourceResolver = (request, cancellationToken) => {
+                cancellationToken.ThrowIfCancellationRequested();
+                fallbackCalls++;
+                return Task.FromResult<HtmlResolvedResource?>(
+                    new HtmlResolvedResource(PixelPng, "image/png"));
+            }
+        };
+
+        await email.ExportImageAsync(OfficeImageExportFormat.Png, options);
+
+        Assert.Equal(0, fallbackCalls);
+    }
+
+    [Fact]
     public async Task FluentEmailBatchSaveStreamsPagesAndReturnsPayloadFreeMetadata() {
         var email = new EmailDocument { Subject = "Paged message" };
         email.Body.Html =

--- a/OfficeIMO.Html.Tests/Html.EmailImageExport.cs
+++ b/OfficeIMO.Html.Tests/Html.EmailImageExport.cs
@@ -173,6 +173,38 @@ public sealed class HtmlEmailImageExportTests {
     }
 
     [Fact]
+    public void EmailImageExportRejectsTooManyInlineResourcesBeforeRendering() {
+        var email = new EmailDocument { Subject = "Too many inline images" };
+        email.Body.Html = "<img src=\"cid:first@example\"><img src=\"cid:second@example\">";
+        email.Attachments.Add(CreateInlineImage("first@example"));
+        email.Attachments.Add(CreateInlineImage("second@example"));
+
+        EmailLimitExceededException exception = Assert.Throws<EmailLimitExceededException>(() =>
+            email.ExportImage(
+                OfficeImageExportFormat.Png,
+                new EmailImageExportOptions { MaxInlineResourceCount = 1 }));
+
+        Assert.Equal("EmailBodyProjectionOptions.MaxResourceCount", exception.LimitName);
+    }
+
+    [Fact]
+    public async Task EmailImageExportRejectsAggregateInlineBytesBeforeRendering() {
+        var email = new EmailDocument { Subject = "Oversized inline image set" };
+        email.Body.Html = "<img src=\"cid:first@example\"><img src=\"cid:second@example\">";
+        email.Attachments.Add(CreateInlineImage("first@example"));
+        email.Attachments.Add(CreateInlineImage("second@example"));
+
+        EmailLimitExceededException exception = await Assert.ThrowsAsync<EmailLimitExceededException>(() =>
+            email.ExportImageAsync(
+                OfficeImageExportFormat.Png,
+                new EmailImageExportOptions {
+                    MaxTotalInlineResourceBytes = PixelPng.LongLength * 2L - 1L
+                }));
+
+        Assert.Equal("EmailBodyProjectionOptions.MaxTotalResourceBytes", exception.LimitName);
+    }
+
+    [Fact]
     public void EmailSyncBatchCancellationReachesRetainedResourceRead() {
         using var cancellation = new CancellationTokenSource();
         var email = new EmailDocument { Subject = "Cancelable inline image" };
@@ -295,6 +327,15 @@ public sealed class HtmlEmailImageExportTests {
             return Task.FromResult(OpenRead());
         }
     }
+
+    private static EmailAttachment CreateInlineImage(string contentId) => new EmailAttachment {
+        FileName = contentId + ".png",
+        ContentType = "image/png",
+        ContentId = contentId,
+        IsInline = true,
+        Content = PixelPng,
+        Length = PixelPng.Length
+    };
 
     private sealed class CancelOnReadStream : Stream {
         private readonly MemoryStream _inner;

--- a/OfficeIMO.Html.Tests/Html.EmailImageExport.cs
+++ b/OfficeIMO.Html.Tests/Html.EmailImageExport.cs
@@ -205,6 +205,49 @@ public sealed class HtmlEmailImageExportTests {
     }
 
     [Fact]
+    public void DisabledInlineResourcesBypassResourceInventoryLimits() {
+        var email = new EmailDocument { Subject = "Body-only image" };
+        email.Body.Html = "<p>No inline resources are needed.</p>";
+        email.Attachments.Add(CreateInlineImage("first@example"));
+        email.Attachments.Add(CreateInlineImage("second@example"));
+
+        OfficeImageExportResult result = email.ExportImage(
+            OfficeImageExportFormat.Svg,
+            new EmailImageExportOptions {
+                IncludeInlineResources = false,
+                MaxInlineResourceCount = 1,
+                MaxTotalInlineResourceBytes = 1
+            });
+
+        Assert.NotEmpty(result.Bytes);
+    }
+
+    [Fact]
+    public async Task AggregateInlineReadFailureUsesTheOperationWideDiagnostic() {
+        var email = new EmailDocument { Subject = "Aggregate inline limit" };
+        email.Body.Html = "<img src=\"cid:logo@example\" alt=\"Logo\">";
+        EmailAttachment attachment = CreateInlineImage("logo@example");
+        attachment.Length = 0;
+        email.Attachments.Add(attachment);
+
+        OfficeImageExportPolicyException exception = await Assert.ThrowsAsync<OfficeImageExportPolicyException>(() =>
+            email.ExportImageAsync(
+                OfficeImageExportFormat.Png,
+                new EmailImageExportOptions {
+                    MaxTotalInlineResourceBytes = PixelPng.LongLength - 1L
+                }));
+
+        Assert.Contains(
+            exception.Diagnostics,
+            diagnostic => diagnostic.Code ==
+                          HtmlRenderDiagnosticCodes.TotalResourceByteLimitExceeded);
+        Assert.DoesNotContain(
+            exception.Diagnostics,
+            diagnostic => diagnostic.Code ==
+                          HtmlRenderDiagnosticCodes.ResourceByteLimitExceeded);
+    }
+
+    [Fact]
     public void EmailSyncBatchCancellationReachesRetainedResourceRead() {
         using var cancellation = new CancellationTokenSource();
         var email = new EmailDocument { Subject = "Cancelable inline image" };

--- a/OfficeIMO.Html/Engine/HtmlConversionDocument.cs
+++ b/OfficeIMO.Html/Engine/HtmlConversionDocument.cs
@@ -29,6 +29,10 @@ public sealed partial class HtmlConversionDocument {
         Uri? baseUri) {
         SourceHtml = sourceHtml ?? throw new ArgumentNullException(nameof(sourceHtml));
         _sourceDocument = sourceDocument ?? throw new ArgumentNullException(nameof(sourceDocument));
+        HasExplicitDocumentEnvelope = sourceDocument.Doctype != null ||
+            sourceDocument.DocumentElement?.SourceReference?.Position.Index >= 0 ||
+            sourceDocument.Head?.SourceReference?.Position.Index >= 0 ||
+            sourceDocument.Body?.SourceReference?.Position.Index >= 0;
         // Parse owns this already-resolved snapshot; retaining it avoids cloning the full policy
         // and limits graph a second time before any lazy projection has been requested.
         _options = options ?? throw new ArgumentNullException(nameof(options));
@@ -67,6 +71,12 @@ public sealed partial class HtmlConversionDocument {
 
     /// <summary>Original HTML supplied by the caller.</summary>
     public string SourceHtml { get; }
+
+    /// <summary>
+    /// Gets whether the parsed source contained an actual document envelope tag or doctype.
+    /// Text in comments, escaped markup, and prefix tags such as <c>bodyguard</c> do not count.
+    /// </summary>
+    public bool HasExplicitDocumentEnvelope { get; }
 
     /// <summary>
     /// Creates an independent policy-normalized DOM for the conversion profile's default media context.

--- a/OfficeIMO.Html/Engine/HtmlConversionDocument.cs
+++ b/OfficeIMO.Html/Engine/HtmlConversionDocument.cs
@@ -76,7 +76,7 @@ public sealed partial class HtmlConversionDocument {
     /// Gets whether the parsed source contained an actual document envelope tag or doctype.
     /// Text in comments, escaped markup, and prefix tags such as <c>bodyguard</c> do not count.
     /// </summary>
-    public bool HasExplicitDocumentEnvelope { get; }
+    internal bool HasExplicitDocumentEnvelope { get; }
 
     /// <summary>
     /// Creates an independent policy-normalized DOM for the conversion profile's default media context.

--- a/OfficeIMO.Html/OfficeIMO.Html.csproj
+++ b/OfficeIMO.Html/OfficeIMO.Html.csproj
@@ -58,6 +58,7 @@
     <InternalsVisibleTo Include="OfficeIMO.Html.Rtf" />
     <InternalsVisibleTo Include="OfficeIMO.Mhtml" />
     <InternalsVisibleTo Include="OfficeIMO.Email.Image" />
+    <InternalsVisibleTo Include="OfficeIMO.Email.Html" />
     <InternalsVisibleTo Include="OfficeIMO.Mhtml.Pdf" />
     <InternalsVisibleTo Include="OfficeIMO.Markdown.Html" />
     <InternalsVisibleTo Include="OfficeIMO.OneNote.Html" />

--- a/OfficeIMO.Html/Policies/HtmlUrlPolicy.cs
+++ b/OfficeIMO.Html/Policies/HtmlUrlPolicy.cs
@@ -30,6 +30,23 @@ public sealed class HtmlUrlPolicy {
     };
 
     /// <summary>
+    /// Creates a resource policy that accepts only HTTP and HTTPS network references.
+    /// Mail, telephone, script, file, and data URLs are rejected.
+    /// </summary>
+    public static HtmlUrlPolicy CreateWebResourceProfile() {
+        var policy = new HtmlUrlPolicy {
+            DisallowFileUrls = true,
+            AllowMailtoUrls = false,
+            AllowDataUrls = false,
+            RestrictUrlSchemes = true
+        };
+        policy.AllowedUrlSchemes.Clear();
+        policy.AllowedUrlSchemes.Add(Uri.UriSchemeHttp);
+        policy.AllowedUrlSchemes.Add(Uri.UriSchemeHttps);
+        return policy;
+    }
+
+    /// <summary>
     /// Creates an offline resource policy that accepts bounded embedded data while rejecting file and network schemes.
     /// </summary>
     public static HtmlUrlPolicy CreateEmbeddedResourceProfile() {

--- a/OfficeIMO.Html/Rendering/HtmlRenderResourceLoader.cs
+++ b/OfficeIMO.Html/Rendering/HtmlRenderResourceLoader.cs
@@ -576,7 +576,12 @@ internal static class HtmlRenderResourceLoader {
                 PendingResource pendingResource = item.Pending;
                 HtmlResourceReference reference = pendingResource.Reference;
                 if (item.Exception != null) {
-                    if (item.Exception is HtmlRenderResourceByteLimitException byteLimit) {
+                    if (item.Exception is HtmlRenderTotalResourceByteLimitException totalByteLimit) {
+                        result.MarkAttempted(reference);
+                        diagnostics.Add(ComponentName, HtmlRenderDiagnosticCodes.TotalResourceByteLimitExceeded, "Resolved resources exceeded the configured total byte limit.", HtmlDiagnosticSeverity.Error, reference.Source, "bytes=" + totalByteLimit.ActualBytes, OfficeConversionLossKind.Omission);
+                        stop = true;
+                        break;
+                    } else if (item.Exception is HtmlRenderResourceByteLimitException byteLimit) {
                         result.MarkAttempted(reference);
                         diagnostics.Add(ComponentName, HtmlRenderDiagnosticCodes.ResourceByteLimitExceeded, "A resolved resource exceeded the configured per-resource byte limit.", HtmlDiagnosticSeverity.Warning, reference.Source, "bytes=" + byteLimit.ActualBytes, OfficeConversionLossKind.Omission);
                     } else if (item.Exception is OperationCanceledException) {

--- a/OfficeIMO.Html/Rendering/HtmlRenderResourceResolver.cs
+++ b/OfficeIMO.Html/Rendering/HtmlRenderResourceResolver.cs
@@ -21,6 +21,14 @@ internal sealed class HtmlRenderResourceByteLimitException : Exception {
     internal long ActualBytes { get; }
 }
 
+internal sealed class HtmlRenderTotalResourceByteLimitException : Exception {
+    internal HtmlRenderTotalResourceByteLimitException(long actualBytes) {
+        ActualBytes = actualBytes;
+    }
+
+    internal long ActualBytes { get; }
+}
+
 /// <summary>
 /// Policy-approved resource request passed to an application-supplied resolver.
 /// </summary>

--- a/OfficeIMO.Reader.Email/EmailReaderProjection.cs
+++ b/OfficeIMO.Reader.Email/EmailReaderProjection.cs
@@ -119,6 +119,7 @@ internal static class EmailReaderProjection {
 
         EmailBodyProjectionResult bodyProjection = EmailBodyProjection.Create(document,
             new EmailBodyProjectionOptions {
+                IncludeResources = false,
                 SelectionPolicy = EmailBodySelectionPolicy.Richest,
                 RemoteResourcePolicy = EmailRemoteResourcePolicy.Block
             });


### PR DESCRIPTION
## Summary

This hardens OfficeIMO.Email's embedded-resource pipeline across HTML import, serialization, and image export.

- Bounds resource indexing and reads, including aggregate limits and deterministic limit exceptions.
- Uses ambiguity-aware resource identities and collision-free aliases so duplicate CIDs or filenames cannot select the wrong payload.
- Snapshots projected resource identity, metadata, and content-source selection so later attachment edits cannot desynchronize resolution from the exposed resource.
- Preserves case-insensitive filename compatibility while keeping Content-Location URI path and query matching case-sensitive.
- Preserves effective document base URIs, fragments, and document-relative references during HTML projection.
- Prevents unsafe retries after a resource source has begun and then fails or is cancelled, while keeping pre-read contention cancellation retryable.
- Aligns synchronous and asynchronous image resolution so unresolved or ambiguous embedded resources cannot fall through to an unintended resolver.
- Documents the public parse/discover/rewrite/serialize image workflow in the package README.
- Keeps existing compatibility defaults while exposing explicit policy controls for stricter callers.

## Validation

- `OfficeIMO.Email.Tests`: 1,380 passed / 11 skipped on .NET 8; 1,338 passed / 11 skipped on .NET Framework 4.7.2.
- Focused projection/resource tests: 41 passed on each target.
- Focused email-image export tests: 18 passed on each target.
- Release build of `OfficeIMO.Email.Image` across .NET Standard 2.0, .NET 8, .NET 10, and .NET Framework 4.7.2 with zero warnings.