### PR TITLE
Scope HTML/PDF compliance proof to opted-in releases

### DIFF
--- a/Build/Build-Project.ps1
+++ b/Build/Build-Project.ps1
@@ -2,17 +2,18 @@ param(
     [string] $ConfigPath = "$PSScriptRoot\project.build.json",
     [Nullable[bool]] $UpdateVersions,
     [Nullable[bool]] $Build,
-    [Nullable[bool]] $PublishNuget =$false,
+    [Nullable[bool]] $PublishNuget = $false,
     [Nullable[bool]] $PublishGitHub = $false,
     [Nullable[bool]] $Plan,
     [string] $PlanPath,
+    [bool] $RequireHtmlPdfReleaseProof = $false,
     [string] $PdfComplianceProofPath = $env:OFFICEIMO_PDF_COMPLIANCE_PROOF_PATH
 )
 
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
-if (($PublishNuget -eq $true -or $PublishGitHub -eq $true) -and $Plan -ne $true) {
+if ($RequireHtmlPdfReleaseProof -and $Plan -ne $true) {
     & "$PSScriptRoot/Test-HtmlPdfReleaseGate.ps1" -PdfComplianceProofPath $PdfComplianceProofPath
 }
 


### PR DESCRIPTION
## Summary

OfficeIMO's project build no longer requires HTML/PDF exact-artifact compliance proof for every NuGet or GitHub publication.

Releases that specifically require the HTML/PDF compliance gate can opt in with:

```powershell
./Build/Build-Project.ps1 -RequireHtmlPdfReleaseProof $true -PdfComplianceProofPath <path>
```

The existing `OFFICEIMO_PDF_COMPLIANCE_PROOF_PATH` fallback and fail-closed validation remain unchanged when the gate is enabled.

## Why

The HTML/PDF gate was wired to the generic `PublishNuget` and `PublishGitHub` switches. That made missing PDF/X evidence block every repository release, including releases unrelated to the HTML/PDF compliance claim.

This PR keeps the specialized gate available while making its policy explicit at the release entry point.

## Validation

- `Build/Build-Project.ps1` parses without PowerShell syntax errors.
- A stubbed NuGet publish reaches `Invoke-ProjectBuild` without proof when the new switch is not enabled; no package was published during validation.
- Enabling `-RequireHtmlPdfReleaseProof $true` without a proof path still fails closed with the existing release-blocking error.

The separate shared-engine performance fix is EvotecIT/PSPublishModule#859. This OfficeIMO policy fix can merge independently; the planning speed improvement requires that PowerForge change to be merged and released before normal consumers receive it.
