### PR TITLE
Harden PDF production validation and variation fallback

### DIFF
--- a/OfficeIMO.Core/OfficeOpenTypeCffFont.cs
+++ b/OfficeIMO.Core/OfficeOpenTypeCffFont.cs
@@ -87,9 +87,9 @@ internal sealed class OfficeOpenTypeCffFont : IOfficeCffBoundedFontProgram, IOff
         var glyphs = new List<int>();
         var scalars = new List<int>();
         for (int index = 0; index < text.Length;) {
-            int scalar = ReadScalar(text, ref index);
-            if (OfficeTextElements.IsIgnorableFontCoverageScalar(scalar)) continue;
-            glyphs.Add(_reader.MapGlyph(scalar));
+            int glyph = _reader.ReadMappedGlyph(text, ref index, out int scalar);
+            if (glyph < 0) continue;
+            glyphs.Add(glyph);
             scalars.Add(scalar);
         }
         OfficeOpenTypeGlyphPositioning[] positioning = _kerning.PositionRun(glyphs, scalars);
@@ -110,9 +110,9 @@ internal sealed class OfficeOpenTypeCffFont : IOfficeCffBoundedFontProgram, IOff
         for (int elementIndex = 0; elementIndex < elements.Count; elementIndex++) {
             string text = elements[elementIndex];
             for (int textIndex = 0; textIndex < text.Length;) {
-                int scalar = ReadScalar(text, ref textIndex);
-                if (OfficeTextElements.IsIgnorableFontCoverageScalar(scalar)) continue;
-                glyphs.Add(_reader.MapGlyph(scalar));
+                int glyph = _reader.ReadMappedGlyph(text, ref textIndex, out int scalar);
+                if (glyph < 0) continue;
+                glyphs.Add(glyph);
                 scalars.Add(scalar);
                 elementIndexes.Add(elementIndex);
             }
@@ -173,9 +173,9 @@ internal sealed class OfficeOpenTypeCffFont : IOfficeCffBoundedFontProgram, IOff
         var glyphs = new List<(int Glyph, int Scalar)>();
         for (int index = 0; index < text.Length;) {
             cancellationToken.ThrowIfCancellationRequested();
-            int scalar = ReadScalar(text, ref index);
-            if (OfficeTextElements.IsIgnorableFontCoverageScalar(scalar)) continue;
-            glyphs.Add((_reader.MapGlyph(scalar), scalar));
+            int glyph = _reader.ReadMappedGlyph(text, ref index, out int scalar);
+            if (glyph < 0) continue;
+            glyphs.Add((glyph, scalar));
         }
 
         var glyphIds = new List<int>(glyphs.Count);

--- a/OfficeIMO.Core/OfficeOpenTypeCffFont.cs
+++ b/OfficeIMO.Core/OfficeOpenTypeCffFont.cs
@@ -77,13 +77,7 @@ internal sealed class OfficeOpenTypeCffFont : IOfficeCffBoundedFontProgram, IOff
     public byte[] GetFontDataForShaping() => (byte[])_data.Clone();
 
     public bool HasGlyphs(string text) {
-        if (text == null) throw new ArgumentNullException(nameof(text));
-        for (int index = 0; index < text.Length;) {
-            int scalar = ReadScalar(text, ref index);
-            if (OfficeTextElements.IsIgnorableFontCoverageScalar(scalar)) continue;
-            if (_reader.MapGlyph(scalar) == 0) return false;
-        }
-        return true;
+        return _reader.HasGlyphs(text);
     }
 
     public double Measure(string text, double fontSize) {

--- a/OfficeIMO.Core/OfficeOpenTypeCmap.cs
+++ b/OfficeIMO.Core/OfficeOpenTypeCmap.cs
@@ -8,7 +8,6 @@ internal static class OfficeOpenTypeCmap {
     internal const int MaximumSubtables = 64;
     internal const uint MaximumFormat12Groups = 4096;
     private const uint MaximumVariationSelectorRecords = 256;
-    private const uint MaximumVariationMappings = 4096;
 
     internal static bool IsUnicodeEncoding(int platform, int encoding) =>
         platform == 0 ||
@@ -43,7 +42,7 @@ internal static class OfficeOpenTypeCmap {
         Func<int, int, int> mapVariationSequence,
         out int scalar) {
         scalar = ReadScalar(text, ref index);
-        if (IsVariationSelector(scalar)) return 0;
+        if (IsVariationSelector(scalar) || OfficeTextElements.IsIgnorableFontCoverageScalar(scalar)) return -1;
 
         int followingIndex = index;
         int followingScalar = followingIndex < text.Length
@@ -54,7 +53,7 @@ internal static class OfficeOpenTypeCmap {
             return mapVariationSequence(scalar, followingScalar);
         }
 
-        return OfficeTextElements.IsIgnorableFontCoverageScalar(scalar) ? -1 : mapGlyph(scalar);
+        return mapGlyph(scalar);
     }
 
     internal static int MapVariationSequence(
@@ -143,16 +142,23 @@ internal static class OfficeOpenTypeCmap {
         int offset = table + (int)relativeOffset;
         if (offset < table || offset > tableEnd - 4) return false;
         uint countValue = ReadUInt32(data, offset);
-        if (countValue > MaximumVariationMappings || countValue > (uint)((tableEnd - offset - 4) / 5)) return false;
-        int previousScalar = -1;
-        for (int index = 0; index < (int)countValue; index++) {
+        if (countValue > int.MaxValue || countValue > (uint)((tableEnd - offset - 4) / 5)) return false;
+        int low = 0;
+        int high = (int)countValue - 1;
+        while (low <= high) {
+            int index = low + ((high - low) / 2);
             int mapping = offset + 4 + index * 5;
             int unicodeValue = ReadUInt24(data, mapping);
-            int mappedGlyph = ReadUInt16(data, mapping + 3);
-            if (unicodeValue > 0x10FFFF || unicodeValue <= previousScalar ||
-                mappedGlyph <= 0 || mappedGlyph >= glyphCount) return false;
-            if (unicodeValue == scalar) glyph = mappedGlyph;
-            previousScalar = unicodeValue;
+            if (unicodeValue < scalar) {
+                low = index + 1;
+            } else if (unicodeValue > scalar) {
+                high = index - 1;
+            } else {
+                int mappedGlyph = ReadUInt16(data, mapping + 3);
+                if (mappedGlyph <= 0 || mappedGlyph >= glyphCount) return false;
+                glyph = mappedGlyph;
+                return true;
+            }
         }
         return true;
     }
@@ -169,15 +175,23 @@ internal static class OfficeOpenTypeCmap {
         int offset = table + (int)relativeOffset;
         if (offset < table || offset > tableEnd - 4) return false;
         uint countValue = ReadUInt32(data, offset);
-        if (countValue > MaximumVariationMappings || countValue > (uint)((tableEnd - offset - 4) / 4)) return false;
-        int previousEnd = -1;
-        for (int index = 0; index < (int)countValue; index++) {
+        if (countValue > int.MaxValue || countValue > (uint)((tableEnd - offset - 4) / 4)) return false;
+        int low = 0;
+        int high = (int)countValue - 1;
+        while (low <= high) {
+            int index = low + ((high - low) / 2);
             int range = offset + 4 + index * 4;
             int start = ReadUInt24(data, range);
             int end = start + data[range + 3];
-            if (start <= previousEnd || end > 0x10FFFF) return false;
-            if (scalar >= start && scalar <= end) isDefault = true;
-            previousEnd = end;
+            if (end > 0x10FFFF) return false;
+            if (scalar < start) {
+                high = index - 1;
+            } else if (scalar > end) {
+                low = index + 1;
+            } else {
+                isDefault = true;
+                return true;
+            }
         }
         return true;
     }

--- a/OfficeIMO.Core/OfficeOpenTypeCmap.cs
+++ b/OfficeIMO.Core/OfficeOpenTypeCmap.cs
@@ -26,30 +26,38 @@ internal static class OfficeOpenTypeCmap {
     internal static bool HasGlyphs(
         string text,
         Func<int, int> mapGlyph,
-        Func<int, int, bool> supportsVariationSequence) {
+        Func<int, int, int> mapVariationSequence) {
         if (text == null) throw new ArgumentNullException(nameof(text));
         for (int index = 0; index < text.Length;) {
-            int scalar = ReadScalar(text, ref index);
-            if (IsVariationSelector(scalar)) return false;
-
-            int followingIndex = index;
-            int followingScalar = followingIndex < text.Length
-                ? ReadScalar(text, ref followingIndex)
-                : -1;
-            if (IsVariationSelector(followingScalar)) {
-                if (!supportsVariationSequence(scalar, followingScalar)) return false;
-                index = followingIndex;
-                continue;
-            }
-
-            if (scalar <= char.MaxValue && char.IsWhiteSpace((char)scalar) ||
-                OfficeTextElements.IsIgnorableFontCoverageScalar(scalar)) continue;
-            if (mapGlyph(scalar) == 0) return false;
+            int glyph = ReadMappedGlyph(text, ref index, mapGlyph, mapVariationSequence, out int scalar);
+            if (glyph < 0) continue;
+            if (glyph == 0 && !(scalar <= char.MaxValue && char.IsWhiteSpace((char)scalar))) return false;
         }
         return true;
     }
 
-    internal static bool SupportsVariationSequence(
+    internal static int ReadMappedGlyph(
+        string text,
+        ref int index,
+        Func<int, int> mapGlyph,
+        Func<int, int, int> mapVariationSequence,
+        out int scalar) {
+        scalar = ReadScalar(text, ref index);
+        if (IsVariationSelector(scalar)) return 0;
+
+        int followingIndex = index;
+        int followingScalar = followingIndex < text.Length
+            ? ReadScalar(text, ref followingIndex)
+            : -1;
+        if (IsVariationSelector(followingScalar)) {
+            index = followingIndex;
+            return mapVariationSequence(scalar, followingScalar);
+        }
+
+        return OfficeTextElements.IsIgnorableFontCoverageScalar(scalar) ? -1 : mapGlyph(scalar);
+    }
+
+    internal static int MapVariationSequence(
         byte[] data,
         int cmapOffset,
         int cmapLength,
@@ -58,10 +66,10 @@ internal static class OfficeOpenTypeCmap {
         int variationSelector,
         Func<int, int> mapGlyph) {
         if (data == null || cmapOffset < 0 || cmapLength < 4 || cmapOffset > data.Length - cmapLength ||
-            glyphCount <= 0 || scalar < 0 || scalar > 0x10FFFF || !IsVariationSelector(variationSelector)) return false;
+            glyphCount <= 0 || scalar < 0 || scalar > 0x10FFFF || !IsVariationSelector(variationSelector)) return 0;
         int cmapEnd = cmapOffset + cmapLength;
         int count = ReadUInt16(data, cmapOffset + 2);
-        if (count <= 0 || count > MaximumSubtables || cmapLength < 4 + count * 8) return false;
+        if (count <= 0 || count > MaximumSubtables || cmapLength < 4 + count * 8) return 0;
         for (int index = 0; index < count; index++) {
             int record = cmapOffset + 4 + index * 8;
             int platform = ReadUInt16(data, record);
@@ -71,12 +79,13 @@ internal static class OfficeOpenTypeCmap {
             if (relativeValue > (uint)(cmapLength - 10)) continue;
             int table = cmapOffset + (int)relativeValue;
             if (table < cmapOffset || table > cmapEnd - 10 || ReadUInt16(data, table) != 14) continue;
-            if (SupportsVariationSequenceSubtable(data, table, cmapEnd, glyphCount, scalar, variationSelector, mapGlyph)) return true;
+            int glyph = MapVariationSequenceSubtable(data, table, cmapEnd, glyphCount, scalar, variationSelector, mapGlyph);
+            if (glyph != 0) return glyph;
         }
-        return false;
+        return 0;
     }
 
-    private static bool SupportsVariationSequenceSubtable(
+    private static int MapVariationSequenceSubtable(
         byte[] data,
         int table,
         int cmapEnd,
@@ -86,10 +95,10 @@ internal static class OfficeOpenTypeCmap {
         Func<int, int> mapGlyph) {
         uint lengthValue = ReadUInt32(data, table + 2);
         uint recordCountValue = ReadUInt32(data, table + 6);
-        if (lengthValue > int.MaxValue || recordCountValue > MaximumVariationSelectorRecords) return false;
+        if (lengthValue > int.MaxValue || recordCountValue > MaximumVariationSelectorRecords) return 0;
         int length = (int)lengthValue;
         int recordCount = (int)recordCountValue;
-        if (length < 10 || table > cmapEnd - length || 10L + recordCount * 11L > length) return false;
+        if (length < 10 || table > cmapEnd - length || 10L + recordCount * 11L > length) return 0;
         int tableEnd = table + length;
 
         int matchingRecord = -1;
@@ -97,11 +106,11 @@ internal static class OfficeOpenTypeCmap {
         for (int index = 0; index < recordCount; index++) {
             int record = table + 10 + index * 11;
             int selector = ReadUInt24(data, record);
-            if (!IsVariationSelector(selector) || selector <= previousSelector) return false;
+            if (!IsVariationSelector(selector) || selector <= previousSelector) return 0;
             if (selector == variationSelector) matchingRecord = record;
             previousSelector = selector;
         }
-        if (matchingRecord < 0) return false;
+        if (matchingRecord < 0) return 0;
 
         uint defaultOffset = ReadUInt32(data, matchingRecord + 3);
         uint nonDefaultOffset = ReadUInt32(data, matchingRecord + 7);
@@ -113,12 +122,12 @@ internal static class OfficeOpenTypeCmap {
                     nonDefaultOffset,
                     glyphCount,
                     scalar,
-                    out int glyph)) return false;
-            if (glyph != 0) return glyph == mapGlyph(scalar);
+                    out int glyph)) return 0;
+            if (glyph != 0) return glyph;
         }
         if (defaultOffset == 0 ||
-            !TryResolveDefaultVariation(data, table, tableEnd, defaultOffset, scalar, out bool isDefault)) return false;
-        return isDefault && mapGlyph(scalar) != 0;
+            !TryResolveDefaultVariation(data, table, tableEnd, defaultOffset, scalar, out bool isDefault)) return 0;
+        return isDefault ? mapGlyph(scalar) : 0;
     }
 
     private static bool TryResolveNonDefaultVariation(

--- a/OfficeIMO.Core/OfficeOpenTypeCmap.cs
+++ b/OfficeIMO.Core/OfficeOpenTypeCmap.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace OfficeIMO.Drawing;
@@ -18,6 +19,164 @@ internal static class OfficeOpenTypeCmap {
         else if (platform == 0) score += 15;
         else if (platform == 3 && encoding == 1) score += 10;
         return score;
+    }
+
+    internal static bool HasGlyphs(
+        string text,
+        Func<int, int> mapGlyph,
+        Func<int, int, bool> supportsVariationSequence) {
+        if (text == null) throw new ArgumentNullException(nameof(text));
+        for (int index = 0; index < text.Length;) {
+            int scalar = ReadScalar(text, ref index);
+            if (IsVariationSelector(scalar)) return false;
+
+            int followingIndex = index;
+            int followingScalar = followingIndex < text.Length
+                ? ReadScalar(text, ref followingIndex)
+                : -1;
+            if (IsVariationSelector(followingScalar)) {
+                if (!supportsVariationSequence(scalar, followingScalar)) return false;
+                index = followingIndex;
+                continue;
+            }
+
+            if (scalar <= char.MaxValue && char.IsWhiteSpace((char)scalar) ||
+                OfficeTextElements.IsIgnorableFontCoverageScalar(scalar)) continue;
+            if (mapGlyph(scalar) == 0) return false;
+        }
+        return true;
+    }
+
+    internal static bool SupportsVariationSequence(
+        byte[] data,
+        int cmapOffset,
+        int cmapLength,
+        int glyphCount,
+        int scalar,
+        int variationSelector,
+        Func<int, int> mapGlyph) {
+        if (data == null || cmapOffset < 0 || cmapLength < 4 || cmapOffset > data.Length - cmapLength ||
+            glyphCount <= 0 || scalar < 0 || scalar > 0x10FFFF || !IsVariationSelector(variationSelector)) return false;
+        int cmapEnd = cmapOffset + cmapLength;
+        int count = ReadUInt16(data, cmapOffset + 2);
+        if (count <= 0 || count > MaximumSubtables || cmapLength < 4 + count * 8) return false;
+        for (int index = 0; index < count; index++) {
+            int record = cmapOffset + 4 + index * 8;
+            uint relativeValue = ReadUInt32(data, record + 4);
+            if (relativeValue > (uint)(cmapLength - 10)) continue;
+            int table = cmapOffset + (int)relativeValue;
+            if (table < cmapOffset || table > cmapEnd - 10 || ReadUInt16(data, table) != 14) continue;
+            if (SupportsVariationSequenceSubtable(data, table, cmapEnd, glyphCount, scalar, variationSelector, mapGlyph)) return true;
+        }
+        return false;
+    }
+
+    private static bool SupportsVariationSequenceSubtable(
+        byte[] data,
+        int table,
+        int cmapEnd,
+        int glyphCount,
+        int scalar,
+        int variationSelector,
+        Func<int, int> mapGlyph) {
+        uint lengthValue = ReadUInt32(data, table + 2);
+        uint recordCountValue = ReadUInt32(data, table + 6);
+        if (lengthValue > int.MaxValue || recordCountValue > 4096) return false;
+        int length = (int)lengthValue;
+        int recordCount = (int)recordCountValue;
+        if (length < 10 || table > cmapEnd - length || 10L + recordCount * 11L > length) return false;
+        int tableEnd = table + length;
+
+        int matchingRecord = -1;
+        int previousSelector = -1;
+        for (int index = 0; index < recordCount; index++) {
+            int record = table + 10 + index * 11;
+            int selector = ReadUInt24(data, record);
+            if (!IsVariationSelector(selector) || selector <= previousSelector) return false;
+            if (selector == variationSelector) matchingRecord = record;
+            previousSelector = selector;
+        }
+        if (matchingRecord < 0) return false;
+
+        uint defaultOffset = ReadUInt32(data, matchingRecord + 3);
+        uint nonDefaultOffset = ReadUInt32(data, matchingRecord + 7);
+        if (nonDefaultOffset != 0) {
+            if (!TryResolveNonDefaultVariation(
+                    data,
+                    table,
+                    tableEnd,
+                    nonDefaultOffset,
+                    glyphCount,
+                    scalar,
+                    out int glyph)) return false;
+            if (glyph != 0) return true;
+        }
+        if (defaultOffset == 0 ||
+            !TryResolveDefaultVariation(data, table, tableEnd, defaultOffset, scalar, out bool isDefault)) return false;
+        return isDefault && mapGlyph(scalar) != 0;
+    }
+
+    private static bool TryResolveNonDefaultVariation(
+        byte[] data,
+        int table,
+        int tableEnd,
+        uint relativeOffset,
+        int glyphCount,
+        int scalar,
+        out int glyph) {
+        glyph = 0;
+        if (relativeOffset > int.MaxValue) return false;
+        int offset = table + (int)relativeOffset;
+        if (offset < table || offset > tableEnd - 4) return false;
+        uint countValue = ReadUInt32(data, offset);
+        if (countValue > (uint)((tableEnd - offset - 4) / 5)) return false;
+        int previousScalar = -1;
+        for (int index = 0; index < (int)countValue; index++) {
+            int mapping = offset + 4 + index * 5;
+            int unicodeValue = ReadUInt24(data, mapping);
+            int mappedGlyph = ReadUInt16(data, mapping + 3);
+            if (unicodeValue > 0x10FFFF || unicodeValue <= previousScalar ||
+                mappedGlyph <= 0 || mappedGlyph >= glyphCount) return false;
+            if (unicodeValue == scalar) glyph = mappedGlyph;
+            previousScalar = unicodeValue;
+        }
+        return true;
+    }
+
+    private static bool TryResolveDefaultVariation(
+        byte[] data,
+        int table,
+        int tableEnd,
+        uint relativeOffset,
+        int scalar,
+        out bool isDefault) {
+        isDefault = false;
+        if (relativeOffset > int.MaxValue) return false;
+        int offset = table + (int)relativeOffset;
+        if (offset < table || offset > tableEnd - 4) return false;
+        uint countValue = ReadUInt32(data, offset);
+        if (countValue > (uint)((tableEnd - offset - 4) / 4)) return false;
+        int previousEnd = -1;
+        for (int index = 0; index < (int)countValue; index++) {
+            int range = offset + 4 + index * 4;
+            int start = ReadUInt24(data, range);
+            int end = start + data[range + 3];
+            if (start <= previousEnd || end > 0x10FFFF) return false;
+            if (scalar >= start && scalar <= end) isDefault = true;
+            previousEnd = end;
+        }
+        return true;
+    }
+
+    private static bool IsVariationSelector(int scalar) =>
+        scalar >= 0xFE00 && scalar <= 0xFE0F || scalar >= 0xE0100 && scalar <= 0xE01EF;
+
+    private static int ReadScalar(string value, ref int index) {
+        char first = value[index++];
+        if (char.IsHighSurrogate(first) && index < value.Length && char.IsLowSurrogate(value[index])) {
+            return char.ConvertToUtf32(first, value[index++]);
+        }
+        return first;
     }
 
     internal static HashSet<int> CollectValidFormat12Subtables(
@@ -126,6 +285,9 @@ internal static class OfficeOpenTypeCmap {
     }
 
     private static int ReadUInt16(byte[] data, int offset) => (data[offset] << 8) | data[offset + 1];
+
+    private static int ReadUInt24(byte[] data, int offset) =>
+        (data[offset] << 16) | (data[offset + 1] << 8) | data[offset + 2];
 
     private static uint ReadUInt32(byte[] data, int offset) =>
         ((uint)data[offset] << 24)

--- a/OfficeIMO.Core/OfficeOpenTypeCmap.cs
+++ b/OfficeIMO.Core/OfficeOpenTypeCmap.cs
@@ -7,6 +7,8 @@ namespace OfficeIMO.Drawing;
 internal static class OfficeOpenTypeCmap {
     internal const int MaximumSubtables = 64;
     internal const uint MaximumFormat12Groups = 4096;
+    private const uint MaximumVariationSelectorRecords = 256;
+    private const uint MaximumVariationMappings = 4096;
 
     internal static bool IsUnicodeEncoding(int platform, int encoding) =>
         platform == 0 ||
@@ -62,6 +64,9 @@ internal static class OfficeOpenTypeCmap {
         if (count <= 0 || count > MaximumSubtables || cmapLength < 4 + count * 8) return false;
         for (int index = 0; index < count; index++) {
             int record = cmapOffset + 4 + index * 8;
+            int platform = ReadUInt16(data, record);
+            int encoding = ReadUInt16(data, record + 2);
+            if (platform != 0 || encoding != 5) continue;
             uint relativeValue = ReadUInt32(data, record + 4);
             if (relativeValue > (uint)(cmapLength - 10)) continue;
             int table = cmapOffset + (int)relativeValue;
@@ -81,7 +86,7 @@ internal static class OfficeOpenTypeCmap {
         Func<int, int> mapGlyph) {
         uint lengthValue = ReadUInt32(data, table + 2);
         uint recordCountValue = ReadUInt32(data, table + 6);
-        if (lengthValue > int.MaxValue || recordCountValue > 4096) return false;
+        if (lengthValue > int.MaxValue || recordCountValue > MaximumVariationSelectorRecords) return false;
         int length = (int)lengthValue;
         int recordCount = (int)recordCountValue;
         if (length < 10 || table > cmapEnd - length || 10L + recordCount * 11L > length) return false;
@@ -109,7 +114,7 @@ internal static class OfficeOpenTypeCmap {
                     glyphCount,
                     scalar,
                     out int glyph)) return false;
-            if (glyph != 0) return true;
+            if (glyph != 0) return glyph == mapGlyph(scalar);
         }
         if (defaultOffset == 0 ||
             !TryResolveDefaultVariation(data, table, tableEnd, defaultOffset, scalar, out bool isDefault)) return false;
@@ -129,7 +134,7 @@ internal static class OfficeOpenTypeCmap {
         int offset = table + (int)relativeOffset;
         if (offset < table || offset > tableEnd - 4) return false;
         uint countValue = ReadUInt32(data, offset);
-        if (countValue > (uint)((tableEnd - offset - 4) / 5)) return false;
+        if (countValue > MaximumVariationMappings || countValue > (uint)((tableEnd - offset - 4) / 5)) return false;
         int previousScalar = -1;
         for (int index = 0; index < (int)countValue; index++) {
             int mapping = offset + 4 + index * 5;
@@ -155,7 +160,7 @@ internal static class OfficeOpenTypeCmap {
         int offset = table + (int)relativeOffset;
         if (offset < table || offset > tableEnd - 4) return false;
         uint countValue = ReadUInt32(data, offset);
-        if (countValue > (uint)((tableEnd - offset - 4) / 4)) return false;
+        if (countValue > MaximumVariationMappings || countValue > (uint)((tableEnd - offset - 4) / 4)) return false;
         int previousEnd = -1;
         for (int index = 0; index < (int)countValue; index++) {
             int range = offset + 4 + index * 4;

--- a/OfficeIMO.Core/OfficeOpenTypeReader.cs
+++ b/OfficeIMO.Core/OfficeOpenTypeReader.cs
@@ -129,6 +129,18 @@ internal sealed class OfficeOpenTypeReader {
         return glyph != 0 ? glyph : MapFallbackCmapSubtable(table, cmapEnd, scalar);
     }
 
+    internal bool HasGlyphs(string text) => OfficeOpenTypeCmap.HasGlyphs(
+        text,
+        MapGlyph,
+        (scalar, selector) => OfficeOpenTypeCmap.SupportsVariationSequence(
+            _data,
+            _cmap.Offset,
+            _cmap.Length,
+            GlyphCount,
+            scalar,
+            selector,
+            MapGlyph));
+
     private int MapCmapSubtable(int table, int cmapEnd, int scalar) {
         int format = ReadUInt16(table);
         return format == 12

--- a/OfficeIMO.Core/OfficeOpenTypeReader.cs
+++ b/OfficeIMO.Core/OfficeOpenTypeReader.cs
@@ -132,14 +132,20 @@ internal sealed class OfficeOpenTypeReader {
     internal bool HasGlyphs(string text) => OfficeOpenTypeCmap.HasGlyphs(
         text,
         MapGlyph,
-        (scalar, selector) => OfficeOpenTypeCmap.SupportsVariationSequence(
+        MapVariationGlyph);
+
+    internal int ReadMappedGlyph(string text, ref int index, out int scalar) =>
+        OfficeOpenTypeCmap.ReadMappedGlyph(text, ref index, MapGlyph, MapVariationGlyph, out scalar);
+
+    private int MapVariationGlyph(int scalar, int selector) =>
+        OfficeOpenTypeCmap.MapVariationSequence(
             _data,
             _cmap.Offset,
             _cmap.Length,
             GlyphCount,
             scalar,
             selector,
-            MapGlyph));
+            MapGlyph);
 
     private int MapCmapSubtable(int table, int cmapEnd, int scalar) {
         int format = ReadUInt16(table);

--- a/OfficeIMO.Core/OfficeTrueTypeFont.cs
+++ b/OfficeIMO.Core/OfficeTrueTypeFont.cs
@@ -302,9 +302,9 @@ public sealed partial class OfficeTrueTypeFont : IOfficeBoundedFontProgram, IOff
         var glyphs = new List<int>();
         var scalars = new List<int>();
         for (int index = 0; index < text.Length;) {
-            int scalar = ReadScalar(text, ref index);
-            if (OfficeTextElements.IsIgnorableFontCoverageScalar(scalar)) continue;
-            glyphs.Add(MapGlyph(scalar));
+            int glyph = ReadMappedGlyph(text, ref index, out int scalar);
+            if (glyph < 0) continue;
+            glyphs.Add(glyph);
             scalars.Add(scalar);
         }
         OfficeOpenTypeGlyphPositioning[] positioning = _kerning.PositionRun(glyphs, scalars);
@@ -325,9 +325,9 @@ public sealed partial class OfficeTrueTypeFont : IOfficeBoundedFontProgram, IOff
         for (int elementIndex = 0; elementIndex < elements.Count; elementIndex++) {
             string text = elements[elementIndex];
             for (int textIndex = 0; textIndex < text.Length;) {
-                int scalar = ReadScalar(text, ref textIndex);
-                if (OfficeTextElements.IsIgnorableFontCoverageScalar(scalar)) continue;
-                glyphs.Add(MapGlyph(scalar));
+                int glyph = ReadMappedGlyph(text, ref textIndex, out int scalar);
+                if (glyph < 0) continue;
+                glyphs.Add(glyph);
                 scalars.Add(scalar);
                 elementIndexes.Add(elementIndex);
             }
@@ -380,9 +380,9 @@ public sealed partial class OfficeTrueTypeFont : IOfficeBoundedFontProgram, IOff
         var glyphs = new List<(ushort Glyph, int Scalar)>();
         for (int index = 0; index < text.Length;) {
             cancellationToken.ThrowIfCancellationRequested();
-            int scalar = ReadScalar(text, ref index);
-            if (OfficeTextElements.IsIgnorableFontCoverageScalar(scalar)) continue;
-            glyphs.Add((MapGlyph(scalar), scalar));
+            int glyph = ReadMappedGlyph(text, ref index, out int scalar);
+            if (glyph < 0) continue;
+            glyphs.Add((checked((ushort)glyph), scalar));
         }
 
         var glyphIds = new List<int>(glyphs.Count);
@@ -426,15 +426,20 @@ public sealed partial class OfficeTrueTypeFont : IOfficeBoundedFontProgram, IOff
         return OfficeOpenTypeCmap.HasGlyphs(
             value,
             scalar => MapGlyph(scalar),
-            (scalar, selector) => OfficeOpenTypeCmap.SupportsVariationSequence(
-                _data,
-                _cmap,
-                _cmapLength,
-                _numGlyphs,
-                scalar,
-                selector,
-                mappedScalar => MapGlyph(mappedScalar)));
+            MapVariationGlyph);
     }
+
+    private int ReadMappedGlyph(string text, ref int index, out int scalar) =>
+        OfficeOpenTypeCmap.ReadMappedGlyph(text, ref index, scalarValue => MapGlyph(scalarValue), MapVariationGlyph, out scalar);
+
+    private int MapVariationGlyph(int scalar, int selector) => OfficeOpenTypeCmap.MapVariationSequence(
+        _data,
+        _cmap,
+        _cmapLength,
+        _numGlyphs,
+        scalar,
+        selector,
+        mappedScalar => MapGlyph(mappedScalar));
 
     private bool MatchesName(string? faceName) {
         if (string.IsNullOrWhiteSpace(faceName)) return true;

--- a/OfficeIMO.Core/OfficeTrueTypeFont.cs
+++ b/OfficeIMO.Core/OfficeTrueTypeFont.cs
@@ -423,12 +423,17 @@ public sealed partial class OfficeTrueTypeFont : IOfficeBoundedFontProgram, IOff
     public int? CollectionIndex => _collectionIndex;
 
     internal bool HasGlyphs(string value) {
-        for (int index = 0; index < value.Length;) {
-            int scalar = ReadScalar(value, ref index);
-            if (!IsWhitespaceScalar(scalar) && !OfficeTextElements.IsIgnorableFontCoverageScalar(scalar) && MapGlyph(scalar) == 0) return false;
-        }
-
-        return true;
+        return OfficeOpenTypeCmap.HasGlyphs(
+            value,
+            scalar => MapGlyph(scalar),
+            (scalar, selector) => OfficeOpenTypeCmap.SupportsVariationSequence(
+                _data,
+                _cmap,
+                _cmapLength,
+                _numGlyphs,
+                scalar,
+                selector,
+                mappedScalar => MapGlyph(mappedScalar)));
     }
 
     private bool MatchesName(string? faceName) {

--- a/OfficeIMO.Drawing.Tests/Drawing.FontUnicodeRanges.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.FontUnicodeRanges.cs
@@ -59,10 +59,9 @@ public sealed class DrawingFontUnicodeRangeTests {
             });
     }
 
-    [Theory]
-    [InlineData("A\uFE0F")]
-    [InlineData("A\u200D")]
-    public void FontCollection_IgnoresShapingControlsWhenMatchingUnicodeRanges(string text) {
+    [Fact]
+    public void FontCollection_IgnoresJoiningControlsWhenMatchingUnicodeRanges() {
+        const string text = "A\u200D";
         byte[] font = ManagedTextShapingTestAssets.CreateFont('A');
         Assert.True(OfficeFontUnicodeRangeSet.TryParseCss("U+0041", out OfficeFontUnicodeRangeSet? latin));
         var fonts = new OfficeFontFaceCollection().Add("Scoped", font, OfficeFontStyle.Regular, latin!);

--- a/OfficeIMO.Drawing.Tests/Drawing.OpenTypeCmap.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.OpenTypeCmap.cs
@@ -28,4 +28,24 @@ public sealed class DrawingOpenTypeCmapTests {
         Assert.True(font.TryGetGlyphMetrics('A', out int glyphId, out _));
         Assert.Equal(2, glyphId);
     }
+
+    [Fact]
+    public void FontFallbackSelectsTheFaceThatSupportsTheRequestedVariationSequence() {
+        const string sequence = "\u2764\uFE0F";
+        Assert.True(OfficeFontUnicodeRangeSet.TryParseCss("U+2764", out OfficeFontUnicodeRangeSet? narrow));
+        Assert.True(OfficeFontUnicodeRangeSet.TryParseCss("U+2700-27BF", out OfficeFontUnicodeRangeSet? broad));
+        var fonts = new OfficeFontFaceCollection()
+            .Add("Scoped", ManagedTextShapingTestAssets.CreateFont(0x2764), OfficeFontStyle.Regular, narrow!)
+            .Add(
+                "Scoped",
+                ManagedTextShapingTestAssets.CreateFontWithVariationSequence(0x2764, 0xFE0F),
+                OfficeFontStyle.Regular,
+                broad!);
+
+        OfficeFontFallbackRun run = Assert.Single(fonts.PlanFallbackRuns(sequence, "Scoped"));
+
+        Assert.Equal(sequence, run.Text);
+        Assert.Equal(fonts.Faces[1].ResourceFamilyName, run.FamilyName);
+        Assert.NotEqual(fonts.Faces[0].ResourceFamilyName, run.FamilyName);
+    }
 }

--- a/OfficeIMO.Drawing.Tests/Drawing.OpenTypeCmap.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.OpenTypeCmap.cs
@@ -69,4 +69,16 @@ public sealed class DrawingOpenTypeCmapTests {
 
         Assert.False(font.HasGlyphs(sequence));
     }
+
+    [Fact]
+    public void VariationCoverageSupportsLargeValidNonDefaultMappingTables() {
+        const string sequence = "\u2764\uFE0F";
+        OfficeTrueTypeFont font = Assert.IsType<OfficeTrueTypeFont>(OfficeTrueTypeFont.TryLoad(
+            ManagedTextShapingTestAssets.CreateFontWithLargeNonDefaultVariationSequence(0x2764, 0xFE0F)));
+
+        Assert.True(font.HasGlyphs(sequence));
+        double baseMaximumX = font.GetTextContours("\u2764", 0, 0, 1000).SelectMany(contour => contour).Max(point => point.X);
+        double variationMaximumX = font.GetTextContours(sequence, 0, 0, 1000).SelectMany(contour => contour).Max(point => point.X);
+        Assert.True(variationMaximumX > baseMaximumX);
+    }
 }

--- a/OfficeIMO.Drawing.Tests/Drawing.OpenTypeCmap.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.OpenTypeCmap.cs
@@ -50,12 +50,15 @@ public sealed class DrawingOpenTypeCmapTests {
     }
 
     [Fact]
-    public void ManagedFontDoesNotClaimANonDefaultVariationGlyphItCannotRender() {
+    public void ManagedFontMapsANonDefaultVariationGlyphForRendering() {
         const string sequence = "\u2764\uFE0F";
         OfficeTrueTypeFont font = Assert.IsType<OfficeTrueTypeFont>(OfficeTrueTypeFont.TryLoad(
             ManagedTextShapingTestAssets.CreateFontWithNonDefaultVariationSequence(0x2764, 0xFE0F)));
 
-        Assert.False(font.HasGlyphs(sequence));
+        Assert.True(font.HasGlyphs(sequence));
+        double baseMaximumX = font.GetTextContours("\u2764", 0, 0, 1000).SelectMany(contour => contour).Max(point => point.X);
+        double variationMaximumX = font.GetTextContours(sequence, 0, 0, 1000).SelectMany(contour => contour).Max(point => point.X);
+        Assert.True(variationMaximumX > baseMaximumX);
     }
 
     [Fact]

--- a/OfficeIMO.Drawing.Tests/Drawing.OpenTypeCmap.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.OpenTypeCmap.cs
@@ -48,4 +48,22 @@ public sealed class DrawingOpenTypeCmapTests {
         Assert.Equal(fonts.Faces[1].ResourceFamilyName, run.FamilyName);
         Assert.NotEqual(fonts.Faces[0].ResourceFamilyName, run.FamilyName);
     }
+
+    [Fact]
+    public void ManagedFontDoesNotClaimANonDefaultVariationGlyphItCannotRender() {
+        const string sequence = "\u2764\uFE0F";
+        OfficeTrueTypeFont font = Assert.IsType<OfficeTrueTypeFont>(OfficeTrueTypeFont.TryLoad(
+            ManagedTextShapingTestAssets.CreateFontWithNonDefaultVariationSequence(0x2764, 0xFE0F)));
+
+        Assert.False(font.HasGlyphs(sequence));
+    }
+
+    [Fact]
+    public void VariationCoverageRejectsFormat14OutsideTheUnicodeUvsEncodingRecord() {
+        const string sequence = "\u2764\uFE0F";
+        OfficeTrueTypeFont font = Assert.IsType<OfficeTrueTypeFont>(OfficeTrueTypeFont.TryLoad(
+            ManagedTextShapingTestAssets.CreateFontWithMistypedVariationSequenceRecord(0x2764, 0xFE0F)));
+
+        Assert.False(font.HasGlyphs(sequence));
+    }
 }

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfComposePageDictionaryBuilderTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfComposePageDictionaryBuilderTests.cs
@@ -375,6 +375,45 @@ namespace OfficeIMO.Tests.Pdf {
         }
 
         [Fact]
+        public void PageDictionaryBuilder_RejectsPrintProductionBoxCollapsedBySerialization() {
+            var boxes = new PdfPrintProductionPageBoxes(
+                PageMargins.Uniform(49.9996D),
+                PageMargins.Uniform(0D));
+
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+                PdfPageDictionaryBuilder.BuildGeneratedPageDictionary(
+                    2,
+                    100,
+                    100,
+                    10,
+                    Array.Empty<(string Name, int Id)>(),
+                    Array.Empty<(string Name, int Id)>(),
+                    Array.Empty<(string Name, int Id)>(),
+                    Array.Empty<(string Name, int Id)>(),
+                    Array.Empty<int>(),
+                    printProductionPageBoxes: boxes));
+
+            Assert.Contains("TrimBox", exception.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void PageDictionaryBuilder_RejectsMediaBoxCollapsedBySerialization() {
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+                PdfPageDictionaryBuilder.BuildGeneratedPageDictionary(
+                    2,
+                    0.0004D,
+                    100,
+                    10,
+                    Array.Empty<(string Name, int Id)>(),
+                    Array.Empty<(string Name, int Id)>(),
+                    Array.Empty<(string Name, int Id)>(),
+                    Array.Empty<(string Name, int Id)>(),
+                    Array.Empty<int>()));
+
+            Assert.Contains("MediaBox", exception.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void StructTreeRootDictionaryBuilder_EmitsParentTreeNextKey() {
             var parentTreeEntries = new[] {
                 PdfStructTreeRootDictionaryBuilder.ParentTreeEntry.ForMarkedContentPage(0, new[] { 6 }),

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfPrintProductionInspectorRegressionTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfPrintProductionInspectorRegressionTests.cs
@@ -1280,6 +1280,23 @@ public sealed class PdfPrintProductionInspectorRegressionTests {
         Assert.Equal(0, evidence.UninspectableFontResourceCount);
     }
 
+    [Theory]
+    [InlineData("")]
+    [InlineData("/Type /XObject")]
+    public void StructureInspectorRejectsReachableTilingPatternsWithoutThePatternType(string typeEntry) {
+        byte[] pdf = BuildInspectionPdf(
+            "/Pattern cs /P1 scn",
+            resources: "/Pattern << /P1 5 0 R >>",
+            extraObjects:
+                "5 0 obj\n<< " + typeEntry + " /PatternType 1 /PaintType 1 /TilingType 1 " +
+                "/BBox [0 0 10 10] /XStep 10 /YStep 10 /Resources << >> /Length 0 >>\n" +
+                "stream\n\nendstream\nendobj\n");
+
+        PdfPrintProductionStructureEvidence evidence = PdfReadDocument.Open(pdf).InspectPrintProductionStructure();
+
+        Assert.True(evidence.UninspectableFontResourceCount > 0);
+    }
+
     [Fact]
     public void StructureInspectorBoundsIndirectFontResourceGraphTraversal() {
         const int firstObject = 5;

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfPrintProductionInspectorRegressionTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfPrintProductionInspectorRegressionTests.cs
@@ -552,6 +552,21 @@ public sealed class PdfPrintProductionInspectorRegressionTests {
         Assert.Equal(0, evidence.UninspectableContentStreamCount);
     }
 
+    [Fact]
+    public void ColorInspectorRejectsSoftMaskFormsWithoutTheXObjectType() {
+        byte[] pdf = BuildInspectionPdf(
+            "/GS1 gs",
+            resources: "/ExtGState << /GS1 << /SMask << /S /Alpha /G 5 0 R >> >> >>",
+            extraObjects:
+                "5 0 obj\n<< /Type /Pattern /Subtype /Form /BBox [0 0 10 10] " +
+                "/Group << /S /Transparency >> /Length 0 >>\nstream\n\nendstream\nendobj\n");
+
+        PdfPrintProductionColorEvidence evidence = PdfReadDocument.Open(pdf).InspectPrintProductionColors();
+
+        Assert.False(evidence.IsComplete);
+        Assert.Equal(1, evidence.UninspectableContentStreamCount);
+    }
+
     [Theory]
     [InlineData("/G 5 0 R", "/Group << /S /Transparency >>")]
     [InlineData("/S /Bogus /G 5 0 R", "/Group << /S /Transparency >>")]

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfPrintProductionInspectorRegressionTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfPrintProductionInspectorRegressionTests.cs
@@ -1298,6 +1298,20 @@ public sealed class PdfPrintProductionInspectorRegressionTests {
     }
 
     [Fact]
+    public void StructureInspectorAcceptsValidShadingPatternsWithoutFontContent() {
+        byte[] pdf = BuildInspectionPdf(
+            "/Pattern cs /P1 scn",
+            resources:
+                "/Pattern << /P1 << /Type /Pattern /PatternType 2 " +
+                "/Shading << /ShadingType 3 /ColorSpace /DeviceCMYK >> >> >>");
+
+        PdfPrintProductionStructureEvidence evidence = PdfReadDocument.Open(pdf).InspectPrintProductionStructure();
+
+        Assert.Equal(0, evidence.FontResourceCount);
+        Assert.Equal(0, evidence.UninspectableFontResourceCount);
+    }
+
+    [Fact]
     public void StructureInspectorBoundsIndirectFontResourceGraphTraversal() {
         const int firstObject = 5;
         const int lastObject = 40;

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfPrintProductionInspectorRegressionTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfPrintProductionInspectorRegressionTests.cs
@@ -497,15 +497,29 @@ public sealed class PdfPrintProductionInspectorRegressionTests {
         Assert.Equal(1, evidence.UninspectableContentStreamCount);
     }
 
-    [Theory]
-    [InlineData("")]
-    [InlineData("/Type /Pattern")]
-    public void ColorInspectorRejectsReachableXObjectsWithoutTheXObjectType(string typeEntry) {
+    [Fact]
+    public void ColorInspectorAcceptsReachableXObjectsWithoutTheOptionalType() {
         byte[] pdf = BuildInspectionPdf(
             "/Im1 Do",
             resources: "/XObject << /Im1 5 0 R >>",
             extraObjects:
-                "5 0 obj\n<< " + typeEntry + " /Subtype /Image /Width 1 /Height 1 " +
+                "5 0 obj\n<< /Subtype /Image /Width 1 /Height 1 " +
+                "/ColorSpace /DeviceCMYK /BitsPerComponent 8 /Length 4 >>\nstream\ncmyk\nendstream\nendobj\n");
+
+        PdfPrintProductionColorEvidence evidence = PdfReadDocument.Open(pdf).InspectPrintProductionColors();
+
+        Assert.True(evidence.IsComplete);
+        Assert.Equal(1, evidence.DeviceCmykImageCount);
+        Assert.Equal(0, evidence.UninspectableContentStreamCount);
+    }
+
+    [Fact]
+    public void ColorInspectorRejectsReachableXObjectsWithTheWrongType() {
+        byte[] pdf = BuildInspectionPdf(
+            "/Im1 Do",
+            resources: "/XObject << /Im1 5 0 R >>",
+            extraObjects:
+                "5 0 obj\n<< /Type /Pattern /Subtype /Image /Width 1 /Height 1 " +
                 "/ColorSpace /DeviceCMYK /BitsPerComponent 8 /Length 4 >>\nstream\ncmyk\nendstream\nendobj\n");
 
         PdfPrintProductionColorEvidence evidence = PdfReadDocument.Open(pdf).InspectPrintProductionColors();
@@ -543,7 +557,7 @@ public sealed class PdfPrintProductionInspectorRegressionTests {
                 "/ColorSpace << /PrintRgb /DeviceRGB >> " +
                 "/ExtGState << /GS1 << /SMask << /S /Luminosity /G 5 0 R >> >> >>",
             extraObjects:
-                "5 0 obj\n<< /Type /XObject /Subtype /Form /BBox [0 0 10 10] /Group << /S /Transparency /CS /DeviceRGB >> /Length " +
+                "5 0 obj\n<< /Subtype /Form /BBox [0 0 10 10] /Group << /S /Transparency /CS /DeviceRGB >> /Length " +
                 formContent.Length + " >>\nstream\n" + formContent + "\nendstream\nendobj\n");
 
         PdfPrintProductionColorEvidence evidence = PdfReadDocument.Open(pdf).InspectPrintProductionColors();
@@ -553,7 +567,7 @@ public sealed class PdfPrintProductionInspectorRegressionTests {
     }
 
     [Fact]
-    public void ColorInspectorRejectsSoftMaskFormsWithoutTheXObjectType() {
+    public void ColorInspectorRejectsSoftMaskFormsWithTheWrongXObjectType() {
         byte[] pdf = BuildInspectionPdf(
             "/GS1 gs",
             resources: "/ExtGState << /GS1 << /SMask << /S /Alpha /G 5 0 R >> >> >>",

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfPrintProductionInspectorRegressionTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfPrintProductionInspectorRegressionTests.cs
@@ -210,6 +210,18 @@ public sealed class PdfPrintProductionInspectorRegressionTests {
     }
 
     [Fact]
+    public void ColorInspectorRejectsPatternAsTheBaseOfAnUncoloredPatternColorSpace() {
+        byte[] pdf = BuildInspectionPdf(
+            "/CS1 cs /P1 scn",
+            resources: "/ColorSpace << /CS1 [/Pattern /Pattern] >>");
+
+        PdfPrintProductionColorEvidence evidence = PdfReadDocument.Open(pdf).InspectPrintProductionColors();
+
+        Assert.False(evidence.IsComplete);
+        Assert.Equal(1, evidence.UninspectableContentStreamCount);
+    }
+
+    [Fact]
     public void ColorInspectorRejectsUndersizedIndexedLookupPayload() {
         byte[] pdf = BuildInspectionPdf(
             "/CS1 cs 0 sc",
@@ -478,6 +490,23 @@ public sealed class PdfPrintProductionInspectorRegressionTests {
                 "5 0 obj\n<< /Type /XObject /Subtype /Form /BBox [0 0 10 10] /Length " +
                 formContent.Length +
                 " >>\nstream\n" + formContent + "\nendstream\nendobj\n");
+
+        PdfPrintProductionColorEvidence evidence = PdfReadDocument.Open(pdf).InspectPrintProductionColors();
+
+        Assert.False(evidence.IsComplete);
+        Assert.Equal(1, evidence.UninspectableContentStreamCount);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("/Type /Pattern")]
+    public void ColorInspectorRejectsReachableXObjectsWithoutTheXObjectType(string typeEntry) {
+        byte[] pdf = BuildInspectionPdf(
+            "/Im1 Do",
+            resources: "/XObject << /Im1 5 0 R >>",
+            extraObjects:
+                "5 0 obj\n<< " + typeEntry + " /Subtype /Image /Width 1 /Height 1 " +
+                "/ColorSpace /DeviceCMYK /BitsPerComponent 8 /Length 4 >>\nstream\ncmyk\nendstream\nendobj\n");
 
         PdfPrintProductionColorEvidence evidence = PdfReadDocument.Open(pdf).InspectPrintProductionColors();
 
@@ -1083,6 +1112,25 @@ public sealed class PdfPrintProductionInspectorRegressionTests {
             resources: "/Pattern << /P1 5 0 R >>",
             extraObjects:
                 "5 0 obj\n<< /Type /Pattern /PatternType 1 " + entries + " /Length " +
+                patternContent.Length + " >>\nstream\n" + patternContent + "\nendstream\nendobj\n");
+
+        PdfPrintProductionColorEvidence evidence = PdfReadDocument.Open(pdf).InspectPrintProductionColors();
+
+        Assert.False(evidence.IsComplete);
+        Assert.Equal(1, evidence.UninspectableContentStreamCount);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("/Type /XObject")]
+    public void ColorInspectorRejectsReachablePatternsWithoutThePatternType(string typeEntry) {
+        const string patternContent = "0 0 0 k";
+        byte[] pdf = BuildInspectionPdf(
+            "/Pattern cs /P1 scn",
+            resources: "/Pattern << /P1 5 0 R >>",
+            extraObjects:
+                "5 0 obj\n<< " + typeEntry + " /PatternType 1 /PaintType 1 /TilingType 1 " +
+                "/BBox [0 0 5 5] /XStep 5 /YStep 5 /Resources << >> /Length " +
                 patternContent.Length + " >>\nstream\n" + patternContent + "\nendstream\nendobj\n");
 
         PdfPrintProductionColorEvidence evidence = PdfReadDocument.Open(pdf).InspectPrintProductionColors();

--- a/OfficeIMO.Pdf/Compliance/PdfPrintProductionColorInspector.Resources.cs
+++ b/OfficeIMO.Pdf/Compliance/PdfPrintProductionColorInspector.Resources.cs
@@ -755,7 +755,21 @@ internal static partial class PdfPrintProductionColorInspector {
         int formDepth,
         Dictionary<int, PdfIndirectObject> objects,
         int maximumObjectDepth) {
-        if (!HasExactFiniteNumberArray(form, "BBox", 4, objects, maximumObjectDepth, out double[] bounds) ||
+        if (!string.Equals(
+                ResolveName(
+                    form.Items.TryGetValue("Type", out PdfObject? typeObject) ? typeObject : null,
+                    objects,
+                    maximumObjectDepth),
+                "XObject",
+                StringComparison.Ordinal) ||
+            !string.Equals(
+                ResolveName(
+                    form.Items.TryGetValue("Subtype", out PdfObject? subtypeObject) ? subtypeObject : null,
+                    objects,
+                    maximumObjectDepth),
+                "Form",
+                StringComparison.Ordinal) ||
+            !HasExactFiniteNumberArray(form, "BBox", 4, objects, maximumObjectDepth, out double[] bounds) ||
             bounds[2] < bounds[0] || bounds[3] < bounds[1] ||
             !HasOptionalExactFiniteNumberArray(form, "Matrix", 6, objects, maximumObjectDepth)) {
             return false;

--- a/OfficeIMO.Pdf/Compliance/PdfPrintProductionColorInspector.Resources.cs
+++ b/OfficeIMO.Pdf/Compliance/PdfPrintProductionColorInspector.Resources.cs
@@ -667,7 +667,7 @@ internal static partial class PdfPrintProductionColorInspector {
                 patternDepth + 1,
                 limits.MaxObjectNestingDepth) is not PdfNumber patternType) return false;
         if (patternType.Value == 1D && resolved is PdfStream tilingPattern) {
-            if (!IsStructurallyValidTilingPattern(
+            if (!IsStructurallyValidTilingPatternResource(
                     tilingPattern.Dictionary,
                     patternDepth,
                     objects,
@@ -746,6 +746,22 @@ internal static partial class PdfPrintProductionColorInspector {
         }
 
         return true;
+    }
+
+    internal static bool IsStructurallyValidTilingPatternResource(
+        PdfDictionary pattern,
+        int patternDepth,
+        Dictionary<int, PdfIndirectObject> objects,
+        int maximumObjectDepth) {
+        return string.Equals(
+                ResolveName(
+                    pattern.Items.TryGetValue("Type", out PdfObject? typeObject) ? typeObject : null,
+                    objects,
+                    maximumObjectDepth),
+                "Pattern",
+                StringComparison.Ordinal) &&
+            TryResolveInteger(pattern, "PatternType", objects, maximumObjectDepth, 1, 1, out _) &&
+            IsStructurallyValidTilingPattern(pattern, patternDepth, objects, maximumObjectDepth);
     }
 
     internal static bool IsStructurallyValidFormXObject(

--- a/OfficeIMO.Pdf/Compliance/PdfPrintProductionColorInspector.Resources.cs
+++ b/OfficeIMO.Pdf/Compliance/PdfPrintProductionColorInspector.Resources.cs
@@ -179,19 +179,17 @@ internal static partial class PdfPrintProductionColorInspector {
                                     contextWasUninspectable = true;
                                     break;
                                 }
-                                string? type = ResolveName(
-                                    xObjectStream.Dictionary.Items.TryGetValue("Type", out PdfObject? typeObject)
-                                        ? typeObject
-                                        : null,
-                                    objects,
-                                    limits.MaxObjectNestingDepth);
                                 string? subtype = ResolveName(
                                     xObjectStream.Dictionary.Items.TryGetValue("Subtype", out PdfObject? subtypeObject)
                                         ? subtypeObject
                                         : null,
                                     objects,
                                     limits.MaxObjectNestingDepth);
-                                if (!string.Equals(type, "XObject", StringComparison.Ordinal)) {
+                                if (!HasValidOptionalDictionaryType(
+                                        xObjectStream.Dictionary,
+                                        "XObject",
+                                        objects,
+                                        limits.MaxObjectNestingDepth)) {
                                     contextWasUninspectable = true;
                                 } else if (string.Equals(subtype, "Image", StringComparison.Ordinal)) {
                                     AddImageContext(xObjectStream, context.Aliases, images);
@@ -755,13 +753,7 @@ internal static partial class PdfPrintProductionColorInspector {
         int formDepth,
         Dictionary<int, PdfIndirectObject> objects,
         int maximumObjectDepth) {
-        if (!string.Equals(
-                ResolveName(
-                    form.Items.TryGetValue("Type", out PdfObject? typeObject) ? typeObject : null,
-                    objects,
-                    maximumObjectDepth),
-                "XObject",
-                StringComparison.Ordinal) ||
+        if (!HasValidOptionalDictionaryType(form, "XObject", objects, maximumObjectDepth) ||
             !string.Equals(
                 ResolveName(
                     form.Items.TryGetValue("Subtype", out PdfObject? subtypeObject) ? subtypeObject : null,
@@ -782,6 +774,19 @@ internal static partial class PdfPrintProductionColorInspector {
 
         return !form.Items.TryGetValue("Resources", out PdfObject? resourcesObject) ||
             ResolveObject(objects, resourcesObject, formDepth + 1, maximumObjectDepth, out _) is PdfNull or PdfDictionary;
+    }
+
+    private static bool HasValidOptionalDictionaryType(
+        PdfDictionary dictionary,
+        string expectedType,
+        Dictionary<int, PdfIndirectObject> objects,
+        int maximumObjectDepth) {
+        if (!dictionary.Items.TryGetValue("Type", out PdfObject? typeObject)) return true;
+        if (ResolveObject(objects, typeObject, 0, maximumObjectDepth) is PdfNull) return true;
+        return string.Equals(
+            ResolveName(typeObject, objects, maximumObjectDepth),
+            expectedType,
+            StringComparison.Ordinal);
     }
 
     private static bool TryAddShownType3CharProcs(

--- a/OfficeIMO.Pdf/Compliance/PdfPrintProductionColorInspector.Resources.cs
+++ b/OfficeIMO.Pdf/Compliance/PdfPrintProductionColorInspector.Resources.cs
@@ -179,13 +179,21 @@ internal static partial class PdfPrintProductionColorInspector {
                                     contextWasUninspectable = true;
                                     break;
                                 }
+                                string? type = ResolveName(
+                                    xObjectStream.Dictionary.Items.TryGetValue("Type", out PdfObject? typeObject)
+                                        ? typeObject
+                                        : null,
+                                    objects,
+                                    limits.MaxObjectNestingDepth);
                                 string? subtype = ResolveName(
                                     xObjectStream.Dictionary.Items.TryGetValue("Subtype", out PdfObject? subtypeObject)
                                         ? subtypeObject
                                         : null,
                                     objects,
                                     limits.MaxObjectNestingDepth);
-                                if (string.Equals(subtype, "Image", StringComparison.Ordinal)) {
+                                if (!string.Equals(type, "XObject", StringComparison.Ordinal)) {
+                                    contextWasUninspectable = true;
+                                } else if (string.Equals(subtype, "Image", StringComparison.Ordinal)) {
                                     AddImageContext(xObjectStream, context.Aliases, images);
                                 } else if (!string.Equals(subtype, "Form", StringComparison.Ordinal) ||
                                     !IsStructurallyValidFormXObject(
@@ -648,6 +656,12 @@ internal static partial class PdfPrintProductionColorInspector {
             _ => null
         };
         if (pattern == null ||
+            !pattern.Items.TryGetValue("Type", out PdfObject? patternObjectType) ||
+            ResolveName(
+                patternObjectType,
+                objects,
+                limits.MaxObjectNestingDepth) is not string resolvedPatternType ||
+            !string.Equals(resolvedPatternType, "Pattern", StringComparison.Ordinal) ||
             !pattern.Items.TryGetValue("PatternType", out PdfObject? patternTypeObject) ||
             ResolveObject(
                 objects,

--- a/OfficeIMO.Pdf/Compliance/PdfPrintProductionColorInspector.Resources.cs
+++ b/OfficeIMO.Pdf/Compliance/PdfPrintProductionColorInspector.Resources.cs
@@ -764,6 +764,40 @@ internal static partial class PdfPrintProductionColorInspector {
             IsStructurallyValidTilingPattern(pattern, patternDepth, objects, maximumObjectDepth);
     }
 
+    internal static bool IsStructurallyValidShadingPatternResource(
+        PdfDictionary pattern,
+        int patternDepth,
+        Dictionary<int, PdfIndirectObject> objects,
+        int maximumObjectDepth,
+        out PdfObject? graphicsStateObject) {
+        graphicsStateObject = null;
+        if (!string.Equals(
+                ResolveName(
+                    pattern.Items.TryGetValue("Type", out PdfObject? typeObject) ? typeObject : null,
+                    objects,
+                    maximumObjectDepth),
+                "Pattern",
+                StringComparison.Ordinal) ||
+            !TryResolveInteger(pattern, "PatternType", objects, maximumObjectDepth, 2, 2, out _) ||
+            !pattern.Items.TryGetValue("Shading", out PdfObject? shadingObject) ||
+            ResolveObject(objects, shadingObject, patternDepth + 1, maximumObjectDepth) is not (PdfDictionary or PdfStream) ||
+            !HasOptionalExactFiniteNumberArray(pattern, "Matrix", 6, objects, maximumObjectDepth)) {
+            return false;
+        }
+
+        if (!pattern.Items.TryGetValue("ExtGState", out graphicsStateObject)) return true;
+        PdfObject? resolvedGraphicsState = ResolveObject(
+            objects,
+            graphicsStateObject,
+            patternDepth + 1,
+            maximumObjectDepth);
+        if (resolvedGraphicsState is PdfNull) {
+            graphicsStateObject = null;
+            return true;
+        }
+        return resolvedGraphicsState is PdfDictionary;
+    }
+
     internal static bool IsStructurallyValidFormXObject(
         PdfDictionary form,
         int formDepth,

--- a/OfficeIMO.Pdf/Compliance/PdfPrintProductionColorInspector.cs
+++ b/OfficeIMO.Pdf/Compliance/PdfPrintProductionColorInspector.cs
@@ -899,7 +899,9 @@ internal static partial class PdfPrintProductionColorInspector {
                     ColorSpaceUsage baseUsage = ClassifyColorSpaceCore(
                         array.Items[1], objects, maximumObjectDepth, maximumDecodedStreamBytes, aliases, normalizeInlineImageAbbreviations,
                         activeArrays, resolvedDepth + 1);
-                    return baseUsage.IsKnown ? baseUsage.WithPattern() : ColorSpaceUsage.Unknown;
+                    return baseUsage.IsKnown && !baseUsage.UsesPattern
+                        ? baseUsage.WithPattern()
+                        : ColorSpaceUsage.Unknown;
                 default:
                     return ColorSpaceUsage.Unknown;
             }

--- a/OfficeIMO.Pdf/Compliance/PdfPrintProductionStructureInspector.FontUsage.cs
+++ b/OfficeIMO.Pdf/Compliance/PdfPrintProductionStructureInspector.FontUsage.cs
@@ -172,7 +172,9 @@ internal static partial class PdfPrintProductionStructureInspector {
                         case "scn":
                         case "SCN":
                             if (operation.Operands.Count > 0 && operation.Operands[operation.Operands.Count - 1] is string patternName) {
-                                AddPatternContent(patternName, context.Resources, context.ContentDepth + 1, activeFontObject);
+                                if (!AddPatternContent(patternName, context.Resources, context.ContentDepth + 1, activeFontObject)) {
+                                    contextWasUninspectable = true;
+                                }
                             }
                             break;
                         case "Tj":
@@ -211,18 +213,16 @@ internal static partial class PdfPrintProductionStructureInspector {
             _fonts.Add(font);
         }
 
-        private void AddPatternContent(string name, PdfDictionary? resources, int contentDepth, PdfObject? selectedFontObject) {
+        private bool AddPatternContent(string name, PdfDictionary? resources, int contentDepth, PdfObject? selectedFontObject) {
             if (!TryResolveResource(resources, "Pattern", name, out PdfObject? patternObject) ||
-                ResolveObject(_objects, patternObject, 0, _limits.MaxObjectNestingDepth, out _) is not PdfStream pattern) return;
-            PdfObject? patternType = ResolveObject(
-                _objects,
-                pattern.Dictionary.Items.TryGetValue("PatternType", out PdfObject? value) ? value : null,
-                0,
-                _limits.MaxObjectNestingDepth,
-                out _);
-            if (patternType is PdfNumber { Value: 1D }) {
-                AddStream(pattern, ResolveStreamResources(pattern, resources), contentDepth, selectedFontObject);
-            }
+                ResolveObject(_objects, patternObject, 0, _limits.MaxObjectNestingDepth, out int patternDepth) is not PdfStream pattern ||
+                !PdfPrintProductionColorInspector.IsStructurallyValidTilingPatternResource(
+                    pattern.Dictionary,
+                    patternDepth,
+                    _objects,
+                    _limits.MaxObjectNestingDepth)) return false;
+            AddStream(pattern, ResolveStreamResources(pattern, resources), contentDepth, selectedFontObject);
+            return true;
         }
 
         private bool AddSoftMaskContent(PdfObject graphicsStateObject, PdfDictionary? resources, int contentDepth, PdfObject? selectedFontObject) {

--- a/OfficeIMO.Pdf/Compliance/PdfPrintProductionStructureInspector.FontUsage.cs
+++ b/OfficeIMO.Pdf/Compliance/PdfPrintProductionStructureInspector.FontUsage.cs
@@ -215,14 +215,33 @@ internal static partial class PdfPrintProductionStructureInspector {
 
         private bool AddPatternContent(string name, PdfDictionary? resources, int contentDepth, PdfObject? selectedFontObject) {
             if (!TryResolveResource(resources, "Pattern", name, out PdfObject? patternObject) ||
-                ResolveObject(_objects, patternObject, 0, _limits.MaxObjectNestingDepth, out int patternDepth) is not PdfStream pattern ||
-                !PdfPrintProductionColorInspector.IsStructurallyValidTilingPatternResource(
-                    pattern.Dictionary,
+                ResolveObject(_objects, patternObject, 0, _limits.MaxObjectNestingDepth, out int patternDepth) is not PdfObject resolved) {
+                return false;
+            }
+            if (resolved is PdfStream tilingPattern &&
+                PdfPrintProductionColorInspector.IsStructurallyValidTilingPatternResource(
+                    tilingPattern.Dictionary,
                     patternDepth,
                     _objects,
-                    _limits.MaxObjectNestingDepth)) return false;
-            AddStream(pattern, ResolveStreamResources(pattern, resources), contentDepth, selectedFontObject);
-            return true;
+                    _limits.MaxObjectNestingDepth)) {
+                AddStream(tilingPattern, ResolveStreamResources(tilingPattern, resources), contentDepth, selectedFontObject);
+                return true;
+            }
+
+            PdfDictionary? shadingPattern = resolved switch {
+                PdfDictionary dictionary => dictionary,
+                PdfStream stream => stream.Dictionary,
+                _ => null
+            };
+            if (shadingPattern == null ||
+                !PdfPrintProductionColorInspector.IsStructurallyValidShadingPatternResource(
+                    shadingPattern,
+                    patternDepth,
+                    _objects,
+                    _limits.MaxObjectNestingDepth,
+                    out PdfObject? graphicsStateObject)) return false;
+            return graphicsStateObject == null ||
+                AddSoftMaskContent(graphicsStateObject, resources, contentDepth, selectedFontObject);
         }
 
         private bool AddSoftMaskContent(PdfObject graphicsStateObject, PdfDictionary? resources, int contentDepth, PdfObject? selectedFontObject) {

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfPageDictionaryBuilder.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfPageDictionaryBuilder.cs
@@ -19,14 +19,17 @@ internal static class PdfPageDictionaryBuilder {
         PdfPrintProductionPageBoxes? printProductionPageBoxes = null) {
         ValidatePositiveFinite(pageWidth, nameof(pageWidth));
         ValidatePositiveFinite(pageHeight, nameof(pageHeight));
+        string serializedPageWidth = FormatNumber(pageWidth);
+        string serializedPageHeight = FormatNumber(pageHeight);
+        ValidateSerializedBox("MediaBox", "0", "0", serializedPageWidth, serializedPageHeight);
 
         var sb = new StringBuilder();
         sb.Append("<< /Type /Page /Parent ")
             .Append(PdfSyntaxEscaper.IndirectReference(parentPagesId))
             .Append(" /MediaBox [0 0 ")
-            .Append(FormatNumber(pageWidth))
+            .Append(serializedPageWidth)
             .Append(' ')
-            .Append(FormatNumber(pageHeight))
+            .Append(serializedPageHeight)
             .Append(']');
 
         if (printProductionPageBoxes != null) {
@@ -117,15 +120,36 @@ internal static class PdfPageDictionaryBuilder {
     }
 
     private static void AppendBox(StringBuilder sb, string name, double left, double bottom, double right, double top) {
+        string serializedLeft = FormatNumber(left);
+        string serializedBottom = FormatNumber(bottom);
+        string serializedRight = FormatNumber(right);
+        string serializedTop = FormatNumber(top);
+        ValidateSerializedBox(name, serializedLeft, serializedBottom, serializedRight, serializedTop);
         sb.Append(" /").Append(name).Append(" [")
-            .Append(FormatNumber(left)).Append(' ')
-            .Append(FormatNumber(bottom)).Append(' ')
-            .Append(FormatNumber(right)).Append(' ')
-            .Append(FormatNumber(top)).Append(']');
+            .Append(serializedLeft).Append(' ')
+            .Append(serializedBottom).Append(' ')
+            .Append(serializedRight).Append(' ')
+            .Append(serializedTop).Append(']');
     }
 
     private static string FormatNumber(double value) =>
         value.ToString("0.###", CultureInfo.InvariantCulture);
+
+    private static void ValidateSerializedBox(
+        string name,
+        string left,
+        string bottom,
+        string right,
+        string top) {
+        double serializedLeft = double.Parse(left, CultureInfo.InvariantCulture);
+        double serializedBottom = double.Parse(bottom, CultureInfo.InvariantCulture);
+        double serializedRight = double.Parse(right, CultureInfo.InvariantCulture);
+        double serializedTop = double.Parse(top, CultureInfo.InvariantCulture);
+        if (serializedRight <= serializedLeft || serializedTop <= serializedBottom) {
+            throw new InvalidOperationException(
+                "PDF " + name + " coordinates must retain positive width and height after serialization.");
+        }
+    }
 
     private static void ValidatePositiveFinite(double value, string paramName) {
         if (double.IsNaN(value) || double.IsInfinity(value) || value <= 0) {

--- a/OfficeIMO.TestAssets/ManagedTextShapingTestAssets.cs
+++ b/OfficeIMO.TestAssets/ManagedTextShapingTestAssets.cs
@@ -79,6 +79,21 @@ internal static class ManagedTextShapingTestAssets {
             variationPlatform: 3,
             variationEncoding: 10));
 
+    internal static byte[] CreateFontWithLargeNonDefaultVariationSequence(int scalar, int variationSelector) {
+        const int mappingCount = 4097;
+        if (scalar < mappingCount - 1) throw new ArgumentOutOfRangeException(nameof(scalar));
+        return CreateFontFromCmap(
+            CreateUnicodeCmapWithVariationSequence(
+                scalar,
+                variationSelector,
+                nonDefaultGlyph: 2,
+                variationPlatform: 0,
+                variationEncoding: 5,
+                nonDefaultMappingCount: mappingCount),
+            glyphCount: 3,
+            distinctSecondGlyph: true);
+    }
+
     private static byte[] CreateFontFromCmap(
         byte[] cmap,
         bool includeTrailingMetric = false,
@@ -278,10 +293,12 @@ internal static class ManagedTextShapingTestAssets {
         int variationSelector,
         int? nonDefaultGlyph,
         int variationPlatform,
-        int variationEncoding) {
+        int variationEncoding,
+        int nonDefaultMappingCount = 1) {
         const int cmapHeaderLength = 20;
         const int format12Length = 28;
-        int format14Length = nonDefaultGlyph.HasValue ? 30 : 29;
+        if (nonDefaultMappingCount <= 0) throw new ArgumentOutOfRangeException(nameof(nonDefaultMappingCount));
+        int format14Length = nonDefaultGlyph.HasValue ? checked(25 + nonDefaultMappingCount * 5) : 29;
         int format12 = cmapHeaderLength;
         int format14 = format12 + format12Length;
         var data = new byte[cmapHeaderLength + format12Length + format14Length];
@@ -307,11 +324,16 @@ internal static class ManagedTextShapingTestAssets {
         WriteUInt24(data, format14 + 10, variationSelector);
         WriteUInt32(data, format14 + 13, nonDefaultGlyph.HasValue ? 0U : 21U);
         WriteUInt32(data, format14 + 17, nonDefaultGlyph.HasValue ? 21U : 0U);
-        WriteUInt32(data, format14 + 21, 1);
-        WriteUInt24(data, format14 + 25, scalar);
+        WriteUInt32(data, format14 + 21, nonDefaultGlyph.HasValue ? checked((uint)nonDefaultMappingCount) : 1U);
         if (nonDefaultGlyph.HasValue) {
-            WriteUInt16(data, format14 + 28, checked((ushort)nonDefaultGlyph.Value));
+            int firstScalar = checked(scalar - nonDefaultMappingCount + 1);
+            for (int index = 0; index < nonDefaultMappingCount; index++) {
+                int mapping = format14 + 25 + index * 5;
+                WriteUInt24(data, mapping, firstScalar + index);
+                WriteUInt16(data, mapping + 3, checked((ushort)nonDefaultGlyph.Value));
+            }
         } else {
+            WriteUInt24(data, format14 + 25, scalar);
             data[format14 + 28] = 0;
         }
         return data;

--- a/OfficeIMO.TestAssets/ManagedTextShapingTestAssets.cs
+++ b/OfficeIMO.TestAssets/ManagedTextShapingTestAssets.cs
@@ -42,6 +42,14 @@ internal static class ManagedTextShapingTestAssets {
             glyphCount: 3);
     }
 
+    internal static byte[] CreateFontWithVariationSequence(int scalar, int variationSelector) {
+        if (scalar < 0 || scalar > 0x10FFFF) throw new ArgumentOutOfRangeException(nameof(scalar));
+        if (variationSelector < 0xFE00 || variationSelector > 0xFE0F) {
+            throw new ArgumentOutOfRangeException(nameof(variationSelector));
+        }
+        return CreateFontFromCmap(CreateUnicodeCmapWithVariationSequence(scalar, variationSelector));
+    }
+
     private static byte[] CreateFontFromCmap(
         byte[] cmap,
         bool includeTrailingMetric = false,
@@ -234,6 +242,41 @@ internal static class ManagedTextShapingTestAssets {
         return data;
     }
 
+    private static byte[] CreateUnicodeCmapWithVariationSequence(int scalar, int variationSelector) {
+        const int cmapHeaderLength = 20;
+        const int format12Length = 28;
+        const int format14Length = 30;
+        int format12 = cmapHeaderLength;
+        int format14 = format12 + format12Length;
+        var data = new byte[cmapHeaderLength + format12Length + format14Length];
+        WriteUInt16(data, 2, 2);
+
+        WriteUInt16(data, 4, 3);
+        WriteUInt16(data, 6, 10);
+        WriteUInt32(data, 8, (uint)format12);
+        WriteUInt16(data, 12, 0);
+        WriteUInt16(data, 14, 5);
+        WriteUInt32(data, 16, (uint)format14);
+
+        WriteUInt16(data, format12, 12);
+        WriteUInt32(data, format12 + 4, format12Length);
+        WriteUInt32(data, format12 + 12, 1);
+        WriteUInt32(data, format12 + 16, checked((uint)scalar));
+        WriteUInt32(data, format12 + 20, checked((uint)scalar));
+        WriteUInt32(data, format12 + 24, 1);
+
+        WriteUInt16(data, format14, 14);
+        WriteUInt32(data, format14 + 2, format14Length);
+        WriteUInt32(data, format14 + 6, 1);
+        WriteUInt24(data, format14 + 10, variationSelector);
+        WriteUInt32(data, format14 + 13, 0);
+        WriteUInt32(data, format14 + 17, 21);
+        WriteUInt32(data, format14 + 21, 1);
+        WriteUInt24(data, format14 + 25, scalar);
+        WriteUInt16(data, format14 + 28, 1);
+        return data;
+    }
+
     private static byte[] CreateFormat12Cmap(
         int firstScalar,
         int firstGlyph,
@@ -403,6 +446,12 @@ internal static class ManagedTextShapingTestAssets {
     private static void WriteUInt16(byte[] data, int offset, ushort value) {
         data[offset] = (byte)(value >> 8);
         data[offset + 1] = (byte)value;
+    }
+
+    private static void WriteUInt24(byte[] data, int offset, int value) {
+        data[offset] = (byte)(value >> 16);
+        data[offset + 1] = (byte)(value >> 8);
+        data[offset + 2] = (byte)value;
     }
 
     private static void WriteUInt32(byte[] data, int offset, uint value) {

--- a/OfficeIMO.TestAssets/ManagedTextShapingTestAssets.cs
+++ b/OfficeIMO.TestAssets/ManagedTextShapingTestAssets.cs
@@ -67,7 +67,8 @@ internal static class ManagedTextShapingTestAssets {
                 nonDefaultGlyph: 2,
                 variationPlatform: 0,
                 variationEncoding: 5),
-            glyphCount: 3);
+            glyphCount: 3,
+            distinctSecondGlyph: true);
     }
 
     internal static byte[] CreateFontWithMistypedVariationSequenceRecord(int scalar, int variationSelector) =>
@@ -82,14 +83,16 @@ internal static class ManagedTextShapingTestAssets {
         byte[] cmap,
         bool includeTrailingMetric = false,
         int glyphCount = 2,
-        byte[]? kern = null) {
-        byte[] glyph = CreateVisibleGlyph();
+        byte[]? kern = null,
+        bool distinctSecondGlyph = false) {
+        byte[] glyph = CreateVisibleGlyph(400);
         var glyf = new byte[(glyphCount - 1) * glyph.Length];
         var loca = new byte[(glyphCount + 1) * 2];
         var hmtx = new byte[4 + (glyphCount - 1) * 2];
         Array.Copy(new byte[] { 0x01, 0xF4, 0x00, 0x00 }, hmtx, 4);
         for (int glyphIndex = 1; glyphIndex < glyphCount; glyphIndex++) {
-            Array.Copy(glyph, 0, glyf, (glyphIndex - 1) * glyph.Length, glyph.Length);
+            byte[] currentGlyph = distinctSecondGlyph && glyphIndex == 2 ? CreateVisibleGlyph(600) : glyph;
+            Array.Copy(currentGlyph, 0, glyf, (glyphIndex - 1) * glyph.Length, glyph.Length);
             WriteUInt16(loca, (glyphIndex + 1) * 2, checked((ushort)(glyphIndex * glyph.Length / 2)));
         }
         if (!includeTrailingMetric && glyphCount == 2) hmtx = new byte[] { 0x01, 0xF4, 0x00, 0x00 };
@@ -433,18 +436,18 @@ internal static class ManagedTextShapingTestAssets {
         WriteUInt16(data, offset + 26, 1);
     }
 
-    private static byte[] CreateVisibleGlyph() {
+    private static byte[] CreateVisibleGlyph(int width) {
         var glyph = new byte[34];
         WriteUInt16(glyph, 0, 1);
-        WriteUInt16(glyph, 6, 400);
+        WriteUInt16(glyph, 6, checked((ushort)width));
         WriteUInt16(glyph, 8, 700);
         WriteUInt16(glyph, 10, 3);
         glyph[14] = 0x01;
         glyph[15] = 0x01;
         glyph[16] = 0x01;
         glyph[17] = 0x01;
-        WriteUInt16(glyph, 20, 400);
-        WriteUInt16(glyph, 24, unchecked((ushort)-400));
+        WriteUInt16(glyph, 20, checked((ushort)width));
+        WriteUInt16(glyph, 24, unchecked((ushort)-width));
         WriteUInt16(glyph, 30, 700);
         return glyph;
     }

--- a/OfficeIMO.TestAssets/ManagedTextShapingTestAssets.cs
+++ b/OfficeIMO.TestAssets/ManagedTextShapingTestAssets.cs
@@ -47,8 +47,36 @@ internal static class ManagedTextShapingTestAssets {
         if (variationSelector < 0xFE00 || variationSelector > 0xFE0F) {
             throw new ArgumentOutOfRangeException(nameof(variationSelector));
         }
-        return CreateFontFromCmap(CreateUnicodeCmapWithVariationSequence(scalar, variationSelector));
+        return CreateFontFromCmap(CreateUnicodeCmapWithVariationSequence(
+            scalar,
+            variationSelector,
+            nonDefaultGlyph: null,
+            variationPlatform: 0,
+            variationEncoding: 5));
     }
+
+    internal static byte[] CreateFontWithNonDefaultVariationSequence(int scalar, int variationSelector) {
+        if (scalar < 0 || scalar > 0x10FFFF) throw new ArgumentOutOfRangeException(nameof(scalar));
+        if (variationSelector < 0xFE00 || variationSelector > 0xFE0F) {
+            throw new ArgumentOutOfRangeException(nameof(variationSelector));
+        }
+        return CreateFontFromCmap(
+            CreateUnicodeCmapWithVariationSequence(
+                scalar,
+                variationSelector,
+                nonDefaultGlyph: 2,
+                variationPlatform: 0,
+                variationEncoding: 5),
+            glyphCount: 3);
+    }
+
+    internal static byte[] CreateFontWithMistypedVariationSequenceRecord(int scalar, int variationSelector) =>
+        CreateFontFromCmap(CreateUnicodeCmapWithVariationSequence(
+            scalar,
+            variationSelector,
+            nonDefaultGlyph: null,
+            variationPlatform: 3,
+            variationEncoding: 10));
 
     private static byte[] CreateFontFromCmap(
         byte[] cmap,
@@ -242,10 +270,15 @@ internal static class ManagedTextShapingTestAssets {
         return data;
     }
 
-    private static byte[] CreateUnicodeCmapWithVariationSequence(int scalar, int variationSelector) {
+    private static byte[] CreateUnicodeCmapWithVariationSequence(
+        int scalar,
+        int variationSelector,
+        int? nonDefaultGlyph,
+        int variationPlatform,
+        int variationEncoding) {
         const int cmapHeaderLength = 20;
         const int format12Length = 28;
-        const int format14Length = 30;
+        int format14Length = nonDefaultGlyph.HasValue ? 30 : 29;
         int format12 = cmapHeaderLength;
         int format14 = format12 + format12Length;
         var data = new byte[cmapHeaderLength + format12Length + format14Length];
@@ -254,8 +287,8 @@ internal static class ManagedTextShapingTestAssets {
         WriteUInt16(data, 4, 3);
         WriteUInt16(data, 6, 10);
         WriteUInt32(data, 8, (uint)format12);
-        WriteUInt16(data, 12, 0);
-        WriteUInt16(data, 14, 5);
+        WriteUInt16(data, 12, checked((ushort)variationPlatform));
+        WriteUInt16(data, 14, checked((ushort)variationEncoding));
         WriteUInt32(data, 16, (uint)format14);
 
         WriteUInt16(data, format12, 12);
@@ -266,14 +299,18 @@ internal static class ManagedTextShapingTestAssets {
         WriteUInt32(data, format12 + 24, 1);
 
         WriteUInt16(data, format14, 14);
-        WriteUInt32(data, format14 + 2, format14Length);
+        WriteUInt32(data, format14 + 2, (uint)format14Length);
         WriteUInt32(data, format14 + 6, 1);
         WriteUInt24(data, format14 + 10, variationSelector);
-        WriteUInt32(data, format14 + 13, 0);
-        WriteUInt32(data, format14 + 17, 21);
+        WriteUInt32(data, format14 + 13, nonDefaultGlyph.HasValue ? 0U : 21U);
+        WriteUInt32(data, format14 + 17, nonDefaultGlyph.HasValue ? 21U : 0U);
         WriteUInt32(data, format14 + 21, 1);
         WriteUInt24(data, format14 + 25, scalar);
-        WriteUInt16(data, format14 + 28, 1);
+        if (nonDefaultGlyph.HasValue) {
+            WriteUInt16(data, format14 + 28, checked((ushort)nonDefaultGlyph.Value));
+        } else {
+            data[format14 + 28] = 0;
+        }
         return data;
     }
 


### PR DESCRIPTION
## Summary

This focused follow-up to #2394 closes the remaining production-validation findings without reopening the broader HTML-to-PDF scope.

- select fallback font faces using complete OpenType variation-sequence coverage, including large bounded tables
- map non-default UVS records to their actual managed TrueType/CFF glyphs while retaining matching faces for external shapers and ignoring detached selectors
- reject recursive Pattern base color spaces and explicitly mistyped reachable XObject/Pattern resources consistently across color and font traversal, while accepting optional omitted XObject types and valid shading-pattern dictionaries
- reject page boxes that lose positive area when serialized at PDF coordinate precision

## Validation

- 19 focused Drawing/font coverage tests on net472, net8.0, and net10.0
- 11 focused PDF production and page-dictionary tests on net472, net8.0, and net10.0
- hosted typography failure reproduced locally; the exact failing TrueType/CFF ignorable-control contracts pass on net8.0 and net10.0