### PR TITLE
Add cross-format provenance workflows

### DIFF
--- a/Docs/officeimo.provenance-support-matrix.md
+++ b/Docs/officeimo.provenance-support-matrix.md
@@ -34,6 +34,8 @@ Structural inspection reports whether the carrier shape is safe to interpret or 
 
 `IOfficeProvenanceSignalDetector` is the extension point for vendor-specific watermark and disclosure services. Each result retains the provider name, signal type, and `Detected`, `NotDetected`, `Inconclusive`, `ProviderUnavailable`, or `Error` status. `OfficeProvenanceAssessment` combines those results with structural, verification, and Unicode evidence without producing an `IsAi` property.
 
+Providers can opt into cooperative cancellation through `ICancellableOfficeProvenanceSignalDetector` and `ICancellableOfficeProvenanceVerifier`. The original interfaces remain supported, so existing provider implementations do not need to change.
+
 ## Transformation and authoring
 
 `OfficeProvenanceLifecycle` compares the source and candidate bytes before commit. Its default `PreserveIfUnchanged` policy blocks changed output when the source has an embedded or external Content Credential. `RemoveInvalidated` records before/after evidence; `SignAsDerived` requires an `IOfficeProvenanceSigner`, signs immutable snapshots of the inspected source and candidate, and always passes the source snapshot as the parent ingredient. The lifecycle independently checks provider identity, output location, file existence, and actual committed structural evidence.

--- a/Docs/officeimo.provenance-support-matrix.md
+++ b/Docs/officeimo.provenance-support-matrix.md
@@ -77,6 +77,7 @@ Provider-backed verification and signal detection are dependency-injected workfl
 - OfficeIMO does not alter visible pixels, reconstruct images, suppress durable media watermarks, or rewrite generated text to defeat statistical watermarking.
 - OfficeIMO does not ship vendor detector credentials or private APIs. Applications can add authorized detectors through `IOfficeProvenanceSignalDetector`.
 - Strict removal preserves duplicate, competing, malformed, unsupported, signed, or structurally shared carriers when a targeted rewrite could discard unrelated data.
+- Provider-backed HTML assessment snapshots local relative external manifests. An absolute `file:` base is rejected before providers run because the unchanged snapshot would otherwise resolve that dependency back to mutable source storage.
 - Resource limits are configurable through `OfficeProvenanceOptions` and `OfficeProvenanceRemovalOptions`; inputs that exceed them are rejected instead of partially inspected.
 - Cryptographic signing and verification currently depend on the external `c2patool` adapter. Core inspection, assessment, lifecycle policy, text integrity, and removal remain dependency-free.
 - Unix process containment requires `setsid` from `util-linux`. The adapter recognizes standard Linux paths and Homebrew's macOS keg paths, and fails closed before launching `c2patool` when a session launcher is unavailable.

--- a/Docs/officeimo.provenance-support-matrix.md
+++ b/Docs/officeimo.provenance-support-matrix.md
@@ -46,6 +46,16 @@ For signed Office, OpenDocument, EPUB, or PDF packages, use the owning package's
 
 `OfficeTextIntegrityInspector` reports exact BOMs, zero-width characters, word joiners, bidi controls, Unicode tags, variation selectors, typographic spaces, selected invisible format characters, controls, and unpaired surrogates. Findings retain UTF-16 offsets and distinguish informational, context-dependent, and potentially dangerous values. `OfficeTextIntegrityCleaner` removes only findings explicitly selected by the caller and verifies that the selected code point still occupies the recorded range.
 
+## Workflow and command-line orchestration
+
+`OfficeIMO.Workflows` exposes `IOfficeProvenanceWorkflowRunner` and `OfficeProvenanceWorkflowCatalog` for desktop, PowerShell, command-line, and service hosts. Inspect and assess are report-only operations. Removal preserves the source format, calls the package-owned adapter, stages the result beside its destination, reopens it through the same owner, compares the reopened structural evidence with the removal result, and publishes it only after that check succeeds. Batches are sequential and have an explicit item limit.
+
+Files with unknown extensions remain signature-driven: recognized image, HTML, and PDF content can use the corresponding removal path, while a generic ZIP package remains inspection-only until a document owner establishes its mutation contract. Batch removal rejects duplicate effective output paths before processing any item, including collisions caused by equal basenames in one output directory.
+
+`OfficeIMO.Tool` exposes the same contract under `officeimo provenance`. Its default JSON envelopes carry versioned schema identifiers, while `--format text` provides an interactive summary. Structural findings do not by themselves produce a failing exit code. Invalid requests, missing or unsupported inputs, output failures, cancellation, and execution failures use the tool's stable shared exit codes.
+
+Provider-backed verification and signal detection are dependency-injected workflow services. The default CLI does not bundle credentials, trust material, vendor APIs, or a `c2patool` executable, so its `assess` command reports structural and text-integrity evidence unless a host composes additional providers.
+
 ## Package-owned adapters
 
 | Package | Inspected content | Signature policy during removal |

--- a/OfficeIMO.Core/ContentSafety/OfficeContentSafetyProvenanceOptions.cs
+++ b/OfficeIMO.Core/ContentSafety/OfficeContentSafetyProvenanceOptions.cs
@@ -1,0 +1,23 @@
+using System;
+using OfficeIMO.Provenance;
+
+namespace OfficeIMO.ContentSafety;
+
+/// <summary>Maps content-safety resource policy into the provenance pass used for signature handling.</summary>
+internal static class OfficeContentSafetyProvenanceOptions {
+    internal static OfficeProvenanceRemovalOptions CreateSignatureRemovalOptions(
+        OfficeContentCleanupOptions cleanupOptions) {
+        if (cleanupOptions == null) throw new ArgumentNullException(nameof(cleanupOptions));
+        var provenanceOptions = new OfficeProvenanceRemovalOptions {
+            SignatureMutationPolicy = cleanupOptions.SignatureMutationPolicy,
+            MaxOutputBytes = cleanupOptions.Inspection.MaxInputBytes
+        };
+        provenanceOptions.Limits.MaxAssetBytes = cleanupOptions.Inspection.MaxInputBytes;
+        provenanceOptions.Limits.MaxManifestBytes = Math.Min(
+            provenanceOptions.Limits.MaxManifestBytes,
+            cleanupOptions.Inspection.MaxInputBytes);
+        provenanceOptions.Limits.MaxContainerEntries = cleanupOptions.Inspection.MaxPackageEntries;
+        provenanceOptions.Limits.MaxExpandedContainerBytes = cleanupOptions.Inspection.MaxExpandedPackageBytes;
+        return provenanceOptions;
+    }
+}

--- a/OfficeIMO.Core/IO/OfficePathIdentity.cs
+++ b/OfficeIMO.Core/IO/OfficePathIdentity.cs
@@ -9,6 +9,11 @@ using System.Text;
 namespace OfficeIMO.Internal {
     /// <summary>Provides strict physical, link-aware path identity for trusted in-process consumers.</summary>
     internal static partial class OfficePathIdentity {
+        internal static bool SupportsPhysicalIdentity =>
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
+            RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
+            RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+
         internal static string Normalize(string path) {
             string identity = ResolvePhysicalPath(path);
             return Normalize(identity, IsCaseInsensitiveFileSystem(identity));
@@ -210,6 +215,7 @@ namespace OfficeIMO.Internal {
                     : normalizedRoot + Path.DirectorySeparatorChar;
 
         internal static bool IsCaseInsensitiveFileSystem(string path) {
+            if (!SupportsPhysicalIdentity) return IsConservativelyCaseInsensitivePlatform;
             return TryGetFileSystemCaseBehavior(path, out bool caseInsensitive)
                 ? caseInsensitive
                 : IsConservativelyCaseInsensitivePlatform;

--- a/OfficeIMO.Core/Internal/OfficeFileCommit.cs
+++ b/OfficeIMO.Core/Internal/OfficeFileCommit.cs
@@ -281,6 +281,25 @@ namespace OfficeIMO.Core.Internal {
                 targetPath,
                 destinationMatchesExpected,
                 installedFileMatchesExpected,
+                beforeCommitFinalized: null,
+                afterFirstRollbackReplacement: null);
+
+        /// <summary>
+        /// Atomically installs a staging file and invokes a final validation callback while the
+        /// displaced destination remains available for rollback.
+        /// </summary>
+        internal static bool TryCommitTemporaryFileAtomicallyIfDestinationUnchangedAndFinalize(
+            string temporaryPath,
+            string targetPath,
+            Func<string, bool> destinationMatchesExpected,
+            Func<string, bool>? installedFileMatchesExpected,
+            Action<string> beforeCommitFinalized) =>
+            TryCommitTemporaryFileAtomicallyIfDestinationUnchangedCore(
+                temporaryPath,
+                targetPath,
+                destinationMatchesExpected,
+                installedFileMatchesExpected,
+                beforeCommitFinalized,
                 afterFirstRollbackReplacement: null);
 
         internal static bool TryCommitTemporaryFileAtomicallyIfDestinationUnchangedForTesting(
@@ -294,6 +313,7 @@ namespace OfficeIMO.Core.Internal {
                 targetPath,
                 destinationMatchesExpected,
                 installedFileMatchesExpected,
+                beforeCommitFinalized: null,
                 afterFirstRollbackReplacement);
 
         private static bool TryCommitTemporaryFileAtomicallyIfDestinationUnchangedCore(
@@ -301,6 +321,7 @@ namespace OfficeIMO.Core.Internal {
             string targetPath,
             Func<string, bool> destinationMatchesExpected,
             Func<string, bool>? installedFileMatchesExpected,
+            Action<string>? beforeCommitFinalized,
             Action<string>? afterFirstRollbackReplacement) {
             if (string.IsNullOrWhiteSpace(temporaryPath)) {
                 throw new ArgumentException("Temporary path cannot be empty.", nameof(temporaryPath));
@@ -329,6 +350,7 @@ namespace OfficeIMO.Core.Internal {
                 targetContainsTemporary = true;
                 if (destinationMatchesExpected(backupPath) &&
                     (installedFileMatchesExpected == null || installedFileMatchesExpected(fullTargetPath))) {
+                    beforeCommitFinalized?.Invoke(fullTargetPath);
                     DeleteIfExists(backupPath);
                     targetContainsTemporary = false;
                     return true;
@@ -345,17 +367,25 @@ namespace OfficeIMO.Core.Internal {
                     ref preserveDisplacedPath);
                 return false;
             } catch (Exception commitException) {
-                if (targetContainsTemporary && File.Exists(backupPath) && File.Exists(fullTargetPath)) {
+                if (targetContainsTemporary && File.Exists(backupPath)) {
                     try {
-                        RestoreDisplacedDestinationWithoutLosingConcurrentSave(
-                            fullTargetPath,
-                            backupPath,
-                            displacedPath,
-                            installedTemporaryIdentity,
-                            ref targetContainsTemporary,
-                            ref preserveBackupPath,
-                            afterFirstRollbackReplacement,
-                            ref preserveDisplacedPath);
+                        if (File.Exists(fullTargetPath)) {
+                            RestoreDisplacedDestinationWithoutLosingConcurrentSave(
+                                fullTargetPath,
+                                backupPath,
+                                displacedPath,
+                                installedTemporaryIdentity,
+                                ref targetContainsTemporary,
+                                ref preserveBackupPath,
+                                afterFirstRollbackReplacement,
+                                ref preserveDisplacedPath);
+                        } else {
+                            RestoreMissingDisplacedDestination(
+                                fullTargetPath,
+                                backupPath,
+                                ref targetContainsTemporary,
+                                ref preserveBackupPath);
+                        }
                     } catch (Exception rollbackException) {
                         throw new IOException(
                             "The guarded atomic commit failed and the displaced destination could not be restored. " +
@@ -367,6 +397,23 @@ namespace OfficeIMO.Core.Internal {
             } finally {
                 if (!targetContainsTemporary && !preserveBackupPath) DeleteIfExists(backupPath);
                 if (!preserveDisplacedPath) DeleteIfExists(displacedPath);
+            }
+        }
+
+        private static void RestoreMissingDisplacedDestination(
+            string targetPath,
+            string backupPath,
+            ref bool targetContainsTemporary,
+            ref bool preserveBackupPath) {
+            try {
+                File.Move(backupPath, targetPath);
+                targetContainsTemporary = false;
+            } catch (IOException) when (File.Exists(targetPath)) {
+                targetContainsTemporary = false;
+                preserveBackupPath = true;
+                throw new IOException(
+                    "A newer concurrent save claimed the destination while the displaced file was being restored. " +
+                    "The original destination remains recoverable at '" + backupPath + "'.");
             }
         }
 

--- a/OfficeIMO.Core/Internal/OfficeFileCommit.cs
+++ b/OfficeIMO.Core/Internal/OfficeFileCommit.cs
@@ -282,7 +282,8 @@ namespace OfficeIMO.Core.Internal {
                 destinationMatchesExpected,
                 installedFileMatchesExpected,
                 beforeCommitFinalized: null,
-                afterFirstRollbackReplacement: null);
+                afterFirstRollbackReplacement: null,
+                backupCleanupFailed: null);
 
         /// <summary>
         /// Atomically installs a staging file and invokes a final validation callback while the
@@ -293,14 +294,16 @@ namespace OfficeIMO.Core.Internal {
             string targetPath,
             Func<string, bool> destinationMatchesExpected,
             Func<string, bool>? installedFileMatchesExpected,
-            Action<string> beforeCommitFinalized) =>
+            Action<string> beforeCommitFinalized,
+            Action<string, Exception>? backupCleanupFailed = null) =>
             TryCommitTemporaryFileAtomicallyIfDestinationUnchangedCore(
                 temporaryPath,
                 targetPath,
                 destinationMatchesExpected,
                 installedFileMatchesExpected,
                 beforeCommitFinalized,
-                afterFirstRollbackReplacement: null);
+                afterFirstRollbackReplacement: null,
+                backupCleanupFailed);
 
         internal static bool TryCommitTemporaryFileAtomicallyIfDestinationUnchangedForTesting(
             string temporaryPath,
@@ -314,7 +317,8 @@ namespace OfficeIMO.Core.Internal {
                 destinationMatchesExpected,
                 installedFileMatchesExpected,
                 beforeCommitFinalized: null,
-                afterFirstRollbackReplacement);
+                afterFirstRollbackReplacement,
+                backupCleanupFailed: null);
 
         private static bool TryCommitTemporaryFileAtomicallyIfDestinationUnchangedCore(
             string temporaryPath,
@@ -322,7 +326,8 @@ namespace OfficeIMO.Core.Internal {
             Func<string, bool> destinationMatchesExpected,
             Func<string, bool>? installedFileMatchesExpected,
             Action<string>? beforeCommitFinalized,
-            Action<string>? afterFirstRollbackReplacement) {
+            Action<string>? afterFirstRollbackReplacement,
+            Action<string, Exception>? backupCleanupFailed) {
             if (string.IsNullOrWhiteSpace(temporaryPath)) {
                 throw new ArgumentException("Temporary path cannot be empty.", nameof(temporaryPath));
             }
@@ -351,7 +356,12 @@ namespace OfficeIMO.Core.Internal {
                 if (destinationMatchesExpected(backupPath) &&
                     (installedFileMatchesExpected == null || installedFileMatchesExpected(fullTargetPath))) {
                     beforeCommitFinalized?.Invoke(fullTargetPath);
-                    DeleteIfExists(backupPath);
+                    try {
+                        if (File.Exists(backupPath)) File.Delete(backupPath);
+                    } catch (Exception exception) when (exception is IOException or UnauthorizedAccessException) {
+                        preserveBackupPath = true;
+                        backupCleanupFailed?.Invoke(backupPath, exception);
+                    }
                     targetContainsTemporary = false;
                     return true;
                 }

--- a/OfficeIMO.Core/Properties/AssemblyInfo.cs
+++ b/OfficeIMO.Core/Properties/AssemblyInfo.cs
@@ -25,6 +25,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("OfficeIMO.Rtf.Markdown")]
 [assembly: InternalsVisibleTo("OfficeIMO.Reader")]
 [assembly: InternalsVisibleTo("OfficeIMO.Shared.Tests")]
+[assembly: InternalsVisibleTo("OfficeIMO.Workflows")]
 [assembly: InternalsVisibleTo("OfficeIMO.Visio")]
 [assembly: InternalsVisibleTo("OfficeIMO.Word")]
 [assembly: InternalsVisibleTo("OfficeIMO.Word.Pdf")]

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceAssessment.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceAssessment.cs
@@ -135,6 +135,7 @@ public static class OfficeProvenanceAssessment {
         using (OfficeProvenanceFileSnapshot snapshot = OfficeProvenanceFileSnapshot.Capture(
                    fullPath,
                    options.Structural.MaxAssetBytes)) {
+            snapshot.SealForProviderAccess();
             OfficeProvenanceReport structural = OfficeProvenanceInspector.InspectFile(snapshot.FilePath, options.Structural);
             if (hasExternalProviders) {
                 snapshot.CaptureExternalManifestDependencies(

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceAssessment.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceAssessment.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading;
 
 namespace OfficeIMO.Provenance;
@@ -148,7 +149,8 @@ public static class OfficeProvenanceAssessment {
                 structural,
                 options,
                 verifier,
-                detectors);
+                detectors,
+                textEncoding: structural.Format == OfficeProvenanceAssetFormat.Html ? Encoding.UTF8 : null);
             snapshot.VerifyPrimaryFile();
             if (hasExternalProviders) snapshot.VerifyExternalManifestDependencies();
             return assessment;
@@ -183,14 +185,16 @@ public static class OfficeProvenanceAssessment {
         OfficeProvenanceAssessmentOptions? options = null,
         IOfficeProvenanceVerifier? verifier = null,
         IEnumerable<IOfficeProvenanceSignalDetector>? signalDetectors = null,
-        CancellationToken cancellationToken = default) => AssessFileCore(
+        CancellationToken cancellationToken = default,
+        Encoding? textEncoding = null) => AssessFileCore(
             snapshotFilePath,
             logicalFilePath,
             structural,
             options,
             verifier,
             signalDetectors,
-            cancellationToken);
+            cancellationToken,
+            textEncoding);
 
     private static OfficeProvenanceAssessmentReport AssessFileCore(
         string filePath,
@@ -199,7 +203,8 @@ public static class OfficeProvenanceAssessment {
         OfficeProvenanceAssessmentOptions? options,
         IOfficeProvenanceVerifier? verifier,
         IEnumerable<IOfficeProvenanceSignalDetector>? signalDetectors,
-        CancellationToken cancellationToken) {
+        CancellationToken cancellationToken,
+        Encoding? textEncoding = null) {
         if (string.IsNullOrWhiteSpace(filePath)) throw new ArgumentException("A file path is required.", nameof(filePath));
         if (string.IsNullOrWhiteSpace(logicalFilePath)) throw new ArgumentException("A logical file path is required.", nameof(logicalFilePath));
         string fullPath = Path.GetFullPath(filePath);
@@ -215,6 +220,7 @@ public static class OfficeProvenanceAssessment {
                 fullPath,
                 options.TextIntegrity,
                 logicalFullPath,
+                textEncoding,
                 cancellationToken);
             cancellationToken.ThrowIfCancellationRequested();
         }

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceAssessment.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceAssessment.cs
@@ -64,7 +64,7 @@ public interface IOfficeProvenanceSignalDetector {
     /// <summary>Gets the signal kind detected by this provider.</summary>
     OfficeProvenanceSignalKind SignalKind { get; }
     /// <summary>Inspects one asset and returns a normalized provider result.</summary>
-    OfficeProvenanceSignalResult Detect(string filePath);
+    OfficeProvenanceSignalResult Detect(string filePath, CancellationToken cancellationToken = default);
 }
 
 /// <summary>Configures a combined provenance assessment.</summary>
@@ -208,7 +208,10 @@ public static class OfficeProvenanceAssessment {
             textIntegrity = OfficeTextIntegrityInspector.InspectFile(fullPath, options.TextIntegrity, logicalFullPath);
             cancellationToken.ThrowIfCancellationRequested();
         }
-        OfficeProvenanceVerificationResult? verification = verifier?.Verify(fullPath, options.Verification);
+        OfficeProvenanceVerificationResult? verification = verifier?.Verify(
+            fullPath,
+            options.Verification,
+            cancellationToken);
         cancellationToken.ThrowIfCancellationRequested();
         if (verifier != null && verification == null) {
             throw new InvalidDataException($"The '{verifier.Name}' provenance verifier returned no result.");
@@ -221,7 +224,7 @@ public static class OfficeProvenanceAssessment {
             foreach (IOfficeProvenanceSignalDetector detector in signalDetectors) {
                 cancellationToken.ThrowIfCancellationRequested();
                 if (detector == null) throw new ArgumentException("Signal detector collections cannot contain null entries.", nameof(signalDetectors));
-                OfficeProvenanceSignalResult result = detector.Detect(fullPath) ??
+                OfficeProvenanceSignalResult result = detector.Detect(fullPath, cancellationToken) ??
                     throw new InvalidDataException($"The '{detector.Name}' signal detector returned no result.");
                 cancellationToken.ThrowIfCancellationRequested();
                 if (!string.Equals(result.ProviderName, detector.Name, StringComparison.Ordinal) || result.SignalKind != detector.SignalKind) {

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceAssessment.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceAssessment.cs
@@ -211,7 +211,11 @@ public static class OfficeProvenanceAssessment {
         cancellationToken.ThrowIfCancellationRequested();
         OfficeTextIntegrityReport? textIntegrity = null;
         if (options.InspectTextIntegrity && IsTextLike(structural.Format)) {
-            textIntegrity = OfficeTextIntegrityInspector.InspectFile(fullPath, options.TextIntegrity, logicalFullPath);
+            textIntegrity = OfficeTextIntegrityInspector.InspectFile(
+                fullPath,
+                options.TextIntegrity,
+                logicalFullPath,
+                cancellationToken);
             cancellationToken.ThrowIfCancellationRequested();
         }
         OfficeProvenanceVerificationResult? verification = verifier == null

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceAssessment.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceAssessment.cs
@@ -143,6 +143,7 @@ public static class OfficeProvenanceAssessment {
                 options,
                 verifier,
                 detectors);
+            snapshot.VerifyPrimaryFile();
             if (hasExternalProviders) snapshot.VerifyExternalManifestDependencies();
             return assessment;
         }

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceAssessment.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceAssessment.cs
@@ -119,23 +119,31 @@ public static class OfficeProvenanceAssessment {
         string fullPath = Path.GetFullPath(filePath);
         if (!File.Exists(fullPath)) throw new FileNotFoundException("The asset to assess was not found.", fullPath);
         options ??= new OfficeProvenanceAssessmentOptions();
+        IOfficeProvenanceSignalDetector[] detectors = (signalDetectors ?? Array.Empty<IOfficeProvenanceSignalDetector>())
+            .Select(detector => detector ?? throw new ArgumentException(
+                "Signal detector collections cannot contain null entries.", nameof(signalDetectors)))
+            .ToArray();
+        bool hasExternalProviders = verifier != null || detectors.Length != 0;
 
         using (OfficeProvenanceFileSnapshot snapshot = OfficeProvenanceFileSnapshot.Capture(
                    fullPath,
                    options.Structural.MaxAssetBytes)) {
             OfficeProvenanceReport structural = OfficeProvenanceInspector.InspectFile(snapshot.FilePath, options.Structural);
-            snapshot.CaptureExternalManifestDependencies(
-                fullPath,
-                structural,
-                options.Structural.MaxManifestBytes);
+            if (hasExternalProviders) {
+                snapshot.CaptureExternalManifestDependencies(
+                    fullPath,
+                    structural,
+                    options.Structural.MaxManifestBytes,
+                    options.Structural.MaxExpandedContainerBytes);
+            }
             OfficeProvenanceAssessmentReport assessment = AssessSnapshotFile(
                 snapshot.FilePath,
                 fullPath,
                 structural,
                 options,
                 verifier,
-                signalDetectors);
-            snapshot.VerifyExternalManifestDependencies();
+                detectors);
+            if (hasExternalProviders) snapshot.VerifyExternalManifestDependencies();
             return assessment;
         }
     }

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceAssessment.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceAssessment.cs
@@ -64,7 +64,13 @@ public interface IOfficeProvenanceSignalDetector {
     /// <summary>Gets the signal kind detected by this provider.</summary>
     OfficeProvenanceSignalKind SignalKind { get; }
     /// <summary>Inspects one asset and returns a normalized provider result.</summary>
-    OfficeProvenanceSignalResult Detect(string filePath, CancellationToken cancellationToken = default);
+    OfficeProvenanceSignalResult Detect(string filePath);
+}
+
+/// <summary>Optional cancellation-aware extension for provider-specific signal detectors.</summary>
+public interface ICancellableOfficeProvenanceSignalDetector : IOfficeProvenanceSignalDetector {
+    /// <summary>Inspects one asset while observing cancellation and returns a normalized provider result.</summary>
+    OfficeProvenanceSignalResult Detect(string filePath, CancellationToken cancellationToken);
 }
 
 /// <summary>Configures a combined provenance assessment.</summary>
@@ -208,10 +214,9 @@ public static class OfficeProvenanceAssessment {
             textIntegrity = OfficeTextIntegrityInspector.InspectFile(fullPath, options.TextIntegrity, logicalFullPath);
             cancellationToken.ThrowIfCancellationRequested();
         }
-        OfficeProvenanceVerificationResult? verification = verifier?.Verify(
-            fullPath,
-            options.Verification,
-            cancellationToken);
+        OfficeProvenanceVerificationResult? verification = verifier == null
+            ? null
+            : Verify(verifier, fullPath, options.Verification, cancellationToken);
         cancellationToken.ThrowIfCancellationRequested();
         if (verifier != null && verification == null) {
             throw new InvalidDataException($"The '{verifier.Name}' provenance verifier returned no result.");
@@ -224,7 +229,7 @@ public static class OfficeProvenanceAssessment {
             foreach (IOfficeProvenanceSignalDetector detector in signalDetectors) {
                 cancellationToken.ThrowIfCancellationRequested();
                 if (detector == null) throw new ArgumentException("Signal detector collections cannot contain null entries.", nameof(signalDetectors));
-                OfficeProvenanceSignalResult result = detector.Detect(fullPath, cancellationToken) ??
+                OfficeProvenanceSignalResult result = Detect(detector, fullPath, cancellationToken) ??
                     throw new InvalidDataException($"The '{detector.Name}' signal detector returned no result.");
                 cancellationToken.ThrowIfCancellationRequested();
                 if (!string.Equals(result.ProviderName, detector.Name, StringComparison.Ordinal) || result.SignalKind != detector.SignalKind) {
@@ -240,4 +245,19 @@ public static class OfficeProvenanceAssessment {
     private static bool IsTextLike(OfficeProvenanceAssetFormat format) =>
         format is OfficeProvenanceAssetFormat.StructuredText or OfficeProvenanceAssetFormat.UnstructuredText or
             OfficeProvenanceAssetFormat.Html or OfficeProvenanceAssetFormat.Svg;
+
+    private static OfficeProvenanceVerificationResult Verify(
+        IOfficeProvenanceVerifier verifier,
+        string filePath,
+        OfficeProvenanceVerificationOptions options,
+        CancellationToken cancellationToken) => verifier is ICancellableOfficeProvenanceVerifier cancellable
+            ? cancellable.Verify(filePath, options, cancellationToken)
+            : verifier.Verify(filePath, options);
+
+    private static OfficeProvenanceSignalResult Detect(
+        IOfficeProvenanceSignalDetector detector,
+        string filePath,
+        CancellationToken cancellationToken) => detector is ICancellableOfficeProvenanceSignalDetector cancellable
+            ? cancellable.Detect(filePath, cancellationToken)
+            : detector.Detect(filePath);
 }

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceAssessment.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceAssessment.cs
@@ -150,8 +150,7 @@ public static class OfficeProvenanceAssessment {
                 structural,
                 options,
                 verifier,
-                detectors,
-                textEncoding: structural.Format == OfficeProvenanceAssetFormat.Html ? Encoding.UTF8 : null);
+                detectors);
             snapshot.VerifyPrimaryFile();
             if (hasExternalProviders) snapshot.VerifyExternalManifestDependencies();
             return assessment;

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceAssessment.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceAssessment.cs
@@ -229,10 +229,12 @@ public static class OfficeProvenanceAssessment {
             : Verify(verifier, fullPath, options.Verification, cancellationToken);
         cancellationToken.ThrowIfCancellationRequested();
         if (verifier != null && verification == null) {
-            throw new InvalidDataException($"The '{verifier.Name}' provenance verifier returned no result.");
+            throw OfficeProvenanceProviderContractException.Create(
+                $"The '{verifier.Name}' provenance verifier returned no result.");
         }
         if (verifier != null && !string.Equals(verification!.ProviderName, verifier.Name, StringComparison.Ordinal)) {
-            throw new InvalidDataException($"The '{verifier.Name}' provenance verifier returned inconsistent provider metadata.");
+            throw OfficeProvenanceProviderContractException.Create(
+                $"The '{verifier.Name}' provenance verifier returned inconsistent provider metadata.");
         }
         var signals = new List<OfficeProvenanceSignalResult>();
         if (signalDetectors != null) {
@@ -240,10 +242,12 @@ public static class OfficeProvenanceAssessment {
                 cancellationToken.ThrowIfCancellationRequested();
                 if (detector == null) throw new ArgumentException("Signal detector collections cannot contain null entries.", nameof(signalDetectors));
                 OfficeProvenanceSignalResult result = Detect(detector, fullPath, cancellationToken) ??
-                    throw new InvalidDataException($"The '{detector.Name}' signal detector returned no result.");
+                    throw OfficeProvenanceProviderContractException.Create(
+                        $"The '{detector.Name}' signal detector returned no result.");
                 cancellationToken.ThrowIfCancellationRequested();
                 if (!string.Equals(result.ProviderName, detector.Name, StringComparison.Ordinal) || result.SignalKind != detector.SignalKind) {
-                    throw new InvalidDataException($"The '{detector.Name}' signal detector returned inconsistent provider metadata.");
+                    throw OfficeProvenanceProviderContractException.Create(
+                        $"The '{detector.Name}' signal detector returned inconsistent provider metadata.");
                 }
                 signals.Add(result);
             }

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceAssessment.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceAssessment.cs
@@ -120,14 +120,19 @@ public static class OfficeProvenanceAssessment {
         if (!File.Exists(fullPath)) throw new FileNotFoundException("The asset to assess was not found.", fullPath);
         options ??= new OfficeProvenanceAssessmentOptions();
 
-        OfficeProvenanceReport structural = OfficeProvenanceInspector.InspectFile(fullPath, options.Structural);
-        return AssessFile(fullPath, structural, options, verifier, signalDetectors);
+        using (OfficeProvenanceFileSnapshot snapshot = OfficeProvenanceFileSnapshot.Capture(
+                   fullPath,
+                   options.Structural.MaxAssetBytes)) {
+            OfficeProvenanceReport structural = OfficeProvenanceInspector.InspectFile(snapshot.FilePath, options.Structural);
+            return AssessFile(snapshot.FilePath, structural, options, verifier, signalDetectors);
+        }
     }
 
     /// <summary>Combines an existing structural report with optional text, cryptographic, and provider evidence.</summary>
     /// <remarks>
     /// This overload lets workflow hosts preserve format-owner structural inspection while keeping evidence
-    /// composition and provider-result validation in the canonical provenance owner.
+    /// composition and provider-result validation in the canonical provenance owner. The caller must ensure
+    /// <paramref name="filePath"/> identifies the same immutable bytes used to create <paramref name="structural"/>.
     /// </remarks>
     public static OfficeProvenanceAssessmentReport AssessFile(
         string filePath,

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceAssessment.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceAssessment.cs
@@ -124,7 +124,19 @@ public static class OfficeProvenanceAssessment {
                    fullPath,
                    options.Structural.MaxAssetBytes)) {
             OfficeProvenanceReport structural = OfficeProvenanceInspector.InspectFile(snapshot.FilePath, options.Structural);
-            return AssessFile(snapshot.FilePath, structural, options, verifier, signalDetectors);
+            snapshot.CaptureExternalManifestDependencies(
+                fullPath,
+                structural,
+                options.Structural.MaxManifestBytes);
+            OfficeProvenanceAssessmentReport assessment = AssessSnapshotFile(
+                snapshot.FilePath,
+                fullPath,
+                structural,
+                options,
+                verifier,
+                signalDetectors);
+            snapshot.VerifyExternalManifestDependencies();
+            return assessment;
         }
     }
 
@@ -140,9 +152,43 @@ public static class OfficeProvenanceAssessment {
         OfficeProvenanceAssessmentOptions? options = null,
         IOfficeProvenanceVerifier? verifier = null,
         IEnumerable<IOfficeProvenanceSignalDetector>? signalDetectors = null,
-        CancellationToken cancellationToken = default) {
+        CancellationToken cancellationToken = default) => AssessFileCore(
+            filePath,
+            filePath,
+            structural,
+            options,
+            verifier,
+            signalDetectors,
+            cancellationToken);
+
+    internal static OfficeProvenanceAssessmentReport AssessSnapshotFile(
+        string snapshotFilePath,
+        string logicalFilePath,
+        OfficeProvenanceReport structural,
+        OfficeProvenanceAssessmentOptions? options = null,
+        IOfficeProvenanceVerifier? verifier = null,
+        IEnumerable<IOfficeProvenanceSignalDetector>? signalDetectors = null,
+        CancellationToken cancellationToken = default) => AssessFileCore(
+            snapshotFilePath,
+            logicalFilePath,
+            structural,
+            options,
+            verifier,
+            signalDetectors,
+            cancellationToken);
+
+    private static OfficeProvenanceAssessmentReport AssessFileCore(
+        string filePath,
+        string logicalFilePath,
+        OfficeProvenanceReport structural,
+        OfficeProvenanceAssessmentOptions? options,
+        IOfficeProvenanceVerifier? verifier,
+        IEnumerable<IOfficeProvenanceSignalDetector>? signalDetectors,
+        CancellationToken cancellationToken) {
         if (string.IsNullOrWhiteSpace(filePath)) throw new ArgumentException("A file path is required.", nameof(filePath));
+        if (string.IsNullOrWhiteSpace(logicalFilePath)) throw new ArgumentException("A logical file path is required.", nameof(logicalFilePath));
         string fullPath = Path.GetFullPath(filePath);
+        string logicalFullPath = Path.GetFullPath(logicalFilePath);
         if (!File.Exists(fullPath)) throw new FileNotFoundException("The asset to assess was not found.", fullPath);
         if (structural == null) throw new ArgumentNullException(nameof(structural));
         options ??= new OfficeProvenanceAssessmentOptions();
@@ -150,7 +196,7 @@ public static class OfficeProvenanceAssessment {
         cancellationToken.ThrowIfCancellationRequested();
         OfficeTextIntegrityReport? textIntegrity = null;
         if (options.InspectTextIntegrity && IsTextLike(structural.Format)) {
-            textIntegrity = OfficeTextIntegrityInspector.InspectFile(fullPath, options.TextIntegrity);
+            textIntegrity = OfficeTextIntegrityInspector.InspectFile(fullPath, options.TextIntegrity, logicalFullPath);
             cancellationToken.ThrowIfCancellationRequested();
         }
         OfficeProvenanceVerificationResult? verification = verifier?.Verify(fullPath, options.Verification);

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceAssessment.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceAssessment.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 
 namespace OfficeIMO.Provenance;
 
@@ -120,11 +121,35 @@ public static class OfficeProvenanceAssessment {
         options ??= new OfficeProvenanceAssessmentOptions();
 
         OfficeProvenanceReport structural = OfficeProvenanceInspector.InspectFile(fullPath, options.Structural);
+        return AssessFile(fullPath, structural, options, verifier, signalDetectors);
+    }
+
+    /// <summary>Combines an existing structural report with optional text, cryptographic, and provider evidence.</summary>
+    /// <remarks>
+    /// This overload lets workflow hosts preserve format-owner structural inspection while keeping evidence
+    /// composition and provider-result validation in the canonical provenance owner.
+    /// </remarks>
+    public static OfficeProvenanceAssessmentReport AssessFile(
+        string filePath,
+        OfficeProvenanceReport structural,
+        OfficeProvenanceAssessmentOptions? options = null,
+        IOfficeProvenanceVerifier? verifier = null,
+        IEnumerable<IOfficeProvenanceSignalDetector>? signalDetectors = null,
+        CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(filePath)) throw new ArgumentException("A file path is required.", nameof(filePath));
+        string fullPath = Path.GetFullPath(filePath);
+        if (!File.Exists(fullPath)) throw new FileNotFoundException("The asset to assess was not found.", fullPath);
+        if (structural == null) throw new ArgumentNullException(nameof(structural));
+        options ??= new OfficeProvenanceAssessmentOptions();
+
+        cancellationToken.ThrowIfCancellationRequested();
         OfficeTextIntegrityReport? textIntegrity = null;
         if (options.InspectTextIntegrity && IsTextLike(structural.Format)) {
             textIntegrity = OfficeTextIntegrityInspector.InspectFile(fullPath, options.TextIntegrity);
+            cancellationToken.ThrowIfCancellationRequested();
         }
         OfficeProvenanceVerificationResult? verification = verifier?.Verify(fullPath, options.Verification);
+        cancellationToken.ThrowIfCancellationRequested();
         if (verifier != null && verification == null) {
             throw new InvalidDataException($"The '{verifier.Name}' provenance verifier returned no result.");
         }
@@ -134,15 +159,18 @@ public static class OfficeProvenanceAssessment {
         var signals = new List<OfficeProvenanceSignalResult>();
         if (signalDetectors != null) {
             foreach (IOfficeProvenanceSignalDetector detector in signalDetectors) {
+                cancellationToken.ThrowIfCancellationRequested();
                 if (detector == null) throw new ArgumentException("Signal detector collections cannot contain null entries.", nameof(signalDetectors));
                 OfficeProvenanceSignalResult result = detector.Detect(fullPath) ??
                     throw new InvalidDataException($"The '{detector.Name}' signal detector returned no result.");
+                cancellationToken.ThrowIfCancellationRequested();
                 if (!string.Equals(result.ProviderName, detector.Name, StringComparison.Ordinal) || result.SignalKind != detector.SignalKind) {
                     throw new InvalidDataException($"The '{detector.Name}' signal detector returned inconsistent provider metadata.");
                 }
                 signals.Add(result);
             }
         }
+        cancellationToken.ThrowIfCancellationRequested();
         return new OfficeProvenanceAssessmentReport(structural, verification, textIntegrity, signals.AsReadOnly());
     }
 

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceBinary.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceBinary.cs
@@ -51,10 +51,30 @@ internal static class OfficeProvenanceBinary {
     internal static void ValidateRemovalOptions(OfficeProvenanceRemovalOptions options) {
         if (options == null) throw new ArgumentNullException(nameof(options));
         ValidateLimits(options.Limits);
+        if (options.MaxOutputBytes.HasValue &&
+            (options.MaxOutputBytes.Value <= 0 || options.MaxOutputBytes.Value > int.MaxValue)) {
+            throw new ArgumentOutOfRangeException(nameof(options.MaxOutputBytes));
+        }
         if (options.MaxEmbeddedAssets <= 0) throw new ArgumentOutOfRangeException(nameof(options.MaxEmbeddedAssets));
         if (!Enum.IsDefined(typeof(OfficeIMO.OfficeSignatureMutationPolicy), options.SignatureMutationPolicy)) {
             throw new ArgumentOutOfRangeException(nameof(options.SignatureMutationPolicy));
         }
+    }
+
+    internal static void EnsureOutputWithinLimit(long outputBytes, long maximumOutputBytes) {
+        if (maximumOutputBytes <= 0 || maximumOutputBytes > int.MaxValue) {
+            throw new ArgumentOutOfRangeException(nameof(maximumOutputBytes));
+        }
+        if (outputBytes < 0 || outputBytes > maximumOutputBytes) {
+            throw OfficeProvenanceLimitException.CreateOutput(
+                $"The rewritten asset exceeds the configured output limit of {maximumOutputBytes} bytes.");
+        }
+    }
+
+    internal static byte[] CloneForOutput(byte[] data, long maximumOutputBytes) {
+        if (data == null) throw new ArgumentNullException(nameof(data));
+        EnsureOutputWithinLimit(data.LongLength, maximumOutputBytes);
+        return (byte[])data.Clone();
     }
 
     internal static bool HasPrefix(byte[] data, params byte[] prefix) {

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceBinary.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceBinary.cs
@@ -1,11 +1,27 @@
 using System;
 using System.IO;
+using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 
 namespace OfficeIMO.Provenance;
 
 internal static class OfficeProvenanceBinary {
+    internal static byte[] ComputeSha256(byte[] data, CancellationToken cancellationToken = default) {
+        if (data == null) throw new ArgumentNullException(nameof(data));
+        using IncrementalHash algorithm = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        const int chunkSize = 81920;
+        int offset = 0;
+        while (offset < data.Length) {
+            cancellationToken.ThrowIfCancellationRequested();
+            int count = Math.Min(chunkSize, data.Length - offset);
+            algorithm.AppendData(data, offset, count);
+            offset += count;
+        }
+        cancellationToken.ThrowIfCancellationRequested();
+        return algorithm.GetHashAndReset();
+    }
+
     internal static byte[] ReadBounded(Stream stream, long maximumBytes, CancellationToken cancellationToken = default) {
         if (stream == null) throw new ArgumentNullException(nameof(stream));
         if (maximumBytes <= 0 || maximumBytes > int.MaxValue) {

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceBinary.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceBinary.cs
@@ -1,11 +1,12 @@
 using System;
 using System.IO;
 using System.Text;
+using System.Threading;
 
 namespace OfficeIMO.Provenance;
 
 internal static class OfficeProvenanceBinary {
-    internal static byte[] ReadBounded(Stream stream, long maximumBytes) {
+    internal static byte[] ReadBounded(Stream stream, long maximumBytes, CancellationToken cancellationToken = default) {
         if (stream == null) throw new ArgumentNullException(nameof(stream));
         if (maximumBytes <= 0 || maximumBytes > int.MaxValue) {
             throw new ArgumentOutOfRangeException(nameof(maximumBytes), "The asset limit must be between 1 byte and Int32.MaxValue.");
@@ -17,13 +18,14 @@ internal static class OfficeProvenanceBinary {
                 throw new InvalidDataException($"The asset exceeds the configured limit of {maximumBytes} bytes.");
             }
             byte[] data = new byte[(int)remaining];
-            ReadExactly(stream, data, 0, data.Length);
+            ReadExactly(stream, data, 0, data.Length, cancellationToken);
             return data;
         }
 
         using var buffer = new MemoryStream();
         byte[] chunk = new byte[8192];
         while (true) {
+            cancellationToken.ThrowIfCancellationRequested();
             int read = stream.Read(chunk, 0, chunk.Length);
             if (read <= 0) break;
             if (buffer.Length > maximumBytes - read) {
@@ -165,8 +167,9 @@ internal static class OfficeProvenanceBinary {
         return encoding.GetString(data, offset, count);
     }
 
-    internal static void ReadExactly(Stream stream, byte[] buffer, int offset, int count) {
+    internal static void ReadExactly(Stream stream, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {
         while (count > 0) {
+            cancellationToken.ThrowIfCancellationRequested();
             int read = stream.Read(buffer, offset, count);
             if (read <= 0) throw new EndOfStreamException("Unexpected end of provenance data.");
             offset += read;

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceBoundedMemoryStream.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceBoundedMemoryStream.cs
@@ -1,0 +1,56 @@
+using System;
+using System.IO;
+
+namespace OfficeIMO.Provenance;
+
+/// <summary>Bounds in-memory provenance serialization before a write can grow the backing buffer.</summary>
+internal sealed class OfficeProvenanceBoundedMemoryStream : MemoryStream {
+    private readonly long _maximumBytes;
+
+    internal OfficeProvenanceBoundedMemoryStream(long maximumBytes, int capacityHint = 0)
+        : base(GetInitialCapacity(maximumBytes, capacityHint)) {
+        _maximumBytes = maximumBytes;
+    }
+
+    public override void Write(byte[] buffer, int offset, int count) {
+        EnsureWrite(count);
+        base.Write(buffer, offset, count);
+    }
+
+    public override void WriteByte(byte value) {
+        EnsureWrite(1);
+        base.WriteByte(value);
+    }
+
+#if NET8_0_OR_GREATER
+    public override void Write(ReadOnlySpan<byte> buffer) {
+        EnsureWrite(buffer.Length);
+        base.Write(buffer);
+    }
+#endif
+
+    public override void SetLength(long value) {
+        OfficeProvenanceBinary.EnsureOutputWithinLimit(value, _maximumBytes);
+        base.SetLength(value);
+    }
+
+    private void EnsureWrite(int count) {
+        if (count < 0) throw new ArgumentOutOfRangeException(nameof(count));
+        long end;
+        try {
+            end = checked(Position + count);
+        } catch (OverflowException) {
+            throw OfficeProvenanceLimitException.CreateOutput(
+                $"The rewritten asset exceeds the configured output limit of {_maximumBytes} bytes.");
+        }
+        OfficeProvenanceBinary.EnsureOutputWithinLimit(Math.Max(Length, end), _maximumBytes);
+    }
+
+    private static int GetInitialCapacity(long maximumBytes, int capacityHint) {
+        if (maximumBytes <= 0 || maximumBytes > int.MaxValue) {
+            throw new ArgumentOutOfRangeException(nameof(maximumBytes));
+        }
+        if (capacityHint < 0) throw new ArgumentOutOfRangeException(nameof(capacityHint));
+        return (int)Math.Min(maximumBytes, capacityHint);
+    }
+}

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceContext.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceContext.cs
@@ -6,6 +6,8 @@ namespace OfficeIMO.Provenance;
 
 internal sealed class OfficeProvenanceContext {
     private readonly OfficeProvenanceOptions _options;
+    private readonly Dictionary<OfficeProvenanceEvidence, string> _resolvedExternalManifestReferences =
+        new Dictionary<OfficeProvenanceEvidence, string>();
 
     internal OfficeProvenanceContext(OfficeProvenanceAssetFormat format, OfficeProvenanceOptions options) {
         Format = format;
@@ -15,6 +17,7 @@ internal sealed class OfficeProvenanceContext {
     internal OfficeProvenanceAssetFormat Format { get; }
     internal List<OfficeProvenanceEvidence> Evidence { get; } = new List<OfficeProvenanceEvidence>();
     internal List<string> Diagnostics { get; } = new List<string>();
+    internal long ExpandedInspectionBytes { get; private set; }
 
     internal void Add(OfficeProvenanceEvidence evidence) {
         if (Evidence.Count >= _options.MaxCarriers) {
@@ -23,5 +26,23 @@ internal sealed class OfficeProvenanceContext {
         Evidence.Add(evidence);
     }
 
-    internal OfficeProvenanceReport ToReport() => new OfficeProvenanceReport(Format, Evidence.AsReadOnly(), Diagnostics.AsReadOnly());
+    internal void AddResolvedExternalManifestReference(OfficeProvenanceEvidence evidence, string reference) {
+        if (evidence == null) throw new ArgumentNullException(nameof(evidence));
+        if (string.IsNullOrWhiteSpace(reference)) throw new ArgumentException("A resolved manifest reference is required.", nameof(reference));
+        _resolvedExternalManifestReferences.Add(evidence, reference);
+    }
+
+    internal void ReserveExpandedBytes(long additionalBytes, string limitMessage) {
+        if (additionalBytes < 0 || ExpandedInspectionBytes > _options.MaxExpandedContainerBytes - additionalBytes) {
+            throw new InvalidDataException(limitMessage);
+        }
+        ExpandedInspectionBytes += additionalBytes;
+    }
+
+    internal OfficeProvenanceReport ToReport() => new OfficeProvenanceReport(
+        Format,
+        Evidence.AsReadOnly(),
+        Diagnostics.AsReadOnly(),
+        ExpandedInspectionBytes,
+        _resolvedExternalManifestReferences);
 }

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceContracts.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceContracts.cs
@@ -99,10 +99,19 @@ public sealed class OfficeProvenanceReport {
     public OfficeProvenanceReport(
         OfficeProvenanceAssetFormat format,
         IReadOnlyList<OfficeProvenanceEvidence> evidence,
-        IReadOnlyList<string>? diagnostics = null) {
+        IReadOnlyList<string>? diagnostics = null)
+        : this(format, evidence, diagnostics, expandedInspectionBytes: 0) { }
+
+    internal OfficeProvenanceReport(
+        OfficeProvenanceAssetFormat format,
+        IReadOnlyList<OfficeProvenanceEvidence> evidence,
+        IReadOnlyList<string>? diagnostics,
+        long expandedInspectionBytes) {
+        if (expandedInspectionBytes < 0) throw new ArgumentOutOfRangeException(nameof(expandedInspectionBytes));
         Format = format;
         Evidence = new List<OfficeProvenanceEvidence>(evidence ?? throw new ArgumentNullException(nameof(evidence))).AsReadOnly();
         Diagnostics = new List<string>(diagnostics ?? Array.Empty<string>()).AsReadOnly();
+        ExpandedInspectionBytes = expandedInspectionBytes;
     }
 
     /// <summary>Gets the identified asset format.</summary>
@@ -111,6 +120,8 @@ public sealed class OfficeProvenanceReport {
     public IReadOnlyList<OfficeProvenanceEvidence> Evidence { get; }
     /// <summary>Gets structural diagnostics that did not prevent inspection.</summary>
     public IReadOnlyList<string> Diagnostics { get; }
+    /// <summary>Gets expanded bytes already consumed by structural inspection for shared assessment limits.</summary>
+    internal long ExpandedInspectionBytes { get; }
     /// <summary>Gets whether an embedded C2PA carrier was discovered.</summary>
     public bool HasC2paManifest {
         get {

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceContracts.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceContracts.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace OfficeIMO.Provenance;
 
@@ -206,6 +207,7 @@ public sealed class OfficeProvenanceRemovalOptions {
     public OfficeProvenanceOptions Limits { get; } = new OfficeProvenanceOptions();
 
     internal long EffectiveMaxOutputBytes => MaxOutputBytes ?? Limits.MaxAssetBytes;
+    internal long EffectiveMaxIntermediateBytes => Math.Max(EffectiveMaxOutputBytes, Limits.MaxAssetBytes);
 }
 
 /// <summary>One format-native provenance mutation.</summary>
@@ -371,5 +373,8 @@ public interface IOfficeProvenanceVerifier {
     /// <summary>Gets the provider name.</summary>
     string Name { get; }
     /// <summary>Verifies provenance carried by an asset file.</summary>
-    OfficeProvenanceVerificationResult Verify(string filePath, OfficeProvenanceVerificationOptions? options = null);
+    OfficeProvenanceVerificationResult Verify(
+        string filePath,
+        OfficeProvenanceVerificationOptions? options = null,
+        CancellationToken cancellationToken = default);
 }

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceContracts.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceContracts.cs
@@ -373,8 +373,14 @@ public interface IOfficeProvenanceVerifier {
     /// <summary>Gets the provider name.</summary>
     string Name { get; }
     /// <summary>Verifies provenance carried by an asset file.</summary>
+    OfficeProvenanceVerificationResult Verify(string filePath, OfficeProvenanceVerificationOptions? options = null);
+}
+
+/// <summary>Optional cancellation-aware extension for cryptographic provenance verification providers.</summary>
+public interface ICancellableOfficeProvenanceVerifier : IOfficeProvenanceVerifier {
+    /// <summary>Verifies provenance carried by an asset file while observing cancellation.</summary>
     OfficeProvenanceVerificationResult Verify(
         string filePath,
-        OfficeProvenanceVerificationOptions? options = null,
-        CancellationToken cancellationToken = default);
+        OfficeProvenanceVerificationOptions? options,
+        CancellationToken cancellationToken);
 }

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceContracts.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceContracts.cs
@@ -175,8 +175,15 @@ public sealed class OfficeProvenanceRemovalOptions {
     public bool ProcessEmbeddedAssets { get; set; } = true;
     /// <summary>Maximum embedded assets processed by one document operation. Defaults to 4096.</summary>
     public int MaxEmbeddedAssets { get; set; } = 4096;
+    /// <summary>
+    /// Maximum encoded bytes that the rewritten asset may contain. A null value preserves the
+    /// historical behavior by using <see cref="OfficeProvenanceOptions.MaxAssetBytes"/>.
+    /// </summary>
+    public long? MaxOutputBytes { get; set; }
     /// <summary>Inspection and removal resource limits.</summary>
     public OfficeProvenanceOptions Limits { get; } = new OfficeProvenanceOptions();
+
+    internal long EffectiveMaxOutputBytes => MaxOutputBytes ?? Limits.MaxAssetBytes;
 }
 
 /// <summary>One format-native provenance mutation.</summary>

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceContracts.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceContracts.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Security.Cryptography;
 using System.Threading;
 
 namespace OfficeIMO.Provenance;
@@ -305,6 +306,10 @@ public sealed class OfficeProvenanceRemovalResult {
     /// <summary>Gets whether an owning document API removed signatures that the provenance mutation invalidated.</summary>
     public bool WereInvalidatedSignaturesRemoved { get; }
     internal long DataLength => _data.LongLength;
+    internal byte[] ComputeDataSha256() {
+        using SHA256 algorithm = SHA256.Create();
+        return algorithm.ComputeHash(_data);
+    }
     /// <summary>Returns an owned copy of the resulting asset.</summary>
     public byte[] ToArray() => (byte[])_data.Clone();
 }

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceContracts.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceContracts.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Security.Cryptography;
 using System.Threading;
 
 namespace OfficeIMO.Provenance;
@@ -307,10 +306,8 @@ public sealed class OfficeProvenanceRemovalResult {
     /// <summary>Gets whether an owning document API removed signatures that the provenance mutation invalidated.</summary>
     public bool WereInvalidatedSignaturesRemoved { get; }
     internal long DataLength => _data.LongLength;
-    internal byte[] ComputeDataSha256() {
-        using SHA256 algorithm = SHA256.Create();
-        return algorithm.ComputeHash(_data);
-    }
+    internal byte[] ComputeDataSha256(CancellationToken cancellationToken = default) =>
+        OfficeProvenanceBinary.ComputeSha256(_data, cancellationToken);
     /// <summary>Returns an owned copy of the resulting asset.</summary>
     public byte[] ToArray() => (byte[])_data.Clone();
 }

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceContracts.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceContracts.cs
@@ -151,7 +151,7 @@ public sealed class OfficeProvenanceOptions {
     public int MaxCarriers { get; set; } = 128;
     /// <summary>Maximum structural entries or materialized XML nodes accepted in a container. Defaults to 65,536.</summary>
     public int MaxContainerEntries { get; set; } = 65536;
-    /// <summary>Maximum cumulative expanded bytes copied while rewriting a container. Defaults to 1 GiB.</summary>
+    /// <summary>Maximum cumulative expanded bytes inspected or copied across a container or its external provenance dependencies. Defaults to 1 GiB.</summary>
     public long MaxExpandedContainerBytes { get; set; } = 1024L * 1024L * 1024L;
     /// <summary>Whether supported image assets inside ZIP-based documents are inspected. Defaults to true.</summary>
     public bool ProcessEmbeddedAssets { get; set; } = true;

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceContracts.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceContracts.cs
@@ -302,6 +302,7 @@ public sealed class OfficeProvenanceRemovalResult {
     public bool WasReserialized { get; }
     /// <summary>Gets whether an owning document API removed signatures that the provenance mutation invalidated.</summary>
     public bool WereInvalidatedSignaturesRemoved { get; }
+    internal long DataLength => _data.LongLength;
     /// <summary>Returns an owned copy of the resulting asset.</summary>
     public byte[] ToArray() => (byte[])_data.Clone();
 }

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceContracts.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceContracts.cs
@@ -167,6 +167,7 @@ public sealed class OfficeProvenanceReport {
 
 /// <summary>Bounds structural provenance inspection and removal.</summary>
 public sealed class OfficeProvenanceOptions {
+    internal CancellationToken CancellationToken { get; set; }
     /// <summary>Maximum encoded asset bytes accepted. Defaults to 256 MiB.</summary>
     public long MaxAssetBytes { get; set; } = 256L * 1024L * 1024L;
     /// <summary>Maximum single manifest-store bytes accepted. Defaults to 64 MiB.</summary>

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceContracts.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceContracts.cs
@@ -106,12 +106,20 @@ public sealed class OfficeProvenanceReport {
         OfficeProvenanceAssetFormat format,
         IReadOnlyList<OfficeProvenanceEvidence> evidence,
         IReadOnlyList<string>? diagnostics,
-        long expandedInspectionBytes) {
+        long expandedInspectionBytes,
+        IReadOnlyDictionary<OfficeProvenanceEvidence, string>? resolvedExternalManifestReferences = null) {
         if (expandedInspectionBytes < 0) throw new ArgumentOutOfRangeException(nameof(expandedInspectionBytes));
         Format = format;
         Evidence = new List<OfficeProvenanceEvidence>(evidence ?? throw new ArgumentNullException(nameof(evidence))).AsReadOnly();
         Diagnostics = new List<string>(diagnostics ?? Array.Empty<string>()).AsReadOnly();
         ExpandedInspectionBytes = expandedInspectionBytes;
+        var resolvedReferences = new Dictionary<OfficeProvenanceEvidence, string>();
+        if (resolvedExternalManifestReferences is not null) {
+            foreach (KeyValuePair<OfficeProvenanceEvidence, string> pair in resolvedExternalManifestReferences) {
+                resolvedReferences.Add(pair.Key, pair.Value);
+            }
+        }
+        ResolvedExternalManifestReferences = resolvedReferences;
     }
 
     /// <summary>Gets the identified asset format.</summary>
@@ -122,6 +130,9 @@ public sealed class OfficeProvenanceReport {
     public IReadOnlyList<string> Diagnostics { get; }
     /// <summary>Gets expanded bytes already consumed by structural inspection for shared assessment limits.</summary>
     internal long ExpandedInspectionBytes { get; }
+    private IReadOnlyDictionary<OfficeProvenanceEvidence, string> ResolvedExternalManifestReferences { get; }
+    internal string? GetExternalManifestReference(OfficeProvenanceEvidence evidence) =>
+        ResolvedExternalManifestReferences.TryGetValue(evidence, out string? resolved) ? resolved : evidence.Value;
     /// <summary>Gets whether an embedded C2PA carrier was discovered.</summary>
     public bool HasC2paManifest {
         get {

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceFileSnapshot.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceFileSnapshot.cs
@@ -12,6 +12,7 @@ namespace OfficeIMO.Provenance;
 /// <summary>Owns one bounded, private, read-only file snapshot used by multi-stage provenance operations.</summary>
 internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
     private const uint UnixOwnerDirectoryMode = 0x1C0; // 0700
+    private const uint UnixOwnerReadExecuteDirectoryMode = 0x140; // 0500
     private const uint UnixOwnerReadOnlyMode = 0x100; // 0400
     private const uint UnixOwnerReadWriteMode = 0x180; // 0600
     private readonly string _directoryPath;
@@ -23,6 +24,7 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
     private readonly List<DependencySnapshot> _dependentSnapshots = new List<DependencySnapshot>();
     private bool _dependentLeasesDisposed;
     private bool _leaseDisposed;
+    private bool _directorySealed;
     private bool _disposed;
 
     private OfficeProvenanceFileSnapshot(
@@ -61,45 +63,65 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
         if (maximumDependencyBytes <= 0) throw new ArgumentOutOfRangeException(nameof(maximumDependencyBytes));
         if (maximumTotalBytes <= 0) throw new ArgumentOutOfRangeException(nameof(maximumTotalBytes));
 
-        string sourceDirectory = Path.GetDirectoryName(Path.GetFullPath(sourcePath))!;
-        string sourceDirectoryIdentity = _usesPhysicalIdentity
-            ? OfficePathIdentity.ResolvePhysicalPath(sourceDirectory)
-            : Path.GetFullPath(sourceDirectory);
-        long capturedBytes = 0;
-        var capturedTargets = new HashSet<string>(StringComparer.Ordinal);
-        foreach (OfficeProvenanceEvidence evidence in report.Evidence.Where(item =>
-                     item.IsStructurallyValid &&
-                     item.Carrier == OfficeProvenanceCarrierKind.C2paExternalManifest &&
-                     !string.IsNullOrWhiteSpace(item.Value))) {
-            cancellationToken.ThrowIfCancellationRequested();
-            if (!TryResolveRelativeDependency(
-                    sourceDirectory,
-                    _directoryPath,
-                    FilePath,
-                    report.GetExternalManifestReference(evidence)!,
-                    out string sourceDependency,
-                    out string targetDependency) ||
-                !capturedTargets.Add(GetDependencyTargetIdentity(targetDependency)) ||
-                !File.Exists(sourceDependency)) continue;
+        bool resealDirectory = _directorySealed;
+        if (resealDirectory) MakeSnapshotDirectoriesWritable();
+        try {
+            string sourceDirectory = Path.GetDirectoryName(Path.GetFullPath(sourcePath))!;
+            string sourceDirectoryIdentity = _usesPhysicalIdentity
+                ? OfficePathIdentity.ResolvePhysicalPath(sourceDirectory)
+                : Path.GetFullPath(sourceDirectory);
+            long capturedBytes = 0;
+            var capturedTargets = new HashSet<string>(StringComparer.Ordinal);
+            foreach (OfficeProvenanceEvidence evidence in report.Evidence.Where(item =>
+                         item.IsStructurallyValid &&
+                         item.Carrier == OfficeProvenanceCarrierKind.C2paExternalManifest &&
+                         !string.IsNullOrWhiteSpace(item.Value))) {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (!TryResolveRelativeDependency(
+                        sourceDirectory,
+                        _directoryPath,
+                        FilePath,
+                        report.GetExternalManifestReference(evidence)!,
+                        out string sourceDependency,
+                        out string targetDependency) ||
+                    !capturedTargets.Add(GetDependencyTargetIdentity(targetDependency)) ||
+                    !File.Exists(sourceDependency)) continue;
 
-            string? targetDirectory = Path.GetDirectoryName(targetDependency);
-            if (!string.IsNullOrEmpty(targetDirectory)) Directory.CreateDirectory(targetDirectory);
-            _dependentFiles.Add(targetDependency);
-            try {
-                long copiedBytes = CopyDependency(
-                    sourceDependency,
-                    targetDependency,
-                    sourceDirectoryIdentity,
-                    _usesPhysicalIdentity,
-                    maximumDependencyBytes,
-                    maximumTotalBytes - report.ExpandedInspectionBytes - capturedBytes,
-                    cancellationToken);
-                capturedBytes += copiedBytes;
-                MakeReadOnly(targetDependency);
-                _dependentSnapshots.Add(DependencySnapshot.Capture(targetDependency, cancellationToken));
-            } catch {
-                _ = TryEraseAndDeleteFile(targetDependency);
-                throw;
+                string? targetDirectory = Path.GetDirectoryName(targetDependency);
+                if (!string.IsNullOrEmpty(targetDirectory)) Directory.CreateDirectory(targetDirectory);
+                _dependentFiles.Add(targetDependency);
+                try {
+                    long copiedBytes = CopyDependency(
+                        sourceDependency,
+                        targetDependency,
+                        sourceDirectoryIdentity,
+                        _usesPhysicalIdentity,
+                        maximumDependencyBytes,
+                        maximumTotalBytes - report.ExpandedInspectionBytes - capturedBytes,
+                        cancellationToken);
+                    capturedBytes += copiedBytes;
+                    MakeReadOnly(targetDependency);
+                    _dependentSnapshots.Add(DependencySnapshot.Capture(targetDependency, cancellationToken));
+                } catch {
+                    _ = TryEraseAndDeleteFile(targetDependency);
+                    throw;
+                }
+            }
+        } finally {
+            if (resealDirectory) SealForProviderAccess();
+        }
+    }
+
+    /// <summary>Removes directory write access while path-based owners and providers consume the snapshot.</summary>
+    internal void SealForProviderAccess() {
+        if (_disposed) throw new ObjectDisposedException(nameof(OfficeProvenanceFileSnapshot));
+        if (_directorySealed) return;
+        _directorySealed = true;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
+        foreach (string directory in EnumerateSnapshotDirectories().OrderByDescending(path => path.Length)) {
+            if (Directory.Exists(directory) && UnixChmod(directory, UnixOwnerReadExecuteDirectoryMode) != 0) {
+                throw new IOException(
+                    $"Unable to seal the provenance snapshot directory (errno {Marshal.GetLastWin32Error()}).");
             }
         }
     }
@@ -257,9 +279,28 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
             foreach (DependencySnapshot dependency in _dependentSnapshots) dependency.Dispose();
             _dependentLeasesDisposed = true;
         }
+        MakeSnapshotDirectoriesWritable();
         Cleanup(FilePath, _directoryPath, throwIfSensitiveDataRemains: true, _dependentFiles);
         _disposed = true;
     }
+
+    private void MakeSnapshotDirectoriesWritable() {
+        if (!_directorySealed) return;
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            foreach (string directory in EnumerateSnapshotDirectories().OrderBy(path => path.Length)) {
+                if (Directory.Exists(directory) && UnixChmod(directory, UnixOwnerDirectoryMode) != 0) {
+                    throw new IOException(
+                        $"Unable to unlock the provenance snapshot directory for cleanup (errno {Marshal.GetLastWin32Error()}).");
+                }
+            }
+        }
+        _directorySealed = false;
+    }
+
+    private IEnumerable<string> EnumerateSnapshotDirectories() => _dependentFiles
+        .SelectMany(path => EnumerateDependencyDirectories(path, _directoryPath))
+        .Concat(new[] { _directoryPath })
+        .Distinct(OfficePathIdentity.GetComparer(_directoryPath));
 
     private static long CopyDependency(
         string sourcePath,

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceFileSnapshot.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceFileSnapshot.cs
@@ -73,15 +73,20 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
             long capturedBytes = 0;
             var capturedTargets = new HashSet<string>(StringComparer.Ordinal);
             foreach (OfficeProvenanceEvidence evidence in report.Evidence.Where(item =>
-                         item.IsStructurallyValid &&
                          item.Carrier == OfficeProvenanceCarrierKind.C2paExternalManifest &&
                          !string.IsNullOrWhiteSpace(item.Value))) {
                 cancellationToken.ThrowIfCancellationRequested();
+                string reference = report.GetExternalManifestReference(evidence)!;
+                if (Uri.TryCreate(reference, UriKind.Absolute, out Uri? absoluteReference) && absoluteReference.IsFile) {
+                    throw new InvalidDataException(
+                        "An absolute file-based external provenance manifest cannot be bound to the immutable snapshot.");
+                }
+                if (!evidence.IsStructurallyValid) continue;
                 if (!TryResolveRelativeDependency(
                         sourceDirectory,
                         _directoryPath,
                         FilePath,
-                        report.GetExternalManifestReference(evidence)!,
+                        reference,
                         out string sourceDependency,
                         out string targetDependency) ||
                     !capturedTargets.Add(GetDependencyTargetIdentity(targetDependency)) ||

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceFileSnapshot.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceFileSnapshot.cs
@@ -73,7 +73,7 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
                     sourceDirectory,
                     _directoryPath,
                     FilePath,
-                    evidence.Value!,
+                    report.GetExternalManifestReference(evidence)!,
                     out string sourceDependency,
                     out string targetDependency) ||
                 !capturedTargets.Add(targetDependency) ||
@@ -147,13 +147,9 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
         string filePath = Path.Combine(directoryPath, "snapshot" + extension);
         try {
             long copiedBytes = 0;
-            using (var source = new FileStream(
-                       fullPath,
-                       FileMode.Open,
-                       FileAccess.Read,
-                       FileShare.Read,
-                       81920,
-                       FileOptions.SequentialScan))
+            string physicalSourceDirectory = OfficePathIdentity.ResolvePhysicalPath(
+                Path.GetDirectoryName(fullPath)!);
+            using (FileStream source = OpenSnapshotSource(fullPath, physicalSourceDirectory))
             using (var destination = new FileStream(
                        filePath,
                        FileMode.CreateNew,
@@ -456,6 +452,20 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
         }
 
         public void Dispose() => _lease.Dispose();
+    }
+
+    private static FileStream OpenSnapshotSource(string path, string physicalSourceDirectory) {
+        try {
+            return OfficePathIdentity.OpenRegularFileForRead(path, physicalSourceDirectory, 81920);
+        } catch (InvalidDataException) {
+            throw;
+        } catch (FileNotFoundException) {
+            throw;
+        } catch (Exception exception) when (exception is IOException or UnauthorizedAccessException) {
+            throw new InvalidDataException(
+                "The provenance snapshot source could not be opened as a regular file.",
+                exception);
+        }
     }
 
     private static byte[] ComputeHash(Stream stream, CancellationToken cancellationToken) {

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceFileSnapshot.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceFileSnapshot.cs
@@ -16,7 +16,8 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
     private const uint UnixOwnerReadWriteMode = 0x180; // 0600
     private readonly string _directoryPath;
     private readonly FileStream _lease;
-    private readonly string _physicalIdentity;
+    private readonly string? _physicalIdentity;
+    private readonly bool _usesPhysicalIdentity;
     private readonly byte[] _sha256;
     private readonly List<string> _dependentFiles = new List<string>();
     private readonly List<DependencySnapshot> _dependentSnapshots = new List<DependencySnapshot>();
@@ -28,15 +29,17 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
         string directoryPath,
         string filePath,
         long length,
-        string physicalIdentity,
+        string? physicalIdentity,
         byte[] sha256,
-        FileStream lease) {
+        FileStream lease,
+        bool usesPhysicalIdentity) {
         _directoryPath = directoryPath;
         FilePath = filePath;
         Length = length;
         _physicalIdentity = physicalIdentity;
         _sha256 = sha256;
         _lease = lease;
+        _usesPhysicalIdentity = usesPhysicalIdentity;
     }
 
     /// <summary>Gets the immutable snapshot path supplied to format owners and assessment providers.</summary>
@@ -59,7 +62,9 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
         if (maximumTotalBytes <= 0) throw new ArgumentOutOfRangeException(nameof(maximumTotalBytes));
 
         string sourceDirectory = Path.GetDirectoryName(Path.GetFullPath(sourcePath))!;
-        string physicalSourceDirectory = OfficePathIdentity.ResolvePhysicalPath(sourceDirectory);
+        string sourceDirectoryIdentity = _usesPhysicalIdentity
+            ? OfficePathIdentity.ResolvePhysicalPath(sourceDirectory)
+            : Path.GetFullPath(sourceDirectory);
         long capturedBytes = 0;
         var capturedTargets = new HashSet<string>(OfficePathIdentity.GetComparer(_directoryPath));
         foreach (OfficeProvenanceEvidence evidence in report.Evidence.Where(item =>
@@ -84,7 +89,8 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
                 long copiedBytes = CopyDependency(
                     sourceDependency,
                     targetDependency,
-                    physicalSourceDirectory,
+                    sourceDirectoryIdentity,
+                    _usesPhysicalIdentity,
                     maximumDependencyBytes,
                     maximumTotalBytes - report.ExpandedInspectionBytes - capturedBytes,
                     cancellationToken);
@@ -110,14 +116,19 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
     internal void VerifyPrimaryFile(CancellationToken cancellationToken = default) {
         if (_disposed) throw new ObjectDisposedException(nameof(OfficeProvenanceFileSnapshot));
         try {
-            string physicalDirectory = OfficePathIdentity.ResolvePhysicalPath(_directoryPath);
-            using FileStream stream = OfficePathIdentity.OpenRegularFileForRead(
+            string directoryIdentity = _usesPhysicalIdentity
+                ? OfficePathIdentity.ResolvePhysicalPath(_directoryPath)
+                : Path.GetFullPath(_directoryPath);
+            using FileStream stream = OpenRegularFileForRead(
                 FilePath,
-                physicalDirectory,
-                81920);
-            string identity = OfficePathIdentity.GetPhysicalIdentityKey(FilePath, stream.SafeFileHandle);
+                directoryIdentity,
+                _usesPhysicalIdentity,
+                "The primary provenance snapshot could not be opened as a regular file.");
+            string? identity = _usesPhysicalIdentity
+                ? OfficePathIdentity.GetPhysicalIdentityKey(FilePath, stream.SafeFileHandle)
+                : null;
             if (stream.Length != Length ||
-                !string.Equals(identity, _physicalIdentity, StringComparison.Ordinal) ||
+                (_usesPhysicalIdentity && !string.Equals(identity, _physicalIdentity, StringComparison.Ordinal)) ||
                 !FixedTimeEquals(ComputeHash(stream, cancellationToken), _sha256)) {
                 throw new InvalidDataException(
                     "The primary provenance snapshot changed while the operation was running.");
@@ -135,7 +146,27 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
     internal static OfficeProvenanceFileSnapshot Capture(
         string sourcePath,
         long maximumBytes,
-        CancellationToken cancellationToken = default) {
+        CancellationToken cancellationToken = default) => CaptureCore(
+            sourcePath,
+            maximumBytes,
+            cancellationToken,
+            OfficePathIdentity.SupportsPhysicalIdentity);
+
+    /// <summary>Exercises the portable snapshot path on platforms where physical file identity is unavailable.</summary>
+    internal static OfficeProvenanceFileSnapshot CapturePortable(
+        string sourcePath,
+        long maximumBytes,
+        CancellationToken cancellationToken = default) => CaptureCore(
+            sourcePath,
+            maximumBytes,
+            cancellationToken,
+            usesPhysicalIdentity: false);
+
+    private static OfficeProvenanceFileSnapshot CaptureCore(
+        string sourcePath,
+        long maximumBytes,
+        CancellationToken cancellationToken,
+        bool usesPhysicalIdentity) {
         if (string.IsNullOrWhiteSpace(sourcePath)) throw new ArgumentException("A source path is required.", nameof(sourcePath));
         if (maximumBytes <= 0) throw new ArgumentOutOfRangeException(nameof(maximumBytes));
 
@@ -145,9 +176,11 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
         try {
             long copiedBytes;
             byte[] copiedSha256;
-            string physicalSourceDirectory = OfficePathIdentity.ResolvePhysicalPath(
-                Path.GetDirectoryName(fullPath)!);
-            using (FileStream source = OpenSnapshotSource(fullPath, physicalSourceDirectory))
+            string sourceDirectory = Path.GetDirectoryName(fullPath)!;
+            string sourceDirectoryIdentity = usesPhysicalIdentity
+                ? OfficePathIdentity.ResolvePhysicalPath(sourceDirectory)
+                : Path.GetFullPath(sourceDirectory);
+            using (FileStream source = OpenSnapshotSource(fullPath, sourceDirectoryIdentity, usesPhysicalIdentity))
             using (var destination = new FileStream(
                        filePath,
                        FileMode.CreateNew,
@@ -162,9 +195,9 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
                     "The asset snapshot exceeds the configured input limit.",
                     cancellationToken,
                     out copiedBytes);
-                if (!OfficePathIdentity.IsOpenedFileWithinRootByIdentity(
+                if (usesPhysicalIdentity && !OfficePathIdentity.IsOpenedFileWithinRootByIdentity(
                         fullPath,
-                        physicalSourceDirectory,
+                        sourceDirectoryIdentity,
                         source.SafeFileHandle)) {
                     throw new InvalidDataException(
                         "The asset snapshot source changed identity while it was being captured.");
@@ -182,7 +215,9 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
                 81920,
                 FileOptions.SequentialScan);
             try {
-                string physicalIdentity = OfficePathIdentity.GetPhysicalIdentityKey(filePath, lease.SafeFileHandle);
+                string? physicalIdentity = usesPhysicalIdentity
+                    ? OfficePathIdentity.GetPhysicalIdentityKey(filePath, lease.SafeFileHandle)
+                    : null;
                 byte[] sha256 = ComputeHash(lease, cancellationToken);
                 if (lease.Length != copiedBytes || !FixedTimeEquals(sha256, copiedSha256)) {
                     throw new InvalidDataException(
@@ -195,7 +230,8 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
                     copiedBytes,
                     physicalIdentity,
                     sha256,
-                    lease);
+                    lease,
+                    usesPhysicalIdentity);
             } catch {
                 lease.Dispose();
                 throw;
@@ -224,7 +260,8 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
     private static long CopyDependency(
         string sourcePath,
         string targetPath,
-        string physicalSourceDirectory,
+        string sourceDirectoryIdentity,
+        bool usesPhysicalIdentity,
         long maximumDependencyBytes,
         long remainingTotalBytes,
         CancellationToken cancellationToken) {
@@ -232,19 +269,11 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
             throw new InvalidDataException("External provenance manifests exceed the configured expanded-data limit.");
         }
         long copiedBytes = 0;
-        FileStream source;
-        try {
-            source = OfficePathIdentity.OpenRegularFileForRead(
-                sourcePath,
-                physicalSourceDirectory,
-                81920);
-        } catch (InvalidDataException) {
-            throw;
-        } catch (Exception exception) when (exception is IOException or UnauthorizedAccessException) {
-            throw new InvalidDataException(
-                "The external provenance manifest could not be opened as a regular file within the source directory.",
-                exception);
-        }
+        FileStream source = OpenRegularFileForRead(
+            sourcePath,
+            sourceDirectoryIdentity,
+            usesPhysicalIdentity,
+            "The external provenance manifest could not be opened as a regular file within the source directory.");
         using (source) {
             if (source.Length > maximumDependencyBytes) {
                 throw new InvalidDataException("An external provenance manifest exceeds the configured manifest limit.");
@@ -264,9 +293,9 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
                 limitMessage,
                 cancellationToken,
                 out copiedBytes);
-            if (!OfficePathIdentity.IsOpenedFileWithinRootByIdentity(
+            if (usesPhysicalIdentity && !OfficePathIdentity.IsOpenedFileWithinRootByIdentity(
                     sourcePath,
-                    physicalSourceDirectory,
+                    sourceDirectoryIdentity,
                     source.SafeFileHandle)) {
                 throw new InvalidDataException(
                     "An external provenance manifest changed identity while it was being captured.");
@@ -455,17 +484,51 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
         public void Dispose() => _lease.Dispose();
     }
 
-    private static FileStream OpenSnapshotSource(string path, string physicalSourceDirectory) {
+    private static FileStream OpenSnapshotSource(
+        string path,
+        string sourceDirectoryIdentity,
+        bool usesPhysicalIdentity) => OpenRegularFileForRead(
+            path,
+            sourceDirectoryIdentity,
+            usesPhysicalIdentity,
+            "The provenance snapshot source could not be opened as a regular file.");
+
+    private static FileStream OpenRegularFileForRead(
+        string path,
+        string sourceDirectoryIdentity,
+        bool usesPhysicalIdentity,
+        string failureMessage) {
         try {
-            return OfficePathIdentity.OpenRegularFileForRead(path, physicalSourceDirectory, 81920);
+            if (usesPhysicalIdentity) {
+                return OfficePathIdentity.OpenRegularFileForRead(path, sourceDirectoryIdentity, 81920);
+            }
+
+            string fullPath = Path.GetFullPath(path);
+            if (!IsWithinDirectory(fullPath, sourceDirectoryIdentity)) {
+                throw new InvalidDataException("The opened filesystem entry resolves outside the source directory.");
+            }
+            FileAttributes attributes = File.GetAttributes(fullPath);
+            if ((attributes & (FileAttributes.Directory | FileAttributes.ReparsePoint)) != 0) {
+                throw new InvalidDataException("The filesystem entry is not a portable regular file.");
+            }
+            var stream = new FileStream(
+                fullPath,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.Read,
+                81920,
+                FileOptions.SequentialScan);
+            if (!stream.CanSeek) {
+                stream.Dispose();
+                throw new InvalidDataException("The filesystem entry is not a seekable regular file.");
+            }
+            return stream;
         } catch (InvalidDataException) {
             throw;
         } catch (FileNotFoundException) {
             throw;
         } catch (Exception exception) when (exception is IOException or UnauthorizedAccessException) {
-            throw new InvalidDataException(
-                "The provenance snapshot source could not be opened as a regular file.",
-                exception);
+            throw new InvalidDataException(failureMessage, exception);
         }
     }
 

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceFileSnapshot.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceFileSnapshot.cs
@@ -66,7 +66,7 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
             ? OfficePathIdentity.ResolvePhysicalPath(sourceDirectory)
             : Path.GetFullPath(sourceDirectory);
         long capturedBytes = 0;
-        var capturedTargets = new HashSet<string>(OfficePathIdentity.GetComparer(_directoryPath));
+        var capturedTargets = new HashSet<string>(StringComparer.Ordinal);
         foreach (OfficeProvenanceEvidence evidence in report.Evidence.Where(item =>
                      item.IsStructurallyValid &&
                      item.Carrier == OfficeProvenanceCarrierKind.C2paExternalManifest &&
@@ -79,7 +79,7 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
                     report.GetExternalManifestReference(evidence)!,
                     out string sourceDependency,
                     out string targetDependency) ||
-                !capturedTargets.Add(targetDependency) ||
+                !capturedTargets.Add(GetDependencyTargetIdentity(targetDependency)) ||
                 !File.Exists(sourceDependency)) continue;
 
             string? targetDirectory = Path.GetDirectoryName(targetDependency);
@@ -111,6 +111,10 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
             dependency.Verify(cancellationToken);
         }
     }
+
+    private string GetDependencyTargetIdentity(string targetPath) => _usesPhysicalIdentity
+        ? OfficePathIdentity.Normalize(targetPath)
+        : Path.GetFullPath(targetPath);
 
     /// <summary>Verifies that the primary snapshot stayed identical throughout owner and provider execution.</summary>
     internal void VerifyPrimaryFile(CancellationToken cancellationToken = default) {

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceFileSnapshot.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceFileSnapshot.cs
@@ -61,9 +61,7 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
         string sourceDirectory = Path.GetDirectoryName(Path.GetFullPath(sourcePath))!;
         string physicalSourceDirectory = OfficePathIdentity.ResolvePhysicalPath(sourceDirectory);
         long capturedBytes = 0;
-        var capturedTargets = new HashSet<string>(RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-            ? StringComparer.OrdinalIgnoreCase
-            : StringComparer.Ordinal);
+        var capturedTargets = new HashSet<string>(OfficePathIdentity.GetComparer(_directoryPath));
         foreach (OfficeProvenanceEvidence evidence in report.Evidence.Where(item =>
                      item.IsStructurallyValid &&
                      item.Carrier == OfficeProvenanceCarrierKind.C2paExternalManifest &&
@@ -300,18 +298,14 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
 
     private static bool IsWithinDirectory(string path, string directory) {
         string root = Path.GetFullPath(directory).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
-        StringComparison comparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-            ? StringComparison.OrdinalIgnoreCase
-            : StringComparison.Ordinal;
+        StringComparison comparison = OfficePathIdentity.GetComparison(directory);
         return path.StartsWith(root, comparison);
     }
 
     private static bool PathsEqual(string left, string right) => string.Equals(
         left,
         right,
-        RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-            ? StringComparison.OrdinalIgnoreCase
-            : StringComparison.Ordinal);
+        OfficePathIdentity.GetComparison(left));
 
     private static string CreatePrivateDirectory() {
         string tempPath = Path.GetTempPath();
@@ -362,9 +356,7 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
         foreach (string? directory in dependencies
                      .SelectMany(path => EnumerateDependencyDirectories(path, directoryPath))
                      .Where(path => !string.IsNullOrEmpty(path) && !PathsEqual(path!, directoryPath))
-                     .Distinct(RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                         ? StringComparer.OrdinalIgnoreCase
-                         : StringComparer.Ordinal)
+                     .Distinct(OfficePathIdentity.GetComparer(directoryPath))
                      .OrderByDescending(path => path!.Length)) {
             try {
                 if (Directory.Exists(directory)) Directory.Delete(directory!, recursive: false);

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceFileSnapshot.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceFileSnapshot.cs
@@ -1,0 +1,175 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace OfficeIMO.Provenance;
+
+/// <summary>Owns one bounded, private, read-only file snapshot used by multi-stage provenance operations.</summary>
+internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
+    private const uint UnixOwnerDirectoryMode = 0x1C0; // 0700
+    private const uint UnixOwnerReadOnlyMode = 0x100; // 0400
+    private const uint UnixOwnerReadWriteMode = 0x180; // 0600
+    private readonly string _directoryPath;
+    private readonly FileStream _lease;
+    private bool _leaseDisposed;
+    private bool _disposed;
+
+    private OfficeProvenanceFileSnapshot(string directoryPath, string filePath, long length, FileStream lease) {
+        _directoryPath = directoryPath;
+        FilePath = filePath;
+        Length = length;
+        _lease = lease;
+    }
+
+    /// <summary>Gets the immutable snapshot path supplied to format owners and assessment providers.</summary>
+    internal string FilePath { get; }
+
+    /// <summary>Gets the captured encoded byte length.</summary>
+    internal long Length { get; }
+
+    /// <summary>Captures one input through a single bounded read and holds a shared-read lease until disposal.</summary>
+    internal static OfficeProvenanceFileSnapshot Capture(
+        string sourcePath,
+        long maximumBytes,
+        CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(sourcePath)) throw new ArgumentException("A source path is required.", nameof(sourcePath));
+        if (maximumBytes <= 0 || maximumBytes > int.MaxValue) throw new ArgumentOutOfRangeException(nameof(maximumBytes));
+
+        string fullPath = Path.GetFullPath(sourcePath);
+        string directoryPath = CreatePrivateDirectory();
+        string extension = Path.GetExtension(fullPath);
+        string filePath = Path.Combine(directoryPath, "snapshot" + extension);
+        try {
+            long copiedBytes = 0;
+            using (var source = new FileStream(
+                       fullPath,
+                       FileMode.Open,
+                       FileAccess.Read,
+                       FileShare.Read,
+                       81920,
+                       FileOptions.SequentialScan))
+            using (var destination = new FileStream(
+                       filePath,
+                       FileMode.CreateNew,
+                       FileAccess.Write,
+                       FileShare.None,
+                       81920,
+                       FileOptions.SequentialScan)) {
+                if (source.Length > maximumBytes) {
+                    throw new InvalidDataException("The asset snapshot exceeds the configured input limit.");
+                }
+
+                var buffer = new byte[81920];
+                int read;
+                while ((read = source.Read(buffer, 0, buffer.Length)) != 0) {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    copiedBytes += read;
+                    if (copiedBytes > maximumBytes) {
+                        throw new InvalidDataException("The asset snapshot exceeds the configured input limit.");
+                    }
+                    destination.Write(buffer, 0, read);
+                }
+                cancellationToken.ThrowIfCancellationRequested();
+                destination.Flush(flushToDisk: true);
+            }
+
+            MakeReadOnly(filePath);
+            var lease = new FileStream(
+                filePath,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.Read,
+                1,
+                FileOptions.RandomAccess);
+            return new OfficeProvenanceFileSnapshot(directoryPath, filePath, copiedBytes, lease);
+        } catch {
+            Cleanup(filePath, directoryPath, throwIfSensitiveDataRemains: true);
+            throw;
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose() {
+        if (_disposed) return;
+        if (!_leaseDisposed) {
+            _lease.Dispose();
+            _leaseDisposed = true;
+        }
+        Cleanup(FilePath, _directoryPath, throwIfSensitiveDataRemains: true);
+        _disposed = true;
+    }
+
+    private static string CreatePrivateDirectory() {
+        string tempPath = Path.GetTempPath();
+        for (int attempt = 0; attempt < 16; attempt++) {
+            string path = Path.Combine(tempPath, "officeimo-provenance-" + Guid.NewGuid().ToString("N"));
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+                Directory.CreateDirectory(path);
+                return path;
+            }
+            if (UnixMkdir(path, UnixOwnerDirectoryMode) == 0) return path;
+            int error = Marshal.GetLastWin32Error();
+            if (error != 17) throw new IOException($"Unable to create a private provenance snapshot directory (errno {error}).");
+        }
+        throw new IOException("Unable to allocate a unique private provenance snapshot directory.");
+    }
+
+    private static void MakeReadOnly(string path) {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            File.SetAttributes(path, FileAttributes.ReadOnly);
+            return;
+        }
+        if (UnixChmod(path, UnixOwnerReadOnlyMode) != 0) {
+            throw new IOException($"Unable to protect the provenance snapshot (errno {Marshal.GetLastWin32Error()}).");
+        }
+    }
+
+    private static void MakeWritable(string path) {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            File.SetAttributes(path, FileAttributes.Normal);
+            return;
+        }
+        if (UnixChmod(path, UnixOwnerReadWriteMode) != 0) {
+            throw new IOException($"Unable to unlock the provenance snapshot for cleanup (errno {Marshal.GetLastWin32Error()}).");
+        }
+    }
+
+    private static void Cleanup(string filePath, string directoryPath, bool throwIfSensitiveDataRemains) {
+        Exception? cleanupFailure = null;
+        if (File.Exists(filePath)) {
+            try {
+                MakeWritable(filePath);
+                File.Delete(filePath);
+            } catch (Exception exception) when (exception is IOException or UnauthorizedAccessException) {
+                cleanupFailure = exception;
+                try {
+                    using var scrub = new FileStream(filePath, FileMode.Truncate, FileAccess.Write, FileShare.Read);
+                    scrub.Flush(flushToDisk: true);
+                    try { File.Delete(filePath); } catch (Exception deleteException) when (deleteException is IOException or UnauthorizedAccessException) { }
+                    cleanupFailure = null;
+                } catch (Exception scrubException) when (scrubException is IOException or UnauthorizedAccessException) {
+                    cleanupFailure = scrubException;
+                }
+            }
+        }
+
+        try {
+            if (Directory.Exists(directoryPath)) Directory.Delete(directoryPath, recursive: false);
+        } catch (Exception exception) when (exception is IOException or UnauthorizedAccessException) {
+            if (File.Exists(filePath)) cleanupFailure ??= exception;
+        }
+
+        if (throwIfSensitiveDataRemains && cleanupFailure != null && File.Exists(filePath)) {
+            throw new IOException(
+                $"The provenance snapshot could not be removed or erased; '{filePath}' is retained for operator cleanup.",
+                cleanupFailure);
+        }
+    }
+
+    [DllImport("libc", SetLastError = true, EntryPoint = "mkdir")]
+    private static extern int UnixMkdir(string path, uint mode);
+
+    [DllImport("libc", SetLastError = true, EntryPoint = "chmod")]
+    private static extern int UnixChmod(string path, uint mode);
+}

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceFileSnapshot.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceFileSnapshot.cs
@@ -16,16 +16,26 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
     private const uint UnixOwnerReadWriteMode = 0x180; // 0600
     private readonly string _directoryPath;
     private readonly FileStream _lease;
+    private readonly string _physicalIdentity;
+    private readonly byte[] _sha256;
     private readonly List<string> _dependentFiles = new List<string>();
     private readonly List<DependencySnapshot> _dependentSnapshots = new List<DependencySnapshot>();
     private bool _dependentLeasesDisposed;
     private bool _leaseDisposed;
     private bool _disposed;
 
-    private OfficeProvenanceFileSnapshot(string directoryPath, string filePath, long length, FileStream lease) {
+    private OfficeProvenanceFileSnapshot(
+        string directoryPath,
+        string filePath,
+        long length,
+        string physicalIdentity,
+        byte[] sha256,
+        FileStream lease) {
         _directoryPath = directoryPath;
         FilePath = filePath;
         Length = length;
+        _physicalIdentity = physicalIdentity;
+        _sha256 = sha256;
         _lease = lease;
     }
 
@@ -78,7 +88,7 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
                     targetDependency,
                     physicalSourceDirectory,
                     maximumDependencyBytes,
-                    maximumTotalBytes - capturedBytes,
+                    maximumTotalBytes - report.ExpandedInspectionBytes - capturedBytes,
                     cancellationToken);
                 capturedBytes += copiedBytes;
                 MakeReadOnly(targetDependency);
@@ -95,6 +105,31 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
         if (_disposed) throw new ObjectDisposedException(nameof(OfficeProvenanceFileSnapshot));
         foreach (DependencySnapshot dependency in _dependentSnapshots) {
             dependency.Verify(cancellationToken);
+        }
+    }
+
+    /// <summary>Verifies that the primary snapshot stayed identical throughout owner and provider execution.</summary>
+    internal void VerifyPrimaryFile(CancellationToken cancellationToken = default) {
+        if (_disposed) throw new ObjectDisposedException(nameof(OfficeProvenanceFileSnapshot));
+        try {
+            string physicalDirectory = OfficePathIdentity.ResolvePhysicalPath(_directoryPath);
+            using FileStream stream = OfficePathIdentity.OpenRegularFileForRead(
+                FilePath,
+                physicalDirectory,
+                81920);
+            string identity = OfficePathIdentity.GetPhysicalIdentityKey(FilePath, stream.SafeFileHandle);
+            if (stream.Length != Length ||
+                !string.Equals(identity, _physicalIdentity, StringComparison.Ordinal) ||
+                !FixedTimeEquals(ComputeHash(stream, cancellationToken), _sha256)) {
+                throw new InvalidDataException(
+                    "The primary provenance snapshot changed while the operation was running.");
+            }
+        } catch (InvalidDataException) {
+            throw;
+        } catch (Exception exception) when (exception is IOException or UnauthorizedAccessException) {
+            throw new InvalidDataException(
+                "The primary provenance snapshot disappeared or became inaccessible while the operation was running.",
+                exception);
         }
     }
 
@@ -150,9 +185,23 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
                 FileMode.Open,
                 FileAccess.Read,
                 FileShare.Read,
-                1,
-                FileOptions.RandomAccess);
-            return new OfficeProvenanceFileSnapshot(directoryPath, filePath, copiedBytes, lease);
+                81920,
+                FileOptions.SequentialScan);
+            try {
+                string physicalIdentity = OfficePathIdentity.GetPhysicalIdentityKey(filePath, lease.SafeFileHandle);
+                byte[] sha256 = ComputeHash(lease, cancellationToken);
+                lease.Position = 0;
+                return new OfficeProvenanceFileSnapshot(
+                    directoryPath,
+                    filePath,
+                    copiedBytes,
+                    physicalIdentity,
+                    sha256,
+                    lease);
+            } catch {
+                lease.Dispose();
+                throw;
+            }
         } catch {
             Cleanup(filePath, directoryPath, throwIfSensitiveDataRemains: true);
             throw;
@@ -185,32 +234,43 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
             throw new InvalidDataException("External provenance manifests exceed the configured expanded-data limit.");
         }
         long copiedBytes = 0;
-        using FileStream source = OfficePathIdentity.OpenRegularFileForRead(
-            sourcePath,
-            physicalSourceDirectory,
-            81920);
-        if (source.Length > maximumDependencyBytes) {
-            throw new InvalidDataException("An external provenance manifest exceeds the configured manifest limit.");
+        FileStream source;
+        try {
+            source = OfficePathIdentity.OpenRegularFileForRead(
+                sourcePath,
+                physicalSourceDirectory,
+                81920);
+        } catch (InvalidDataException) {
+            throw;
+        } catch (Exception exception) when (exception is IOException or UnauthorizedAccessException) {
+            throw new InvalidDataException(
+                "The external provenance manifest could not be opened as a regular file within the source directory.",
+                exception);
         }
-        if (source.Length > remainingTotalBytes) {
-            throw new InvalidDataException("External provenance manifests exceed the configured expanded-data limit.");
-        }
-        using var target = new FileStream(targetPath, FileMode.CreateNew, FileAccess.Write, FileShare.None, 81920, FileOptions.SequentialScan);
-        var buffer = new byte[81920];
-        int read;
-        while ((read = source.Read(buffer, 0, buffer.Length)) != 0) {
-            cancellationToken.ThrowIfCancellationRequested();
-            copiedBytes += read;
-            if (copiedBytes > maximumDependencyBytes) {
+        using (source) {
+            if (source.Length > maximumDependencyBytes) {
                 throw new InvalidDataException("An external provenance manifest exceeds the configured manifest limit.");
             }
-            if (copiedBytes > remainingTotalBytes) {
+            if (source.Length > remainingTotalBytes) {
                 throw new InvalidDataException("External provenance manifests exceed the configured expanded-data limit.");
             }
-            target.Write(buffer, 0, read);
+            using var target = new FileStream(targetPath, FileMode.CreateNew, FileAccess.Write, FileShare.None, 81920, FileOptions.SequentialScan);
+            var buffer = new byte[81920];
+            int read;
+            while ((read = source.Read(buffer, 0, buffer.Length)) != 0) {
+                cancellationToken.ThrowIfCancellationRequested();
+                copiedBytes += read;
+                if (copiedBytes > maximumDependencyBytes) {
+                    throw new InvalidDataException("An external provenance manifest exceeds the configured manifest limit.");
+                }
+                if (copiedBytes > remainingTotalBytes) {
+                    throw new InvalidDataException("External provenance manifests exceed the configured expanded-data limit.");
+                }
+                target.Write(buffer, 0, read);
+            }
+            target.Flush(flushToDisk: true);
+            return copiedBytes;
         }
-        target.Flush(flushToDisk: true);
-        return copiedBytes;
     }
 
     private static bool TryResolveRelativeDependency(
@@ -363,7 +423,7 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
                 81920,
                 FileOptions.SequentialScan);
             try {
-                byte[] sha256 = ComputeHash(lease, cancellationToken);
+                byte[] sha256 = OfficeProvenanceFileSnapshot.ComputeHash(lease, cancellationToken);
                 lease.Position = 0;
                 return new DependencySnapshot(path, lease.Length, sha256, lease);
             } catch {
@@ -382,7 +442,9 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
                     81920,
                     FileOptions.SequentialScan);
                 if (stream.Length != _length ||
-                    !FixedTimeEquals(ComputeHash(stream, cancellationToken), _sha256)) {
+                    !OfficeProvenanceFileSnapshot.FixedTimeEquals(
+                        OfficeProvenanceFileSnapshot.ComputeHash(stream, cancellationToken),
+                        _sha256)) {
                     throw new InvalidDataException(
                         "An external provenance manifest changed while the assessment was running.");
                 }
@@ -394,24 +456,24 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
         }
 
         public void Dispose() => _lease.Dispose();
+    }
 
-        private static byte[] ComputeHash(Stream stream, CancellationToken cancellationToken) {
-            using IncrementalHash algorithm = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
-            var buffer = new byte[81920];
-            int read;
-            while ((read = stream.Read(buffer, 0, buffer.Length)) != 0) {
-                cancellationToken.ThrowIfCancellationRequested();
-                algorithm.AppendData(buffer, 0, read);
-            }
-            return algorithm.GetHashAndReset();
+    private static byte[] ComputeHash(Stream stream, CancellationToken cancellationToken) {
+        using IncrementalHash algorithm = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        var buffer = new byte[81920];
+        int read;
+        while ((read = stream.Read(buffer, 0, buffer.Length)) != 0) {
+            cancellationToken.ThrowIfCancellationRequested();
+            algorithm.AppendData(buffer, 0, read);
         }
+        return algorithm.GetHashAndReset();
+    }
 
-        private static bool FixedTimeEquals(byte[] left, byte[] right) {
-            if (left.Length != right.Length) return false;
-            int difference = 0;
-            for (int index = 0; index < left.Length; index++) difference |= left[index] ^ right[index];
-            return difference == 0;
-        }
+    private static bool FixedTimeEquals(byte[] left, byte[] right) {
+        if (left.Length != right.Length) return false;
+        int difference = 0;
+        for (int index = 0; index < left.Length; index++) difference |= left[index] ^ right[index];
+        return difference == 0;
     }
 
     private static Exception? TryEraseAndDeleteFile(string path) {

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceFileSnapshot.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceFileSnapshot.cs
@@ -141,8 +141,7 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
 
         string fullPath = Path.GetFullPath(sourcePath);
         string directoryPath = CreatePrivateDirectory();
-        string extension = Path.GetExtension(fullPath);
-        string filePath = Path.Combine(directoryPath, "snapshot" + extension);
+        string filePath = Path.Combine(directoryPath, Path.GetFileName(fullPath));
         try {
             long copiedBytes = 0;
             string physicalSourceDirectory = OfficePathIdentity.ResolvePhysicalPath(

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceFileSnapshot.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceFileSnapshot.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Threading;
+using OfficeIMO.Internal;
 
 namespace OfficeIMO.Provenance;
 
@@ -38,14 +39,17 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
     internal void CaptureExternalManifestDependencies(
         string sourcePath,
         OfficeProvenanceReport report,
+        long maximumDependencyBytes,
         long maximumTotalBytes,
         CancellationToken cancellationToken = default) {
         if (_disposed) throw new ObjectDisposedException(nameof(OfficeProvenanceFileSnapshot));
         if (string.IsNullOrWhiteSpace(sourcePath)) throw new ArgumentException("A source path is required.", nameof(sourcePath));
         if (report == null) throw new ArgumentNullException(nameof(report));
+        if (maximumDependencyBytes <= 0) throw new ArgumentOutOfRangeException(nameof(maximumDependencyBytes));
         if (maximumTotalBytes <= 0) throw new ArgumentOutOfRangeException(nameof(maximumTotalBytes));
 
         string sourceDirectory = Path.GetDirectoryName(Path.GetFullPath(sourcePath))!;
+        string physicalSourceDirectory = OfficePathIdentity.ResolvePhysicalPath(sourceDirectory);
         long capturedBytes = 0;
         var capturedTargets = new HashSet<string>(RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
             ? StringComparer.OrdinalIgnoreCase
@@ -72,6 +76,8 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
                 long copiedBytes = CopyDependency(
                     sourceDependency,
                     targetDependency,
+                    physicalSourceDirectory,
+                    maximumDependencyBytes,
                     maximumTotalBytes - capturedBytes,
                     cancellationToken);
                 capturedBytes += copiedBytes;
@@ -171,13 +177,23 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
     private static long CopyDependency(
         string sourcePath,
         string targetPath,
-        long maximumBytes,
+        string physicalSourceDirectory,
+        long maximumDependencyBytes,
+        long remainingTotalBytes,
         CancellationToken cancellationToken) {
-        if (maximumBytes <= 0) throw new InvalidDataException("External provenance manifests exceed the configured manifest limit.");
+        if (remainingTotalBytes <= 0) {
+            throw new InvalidDataException("External provenance manifests exceed the configured expanded-data limit.");
+        }
         long copiedBytes = 0;
-        using var source = new FileStream(sourcePath, FileMode.Open, FileAccess.Read, FileShare.Read, 81920, FileOptions.SequentialScan);
-        if (source.Length > maximumBytes) {
-            throw new InvalidDataException("External provenance manifests exceed the configured manifest limit.");
+        using FileStream source = OfficePathIdentity.OpenRegularFileForRead(
+            sourcePath,
+            physicalSourceDirectory,
+            81920);
+        if (source.Length > maximumDependencyBytes) {
+            throw new InvalidDataException("An external provenance manifest exceeds the configured manifest limit.");
+        }
+        if (source.Length > remainingTotalBytes) {
+            throw new InvalidDataException("External provenance manifests exceed the configured expanded-data limit.");
         }
         using var target = new FileStream(targetPath, FileMode.CreateNew, FileAccess.Write, FileShare.None, 81920, FileOptions.SequentialScan);
         var buffer = new byte[81920];
@@ -185,8 +201,11 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
         while ((read = source.Read(buffer, 0, buffer.Length)) != 0) {
             cancellationToken.ThrowIfCancellationRequested();
             copiedBytes += read;
-            if (copiedBytes > maximumBytes) {
-                throw new InvalidDataException("External provenance manifests exceed the configured manifest limit.");
+            if (copiedBytes > maximumDependencyBytes) {
+                throw new InvalidDataException("An external provenance manifest exceeds the configured manifest limit.");
+            }
+            if (copiedBytes > remainingTotalBytes) {
+                throw new InvalidDataException("External provenance manifests exceed the configured expanded-data limit.");
             }
             target.Write(buffer, 0, read);
         }

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceFileSnapshot.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceFileSnapshot.cs
@@ -77,9 +77,12 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
                          !string.IsNullOrWhiteSpace(item.Value))) {
                 cancellationToken.ThrowIfCancellationRequested();
                 string reference = report.GetExternalManifestReference(evidence)!;
-                if (Uri.TryCreate(reference, UriKind.Absolute, out Uri? absoluteReference) && absoluteReference.IsFile) {
-                    throw new InvalidDataException(
-                        "An absolute file-based external provenance manifest cannot be bound to the immutable snapshot.");
+                if (Uri.TryCreate(reference, UriKind.Absolute, out Uri? absoluteReference)) {
+                    if (absoluteReference.IsFile) {
+                        throw new InvalidDataException(
+                            "An absolute file-based external provenance manifest cannot be bound to the immutable snapshot.");
+                    }
+                    continue;
                 }
                 if (!evidence.IsStructurallyValid) continue;
                 if (!TryResolveRelativeDependency(
@@ -88,8 +91,11 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
                         FilePath,
                         reference,
                         out string sourceDependency,
-                        out string targetDependency) ||
-                    !capturedTargets.Add(GetDependencyTargetIdentity(targetDependency)) ||
+                        out string targetDependency)) {
+                    throw new InvalidDataException(
+                        "A relative external provenance manifest cannot be bound within the immutable snapshot.");
+                }
+                if (!capturedTargets.Add(GetDependencyTargetIdentity(targetDependency)) ||
                     !File.Exists(sourceDependency)) continue;
 
                 string? targetDirectory = Path.GetDirectoryName(targetDependency);

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceFileSnapshot.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceFileSnapshot.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 using System.Threading;
 
 namespace OfficeIMO.Provenance;
@@ -12,6 +15,9 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
     private const uint UnixOwnerReadWriteMode = 0x180; // 0600
     private readonly string _directoryPath;
     private readonly FileStream _lease;
+    private readonly List<string> _dependentFiles = new List<string>();
+    private readonly List<DependencySnapshot> _dependentSnapshots = new List<DependencySnapshot>();
+    private bool _dependentLeasesDisposed;
     private bool _leaseDisposed;
     private bool _disposed;
 
@@ -28,13 +34,71 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
     /// <summary>Gets the captured encoded byte length.</summary>
     internal long Length { get; }
 
+    /// <summary>Captures local relative manifest references beside the immutable asset snapshot.</summary>
+    internal void CaptureExternalManifestDependencies(
+        string sourcePath,
+        OfficeProvenanceReport report,
+        long maximumTotalBytes,
+        CancellationToken cancellationToken = default) {
+        if (_disposed) throw new ObjectDisposedException(nameof(OfficeProvenanceFileSnapshot));
+        if (string.IsNullOrWhiteSpace(sourcePath)) throw new ArgumentException("A source path is required.", nameof(sourcePath));
+        if (report == null) throw new ArgumentNullException(nameof(report));
+        if (maximumTotalBytes <= 0) throw new ArgumentOutOfRangeException(nameof(maximumTotalBytes));
+
+        string sourceDirectory = Path.GetDirectoryName(Path.GetFullPath(sourcePath))!;
+        long capturedBytes = 0;
+        var capturedTargets = new HashSet<string>(RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal);
+        foreach (OfficeProvenanceEvidence evidence in report.Evidence.Where(item =>
+                     item.IsStructurallyValid &&
+                     item.Carrier == OfficeProvenanceCarrierKind.C2paExternalManifest &&
+                     !string.IsNullOrWhiteSpace(item.Value))) {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!TryResolveRelativeDependency(
+                    sourceDirectory,
+                    _directoryPath,
+                    FilePath,
+                    evidence.Value!,
+                    out string sourceDependency,
+                    out string targetDependency) ||
+                !capturedTargets.Add(targetDependency) ||
+                !File.Exists(sourceDependency)) continue;
+
+            string? targetDirectory = Path.GetDirectoryName(targetDependency);
+            if (!string.IsNullOrEmpty(targetDirectory)) Directory.CreateDirectory(targetDirectory);
+            _dependentFiles.Add(targetDependency);
+            try {
+                long copiedBytes = CopyDependency(
+                    sourceDependency,
+                    targetDependency,
+                    maximumTotalBytes - capturedBytes,
+                    cancellationToken);
+                capturedBytes += copiedBytes;
+                MakeReadOnly(targetDependency);
+                _dependentSnapshots.Add(DependencySnapshot.Capture(targetDependency, cancellationToken));
+            } catch {
+                _ = TryEraseAndDeleteFile(targetDependency);
+                throw;
+            }
+        }
+    }
+
+    /// <summary>Verifies that captured external manifests stayed identical throughout provider execution.</summary>
+    internal void VerifyExternalManifestDependencies(CancellationToken cancellationToken = default) {
+        if (_disposed) throw new ObjectDisposedException(nameof(OfficeProvenanceFileSnapshot));
+        foreach (DependencySnapshot dependency in _dependentSnapshots) {
+            dependency.Verify(cancellationToken);
+        }
+    }
+
     /// <summary>Captures one input through a single bounded read and holds a shared-read lease until disposal.</summary>
     internal static OfficeProvenanceFileSnapshot Capture(
         string sourcePath,
         long maximumBytes,
         CancellationToken cancellationToken = default) {
         if (string.IsNullOrWhiteSpace(sourcePath)) throw new ArgumentException("A source path is required.", nameof(sourcePath));
-        if (maximumBytes <= 0 || maximumBytes > int.MaxValue) throw new ArgumentOutOfRangeException(nameof(maximumBytes));
+        if (maximumBytes <= 0) throw new ArgumentOutOfRangeException(nameof(maximumBytes));
 
         string fullPath = Path.GetFullPath(sourcePath);
         string directoryPath = CreatePrivateDirectory();
@@ -96,9 +160,83 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
             _lease.Dispose();
             _leaseDisposed = true;
         }
-        Cleanup(FilePath, _directoryPath, throwIfSensitiveDataRemains: true);
+        if (!_dependentLeasesDisposed) {
+            foreach (DependencySnapshot dependency in _dependentSnapshots) dependency.Dispose();
+            _dependentLeasesDisposed = true;
+        }
+        Cleanup(FilePath, _directoryPath, throwIfSensitiveDataRemains: true, _dependentFiles);
         _disposed = true;
     }
+
+    private static long CopyDependency(
+        string sourcePath,
+        string targetPath,
+        long maximumBytes,
+        CancellationToken cancellationToken) {
+        if (maximumBytes <= 0) throw new InvalidDataException("External provenance manifests exceed the configured manifest limit.");
+        long copiedBytes = 0;
+        using var source = new FileStream(sourcePath, FileMode.Open, FileAccess.Read, FileShare.Read, 81920, FileOptions.SequentialScan);
+        if (source.Length > maximumBytes) {
+            throw new InvalidDataException("External provenance manifests exceed the configured manifest limit.");
+        }
+        using var target = new FileStream(targetPath, FileMode.CreateNew, FileAccess.Write, FileShare.None, 81920, FileOptions.SequentialScan);
+        var buffer = new byte[81920];
+        int read;
+        while ((read = source.Read(buffer, 0, buffer.Length)) != 0) {
+            cancellationToken.ThrowIfCancellationRequested();
+            copiedBytes += read;
+            if (copiedBytes > maximumBytes) {
+                throw new InvalidDataException("External provenance manifests exceed the configured manifest limit.");
+            }
+            target.Write(buffer, 0, read);
+        }
+        target.Flush(flushToDisk: true);
+        return copiedBytes;
+    }
+
+    private static bool TryResolveRelativeDependency(
+        string sourceDirectory,
+        string snapshotDirectory,
+        string snapshotFilePath,
+        string reference,
+        out string sourcePath,
+        out string targetPath) {
+        sourcePath = string.Empty;
+        targetPath = string.Empty;
+        if (!Uri.TryCreate(reference, UriKind.RelativeOrAbsolute, out Uri? uri) || uri.IsAbsoluteUri) return false;
+        string relative = reference;
+        int delimiter = relative.IndexOfAny(new[] { '?', '#' });
+        if (delimiter >= 0) relative = relative.Substring(0, delimiter);
+        if (relative.Length == 0) return false;
+        try {
+            relative = Uri.UnescapeDataString(relative).Replace('/', Path.DirectorySeparatorChar);
+            if (Path.IsPathRooted(relative)) return false;
+            sourcePath = Path.GetFullPath(Path.Combine(sourceDirectory, relative));
+            targetPath = Path.GetFullPath(Path.Combine(snapshotDirectory, relative));
+            return IsWithinDirectory(sourcePath, sourceDirectory) &&
+                   IsWithinDirectory(targetPath, snapshotDirectory) &&
+                   !PathsEqual(targetPath, snapshotFilePath);
+        } catch (Exception exception) when (exception is ArgumentException or NotSupportedException or UriFormatException) {
+            sourcePath = string.Empty;
+            targetPath = string.Empty;
+            return false;
+        }
+    }
+
+    private static bool IsWithinDirectory(string path, string directory) {
+        string root = Path.GetFullPath(directory).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
+        StringComparison comparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        return path.StartsWith(root, comparison);
+    }
+
+    private static bool PathsEqual(string left, string right) => string.Equals(
+        left,
+        right,
+        RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal);
 
     private static string CreatePrivateDirectory() {
         string tempPath = Path.GetTempPath();
@@ -135,35 +273,143 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
         }
     }
 
-    private static void Cleanup(string filePath, string directoryPath, bool throwIfSensitiveDataRemains) {
+    private static void Cleanup(
+        string filePath,
+        string directoryPath,
+        bool throwIfSensitiveDataRemains,
+        IEnumerable<string>? dependentFiles = null) {
         Exception? cleanupFailure = null;
-        if (File.Exists(filePath)) {
+        string[] dependencies = (dependentFiles ?? Array.Empty<string>()).ToArray();
+        foreach (string candidate in dependencies.AsEnumerable().Reverse().Concat(new[] { filePath })) {
+            cleanupFailure = TryEraseAndDeleteFile(candidate) ?? cleanupFailure;
+        }
+
+        foreach (string? directory in dependencies
+                     .SelectMany(path => EnumerateDependencyDirectories(path, directoryPath))
+                     .Where(path => !string.IsNullOrEmpty(path) && !PathsEqual(path!, directoryPath))
+                     .Distinct(RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                         ? StringComparer.OrdinalIgnoreCase
+                         : StringComparer.Ordinal)
+                     .OrderByDescending(path => path!.Length)) {
             try {
-                MakeWritable(filePath);
-                File.Delete(filePath);
+                if (Directory.Exists(directory)) Directory.Delete(directory!, recursive: false);
             } catch (Exception exception) when (exception is IOException or UnauthorizedAccessException) {
-                cleanupFailure = exception;
-                try {
-                    using var scrub = new FileStream(filePath, FileMode.Truncate, FileAccess.Write, FileShare.Read);
-                    scrub.Flush(flushToDisk: true);
-                    try { File.Delete(filePath); } catch (Exception deleteException) when (deleteException is IOException or UnauthorizedAccessException) { }
-                    cleanupFailure = null;
-                } catch (Exception scrubException) when (scrubException is IOException or UnauthorizedAccessException) {
-                    cleanupFailure = scrubException;
-                }
+                cleanupFailure ??= exception;
             }
         }
 
         try {
             if (Directory.Exists(directoryPath)) Directory.Delete(directoryPath, recursive: false);
         } catch (Exception exception) when (exception is IOException or UnauthorizedAccessException) {
-            if (File.Exists(filePath)) cleanupFailure ??= exception;
+            cleanupFailure ??= exception;
         }
 
-        if (throwIfSensitiveDataRemains && cleanupFailure != null && File.Exists(filePath)) {
+        if (throwIfSensitiveDataRemains && cleanupFailure != null && Directory.Exists(directoryPath)) {
+            string retainedPath = File.Exists(filePath) ? filePath : directoryPath;
             throw new IOException(
-                $"The provenance snapshot could not be removed or erased; '{filePath}' is retained for operator cleanup.",
+                $"The provenance snapshot could not be removed or erased; '{retainedPath}' is retained for operator cleanup.",
                 cleanupFailure);
+        }
+    }
+
+    private static IEnumerable<string> EnumerateDependencyDirectories(string filePath, string rootDirectory) {
+        string? current = Path.GetDirectoryName(filePath);
+        while (!string.IsNullOrEmpty(current) &&
+               !PathsEqual(current, rootDirectory) &&
+               IsWithinDirectory(current, rootDirectory)) {
+            yield return current;
+            current = Path.GetDirectoryName(current);
+        }
+    }
+
+    private sealed class DependencySnapshot : IDisposable {
+        private readonly string _path;
+        private readonly long _length;
+        private readonly byte[] _sha256;
+        private readonly FileStream _lease;
+
+        private DependencySnapshot(string path, long length, byte[] sha256, FileStream lease) {
+            _path = path;
+            _length = length;
+            _sha256 = sha256;
+            _lease = lease;
+        }
+
+        internal static DependencySnapshot Capture(string path, CancellationToken cancellationToken) {
+            var lease = new FileStream(
+                path,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.Read,
+                81920,
+                FileOptions.SequentialScan);
+            try {
+                byte[] sha256 = ComputeHash(lease, cancellationToken);
+                lease.Position = 0;
+                return new DependencySnapshot(path, lease.Length, sha256, lease);
+            } catch {
+                lease.Dispose();
+                throw;
+            }
+        }
+
+        internal void Verify(CancellationToken cancellationToken) {
+            try {
+                using var stream = new FileStream(
+                    _path,
+                    FileMode.Open,
+                    FileAccess.Read,
+                    FileShare.Read,
+                    81920,
+                    FileOptions.SequentialScan);
+                if (stream.Length != _length ||
+                    !FixedTimeEquals(ComputeHash(stream, cancellationToken), _sha256)) {
+                    throw new InvalidDataException(
+                        "An external provenance manifest changed while the assessment was running.");
+                }
+            } catch (Exception exception) when (exception is FileNotFoundException or DirectoryNotFoundException) {
+                throw new InvalidDataException(
+                    "An external provenance manifest disappeared while the assessment was running.",
+                    exception);
+            }
+        }
+
+        public void Dispose() => _lease.Dispose();
+
+        private static byte[] ComputeHash(Stream stream, CancellationToken cancellationToken) {
+            using IncrementalHash algorithm = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+            var buffer = new byte[81920];
+            int read;
+            while ((read = stream.Read(buffer, 0, buffer.Length)) != 0) {
+                cancellationToken.ThrowIfCancellationRequested();
+                algorithm.AppendData(buffer, 0, read);
+            }
+            return algorithm.GetHashAndReset();
+        }
+
+        private static bool FixedTimeEquals(byte[] left, byte[] right) {
+            if (left.Length != right.Length) return false;
+            int difference = 0;
+            for (int index = 0; index < left.Length; index++) difference |= left[index] ^ right[index];
+            return difference == 0;
+        }
+    }
+
+    private static Exception? TryEraseAndDeleteFile(string path) {
+        if (!File.Exists(path)) return null;
+        try {
+            MakeWritable(path);
+            File.Delete(path);
+            return null;
+        } catch (Exception exception) when (exception is IOException or UnauthorizedAccessException) {
+            try {
+                using var scrub = new FileStream(path, FileMode.Truncate, FileAccess.Write, FileShare.Read);
+                scrub.Flush(flushToDisk: true);
+                try { File.Delete(path); } catch (Exception deleteException) when (deleteException is IOException or UnauthorizedAccessException) { }
+                return File.Exists(path) ? exception : null;
+            } catch (Exception scrubException) when (scrubException is IOException or UnauthorizedAccessException) {
+                return scrubException;
+            }
         }
     }
 

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceFileSnapshot.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceFileSnapshot.cs
@@ -143,7 +143,8 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
         string directoryPath = CreatePrivateDirectory();
         string filePath = Path.Combine(directoryPath, Path.GetFileName(fullPath));
         try {
-            long copiedBytes = 0;
+            long copiedBytes;
+            byte[] copiedSha256;
             string physicalSourceDirectory = OfficePathIdentity.ResolvePhysicalPath(
                 Path.GetDirectoryName(fullPath)!);
             using (FileStream source = OpenSnapshotSource(fullPath, physicalSourceDirectory))
@@ -154,19 +155,19 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
                        FileShare.None,
                        81920,
                        FileOptions.SequentialScan)) {
-                if (source.Length > maximumBytes) {
-                    throw new InvalidDataException("The asset snapshot exceeds the configured input limit.");
-                }
-
-                var buffer = new byte[81920];
-                int read;
-                while ((read = source.Read(buffer, 0, buffer.Length)) != 0) {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    copiedBytes += read;
-                    if (copiedBytes > maximumBytes) {
-                        throw new InvalidDataException("The asset snapshot exceeds the configured input limit.");
-                    }
-                    destination.Write(buffer, 0, read);
+                copiedSha256 = CopyStableSource(
+                    source,
+                    destination,
+                    maximumBytes,
+                    "The asset snapshot exceeds the configured input limit.",
+                    cancellationToken,
+                    out copiedBytes);
+                if (!OfficePathIdentity.IsOpenedFileWithinRootByIdentity(
+                        fullPath,
+                        physicalSourceDirectory,
+                        source.SafeFileHandle)) {
+                    throw new InvalidDataException(
+                        "The asset snapshot source changed identity while it was being captured.");
                 }
                 cancellationToken.ThrowIfCancellationRequested();
                 destination.Flush(flushToDisk: true);
@@ -183,6 +184,10 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
             try {
                 string physicalIdentity = OfficePathIdentity.GetPhysicalIdentityKey(filePath, lease.SafeFileHandle);
                 byte[] sha256 = ComputeHash(lease, cancellationToken);
+                if (lease.Length != copiedBytes || !FixedTimeEquals(sha256, copiedSha256)) {
+                    throw new InvalidDataException(
+                        "The primary provenance snapshot did not match the stable source bytes that were captured.");
+                }
                 lease.Position = 0;
                 return new OfficeProvenanceFileSnapshot(
                     directoryPath,
@@ -248,18 +253,23 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
                 throw new InvalidDataException("External provenance manifests exceed the configured expanded-data limit.");
             }
             using var target = new FileStream(targetPath, FileMode.CreateNew, FileAccess.Write, FileShare.None, 81920, FileOptions.SequentialScan);
-            var buffer = new byte[81920];
-            int read;
-            while ((read = source.Read(buffer, 0, buffer.Length)) != 0) {
-                cancellationToken.ThrowIfCancellationRequested();
-                copiedBytes += read;
-                if (copiedBytes > maximumDependencyBytes) {
-                    throw new InvalidDataException("An external provenance manifest exceeds the configured manifest limit.");
-                }
-                if (copiedBytes > remainingTotalBytes) {
-                    throw new InvalidDataException("External provenance manifests exceed the configured expanded-data limit.");
-                }
-                target.Write(buffer, 0, read);
+            long effectiveMaximum = Math.Min(maximumDependencyBytes, remainingTotalBytes);
+            string limitMessage = remainingTotalBytes < maximumDependencyBytes
+                ? "External provenance manifests exceed the configured expanded-data limit."
+                : "An external provenance manifest exceeds the configured manifest limit.";
+            _ = CopyStableSource(
+                source,
+                target,
+                effectiveMaximum,
+                limitMessage,
+                cancellationToken,
+                out copiedBytes);
+            if (!OfficePathIdentity.IsOpenedFileWithinRootByIdentity(
+                    sourcePath,
+                    physicalSourceDirectory,
+                    source.SafeFileHandle)) {
+                throw new InvalidDataException(
+                    "An external provenance manifest changed identity while it was being captured.");
             }
             target.Flush(flushToDisk: true);
             return copiedBytes;
@@ -459,14 +469,89 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
         }
     }
 
+    internal static byte[] CopyStableSource(
+        Stream source,
+        Stream destination,
+        long maximumBytes,
+        string limitMessage,
+        CancellationToken cancellationToken,
+        out long copiedBytes) {
+        if (source == null) throw new ArgumentNullException(nameof(source));
+        if (destination == null) throw new ArgumentNullException(nameof(destination));
+        if (!source.CanRead || !source.CanSeek) {
+            throw new ArgumentException("The snapshot source must be a readable, seekable stream.", nameof(source));
+        }
+        if (!destination.CanWrite) {
+            throw new ArgumentException("The snapshot destination must be writable.", nameof(destination));
+        }
+        if (maximumBytes <= 0) throw new ArgumentOutOfRangeException(nameof(maximumBytes));
+        if (string.IsNullOrWhiteSpace(limitMessage)) throw new ArgumentException("A limit message is required.", nameof(limitMessage));
+
+        source.Position = 0;
+        if (source.Length > maximumBytes) throw new InvalidDataException(limitMessage);
+
+        using IncrementalHash copiedHash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        var buffer = new byte[81920];
+        copiedBytes = 0;
+        while (true) {
+            cancellationToken.ThrowIfCancellationRequested();
+            int read = source.Read(buffer, 0, buffer.Length);
+            if (read == 0) break;
+            copiedBytes += read;
+            if (copiedBytes > maximumBytes) throw new InvalidDataException(limitMessage);
+            copiedHash.AppendData(buffer, 0, read);
+            destination.Write(buffer, 0, read);
+        }
+        cancellationToken.ThrowIfCancellationRequested();
+        byte[] sha256 = copiedHash.GetHashAndReset();
+
+        if (source.Length != copiedBytes) {
+            throw new InvalidDataException("The snapshot source changed length while it was being captured.");
+        }
+        source.Position = 0;
+        byte[] verificationHash = ComputeHashBounded(
+            source,
+            maximumBytes,
+            limitMessage,
+            cancellationToken,
+            out long verifiedBytes);
+        if (verifiedBytes != copiedBytes || source.Length != copiedBytes || !FixedTimeEquals(verificationHash, sha256)) {
+            throw new InvalidDataException("The snapshot source changed content while it was being captured.");
+        }
+        return sha256;
+    }
+
+    private static byte[] ComputeHashBounded(
+        Stream stream,
+        long maximumBytes,
+        string limitMessage,
+        CancellationToken cancellationToken,
+        out long hashedBytes) {
+        using IncrementalHash algorithm = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        var buffer = new byte[81920];
+        hashedBytes = 0;
+        while (true) {
+            cancellationToken.ThrowIfCancellationRequested();
+            int read = stream.Read(buffer, 0, buffer.Length);
+            if (read == 0) break;
+            hashedBytes += read;
+            if (hashedBytes > maximumBytes) throw new InvalidDataException(limitMessage);
+            algorithm.AppendData(buffer, 0, read);
+        }
+        cancellationToken.ThrowIfCancellationRequested();
+        return algorithm.GetHashAndReset();
+    }
+
     private static byte[] ComputeHash(Stream stream, CancellationToken cancellationToken) {
         using IncrementalHash algorithm = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
         var buffer = new byte[81920];
-        int read;
-        while ((read = stream.Read(buffer, 0, buffer.Length)) != 0) {
+        while (true) {
             cancellationToken.ThrowIfCancellationRequested();
+            int read = stream.Read(buffer, 0, buffer.Length);
+            if (read == 0) break;
             algorithm.AppendData(buffer, 0, read);
         }
+        cancellationToken.ThrowIfCancellationRequested();
         return algorithm.GetHashAndReset();
     }
 

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceFileSnapshot.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceFileSnapshot.cs
@@ -18,6 +18,8 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
     private readonly string _directoryPath;
     private readonly FileStream _lease;
     private readonly string? _physicalIdentity;
+    private readonly string? _sourcePhysicalIdentity;
+    private readonly string _sourceDirectoryIdentity;
     private readonly bool _usesPhysicalIdentity;
     private readonly byte[] _sha256;
     private readonly List<string> _dependentFiles = new List<string>();
@@ -32,6 +34,8 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
         string filePath,
         long length,
         string? physicalIdentity,
+        string? sourcePhysicalIdentity,
+        string sourceDirectoryIdentity,
         byte[] sha256,
         FileStream lease,
         bool usesPhysicalIdentity) {
@@ -39,6 +43,8 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
         FilePath = filePath;
         Length = length;
         _physicalIdentity = physicalIdentity;
+        _sourcePhysicalIdentity = sourcePhysicalIdentity;
+        _sourceDirectoryIdentity = sourceDirectoryIdentity;
         _sha256 = sha256;
         _lease = lease;
         _usesPhysicalIdentity = usesPhysicalIdentity;
@@ -179,6 +185,30 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
         }
     }
 
+    /// <summary>Checks whether a displaced file is the same source captured by this snapshot.</summary>
+    internal bool MatchesCapturedSource(
+        string path,
+        CancellationToken cancellationToken = default) {
+        if (_disposed) throw new ObjectDisposedException(nameof(OfficeProvenanceFileSnapshot));
+        try {
+            using FileStream stream = OpenRegularFileForRead(
+                path,
+                _sourceDirectoryIdentity,
+                _usesPhysicalIdentity,
+                "The captured provenance source could not be reopened as a regular file.");
+            string? identity = _usesPhysicalIdentity
+                ? OfficePathIdentity.GetPhysicalIdentityKey(path, stream.SafeFileHandle)
+                : null;
+            return stream.Length == Length &&
+                   (!_usesPhysicalIdentity || string.Equals(identity, _sourcePhysicalIdentity, StringComparison.Ordinal)) &&
+                   FixedTimeEquals(ComputeHash(stream, cancellationToken), _sha256);
+        } catch (OperationCanceledException) {
+            throw;
+        } catch (Exception exception) when (exception is InvalidDataException or IOException or UnauthorizedAccessException) {
+            return false;
+        }
+    }
+
     /// <summary>Captures one input through a single bounded read and holds a shared-read lease until disposal.</summary>
     internal static OfficeProvenanceFileSnapshot Capture(
         string sourcePath,
@@ -217,6 +247,7 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
             string sourceDirectoryIdentity = usesPhysicalIdentity
                 ? OfficePathIdentity.ResolvePhysicalPath(sourceDirectory)
                 : Path.GetFullPath(sourceDirectory);
+            string? sourcePhysicalIdentity;
             using (FileStream source = OpenSnapshotSource(fullPath, sourceDirectoryIdentity, usesPhysicalIdentity))
             using (var destination = new FileStream(
                        filePath,
@@ -225,6 +256,9 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
                        FileShare.None,
                        81920,
                        FileOptions.SequentialScan)) {
+                sourcePhysicalIdentity = usesPhysicalIdentity
+                    ? OfficePathIdentity.GetPhysicalIdentityKey(fullPath, source.SafeFileHandle)
+                    : null;
                 copiedSha256 = CopyStableSource(
                     source,
                     destination,
@@ -266,6 +300,8 @@ internal sealed class OfficeProvenanceFileSnapshot : IDisposable {
                     filePath,
                     copiedBytes,
                     physicalIdentity,
+                    sourcePhysicalIdentity,
+                    sourceDirectoryIdentity,
                     sha256,
                     lease,
                     usesPhysicalIdentity);

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceGif.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceGif.cs
@@ -16,8 +16,10 @@ internal static class OfficeProvenanceGif {
         List<OfficeProvenanceChange> changes,
         out bool reserialized) {
         reserialized = false;
-        if (!options.RemoveC2paManifests && !options.RemoveAiSourceMetadata) return (byte[])data.Clone();
-        using var output = new MemoryStream(data.Length);
+        if (!options.RemoveC2paManifests && !options.RemoveAiSourceMetadata) {
+            return OfficeProvenanceBinary.CloneForOutput(data, options.EffectiveMaxOutputBytes);
+        }
+        using var output = new OfficeProvenanceBoundedMemoryStream(options.EffectiveMaxOutputBytes, data.Length);
         int bodyOffset = GetBodyOffset(data);
         output.Write(data, 0, bodyOffset);
         Walk(data, options.Limits, context: null, output, options, changes, out reserialized);

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceHtml.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceHtml.cs
@@ -31,10 +31,21 @@ internal static class OfficeProvenanceHtml {
             options.CancellationToken.ThrowIfCancellationRequested();
             int opening = html.IndexOf('<', index);
             if (opening < 0) break;
+            if (!bodyStarted && (inHead || (!headSeen && !headFinished)) &&
+                ContainsBodyText(html, index, opening)) {
+                inHead = false;
+                headFinished = true;
+                bodyStarted = true;
+            }
             if (StartsWith(html, opening, "<!--")) {
                 int commentEnd = html.IndexOf("-->", opening + 4, StringComparison.Ordinal);
                 if (commentEnd < 0) break;
                 index = commentEnd + 3;
+                continue;
+            }
+            if (opening + 1 < html.Length && (html[opening + 1] == '!' || html[opening + 1] == '?')) {
+                int declarationEnd = html.IndexOf('>', opening + 2);
+                index = declarationEnd < 0 ? html.Length : declarationEnd + 1;
                 continue;
             }
 
@@ -64,6 +75,12 @@ internal static class OfficeProvenanceHtml {
                 inHead = false;
                 headFinished = true;
                 continue;
+            }
+            if (!bodyStarted && (inHead || (!headSeen && !headFinished)) &&
+                IsBodyContentElement(tag.Name)) {
+                bodyStarted = true;
+                inHead = false;
+                headFinished = true;
             }
 
             bool isHeadAssociation = inHead || (!headSeen && !headFinished && !bodyStarted);
@@ -207,6 +224,28 @@ internal static class OfficeProvenanceHtml {
         }
         return false;
     }
+
+    private static bool ContainsBodyText(string html, int start, int end) {
+        for (int index = start; index < end; index++) {
+            char value = html[index];
+            if (value != '\t' && value != '\n' && value != '\f' && value != '\r' && value != ' ') return true;
+        }
+        return false;
+    }
+
+    private static bool IsBodyContentElement(string name) =>
+        !name.Equals("html", StringComparison.OrdinalIgnoreCase) &&
+        !name.Equals("base", StringComparison.OrdinalIgnoreCase) &&
+        !name.Equals("basefont", StringComparison.OrdinalIgnoreCase) &&
+        !name.Equals("bgsound", StringComparison.OrdinalIgnoreCase) &&
+        !name.Equals("link", StringComparison.OrdinalIgnoreCase) &&
+        !name.Equals("meta", StringComparison.OrdinalIgnoreCase) &&
+        !name.Equals("noframes", StringComparison.OrdinalIgnoreCase) &&
+        !name.Equals("noscript", StringComparison.OrdinalIgnoreCase) &&
+        !name.Equals("script", StringComparison.OrdinalIgnoreCase) &&
+        !name.Equals("style", StringComparison.OrdinalIgnoreCase) &&
+        !name.Equals("template", StringComparison.OrdinalIgnoreCase) &&
+        !name.Equals("title", StringComparison.OrdinalIgnoreCase);
 
     private static bool TryReadTag(string html, int start, out HtmlTag tag) {
         tag = default;

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceHtml.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceHtml.cs
@@ -24,6 +24,7 @@ internal static class OfficeProvenanceHtml {
         bool headSeen = false;
         bool headFinished = false;
         bool bodyStarted = false;
+        int templateDepth = 0;
         int elementCount = 0;
         int index = 0;
 
@@ -55,6 +56,10 @@ internal static class OfficeProvenanceHtml {
             }
             index = tag.End;
             if (tag.IsClosing) {
+                if (templateDepth != 0) {
+                    if (tag.Name.Equals("template", StringComparison.OrdinalIgnoreCase)) templateDepth--;
+                    continue;
+                }
                 if (tag.Name.Equals("head", StringComparison.OrdinalIgnoreCase)) {
                     inHead = false;
                     headFinished = true;
@@ -63,6 +68,11 @@ internal static class OfficeProvenanceHtml {
             }
             if (++elementCount > options.MaxContainerEntries) {
                 throw new InvalidDataException("The HTML document exceeds the configured container-entry limit.");
+            }
+            if (templateDepth != 0) {
+                if (tag.Name.Equals("template", StringComparison.OrdinalIgnoreCase)) templateDepth++;
+                if (IsRawTextElement(tag.Name)) index = SkipRawTextElement(html, index, tag.Name);
+                continue;
             }
 
             if (tag.Name.Equals("head", StringComparison.OrdinalIgnoreCase)) {
@@ -74,6 +84,10 @@ internal static class OfficeProvenanceHtml {
                 bodyStarted = true;
                 inHead = false;
                 headFinished = true;
+                continue;
+            }
+            if (tag.Name.Equals("template", StringComparison.OrdinalIgnoreCase)) {
+                templateDepth = 1;
                 continue;
             }
             if (!bodyStarted && (inHead || (!headSeen && !headFinished)) &&
@@ -302,7 +316,6 @@ internal static class OfficeProvenanceHtml {
         int index = start + 1;
         bool closing = index < html.Length && html[index] == '/';
         if (closing) index++;
-        while (index < html.Length && IsAsciiWhitespace(html[index])) index++;
         int nameStart = index;
         while (index < html.Length && IsNameCharacter(html[index])) index++;
         if (index == nameStart) return false;
@@ -374,6 +387,14 @@ internal static class OfficeProvenanceHtml {
             search = boundary;
         }
         return -1;
+    }
+
+    private static int SkipRawTextElement(string html, int start, string name) {
+        string closingToken = "</" + name;
+        int closeStart = FindClosingTag(html, start, closingToken);
+        if (closeStart < 0) return html.Length;
+        int closeEnd = html.IndexOf('>', closeStart + closingToken.Length);
+        return closeEnd < 0 ? html.Length : closeEnd + 1;
     }
 
     internal static string DecodeHtml(byte[] data, System.Threading.CancellationToken cancellationToken) {

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceHtml.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceHtml.cs
@@ -228,9 +228,59 @@ internal static class OfficeProvenanceHtml {
     private static bool ContainsBodyText(string html, int start, int end) {
         for (int index = start; index < end; index++) {
             char value = html[index];
-            if (value != '\t' && value != '\n' && value != '\f' && value != '\r' && value != ' ') return true;
+            if (IsAsciiWhitespace(value)) continue;
+            if (value == '&' && TryConsumeWhitespaceCharacterReference(html, end, ref index)) continue;
+            return true;
         }
         return false;
+    }
+
+    private static bool TryConsumeWhitespaceCharacterReference(string html, int end, ref int index) {
+        int valueStart = index + 1;
+        if (valueStart >= end) return false;
+        if (html[valueStart] != '#') {
+            if (MatchesCharacterReference(html, valueStart, end, "Tab;")) {
+                index = valueStart + 3;
+                return true;
+            }
+            if (MatchesCharacterReference(html, valueStart, end, "NewLine;")) {
+                index = valueStart + 7;
+                return true;
+            }
+            return false;
+        }
+
+        int cursor = valueStart + 1;
+        bool hexadecimal = cursor < end && (html[cursor] == 'x' || html[cursor] == 'X');
+        if (hexadecimal) cursor++;
+        int digitStart = cursor;
+        int scalar = 0;
+        while (cursor < end) {
+            int digit = hexadecimal ? HexDigit(html[cursor]) : DecimalDigit(html[cursor]);
+            if (digit < 0) break;
+            if (scalar > (0x10FFFF - digit) / (hexadecimal ? 16 : 10)) return false;
+            scalar = scalar * (hexadecimal ? 16 : 10) + digit;
+            cursor++;
+        }
+        if (cursor == digitStart || !IsHtmlWhitespaceScalar(scalar)) return false;
+        if (cursor < end && html[cursor] == ';') cursor++;
+        index = cursor - 1;
+        return true;
+    }
+
+    private static bool MatchesCharacterReference(string html, int start, int end, string value) =>
+        start + value.Length <= end &&
+        string.Compare(html, start, value, 0, value.Length, StringComparison.Ordinal) == 0;
+
+    private static int DecimalDigit(char value) => value is >= '0' and <= '9' ? value - '0' : -1;
+
+    private static bool IsHtmlWhitespaceScalar(int value) => value is 0x09 or 0x0A or 0x0C or 0x0D or 0x20;
+
+    private static int HexDigit(char value) {
+        if (value is >= '0' and <= '9') return value - '0';
+        if (value is >= 'a' and <= 'f') return value - 'a' + 10;
+        if (value is >= 'A' and <= 'F') return value - 'A' + 10;
+        return -1;
     }
 
     private static bool IsBodyContentElement(string name) =>

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceHtml.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceHtml.cs
@@ -1,0 +1,391 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Text;
+
+namespace OfficeIMO.Provenance;
+
+/// <summary>
+/// Provides the dependency-free HTML manifest-association baseline used by Core. The OfficeIMO.Html
+/// package remains the full DOM owner and additionally inspects embedded image resources.
+/// </summary>
+internal static class OfficeProvenanceHtml {
+    private const string SyntheticBaseUri = "https://officeimo.invalid/__officeimo__/";
+
+    internal static void Inspect(
+        byte[] data,
+        OfficeProvenanceOptions options,
+        OfficeProvenanceContext context) {
+        string html = DecodeHtml(data, options.CancellationToken);
+        var associations = new List<ManifestAssociation>();
+        string? baseReference = null;
+        bool inHead = false;
+        bool headSeen = false;
+        bool headFinished = false;
+        bool bodyStarted = false;
+        int elementCount = 0;
+        int index = 0;
+
+        while (index < html.Length) {
+            options.CancellationToken.ThrowIfCancellationRequested();
+            int opening = html.IndexOf('<', index);
+            if (opening < 0) break;
+            if (StartsWith(html, opening, "<!--")) {
+                int commentEnd = html.IndexOf("-->", opening + 4, StringComparison.Ordinal);
+                if (commentEnd < 0) break;
+                index = commentEnd + 3;
+                continue;
+            }
+
+            if (!TryReadTag(html, opening, out HtmlTag tag)) {
+                index = tag.End > opening ? tag.End : opening + 1;
+                continue;
+            }
+            index = tag.End;
+            if (tag.IsClosing) {
+                if (tag.Name.Equals("head", StringComparison.OrdinalIgnoreCase)) {
+                    inHead = false;
+                    headFinished = true;
+                }
+                continue;
+            }
+            if (++elementCount > options.MaxContainerEntries) {
+                throw new InvalidDataException("The HTML document exceeds the configured container-entry limit.");
+            }
+
+            if (tag.Name.Equals("head", StringComparison.OrdinalIgnoreCase)) {
+                headSeen = true;
+                inHead = true;
+                continue;
+            }
+            if (tag.Name.Equals("body", StringComparison.OrdinalIgnoreCase)) {
+                bodyStarted = true;
+                inHead = false;
+                headFinished = true;
+                continue;
+            }
+
+            bool isHeadAssociation = inHead || (!headSeen && !headFinished && !bodyStarted);
+            if (isHeadAssociation && baseReference == null &&
+                tag.Name.Equals("base", StringComparison.OrdinalIgnoreCase) &&
+                tag.Attributes.TryGetValue("href", out string? candidateBase)) {
+                baseReference = candidateBase;
+            }
+
+            if (isHeadAssociation && tag.Name.Equals("link", StringComparison.OrdinalIgnoreCase) &&
+                HasRelationship(tag.Attributes, "c2pa-manifest") &&
+                tag.Attributes.TryGetValue("href", out string? href)) {
+                associations.Add(ManifestAssociation.External(href));
+            }
+
+            if (!IsRawTextElement(tag.Name)) continue;
+            string closingToken = "</" + tag.Name;
+            int closeStart = FindClosingTag(html, index, closingToken);
+            int contentEnd = closeStart < 0 ? html.Length : closeStart;
+            if (tag.Name.Equals("script", StringComparison.OrdinalIgnoreCase) &&
+                isHeadAssociation && tag.Attributes.TryGetValue("type", out string? type) &&
+                TrimAsciiWhitespace(type).Equals("application/c2pa", StringComparison.OrdinalIgnoreCase)) {
+                associations.Add(ManifestAssociation.Embedded(html.Substring(index, contentEnd - index)));
+            }
+            if (closeStart >= 0) {
+                int closeEnd = html.IndexOf('>', closeStart + closingToken.Length);
+                index = closeEnd < 0 ? html.Length : closeEnd + 1;
+            } else {
+                index = html.Length;
+            }
+        }
+
+        bool singleAssociation = associations.Count == 1;
+        if (!singleAssociation && associations.Count > 1) {
+            context.Diagnostics.Add("HTML: manifest.html.multipleManifests: the HTML head contains multiple C2PA manifest associations.");
+        }
+
+        int carrierIndex = 0;
+        foreach (ManifestAssociation association in associations) {
+            options.CancellationToken.ThrowIfCancellationRequested();
+            if (association.IsExternal) {
+                string reference = NormalizeReference(association.Value);
+                bool safeReference = TryValidateReference(reference, out Uri? parsed);
+                bool valid = singleAssociation && safeReference;
+                var evidence = new OfficeProvenanceEvidence(
+                    OfficeProvenanceCarrierKind.C2paExternalManifest,
+                    $"HTML/link[rel=c2pa-manifest][{carrierIndex++}]",
+                    valid,
+                    value: valid && parsed!.IsAbsoluteUri ? parsed.AbsoluteUri : reference);
+                context.Add(evidence);
+                if (valid) {
+                    string resolved = ResolveReference(reference, baseReference);
+                    if (!string.Equals(resolved, evidence.Value, StringComparison.Ordinal)) {
+                        context.AddResolvedExternalManifestReference(evidence, resolved);
+                    }
+                }
+                continue;
+            }
+
+            byte[] manifest = DecodeManifest(association.Value, options, context);
+            bool embeddedValid = singleAssociation && manifest.Length != 0 &&
+                OfficeC2paManifestStore.IsValid(
+                    manifest,
+                    0,
+                    manifest.Length,
+                    options.MaxManifestBytes,
+                    options.MaxContainerEntries,
+                    out _);
+            context.Add(new OfficeProvenanceEvidence(
+                OfficeProvenanceCarrierKind.C2paManifest,
+                $"HTML/script[type=application/c2pa][{carrierIndex++}]",
+                embeddedValid,
+                manifest.Length));
+        }
+    }
+
+    private static byte[] DecodeManifest(
+        string value,
+        OfficeProvenanceOptions options,
+        OfficeProvenanceContext context) {
+        string encoded = TrimAsciiWhitespace(value);
+        const string prefix = "data:application/c2pa;base64,";
+        if (encoded.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) encoded = encoded.Substring(prefix.Length);
+        if (encoded.Length == 0 || encoded.Length > options.MaxManifestBytes * 2L || encoded.Length > int.MaxValue) {
+            return Array.Empty<byte>();
+        }
+        long encodedCharacters = 0;
+        for (int index = 0; index < encoded.Length; index++) {
+            if ((index & 0xFFF) == 0) options.CancellationToken.ThrowIfCancellationRequested();
+            if (!char.IsWhiteSpace(encoded[index])) encodedCharacters++;
+        }
+        long maximumEncodedCharacters = ((options.MaxManifestBytes + 2L) / 3L) * 4L;
+        if (encodedCharacters > maximumEncodedCharacters) return Array.Empty<byte>();
+        try {
+            options.CancellationToken.ThrowIfCancellationRequested();
+            byte[] manifest = Convert.FromBase64String(encoded);
+            options.CancellationToken.ThrowIfCancellationRequested();
+            if (manifest.LongLength > options.MaxManifestBytes) return Array.Empty<byte>();
+            context.ReserveExpandedBytes(
+                manifest.LongLength,
+                "HTML provenance payloads exceed the configured expanded-container limit.");
+            return manifest;
+        } catch (FormatException) {
+            return Array.Empty<byte>();
+        }
+    }
+
+    private static string ResolveReference(string reference, string? baseReference) {
+        if (string.IsNullOrWhiteSpace(baseReference)) return reference;
+        string normalizedBase = NormalizeReference(baseReference!);
+        if (!Uri.TryCreate(normalizedBase, UriKind.RelativeOrAbsolute, out Uri? parsedBase)) return reference;
+        if (parsedBase.IsAbsoluteUri) {
+            return Uri.TryCreate(parsedBase, reference, out Uri? absolute) ? absolute.AbsoluteUri : reference;
+        }
+        if (!Uri.TryCreate(new Uri(SyntheticBaseUri), parsedBase, out Uri? syntheticBase) ||
+            !Uri.TryCreate(syntheticBase, reference, out Uri? resolved)) return reference;
+        if (!resolved.AbsoluteUri.StartsWith(SyntheticBaseUri, StringComparison.Ordinal)) {
+            return resolved.PathAndQuery + resolved.Fragment;
+        }
+        return resolved.AbsoluteUri.Substring(SyntheticBaseUri.Length);
+    }
+
+    private static bool TryValidateReference(string value, out Uri? uri) {
+        uri = null;
+        if (value.Length == 0 || !Uri.TryCreate(value, UriKind.RelativeOrAbsolute, out Uri? parsed)) return false;
+        if (parsed.IsAbsoluteUri && parsed.Scheme != Uri.UriSchemeHttp && parsed.Scheme != Uri.UriSchemeHttps) return false;
+        uri = parsed;
+        return true;
+    }
+
+    private static string NormalizeReference(string? value) =>
+        TrimAsciiWhitespace(WebUtility.HtmlDecode(value ?? string.Empty))
+            .Replace("\t", string.Empty)
+            .Replace("\n", string.Empty)
+            .Replace("\r", string.Empty);
+
+    private static bool HasRelationship(Dictionary<string, string> attributes, string relationship) {
+        if (!attributes.TryGetValue("rel", out string? value)) return false;
+        foreach (string token in value.Split(new[] { '\t', '\n', '\f', '\r', ' ' }, StringSplitOptions.RemoveEmptyEntries)) {
+            if (token.Equals(relationship, StringComparison.OrdinalIgnoreCase)) return true;
+        }
+        return false;
+    }
+
+    private static bool TryReadTag(string html, int start, out HtmlTag tag) {
+        tag = default;
+        int index = start + 1;
+        bool closing = index < html.Length && html[index] == '/';
+        if (closing) index++;
+        while (index < html.Length && IsAsciiWhitespace(html[index])) index++;
+        int nameStart = index;
+        while (index < html.Length && IsNameCharacter(html[index])) index++;
+        if (index == nameStart) return false;
+        string name = html.Substring(nameStart, index - nameStart);
+        var attributes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        while (index < html.Length) {
+            while (index < html.Length && IsAsciiWhitespace(html[index])) index++;
+            if (index >= html.Length) {
+                tag = new HtmlTag(name, closing, attributes, html.Length);
+                return false;
+            }
+            if (html[index] == '<') {
+                tag = new HtmlTag(name, closing, attributes, index);
+                return false;
+            }
+            if (html[index] == '>') {
+                tag = new HtmlTag(name, closing, attributes, index + 1);
+                return true;
+            }
+            if (html[index] == '/' && index + 1 < html.Length && html[index + 1] == '>') {
+                tag = new HtmlTag(name, closing, attributes, index + 2);
+                return true;
+            }
+
+            int attributeStart = index;
+            while (index < html.Length && IsAttributeNameCharacter(html[index])) index++;
+            if (index == attributeStart) {
+                index++;
+                continue;
+            }
+            string attributeName = html.Substring(attributeStart, index - attributeStart);
+            while (index < html.Length && IsAsciiWhitespace(html[index])) index++;
+            string attributeValue = string.Empty;
+            if (index < html.Length && html[index] == '=') {
+                index++;
+                while (index < html.Length && IsAsciiWhitespace(html[index])) index++;
+                if (index < html.Length && (html[index] == '\'' || html[index] == '"')) {
+                    char quote = html[index++];
+                    int valueStart = index;
+                    while (index < html.Length && html[index] != quote) index++;
+                    if (index >= html.Length) {
+                        tag = new HtmlTag(name, closing, attributes, html.Length);
+                        return false;
+                    }
+                    attributeValue = html.Substring(valueStart, index - valueStart);
+                    index++;
+                } else {
+                    int valueStart = index;
+                    while (index < html.Length && !IsAsciiWhitespace(html[index]) && html[index] != '>') index++;
+                    attributeValue = html.Substring(valueStart, index - valueStart);
+                }
+            }
+            if (!attributes.ContainsKey(attributeName)) {
+                attributes.Add(attributeName, WebUtility.HtmlDecode(attributeValue));
+            }
+        }
+        tag = new HtmlTag(name, closing, attributes, html.Length);
+        return false;
+    }
+
+    private static int FindClosingTag(string html, int start, string token) {
+        int search = start;
+        while (search < html.Length) {
+            int candidate = html.IndexOf(token, search, StringComparison.OrdinalIgnoreCase);
+            if (candidate < 0) return -1;
+            int boundary = candidate + token.Length;
+            if (boundary >= html.Length || IsAsciiWhitespace(html[boundary]) || html[boundary] == '>') return candidate;
+            search = boundary;
+        }
+        return -1;
+    }
+
+    private static string DecodeHtml(byte[] data, System.Threading.CancellationToken cancellationToken) {
+        Encoding encoding;
+        int offset;
+        if (data.Length >= 4 && data[0] == 0x00 && data[1] == 0x00 && data[2] == 0xFE && data[3] == 0xFF) {
+            encoding = new UTF32Encoding(true, true);
+            offset = 4;
+        } else if (data.Length >= 4 && data[0] == 0xFF && data[1] == 0xFE && data[2] == 0x00 && data[3] == 0x00) {
+            encoding = new UTF32Encoding(false, true);
+            offset = 4;
+        } else if (data.Length >= 2 && data[0] == 0xFE && data[1] == 0xFF) {
+            encoding = Encoding.BigEndianUnicode;
+            offset = 2;
+        } else if (data.Length >= 2 && data[0] == 0xFF && data[1] == 0xFE) {
+            encoding = Encoding.Unicode;
+            offset = 2;
+        } else {
+            encoding = Encoding.UTF8;
+            offset = data.Length >= 3 && data[0] == 0xEF && data[1] == 0xBB && data[2] == 0xBF ? 3 : 0;
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        Decoder decoder = encoding.GetDecoder();
+        var output = new StringBuilder(Math.Min(data.Length - offset, 4096));
+        var characters = new char[4096];
+        int byteOffset = offset;
+        bool completed;
+        do {
+            cancellationToken.ThrowIfCancellationRequested();
+            decoder.Convert(
+                data,
+                byteOffset,
+                data.Length - byteOffset,
+                characters,
+                0,
+                characters.Length,
+                flush: true,
+                out int bytesUsed,
+                out int charactersUsed,
+                out completed);
+            output.Append(characters, 0, charactersUsed);
+            byteOffset += bytesUsed;
+            if (!completed && bytesUsed == 0 && charactersUsed == 0) {
+                throw new InvalidDataException("The HTML document could not be decoded incrementally.");
+            }
+        } while (!completed);
+        cancellationToken.ThrowIfCancellationRequested();
+        return output.ToString();
+    }
+
+    private static string TrimAsciiWhitespace(string value) {
+        int start = 0;
+        int end = value.Length;
+        while (start < end && IsAsciiWhitespace(value[start])) start++;
+        while (end > start && IsAsciiWhitespace(value[end - 1])) end--;
+        return start == 0 && end == value.Length ? value : value.Substring(start, end - start);
+    }
+
+    private static bool StartsWith(string value, int offset, string candidate) =>
+        offset >= 0 && offset <= value.Length - candidate.Length &&
+        string.Compare(value, offset, candidate, 0, candidate.Length, StringComparison.Ordinal) == 0;
+
+    private static bool IsAsciiWhitespace(char value) => value is '\t' or '\n' or '\f' or '\r' or ' ';
+    private static bool IsRawTextElement(string name) =>
+        name.Equals("script", StringComparison.OrdinalIgnoreCase) ||
+        name.Equals("style", StringComparison.OrdinalIgnoreCase) ||
+        name.Equals("title", StringComparison.OrdinalIgnoreCase) ||
+        name.Equals("textarea", StringComparison.OrdinalIgnoreCase) ||
+        name.Equals("xmp", StringComparison.OrdinalIgnoreCase) ||
+        name.Equals("iframe", StringComparison.OrdinalIgnoreCase) ||
+        name.Equals("noembed", StringComparison.OrdinalIgnoreCase) ||
+        name.Equals("noframes", StringComparison.OrdinalIgnoreCase) ||
+        name.Equals("plaintext", StringComparison.OrdinalIgnoreCase);
+    private static bool IsNameCharacter(char value) => char.IsLetterOrDigit(value) || value is ':' or '-' or '_';
+    private static bool IsAttributeNameCharacter(char value) =>
+        !IsAsciiWhitespace(value) && value is not '=' and not '>' and not '/' and not '<' and not '\'' and not '"';
+
+    private readonly struct HtmlTag {
+        internal HtmlTag(string name, bool isClosing, Dictionary<string, string> attributes, int end) {
+            Name = name;
+            IsClosing = isClosing;
+            Attributes = attributes;
+            End = end;
+        }
+
+        internal string Name { get; }
+        internal bool IsClosing { get; }
+        internal Dictionary<string, string> Attributes { get; }
+        internal int End { get; }
+    }
+
+    private readonly struct ManifestAssociation {
+        private ManifestAssociation(string value, bool isExternal) {
+            Value = value;
+            IsExternal = isExternal;
+        }
+
+        internal string Value { get; }
+        internal bool IsExternal { get; }
+        internal static ManifestAssociation External(string value) => new ManifestAssociation(value, true);
+        internal static ManifestAssociation Embedded(string value) => new ManifestAssociation(value, false);
+    }
+}

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceHtml.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceHtml.cs
@@ -67,7 +67,7 @@ internal static class OfficeProvenanceHtml {
 
             if (tag.Name.Equals("head", StringComparison.OrdinalIgnoreCase)) {
                 headSeen = true;
-                inHead = true;
+                if (!bodyStarted && !headFinished) inHead = true;
                 continue;
             }
             if (tag.Name.Equals("body", StringComparison.OrdinalIgnoreCase)) {

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceHtml.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceHtml.cs
@@ -90,14 +90,18 @@ internal static class OfficeProvenanceHtml {
                 templateDepth = 1;
                 continue;
             }
-            if (!bodyStarted && (inHead || (!headSeen && !headFinished)) &&
-                IsBodyContentElement(tag.Name)) {
+            bool isAfterHeadMetadata = !bodyStarted && headFinished && IsAfterHeadMetadataElement(tag.Name);
+            if (!bodyStarted &&
+                ((headFinished && !isAfterHeadMetadata && !tag.Name.Equals("html", StringComparison.OrdinalIgnoreCase)) ||
+                 ((inHead || (!headSeen && !headFinished)) && IsBodyContentElement(tag.Name)))) {
                 bodyStarted = true;
                 inHead = false;
                 headFinished = true;
             }
 
-            bool isHeadAssociation = inHead || (!headSeen && !headFinished && !bodyStarted);
+            bool isHeadAssociation = inHead ||
+                (!headSeen && !headFinished && !bodyStarted) ||
+                isAfterHeadMetadata;
             if (isHeadAssociation && baseReference == null &&
                 tag.Name.Equals("base", StringComparison.OrdinalIgnoreCase) &&
                 tag.Attributes.TryGetValue("href", out string? candidateBase)) {
@@ -310,6 +314,18 @@ internal static class OfficeProvenanceHtml {
         !name.Equals("style", StringComparison.OrdinalIgnoreCase) &&
         !name.Equals("template", StringComparison.OrdinalIgnoreCase) &&
         !name.Equals("title", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsAfterHeadMetadataElement(string name) =>
+        name.Equals("base", StringComparison.OrdinalIgnoreCase) ||
+        name.Equals("basefont", StringComparison.OrdinalIgnoreCase) ||
+        name.Equals("bgsound", StringComparison.OrdinalIgnoreCase) ||
+        name.Equals("link", StringComparison.OrdinalIgnoreCase) ||
+        name.Equals("meta", StringComparison.OrdinalIgnoreCase) ||
+        name.Equals("noframes", StringComparison.OrdinalIgnoreCase) ||
+        name.Equals("script", StringComparison.OrdinalIgnoreCase) ||
+        name.Equals("style", StringComparison.OrdinalIgnoreCase) ||
+        name.Equals("template", StringComparison.OrdinalIgnoreCase) ||
+        name.Equals("title", StringComparison.OrdinalIgnoreCase);
 
     private static bool TryReadTag(string html, int start, out HtmlTag tag) {
         tag = default;

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceHtml.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceHtml.cs
@@ -195,7 +195,7 @@ internal static class OfficeProvenanceHtml {
     }
 
     private static string NormalizeReference(string? value) =>
-        TrimAsciiWhitespace(WebUtility.HtmlDecode(value ?? string.Empty))
+        TrimAsciiWhitespace(value ?? string.Empty)
             .Replace("\t", string.Empty)
             .Replace("\n", string.Empty)
             .Replace("\r", string.Empty);
@@ -287,7 +287,7 @@ internal static class OfficeProvenanceHtml {
         return -1;
     }
 
-    private static string DecodeHtml(byte[] data, System.Threading.CancellationToken cancellationToken) {
+    internal static string DecodeHtml(byte[] data, System.Threading.CancellationToken cancellationToken) {
         Encoding encoding;
         int offset;
         if (data.Length >= 4 && data[0] == 0x00 && data[1] == 0x00 && data[2] == 0xFE && data[3] == 0xFF) {

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceInspector.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceInspector.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Xml;
 using OfficeIMO.Core.Internal;
 
@@ -107,7 +108,7 @@ public static class OfficeProvenanceInspector {
         if (OfficeProvenanceZip.HasSignature(data)) return OfficeProvenanceAssetFormat.ZipPackage;
         if (OfficeProvenanceBinary.MatchesAscii(data, 0, "%PDF-")) return OfficeProvenanceAssetFormat.Pdf;
         if (LooksLikeSvg(data, null, options.MaxContainerEntries)) return OfficeProvenanceAssetFormat.Svg;
-        if (LooksLikeHtml(data, null, options.MaxContainerEntries)) return OfficeProvenanceAssetFormat.Html;
+        if (LooksLikeHtml(data, null, options.MaxContainerEntries, options.CancellationToken)) return OfficeProvenanceAssetFormat.Html;
         if (OfficeProvenanceText.HasUnstructuredWrapperPrefix(data, options.MaxContainerEntries)) return OfficeProvenanceAssetFormat.UnstructuredText;
         if (OfficeProvenanceText.HasStructuredDelimiter(data)) return OfficeProvenanceAssetFormat.StructuredText;
         string extension = Path.GetExtension(fileName ?? string.Empty);
@@ -119,10 +120,20 @@ public static class OfficeProvenanceInspector {
         return OfficeProvenanceAssetFormat.Unknown;
     }
 
-    private static bool LooksLikeHtml(byte[] data, string? fileName, int maximumContainerEntries) {
+    private static bool LooksLikeHtml(
+        byte[] data,
+        string? fileName,
+        int maximumContainerEntries,
+        CancellationToken cancellationToken) {
         string extension = Path.GetExtension(fileName ?? string.Empty);
         if (extension.Equals(".html", StringComparison.OrdinalIgnoreCase) ||
             extension.Equals(".htm", StringComparison.OrdinalIgnoreCase)) return true;
+        if (HasUtf16OrUtf32Preamble(data)) {
+            return LooksLikeHtml(
+                OfficeProvenanceHtml.DecodeHtml(data, cancellationToken),
+                maximumContainerEntries,
+                cancellationToken);
+        }
         int offset = 0;
         if (data.Length >= 3 && data[0] == 0xEF && data[1] == 0xBB && data[2] == 0xBF) offset = 3;
         int commentCount = 0;
@@ -132,6 +143,7 @@ public static class OfficeProvenanceInspector {
             if (++commentCount > maximumContainerEntries) {
                 throw new InvalidDataException("HTML format detection exceeds the configured container-entry limit.");
             }
+            cancellationToken.ThrowIfCancellationRequested();
             int commentEnd = FindAscii(data, offset + 4, "-->");
             if (commentEnd < 0) return false;
             offset = commentEnd + 3;
@@ -148,6 +160,47 @@ public static class OfficeProvenanceInspector {
         return value is 0x09 or 0x0A or 0x0C or 0x0D or 0x20 or (byte)'>' ||
             allowSelfClosing && value == (byte)'/';
     }
+
+    private static bool LooksLikeHtml(
+        string data,
+        int maximumContainerEntries,
+        CancellationToken cancellationToken) {
+        int offset = 0;
+        int commentCount = 0;
+        while (true) {
+            cancellationToken.ThrowIfCancellationRequested();
+            while (offset < data.Length && IsHtmlWhitespace(data[offset])) offset++;
+            if (!MatchesHtmlToken(data, offset, "<!--")) break;
+            if (++commentCount > maximumContainerEntries) {
+                throw new InvalidDataException("HTML format detection exceeds the configured container-entry limit.");
+            }
+            int commentEnd = data.IndexOf("-->", offset + 4, StringComparison.OrdinalIgnoreCase);
+            if (commentEnd < 0) return false;
+            offset = commentEnd + 3;
+        }
+        return MatchesHtmlTokenWithBoundary(data, offset, "<!doctype html", allowSelfClosing: false) ||
+            MatchesHtmlTokenWithBoundary(data, offset, "<html", allowSelfClosing: true);
+    }
+
+    private static bool MatchesHtmlTokenWithBoundary(string data, int offset, string token, bool allowSelfClosing) {
+        if (!MatchesHtmlToken(data, offset, token)) return false;
+        int boundary = offset + token.Length;
+        if (boundary >= data.Length) return false;
+        char value = data[boundary];
+        return IsHtmlWhitespace(value) || value == '>' || allowSelfClosing && value == '/';
+    }
+
+    private static bool MatchesHtmlToken(string data, int offset, string token) =>
+        offset >= 0 && token.Length <= data.Length - offset &&
+        string.Compare(data, offset, token, 0, token.Length, StringComparison.OrdinalIgnoreCase) == 0;
+
+    private static bool IsHtmlWhitespace(char value) => value is '\t' or '\n' or '\f' or '\r' or ' ';
+
+    private static bool HasUtf16OrUtf32Preamble(byte[] data) =>
+        data.Length >= 2 &&
+        ((data[0] == 0xFE && data[1] == 0xFF) ||
+         (data[0] == 0xFF && data[1] == 0xFE) ||
+         (data.Length >= 4 && data[0] == 0x00 && data[1] == 0x00 && data[2] == 0xFE && data[3] == 0xFF));
 
     private static int FindAscii(byte[] data, int offset, string expected) {
         for (int index = Math.Max(0, offset); index <= data.Length - expected.Length; index++) {

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceInspector.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceInspector.cs
@@ -74,6 +74,9 @@ public static class OfficeProvenanceInspector {
             case OfficeProvenanceAssetFormat.Svg:
                 OfficeProvenanceSvg.Inspect(data, options, context);
                 break;
+            case OfficeProvenanceAssetFormat.Html:
+                OfficeProvenanceHtml.Inspect(data, options, context);
+                break;
             case OfficeProvenanceAssetFormat.ZipPackage:
                 OfficeProvenanceZip.Inspect(data, options, context);
                 break;

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceInspector.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceInspector.cs
@@ -23,7 +23,7 @@ public static class OfficeProvenanceInspector {
         OfficeProvenanceBinary.ValidateLimits(options);
         long originalPosition = stream.CanSeek ? stream.Position : 0L;
         try {
-            byte[] data = OfficeProvenanceBinary.ReadBounded(stream, options.MaxAssetBytes);
+            byte[] data = OfficeProvenanceBinary.ReadBounded(stream, options.MaxAssetBytes, options.CancellationToken);
             return Inspect(data, fileName, options);
         } finally {
             if (stream.CanSeek) stream.Position = originalPosition;
@@ -35,6 +35,7 @@ public static class OfficeProvenanceInspector {
         if (data == null) throw new ArgumentNullException(nameof(data));
         options ??= new OfficeProvenanceOptions();
         OfficeProvenanceBinary.ValidateLimits(options);
+        options.CancellationToken.ThrowIfCancellationRequested();
         if (data.LongLength > options.MaxAssetBytes) {
             throw OfficeProvenanceLimitException.Create($"The asset exceeds the configured limit of {options.MaxAssetBytes} bytes.");
         }
@@ -341,6 +342,7 @@ public static class OfficeProvenanceRemover {
         MaxCarriers = source.Limits.MaxCarriers,
         MaxContainerEntries = source.Limits.MaxContainerEntries,
         MaxExpandedContainerBytes = source.Limits.MaxExpandedContainerBytes,
+        CancellationToken = source.Limits.CancellationToken,
         ProcessEmbeddedAssets = source.ProcessEmbeddedAssets && source.Limits.ProcessEmbeddedAssets,
         MaxEmbeddedAssets = Math.Min(source.MaxEmbeddedAssets, source.Limits.MaxEmbeddedAssets)
     };
@@ -351,6 +353,7 @@ public static class OfficeProvenanceRemover {
         MaxCarriers = source.Limits.MaxCarriers,
         MaxContainerEntries = source.Limits.MaxContainerEntries,
         MaxExpandedContainerBytes = source.Limits.MaxExpandedContainerBytes,
+        CancellationToken = source.Limits.CancellationToken,
         ProcessEmbeddedAssets = source.ProcessEmbeddedAssets && source.Limits.ProcessEmbeddedAssets,
         MaxEmbeddedAssets = Math.Min(source.MaxEmbeddedAssets, source.Limits.MaxEmbeddedAssets)
     };
@@ -367,7 +370,7 @@ public static class OfficeProvenanceRemover {
         options ??= new OfficeProvenanceRemovalOptions();
         OfficeProvenanceBinary.ValidateRemovalOptions(options);
         byte[] data;
-        using (var stream = File.OpenRead(fullInputPath)) data = OfficeProvenanceBinary.ReadBounded(stream, options.Limits.MaxAssetBytes);
+        using (var stream = File.OpenRead(fullInputPath)) data = OfficeProvenanceBinary.ReadBounded(stream, options.Limits.MaxAssetBytes, options.Limits.CancellationToken);
         OfficeProvenanceRemovalResult result = Remove(data, fullInputPath, options);
         OfficeFileCommit.WriteAllBytes(fullOutputPath, result.ToArray());
         return result;

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceInspector.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceInspector.cs
@@ -327,15 +327,27 @@ public static class OfficeProvenanceRemover {
                 break;
         }
 
+        OfficeProvenanceBinary.EnsureOutputWithinLimit(output.LongLength, options.EffectiveMaxOutputBytes);
+        OfficeProvenanceOptions outputInspectionOptions = CreateOutputInspectionOptions(options);
         OfficeProvenanceReport after = forcedFormat.HasValue
-            ? OfficeProvenanceInspector.InspectStructuredText(output, inspectionOptions)
-            : OfficeProvenanceInspector.InspectCore(output, fileName, inspectionOptions);
+            ? OfficeProvenanceInspector.InspectStructuredText(output, outputInspectionOptions)
+            : OfficeProvenanceInspector.InspectCore(output, fileName, outputInspectionOptions);
         return OfficeProvenanceRemovalResult.CreateOwned(output, before, after, changes.AsReadOnly(), reserialized);
     }
 
     private static OfficeProvenanceOptions CreateInspectionOptions(OfficeProvenanceRemovalOptions source) => new OfficeProvenanceOptions {
         MaxAssetBytes = source.Limits.MaxAssetBytes,
         MaxManifestBytes = source.Limits.MaxManifestBytes,
+        MaxCarriers = source.Limits.MaxCarriers,
+        MaxContainerEntries = source.Limits.MaxContainerEntries,
+        MaxExpandedContainerBytes = source.Limits.MaxExpandedContainerBytes,
+        ProcessEmbeddedAssets = source.ProcessEmbeddedAssets && source.Limits.ProcessEmbeddedAssets,
+        MaxEmbeddedAssets = Math.Min(source.MaxEmbeddedAssets, source.Limits.MaxEmbeddedAssets)
+    };
+
+    private static OfficeProvenanceOptions CreateOutputInspectionOptions(OfficeProvenanceRemovalOptions source) => new OfficeProvenanceOptions {
+        MaxAssetBytes = source.EffectiveMaxOutputBytes,
+        MaxManifestBytes = Math.Min(source.Limits.MaxManifestBytes, source.EffectiveMaxOutputBytes),
         MaxCarriers = source.Limits.MaxCarriers,
         MaxContainerEntries = source.Limits.MaxContainerEntries,
         MaxExpandedContainerBytes = source.Limits.MaxExpandedContainerBytes,

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceInspector.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceInspector.cs
@@ -109,8 +109,9 @@ public static class OfficeProvenanceInspector {
         if (OfficeProvenanceBinary.MatchesAscii(data, 0, "%PDF-")) return OfficeProvenanceAssetFormat.Pdf;
         if (LooksLikeSvg(data, null, options.MaxContainerEntries)) return OfficeProvenanceAssetFormat.Svg;
         if (LooksLikeHtml(data, null, options.MaxContainerEntries, options.CancellationToken)) return OfficeProvenanceAssetFormat.Html;
-        if (OfficeProvenanceText.HasUnstructuredWrapperPrefix(data, options.MaxContainerEntries)) return OfficeProvenanceAssetFormat.UnstructuredText;
-        if (OfficeProvenanceText.HasStructuredDelimiter(data)) return OfficeProvenanceAssetFormat.StructuredText;
+        if (OfficeProvenanceText.HasUnstructuredWrapperPrefix(
+                data, options.MaxContainerEntries, options.CancellationToken)) return OfficeProvenanceAssetFormat.UnstructuredText;
+        if (OfficeProvenanceText.HasStructuredDelimiter(data, options.CancellationToken)) return OfficeProvenanceAssetFormat.StructuredText;
         string extension = Path.GetExtension(fileName ?? string.Empty);
         if (extension.Equals(".svg", StringComparison.OrdinalIgnoreCase)) return OfficeProvenanceAssetFormat.Svg;
         if (extension.Equals(".html", StringComparison.OrdinalIgnoreCase) ||

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceJpeg.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceJpeg.cs
@@ -14,8 +14,10 @@ internal static class OfficeProvenanceJpeg {
 
     internal static byte[] Remove(byte[] data, OfficeProvenanceRemovalOptions options, List<OfficeProvenanceChange> changes, out bool reserialized) {
         reserialized = false;
-        if (!options.RemoveC2paManifests && !options.RemoveAiSourceMetadata) return (byte[])data.Clone();
-        using var output = new MemoryStream(data.Length);
+        if (!options.RemoveC2paManifests && !options.RemoveAiSourceMetadata) {
+            return OfficeProvenanceBinary.CloneForOutput(data, options.EffectiveMaxOutputBytes);
+        }
+        using var output = new OfficeProvenanceBoundedMemoryStream(options.EffectiveMaxOutputBytes, data.Length);
         reserialized = Walk(data, options.Limits, context: null, output, options, changes);
         return output.ToArray();
     }

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceJpegXmp.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceJpegXmp.cs
@@ -121,7 +121,13 @@ internal static class OfficeProvenanceJpegXmp {
             var updatedStandards = new Dictionary<int, byte[]>();
             bool referencesUpdated = true;
             foreach (int standardStart in reference.Value.Distinct()) {
-                if (!TryReplaceExtendedGuid(currentPackets[standardStart], reference.Key, replacementGuid, options, out byte[] updated)) {
+                if (!TryReplaceExtendedGuid(
+                    currentPackets[standardStart],
+                    reference.Key,
+                    replacementGuid,
+                    options,
+                    removalOptions.EffectiveMaxOutputBytes,
+                    out byte[] updated)) {
                     referencesUpdated = false;
                     break;
                 }
@@ -130,14 +136,22 @@ internal static class OfficeProvenanceJpegXmp {
             if (!referencesUpdated) continue;
 
             foreach (KeyValuePair<int, byte[]> updated in updatedStandards) currentPackets[updated.Key] = updated.Value;
-            ApplyExtendedReplacement(result.Replacements, chunks, replacementGuid, cleanedPacket);
+            ApplyExtendedReplacement(
+                result.Replacements,
+                chunks,
+                replacementGuid,
+                cleanedPacket,
+                removalOptions.EffectiveMaxOutputBytes);
             changes.AddRange(pendingChanges);
         }
 
         foreach (StandardPacket standard in standards) {
             byte[] current = currentPackets[standard.SegmentStart];
             if (!ReferenceEquals(current, standard.Packet)) {
-                result.Replacements[standard.SegmentStart] = CreateSegment(Join(StandardHeader, current));
+                result.Replacements[standard.SegmentStart] = CreateSegment(
+                    StandardHeader,
+                    current,
+                    removalOptions!.EffectiveMaxOutputBytes);
             }
         }
         return result;
@@ -200,6 +214,7 @@ internal static class OfficeProvenanceJpegXmp {
         string oldGuid,
         string newGuid,
         OfficeProvenanceOptions options,
+        long maximumOutputBytes,
         out byte[] updated) {
         updated = packet;
         if (!TryLoad(packet, options, out XDocument? document) || document == null) return false;
@@ -212,7 +227,7 @@ internal static class OfficeProvenanceJpegXmp {
             changed = true;
         }
         if (!changed) return false;
-        updated = Serialize(document);
+        updated = Serialize(document, maximumOutputBytes);
         return true;
     }
 
@@ -244,8 +259,8 @@ internal static class OfficeProvenanceJpegXmp {
         return OfficeProvenanceXml.TryLoadDocument(packet, options, out document);
     }
 
-    private static byte[] Serialize(XDocument document) {
-        using var stream = new MemoryStream();
+    private static byte[] Serialize(XDocument document, long maximumOutputBytes) {
+        using var stream = new OfficeProvenanceBoundedMemoryStream(maximumOutputBytes);
         var settings = new XmlWriterSettings {
             Encoding = new UTF8Encoding(false),
             Indent = false,
@@ -260,18 +275,22 @@ internal static class OfficeProvenanceJpegXmp {
         Dictionary<int, byte[]> replacements,
         ExtendedChunk[] chunks,
         string guid,
-        byte[] packet) {
+        byte[] packet,
+        long maximumOutputBytes) {
         int maximumChunkBytes = MaximumSegmentPayload - ExtendedHeader.Length - ExtendedChunkMetadataLength;
-        using var segments = new MemoryStream();
+        using var segments = new OfficeProvenanceBoundedMemoryStream(maximumOutputBytes);
         for (int offset = 0; offset < packet.Length; offset += maximumChunkBytes) {
             int count = Math.Min(maximumChunkBytes, packet.Length - offset);
+            OfficeProvenanceBinary.EnsureOutputWithinLimit(
+                ExtendedHeader.Length + ExtendedChunkMetadataLength + count + 4L,
+                maximumOutputBytes);
             byte[] metadata = new byte[ExtendedHeader.Length + ExtendedChunkMetadataLength + count];
             Buffer.BlockCopy(ExtendedHeader, 0, metadata, 0, ExtendedHeader.Length);
             Encoding.ASCII.GetBytes(guid, 0, guid.Length, metadata, ExtendedHeader.Length);
             WriteUInt32(metadata, ExtendedHeader.Length + GuidLength, (uint)packet.Length);
             WriteUInt32(metadata, ExtendedHeader.Length + GuidLength + 4, (uint)offset);
             Buffer.BlockCopy(packet, offset, metadata, ExtendedHeader.Length + ExtendedChunkMetadataLength, count);
-            byte[] segment = CreateSegment(metadata);
+            byte[] segment = CreateSegment(metadata, maximumOutputBytes);
             segments.Write(segment, 0, segment.Length);
         }
         replacements[chunks[0].SegmentStart] = segments.ToArray();
@@ -286,8 +305,9 @@ internal static class OfficeProvenanceJpegXmp {
         return builder.ToString();
     }
 
-    private static byte[] CreateSegment(byte[] payload) {
+    private static byte[] CreateSegment(byte[] payload, long maximumOutputBytes) {
         if (payload.Length > MaximumSegmentPayload) throw new InvalidDataException("JPEG XMP packet exceeds the APP1 segment limit.");
+        OfficeProvenanceBinary.EnsureOutputWithinLimit(payload.LongLength + 4L, maximumOutputBytes);
         byte[] segment = new byte[payload.Length + 4];
         segment[0] = 0xFF;
         segment[1] = 0xE1;
@@ -296,6 +316,11 @@ internal static class OfficeProvenanceJpegXmp {
         segment[3] = (byte)length;
         Buffer.BlockCopy(payload, 0, segment, 4, payload.Length);
         return segment;
+    }
+
+    private static byte[] CreateSegment(byte[] first, byte[] second, long maximumOutputBytes) {
+        OfficeProvenanceBinary.EnsureOutputWithinLimit(first.LongLength + second.LongLength + 4L, maximumOutputBytes);
+        return CreateSegment(Join(first, second), maximumOutputBytes);
     }
 
     private static byte[] Join(byte[] first, byte[] second) {

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceLimitException.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceLimitException.cs
@@ -6,6 +6,7 @@ namespace OfficeIMO.Provenance;
 /// <summary>Marks configured provenance resource limits without changing the public exception contract.</summary>
 internal static class OfficeProvenanceLimitException {
     private const string Marker = "OfficeIMO.Provenance.ResourceLimit";
+    private const string OutputMarker = "OfficeIMO.Provenance.OutputLimit";
 
     internal static InvalidDataException Create(string message) {
         var exception = new InvalidDataException(message);
@@ -13,6 +14,15 @@ internal static class OfficeProvenanceLimitException {
         return exception;
     }
 
+    internal static InvalidDataException CreateOutput(string message) {
+        InvalidDataException exception = Create(message);
+        exception.Data[OutputMarker] = true;
+        return exception;
+    }
+
     internal static bool Is(Exception exception) =>
         exception is InvalidDataException && exception.Data.Contains(Marker);
+
+    internal static bool IsOutput(Exception exception) =>
+        exception is InvalidDataException && exception.Data.Contains(OutputMarker);
 }

--- a/OfficeIMO.Core/Provenance/OfficeProvenancePackageMutation.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenancePackageMutation.cs
@@ -36,7 +36,7 @@ internal static class OfficeProvenancePackageMutation {
         string inputPath,
         string outputPath,
         OfficeProvenanceRemovalOptions? options,
-        Func<byte[], OfficeProvenanceOptions, OfficeProvenanceSignatureStripResult> stripSignatures,
+        Func<byte[], OfficeProvenanceRemovalOptions, OfficeProvenanceSignatureStripResult> stripSignatures,
         Func<byte[], OfficeProvenanceRemovalOptions, bool>? hasSignatures = null,
         Action<byte[], OfficeProvenanceOptions>? validatePackage = null,
         bool removeOpcManifestReferences = true,
@@ -68,7 +68,7 @@ internal static class OfficeProvenancePackageMutation {
         byte[] data,
         string fileName,
         OfficeProvenanceRemovalOptions? options,
-        Func<byte[], OfficeProvenanceOptions, OfficeProvenanceSignatureStripResult> stripSignatures,
+        Func<byte[], OfficeProvenanceRemovalOptions, OfficeProvenanceSignatureStripResult> stripSignatures,
         Func<byte[], OfficeProvenanceRemovalOptions, bool>? hasSignatures = null,
         Action<byte[], OfficeProvenanceOptions>? validatePackage = null,
         bool removeOpcManifestReferences = true,
@@ -115,7 +115,7 @@ internal static class OfficeProvenancePackageMutation {
 
         byte[] previewData = preview.ToArray();
         ValidateAggregateRewriteBudget(data, previewData, options.Limits);
-        OfficeProvenanceSignatureStripResult stripped = stripSignatures(previewData, options.Limits);
+        OfficeProvenanceSignatureStripResult stripped = stripSignatures(previewData, options);
         if (!stripped.HadSignatures) {
             throw new InvalidOperationException("The package contains signature evidence that its owning adapter could not remove safely.");
         }
@@ -125,6 +125,7 @@ internal static class OfficeProvenancePackageMutation {
         if (hasSignatures?.Invoke(stripped.Data, options) ?? OfficeProvenanceZip.HasPackageSignature(stripped.Data, options)) {
             throw new InvalidOperationException("The owning package adapter left signature evidence in the rewritten document.");
         }
+        OfficeProvenanceBinary.EnsureOutputWithinLimit(stripped.Data.LongLength, options.EffectiveMaxOutputBytes);
         return new OfficeProvenanceRemovalResult(
             stripped.Data,
             preview.Before,
@@ -170,7 +171,8 @@ internal static class OfficeProvenancePackageMutation {
             RequireStructurallyValidCarrier = source.RequireStructurallyValidCarrier,
             SignatureMutationPolicy = signaturePolicy,
             ProcessEmbeddedAssets = source.ProcessEmbeddedAssets && source.Limits.ProcessEmbeddedAssets,
-            MaxEmbeddedAssets = Math.Min(source.MaxEmbeddedAssets, source.Limits.MaxEmbeddedAssets)
+            MaxEmbeddedAssets = Math.Min(source.MaxEmbeddedAssets, source.Limits.MaxEmbeddedAssets),
+            MaxOutputBytes = source.MaxOutputBytes
         };
         clone.Limits.MaxAssetBytes = source.Limits.MaxAssetBytes;
         clone.Limits.MaxManifestBytes = source.Limits.MaxManifestBytes;

--- a/OfficeIMO.Core/Provenance/OfficeProvenancePackageMutation.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenancePackageMutation.cs
@@ -27,7 +27,8 @@ internal static class OfficeProvenancePackageMutation {
         OfficeProvenanceBinary.ValidateLimits(options);
         string fullPath = Path.GetFullPath(filePath);
         byte[] data;
-        using (var stream = File.OpenRead(fullPath)) data = OfficeProvenanceBinary.ReadBounded(stream, options.MaxAssetBytes);
+        using (var stream = File.OpenRead(fullPath)) data = OfficeProvenanceBinary.ReadBounded(stream, options.MaxAssetBytes, options.CancellationToken);
+        options.CancellationToken.ThrowIfCancellationRequested();
         validatePackage(data, options);
         return OfficeProvenanceInspector.Inspect(data, fullPath, options);
     }
@@ -48,7 +49,8 @@ internal static class OfficeProvenancePackageMutation {
         options ??= new OfficeProvenanceRemovalOptions();
         string fullInputPath = Path.GetFullPath(inputPath);
         byte[] data;
-        using (var stream = File.OpenRead(fullInputPath)) data = OfficeProvenanceBinary.ReadBounded(stream, options.Limits.MaxAssetBytes);
+        using (var stream = File.OpenRead(fullInputPath)) data = OfficeProvenanceBinary.ReadBounded(stream, options.Limits.MaxAssetBytes, options.Limits.CancellationToken);
+        options.Limits.CancellationToken.ThrowIfCancellationRequested();
         OfficeProvenanceRemovalResult result = Remove(
             data,
             fullInputPath,
@@ -79,6 +81,7 @@ internal static class OfficeProvenancePackageMutation {
         if (stripSignatures == null) throw new ArgumentNullException(nameof(stripSignatures));
         options ??= new OfficeProvenanceRemovalOptions();
         OfficeProvenanceBinary.ValidateRemovalOptions(options);
+        options.Limits.CancellationToken.ThrowIfCancellationRequested();
         if (data.LongLength > options.Limits.MaxAssetBytes) {
             throw new InvalidDataException("The package exceeds the configured asset limit.");
         }
@@ -96,7 +99,8 @@ internal static class OfficeProvenancePackageMutation {
         OfficeProvenanceRemovalOptions previewOptions = Clone(
             options,
             OfficeSignatureMutationPolicy.PreserveSignatureMarkup,
-            options.EffectiveMaxIntermediateBytes);
+            options.EffectiveMaxIntermediateBytes,
+            options.Limits.MaxExpandedContainerBytes);
         OfficeProvenanceRemovalResult preview = OfficeProvenanceRemover.RemoveZipPackage(
             data,
             fileName,
@@ -117,8 +121,16 @@ internal static class OfficeProvenancePackageMutation {
         if (!hadSignatureEvidence) return EnforceFinalOutputLimit(preview, options.EffectiveMaxOutputBytes);
 
         byte[] previewData = preview.ToArray();
-        ValidateAggregateRewriteBudget(data, previewData, options.Limits);
-        OfficeProvenanceSignatureStripResult stripped = stripSignatures(previewData, options);
+        long remainingExpandedBytes = ValidateAggregateRewriteBudget(data, previewData, options.Limits);
+        if (remainingExpandedBytes <= 0) {
+            throw OfficeProvenanceLimitException.Create("Package mutation exceeds the configured aggregate expanded-byte limit.");
+        }
+        OfficeProvenanceRemovalOptions stripOptions = Clone(
+            options,
+            options.SignatureMutationPolicy,
+            options.EffectiveMaxOutputBytes,
+            remainingExpandedBytes);
+        OfficeProvenanceSignatureStripResult stripped = stripSignatures(previewData, stripOptions);
         if (!stripped.HadSignatures) {
             throw new InvalidOperationException("The package contains signature evidence that its owning adapter could not remove safely.");
         }
@@ -138,16 +150,29 @@ internal static class OfficeProvenancePackageMutation {
             wereInvalidatedSignaturesRemoved: true);
     }
 
-    private static void ValidateAggregateRewriteBudget(
+    private static long ValidateAggregateRewriteBudget(
         byte[] original,
         byte[] preview,
         OfficeProvenanceOptions limits) {
-        long expandedBytes = GetExpandedPackageBytes(original, limits.MaxContainerEntries, limits.MaxExpandedContainerBytes);
+        long expandedBytes = GetExpandedPackageBytes(
+            original,
+            limits.MaxContainerEntries,
+            limits.MaxExpandedContainerBytes,
+            limits.CancellationToken);
         long remaining = limits.MaxExpandedContainerBytes - expandedBytes;
-        _ = GetExpandedPackageBytes(preview, limits.MaxContainerEntries, remaining);
+        long previewExpandedBytes = GetExpandedPackageBytes(
+            preview,
+            limits.MaxContainerEntries,
+            remaining,
+            limits.CancellationToken);
+        return remaining - previewExpandedBytes;
     }
 
-    private static long GetExpandedPackageBytes(byte[] data, int maximumEntries, long maximumBytes) {
+    private static long GetExpandedPackageBytes(
+        byte[] data,
+        int maximumEntries,
+        long maximumBytes,
+        System.Threading.CancellationToken cancellationToken) {
         if (maximumBytes < 0) {
             throw OfficeProvenanceLimitException.Create("Package mutation exceeds the configured aggregate expanded-byte limit.");
         }
@@ -156,6 +181,7 @@ internal static class OfficeProvenancePackageMutation {
         using var archive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: false);
         long expandedBytes = 0;
         foreach (ZipArchiveEntry entry in archive.Entries) {
+            cancellationToken.ThrowIfCancellationRequested();
             if (entry.Length > maximumBytes - expandedBytes) {
                 throw OfficeProvenanceLimitException.Create("Package mutation exceeds the configured aggregate expanded-byte limit.");
             }
@@ -167,7 +193,8 @@ internal static class OfficeProvenancePackageMutation {
     private static OfficeProvenanceRemovalOptions Clone(
         OfficeProvenanceRemovalOptions source,
         OfficeSignatureMutationPolicy signaturePolicy,
-        long maximumOutputBytes) {
+        long maximumOutputBytes,
+        long maximumExpandedBytes) {
         var clone = new OfficeProvenanceRemovalOptions {
             RemoveC2paManifests = source.RemoveC2paManifests,
             RemoveExternalC2paReferences = source.RemoveExternalC2paReferences,
@@ -182,7 +209,8 @@ internal static class OfficeProvenancePackageMutation {
         clone.Limits.MaxManifestBytes = source.Limits.MaxManifestBytes;
         clone.Limits.MaxCarriers = source.Limits.MaxCarriers;
         clone.Limits.MaxContainerEntries = source.Limits.MaxContainerEntries;
-        clone.Limits.MaxExpandedContainerBytes = source.Limits.MaxExpandedContainerBytes;
+        clone.Limits.MaxExpandedContainerBytes = maximumExpandedBytes;
+        clone.Limits.CancellationToken = source.Limits.CancellationToken;
         clone.Limits.ProcessEmbeddedAssets = source.ProcessEmbeddedAssets && source.Limits.ProcessEmbeddedAssets;
         clone.Limits.MaxEmbeddedAssets = Math.Min(source.MaxEmbeddedAssets, source.Limits.MaxEmbeddedAssets);
         return clone;

--- a/OfficeIMO.Core/Provenance/OfficeProvenancePackageMutation.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenancePackageMutation.cs
@@ -96,7 +96,7 @@ internal static class OfficeProvenancePackageMutation {
         OfficeProvenanceRemovalOptions previewOptions = Clone(
             options,
             OfficeSignatureMutationPolicy.PreserveSignatureMarkup,
-            Math.Max(options.EffectiveMaxOutputBytes, options.Limits.MaxAssetBytes));
+            options.EffectiveMaxIntermediateBytes);
         OfficeProvenanceRemovalResult preview = OfficeProvenanceRemover.RemoveZipPackage(
             data,
             fileName,

--- a/OfficeIMO.Core/Provenance/OfficeProvenancePackageMutation.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenancePackageMutation.cs
@@ -93,7 +93,10 @@ internal static class OfficeProvenancePackageMutation {
                 replacePackageMetadata);
         }
 
-        OfficeProvenanceRemovalOptions previewOptions = Clone(options, OfficeSignatureMutationPolicy.PreserveSignatureMarkup);
+        OfficeProvenanceRemovalOptions previewOptions = Clone(
+            options,
+            OfficeSignatureMutationPolicy.PreserveSignatureMarkup,
+            Math.Max(options.EffectiveMaxOutputBytes, options.Limits.MaxAssetBytes));
         OfficeProvenanceRemovalResult preview = OfficeProvenanceRemover.RemoveZipPackage(
             data,
             fileName,
@@ -101,7 +104,7 @@ internal static class OfficeProvenancePackageMutation {
             removeOpcManifestReferences,
             shouldReplacePackageMetadata,
             replacePackageMetadata);
-        if (!preview.WasChanged) return preview;
+        if (!preview.WasChanged) return EnforceFinalOutputLimit(preview, options.EffectiveMaxOutputBytes);
 
         OfficeProvenanceZip.ValidateForOwningPackageMutation(data, options.Limits, validateOpcMetadata);
         bool hadSignatureEvidence = hasSignatures?.Invoke(data, options) ?? OfficeProvenanceZip.HasPackageSignature(data, options);
@@ -109,9 +112,9 @@ internal static class OfficeProvenancePackageMutation {
             if (hadSignatureEvidence) {
                 throw new InvalidOperationException("Removing provenance would invalidate package signatures. Choose an explicit signature mutation policy.");
             }
-            return preview;
+            return EnforceFinalOutputLimit(preview, options.EffectiveMaxOutputBytes);
         }
-        if (!hadSignatureEvidence) return preview;
+        if (!hadSignatureEvidence) return EnforceFinalOutputLimit(preview, options.EffectiveMaxOutputBytes);
 
         byte[] previewData = preview.ToArray();
         ValidateAggregateRewriteBudget(data, previewData, options.Limits);
@@ -163,7 +166,8 @@ internal static class OfficeProvenancePackageMutation {
 
     private static OfficeProvenanceRemovalOptions Clone(
         OfficeProvenanceRemovalOptions source,
-        OfficeSignatureMutationPolicy signaturePolicy) {
+        OfficeSignatureMutationPolicy signaturePolicy,
+        long maximumOutputBytes) {
         var clone = new OfficeProvenanceRemovalOptions {
             RemoveC2paManifests = source.RemoveC2paManifests,
             RemoveExternalC2paReferences = source.RemoveExternalC2paReferences,
@@ -172,7 +176,7 @@ internal static class OfficeProvenancePackageMutation {
             SignatureMutationPolicy = signaturePolicy,
             ProcessEmbeddedAssets = source.ProcessEmbeddedAssets && source.Limits.ProcessEmbeddedAssets,
             MaxEmbeddedAssets = Math.Min(source.MaxEmbeddedAssets, source.Limits.MaxEmbeddedAssets),
-            MaxOutputBytes = source.MaxOutputBytes
+            MaxOutputBytes = maximumOutputBytes
         };
         clone.Limits.MaxAssetBytes = source.Limits.MaxAssetBytes;
         clone.Limits.MaxManifestBytes = source.Limits.MaxManifestBytes;
@@ -182,5 +186,12 @@ internal static class OfficeProvenancePackageMutation {
         clone.Limits.ProcessEmbeddedAssets = source.ProcessEmbeddedAssets && source.Limits.ProcessEmbeddedAssets;
         clone.Limits.MaxEmbeddedAssets = Math.Min(source.MaxEmbeddedAssets, source.Limits.MaxEmbeddedAssets);
         return clone;
+    }
+
+    private static OfficeProvenanceRemovalResult EnforceFinalOutputLimit(
+        OfficeProvenanceRemovalResult result,
+        long maximumOutputBytes) {
+        OfficeProvenanceBinary.EnsureOutputWithinLimit(result.DataLength, maximumOutputBytes);
+        return result;
     }
 }

--- a/OfficeIMO.Core/Provenance/OfficeProvenancePackageMutation.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenancePackageMutation.cs
@@ -130,6 +130,9 @@ internal static class OfficeProvenancePackageMutation {
             options.SignatureMutationPolicy,
             options.EffectiveMaxOutputBytes,
             remainingExpandedBytes);
+        stripOptions.Limits.MaxAssetBytes = Math.Max(
+            options.Limits.MaxAssetBytes,
+            options.EffectiveMaxOutputBytes);
         OfficeProvenanceSignatureStripResult stripped = stripSignatures(previewData, stripOptions);
         if (!stripped.HadSignatures) {
             throw new InvalidOperationException("The package contains signature evidence that its owning adapter could not remove safely.");
@@ -137,7 +140,7 @@ internal static class OfficeProvenancePackageMutation {
         if (stripped.Data.SequenceEqual(previewData)) {
             throw new InvalidOperationException("The document reports signatures, but its owning package adapter could not remove them safely.");
         }
-        if (hasSignatures?.Invoke(stripped.Data, options) ?? OfficeProvenanceZip.HasPackageSignature(stripped.Data, options)) {
+        if (hasSignatures?.Invoke(stripped.Data, stripOptions) ?? OfficeProvenanceZip.HasPackageSignature(stripped.Data, stripOptions)) {
             throw new InvalidOperationException("The owning package adapter left signature evidence in the rewritten document.");
         }
         OfficeProvenanceBinary.EnsureOutputWithinLimit(stripped.Data.LongLength, options.EffectiveMaxOutputBytes);

--- a/OfficeIMO.Core/Provenance/OfficeProvenancePng.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenancePng.cs
@@ -14,8 +14,12 @@ internal static class OfficeProvenancePng {
 
     internal static byte[] Remove(byte[] data, OfficeProvenanceRemovalOptions options, List<OfficeProvenanceChange> changes, out bool reserialized) {
         reserialized = false;
-        if (!options.RemoveC2paManifests && !options.RemoveAiSourceMetadata) return (byte[])data.Clone();
-        using var output = new MemoryStream(EstimateRemovalOutputCapacity(data, options));
+        if (!options.RemoveC2paManifests && !options.RemoveAiSourceMetadata) {
+            return OfficeProvenanceBinary.CloneForOutput(data, options.EffectiveMaxOutputBytes);
+        }
+        using var output = new OfficeProvenanceBoundedMemoryStream(
+            options.EffectiveMaxOutputBytes,
+            EstimateRemovalOutputCapacity(data, options));
         output.Write(data, 0, SignatureLength);
         reserialized = Walk(data, options.Limits, context: null, output, options, changes);
         return output.ToArray();

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceProviderContractException.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceProviderContractException.cs
@@ -1,0 +1,18 @@
+using System;
+using System.IO;
+
+namespace OfficeIMO.Provenance;
+
+/// <summary>Marks malformed optional-provider results without changing the public exception contract.</summary>
+internal static class OfficeProvenanceProviderContractException {
+    private const string Marker = "OfficeIMO.Provenance.ProviderContract";
+
+    internal static InvalidDataException Create(string message) {
+        var exception = new InvalidDataException(message);
+        exception.Data[Marker] = true;
+        return exception;
+    }
+
+    internal static bool Is(Exception exception) =>
+        exception is InvalidDataException && exception.Data.Contains(Marker);
+}

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceRiff.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceRiff.cs
@@ -12,8 +12,10 @@ internal static class OfficeProvenanceRiff {
 
     internal static byte[] Remove(byte[] data, OfficeProvenanceRemovalOptions options, List<OfficeProvenanceChange> changes, out bool reserialized) {
         reserialized = false;
-        if (!options.RemoveC2paManifests && !options.RemoveAiSourceMetadata) return (byte[])data.Clone();
-        using var output = new MemoryStream(data.Length);
+        if (!options.RemoveC2paManifests && !options.RemoveAiSourceMetadata) {
+            return OfficeProvenanceBinary.CloneForOutput(data, options.EffectiveMaxOutputBytes);
+        }
+        using var output = new OfficeProvenanceBoundedMemoryStream(options.EffectiveMaxOutputBytes, data.Length);
         output.Write(data, 0, 12);
         reserialized = Walk(data, options.Limits, context: null, output, options, changes);
         int sourceDeclaredEnd = checked((int)(8L + OfficeProvenanceBinary.ReadUInt32(data, 4, littleEndian: true)));

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceSvg.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceSvg.cs
@@ -51,7 +51,9 @@ internal static class OfficeProvenanceSvg {
         List<OfficeProvenanceChange> changes,
         out bool reserialized) {
         reserialized = false;
-        if (!options.RemoveC2paManifests && !options.RemoveAiSourceMetadata) return (byte[])data.Clone();
+        if (!options.RemoveC2paManifests && !options.RemoveAiSourceMetadata) {
+            return OfficeProvenanceBinary.CloneForOutput(data, options.EffectiveMaxOutputBytes);
+        }
         XDocument document = Load(data, options.Limits);
         IReadOnlyList<SvgCarrier> carriers = FindCarriers(document);
         int manifestCount = carriers.Count(carrier => carrier.Kind == SvgCarrierKind.Manifest);
@@ -86,8 +88,8 @@ internal static class OfficeProvenanceSvg {
                 $"SVG/metadata/c2pa:manifest[{index}]",
                 0));
         }
-        if (changes.Count == 0) return (byte[])data.Clone();
-        using var output = new MemoryStream();
+        if (changes.Count == 0) return OfficeProvenanceBinary.CloneForOutput(data, options.EffectiveMaxOutputBytes);
+        using var output = new OfficeProvenanceBoundedMemoryStream(options.EffectiveMaxOutputBytes);
         var settings = new XmlWriterSettings {
             Encoding = new UTF8Encoding(false),
             Indent = false,

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceText.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceText.cs
@@ -63,7 +63,9 @@ internal static class OfficeProvenanceText {
     }
 
     internal static byte[] Remove(byte[] data, OfficeProvenanceRemovalOptions options, List<OfficeProvenanceChange> changes) {
-        if (!options.RemoveC2paManifests && !options.RemoveExternalC2paReferences) return (byte[])data.Clone();
+        if (!options.RemoveC2paManifests && !options.RemoveExternalC2paReferences) {
+            return OfficeProvenanceBinary.CloneForOutput(data, options.EffectiveMaxOutputBytes);
+        }
         var candidates = new List<(int Offset, RemovalRange Range, OfficeProvenanceChange Change)>();
         StructuredBlock[] structuredBlocks = FindStructuredBlocks(
             data, options.Limits.MaxManifestBytes, options.Limits.MaxContainerEntries).ToArray();
@@ -87,10 +89,10 @@ internal static class OfficeProvenanceText {
                     wrapper.End - wrapper.Start)));
             }
         }
-        if (candidates.Count == 0) return (byte[])data.Clone();
+        if (candidates.Count == 0) return OfficeProvenanceBinary.CloneForOutput(data, options.EffectiveMaxOutputBytes);
         candidates.Sort((left, right) => left.Offset.CompareTo(right.Offset));
         foreach ((int _, RemovalRange _, OfficeProvenanceChange change) in candidates) changes.Add(change);
-        using var output = new MemoryStream(data.Length);
+        using var output = new OfficeProvenanceBoundedMemoryStream(options.EffectiveMaxOutputBytes, data.Length);
         int offset = 0;
         foreach (RemovalRange range in candidates.Select(item => item.Range).OrderBy(item => item.Start)) {
             if (range.Start < offset) continue;

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceText.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceText.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 
 namespace OfficeIMO.Provenance;
 
@@ -12,12 +13,17 @@ internal static class OfficeProvenanceText {
     private static readonly byte[] WrapperMagic = Encoding.ASCII.GetBytes("C2PATXT\0");
     private static readonly byte[] DataUriPrefix = Encoding.ASCII.GetBytes("data:application/c2pa;base64,");
 
-    internal static bool HasStructuredDelimiter(byte[] data) => IndexOf(data, BeginDelimiter, 0) >= 0;
+    internal static bool HasStructuredDelimiter(byte[] data, CancellationToken cancellationToken = default) =>
+        IndexOf(data, BeginDelimiter, 0, cancellationToken) >= 0;
 
-    internal static bool HasUnstructuredWrapperPrefix(byte[] data, int maximumContainerEntries) {
+    internal static bool HasUnstructuredWrapperPrefix(
+        byte[] data,
+        int maximumContainerEntries,
+        CancellationToken cancellationToken = default) {
         int offset = 0;
         int candidateCount = 0;
         while (offset < data.Length) {
+            if ((offset & 0xFFF) == 0) cancellationToken.ThrowIfCancellationRequested();
             if (!TryReadCodePoint(data, offset, out int codePoint, out int prefixBytes) || codePoint != 0xFEFF) { offset++; continue; }
             if (++candidateCount > maximumContainerEntries) {
                 throw new InvalidDataException("Text provenance wrapper detection exceeds the configured container-entry limit.");
@@ -40,8 +46,10 @@ internal static class OfficeProvenanceText {
 
     internal static void Inspect(byte[] data, OfficeProvenanceOptions options, OfficeProvenanceContext context) {
         var evidence = new List<(int Offset, OfficeProvenanceEvidence Evidence)>();
-        StructuredBlock[] structuredBlocks = FindStructuredBlocks(data, options.MaxManifestBytes, options.MaxContainerEntries).ToArray();
-        TextWrapper[] wrappers = FindWrappers(data, options.MaxManifestBytes, options.MaxContainerEntries, includeInvalid: true).ToArray();
+        StructuredBlock[] structuredBlocks = FindStructuredBlocks(
+            data, options.MaxManifestBytes, options.MaxContainerEntries, options.CancellationToken).ToArray();
+        TextWrapper[] wrappers = FindWrappers(
+            data, options.MaxManifestBytes, options.MaxContainerEntries, includeInvalid: true, options.CancellationToken).ToArray();
         bool carrierSetIsValid = structuredBlocks.Length + wrappers.Length <= 1;
         foreach (StructuredBlock block in structuredBlocks) {
             evidence.Add((block.Start, new OfficeProvenanceEvidence(
@@ -68,9 +76,10 @@ internal static class OfficeProvenanceText {
         }
         var candidates = new List<(int Offset, RemovalRange Range, OfficeProvenanceChange Change)>();
         StructuredBlock[] structuredBlocks = FindStructuredBlocks(
-            data, options.Limits.MaxManifestBytes, options.Limits.MaxContainerEntries).ToArray();
+            data, options.Limits.MaxManifestBytes, options.Limits.MaxContainerEntries, options.Limits.CancellationToken).ToArray();
         TextWrapper[] wrappers = FindWrappers(
-            data, options.Limits.MaxManifestBytes, options.Limits.MaxContainerEntries, includeInvalid: true).ToArray();
+            data, options.Limits.MaxManifestBytes, options.Limits.MaxContainerEntries, includeInvalid: true,
+            options.Limits.CancellationToken).ToArray();
         bool carrierSetIsValid = structuredBlocks.Length + wrappers.Length <= 1;
         foreach (StructuredBlock block in structuredBlocks) {
             bool requested = block.IsExternal ? options.RemoveExternalC2paReferences : options.RemoveC2paManifests;
@@ -106,19 +115,22 @@ internal static class OfficeProvenanceText {
     private static IEnumerable<StructuredBlock> FindStructuredBlocks(
         byte[] data,
         long maximumManifestBytes,
-        int maximumContainerEntries) {
+        int maximumContainerEntries,
+        CancellationToken cancellationToken) {
         int search = 0;
         int pendingEnd = -1;
         int delimiterCount = 0;
         while (search < data.Length) {
-            int begin = IndexOf(data, BeginDelimiter, search);
-            int orphanEnd = FindStandaloneDelimiter(data, EndDelimiter, search);
+            cancellationToken.ThrowIfCancellationRequested();
+            int begin = IndexOf(data, BeginDelimiter, search, cancellationToken);
+            int orphanEnd = FindStandaloneDelimiter(data, EndDelimiter, search, cancellationToken);
             if (orphanEnd >= 0 && (begin < 0 || orphanEnd < begin)) {
                 if (++delimiterCount > maximumContainerEntries) {
                     throw new InvalidDataException("The structured text exceeds the configured container-entry limit.");
                 }
-                int orphanLineStart = FindLineStart(data, orphanEnd);
-                int orphanLineEnd = FindLineEndIncludingTerminator(data, orphanEnd + EndDelimiter.Length);
+                int orphanLineStart = FindLineStart(data, orphanEnd, cancellationToken);
+                int orphanLineEnd = FindLineEndIncludingTerminator(
+                    data, orphanEnd + EndDelimiter.Length, cancellationToken);
                 yield return new StructuredBlock(orphanEnd, orphanLineStart, orphanLineEnd, false, false, 0L, null);
                 search = orphanEnd + EndDelimiter.Length;
                 continue;
@@ -132,27 +144,32 @@ internal static class OfficeProvenanceText {
                 begin,
                 maximumManifestBytes,
                 maximumContainerEntries,
+                cancellationToken,
                 out StructuredBlock? singleLineBlock)) {
                 yield return singleLineBlock!;
                 search = Math.Max(singleLineBlock!.LineEnd, begin + BeginDelimiter.Length);
                 continue;
             }
-            if (!IsStandaloneDelimiter(data, begin, BeginDelimiter.Length)) {
+            if (!IsStandaloneDelimiter(data, begin, BeginDelimiter.Length, cancellationToken)) {
                 search = begin + BeginDelimiter.Length;
                 continue;
             }
             int contentStart = begin + BeginDelimiter.Length;
-            int end = pendingEnd >= contentStart ? pendingEnd : FindStandaloneDelimiter(data, EndDelimiter, contentStart);
+            int end = pendingEnd >= contentStart
+                ? pendingEnd
+                : FindStandaloneDelimiter(data, EndDelimiter, contentStart, cancellationToken);
             if (end < 0) {
-                int unmatchedLineStart = FindLineStart(data, begin);
-                int unmatchedLineEnd = FindLineEndIncludingTerminator(data, begin + BeginDelimiter.Length);
+                int unmatchedLineStart = FindLineStart(data, begin, cancellationToken);
+                int unmatchedLineEnd = FindLineEndIncludingTerminator(
+                    data, begin + BeginDelimiter.Length, cancellationToken);
                 yield return new StructuredBlock(begin, unmatchedLineStart, unmatchedLineEnd, false, false, 0L, null);
                 yield break;
             }
-            int newerBegin = FindStandaloneDelimiter(data, BeginDelimiter, contentStart);
+            int newerBegin = FindStandaloneDelimiter(data, BeginDelimiter, contentStart, cancellationToken);
             if (newerBegin >= 0 && newerBegin < end) {
-                int nestedLineStart = FindLineStart(data, begin);
-                int nestedLineEnd = FindLineEndIncludingTerminator(data, begin + BeginDelimiter.Length);
+                int nestedLineStart = FindLineStart(data, begin, cancellationToken);
+                int nestedLineEnd = FindLineEndIncludingTerminator(
+                    data, begin + BeginDelimiter.Length, cancellationToken);
                 yield return new StructuredBlock(begin, nestedLineStart, nestedLineEnd, false, false, 0L, null);
                 pendingEnd = end;
                 search = newerBegin;
@@ -160,20 +177,27 @@ internal static class OfficeProvenanceText {
             }
             pendingEnd = -1;
             int contentEnd = end;
-            while (contentStart < contentEnd && IsAsciiWhitespace(data[contentStart])) contentStart++;
-            while (contentEnd > contentStart && IsAsciiWhitespace(data[contentEnd - 1])) contentEnd--;
+            while (contentStart < contentEnd && IsAsciiWhitespace(data[contentStart])) {
+                if ((contentStart & 0xFFF) == 0) cancellationToken.ThrowIfCancellationRequested();
+                contentStart++;
+            }
+            while (contentEnd > contentStart && IsAsciiWhitespace(data[contentEnd - 1])) {
+                if ((contentEnd & 0xFFF) == 0) cancellationToken.ThrowIfCancellationRequested();
+                contentEnd--;
+            }
             ParseStructuredValue(
                 data,
                 contentStart,
                 contentEnd,
                 maximumManifestBytes,
                 maximumContainerEntries,
+                cancellationToken,
                 out bool external,
                 out bool valid,
                 out long manifestLength,
                 out string? externalUri);
-            int lineStart = FindLineStart(data, begin);
-            int lineEnd = FindLineEndIncludingTerminator(data, end + EndDelimiter.Length);
+            int lineStart = FindLineStart(data, begin, cancellationToken);
+            int lineEnd = FindLineEndIncludingTerminator(data, end + EndDelimiter.Length, cancellationToken);
             yield return new StructuredBlock(begin, lineStart, lineEnd, external, valid, manifestLength, externalUri);
             search = end + EndDelimiter.Length;
         }
@@ -184,48 +208,68 @@ internal static class OfficeProvenanceText {
         int begin,
         long maximumManifestBytes,
         int maximumContainerEntries,
+        CancellationToken cancellationToken,
         out StructuredBlock? block) {
         block = null;
-        int lineStart = FindLineStart(data, begin);
-        int lineContentEnd = FindLineEnd(data, begin + BeginDelimiter.Length);
+        int lineStart = FindLineStart(data, begin, cancellationToken);
+        int lineContentEnd = FindLineEnd(data, begin + BeginDelimiter.Length, cancellationToken);
         int contentStart = begin + BeginDelimiter.Length;
-        int end = IndexOf(data, EndDelimiter, contentStart);
+        int end = IndexOf(data, EndDelimiter, contentStart, cancellationToken);
         bool hasSameLineEnd = end >= contentStart && end < lineContentEnd;
 
         int prefixStart = lineStart;
-        while (prefixStart < begin && IsHorizontalWhitespace(data[prefixStart])) prefixStart++;
+        while (prefixStart < begin && IsHorizontalWhitespace(data[prefixStart])) {
+            if ((prefixStart & 0xFFF) == 0) cancellationToken.ThrowIfCancellationRequested();
+            prefixStart++;
+        }
         int prefixEnd = begin;
-        while (prefixEnd > prefixStart && IsHorizontalWhitespace(data[prefixEnd - 1])) prefixEnd--;
+        while (prefixEnd > prefixStart && IsHorizontalWhitespace(data[prefixEnd - 1])) {
+            if ((prefixEnd & 0xFFF) == 0) cancellationToken.ThrowIfCancellationRequested();
+            prefixEnd--;
+        }
         int prefixLength = prefixEnd - prefixStart;
 
         if (prefixLength == 0) return false;
         int suffixStart = hasSameLineEnd ? end + EndDelimiter.Length : lineContentEnd;
-        while (suffixStart < lineContentEnd && IsHorizontalWhitespace(data[suffixStart])) suffixStart++;
+        while (suffixStart < lineContentEnd && IsHorizontalWhitespace(data[suffixStart])) {
+            if ((suffixStart & 0xFFF) == 0) cancellationToken.ThrowIfCancellationRequested();
+            suffixStart++;
+        }
         int suffixEnd = lineContentEnd;
-        while (suffixEnd > suffixStart && IsHorizontalWhitespace(data[suffixEnd - 1])) suffixEnd--;
+        while (suffixEnd > suffixStart && IsHorizontalWhitespace(data[suffixEnd - 1])) {
+            if ((suffixEnd & 0xFFF) == 0) cancellationToken.ThrowIfCancellationRequested();
+            suffixEnd--;
+        }
 
         if (!IsSupportedCommentEnvelope(data, prefixStart, prefixLength, suffixStart, suffixEnd - suffixStart)) {
             return false;
         }
 
-        int lineEnd = FindLineEndIncludingTerminator(data, lineContentEnd);
+        int lineEnd = FindLineEndIncludingTerminator(data, lineContentEnd, cancellationToken);
         if (!hasSameLineEnd) {
             block = new StructuredBlock(begin, lineStart, lineEnd, false, false, 0L, null);
             return true;
         }
 
-        int nestedBegin = IndexOf(data, BeginDelimiter, contentStart);
+        int nestedBegin = IndexOf(data, BeginDelimiter, contentStart, cancellationToken);
         bool nested = nestedBegin >= contentStart && nestedBegin < end;
         int valueStart = contentStart;
         int valueEnd = end;
-        while (valueStart < valueEnd && IsHorizontalWhitespace(data[valueStart])) valueStart++;
-        while (valueEnd > valueStart && IsHorizontalWhitespace(data[valueEnd - 1])) valueEnd--;
+        while (valueStart < valueEnd && IsHorizontalWhitespace(data[valueStart])) {
+            if ((valueStart & 0xFFF) == 0) cancellationToken.ThrowIfCancellationRequested();
+            valueStart++;
+        }
+        while (valueEnd > valueStart && IsHorizontalWhitespace(data[valueEnd - 1])) {
+            if ((valueEnd & 0xFFF) == 0) cancellationToken.ThrowIfCancellationRequested();
+            valueEnd--;
+        }
         ParseStructuredValue(
             data,
             valueStart,
             valueEnd,
             maximumManifestBytes,
             maximumContainerEntries,
+            cancellationToken,
             out bool external,
             out bool valid,
             out long manifestLength,
@@ -288,6 +332,7 @@ internal static class OfficeProvenanceText {
         int contentEnd,
         long maximumManifestBytes,
         int maximumContainerEntries,
+        CancellationToken cancellationToken,
         out bool external,
         out bool valid,
         out long manifestLength,
@@ -297,6 +342,7 @@ internal static class OfficeProvenanceText {
         valid = false;
         manifestLength = 0;
         externalUri = null;
+        cancellationToken.ThrowIfCancellationRequested();
         if (StartsWith(data, contentStart, valueLength, DataUriPrefix)) {
             int base64Offset = contentStart + DataUriPrefix.Length;
             int base64Length = contentEnd - base64Offset;
@@ -339,10 +385,12 @@ internal static class OfficeProvenanceText {
         byte[] data,
         long maximumManifestBytes,
         int maximumContainerEntries,
-        bool includeInvalid) {
+        bool includeInvalid,
+        CancellationToken cancellationToken) {
         int offset = 0;
         int selectorCount = 0;
         while (offset < data.Length) {
+            if ((offset & 0xFFF) == 0) cancellationToken.ThrowIfCancellationRequested();
             if (!TryReadCodePoint(data, offset, out int codePoint, out int prefixBytes) || codePoint != 0xFEFF) { offset++; continue; }
             int selectorOffset = offset + prefixBytes;
             var decoded = new List<byte>();
@@ -352,6 +400,7 @@ internal static class OfficeProvenanceText {
                 : maximumManifestBytes + 13L;
             bool exceededLimit = false;
             while (TryReadCodePoint(data, cursor, out int selector, out int selectorBytes) && TrySelectorToByte(selector, out byte value)) {
+                if ((selectorCount & 0xFFF) == 0) cancellationToken.ThrowIfCancellationRequested();
                 if (++selectorCount > maximumContainerEntries) {
                     throw new InvalidDataException("Text provenance wrappers exceed the configured container entry limit.");
                 }
@@ -411,8 +460,9 @@ internal static class OfficeProvenanceText {
         value = 0; return false;
     }
 
-    private static int IndexOf(byte[] data, byte[] pattern, int start) {
+    private static int IndexOf(byte[] data, byte[] pattern, int start, CancellationToken cancellationToken) {
         for (int offset = Math.Max(0, start); offset <= data.Length - pattern.Length; offset++) {
+            if ((offset & 0xFFF) == 0) cancellationToken.ThrowIfCancellationRequested();
             int index = 0;
             while (index < pattern.Length && data[offset + index] == pattern[index]) index++;
             if (index == pattern.Length) return offset;
@@ -420,12 +470,17 @@ internal static class OfficeProvenanceText {
         return -1;
     }
 
-    private static int FindStandaloneDelimiter(byte[] data, byte[] delimiter, int start) {
+    private static int FindStandaloneDelimiter(
+        byte[] data,
+        byte[] delimiter,
+        int start,
+        CancellationToken cancellationToken) {
         int search = start;
         while (search < data.Length) {
-            int offset = IndexOf(data, delimiter, search);
+            cancellationToken.ThrowIfCancellationRequested();
+            int offset = IndexOf(data, delimiter, search, cancellationToken);
             if (offset < 0) return -1;
-            if (IsStandaloneDelimiter(data, offset, delimiter.Length)) return offset;
+            if (IsStandaloneDelimiter(data, offset, delimiter.Length, cancellationToken)) return offset;
             search = offset + delimiter.Length;
         }
         return -1;
@@ -438,25 +493,42 @@ internal static class OfficeProvenanceText {
     }
 
     private static bool IsAsciiWhitespace(byte value) => value is 0x09 or 0x0A or 0x0D or 0x20;
-    private static int FindLineStart(byte[] data, int offset) {
-        while (offset > 0 && data[offset - 1] != 0x0A && data[offset - 1] != 0x0D) offset--;
+    private static int FindLineStart(byte[] data, int offset, CancellationToken cancellationToken) {
+        while (offset > 0 && data[offset - 1] != 0x0A && data[offset - 1] != 0x0D) {
+            if ((offset & 0xFFF) == 0) cancellationToken.ThrowIfCancellationRequested();
+            offset--;
+        }
         return offset;
     }
-    private static int FindLineEndIncludingTerminator(byte[] data, int offset) {
-        offset = FindLineEnd(data, offset);
+    private static int FindLineEndIncludingTerminator(
+        byte[] data,
+        int offset,
+        CancellationToken cancellationToken) {
+        offset = FindLineEnd(data, offset, cancellationToken);
         if (offset >= data.Length) return offset;
         if (data[offset] == 0x0D && offset + 1 < data.Length && data[offset + 1] == 0x0A) return offset + 2;
         return offset + 1;
     }
-    private static int FindLineEnd(byte[] data, int offset) {
-        while (offset < data.Length && data[offset] != 0x0A && data[offset] != 0x0D) offset++;
+    private static int FindLineEnd(byte[] data, int offset, CancellationToken cancellationToken) {
+        while (offset < data.Length && data[offset] != 0x0A && data[offset] != 0x0D) {
+            if ((offset & 0xFFF) == 0) cancellationToken.ThrowIfCancellationRequested();
+            offset++;
+        }
         return offset;
     }
-    private static bool IsStandaloneDelimiter(byte[] data, int offset, int length) {
-        int lineStart = FindLineStart(data, offset);
-        for (int index = lineStart; index < offset; index++) if (!IsHorizontalWhitespace(data[index])) return false;
+    private static bool IsStandaloneDelimiter(
+        byte[] data,
+        int offset,
+        int length,
+        CancellationToken cancellationToken) {
+        int lineStart = FindLineStart(data, offset, cancellationToken);
+        for (int index = lineStart; index < offset; index++) {
+            if ((index & 0xFFF) == 0) cancellationToken.ThrowIfCancellationRequested();
+            if (!IsHorizontalWhitespace(data[index])) return false;
+        }
         int cursor = offset + length;
         while (cursor < data.Length && data[cursor] != 0x0A && data[cursor] != 0x0D) {
+            if ((cursor & 0xFFF) == 0) cancellationToken.ThrowIfCancellationRequested();
             if (!IsHorizontalWhitespace(data[cursor])) return false;
             cursor++;
         }

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceTiff.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceTiff.cs
@@ -71,11 +71,13 @@ internal static class OfficeProvenanceTiff {
 
     internal static byte[] Remove(byte[] data, OfficeProvenanceRemovalOptions options, List<OfficeProvenanceChange> changes, out bool reserialized) {
         reserialized = false;
-        if (!options.RemoveC2paManifests && !options.RemoveAiSourceMetadata) return (byte[])data.Clone();
+        if (!options.RemoveC2paManifests && !options.RemoveAiSourceMetadata) {
+            return OfficeProvenanceBinary.CloneForOutput(data, options.EffectiveMaxOutputBytes);
+        }
         List<TiffIfd> ifds = ReadIfds(data, options.Limits);
         int reachableC2paCount = ifds.Sum(static ifd => ifd.Entries.Count(static entry => entry.Tag == C2paTag));
         bool allEntriesHaveValidStorage = HasValidEntryStorage(data, ifds);
-        byte[] output = (byte[])data.Clone();
+        byte[] output = OfficeProvenanceBinary.CloneForOutput(data, options.EffectiveMaxOutputBytes);
         var processedXmpRanges = new HashSet<long>();
         long processedXmpBytes = 0;
         for (int ifdIndex = 0; ifdIndex < ifds.Count; ifdIndex++) {

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceXml.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceXml.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Text;
+using System.Threading;
 using System.Xml;
 using System.Xml.Linq;
 
@@ -34,6 +36,31 @@ internal static class OfficeProvenanceXml {
             MaxCharactersFromEntities = 0,
             IgnoreWhitespace = false
         };
+
+    internal static Encoding ResolveTextEncoding(
+        string filePath,
+        long maximumBytes,
+        CancellationToken cancellationToken) {
+        string fullPath = Path.GetFullPath(filePath);
+        using var stream = new FileStream(
+            fullPath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            4096,
+            FileOptions.SequentialScan);
+        if (stream.Length > maximumBytes) {
+            throw new InvalidDataException("The XML document exceeds the configured text-integrity byte limit.");
+        }
+        cancellationToken.ThrowIfCancellationRequested();
+        using var reader = new XmlTextReader(stream) {
+            DtdProcessing = DtdProcessing.Prohibit,
+            XmlResolver = null
+        };
+        reader.Read();
+        cancellationToken.ThrowIfCancellationRequested();
+        return reader.Encoding ?? Encoding.UTF8;
+    }
 
     internal static void ValidateMaterializedNodeBudget(
         byte[] data,

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceXmp.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceXmp.cs
@@ -55,7 +55,9 @@ internal static class OfficeProvenanceXmp {
             index++;
         }
         if (!changed) return false;
-        using var stream = new MemoryStream();
+        using var stream = new OfficeProvenanceBoundedMemoryStream(
+            options.EffectiveMaxOutputBytes,
+            packet.Length);
         var settings = new XmlWriterSettings {
             Encoding = new UTF8Encoding(false),
             Indent = false,

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceZip.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceZip.cs
@@ -120,7 +120,9 @@ internal static class OfficeProvenanceZip {
         Func<string, bool>? shouldReplacePackageMetadata = null,
         Func<string, byte[], bool, byte[]>? replacePackageMetadata = null) {
         reserialized = false;
-        if (!options.RemoveC2paManifests && !options.RemoveAiSourceMetadata && !options.RemoveExternalC2paReferences) return (byte[])data.Clone();
+        if (!options.RemoveC2paManifests && !options.RemoveAiSourceMetadata && !options.RemoveExternalC2paReferences) {
+            return OfficeProvenanceBinary.CloneForOutput(data, options.EffectiveMaxOutputBytes);
+        }
         ValidateEntryCount(data, options.Limits.MaxContainerEntries);
         using var inputStream = new MemoryStream(data, writable: false);
         using var input = new ZipArchive(inputStream, ZipArchiveMode.Read, leaveOpen: false);
@@ -178,7 +180,7 @@ internal static class OfficeProvenanceZip {
             }
             if (nested.WasReserialized) reserialized = true;
         }
-        if (changes.Count == 0) return (byte[])data.Clone();
+        if (changes.Count == 0) return OfficeProvenanceBinary.CloneForOutput(data, options.EffectiveMaxOutputBytes);
 
         if (shouldReplacePackageMetadata != null) {
             if (replacePackageMetadata == null) throw new ArgumentNullException(nameof(replacePackageMetadata));
@@ -191,6 +193,9 @@ internal static class OfficeProvenanceZip {
                 ReserveExpandedBytes(ref inspectionBytes, entry.Length, options.Limits.MaxExpandedContainerBytes);
                 byte[] original = ReadEntry(entry, (int)entry.Length);
                 byte[] replacement = replacePackageMetadata(entryName, original, removable.Count != 0);
+                OfficeProvenanceBinary.EnsureOutputWithinLimit(
+                    replacement.LongLength,
+                    options.EffectiveMaxOutputBytes);
                 if (replacement.LongLength > options.Limits.MaxAssetBytes) {
                     throw OfficeProvenanceLimitException.Create("A rewritten package metadata entry exceeds the configured asset limit.");
                 }
@@ -213,7 +218,13 @@ internal static class OfficeProvenanceZip {
 
         if (removeOpcManifestReferences && removable.Count != 0 && removable.Count == occurrence &&
             entryMetadata.Values.Any(metadata => metadata.Name.Equals("[Content_Types].xml", StringComparison.Ordinal))) {
-            RemoveOpcManifestReferences(input, entryMetadata, embeddedRewrites, options.Limits, ref inspectionBytes);
+            RemoveOpcManifestReferences(
+                input,
+                entryMetadata,
+                embeddedRewrites,
+                options.Limits,
+                options.EffectiveMaxOutputBytes,
+                ref inspectionBytes);
         }
 
         var outputEntries = new List<OfficeProvenanceZipWriteEntry>();
@@ -234,7 +245,11 @@ internal static class OfficeProvenanceZip {
         if (remainingExpandedBytes <= 0 && outputEntries.Any(entry => entry.ExpectedLength > 0)) {
             throw new InvalidDataException("ZIP rewrite exceeds the configured expanded-byte limit.");
         }
-        return OfficeProvenanceZipWriter.Write(outputEntries, Math.Max(1, remainingExpandedBytes), ReadArchiveComment(data));
+        return OfficeProvenanceZipWriter.Write(
+            outputEntries,
+            Math.Max(1, remainingExpandedBytes),
+            ReadArchiveComment(data),
+            options.EffectiveMaxOutputBytes);
     }
 
     private static int CountManifestEntries(
@@ -252,6 +267,7 @@ internal static class OfficeProvenanceZip {
         IReadOnlyDictionary<ZipArchiveEntry, OfficeProvenanceZipEntryMetadata> entryMetadata,
         IDictionary<ZipArchiveEntry, byte[]> replacements,
         OfficeProvenanceOptions limits,
+        long maximumOutputBytes,
         ref long expandedBytes) {
         foreach (ZipArchiveEntry entry in archive.Entries) {
             string entryName = entryMetadata[entry].Name;
@@ -290,7 +306,8 @@ internal static class OfficeProvenanceZip {
                 }
             }
             if (!changed) continue;
-            using var output = new MemoryStream();
+            using var output = new OfficeProvenanceBoundedMemoryStream(
+                Math.Min(limits.MaxAssetBytes, maximumOutputBytes));
             using (XmlWriter writer = XmlWriter.Create(output, new XmlWriterSettings {
                 Encoding = new UTF8Encoding(false),
                 Indent = false,
@@ -374,7 +391,8 @@ internal static class OfficeProvenanceZip {
         long maximumExpandedBytes,
         Func<string, bool>? shouldReplace = null,
         Func<string, byte[], byte[]>? replace = null,
-        long maximumReplacementBytes = long.MaxValue) {
+        long maximumReplacementBytes = long.MaxValue,
+        long maximumOutputBytes = int.MaxValue) {
         if (data == null) throw new ArgumentNullException(nameof(data));
         if (shouldRemove == null) throw new ArgumentNullException(nameof(shouldRemove));
         using var inputStream = new MemoryStream(data, writable: false);
@@ -382,7 +400,11 @@ internal static class OfficeProvenanceZip {
         Dictionary<ZipArchiveEntry, OfficeProvenanceZipEntryMetadata> entryMetadata = GetEntryMetadata(data, input);
         bool hadMatches = input.Entries.Any(entry => shouldRemove(entryMetadata[entry].Name));
         bool hadReplacements = shouldReplace != null && input.Entries.Any(entry => shouldReplace(entryMetadata[entry].Name));
-        if (!hadMatches && !hadReplacements) return new OfficeProvenanceSignatureStripResult((byte[])data.Clone(), hadSignatures: false);
+        if (!hadMatches && !hadReplacements) {
+            return new OfficeProvenanceSignatureStripResult(
+                OfficeProvenanceBinary.CloneForOutput(data, maximumOutputBytes),
+                hadSignatures: false);
+        }
 
         var outputEntries = new List<OfficeProvenanceZipWriteEntry>();
         foreach (ZipArchiveEntry entry in input.Entries
@@ -395,6 +417,7 @@ internal static class OfficeProvenanceZip {
                     throw new InvalidDataException("A package metadata entry exceeds its configured rewrite limit.");
                 }
                 replacement = replace(entryName, ReadEntry(entry, (int)entry.Length));
+                OfficeProvenanceBinary.EnsureOutputWithinLimit(replacement.LongLength, maximumOutputBytes);
                 if (replacement.LongLength > maximumReplacementBytes) {
                     throw new InvalidDataException("A rewritten package metadata entry exceeds its configured rewrite limit.");
                 }
@@ -402,7 +425,7 @@ internal static class OfficeProvenanceZip {
             outputEntries.Add(CreateWriteEntry(entry, entryMetadata[entry], replacement));
         }
         return new OfficeProvenanceSignatureStripResult(
-            OfficeProvenanceZipWriter.Write(outputEntries, maximumExpandedBytes, ReadArchiveComment(data)),
+            OfficeProvenanceZipWriter.Write(outputEntries, maximumExpandedBytes, ReadArchiveComment(data), maximumOutputBytes),
             hadSignatures: hadMatches);
     }
 
@@ -1014,7 +1037,8 @@ internal static class OfficeProvenanceZip {
             RequireStructurallyValidCarrier = source.RequireStructurallyValidCarrier,
             SignatureMutationPolicy = source.SignatureMutationPolicy,
             ProcessEmbeddedAssets = false,
-            MaxEmbeddedAssets = source.MaxEmbeddedAssets
+            MaxEmbeddedAssets = source.MaxEmbeddedAssets,
+            MaxOutputBytes = Math.Min(source.EffectiveMaxOutputBytes, source.Limits.MaxAssetBytes)
         };
         nested.Limits.MaxAssetBytes = source.Limits.MaxAssetBytes;
         nested.Limits.MaxManifestBytes = source.Limits.MaxManifestBytes;

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceZip.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceZip.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Xml;
 
 namespace OfficeIMO.Provenance;
@@ -59,6 +60,7 @@ internal static class OfficeProvenanceZip {
     }
 
     internal static void Inspect(byte[] data, OfficeProvenanceOptions options, OfficeProvenanceContext context) {
+        options.CancellationToken.ThrowIfCancellationRequested();
         ValidateEntryCount(data, options.MaxContainerEntries);
         using var stream = new MemoryStream(data, writable: false);
         using var archive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: false);
@@ -68,13 +70,14 @@ internal static class OfficeProvenanceZip {
         int embeddedCount = 0;
         long expandedBytes = 0;
         foreach (ZipArchiveEntry entry in archive.Entries) {
+            options.CancellationToken.ThrowIfCancellationRequested();
             string entryName = entryMetadata[entry].Name;
             if (entryName.Equals(ManifestPath, StringComparison.Ordinal)) {
                 if (entry.Length > options.MaxManifestBytes || entry.Length > int.MaxValue) {
                     throw new InvalidDataException("ZIP provenance manifest exceeds the configured manifest limit.");
                 }
                 ReserveExpandedBytes(ref expandedBytes, entry.Length, options.MaxExpandedContainerBytes);
-                byte[] manifest = ReadEntry(entry, (int)entry.Length);
+                byte[] manifest = ReadEntry(entry, (int)entry.Length, options.CancellationToken);
                 bool valid = !hasDuplicateManifests && OfficeC2paManifestStore.IsValid(
                     manifest, 0, manifest.Length, options.MaxManifestBytes, options.MaxContainerEntries, out _);
                 context.Add(new OfficeProvenanceEvidence(
@@ -91,7 +94,7 @@ internal static class OfficeProvenanceZip {
             }
             if (asset == null) {
                 ReserveExpandedBytes(ref expandedBytes, entry.Length, options.MaxExpandedContainerBytes);
-                asset = ReadEntry(entry, (int)entry.Length);
+                asset = ReadEntry(entry, (int)entry.Length, options.CancellationToken);
             }
             if (!IsSupportedEmbeddedImage(asset, options)) continue;
             embeddedCount++;
@@ -120,6 +123,7 @@ internal static class OfficeProvenanceZip {
         Func<string, bool>? shouldReplacePackageMetadata = null,
         Func<string, byte[], bool, byte[]>? replacePackageMetadata = null) {
         reserialized = false;
+        options.Limits.CancellationToken.ThrowIfCancellationRequested();
         if (!options.RemoveC2paManifests && !options.RemoveAiSourceMetadata && !options.RemoveExternalC2paReferences) {
             return OfficeProvenanceBinary.CloneForOutput(data, options.EffectiveMaxOutputBytes);
         }
@@ -137,11 +141,12 @@ internal static class OfficeProvenanceZip {
         int embeddedCount = 0;
         long inspectionBytes = 0;
         foreach (ZipArchiveEntry entry in input.Entries) {
+            options.Limits.CancellationToken.ThrowIfCancellationRequested();
             string entryName = entryMetadata[entry].Name;
             if (entryName.Equals(ManifestPath, StringComparison.Ordinal)) {
                 if (entry.Length > options.Limits.MaxManifestBytes || entry.Length > int.MaxValue) throw new InvalidDataException("ZIP provenance manifest exceeds the configured limit.");
                 ReserveExpandedBytes(ref inspectionBytes, entry.Length, options.Limits.MaxExpandedContainerBytes);
-                byte[] manifest = ReadEntry(entry, (int)entry.Length);
+                byte[] manifest = ReadEntry(entry, (int)entry.Length, options.Limits.CancellationToken);
                 bool valid = !hasDuplicateManifests && OfficeC2paManifestStore.IsValid(
                     manifest, 0, manifest.Length, options.Limits.MaxManifestBytes, options.Limits.MaxContainerEntries, out _);
                 if (options.RemoveC2paManifests && (valid || !options.RequireStructurallyValidCarrier)) {
@@ -156,7 +161,7 @@ internal static class OfficeProvenanceZip {
             if (entry.Length > options.Limits.MaxAssetBytes || entry.Length > int.MaxValue) throw new InvalidDataException("A supported embedded asset exceeds the configured asset limit.");
             if (asset == null) {
                 ReserveExpandedBytes(ref inspectionBytes, entry.Length, options.Limits.MaxExpandedContainerBytes);
-                asset = ReadEntry(entry, (int)entry.Length);
+                asset = ReadEntry(entry, (int)entry.Length, options.Limits.CancellationToken);
             }
             if (!IsSupportedEmbeddedImage(asset, options.Limits)) continue;
             embeddedCount++;
@@ -185,13 +190,14 @@ internal static class OfficeProvenanceZip {
         if (shouldReplacePackageMetadata != null) {
             if (replacePackageMetadata == null) throw new ArgumentNullException(nameof(replacePackageMetadata));
             foreach (ZipArchiveEntry entry in input.Entries) {
+                options.Limits.CancellationToken.ThrowIfCancellationRequested();
                 string entryName = entryMetadata[entry].Name;
                 if (!shouldReplacePackageMetadata(entryName)) continue;
                 if (entry.Length > options.Limits.MaxAssetBytes || entry.Length > int.MaxValue) {
                     throw OfficeProvenanceLimitException.Create("A package metadata entry exceeds the configured asset limit.");
                 }
                 ReserveExpandedBytes(ref inspectionBytes, entry.Length, options.Limits.MaxExpandedContainerBytes);
-                byte[] original = ReadEntry(entry, (int)entry.Length);
+                byte[] original = ReadEntry(entry, (int)entry.Length, options.Limits.CancellationToken);
                 byte[] replacement = replacePackageMetadata(entryName, original, removable.Count != 0);
                 if (replacement.LongLength > options.Limits.MaxAssetBytes) {
                     throw OfficeProvenanceLimitException.Create("A rewritten package metadata entry exceeds the configured asset limit.");
@@ -228,6 +234,7 @@ internal static class OfficeProvenanceZip {
         IEnumerable<ZipArchiveEntry> orderedEntries = input.Entries
             .OrderByDescending(entry => entryMetadata[entry].Name.Equals("mimetype", StringComparison.Ordinal));
         foreach (ZipArchiveEntry entry in orderedEntries) {
+            options.Limits.CancellationToken.ThrowIfCancellationRequested();
             string entryName = entryMetadata[entry].Name;
             bool isManifest = entryName.Equals(ManifestPath, StringComparison.Ordinal);
             string key = entryName + "\0" + occurrence;
@@ -245,7 +252,8 @@ internal static class OfficeProvenanceZip {
             outputEntries,
             Math.Max(1, remainingExpandedBytes),
             ReadArchiveComment(data),
-            options.EffectiveMaxOutputBytes);
+            options.EffectiveMaxOutputBytes,
+            options.Limits.CancellationToken);
     }
 
     private static int CountManifestEntries(
@@ -265,6 +273,7 @@ internal static class OfficeProvenanceZip {
         OfficeProvenanceOptions limits,
         ref long expandedBytes) {
         foreach (ZipArchiveEntry entry in archive.Entries) {
+            limits.CancellationToken.ThrowIfCancellationRequested();
             string entryName = entryMetadata[entry].Name;
             bool isContentTypes = entryName.Equals("[Content_Types].xml", StringComparison.Ordinal);
             bool isRelationships = entryName.EndsWith(".rels", StringComparison.Ordinal) &&
@@ -274,7 +283,7 @@ internal static class OfficeProvenanceZip {
                 throw new InvalidDataException("An OPC relationship metadata part exceeds the configured asset limit.");
             }
             ReserveExpandedBytes(ref expandedBytes, entry.Length, limits.MaxExpandedContainerBytes);
-            byte[] original = ReadEntry(entry, (int)entry.Length);
+            byte[] original = ReadEntry(entry, (int)entry.Length, limits.CancellationToken);
             OfficeProvenanceXml.ValidateMaterializedNodeBudget(original, limits, "OPC relationship metadata");
             var document = new XmlDocument { PreserveWhitespace = true, XmlResolver = null };
             using (var stream = new MemoryStream(original, writable: false))
@@ -386,7 +395,8 @@ internal static class OfficeProvenanceZip {
         Func<string, bool>? shouldReplace = null,
         Func<string, byte[], byte[]>? replace = null,
         long maximumReplacementBytes = long.MaxValue,
-        long maximumOutputBytes = int.MaxValue) {
+        long maximumOutputBytes = int.MaxValue,
+        CancellationToken cancellationToken = default) {
         if (data == null) throw new ArgumentNullException(nameof(data));
         if (shouldRemove == null) throw new ArgumentNullException(nameof(shouldRemove));
         using var inputStream = new MemoryStream(data, writable: false);
@@ -403,6 +413,7 @@ internal static class OfficeProvenanceZip {
         var outputEntries = new List<OfficeProvenanceZipWriteEntry>();
         foreach (ZipArchiveEntry entry in input.Entries
             .OrderByDescending(candidate => entryMetadata[candidate].Name.Equals("mimetype", StringComparison.Ordinal))) {
+            cancellationToken.ThrowIfCancellationRequested();
             string entryName = entryMetadata[entry].Name;
             if (shouldRemove(entryName)) continue;
             byte[]? replacement = null;
@@ -410,7 +421,7 @@ internal static class OfficeProvenanceZip {
                 if (replace == null || entry.Length > maximumReplacementBytes || entry.Length > int.MaxValue) {
                     throw new InvalidDataException("A package metadata entry exceeds its configured rewrite limit.");
                 }
-                replacement = replace(entryName, ReadEntry(entry, (int)entry.Length));
+                replacement = replace(entryName, ReadEntry(entry, (int)entry.Length, cancellationToken));
                 if (replacement.LongLength > maximumReplacementBytes) {
                     throw new InvalidDataException("A rewritten package metadata entry exceeds its configured rewrite limit.");
                 }
@@ -418,17 +429,24 @@ internal static class OfficeProvenanceZip {
             outputEntries.Add(CreateWriteEntry(entry, entryMetadata[entry], replacement));
         }
         return new OfficeProvenanceSignatureStripResult(
-            OfficeProvenanceZipWriter.Write(outputEntries, maximumExpandedBytes, ReadArchiveComment(data), maximumOutputBytes),
+            OfficeProvenanceZipWriter.Write(outputEntries, maximumExpandedBytes, ReadArchiveComment(data), maximumOutputBytes, cancellationToken),
             hadSignatures: hadMatches);
     }
 
-    internal static bool HasEntry(byte[] data, Func<string, bool> predicate) {
+    internal static bool HasEntry(
+        byte[] data,
+        Func<string, bool> predicate,
+        CancellationToken cancellationToken = default) {
         if (data == null) throw new ArgumentNullException(nameof(data));
         if (predicate == null) throw new ArgumentNullException(nameof(predicate));
         using var stream = new MemoryStream(data, writable: false);
         using var archive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: false);
         Dictionary<ZipArchiveEntry, OfficeProvenanceZipEntryMetadata> entryMetadata = GetEntryMetadata(data, archive);
-        return archive.Entries.Any(entry => predicate(entryMetadata[entry].Name));
+        foreach (ZipArchiveEntry entry in archive.Entries) {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (predicate(entryMetadata[entry].Name)) return true;
+        }
+        return false;
     }
 
     internal static void ValidateEntryCount(byte[] data, int maximumEntries) {
@@ -761,6 +779,7 @@ internal static class OfficeProvenanceZip {
         const string originRelationshipType =
             "http://schemas.openxmlformats.org/package/2006/relationships/digital-signature/origin";
         foreach (ZipArchiveEntry relationships in archive.Entries) {
+            options.CancellationToken.ThrowIfCancellationRequested();
             if (!entryMetadata[relationships].Name.Equals("_rels/.rels", StringComparison.Ordinal) ||
                 relationships.Length <= 0) continue;
             if (relationships.Length > options.MaxAssetBytes) {
@@ -768,13 +787,14 @@ internal static class OfficeProvenanceZip {
             }
             ReserveExpandedBytes(ref expandedBytes, relationships.Length, options.MaxExpandedContainerBytes);
             using Stream source = relationships.Open();
-            byte[] bytes = OfficeProvenanceBinary.ReadBounded(source, options.MaxAssetBytes);
+            byte[] bytes = OfficeProvenanceBinary.ReadBounded(source, options.MaxAssetBytes, options.CancellationToken);
             OfficeProvenanceXml.ValidateMaterializedNodeBudget(bytes, options, "OPC root relationships");
             using var input = new MemoryStream(bytes, writable: false);
             using XmlReader reader = XmlReader.Create(input, OfficeProvenanceXml.CreateReaderSettings(options));
             bool foundRoot = false;
             int rootDepth = -1;
             while (reader.Read()) {
+                options.CancellationToken.ThrowIfCancellationRequested();
                 if (reader.NodeType != XmlNodeType.Element) continue;
                 if (!foundRoot) {
                     if (reader.LocalName != "Relationships") return false;
@@ -810,6 +830,7 @@ internal static class OfficeProvenanceZip {
     }
 
     internal static bool HasApplicationSignatureMetadata(byte[] data, OfficeProvenanceOptions options) {
+        options.CancellationToken.ThrowIfCancellationRequested();
         ValidateEntryCount(data, options.MaxContainerEntries);
         using var stream = new MemoryStream(data, writable: false);
         using var archive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: false);
@@ -831,6 +852,7 @@ internal static class OfficeProvenanceZip {
             using var relationshipsInput = new MemoryStream(relationshipsXml, writable: false);
             using XmlReader relationshipsReader = XmlReader.Create(relationshipsInput, OfficeProvenanceXml.CreateReaderSettings(options));
             while (relationshipsReader.Read()) {
+                options.CancellationToken.ThrowIfCancellationRequested();
                 if (relationshipsReader.NodeType != XmlNodeType.Element ||
                     relationshipsReader.LocalName != "Relationship" ||
                     relationshipsReader.NamespaceURI != "http://schemas.openxmlformats.org/package/2006/relationships" ||
@@ -844,6 +866,7 @@ internal static class OfficeProvenanceZip {
         }
 
         foreach (string partName in applicationMetadataParts) {
+            options.CancellationToken.ThrowIfCancellationRequested();
             ZipArchiveEntry[] entries = archive.Entries
                 .Where(entry => entryMetadata[entry].Name.Equals(partName, StringComparison.Ordinal))
                 .ToArray();
@@ -860,6 +883,7 @@ internal static class OfficeProvenanceZip {
             using var input = new MemoryStream(xml, writable: false);
             using XmlReader reader = XmlReader.Create(input, OfficeProvenanceXml.CreateReaderSettings(options));
             while (reader.Read()) {
+                options.CancellationToken.ThrowIfCancellationRequested();
                 if (reader.NodeType == XmlNodeType.Element &&
                     reader.LocalName == "DigSig" &&
                     reader.NamespaceURI == "http://schemas.openxmlformats.org/officeDocument/2006/extended-properties") return true;
@@ -872,6 +896,7 @@ internal static class OfficeProvenanceZip {
         byte[] data,
         OfficeProvenanceOptions options,
         bool validateOpcMetadata = true) {
+        options.CancellationToken.ThrowIfCancellationRequested();
         ValidateEntryCount(data, options.MaxContainerEntries);
         using var stream = new MemoryStream(data, writable: false);
         using var archive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: false);
@@ -881,6 +906,7 @@ internal static class OfficeProvenanceZip {
         byte[]? rootRelationships = null;
         byte[]? contentTypes = null;
         foreach (ZipArchiveEntry entry in archive.Entries) {
+            options.CancellationToken.ThrowIfCancellationRequested();
             string entryName = entryMetadata[entry].Name;
             if (entry.Length > options.MaxAssetBytes) {
                 throw new InvalidDataException("A package part exceeds the configured asset limit.");
@@ -894,6 +920,7 @@ internal static class OfficeProvenanceZip {
             long entryBytes = 0;
             try {
                 while (true) {
+                    options.CancellationToken.ThrowIfCancellationRequested();
                     int read = source.Read(buffer, 0, buffer.Length);
                     if (read <= 0) break;
                     if (entryBytes > options.MaxAssetBytes - read) {
@@ -957,6 +984,7 @@ internal static class OfficeProvenanceZip {
         };
         OfficeIMO.Security.OfficePackageSignatureInfo signatureInfo =
             OfficeIMO.Security.OfficePackageSignatureService.Inspect(data, inspectionOptions);
+        options.Limits.CancellationToken.ThrowIfCancellationRequested();
         ReserveExpandedBytes(ref expandedBytes, signatureInfo.InspectionBytes, options.Limits.MaxExpandedContainerBytes);
         if (!signatureInfo.SignatureDiscoveryComplete) {
             throw new InvalidDataException("The OPC package signature state could not be determined safely.");
@@ -988,6 +1016,7 @@ internal static class OfficeProvenanceZip {
         using Stream source = entry.Open();
         int read = 0;
         while (read < prefix.Length) {
+            options.CancellationToken.ThrowIfCancellationRequested();
             int current = source.Read(prefix, read, prefix.Length - read);
             if (current <= 0) break;
             ReserveExpandedBytes(ref expandedBytes, current, options.MaxExpandedContainerBytes);
@@ -1018,6 +1047,7 @@ internal static class OfficeProvenanceZip {
         MaxCarriers = source.MaxCarriers,
         MaxContainerEntries = source.MaxContainerEntries,
         MaxExpandedContainerBytes = source.MaxExpandedContainerBytes,
+        CancellationToken = source.CancellationToken,
         ProcessEmbeddedAssets = false,
         MaxEmbeddedAssets = source.MaxEmbeddedAssets
     };
@@ -1038,6 +1068,7 @@ internal static class OfficeProvenanceZip {
         nested.Limits.MaxCarriers = source.Limits.MaxCarriers;
         nested.Limits.MaxContainerEntries = source.Limits.MaxContainerEntries;
         nested.Limits.MaxExpandedContainerBytes = source.Limits.MaxExpandedContainerBytes;
+        nested.Limits.CancellationToken = source.Limits.CancellationToken;
         nested.Limits.ProcessEmbeddedAssets = false;
         nested.Limits.MaxEmbeddedAssets = source.Limits.MaxEmbeddedAssets;
         return nested;
@@ -1052,10 +1083,10 @@ internal static class OfficeProvenanceZip {
             evidence.Value,
             evidence.DigitalSourceKind);
 
-    private static byte[] ReadEntry(ZipArchiveEntry entry, int length) {
+    private static byte[] ReadEntry(ZipArchiveEntry entry, int length, CancellationToken cancellationToken = default) {
         byte[] data = new byte[length];
         using Stream stream = entry.Open();
-        OfficeProvenanceBinary.ReadExactly(stream, data, 0, data.Length);
+        OfficeProvenanceBinary.ReadExactly(stream, data, 0, data.Length, cancellationToken);
         if (stream.ReadByte() != -1) throw new InvalidDataException("ZIP entry expanded beyond its declared length.");
         return data;
     }

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceZip.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceZip.cs
@@ -193,9 +193,6 @@ internal static class OfficeProvenanceZip {
                 ReserveExpandedBytes(ref inspectionBytes, entry.Length, options.Limits.MaxExpandedContainerBytes);
                 byte[] original = ReadEntry(entry, (int)entry.Length);
                 byte[] replacement = replacePackageMetadata(entryName, original, removable.Count != 0);
-                OfficeProvenanceBinary.EnsureOutputWithinLimit(
-                    replacement.LongLength,
-                    options.EffectiveMaxOutputBytes);
                 if (replacement.LongLength > options.Limits.MaxAssetBytes) {
                     throw OfficeProvenanceLimitException.Create("A rewritten package metadata entry exceeds the configured asset limit.");
                 }
@@ -223,7 +220,6 @@ internal static class OfficeProvenanceZip {
                 entryMetadata,
                 embeddedRewrites,
                 options.Limits,
-                options.EffectiveMaxOutputBytes,
                 ref inspectionBytes);
         }
 
@@ -267,7 +263,6 @@ internal static class OfficeProvenanceZip {
         IReadOnlyDictionary<ZipArchiveEntry, OfficeProvenanceZipEntryMetadata> entryMetadata,
         IDictionary<ZipArchiveEntry, byte[]> replacements,
         OfficeProvenanceOptions limits,
-        long maximumOutputBytes,
         ref long expandedBytes) {
         foreach (ZipArchiveEntry entry in archive.Entries) {
             string entryName = entryMetadata[entry].Name;
@@ -306,8 +301,7 @@ internal static class OfficeProvenanceZip {
                 }
             }
             if (!changed) continue;
-            using var output = new OfficeProvenanceBoundedMemoryStream(
-                Math.Min(limits.MaxAssetBytes, maximumOutputBytes));
+            using var output = new OfficeProvenanceBoundedMemoryStream(limits.MaxAssetBytes);
             using (XmlWriter writer = XmlWriter.Create(output, new XmlWriterSettings {
                 Encoding = new UTF8Encoding(false),
                 Indent = false,
@@ -417,7 +411,6 @@ internal static class OfficeProvenanceZip {
                     throw new InvalidDataException("A package metadata entry exceeds its configured rewrite limit.");
                 }
                 replacement = replace(entryName, ReadEntry(entry, (int)entry.Length));
-                OfficeProvenanceBinary.EnsureOutputWithinLimit(replacement.LongLength, maximumOutputBytes);
                 if (replacement.LongLength > maximumReplacementBytes) {
                     throw new InvalidDataException("A rewritten package metadata entry exceeds its configured rewrite limit.");
                 }

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceZip.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceZip.cs
@@ -108,9 +108,13 @@ internal static class OfficeProvenanceZip {
                 context.Diagnostics.Add($"ZIP/{entryName}: embedded asset was preserved because inspection failed: {exception.Message}");
                 continue;
             }
+            ReserveExpandedBytes(ref expandedBytes, nested.ExpandedInspectionBytes, options.MaxExpandedContainerBytes);
             foreach (OfficeProvenanceEvidence evidence in nested.Evidence) context.Add(PrefixEvidence(entryName, evidence));
             foreach (string diagnostic in nested.Diagnostics) context.Diagnostics.Add($"ZIP/{entryName}: {diagnostic}");
         }
+        context.ReserveExpandedBytes(
+            expandedBytes,
+            "ZIP package exceeds the configured expanded-byte limit.");
         if (index > 1) context.Diagnostics.Add("The ZIP package contains multiple C2PA manifest entries.");
     }
 

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceZipWriter.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceZipWriter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Text;
+using System.Threading;
 
 namespace OfficeIMO.Provenance;
 
@@ -30,7 +31,8 @@ internal static class OfficeProvenanceZipWriter {
         IReadOnlyList<OfficeProvenanceZipWriteEntry> entries,
         long maximumExpandedBytes,
         byte[]? archiveComment = null,
-        long maximumOutputBytes = int.MaxValue) {
+        long maximumOutputBytes = int.MaxValue,
+        CancellationToken cancellationToken = default) {
         if (entries == null) throw new ArgumentNullException(nameof(entries));
         if (maximumExpandedBytes <= 0) throw new ArgumentOutOfRangeException(nameof(maximumExpandedBytes));
         archiveComment ??= Array.Empty<byte>();
@@ -42,6 +44,7 @@ internal static class OfficeProvenanceZipWriter {
         byte[] buffer = new byte[81920];
 
         foreach (OfficeProvenanceZipWriteEntry entry in entries) {
+            cancellationToken.ThrowIfCancellationRequested();
             byte[] name = Encoding.UTF8.GetBytes(entry.Name);
             if (name.Length > ushort.MaxValue) throw new InvalidDataException("ZIP entry name exceeds the supported length.");
             byte[] localExtraField = RemoveExtraField(
@@ -68,9 +71,9 @@ internal static class OfficeProvenanceZipWriter {
             using (Stream source = entry.Open()) {
                 if (entry.Compress) {
                     using var compressor = new DeflateStream(output, CompressionLevel.Optimal, leaveOpen: true);
-                    Copy(source, compressor, buffer, ref crc, ref uncompressedLength, ref expandedBytes, maximumExpandedBytes);
+                    Copy(source, compressor, buffer, ref crc, ref uncompressedLength, ref expandedBytes, maximumExpandedBytes, cancellationToken);
                 } else {
-                    Copy(source, output, buffer, ref crc, ref uncompressedLength, ref expandedBytes, maximumExpandedBytes);
+                    Copy(source, output, buffer, ref crc, ref uncompressedLength, ref expandedBytes, maximumExpandedBytes, cancellationToken);
                 }
             }
             if (uncompressedLength != entry.ExpectedLength) throw new InvalidDataException("ZIP entry expanded to an unexpected length.");
@@ -99,6 +102,7 @@ internal static class OfficeProvenanceZipWriter {
 
         uint centralOffset = ToUInt32(output.Position, "central directory offset");
         foreach (OfficeProvenanceZipRecord record in records) {
+            cancellationToken.ThrowIfCancellationRequested();
             WriteCentralHeader(writer, record);
             writer.Write(record.Name);
             writer.Write(record.CentralExtraField);
@@ -124,8 +128,10 @@ internal static class OfficeProvenanceZipWriter {
         ref uint crc,
         ref long entryBytes,
         ref long expandedBytes,
-        long maximumExpandedBytes) {
+        long maximumExpandedBytes,
+        CancellationToken cancellationToken) {
         while (true) {
+            cancellationToken.ThrowIfCancellationRequested();
             int read = source.Read(buffer, 0, buffer.Length);
             if (read <= 0) break;
             if (expandedBytes > maximumExpandedBytes - read) {

--- a/OfficeIMO.Core/Provenance/OfficeProvenanceZipWriter.cs
+++ b/OfficeIMO.Core/Provenance/OfficeProvenanceZipWriter.cs
@@ -26,13 +26,17 @@ internal static class OfficeProvenanceZipWriter {
     private const ushort UnicodeCommentExtraFieldId = 0x6375;
     private static readonly uint[] CrcTable = CreateCrcTable();
 
-    internal static byte[] Write(IReadOnlyList<OfficeProvenanceZipWriteEntry> entries, long maximumExpandedBytes, byte[]? archiveComment = null) {
+    internal static byte[] Write(
+        IReadOnlyList<OfficeProvenanceZipWriteEntry> entries,
+        long maximumExpandedBytes,
+        byte[]? archiveComment = null,
+        long maximumOutputBytes = int.MaxValue) {
         if (entries == null) throw new ArgumentNullException(nameof(entries));
         if (maximumExpandedBytes <= 0) throw new ArgumentOutOfRangeException(nameof(maximumExpandedBytes));
         archiveComment ??= Array.Empty<byte>();
         if (archiveComment.Length > ushort.MaxValue) throw new ArgumentOutOfRangeException(nameof(archiveComment));
         var records = new List<OfficeProvenanceZipRecord>(entries.Count);
-        using var output = new MemoryStream();
+        using var output = new OfficeProvenanceBoundedMemoryStream(maximumOutputBytes);
         using var writer = new BinaryWriter(output, Encoding.UTF8, leaveOpen: true);
         long expandedBytes = 0;
         byte[] buffer = new byte[81920];

--- a/OfficeIMO.Core/Provenance/OfficeTextIntegrity.cs
+++ b/OfficeIMO.Core/Provenance/OfficeTextIntegrity.cs
@@ -128,6 +128,18 @@ public static class OfficeTextIntegrityInspector {
         string filePath,
         OfficeTextIntegrityOptions? options,
         string? location,
+        CancellationToken cancellationToken) => InspectFile(
+            filePath,
+            options,
+            location,
+            encoding: null,
+            cancellationToken);
+
+    internal static OfficeTextIntegrityReport InspectFile(
+        string filePath,
+        OfficeTextIntegrityOptions? options,
+        string? location,
+        Encoding? encoding,
         CancellationToken cancellationToken) {
         if (string.IsNullOrWhiteSpace(filePath)) throw new ArgumentException("A file path is required.", nameof(filePath));
         string fullPath = Path.GetFullPath(filePath);
@@ -140,7 +152,7 @@ public static class OfficeTextIntegrityInspector {
             data = OfficeProvenanceBinary.ReadBounded(stream, options.MaxEncodedBytes, cancellationToken);
         }
         return Inspect(
-            DecodeText(data, options.MaxCharacters, cancellationToken),
+            DecodeText(data, options.MaxCharacters, encoding, cancellationToken),
             options,
             location ?? fullPath,
             cancellationToken);
@@ -309,10 +321,17 @@ public static class OfficeTextIntegrityInspector {
         if (options.MaxFindings <= 0) throw new ArgumentOutOfRangeException(nameof(options), "MaxFindings must be positive.");
     }
 
-    private static string DecodeText(byte[] data, int maximumCharacters, CancellationToken cancellationToken) {
-        Encoding encoding = StrictUtf8;
+    private static string DecodeText(
+        byte[] data,
+        int maximumCharacters,
+        Encoding? requestedEncoding,
+        CancellationToken cancellationToken) {
+        Encoding encoding = requestedEncoding ?? StrictUtf8;
         int offset = 0;
-        if (StartsWith(data, new byte[] { 0x00, 0x00, 0xFE, 0xFF })) {
+        if (requestedEncoding is not null) {
+            byte[] preamble = encoding.GetPreamble();
+            if (preamble.Length != 0 && StartsWith(data, preamble)) offset = preamble.Length;
+        } else if (StartsWith(data, new byte[] { 0x00, 0x00, 0xFE, 0xFF })) {
             encoding = new UTF32Encoding(true, true, true);
             offset = 4;
         } else if (StartsWith(data, new byte[] { 0xFF, 0xFE, 0x00, 0x00 })) {

--- a/OfficeIMO.Core/Provenance/OfficeTextIntegrity.cs
+++ b/OfficeIMO.Core/Provenance/OfficeTextIntegrity.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 
 namespace OfficeIMO.Provenance;
 
@@ -120,24 +121,43 @@ public static class OfficeTextIntegrityInspector {
     public static OfficeTextIntegrityReport InspectFile(
         string filePath,
         OfficeTextIntegrityOptions? options = null,
-        string? location = null) {
+        string? location = null) => InspectFile(filePath, options, location, CancellationToken.None);
+
+    /// <summary>Inspects a BOM-aware UTF-8, UTF-16, or UTF-32 text file with cooperative cancellation.</summary>
+    public static OfficeTextIntegrityReport InspectFile(
+        string filePath,
+        OfficeTextIntegrityOptions? options,
+        string? location,
+        CancellationToken cancellationToken) {
         if (string.IsNullOrWhiteSpace(filePath)) throw new ArgumentException("A file path is required.", nameof(filePath));
         string fullPath = Path.GetFullPath(filePath);
         if (!File.Exists(fullPath)) throw new FileNotFoundException("The text file was not found.", fullPath);
         options ??= new OfficeTextIntegrityOptions();
         Validate(options);
+        cancellationToken.ThrowIfCancellationRequested();
         byte[] data;
         using (var stream = File.OpenRead(fullPath)) {
-            data = OfficeProvenanceBinary.ReadBounded(stream, options.MaxEncodedBytes);
+            data = OfficeProvenanceBinary.ReadBounded(stream, options.MaxEncodedBytes, cancellationToken);
         }
-        return Inspect(DecodeText(data), options, location ?? fullPath);
+        return Inspect(
+            DecodeText(data, options.MaxCharacters, cancellationToken),
+            options,
+            location ?? fullPath,
+            cancellationToken);
     }
 
     /// <summary>Inspects a string and reports exact, context-sensitive Unicode code points.</summary>
     public static OfficeTextIntegrityReport Inspect(
         string text,
         OfficeTextIntegrityOptions? options = null,
-        string location = "Text") {
+        string location = "Text") => Inspect(text, options, location, CancellationToken.None);
+
+    /// <summary>Inspects a string with cooperative cancellation and reports exact, context-sensitive Unicode code points.</summary>
+    public static OfficeTextIntegrityReport Inspect(
+        string text,
+        OfficeTextIntegrityOptions? options,
+        string location,
+        CancellationToken cancellationToken) {
         if (text == null) throw new ArgumentNullException(nameof(text));
         options ??= new OfficeTextIntegrityOptions();
         Validate(options);
@@ -146,8 +166,10 @@ public static class OfficeTextIntegrityInspector {
         }
         if (string.IsNullOrWhiteSpace(location)) throw new ArgumentException("A text location is required.", nameof(location));
 
+        cancellationToken.ThrowIfCancellationRequested();
         var findings = new List<OfficeTextIntegrityFinding>();
         for (int offset = 0; offset < text.Length;) {
+            if ((offset & 0x3FF) == 0) cancellationToken.ThrowIfCancellationRequested();
             char current = text[offset];
             int codePoint;
             int length;
@@ -176,6 +198,7 @@ public static class OfficeTextIntegrityInspector {
             }
             offset += length;
         }
+        cancellationToken.ThrowIfCancellationRequested();
         return new OfficeTextIntegrityReport(findings.AsReadOnly());
     }
 
@@ -286,7 +309,7 @@ public static class OfficeTextIntegrityInspector {
         if (options.MaxFindings <= 0) throw new ArgumentOutOfRangeException(nameof(options), "MaxFindings must be positive.");
     }
 
-    private static string DecodeText(byte[] data) {
+    private static string DecodeText(byte[] data, int maximumCharacters, CancellationToken cancellationToken) {
         Encoding encoding = StrictUtf8;
         int offset = 0;
         if (StartsWith(data, new byte[] { 0x00, 0x00, 0xFE, 0xFF })) {
@@ -306,7 +329,36 @@ public static class OfficeTextIntegrityInspector {
             offset = 2;
         }
         try {
-            return encoding.GetString(data, offset, data.Length - offset);
+            cancellationToken.ThrowIfCancellationRequested();
+            Decoder decoder = encoding.GetDecoder();
+            var builder = new StringBuilder(Math.Min(data.Length - offset, maximumCharacters));
+            var characters = new char[4096];
+            int byteOffset = offset;
+            bool completed;
+            do {
+                cancellationToken.ThrowIfCancellationRequested();
+                decoder.Convert(
+                    data,
+                    byteOffset,
+                    data.Length - byteOffset,
+                    characters,
+                    0,
+                    characters.Length,
+                    flush: true,
+                    out int bytesUsed,
+                    out int charactersUsed,
+                    out completed);
+                if (charactersUsed > maximumCharacters - builder.Length) {
+                    throw new InvalidDataException("The text exceeds the configured character limit.");
+                }
+                builder.Append(characters, 0, charactersUsed);
+                byteOffset += bytesUsed;
+                if (!completed && bytesUsed == 0 && charactersUsed == 0) {
+                    throw new InvalidDataException("The text file could not be decoded incrementally.");
+                }
+            } while (!completed);
+            cancellationToken.ThrowIfCancellationRequested();
+            return builder.ToString();
         } catch (DecoderFallbackException exception) {
             throw new InvalidDataException("The text file contains invalid encoded text.", exception);
         }

--- a/OfficeIMO.Core/README.md
+++ b/OfficeIMO.Core/README.md
@@ -183,6 +183,8 @@ foreach (OfficeProvenanceSignalResult signal in assessment.ProviderSignals) {
 
 `IOfficeProvenanceSignalDetector` is deliberately provider-specific. A detector reports its own durable-media watermark, statistical-text watermark, visible disclosure, or deterministic artifact and keeps `NotDetected`, `Inconclusive`, `ProviderUnavailable`, and `Error` distinct. OfficeIMO does not turn the absence of one vendor's signal into “human-authored.”
 
+Existing detector and verifier implementations remain valid. Providers that perform long-running work can additionally implement `ICancellableOfficeProvenanceSignalDetector` or `ICancellableOfficeProvenanceVerifier`; cancellation-aware assessment and workflow calls pass their token to those providers and fall back to the original contracts for compatibility.
+
 Use `OfficeTextIntegrityInspector` to report exact invisible and context-sensitive Unicode code points. It reports offsets, code points, and risk; it does not call those characters an AI watermark. Format content-safety reports also mirror these as selectable `NonPrintingUnicode` findings when the owning adapter can verify and rewrite the exact native text node. Cleanup has no blanket mode: callers pass only reviewed finding IDs, so legitimate joiners, variation selectors, and typographic spaces are not silently normalized.
 
 ### Inspect concealed content before model ingestion

--- a/OfficeIMO.Core/Security/PackageSignatures/OfficePackageSignatureTransforms.cs
+++ b/OfficeIMO.Core/Security/PackageSignatures/OfficePackageSignatureTransforms.cs
@@ -478,14 +478,20 @@ namespace OfficeIMO.Security {
             using var contentTypeStream = new MemoryStream(contentTypeBytes, writable: false);
             XDocument document = LoadXDocument(contentTypeStream, maxPartBytes);
             XNamespace contentTypes = "http://schemas.openxmlformats.org/package/2006/content-types";
-            var defaults = document.Root?
-                .Elements(contentTypes + "Default")
-                .Where(element => element.Attribute("Extension") != null && element.Attribute("ContentType") != null)
-                .ToDictionary(
-                    element => ((string)element.Attribute("Extension")!).TrimStart('.'),
-                    element => (string)element.Attribute("ContentType")!,
-                    StringComparer.OrdinalIgnoreCase)
-                ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var defaults = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (XElement element in document.Root?.Elements(contentTypes + "Default") ?? Enumerable.Empty<XElement>()) {
+                string extension = ((string?)element.Attribute("Extension") ?? string.Empty).TrimStart('.');
+                string? contentType = (string?)element.Attribute("ContentType");
+                if (extension.Length == 0 || string.IsNullOrWhiteSpace(contentType)) continue;
+                if (defaults.TryGetValue(extension, out string? existing)) {
+                    if (!string.Equals(existing, contentType, StringComparison.OrdinalIgnoreCase)) {
+                        throw new InvalidDataException(
+                            "The OPC package declares conflicting default content types for extension '" + extension + "'.");
+                    }
+                    continue;
+                }
+                defaults.Add(extension, contentType!);
+            }
             var overrides = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             foreach (XElement element in document.Root?.Elements(contentTypes + "Override") ?? Enumerable.Empty<XElement>()) {
                 string partUri = NormalizePartUri((string?)element.Attribute("PartName") ?? string.Empty);

--- a/OfficeIMO.Epub/EpubDocument.Provenance.cs
+++ b/OfficeIMO.Epub/EpubDocument.Provenance.cs
@@ -182,10 +182,11 @@ public sealed partial class EpubDocument {
     private static bool HasPackageSignatures(byte[] data, OfficeProvenanceRemovalOptions _) => OfficeProvenanceZip.HasEntry(data, path =>
         path.Equals("META-INF/signatures.xml", StringComparison.Ordinal));
 
-    private static OfficeProvenanceSignatureStripResult StripPackageSignatures(byte[] data, OfficeProvenanceOptions limits) {
+    private static OfficeProvenanceSignatureStripResult StripPackageSignatures(byte[] data, OfficeProvenanceRemovalOptions options) {
         return OfficeProvenanceZip.RemoveEntries(
             data,
             path => path.Equals("META-INF/signatures.xml", StringComparison.Ordinal),
-            limits.MaxExpandedContainerBytes);
+            options.Limits.MaxExpandedContainerBytes,
+            maximumOutputBytes: options.EffectiveMaxOutputBytes);
     }
 }

--- a/OfficeIMO.Epub/EpubDocument.Provenance.cs
+++ b/OfficeIMO.Epub/EpubDocument.Provenance.cs
@@ -12,7 +12,7 @@ public sealed partial class EpubDocument {
         options ??= new OfficeProvenanceOptions();
         string fullPath = Path.GetFullPath(filePath);
         byte[] data;
-        using (Stream stream = File.OpenRead(fullPath)) data = OfficeProvenanceBinary.ReadBounded(stream, options.MaxAssetBytes);
+        using (Stream stream = File.OpenRead(fullPath)) data = OfficeProvenanceBinary.ReadBounded(stream, options.MaxAssetBytes, options.CancellationToken);
         ValidatePackage(data, options);
         return OfficeProvenanceInspector.Inspect(data, fullPath, options);
     }
@@ -52,6 +52,7 @@ public sealed partial class EpubDocument {
         using var input = new MemoryStream(data, writable: false);
         using var archive = new ZipArchive(input, ZipArchiveMode.Read, leaveOpen: false);
         foreach (ZipArchiveEntry entry in archive.Entries) {
+            options.CancellationToken.ThrowIfCancellationRequested();
             if (!EpubReader.TryNormalizeArchiveEntryPath(entry.FullName, out string normalized) ||
                 !string.Equals(normalized, entry.FullName, StringComparison.Ordinal)) {
                 throw new InvalidDataException($"EPUB package contains unsafe or non-canonical entry path '{entry.FullName}'.");
@@ -62,7 +63,7 @@ public sealed partial class EpubDocument {
             .ToArray();
         if (containers.Length != 1) throw new InvalidDataException("The EPUB package must contain exactly one META-INF/container.xml part.");
         using Stream containerStream = containers[0].Open();
-        byte[] containerXml = OfficeProvenanceBinary.ReadBounded(containerStream, options.MaxAssetBytes);
+        byte[] containerXml = OfficeProvenanceBinary.ReadBounded(containerStream, options.MaxAssetBytes, options.CancellationToken);
         if (containerXml.LongLength > options.MaxExpandedContainerBytes) {
             throw new InvalidDataException("The EPUB container metadata exceeds the configured expanded-container limit.");
         }
@@ -70,6 +71,7 @@ public sealed partial class EpubDocument {
         using var xmlInput = new MemoryStream(containerXml, writable: false);
         using XmlReader reader = XmlReader.Create(xmlInput, OfficeProvenanceXml.CreateReaderSettings(options));
         XDocument document = XDocument.Load(reader, LoadOptions.None);
+        options.CancellationToken.ThrowIfCancellationRequested();
         XNamespace containerNamespace = "urn:oasis:names:tc:opendocument:xmlns:container";
         if (document.Root?.Name != containerNamespace + "container") {
             throw new InvalidDataException("The EPUB container metadata has an unexpected root element.");
@@ -85,6 +87,7 @@ public sealed partial class EpubDocument {
         bool hasValidPackageDocument = false;
         long expandedMetadataBytes = containerXml.LongLength;
         foreach (XElement rootfile in rootfileContainers[0].Elements(containerNamespace + "rootfile")) {
+            options.CancellationToken.ThrowIfCancellationRequested();
             if (++declaredRootfiles > options.MaxContainerEntries) {
                 throw new InvalidDataException("The EPUB container declares too many rootfiles.");
             }
@@ -116,13 +119,14 @@ public sealed partial class EpubDocument {
             throw new InvalidDataException("The EPUB package metadata exceeds the configured expanded-container limit.");
         }
         using Stream source = entry.Open();
-        byte[] opf = OfficeProvenanceBinary.ReadBounded(source, Math.Min(options.MaxAssetBytes, remainingExpandedBytes));
+        byte[] opf = OfficeProvenanceBinary.ReadBounded(source, Math.Min(options.MaxAssetBytes, remainingExpandedBytes), options.CancellationToken);
         expandedMetadataBytes += opf.LongLength;
         try {
             OfficeProvenanceXml.ValidateMaterializedNodeBudget(opf, options, "EPUB package document");
             using var input = new MemoryStream(opf, writable: false);
             using XmlReader reader = XmlReader.Create(input, OfficeProvenanceXml.CreateReaderSettings(options));
             XDocument document = XDocument.Load(reader, LoadOptions.None);
+            options.CancellationToken.ThrowIfCancellationRequested();
             XNamespace opfNamespace = "http://www.idpf.org/2007/opf";
             return document.Root?.Name == opfNamespace + "package";
         } catch (XmlException) {
@@ -179,14 +183,17 @@ public sealed partial class EpubDocument {
     private static bool IsHexDigit(char value) =>
         value is >= '0' and <= '9' or >= 'A' and <= 'F' or >= 'a' and <= 'f';
 
-    private static bool HasPackageSignatures(byte[] data, OfficeProvenanceRemovalOptions _) => OfficeProvenanceZip.HasEntry(data, path =>
-        path.Equals("META-INF/signatures.xml", StringComparison.Ordinal));
+    private static bool HasPackageSignatures(byte[] data, OfficeProvenanceRemovalOptions options) => OfficeProvenanceZip.HasEntry(
+        data,
+        path => path.Equals("META-INF/signatures.xml", StringComparison.Ordinal),
+        options.Limits.CancellationToken);
 
     private static OfficeProvenanceSignatureStripResult StripPackageSignatures(byte[] data, OfficeProvenanceRemovalOptions options) {
         return OfficeProvenanceZip.RemoveEntries(
             data,
             path => path.Equals("META-INF/signatures.xml", StringComparison.Ordinal),
             options.Limits.MaxExpandedContainerBytes,
-            maximumOutputBytes: options.EffectiveMaxOutputBytes);
+            maximumOutputBytes: options.EffectiveMaxOutputBytes,
+            cancellationToken: options.Limits.CancellationToken);
     }
 }

--- a/OfficeIMO.Excel/ExcelDocument.ContentSafety.cs
+++ b/OfficeIMO.Excel/ExcelDocument.ContentSafety.cs
@@ -570,7 +570,7 @@ public partial class ExcelDocument {
             throw new InvalidOperationException("Content cleanup would invalidate existing Excel package signatures. Select RemoveInvalidatedSignatures or PreserveSignatureMarkup explicitly.");
         }
         return policy == OfficeSignatureMutationPolicy.RemoveInvalidatedSignatures
-            ? StripPackageSignatures(data, provenanceOptions.Limits).Data
+            ? StripPackageSignatures(data, provenanceOptions).Data
             : (byte[])data.Clone();
     }
 

--- a/OfficeIMO.Excel/ExcelDocument.ContentSafety.cs
+++ b/OfficeIMO.Excel/ExcelDocument.ContentSafety.cs
@@ -52,7 +52,7 @@ public partial class ExcelDocument {
         if (selected.Count == 0) return new OfficeContentCleanupResult((byte[])workbookBytes.Clone(), before, before, Array.Empty<OfficeContentCleanupChange>());
 
         ExcelFileFormat sourceFormat = ExcelDocumentLoadRouting.DetectFormat(workbookBytes, fileName);
-        byte[] mutableBytes = PrepareExcelContentSafetyMutation(workbookBytes, sourceFormat, options.SignatureMutationPolicy);
+        byte[] mutableBytes = PrepareExcelContentSafetyMutation(workbookBytes, sourceFormat, options);
         using ExcelDocument document = LoadContentSafetyWorkbook(mutableBytes, fileName, readOnly: false);
         var targets = new Dictionary<string, ExcelCleanupTarget>(StringComparer.Ordinal);
         OfficeContentSafetyReport current = InspectContentSafetyDocument(document, options.Inspection, targets);
@@ -554,7 +554,8 @@ public partial class ExcelDocument {
     private static byte[] PrepareExcelContentSafetyMutation(
         byte[] data,
         ExcelFileFormat sourceFormat,
-        OfficeSignatureMutationPolicy policy) {
+        OfficeContentCleanupOptions cleanupOptions) {
+        OfficeSignatureMutationPolicy policy = cleanupOptions.SignatureMutationPolicy;
         if (sourceFormat == ExcelFileFormat.Xls) {
             using ExcelDocument document = LoadContentSafetyWorkbook(data, "workbook.xls", readOnly: true);
             if (document.LegacyXlsCompoundFeatures.Any(item => item.Kind == LegacyXlsCompoundFeatureRecordKind.DigitalSignature)) {
@@ -563,7 +564,8 @@ public partial class ExcelDocument {
             return (byte[])data.Clone();
         }
 
-        var provenanceOptions = new OfficeProvenanceRemovalOptions { SignatureMutationPolicy = policy };
+        OfficeProvenanceRemovalOptions provenanceOptions =
+            OfficeContentSafetyProvenanceOptions.CreateSignatureRemovalOptions(cleanupOptions);
         bool hasSignatures = HasPackageSignatures(data, provenanceOptions);
         if (!hasSignatures) return (byte[])data.Clone();
         if (policy == OfficeSignatureMutationPolicy.BlockSave) {

--- a/OfficeIMO.Excel/ExcelDocument.Provenance.cs
+++ b/OfficeIMO.Excel/ExcelDocument.Provenance.cs
@@ -99,10 +99,11 @@ public partial class ExcelDocument {
         return applicationProperties?.Properties?.DigitalSignature != null;
     }
 
-    private static OfficeProvenanceSignatureStripResult StripPackageSignatures(byte[] data, OfficeProvenanceOptions limits) {
+    private static OfficeProvenanceSignatureStripResult StripPackageSignatures(byte[] data, OfficeProvenanceRemovalOptions options) {
+        OfficeProvenanceOptions limits = options.Limits;
         if (XlsbPackageDetector.TryFindWorkbookPart(
-            data, limits.MaxAssetBytes, limits.MaxAssetBytes, out _)) return StripXlsbPackageSignatures(data, limits);
-        using var stream = new MemoryStream(data.Length);
+            data, limits.MaxAssetBytes, limits.MaxAssetBytes, out _)) return StripXlsbPackageSignatures(data, options);
+        using var stream = new OfficeProvenanceBoundedMemoryStream(options.EffectiveMaxOutputBytes, data.Length);
         stream.Write(data, 0, data.Length);
         stream.Position = 0;
         bool hadSignatures;
@@ -121,7 +122,8 @@ public partial class ExcelDocument {
         return new OfficeProvenanceSignatureStripResult(stream.ToArray(), hadSignatures);
     }
 
-    private static OfficeProvenanceSignatureStripResult StripXlsbPackageSignatures(byte[] data, OfficeProvenanceOptions limits) {
+    private static OfficeProvenanceSignatureStripResult StripXlsbPackageSignatures(byte[] data, OfficeProvenanceRemovalOptions options) {
+        OfficeProvenanceOptions limits = options.Limits;
         var inspectionOptions = new OfficePackageSignatureInspectionOptions {
             MaxPackageBytes = limits.MaxAssetBytes,
             MaxPackageParts = limits.MaxContainerEntries,
@@ -148,8 +150,14 @@ public partial class ExcelDocument {
             entryName => signatureEntries.Contains(NormalizePartName(entryName)),
             limits.MaxExpandedContainerBytes,
             entryName => IsXlsbSignatureMetadataEntry(entryName, applicationMetadataEntries),
-            (entryName, content) => RewriteXlsbSignatureMetadata(entryName, content, signatureEntries, limits),
-            limits.MaxAssetBytes);
+            (entryName, content) => RewriteXlsbSignatureMetadata(
+                entryName,
+                content,
+                signatureEntries,
+                limits,
+                options.EffectiveMaxOutputBytes),
+            Math.Min(limits.MaxAssetBytes, options.EffectiveMaxOutputBytes),
+            options.EffectiveMaxOutputBytes);
         return new OfficeProvenanceSignatureStripResult(rewritten.Data, hadSignatures: true);
     }
 
@@ -366,7 +374,8 @@ public partial class ExcelDocument {
         string entryName,
         byte[] content,
         HashSet<string> signatureEntries,
-        OfficeProvenanceOptions limits) {
+        OfficeProvenanceOptions limits,
+        long maximumOutputBytes) {
         OfficeProvenanceXml.ValidateMaterializedNodeBudget(content, limits, "XLSB signature metadata");
         using var input = new MemoryStream(content, writable: false);
         using XmlReader reader = XmlReader.Create(input, OfficeProvenanceXml.CreateReaderSettings(limits));
@@ -385,7 +394,7 @@ public partial class ExcelDocument {
             XNamespace properties = "http://schemas.openxmlformats.org/officeDocument/2006/extended-properties";
             foreach (XElement signature in document.Descendants(properties + "DigSig").ToArray()) signature.Remove();
         }
-        using var output = new MemoryStream();
+        using var output = new OfficeProvenanceBoundedMemoryStream(maximumOutputBytes, content.Length);
         document.Save(output, SaveOptions.DisableFormatting);
         return output.ToArray();
     }

--- a/OfficeIMO.Excel/ExcelDocument.Provenance.cs
+++ b/OfficeIMO.Excel/ExcelDocument.Provenance.cs
@@ -103,7 +103,7 @@ public partial class ExcelDocument {
         OfficeProvenanceOptions limits = options.Limits;
         if (XlsbPackageDetector.TryFindWorkbookPart(
             data, limits.MaxAssetBytes, limits.MaxAssetBytes, out _)) return StripXlsbPackageSignatures(data, options);
-        using var stream = new OfficeProvenanceBoundedMemoryStream(options.EffectiveMaxOutputBytes, data.Length);
+        using var stream = new OfficeProvenanceBoundedMemoryStream(options.EffectiveMaxIntermediateBytes, data.Length);
         stream.Write(data, 0, data.Length);
         stream.Position = 0;
         bool hadSignatures;
@@ -155,9 +155,9 @@ public partial class ExcelDocument {
                 content,
                 signatureEntries,
                 limits,
-                options.EffectiveMaxOutputBytes),
-            Math.Min(limits.MaxAssetBytes, options.EffectiveMaxOutputBytes),
-            options.EffectiveMaxOutputBytes);
+                options.EffectiveMaxIntermediateBytes),
+            Math.Min(limits.MaxAssetBytes, options.EffectiveMaxIntermediateBytes),
+            options.EffectiveMaxIntermediateBytes);
         return new OfficeProvenanceSignatureStripResult(rewritten.Data, hadSignatures: true);
     }
 

--- a/OfficeIMO.Excel/ExcelDocument.Provenance.cs
+++ b/OfficeIMO.Excel/ExcelDocument.Provenance.cs
@@ -154,10 +154,10 @@ public partial class ExcelDocument {
                 entryName,
                 content,
                 signatureEntries,
-                limits,
-                options.EffectiveMaxIntermediateBytes),
-            Math.Min(limits.MaxAssetBytes, options.EffectiveMaxIntermediateBytes),
-            options.EffectiveMaxIntermediateBytes);
+                limits),
+            limits.MaxAssetBytes,
+            options.EffectiveMaxOutputBytes,
+            limits.CancellationToken);
         return new OfficeProvenanceSignatureStripResult(rewritten.Data, hadSignatures: true);
     }
 
@@ -374,8 +374,8 @@ public partial class ExcelDocument {
         string entryName,
         byte[] content,
         HashSet<string> signatureEntries,
-        OfficeProvenanceOptions limits,
-        long maximumOutputBytes) {
+        OfficeProvenanceOptions limits) {
+        limits.CancellationToken.ThrowIfCancellationRequested();
         OfficeProvenanceXml.ValidateMaterializedNodeBudget(content, limits, "XLSB signature metadata");
         using var input = new MemoryStream(content, writable: false);
         using XmlReader reader = XmlReader.Create(input, OfficeProvenanceXml.CreateReaderSettings(limits));
@@ -394,7 +394,7 @@ public partial class ExcelDocument {
             XNamespace properties = "http://schemas.openxmlformats.org/officeDocument/2006/extended-properties";
             foreach (XElement signature in document.Descendants(properties + "DigSig").ToArray()) signature.Remove();
         }
-        using var output = new OfficeProvenanceBoundedMemoryStream(maximumOutputBytes, content.Length);
+        using var output = new OfficeProvenanceBoundedMemoryStream(limits.MaxAssetBytes, content.Length);
         document.Save(output, SaveOptions.DisableFormatting);
         return output.ToArray();
     }

--- a/OfficeIMO.Html.Tests/Html.Provenance.Wave77.cs
+++ b/OfficeIMO.Html.Tests/Html.Provenance.Wave77.cs
@@ -7,14 +7,20 @@ namespace OfficeIMO.Tests;
 
 public sealed class HtmlProvenanceWave77Tests {
     [Fact]
-    public async Task DocumentParserObservesCancellationDuringLargeParse() {
-        string html = "<!doctype html><html><body>" +
-                      string.Concat(Enumerable.Repeat("<div>content</div>", 100_000)) +
-                      "</body></html>";
+    public async Task DocumentParserRejectsCancellationAtTheWorkerBoundary() {
+        const string html = "<!doctype html><html><body>content</body></html>";
         using var cancellation = new CancellationTokenSource();
+        var enteredWorker = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseWorker = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        Task parse = Task.Run(() => HtmlDocumentParser.ParseDocument(html, cancellation.Token));
-        cancellation.CancelAfter(TimeSpan.FromMilliseconds(10));
+        Task parse = Task.Run(async () => {
+            enteredWorker.SetResult(true);
+            await releaseWorker.Task;
+            HtmlDocumentParser.ParseDocument(html, cancellation.Token);
+        });
+        await enteredWorker.Task;
+        cancellation.Cancel();
+        releaseWorker.SetResult(true);
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => parse);
     }

--- a/OfficeIMO.Html.Tests/Html.Provenance.Wave77.cs
+++ b/OfficeIMO.Html.Tests/Html.Provenance.Wave77.cs
@@ -1,0 +1,21 @@
+using OfficeIMO.Html;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class HtmlProvenanceWave77Tests {
+    [Fact]
+    public async Task DocumentParserObservesCancellationDuringLargeParse() {
+        string html = "<!doctype html><html><body>" +
+                      string.Concat(Enumerable.Repeat("<div>content</div>", 100_000)) +
+                      "</body></html>";
+        using var cancellation = new CancellationTokenSource();
+
+        Task parse = Task.Run(() => HtmlDocumentParser.ParseDocument(html, cancellation.Token));
+        cancellation.CancelAfter(TimeSpan.FromMilliseconds(10));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => parse);
+    }
+}

--- a/OfficeIMO.Html.Tests/Html.Provenance.Wave78.cs
+++ b/OfficeIMO.Html.Tests/Html.Provenance.Wave78.cs
@@ -1,0 +1,36 @@
+using System.Text;
+using OfficeIMO.Html;
+using OfficeIMO.Provenance;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class HtmlProvenanceWave78Tests {
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void InspectionAndRemovalHonorUtf32Preambles(bool bigEndian) {
+        string input = Path.Combine(Path.GetTempPath(), "officeimo-html-utf32-" + Guid.NewGuid().ToString("N") + ".html");
+        string output = Path.Combine(Path.GetTempPath(), "officeimo-html-utf32-" + Guid.NewGuid().ToString("N") + ".html");
+        var encoding = new UTF32Encoding(bigEndian, byteOrderMark: true);
+        const string html = "<!doctype html><html><head><link rel=\"c2pa-manifest\" href=\"claim.c2pa\"></head><body>utf32</body></html>";
+        File.WriteAllBytes(input, encoding.GetPreamble().Concat(encoding.GetBytes(html)).ToArray());
+
+        try {
+            OfficeProvenanceReport before = HtmlProvenance.InspectFile(input);
+            OfficeProvenanceRemovalResult removal = HtmlProvenance.RemoveFile(input, output);
+            OfficeProvenanceReport after = HtmlProvenance.InspectFile(output);
+            byte[] published = File.ReadAllBytes(output);
+
+            Assert.Equal(
+                OfficeProvenanceCarrierKind.C2paExternalManifest,
+                Assert.Single(before.Evidence).Carrier);
+            Assert.True(removal.WasChanged);
+            Assert.Empty(after.Evidence);
+            Assert.True(encoding.GetPreamble().SequenceEqual(published.Take(encoding.GetPreamble().Length)));
+        } finally {
+            File.Delete(input);
+            File.Delete(output);
+        }
+    }
+}

--- a/OfficeIMO.Html/OfficeIMO.Html.csproj
+++ b/OfficeIMO.Html/OfficeIMO.Html.csproj
@@ -64,6 +64,7 @@
     <InternalsVisibleTo Include="OfficeIMO.OneNote.Html" />
     <InternalsVisibleTo Include="OfficeIMO.PowerPoint.Html" />
     <InternalsVisibleTo Include="OfficeIMO.Reader.Html" />
+    <InternalsVisibleTo Include="OfficeIMO.Workflows" />
     <InternalsVisibleTo Include="OfficeIMO.Word.Html" />
   </ItemGroup>
 

--- a/OfficeIMO.Html/Parsing/HtmlDocumentParser.cs
+++ b/OfficeIMO.Html/Parsing/HtmlDocumentParser.cs
@@ -3,6 +3,7 @@ using AngleSharp.Html.Dom;
 using AngleSharp.Html.Parser;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 
 namespace OfficeIMO.Html;
 
@@ -13,12 +14,20 @@ internal static class HtmlDocumentParser {
     /// <summary>
     /// Parses an HTML fragment or document into an AngleSharp document.
     /// </summary>
-    public static IHtmlDocument ParseDocument(string html) {
+    public static IHtmlDocument ParseDocument(string html) => ParseDocument(html, CancellationToken.None);
+
+    /// <summary>
+    /// Parses an HTML fragment or document into an AngleSharp document with cooperative cancellation.
+    /// </summary>
+    public static IHtmlDocument ParseDocument(string html, CancellationToken cancellationToken) {
         if (html == null) throw new ArgumentNullException(nameof(html));
+        cancellationToken.ThrowIfCancellationRequested();
         var parser = new HtmlParser(new HtmlParserOptions {
             IsKeepingSourceReferences = true
         });
-        return parser.ParseDocument(NormalizeSvgHrefAttributeOrder(html));
+        string normalized = NormalizeSvgHrefAttributeOrder(html, cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
+        return parser.ParseDocumentAsync(normalized, cancellationToken).GetAwaiter().GetResult();
     }
 
     internal static string? GetExactAttributeValue(IElement element, string name) =>
@@ -37,12 +46,14 @@ internal static class HtmlDocumentParser {
                   !string.Equals(attribute.NamespaceUri, xlinkNamespace, StringComparison.Ordinal)));
     }
 
-    private static string NormalizeSvgHrefAttributeOrder(string html) {
+    private static string NormalizeSvgHrefAttributeOrder(string html, CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
         if (html.IndexOf("xlink:href", StringComparison.OrdinalIgnoreCase) < 0) return html;
         var replacements = new List<(int Start, int Length, string Value)>();
         var openElements = new List<SourceElement>();
         int cursor = 0;
         while (cursor < html.Length - 1) {
+            cancellationToken.ThrowIfCancellationRequested();
             int markup = html.IndexOf('<', cursor);
             if (markup < 0 || markup == html.Length - 1) break;
             if (markup <= html.Length - 4 && string.CompareOrdinal(html, markup, "<!--", 0, 4) == 0) {
@@ -126,8 +137,10 @@ internal static class HtmlDocumentParser {
         if (replacements.Count == 0) return html;
         var output = new StringBuilder(html);
         foreach ((int start, int length, string value) in replacements.OrderByDescending(item => item.Start)) {
+            cancellationToken.ThrowIfCancellationRequested();
             output.Remove(start, length).Insert(start, value);
         }
+        cancellationToken.ThrowIfCancellationRequested();
         return output.ToString();
     }
 

--- a/OfficeIMO.Html/Parsing/HtmlTextEncodingResolver.cs
+++ b/OfficeIMO.Html/Parsing/HtmlTextEncodingResolver.cs
@@ -306,6 +306,12 @@ internal static class HtmlTextEncodingResolver {
     private static Encoding? ResolveBomEncoding(byte[] bytes, int? count = null) {
         int length = count ?? bytes.Length;
         if (length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF) return new UTF8Encoding(true, true);
+        if (length >= 4 && bytes[0] == 0xFF && bytes[1] == 0xFE && bytes[2] == 0x00 && bytes[3] == 0x00) {
+            return new UTF32Encoding(false, true, true);
+        }
+        if (length >= 4 && bytes[0] == 0x00 && bytes[1] == 0x00 && bytes[2] == 0xFE && bytes[3] == 0xFF) {
+            return new UTF32Encoding(true, true, true);
+        }
         if (length >= 2 && bytes[0] == 0xFF && bytes[1] == 0xFE) return new UnicodeEncoding(false, true, true);
         if (length >= 2 && bytes[0] == 0xFE && bytes[1] == 0xFF) return new UnicodeEncoding(true, true, true);
         return null;

--- a/OfficeIMO.Html/Provenance/HtmlProvenance.cs
+++ b/OfficeIMO.Html/Provenance/HtmlProvenance.cs
@@ -19,10 +19,14 @@ public static partial class HtmlProvenance {
     public static OfficeProvenanceReport Inspect(string html, OfficeProvenanceOptions? options = null) {
         if (html == null) throw new ArgumentNullException(nameof(html));
         options ??= new OfficeProvenanceOptions();
-        return InspectCore(html, options, enforceUtf8Size: true);
+        return InspectCore(html, options, enforceUtf8Size: true, documentUri: null);
     }
 
-    private static OfficeProvenanceReport InspectCore(string html, OfficeProvenanceOptions options, bool enforceUtf8Size) {
+    private static OfficeProvenanceReport InspectCore(
+        string html,
+        OfficeProvenanceOptions options,
+        bool enforceUtf8Size,
+        Uri? documentUri = null) {
         OfficeProvenanceBinary.ValidateLimits(options);
         if (enforceUtf8Size && Encoding.UTF8.GetByteCount(html) > options.MaxAssetBytes) {
             throw new InvalidDataException("The HTML document exceeds the configured asset limit.");
@@ -32,16 +36,30 @@ public static partial class HtmlProvenance {
         IHtmlDocument document = ParseBoundedDocument(html, options.MaxContainerEntries, ref structuralEntries);
         var evidence = new List<OfficeProvenanceEvidence>();
         var diagnostics = new List<string>();
+        var resolvedExternalManifestReferences = new Dictionary<OfficeProvenanceEvidence, string>();
+        Uri? effectiveBaseUri = HtmlDocumentParser.ResolveEffectiveBaseUri(document, documentUri);
+        Uri? sourceDirectoryUri = documentUri is null ? null : new Uri(documentUri, ".");
         long expandedBytes = 0;
-        InspectManifestCarriers(document, options, evidence, diagnostics, "HTML", ref expandedBytes);
+        InspectManifestCarriers(
+            document,
+            options,
+            evidence,
+            diagnostics,
+            resolvedExternalManifestReferences,
+            effectiveBaseUri,
+            sourceDirectoryUri,
+            "HTML",
+            ref expandedBytes);
         int embeddedAssetCount = 0;
         InspectEmbeddedImages(document, options, evidence, diagnostics, ref embeddedAssetCount, ref structuralEntries,
-            ref expandedBytes, "HTML", srcDocDepth: 0);
+            ref expandedBytes, resolvedExternalManifestReferences, effectiveBaseUri, sourceDirectoryUri,
+            "HTML", srcDocDepth: 0);
         return new OfficeProvenanceReport(
             OfficeProvenanceAssetFormat.Html,
             evidence.AsReadOnly(),
             diagnostics.AsReadOnly(),
-            expandedBytes);
+            expandedBytes,
+            resolvedExternalManifestReferences);
     }
 
     private static void InspectManifestCarriers(
@@ -49,6 +67,9 @@ public static partial class HtmlProvenance {
         OfficeProvenanceOptions options,
         List<OfficeProvenanceEvidence> evidence,
         List<string> diagnostics,
+        Dictionary<OfficeProvenanceEvidence, string> resolvedExternalManifestReferences,
+        Uri? effectiveBaseUri,
+        Uri? sourceDirectoryUri,
         string documentLocation,
         ref long expandedBytes) {
         IElement? head = document.Head;
@@ -81,14 +102,33 @@ public static partial class HtmlProvenance {
             string value = TrimAsciiWhitespace(link.GetAttribute("href"));
             bool safeReference = IsSafeManifestReference(value, out Uri? uri);
             bool valid = manifestElements.Length == 1 && safeReference;
-            AddEvidence(evidence, options, new OfficeProvenanceEvidence(
+            var item = new OfficeProvenanceEvidence(
                 OfficeProvenanceCarrierKind.C2paExternalManifest,
                 $"{documentLocation}/link[rel=c2pa-manifest][{carrierIndex++}]",
                 valid,
                 0,
-                valid && uri!.IsAbsoluteUri ? uri.AbsoluteUri : value));
+                valid && uri!.IsAbsoluteUri ? uri.AbsoluteUri : value);
+            AddEvidence(evidence, options, item);
+            if (valid) {
+                string resolved = ResolveExternalManifestReference(value, effectiveBaseUri, sourceDirectoryUri);
+                if (!string.Equals(resolved, item.Value, StringComparison.Ordinal)) {
+                    resolvedExternalManifestReferences.Add(item, resolved);
+                }
+            }
         }
 
+    }
+
+    private static string ResolveExternalManifestReference(
+        string reference,
+        Uri? effectiveBaseUri,
+        Uri? sourceDirectoryUri) {
+        if (effectiveBaseUri is null ||
+            !Uri.TryCreate(effectiveBaseUri, reference, out Uri? resolved)) return reference;
+        if (resolved.IsFile && sourceDirectoryUri?.IsFile == true) {
+            return sourceDirectoryUri.MakeRelativeUri(resolved).ToString();
+        }
+        return resolved.IsAbsoluteUri ? resolved.AbsoluteUri : reference;
     }
 
     /// <summary>Inspects a bounded HTML file without resolving external resources.</summary>
@@ -97,7 +137,11 @@ public static partial class HtmlProvenance {
         options ??= new OfficeProvenanceOptions();
         OfficeProvenanceBinary.ValidateLimits(options);
         byte[] data = ReadBounded(filePath, options.MaxAssetBytes);
-        return InspectCore(DecodeHtml(data, out _, out _), options, enforceUtf8Size: false);
+        return InspectCore(
+            DecodeHtml(data, out _, out _),
+            options,
+            enforceUtf8Size: false,
+            new Uri(Path.GetFullPath(filePath)));
     }
 
     /// <summary>Removes selected HTML provenance and provenance in supported embedded image data URIs.</summary>
@@ -232,6 +276,9 @@ public static partial class HtmlProvenance {
         ref int count,
         ref int structuralEntries,
         ref long expandedBytes,
+        Dictionary<OfficeProvenanceEvidence, string> resolvedExternalManifestReferences,
+        Uri? effectiveBaseUri,
+        Uri? sourceDirectoryUri,
         string documentLocation,
         int srcDocDepth) {
         if (options.ProcessEmbeddedAssets) {
@@ -289,9 +336,20 @@ public static partial class HtmlProvenance {
             if (srcdoc == null || string.IsNullOrWhiteSpace(srcdoc)) continue;
             string location = $"{documentLocation}/iframe[srcdoc][{iframeIndex++}]";
             IHtmlDocument nested = ParseBoundedDocument(srcdoc, options.MaxContainerEntries, ref structuralEntries);
-            InspectManifestCarriers(nested, options, evidence, diagnostics, location, ref expandedBytes);
+            Uri? nestedBaseUri = HtmlDocumentParser.ResolveEffectiveBaseUri(nested, effectiveBaseUri);
+            InspectManifestCarriers(
+                nested,
+                options,
+                evidence,
+                diagnostics,
+                resolvedExternalManifestReferences,
+                nestedBaseUri,
+                sourceDirectoryUri,
+                location,
+                ref expandedBytes);
             InspectEmbeddedImages(nested, options, evidence, diagnostics, ref count, ref structuralEntries,
-                ref expandedBytes, location, srcDocDepth + 1);
+                ref expandedBytes, resolvedExternalManifestReferences, nestedBaseUri, sourceDirectoryUri,
+                location, srcDocDepth + 1);
         }
     }
 

--- a/OfficeIMO.Html/Provenance/HtmlProvenance.cs
+++ b/OfficeIMO.Html/Provenance/HtmlProvenance.cs
@@ -1496,6 +1496,27 @@ public static partial class HtmlProvenance {
         return OfficeProvenanceBinary.ReadBounded(stream, maximumBytes, cancellationToken);
     }
 
+    internal static Encoding ResolveTextEncoding(
+        string filePath,
+        long maximumBytes,
+        CancellationToken cancellationToken) {
+        string fullPath = Path.GetFullPath(filePath);
+        using var stream = new FileStream(
+            fullPath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            4096,
+            FileOptions.SequentialScan);
+        if (stream.Length > maximumBytes) {
+            throw new InvalidDataException("The HTML document exceeds the configured text-integrity byte limit.");
+        }
+        cancellationToken.ThrowIfCancellationRequested();
+        Encoding encoding = HtmlTextEncodingResolver.ResolveHtmlEncoding(stream);
+        cancellationToken.ThrowIfCancellationRequested();
+        return encoding;
+    }
+
     private static string DecodeHtml(byte[] data, out Encoding encoding, out bool hadPreamble) {
         using var stream = new MemoryStream(data, writable: false);
         encoding = HtmlTextEncodingResolver.ResolveHtmlEncoding(stream);

--- a/OfficeIMO.Html/Provenance/HtmlProvenance.cs
+++ b/OfficeIMO.Html/Provenance/HtmlProvenance.cs
@@ -109,8 +109,7 @@ public static partial class HtmlProvenance {
         bool enforceUtf8Size,
         Encoding? outputEncoding,
         bool outputHadPreamble) {
-        OfficeProvenanceBinary.ValidateLimits(options.Limits);
-        if (options.MaxEmbeddedAssets <= 0) throw new ArgumentOutOfRangeException(nameof(options.MaxEmbeddedAssets));
+        OfficeProvenanceBinary.ValidateRemovalOptions(options);
         OfficeProvenanceOptions inspectionOptions = CreateInspectionOptions(options);
         OfficeProvenanceReport before = InspectCore(html, inspectionOptions, enforceUtf8Size);
         int structuralEntries = 0;
@@ -128,7 +127,7 @@ public static partial class HtmlProvenance {
                 original = Array.Empty<byte>();
             } else {
                 int byteCount = Encoding.UTF8.GetByteCount(html);
-                if (byteCount > options.Limits.MaxAssetBytes) throw new InvalidDataException("The HTML document exceeds the configured asset limit.");
+                OfficeProvenanceBinary.EnsureOutputWithinLimit(byteCount, options.EffectiveMaxOutputBytes);
                 original = Encoding.UTF8.GetBytes(html);
             }
             return new OfficeProvenanceRemovalResult(original, before, before, changes.AsReadOnly(), false);
@@ -139,12 +138,15 @@ public static partial class HtmlProvenance {
         byte[] output;
         if (outputEncoding == null) {
             int byteCount = Encoding.UTF8.GetByteCount(outputHtml);
-            if (byteCount > options.Limits.MaxAssetBytes) throw new InvalidDataException("The rewritten HTML document exceeds the configured asset limit.");
+            OfficeProvenanceBinary.EnsureOutputWithinLimit(byteCount, options.EffectiveMaxOutputBytes);
             output = Encoding.UTF8.GetBytes(outputHtml);
         } else {
-            output = EncodeHtml(outputHtml, outputEncoding, outputHadPreamble, options.Limits.MaxAssetBytes);
+            output = EncodeHtml(outputHtml, outputEncoding, outputHadPreamble, options.EffectiveMaxOutputBytes);
         }
-        OfficeProvenanceReport after = InspectCore(outputHtml, inspectionOptions, enforceUtf8Size);
+        OfficeProvenanceReport after = InspectCore(
+            outputHtml,
+            CreateOutputInspectionOptions(options),
+            enforceUtf8Size);
         return new OfficeProvenanceRemovalResult(output, before, after, changes.AsReadOnly(), true);
     }
 
@@ -206,6 +208,7 @@ public static partial class HtmlProvenance {
         OfficeProvenanceRemovalResult result = RemoveCore(
             html, options, enforceUtf8Size: false, outputEncoding: encoding, outputHadPreamble: hadPreamble);
         if (!result.WasChanged) {
+            OfficeProvenanceBinary.EnsureOutputWithinLimit(input.LongLength, options.EffectiveMaxOutputBytes);
             OfficeFileCommit.WriteAllBytes(Path.GetFullPath(outputPath), input);
             return new OfficeProvenanceRemovalResult(
                 (byte[])input.Clone(), result.Before, result.After, result.Changes, result.WasReserialized);
@@ -333,7 +336,15 @@ public static partial class HtmlProvenance {
                             CreateNestedRemovalOptions(options));
                         if (!nested.WasChanged) continue;
                         string metadata = CreateRewrittenDataUriMetadata(dataUri);
-                        replacements.Add((reference, "data:" + metadata + "," + Convert.ToBase64String(nested.ToArray()) + dataUri.Fragment));
+                        byte[] nestedOutput = nested.ToArray();
+                        long base64Characters = checked(((nestedOutput.LongLength + 2L) / 3L) * 4L);
+                        long replacementCharacters = checked(
+                            5L + metadata.Length + base64Characters + dataUri.Fragment.Length);
+                        OfficeProvenanceBinary.EnsureOutputWithinLimit(
+                            replacementCharacters,
+                            options.EffectiveMaxOutputBytes);
+                        replacements.Add((reference,
+                            "data:" + metadata + "," + Convert.ToBase64String(nestedOutput) + dataUri.Fragment));
                         foreach (OfficeProvenanceChange change in nested.Changes) {
                             changes.Add(new OfficeProvenanceChange(
                                 change.Carrier,
@@ -1342,6 +1353,16 @@ public static partial class HtmlProvenance {
         MaxEmbeddedAssets = Math.Min(source.MaxEmbeddedAssets, source.Limits.MaxEmbeddedAssets)
     };
 
+    private static OfficeProvenanceOptions CreateOutputInspectionOptions(OfficeProvenanceRemovalOptions source) => new OfficeProvenanceOptions {
+        MaxAssetBytes = source.EffectiveMaxOutputBytes,
+        MaxManifestBytes = Math.Min(source.Limits.MaxManifestBytes, source.EffectiveMaxOutputBytes),
+        MaxCarriers = source.Limits.MaxCarriers,
+        MaxContainerEntries = source.Limits.MaxContainerEntries,
+        MaxExpandedContainerBytes = source.Limits.MaxExpandedContainerBytes,
+        ProcessEmbeddedAssets = source.ProcessEmbeddedAssets && source.Limits.ProcessEmbeddedAssets,
+        MaxEmbeddedAssets = Math.Min(source.MaxEmbeddedAssets, source.Limits.MaxEmbeddedAssets)
+    };
+
     private static OfficeProvenanceOptions CreateNestedOptions(OfficeProvenanceOptions source) => new OfficeProvenanceOptions {
         MaxAssetBytes = source.MaxAssetBytes,
         MaxManifestBytes = source.MaxManifestBytes,
@@ -1359,7 +1380,8 @@ public static partial class HtmlProvenance {
             RemoveAiSourceMetadata = source.RemoveAiSourceMetadata,
             RequireStructurallyValidCarrier = source.RequireStructurallyValidCarrier,
             ProcessEmbeddedAssets = false,
-            MaxEmbeddedAssets = source.MaxEmbeddedAssets
+            MaxEmbeddedAssets = source.MaxEmbeddedAssets,
+            MaxOutputBytes = Math.Min(source.EffectiveMaxOutputBytes, source.Limits.MaxAssetBytes)
         };
         nested.Limits.MaxAssetBytes = source.Limits.MaxAssetBytes;
         nested.Limits.MaxManifestBytes = source.Limits.MaxManifestBytes;
@@ -1394,7 +1416,8 @@ public static partial class HtmlProvenance {
         byte[] preamble = includePreamble ? encoding.GetPreamble() : Array.Empty<byte>();
         int bodyLength = strictEncoding.GetByteCount(encodableHtml);
         if (bodyLength > maximumBytes - preamble.Length) {
-            throw new InvalidDataException("The rewritten HTML document exceeds the configured asset limit.");
+            throw OfficeProvenanceLimitException.CreateOutput(
+                $"The rewritten HTML document exceeds the configured output limit of {maximumBytes} bytes.");
         }
         byte[] body = strictEncoding.GetBytes(encodableHtml);
         if (preamble.Length == 0) return body;

--- a/OfficeIMO.Html/Provenance/HtmlProvenance.cs
+++ b/OfficeIMO.Html/Provenance/HtmlProvenance.cs
@@ -41,6 +41,7 @@ public static partial class HtmlProvenance {
         var resolvedExternalManifestReferences = new Dictionary<OfficeProvenanceEvidence, string>();
         Uri? effectiveBaseUri = HtmlDocumentParser.ResolveEffectiveBaseUri(document, documentUri);
         Uri? sourceDirectoryUri = documentUri is null ? null : new Uri(documentUri, ".");
+        bool usesAbsoluteFileBase = UsesAbsoluteFileBase(document, inherited: false);
         long expandedBytes = 0;
         InspectManifestCarriers(
             document,
@@ -50,12 +51,13 @@ public static partial class HtmlProvenance {
             resolvedExternalManifestReferences,
             effectiveBaseUri,
             sourceDirectoryUri,
+            usesAbsoluteFileBase,
             "HTML",
             ref expandedBytes);
         int embeddedAssetCount = 0;
         InspectEmbeddedImages(document, options, evidence, diagnostics, ref embeddedAssetCount, ref structuralEntries,
             ref expandedBytes, resolvedExternalManifestReferences, effectiveBaseUri, sourceDirectoryUri,
-            "HTML", srcDocDepth: 0);
+            usesAbsoluteFileBase, "HTML", srcDocDepth: 0);
         return new OfficeProvenanceReport(
             OfficeProvenanceAssetFormat.Html,
             evidence.AsReadOnly(),
@@ -72,6 +74,7 @@ public static partial class HtmlProvenance {
         Dictionary<OfficeProvenanceEvidence, string> resolvedExternalManifestReferences,
         Uri? effectiveBaseUri,
         Uri? sourceDirectoryUri,
+        bool usesAbsoluteFileBase,
         string documentLocation,
         ref long expandedBytes) {
         IElement? head = document.Head;
@@ -113,8 +116,12 @@ public static partial class HtmlProvenance {
                 0,
                 valid && uri!.IsAbsoluteUri ? uri.AbsoluteUri : value);
             AddEvidence(evidence, options, item);
-            if (valid) {
-                string resolved = ResolveExternalManifestReference(value, effectiveBaseUri, sourceDirectoryUri);
+            if (safeReference) {
+                string resolved = ResolveExternalManifestReference(
+                    value,
+                    effectiveBaseUri,
+                    sourceDirectoryUri,
+                    usesAbsoluteFileBase);
                 if (!string.Equals(resolved, item.Value, StringComparison.Ordinal)) {
                     resolvedExternalManifestReferences.Add(item, resolved);
                 }
@@ -126,13 +133,26 @@ public static partial class HtmlProvenance {
     private static string ResolveExternalManifestReference(
         string reference,
         Uri? effectiveBaseUri,
-        Uri? sourceDirectoryUri) {
+        Uri? sourceDirectoryUri,
+        bool usesAbsoluteFileBase) {
         if (effectiveBaseUri is null ||
             !Uri.TryCreate(effectiveBaseUri, reference, out Uri? resolved)) return reference;
         if (resolved.IsFile && sourceDirectoryUri?.IsFile == true) {
-            return sourceDirectoryUri.MakeRelativeUri(resolved).ToString();
+            return usesAbsoluteFileBase
+                ? resolved.AbsoluteUri
+                : sourceDirectoryUri.MakeRelativeUri(resolved).ToString();
         }
         return resolved.IsAbsoluteUri ? resolved.AbsoluteUri : reference;
+    }
+
+    private static bool UsesAbsoluteFileBase(IHtmlDocument document, bool inherited) {
+        string? value = document.QuerySelector("base[href]")?.GetAttribute("href");
+        if (value == null) return inherited;
+        string preprocessed = PreprocessHtmlUrl(value);
+        if (preprocessed.Length == 0) return inherited;
+        if (Uri.TryCreate(preprocessed, UriKind.Absolute, out Uri? absolute)) return absolute.IsFile;
+        if (preprocessed[0] == '/' && !preprocessed.StartsWith("//", StringComparison.Ordinal)) return true;
+        return inherited;
     }
 
     /// <summary>Inspects a bounded HTML file without resolving external resources.</summary>
@@ -292,6 +312,7 @@ public static partial class HtmlProvenance {
         Dictionary<OfficeProvenanceEvidence, string> resolvedExternalManifestReferences,
         Uri? effectiveBaseUri,
         Uri? sourceDirectoryUri,
+        bool usesAbsoluteFileBase,
         string documentLocation,
         int srcDocDepth) {
         if (options.ProcessEmbeddedAssets) {
@@ -353,6 +374,7 @@ public static partial class HtmlProvenance {
             string location = $"{documentLocation}/iframe[srcdoc][{iframeIndex++}]";
             IHtmlDocument nested = ParseBoundedDocument(srcdoc, options.MaxContainerEntries, ref structuralEntries, options.CancellationToken);
             Uri? nestedBaseUri = HtmlDocumentParser.ResolveEffectiveBaseUri(nested, effectiveBaseUri);
+            bool nestedUsesAbsoluteFileBase = UsesAbsoluteFileBase(nested, usesAbsoluteFileBase);
             InspectManifestCarriers(
                 nested,
                 options,
@@ -361,11 +383,12 @@ public static partial class HtmlProvenance {
                 resolvedExternalManifestReferences,
                 nestedBaseUri,
                 sourceDirectoryUri,
+                nestedUsesAbsoluteFileBase,
                 location,
                 ref expandedBytes);
             InspectEmbeddedImages(nested, options, evidence, diagnostics, ref count, ref structuralEntries,
                 ref expandedBytes, resolvedExternalManifestReferences, nestedBaseUri, sourceDirectoryUri,
-                location, srcDocDepth + 1);
+                nestedUsesAbsoluteFileBase, location, srcDocDepth + 1);
         }
     }
 
@@ -973,7 +996,8 @@ public static partial class HtmlProvenance {
         if (remaining <= 0) throw new InvalidDataException("The HTML document exceeds the configured container-entry limit.");
         ValidatePotentialElementCountCore(html, remaining, cancellationToken);
         cancellationToken.ThrowIfCancellationRequested();
-        IHtmlDocument document = HtmlDocumentParser.ParseDocument(html);
+        IHtmlDocument document = HtmlDocumentParser.ParseDocument(html, cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
         int elementCount = document.All.Length;
         if (elementCount > remaining) throw new InvalidDataException("The HTML document exceeds the configured container-entry limit.");
         structuralEntries += elementCount;

--- a/OfficeIMO.Html/Provenance/HtmlProvenance.cs
+++ b/OfficeIMO.Html/Provenance/HtmlProvenance.cs
@@ -3,6 +3,7 @@ using AngleSharp.Html.Dom;
 using OfficeIMO.Core.Internal;
 using OfficeIMO.Provenance;
 using System.Text.RegularExpressions;
+using System.Threading;
 
 namespace OfficeIMO.Html;
 
@@ -28,12 +29,13 @@ public static partial class HtmlProvenance {
         bool enforceUtf8Size,
         Uri? documentUri = null) {
         OfficeProvenanceBinary.ValidateLimits(options);
+        options.CancellationToken.ThrowIfCancellationRequested();
         if (enforceUtf8Size && Encoding.UTF8.GetByteCount(html) > options.MaxAssetBytes) {
             throw new InvalidDataException("The HTML document exceeds the configured asset limit.");
         }
 
         int structuralEntries = 0;
-        IHtmlDocument document = ParseBoundedDocument(html, options.MaxContainerEntries, ref structuralEntries);
+        IHtmlDocument document = ParseBoundedDocument(html, options.MaxContainerEntries, ref structuralEntries, options.CancellationToken);
         var evidence = new List<OfficeProvenanceEvidence>();
         var diagnostics = new List<string>();
         var resolvedExternalManifestReferences = new Dictionary<OfficeProvenanceEvidence, string>();
@@ -80,6 +82,7 @@ public static partial class HtmlProvenance {
         if (manifestElements.Length > 1) diagnostics.Add($"{documentLocation}: manifest.html.multipleManifests: the HTML head contains multiple C2PA manifest associations.");
         int carrierIndex = 0;
         foreach (IElement script in head.QuerySelectorAll("script[type]")) {
+            options.CancellationToken.ThrowIfCancellationRequested();
             if (!string.Equals(TrimAsciiWhitespace(script.GetAttribute("type")), "application/c2pa", StringComparison.OrdinalIgnoreCase)) continue;
             TryDecodeManifest(
                 script.TextContent,
@@ -98,6 +101,7 @@ public static partial class HtmlProvenance {
         }
 
         foreach (IElement link in head.QuerySelectorAll("link[rel][href]")) {
+            options.CancellationToken.ThrowIfCancellationRequested();
             if (!HasRelationship(link.GetAttribute("rel"), "c2pa-manifest")) continue;
             string value = TrimAsciiWhitespace(link.GetAttribute("href"));
             bool safeReference = IsSafeManifestReference(value, out Uri? uri);
@@ -144,7 +148,7 @@ public static partial class HtmlProvenance {
         if (string.IsNullOrWhiteSpace(logicalFilePath)) throw new ArgumentException("A logical file path is required.", nameof(logicalFilePath));
         options ??= new OfficeProvenanceOptions();
         OfficeProvenanceBinary.ValidateLimits(options);
-        byte[] data = ReadBounded(filePath, options.MaxAssetBytes);
+        byte[] data = ReadBounded(filePath, options.MaxAssetBytes, options.CancellationToken);
         return InspectCore(
             DecodeHtml(data, out _, out _),
             options,
@@ -166,10 +170,11 @@ public static partial class HtmlProvenance {
         Encoding? outputEncoding,
         bool outputHadPreamble) {
         OfficeProvenanceBinary.ValidateRemovalOptions(options);
+        options.Limits.CancellationToken.ThrowIfCancellationRequested();
         OfficeProvenanceOptions inspectionOptions = CreateInspectionOptions(options);
         OfficeProvenanceReport before = InspectCore(html, inspectionOptions, enforceUtf8Size);
         int structuralEntries = 0;
-        IHtmlDocument document = ParseBoundedDocument(html, options.Limits.MaxContainerEntries, ref structuralEntries);
+        IHtmlDocument document = ParseBoundedDocument(html, options.Limits.MaxContainerEntries, ref structuralEntries, options.Limits.CancellationToken);
         var changes = new List<OfficeProvenanceChange>();
         long expandedBytes = 0;
         RemoveManifestCarriers(document, options, changes, "HTML", ref expandedBytes);
@@ -259,7 +264,7 @@ public static partial class HtmlProvenance {
         if (string.IsNullOrWhiteSpace(inputPath)) throw new ArgumentException("An input path is required.", nameof(inputPath));
         if (string.IsNullOrWhiteSpace(outputPath)) throw new ArgumentException("An output path is required.", nameof(outputPath));
         options ??= new OfficeProvenanceRemovalOptions();
-        byte[] input = ReadBounded(inputPath, options.Limits.MaxAssetBytes);
+        byte[] input = ReadBounded(inputPath, options.Limits.MaxAssetBytes, options.Limits.CancellationToken);
         string html = DecodeHtml(input, out Encoding encoding, out bool hadPreamble);
         OfficeProvenanceRemovalResult result = RemoveCore(
             html, options, enforceUtf8Size: false, outputEncoding: encoding, outputHadPreamble: hadPreamble);
@@ -297,12 +302,14 @@ public static partial class HtmlProvenance {
                 options.MaxExpandedContainerBytes - expandedBytes);
             ReserveExpandedBytes(ref expandedBytes, cssScope.DecodedStylesheetBytes, options.MaxExpandedContainerBytes);
             foreach (IElement element in elements) {
+                options.CancellationToken.ThrowIfCancellationRequested();
                 cssScope.UsedCustomPropertyDeclarations.TryGetValue(element, out HashSet<int>? usedDeclarations);
                 cssScope.ResolvedVarFallbackStarts.TryGetValue(element, out HashSet<int>? resolvedFallbacks);
                 cssScope.DataStylesheets.TryGetValue(element, out HtmlProvenanceDataStylesheet? dataStylesheet);
                 foreach (EmbeddedImageReference reference in GetEmbeddedImageReferences(
                     document, element, usedDeclarations, resolvedFallbacks, cssScope.ComputedStyles,
                     cssScope.ComputedStyleSet, dataStylesheet)) {
+                    options.CancellationToken.ThrowIfCancellationRequested();
                     if (!HtmlImageDataUri.TryParse(reference.Value, out HtmlImageDataUri dataUri)) continue;
                     if (!IsSupportedProvenanceImage(dataUri.MediaType)) continue;
                     int index = count++;
@@ -340,10 +347,11 @@ public static partial class HtmlProvenance {
         }
         int iframeIndex = 0;
         foreach (IElement iframe in document.QuerySelectorAll("iframe[srcdoc]").Where(IsHtmlIframe)) {
+            options.CancellationToken.ThrowIfCancellationRequested();
             string? srcdoc = iframe.GetAttribute("srcdoc");
             if (srcdoc == null || string.IsNullOrWhiteSpace(srcdoc)) continue;
             string location = $"{documentLocation}/iframe[srcdoc][{iframeIndex++}]";
-            IHtmlDocument nested = ParseBoundedDocument(srcdoc, options.MaxContainerEntries, ref structuralEntries);
+            IHtmlDocument nested = ParseBoundedDocument(srcdoc, options.MaxContainerEntries, ref structuralEntries, options.CancellationToken);
             Uri? nestedBaseUri = HtmlDocumentParser.ResolveEffectiveBaseUri(nested, effectiveBaseUri);
             InspectManifestCarriers(
                 nested,
@@ -379,6 +387,7 @@ public static partial class HtmlProvenance {
                 options.Limits.MaxExpandedContainerBytes - expandedBytes);
             ReserveExpandedBytes(ref expandedBytes, cssScope.DecodedStylesheetBytes, options.Limits.MaxExpandedContainerBytes);
             foreach (IElement element in elements) {
+                options.Limits.CancellationToken.ThrowIfCancellationRequested();
                 cssScope.UsedCustomPropertyDeclarations.TryGetValue(element, out HashSet<int>? usedDeclarations);
                 cssScope.ResolvedVarFallbackStarts.TryGetValue(element, out HashSet<int>? resolvedFallbacks);
                 cssScope.DataStylesheets.TryGetValue(element, out HtmlProvenanceDataStylesheet? dataStylesheet);
@@ -387,6 +396,7 @@ public static partial class HtmlProvenance {
                     cssScope.ComputedStyleSet, dataStylesheet).ToArray();
                 var replacements = new List<(EmbeddedImageReference Reference, string Value)>();
                 foreach (EmbeddedImageReference reference in references) {
+                    options.Limits.CancellationToken.ThrowIfCancellationRequested();
                     if (!HtmlImageDataUri.TryParse(reference.Value, out HtmlImageDataUri dataUri)) continue;
                     if (!IsSupportedProvenanceImage(dataUri.MediaType)) continue;
                     int index = count++;
@@ -436,10 +446,11 @@ public static partial class HtmlProvenance {
         }
         int iframeIndex = 0;
         foreach (IElement iframe in document.QuerySelectorAll("iframe[srcdoc]").Where(IsHtmlIframe)) {
+            options.Limits.CancellationToken.ThrowIfCancellationRequested();
             string? srcdoc = iframe.GetAttribute("srcdoc");
             if (srcdoc == null || string.IsNullOrWhiteSpace(srcdoc)) continue;
             string location = $"{documentLocation}/iframe[srcdoc][{iframeIndex++}]";
-            IHtmlDocument nested = ParseBoundedDocument(srcdoc, options.Limits.MaxContainerEntries, ref structuralEntries);
+            IHtmlDocument nested = ParseBoundedDocument(srcdoc, options.Limits.MaxContainerEntries, ref structuralEntries, options.Limits.CancellationToken);
             int priorChanges = changes.Count;
             RemoveManifestCarriers(nested, options, changes, location, ref expandedBytes);
             RemoveEmbeddedImages(nested, options, changes, ref count, ref structuralEntries,
@@ -953,10 +964,15 @@ public static partial class HtmlProvenance {
             .Replace("\n", string.Empty)
             .Replace("\r", string.Empty);
 
-    private static IHtmlDocument ParseBoundedDocument(string html, int maximumEntries, ref int structuralEntries) {
+    private static IHtmlDocument ParseBoundedDocument(
+        string html,
+        int maximumEntries,
+        ref int structuralEntries,
+        CancellationToken cancellationToken) {
         int remaining = maximumEntries - structuralEntries;
         if (remaining <= 0) throw new InvalidDataException("The HTML document exceeds the configured container-entry limit.");
-        ValidatePotentialElementCount(html, remaining);
+        ValidatePotentialElementCountCore(html, remaining, cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
         IHtmlDocument document = HtmlDocumentParser.ParseDocument(html);
         int elementCount = document.All.Length;
         if (elementCount > remaining) throw new InvalidDataException("The HTML document exceeds the configured container-entry limit.");
@@ -964,7 +980,13 @@ public static partial class HtmlProvenance {
         return document;
     }
 
-    private static void ValidatePotentialElementCount(string html, int maximumEntries) {
+    private static void ValidatePotentialElementCount(string html, int maximumEntries) =>
+        ValidatePotentialElementCountCore(html, maximumEntries, CancellationToken.None);
+
+    private static void ValidatePotentialElementCountCore(
+        string html,
+        int maximumEntries,
+        CancellationToken cancellationToken) {
         int count = 0;
         int index = 0;
         bool sawHtmlElement = false;
@@ -972,6 +994,7 @@ public static partial class HtmlProvenance {
         bool sawBodyElement = false;
         var openElements = new List<HtmlPreflightElement>();
         while (index < html.Length - 1) {
+            cancellationToken.ThrowIfCancellationRequested();
             int markup = html.IndexOf('<', index);
             if (markup < 0 || markup == html.Length - 1) break;
             if (markup <= html.Length - 4 && string.CompareOrdinal(html, markup, "<!--", 0, 4) == 0) {
@@ -1419,6 +1442,7 @@ public static partial class HtmlProvenance {
         MaxCarriers = source.Limits.MaxCarriers,
         MaxContainerEntries = source.Limits.MaxContainerEntries,
         MaxExpandedContainerBytes = source.Limits.MaxExpandedContainerBytes,
+        CancellationToken = source.Limits.CancellationToken,
         ProcessEmbeddedAssets = source.ProcessEmbeddedAssets && source.Limits.ProcessEmbeddedAssets,
         MaxEmbeddedAssets = Math.Min(source.MaxEmbeddedAssets, source.Limits.MaxEmbeddedAssets)
     };
@@ -1429,6 +1453,7 @@ public static partial class HtmlProvenance {
         MaxCarriers = source.Limits.MaxCarriers,
         MaxContainerEntries = source.Limits.MaxContainerEntries,
         MaxExpandedContainerBytes = source.Limits.MaxExpandedContainerBytes,
+        CancellationToken = source.Limits.CancellationToken,
         ProcessEmbeddedAssets = source.ProcessEmbeddedAssets && source.Limits.ProcessEmbeddedAssets,
         MaxEmbeddedAssets = Math.Min(source.MaxEmbeddedAssets, source.Limits.MaxEmbeddedAssets)
     };
@@ -1439,6 +1464,7 @@ public static partial class HtmlProvenance {
         MaxCarriers = source.MaxCarriers,
         MaxContainerEntries = source.MaxContainerEntries,
         MaxExpandedContainerBytes = source.MaxExpandedContainerBytes,
+        CancellationToken = source.CancellationToken,
         ProcessEmbeddedAssets = false,
         MaxEmbeddedAssets = source.MaxEmbeddedAssets
     };
@@ -1458,15 +1484,16 @@ public static partial class HtmlProvenance {
         nested.Limits.MaxCarriers = source.Limits.MaxCarriers;
         nested.Limits.MaxContainerEntries = source.Limits.MaxContainerEntries;
         nested.Limits.MaxExpandedContainerBytes = source.Limits.MaxExpandedContainerBytes;
+        nested.Limits.CancellationToken = source.Limits.CancellationToken;
         nested.Limits.ProcessEmbeddedAssets = false;
         nested.Limits.MaxEmbeddedAssets = source.Limits.MaxEmbeddedAssets;
         return nested;
     }
 
-    private static byte[] ReadBounded(string filePath, long maximumBytes) {
+    private static byte[] ReadBounded(string filePath, long maximumBytes, CancellationToken cancellationToken) {
         string fullPath = Path.GetFullPath(filePath);
         using var stream = File.OpenRead(fullPath);
-        return OfficeProvenanceBinary.ReadBounded(stream, maximumBytes);
+        return OfficeProvenanceBinary.ReadBounded(stream, maximumBytes, cancellationToken);
     }
 
     private static string DecodeHtml(byte[] data, out Encoding encoding, out bool hadPreamble) {

--- a/OfficeIMO.Html/Provenance/HtmlProvenance.cs
+++ b/OfficeIMO.Html/Provenance/HtmlProvenance.cs
@@ -133,7 +133,15 @@ public static partial class HtmlProvenance {
 
     /// <summary>Inspects a bounded HTML file without resolving external resources.</summary>
     public static OfficeProvenanceReport InspectFile(string filePath, OfficeProvenanceOptions? options = null) {
+        return InspectFile(filePath, filePath, options);
+    }
+
+    internal static OfficeProvenanceReport InspectFile(
+        string filePath,
+        string logicalFilePath,
+        OfficeProvenanceOptions? options) {
         if (string.IsNullOrWhiteSpace(filePath)) throw new ArgumentException("A file path is required.", nameof(filePath));
+        if (string.IsNullOrWhiteSpace(logicalFilePath)) throw new ArgumentException("A logical file path is required.", nameof(logicalFilePath));
         options ??= new OfficeProvenanceOptions();
         OfficeProvenanceBinary.ValidateLimits(options);
         byte[] data = ReadBounded(filePath, options.MaxAssetBytes);
@@ -141,7 +149,7 @@ public static partial class HtmlProvenance {
             DecodeHtml(data, out _, out _),
             options,
             enforceUtf8Size: false,
-            new Uri(Path.GetFullPath(filePath)));
+            new Uri(Path.GetFullPath(logicalFilePath)));
     }
 
     /// <summary>Removes selected HTML provenance and provenance in supported embedded image data URIs.</summary>

--- a/OfficeIMO.Html/Provenance/HtmlProvenance.cs
+++ b/OfficeIMO.Html/Provenance/HtmlProvenance.cs
@@ -37,7 +37,11 @@ public static partial class HtmlProvenance {
         int embeddedAssetCount = 0;
         InspectEmbeddedImages(document, options, evidence, diagnostics, ref embeddedAssetCount, ref structuralEntries,
             ref expandedBytes, "HTML", srcDocDepth: 0);
-        return new OfficeProvenanceReport(OfficeProvenanceAssetFormat.Html, evidence.AsReadOnly(), diagnostics.AsReadOnly());
+        return new OfficeProvenanceReport(
+            OfficeProvenanceAssetFormat.Html,
+            evidence.AsReadOnly(),
+            diagnostics.AsReadOnly(),
+            expandedBytes);
     }
 
     private static void InspectManifestCarriers(

--- a/OfficeIMO.Markdown/Core/MarkdownProvenance.cs
+++ b/OfficeIMO.Markdown/Core/MarkdownProvenance.cs
@@ -14,6 +14,7 @@ public static class MarkdownProvenance {
         if (markdown == null) throw new ArgumentNullException(nameof(markdown));
         options ??= new OfficeProvenanceOptions();
         OfficeProvenanceBinary.ValidateLimits(options);
+        options.CancellationToken.ThrowIfCancellationRequested();
         return OfficeProvenanceInspector.InspectStructuredText(
             EncodeUtf8Bounded(markdown, options.MaxAssetBytes),
             options);
@@ -26,7 +27,7 @@ public static class MarkdownProvenance {
         OfficeProvenanceBinary.ValidateLimits(options);
         byte[] input;
         using (var stream = File.OpenRead(Path.GetFullPath(filePath))) {
-            input = OfficeProvenanceBinary.ReadBounded(stream, options.MaxAssetBytes);
+            input = OfficeProvenanceBinary.ReadBounded(stream, options.MaxAssetBytes, options.CancellationToken);
         }
         string markdown = DecodeFileText(input, out _, out _);
         return OfficeProvenanceInspector.InspectStructuredText(
@@ -41,6 +42,7 @@ public static class MarkdownProvenance {
         if (markdown == null) throw new ArgumentNullException(nameof(markdown));
         options ??= new OfficeProvenanceRemovalOptions();
         OfficeProvenanceBinary.ValidateRemovalOptions(options);
+        options.Limits.CancellationToken.ThrowIfCancellationRequested();
         return OfficeProvenanceRemover.RemoveStructuredText(
             EncodeUtf8Bounded(markdown, options.Limits.MaxAssetBytes),
             "document.md",
@@ -57,7 +59,7 @@ public static class MarkdownProvenance {
         options ??= new OfficeProvenanceRemovalOptions();
         byte[] input;
         using (var stream = File.OpenRead(Path.GetFullPath(inputPath))) {
-            input = OfficeProvenanceBinary.ReadBounded(stream, options.Limits.MaxAssetBytes);
+            input = OfficeProvenanceBinary.ReadBounded(stream, options.Limits.MaxAssetBytes, options.Limits.CancellationToken);
         }
         string markdown = DecodeFileText(input, out Encoding encoding, out bool hadPreamble);
         byte[] utf8Input = EncodeDecodedFileTextAsUtf8(markdown);
@@ -102,6 +104,7 @@ public static class MarkdownProvenance {
         clone.Limits.MaxCarriers = source.Limits.MaxCarriers;
         clone.Limits.MaxContainerEntries = source.Limits.MaxContainerEntries;
         clone.Limits.MaxExpandedContainerBytes = source.Limits.MaxExpandedContainerBytes;
+        clone.Limits.CancellationToken = source.Limits.CancellationToken;
         clone.Limits.ProcessEmbeddedAssets = source.Limits.ProcessEmbeddedAssets;
         clone.Limits.MaxEmbeddedAssets = source.Limits.MaxEmbeddedAssets;
         return clone;

--- a/OfficeIMO.Markdown/Core/MarkdownProvenance.cs
+++ b/OfficeIMO.Markdown/Core/MarkdownProvenance.cs
@@ -40,7 +40,7 @@ public static class MarkdownProvenance {
         OfficeProvenanceRemovalOptions? options = null) {
         if (markdown == null) throw new ArgumentNullException(nameof(markdown));
         options ??= new OfficeProvenanceRemovalOptions();
-        OfficeProvenanceBinary.ValidateLimits(options.Limits);
+        OfficeProvenanceBinary.ValidateRemovalOptions(options);
         return OfficeProvenanceRemover.RemoveStructuredText(
             EncodeUtf8Bounded(markdown, options.Limits.MaxAssetBytes),
             "document.md",
@@ -60,15 +60,19 @@ public static class MarkdownProvenance {
             input = OfficeProvenanceBinary.ReadBounded(stream, options.Limits.MaxAssetBytes);
         }
         string markdown = DecodeFileText(input, out Encoding encoding, out bool hadPreamble);
+        byte[] utf8Input = EncodeDecodedFileTextAsUtf8(markdown);
         OfficeProvenanceRemovalResult utf8Result = OfficeProvenanceRemover.RemoveStructuredText(
-            EncodeDecodedFileTextAsUtf8(markdown), inputPath, options);
+            utf8Input,
+            inputPath,
+            CloneForTranscodedProcessing(options, Math.Max(1L, utf8Input.LongLength)));
         if (!utf8Result.WasChanged) {
+            OfficeProvenanceBinary.EnsureOutputWithinLimit(input.LongLength, options.EffectiveMaxOutputBytes);
             OfficeFileCommit.WriteAllBytes(Path.GetFullPath(outputPath), input);
             return new OfficeProvenanceRemovalResult(
                 input, utf8Result.Before, utf8Result.After, utf8Result.Changes, wasReserialized: false);
         }
         string cleaned = Encoding.UTF8.GetString(utf8Result.ToArray());
-        byte[] output = EncodeFileText(cleaned, encoding, hadPreamble, options.Limits.MaxAssetBytes);
+        byte[] output = EncodeFileText(cleaned, encoding, hadPreamble, options.EffectiveMaxOutputBytes);
         OfficeFileCommit.WriteAllBytes(Path.GetFullPath(outputPath), output);
         IReadOnlyList<OfficeProvenanceChange> physicalChanges = utf8Result.Changes;
         if (encoding.CodePage != Encoding.UTF8.CodePage) {
@@ -78,6 +82,29 @@ public static class MarkdownProvenance {
         }
         return new OfficeProvenanceRemovalResult(
             output, utf8Result.Before, utf8Result.After, physicalChanges, wasReserialized: true);
+    }
+
+    private static OfficeProvenanceRemovalOptions CloneForTranscodedProcessing(
+        OfficeProvenanceRemovalOptions source,
+        long maximumTranscodedBytes) {
+        var clone = new OfficeProvenanceRemovalOptions {
+            RemoveC2paManifests = source.RemoveC2paManifests,
+            RemoveExternalC2paReferences = source.RemoveExternalC2paReferences,
+            RemoveAiSourceMetadata = source.RemoveAiSourceMetadata,
+            RequireStructurallyValidCarrier = source.RequireStructurallyValidCarrier,
+            SignatureMutationPolicy = source.SignatureMutationPolicy,
+            ProcessEmbeddedAssets = source.ProcessEmbeddedAssets,
+            MaxEmbeddedAssets = source.MaxEmbeddedAssets,
+            MaxOutputBytes = maximumTranscodedBytes
+        };
+        clone.Limits.MaxAssetBytes = Math.Max(source.Limits.MaxAssetBytes, maximumTranscodedBytes);
+        clone.Limits.MaxManifestBytes = source.Limits.MaxManifestBytes;
+        clone.Limits.MaxCarriers = source.Limits.MaxCarriers;
+        clone.Limits.MaxContainerEntries = source.Limits.MaxContainerEntries;
+        clone.Limits.MaxExpandedContainerBytes = source.Limits.MaxExpandedContainerBytes;
+        clone.Limits.ProcessEmbeddedAssets = source.Limits.ProcessEmbeddedAssets;
+        clone.Limits.MaxEmbeddedAssets = source.Limits.MaxEmbeddedAssets;
+        return clone;
     }
 
     private static string DecodeFileText(byte[] data, out Encoding encoding, out bool hadPreamble) {
@@ -117,7 +144,8 @@ public static class MarkdownProvenance {
         byte[] preamble = includePreamble ? encoding.GetPreamble() : Array.Empty<byte>();
         int bodyLength = encoding.GetByteCount(text);
         if (bodyLength > maximumBytes - preamble.Length) {
-            throw new InvalidDataException("The rewritten Markdown document exceeds the configured asset limit.");
+            throw OfficeProvenanceLimitException.CreateOutput(
+                $"The rewritten Markdown document exceeds the configured output limit of {maximumBytes} bytes.");
         }
         byte[] body = encoding.GetBytes(text);
         if (preamble.Length == 0) return body;

--- a/OfficeIMO.OpenDocument/Core/OdfDocument.Provenance.cs
+++ b/OfficeIMO.OpenDocument/Core/OdfDocument.Provenance.cs
@@ -15,7 +15,7 @@ public abstract partial class OdfDocument {
         options ??= new OfficeProvenanceOptions();
         string fullPath = Path.GetFullPath(filePath);
         byte[] data;
-        using (Stream stream = File.OpenRead(fullPath)) data = OfficeProvenanceBinary.ReadBounded(stream, options.MaxAssetBytes);
+        using (Stream stream = File.OpenRead(fullPath)) data = OfficeProvenanceBinary.ReadBounded(stream, options.MaxAssetBytes, options.CancellationToken);
         ValidatePackageForInspection(data, options);
         return OfficeProvenanceInspector.Inspect(data, fullPath, options);
     }
@@ -29,7 +29,7 @@ public abstract partial class OdfDocument {
         if (string.IsNullOrWhiteSpace(outputPath)) throw new ArgumentException("An output path is required.", nameof(outputPath));
         options ??= new OfficeProvenanceRemovalOptions();
         byte[] data;
-        using (Stream stream = File.OpenRead(Path.GetFullPath(inputPath))) data = OfficeProvenanceBinary.ReadBounded(stream, options.Limits.MaxAssetBytes);
+        using (Stream stream = File.OpenRead(Path.GetFullPath(inputPath))) data = OfficeProvenanceBinary.ReadBounded(stream, options.Limits.MaxAssetBytes, options.Limits.CancellationToken);
         OfficeProvenanceRemovalResult result = RemoveProvenance(data, Path.GetFileName(inputPath), options);
         OfficeFileCommit.WriteAllBytes(Path.GetFullPath(outputPath), result.ToArray());
         return result;
@@ -57,7 +57,6 @@ public abstract partial class OdfDocument {
                     ? RemoveManifestEntries(
                         manifest,
                         options.Limits,
-                        options.EffectiveMaxOutputBytes,
                         path => path == ProvenanceManifestPath)
                     : manifest);
     }
@@ -88,6 +87,7 @@ public abstract partial class OdfDocument {
         var exactEntryNames = new HashSet<string>(StringComparer.Ordinal);
         var foldedEntryNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (ZipArchiveEntry entry in archive.Entries) {
+            options.CancellationToken.ThrowIfCancellationRequested();
             string normalized = OfficeArchiveSafety.NormalizeEntryName(entry.FullName);
             if (!string.Equals(normalized, entry.FullName, StringComparison.Ordinal) ||
                 OfficeArchiveSafety.IsUnsafePath(normalized)) {
@@ -107,7 +107,7 @@ public abstract partial class OdfDocument {
 
         long maximumManifestBytes = Math.Min(options.MaxAssetBytes, options.MaxExpandedContainerBytes);
         byte[] manifestBytes;
-        using (Stream stream = manifestEntries[0].Open()) manifestBytes = OfficeProvenanceBinary.ReadBounded(stream, maximumManifestBytes);
+        using (Stream stream = manifestEntries[0].Open()) manifestBytes = OfficeProvenanceBinary.ReadBounded(stream, maximumManifestBytes, options.CancellationToken);
         OfficeProvenanceXml.ValidateMaterializedNodeBudget(manifestBytes, options, "ODF manifest");
 
         XDocument manifest;
@@ -115,6 +115,7 @@ public abstract partial class OdfDocument {
         using (XmlReader reader = XmlReader.Create(stream, OfficeProvenanceXml.CreateReaderSettings(options))) {
             manifest = XDocument.Load(reader, LoadOptions.PreserveWhitespace);
         }
+        options.CancellationToken.ThrowIfCancellationRequested();
         XNamespace manifestNamespace = "urn:oasis:names:tc:opendocument:xmlns:manifest:1.0";
         XElement root = manifest.Root ?? throw new InvalidDataException("OpenDocument manifest has no root element.");
         if (root.Name != manifestNamespace + "manifest") {
@@ -134,8 +135,8 @@ public abstract partial class OdfDocument {
         }
     }
 
-    private static bool HasPackageSignatures(byte[] data, OfficeProvenanceRemovalOptions _) =>
-        OfficeProvenanceZip.HasEntry(data, OdfPackage.IsSignaturePath);
+    private static bool HasPackageSignatures(byte[] data, OfficeProvenanceRemovalOptions options) =>
+        OfficeProvenanceZip.HasEntry(data, OdfPackage.IsSignaturePath, options.Limits.CancellationToken);
 
     private static OfficeProvenanceSignatureStripResult StripPackageSignatures(byte[] data, OfficeProvenanceRemovalOptions options) {
         OfficeProvenanceOptions limits = options.Limits;
@@ -147,30 +148,31 @@ public abstract partial class OdfDocument {
             (_, manifest) => RemoveManifestEntries(
                 manifest,
                 limits,
-                options.EffectiveMaxOutputBytes,
                 OdfPackage.IsSignaturePath),
-            Math.Min(limits.MaxAssetBytes, options.EffectiveMaxOutputBytes),
-            options.EffectiveMaxOutputBytes);
+            limits.MaxAssetBytes,
+            options.EffectiveMaxOutputBytes,
+            limits.CancellationToken);
     }
 
     private static byte[] RemoveManifestEntries(
         byte[] data,
         OfficeProvenanceOptions limits,
-        long maximumOutputBytes,
         Func<string, bool> shouldRemove) {
+        limits.CancellationToken.ThrowIfCancellationRequested();
         OfficeProvenanceXml.ValidateMaterializedNodeBudget(data, limits, "ODF manifest");
         XDocument document;
         using (var stream = new MemoryStream(data, writable: false))
         using (XmlReader reader = XmlReader.Create(stream, OfficeProvenanceXml.CreateReaderSettings(limits))) {
             document = XDocument.Load(reader, LoadOptions.PreserveWhitespace);
         }
+        limits.CancellationToken.ThrowIfCancellationRequested();
         XNamespace manifestNamespace = "urn:oasis:names:tc:opendocument:xmlns:manifest:1.0";
         foreach (XElement entry in document.Descendants(manifestNamespace + "file-entry").ToArray()) {
+            limits.CancellationToken.ThrowIfCancellationRequested();
             string? path = (string?)entry.Attribute(manifestNamespace + "full-path");
             if (path != null && shouldRemove(path)) entry.Remove();
         }
-        using var output = new OfficeProvenanceBoundedMemoryStream(
-            Math.Min(limits.MaxAssetBytes, maximumOutputBytes));
+        using var output = new OfficeProvenanceBoundedMemoryStream(limits.MaxAssetBytes);
         using (XmlWriter writer = XmlWriter.Create(output, new XmlWriterSettings {
             Encoding = new System.Text.UTF8Encoding(false),
             Indent = false,

--- a/OfficeIMO.OpenDocument/Core/OdfDocument.Provenance.cs
+++ b/OfficeIMO.OpenDocument/Core/OdfDocument.Provenance.cs
@@ -54,14 +54,23 @@ public abstract partial class OdfDocument {
             shouldReplacePackageMetadata: path => path == "META-INF/manifest.xml",
             replacePackageMetadata: (_, manifest, nativeManifestRemoved) =>
                 nativeManifestRemoved
-                    ? RemoveManifestEntries(manifest, options.Limits, path => path == ProvenanceManifestPath)
+                    ? RemoveManifestEntries(
+                        manifest,
+                        options.Limits,
+                        options.EffectiveMaxOutputBytes,
+                        path => path == ProvenanceManifestPath)
                     : manifest);
     }
 
     private static readonly string[] SupportedMimetypes = {
         OdfMediaTypes.Text,
         OdfMediaTypes.Spreadsheet,
-        OdfMediaTypes.Presentation
+        OdfMediaTypes.Presentation,
+        OdfMediaTypes.Graphics,
+        OdfMediaTypes.TextTemplate,
+        OdfMediaTypes.SpreadsheetTemplate,
+        OdfMediaTypes.PresentationTemplate,
+        OdfMediaTypes.GraphicsTemplate
     };
 
     private static void ValidatePackage(byte[] data, OfficeProvenanceOptions options) {
@@ -128,17 +137,27 @@ public abstract partial class OdfDocument {
     private static bool HasPackageSignatures(byte[] data, OfficeProvenanceRemovalOptions _) =>
         OfficeProvenanceZip.HasEntry(data, OdfPackage.IsSignaturePath);
 
-    private static OfficeProvenanceSignatureStripResult StripPackageSignatures(byte[] data, OfficeProvenanceOptions limits) {
+    private static OfficeProvenanceSignatureStripResult StripPackageSignatures(byte[] data, OfficeProvenanceRemovalOptions options) {
+        OfficeProvenanceOptions limits = options.Limits;
         return OfficeProvenanceZip.RemoveEntries(
             data,
             OdfPackage.IsSignaturePath,
             limits.MaxExpandedContainerBytes,
             path => path == "META-INF/manifest.xml",
-            (_, manifest) => RemoveManifestEntries(manifest, limits, OdfPackage.IsSignaturePath),
-            limits.MaxAssetBytes);
+            (_, manifest) => RemoveManifestEntries(
+                manifest,
+                limits,
+                options.EffectiveMaxOutputBytes,
+                OdfPackage.IsSignaturePath),
+            Math.Min(limits.MaxAssetBytes, options.EffectiveMaxOutputBytes),
+            options.EffectiveMaxOutputBytes);
     }
 
-    private static byte[] RemoveManifestEntries(byte[] data, OfficeProvenanceOptions limits, Func<string, bool> shouldRemove) {
+    private static byte[] RemoveManifestEntries(
+        byte[] data,
+        OfficeProvenanceOptions limits,
+        long maximumOutputBytes,
+        Func<string, bool> shouldRemove) {
         OfficeProvenanceXml.ValidateMaterializedNodeBudget(data, limits, "ODF manifest");
         XDocument document;
         using (var stream = new MemoryStream(data, writable: false))
@@ -150,7 +169,8 @@ public abstract partial class OdfDocument {
             string? path = (string?)entry.Attribute(manifestNamespace + "full-path");
             if (path != null && shouldRemove(path)) entry.Remove();
         }
-        using var output = new MemoryStream();
+        using var output = new OfficeProvenanceBoundedMemoryStream(
+            Math.Min(limits.MaxAssetBytes, maximumOutputBytes));
         using (XmlWriter writer = XmlWriter.Create(output, new XmlWriterSettings {
             Encoding = new System.Text.UTF8Encoding(false),
             Indent = false,

--- a/OfficeIMO.OpenDocument/Core/OdfMediaTypes.cs
+++ b/OfficeIMO.OpenDocument/Core/OdfMediaTypes.cs
@@ -8,6 +8,16 @@ public static class OdfMediaTypes {
     public const string Spreadsheet = "application/vnd.oasis.opendocument.spreadsheet";
     /// <summary>ODP package media type.</summary>
     public const string Presentation = "application/vnd.oasis.opendocument.presentation";
+    /// <summary>ODG package media type.</summary>
+    public const string Graphics = "application/vnd.oasis.opendocument.graphics";
+    /// <summary>OTT package media type.</summary>
+    public const string TextTemplate = "application/vnd.oasis.opendocument.text-template";
+    /// <summary>OTS package media type.</summary>
+    public const string SpreadsheetTemplate = "application/vnd.oasis.opendocument.spreadsheet-template";
+    /// <summary>OTP package media type.</summary>
+    public const string PresentationTemplate = "application/vnd.oasis.opendocument.presentation-template";
+    /// <summary>OTG package media type.</summary>
+    public const string GraphicsTemplate = "application/vnd.oasis.opendocument.graphics-template";
 
     internal static string ForKind(OdfDocumentKind kind) {
         switch (kind) {

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfProvenanceTests.Wave79.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfProvenanceTests.Wave79.cs
@@ -1,0 +1,23 @@
+using OfficeIMO.Provenance;
+using OfficeIMO.Pdf;
+using Xunit;
+
+namespace OfficeIMO.Tests.Pdf;
+
+public sealed partial class PdfProvenanceTests {
+    [Fact]
+    public void InspectionAndRemovalReportDecodedBytesAgainstTheSharedBudget() {
+        byte[] pdf = CreatePdfWithCandidateAndRetainedAttachment();
+        var options = new OfficeProvenanceRemovalOptions();
+        options.Limits.MaxExpandedContainerBytes = 1024 * 1024;
+
+        OfficeProvenanceReport inspection = PdfProvenance.Inspect(pdf, options.Limits);
+        OfficeProvenanceRemovalResult removal = PdfProvenance.Remove(pdf, options);
+
+        Assert.True(inspection.ExpandedInspectionBytes > 0);
+        Assert.Equal(inspection.ExpandedInspectionBytes, removal.Before.ExpandedInspectionBytes);
+        Assert.True(
+            removal.Before.ExpandedInspectionBytes + removal.After.ExpandedInspectionBytes <=
+            options.Limits.MaxExpandedContainerBytes);
+    }
+}

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfProvenanceTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfProvenanceTests.cs
@@ -824,16 +824,15 @@ public sealed partial class PdfProvenanceTests {
     }
 
     [Fact]
-    public void RemovalEnforcesExpandedContainerLimitDuringGraphRewrite() {
+    public void RemovalEnforcesIndependentOutputLimitDuringGraphRewrite() {
         byte[] pdf = CreatePdfWithCandidateAndRetainedAttachment();
-        var options = new OfficeProvenanceRemovalOptions();
+        var options = new OfficeProvenanceRemovalOptions { MaxOutputBytes = 300 };
         options.Limits.MaxAssetBytes = pdf.LongLength + 1L;
         options.Limits.MaxManifestBytes = 512;
-        options.Limits.MaxExpandedContainerBytes = 300;
 
         InvalidDataException exception = Assert.Throws<InvalidDataException>(() => PdfProvenance.Remove(pdf, options));
 
-        Assert.Contains("expanded container limit", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("output limit", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -847,7 +846,7 @@ public sealed partial class PdfProvenanceTests {
         InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
             PdfPageExtractor.EnsureSerializedObjectWithinLimit(stream, context, 1024 * 1024));
 
-        Assert.Contains("expanded container limit", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("output limit", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfProvenanceTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfProvenanceTests.cs
@@ -23,14 +23,16 @@ public sealed partial class PdfProvenanceTests {
     public void ProvenanceGraphEditorForwardsCancellationIntoTheFullRewrite() {
         byte[] pdf = PdfDocument.Create().Paragraph(paragraph => paragraph.Text("Cancellation")).ToBytes();
         using var cancellation = new CancellationTokenSource();
+        PdfReadDocument document = PdfReadDocument.Open(pdf);
         cancellation.Cancel();
 
         Assert.Throws<OperationCanceledException>(() => PdfProvenanceGraphEditor.RemoveFileSpecifications(
             pdf,
             new HashSet<int> { int.MaxValue },
+            document,
             readOptions: null,
             maximumOutputBytes: pdf.LongLength * 2L,
-            cancellation.Token));
+            cancellationToken: cancellation.Token));
     }
 
     [Fact]

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfProvenanceTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfProvenanceTests.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Threading;
 using OfficeIMO.Pdf;
 using OfficeIMO.Provenance;
 using Xunit;
@@ -6,6 +7,20 @@ using Xunit;
 namespace OfficeIMO.Tests.Pdf;
 
 public sealed partial class PdfProvenanceTests {
+    [Fact]
+    public void ProvenanceGraphEditorForwardsCancellationIntoTheFullRewrite() {
+        byte[] pdf = PdfDocument.Create().Paragraph(paragraph => paragraph.Text("Cancellation")).ToBytes();
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        Assert.Throws<OperationCanceledException>(() => PdfProvenanceGraphEditor.RemoveFileSpecifications(
+            pdf,
+            new HashSet<int> { int.MaxValue },
+            readOptions: null,
+            maximumOutputBytes: pdf.LongLength * 2L,
+            cancellation.Token));
+    }
+
     [Fact]
     public void InspectAndRemoveUseTheExactC2paAssociatedFileProfile() {
         byte[] manifest = CreateManifestStore();

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfProvenanceTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfProvenanceTests.cs
@@ -8,6 +8,18 @@ namespace OfficeIMO.Tests.Pdf;
 
 public sealed partial class PdfProvenanceTests {
     [Fact]
+    public void ProvenanceReaderForwardsCancellationIntoPdfParsing() {
+        byte[] pdf = PdfDocument.Create().Paragraph(paragraph => paragraph.Text("Cancellation")).ToBytes();
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        Assert.Throws<OperationCanceledException>(() => PdfProvenance.OpenReadDocument(
+            pdf,
+            new PdfLoadOptions(),
+            cancellation.Token));
+    }
+
+    [Fact]
     public void ProvenanceGraphEditorForwardsCancellationIntoTheFullRewrite() {
         byte[] pdf = PdfDocument.Create().Paragraph(paragraph => paragraph.Text("Cancellation")).ToBytes();
         using var cancellation = new CancellationTokenSource();

--- a/OfficeIMO.Pdf/Manipulation/PdfDocumentObjectGraphRewriter.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfDocumentObjectGraphRewriter.cs
@@ -177,7 +177,7 @@ internal static class PdfDocumentObjectGraphRewriter {
         using var boundedOutput = new PdfBoundedWriteStream(
             output,
             maximumOutputBytes,
-            "The rewritten PDF exceeds the configured expanded container limit.");
+            "The rewritten PDF exceeds the configured output limit.");
         if (permanentFileId == null) {
             PdfFileAssembler.Assemble(
                 boundedOutput,
@@ -233,7 +233,7 @@ internal static class PdfDocumentObjectGraphRewriter {
 
     private static void ThrowIfOutputLimitExceeded(long observedBytes, long? maximumOutputBytes) {
         if (maximumOutputBytes.HasValue && observedBytes > maximumOutputBytes.Value) {
-            throw PdfOutputLimitErrors.Create("The rewritten PDF exceeds the configured expanded container limit.");
+            throw PdfOutputLimitErrors.Create("The rewritten PDF exceeds the configured output limit.");
         }
     }
 

--- a/OfficeIMO.Pdf/Manipulation/PdfDocumentObjectGraphRewriter.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfDocumentObjectGraphRewriter.cs
@@ -14,28 +14,70 @@ internal static class PdfDocumentObjectGraphRewriter {
         PdfStandardEncryptionOptions? outputEncryption,
         Func<Dictionary<int, PdfIndirectObject>, PdfDocumentSecurityInfo, int?>? mutateObjectGraph = null,
         long? maximumOutputBytes = null,
-        CancellationToken cancellationToken = default) {
+        CancellationToken cancellationToken = default) => RewriteCore(
+            sourcePdf,
+            sourceDocument: null,
+            sourceReadOptions,
+            outputEncryption,
+            mutateObjectGraph,
+            maximumOutputBytes,
+            cancellationToken);
+
+    internal static byte[] Rewrite(
+        byte[] sourcePdf,
+        PdfReadDocument sourceDocument,
+        PdfLoadOptions? sourceReadOptions,
+        PdfStandardEncryptionOptions? outputEncryption,
+        Func<Dictionary<int, PdfIndirectObject>, PdfDocumentSecurityInfo, int?>? mutateObjectGraph = null,
+        long? maximumOutputBytes = null,
+        CancellationToken cancellationToken = default) => RewriteCore(
+            sourcePdf,
+            sourceDocument,
+            sourceReadOptions,
+            outputEncryption,
+            mutateObjectGraph,
+            maximumOutputBytes,
+            cancellationToken);
+
+    private static byte[] RewriteCore(
+        byte[] sourcePdf,
+        PdfReadDocument? sourceDocument,
+        PdfLoadOptions? sourceReadOptions,
+        PdfStandardEncryptionOptions? outputEncryption,
+        Func<Dictionary<int, PdfIndirectObject>, PdfDocumentSecurityInfo, int?>? mutateObjectGraph,
+        long? maximumOutputBytes,
+        CancellationToken cancellationToken) {
         Guard.NotNull(sourcePdf, nameof(sourcePdf));
         cancellationToken.ThrowIfCancellationRequested();
         if (maximumOutputBytes <= 0L) throw new ArgumentOutOfRangeException(nameof(maximumOutputBytes));
 
-        PdfDocumentSecurityInfo security = PdfSyntax.ReadDocumentSecurityInfo(
-            sourcePdf,
-            sourceReadOptions,
-            includeParsedDetails: false,
-            cancellationToken: cancellationToken);
-        var parsed = PdfSyntax.ParseObjects(sourcePdf, sourceReadOptions, out _, out _, cancellationToken);
-        Dictionary<int, PdfIndirectObject> objects = parsed.Map;
-        security = PdfSyntax.ReadDocumentSecurityInfo(
-            sourcePdf,
-            objects,
-            parsed.TrailerRaw,
-            security,
-            sourceReadOptions,
-            cancellationToken);
+        PdfDocumentSecurityInfo security;
+        Dictionary<int, PdfIndirectObject> objects;
+        string trailerRaw;
+        if (sourceDocument is null) {
+            security = PdfSyntax.ReadDocumentSecurityInfo(
+                sourcePdf,
+                sourceReadOptions,
+                includeParsedDetails: false,
+                cancellationToken: cancellationToken);
+            var parsed = PdfSyntax.ParseObjects(sourcePdf, sourceReadOptions, out _, out _, cancellationToken);
+            objects = parsed.Map;
+            trailerRaw = parsed.TrailerRaw;
+            security = PdfSyntax.ReadDocumentSecurityInfo(
+                sourcePdf,
+                objects,
+                trailerRaw,
+                security,
+                sourceReadOptions,
+                cancellationToken);
+        } else {
+            objects = sourceDocument.Objects;
+            trailerRaw = sourceDocument.TrailerRaw;
+            security = sourceDocument.Security;
+        }
         cancellationToken.ThrowIfCancellationRequested();
         byte[]? permanentFileId = outputEncryption == null
-            ? PdfSyntax.ReadPermanentTrailerIdentifier(parsed.TrailerRaw)
+            ? PdfSyntax.ReadPermanentTrailerIdentifier(trailerRaw)
             : null;
         int rootObjectNumber = RequireRootObjectNumber(security, objects);
         int? infoObjectNumber = mutateObjectGraph is null

--- a/OfficeIMO.Pdf/Manipulation/PdfPageExtractor.Serialization.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageExtractor.Serialization.cs
@@ -94,7 +94,7 @@ internal static partial class PdfPageExtractor {
 
     internal static void EnsureSerializedObjectWithinLimit(PdfObject value, SerializationContext context, long maximumBytes) {
         if (maximumBytes < 0 || CountSerializedObjectBytes(value, context, maximumBytes) > maximumBytes) {
-            throw PdfOutputLimitErrors.Create("The rewritten PDF exceeds the configured expanded container limit.");
+            throw PdfOutputLimitErrors.Create("The rewritten PDF exceeds the configured output limit.");
         }
     }
 
@@ -104,12 +104,12 @@ internal static partial class PdfPageExtractor {
         int objectNumber,
         long maximumBytes) {
         if (maximumBytes < 0) {
-            throw PdfOutputLimitErrors.Create("The rewritten PDF exceeds the configured expanded container limit.");
+            throw PdfOutputLimitErrors.Create("The rewritten PDF exceeds the configured output limit.");
         }
         long total = CountSerializedObjectBytes(value, context, maximumBytes);
         total = AddCounted(total, objectNumber.ToString(CultureInfo.InvariantCulture).Length + 14L, maximumBytes);
         if (maximumBytes < 0 || total > maximumBytes) {
-            throw PdfOutputLimitErrors.Create("The rewritten PDF exceeds the configured expanded container limit.");
+            throw PdfOutputLimitErrors.Create("The rewritten PDF exceeds the configured output limit.");
         }
     }
 

--- a/OfficeIMO.Pdf/OfficeIMO.Pdf.csproj
+++ b/OfficeIMO.Pdf/OfficeIMO.Pdf.csproj
@@ -68,6 +68,8 @@
     <InternalsVisibleTo Include="OfficeIMO.Reader.Pdf" />
     <InternalsVisibleTo Include="OfficeIMO.Html.Pdf" />
     <InternalsVisibleTo Include="OfficeIMO.Html.Tests" />
+    <InternalsVisibleTo Include="OfficeIMO.Workflows" />
+    <InternalsVisibleTo Include="OfficeIMO.Workflows.Tests" />
     <InternalsVisibleTo Include="OfficeIMO.Markdown.Pdf" />
     <InternalsVisibleTo Include="OfficeIMO.Word.Pdf" />
     <InternalsVisibleTo Include="OfficeIMO.Excel.Pdf" />

--- a/OfficeIMO.Pdf/Provenance/PdfProvenance.cs
+++ b/OfficeIMO.Pdf/Provenance/PdfProvenance.cs
@@ -15,12 +15,15 @@ public static partial class PdfProvenance {
         Guard.NotNull(pdf, nameof(pdf));
         options ??= new OfficeProvenanceOptions();
         OfficeProvenanceBinary.ValidateLimits(options);
+        options.CancellationToken.ThrowIfCancellationRequested();
         if (pdf.LongLength > options.MaxAssetBytes) throw new InvalidDataException("The PDF exceeds the configured asset limit.");
 
         long maximumManifestBytes = GetMaximumManifestBytes(options);
         PdfLoadOptions effectiveReadOptions = CreateReadOptionsForInspection(options, readOptions);
         PdfReadDocument document = PdfReadDocument.Open(pdf, effectiveReadOptions);
+        options.CancellationToken.ThrowIfCancellationRequested();
         foreach (PdfOutputIntentInfo outputIntent in document.OutputIntents) {
+            options.CancellationToken.ThrowIfCancellationRequested();
             _ = outputIntent.DestinationOutputProfileSizeBytes;
             _ = outputIntent.DestinationOutputProfileDeviceClass;
         }
@@ -41,6 +44,7 @@ public static partial class PdfProvenance {
             allowedObjectNumbers: reachableObjectNumbers);
         var evidence = new List<OfficeProvenanceEvidence>();
         foreach (PdfExtractedAttachment attachment in attachments) {
+            options.CancellationToken.ThrowIfCancellationRequested();
             if (!IsCandidate(attachment)) continue;
             byte[] manifest = attachment.Bytes;
             if (manifest.LongLength > options.MaxManifestBytes) throw new InvalidDataException("A PDF provenance manifest exceeds the configured manifest limit.");
@@ -70,7 +74,7 @@ public static partial class PdfProvenance {
         PdfLoadOptions? readOptions = null) {
         if (string.IsNullOrWhiteSpace(filePath)) throw new ArgumentException("A file path is required.", nameof(filePath));
         options ??= new OfficeProvenanceOptions();
-        byte[] pdf = ReadBounded(filePath, options.MaxAssetBytes);
+        byte[] pdf = ReadBounded(filePath, options.MaxAssetBytes, options.CancellationToken);
         return Inspect(pdf, options, readOptions);
     }
 
@@ -82,6 +86,7 @@ public static partial class PdfProvenance {
         Guard.NotNull(pdf, nameof(pdf));
         options ??= new OfficeProvenanceRemovalOptions();
         OfficeProvenanceBinary.ValidateRemovalOptions(options);
+        options.Limits.CancellationToken.ThrowIfCancellationRequested();
         long maximumManifestBytes = Math.Min(
             options.Limits.MaxExpandedContainerBytes,
             MultiplySaturating(options.Limits.MaxManifestBytes, options.Limits.MaxCarriers));
@@ -103,6 +108,7 @@ public static partial class PdfProvenance {
         }
 
         PdfReadDocument document = PdfReadDocument.Open(pdf, effectiveReadOptions);
+        options.Limits.CancellationToken.ThrowIfCancellationRequested();
         HashSet<int> pageTreeObjectNumbers = CollectPageTreeObjectNumbers(document, options.Limits.MaxContainerEntries);
         _ = CollectAssociationProfile(
             document,
@@ -122,6 +128,7 @@ public static partial class PdfProvenance {
         var changes = new List<OfficeProvenanceChange>();
         int evidenceIndex = 0;
         for (int index = 0; index < attachments.Count; index++) {
+            options.Limits.CancellationToken.ThrowIfCancellationRequested();
             PdfExtractedAttachment attachment = attachments[index];
             if (!IsCandidate(attachment)) continue;
             OfficeProvenanceEvidence evidence = before.Evidence[evidenceIndex++];
@@ -145,6 +152,7 @@ public static partial class PdfProvenance {
         }
 
         PdfDocumentSecurityInfo security = PdfSyntax.ReadDocumentSecurityInfo(pdf, effectiveReadOptions);
+        options.Limits.CancellationToken.ThrowIfCancellationRequested();
         if (security.HasEncryption) {
             throw new InvalidOperationException("Provenance removal does not remove or replace PDF encryption. Decrypt the document through an explicit PDF security workflow first.");
         }
@@ -160,6 +168,7 @@ public static partial class PdfProvenance {
             removeFileSpecifications,
             effectiveReadOptions,
             options.EffectiveMaxOutputBytes);
+        options.Limits.CancellationToken.ThrowIfCancellationRequested();
         PdfLoadOptions outputReadOptions = PdfLoadOptions.WithMinimumInputBytes(effectiveReadOptions, output.LongLength);
         OfficeProvenanceOptions outputLimits = CreateOutputInspectionOptions(options.Limits, options.EffectiveMaxOutputBytes);
         OfficeProvenanceReport after = Inspect(output, outputLimits, outputReadOptions);
@@ -175,7 +184,7 @@ public static partial class PdfProvenance {
         if (string.IsNullOrWhiteSpace(inputPath)) throw new ArgumentException("An input path is required.", nameof(inputPath));
         if (string.IsNullOrWhiteSpace(outputPath)) throw new ArgumentException("An output path is required.", nameof(outputPath));
         options ??= new OfficeProvenanceRemovalOptions();
-        byte[] pdf = ReadBounded(inputPath, options.Limits.MaxAssetBytes);
+        byte[] pdf = ReadBounded(inputPath, options.Limits.MaxAssetBytes, options.Limits.CancellationToken);
         OfficeProvenanceRemovalResult result = Remove(pdf, options, readOptions);
         OfficeFileCommit.WriteAllBytes(Path.GetFullPath(outputPath), result.ToArray());
         return result;
@@ -283,6 +292,7 @@ public static partial class PdfProvenance {
         MaxCarriers = source.MaxCarriers,
         MaxContainerEntries = source.MaxContainerEntries,
         MaxExpandedContainerBytes = source.MaxExpandedContainerBytes,
+        CancellationToken = source.CancellationToken,
         ProcessEmbeddedAssets = source.ProcessEmbeddedAssets,
         MaxEmbeddedAssets = source.MaxEmbeddedAssets
     };
@@ -1116,8 +1126,8 @@ public static partial class PdfProvenance {
              _documentLevel.Contains(fileSpecObjectNumber) && _secondaryDocumentReferences.Contains(fileSpecObjectNumber));
     }
 
-    private static byte[] ReadBounded(string filePath, long maximumBytes) {
+    private static byte[] ReadBounded(string filePath, long maximumBytes, System.Threading.CancellationToken cancellationToken) {
         using var stream = File.OpenRead(Path.GetFullPath(filePath));
-        return OfficeProvenanceBinary.ReadBounded(stream, maximumBytes);
+        return OfficeProvenanceBinary.ReadBounded(stream, maximumBytes, cancellationToken);
     }
 }

--- a/OfficeIMO.Pdf/Provenance/PdfProvenance.cs
+++ b/OfficeIMO.Pdf/Provenance/PdfProvenance.cs
@@ -1,5 +1,6 @@
 using OfficeIMO.Core.Internal;
 using OfficeIMO.Provenance;
+using System.Threading;
 
 namespace OfficeIMO.Pdf;
 
@@ -20,7 +21,7 @@ public static partial class PdfProvenance {
 
         long maximumManifestBytes = GetMaximumManifestBytes(options);
         PdfLoadOptions effectiveReadOptions = CreateReadOptionsForInspection(options, readOptions);
-        PdfReadDocument document = PdfReadDocument.Open(pdf, effectiveReadOptions);
+        PdfReadDocument document = OpenReadDocument(pdf, effectiveReadOptions, options.CancellationToken);
         options.CancellationToken.ThrowIfCancellationRequested();
         foreach (PdfOutputIntentInfo outputIntent in document.OutputIntents) {
             options.CancellationToken.ThrowIfCancellationRequested();
@@ -41,7 +42,8 @@ public static partial class PdfProvenance {
             options.MaxCarriers,
             options.MaxContainerEntries,
             requireSuccessfulDecoding: true,
-            allowedObjectNumbers: reachableObjectNumbers);
+            allowedObjectNumbers: reachableObjectNumbers,
+            cancellationToken: options.CancellationToken);
         var evidence = new List<OfficeProvenanceEvidence>();
         foreach (PdfExtractedAttachment attachment in attachments) {
             options.CancellationToken.ThrowIfCancellationRequested();
@@ -107,7 +109,7 @@ public static partial class PdfProvenance {
                 false);
         }
 
-        PdfReadDocument document = PdfReadDocument.Open(pdf, effectiveReadOptions);
+        PdfReadDocument document = OpenReadDocument(pdf, effectiveReadOptions, options.Limits.CancellationToken);
         options.Limits.CancellationToken.ThrowIfCancellationRequested();
         HashSet<int> pageTreeObjectNumbers = CollectPageTreeObjectNumbers(document, options.Limits.MaxContainerEntries);
         _ = CollectAssociationProfile(
@@ -123,7 +125,8 @@ public static partial class PdfProvenance {
             options.Limits.MaxCarriers,
             options.Limits.MaxContainerEntries,
             requireSuccessfulDecoding: true,
-            allowedObjectNumbers: reachableObjectNumbers);
+            allowedObjectNumbers: reachableObjectNumbers,
+            cancellationToken: options.Limits.CancellationToken);
         var removeFileSpecifications = new HashSet<int>();
         var changes = new List<OfficeProvenanceChange>();
         int evidenceIndex = 0;
@@ -175,6 +178,12 @@ public static partial class PdfProvenance {
         OfficeProvenanceReport after = Inspect(output, outputLimits, outputReadOptions);
         return new OfficeProvenanceRemovalResult(output, before, after, changes.AsReadOnly(), true);
     }
+
+    internal static PdfReadDocument OpenReadDocument(
+        byte[] pdf,
+        PdfLoadOptions readOptions,
+        CancellationToken cancellationToken) =>
+        PdfReadDocument.Open(pdf, readOptions, cancellationToken);
 
     /// <summary>Removes selected provenance and atomically writes the resulting PDF.</summary>
     public static OfficeProvenanceRemovalResult RemoveFile(

--- a/OfficeIMO.Pdf/Provenance/PdfProvenance.cs
+++ b/OfficeIMO.Pdf/Provenance/PdfProvenance.cs
@@ -13,6 +13,14 @@ public static partial class PdfProvenance {
         byte[] pdf,
         OfficeProvenanceOptions? options = null,
         PdfLoadOptions? readOptions = null) {
+        return InspectCore(pdf, options, readOptions, out _);
+    }
+
+    private static OfficeProvenanceReport InspectCore(
+        byte[] pdf,
+        OfficeProvenanceOptions? options,
+        PdfLoadOptions? readOptions,
+        out PdfReadDocument document) {
         Guard.NotNull(pdf, nameof(pdf));
         options ??= new OfficeProvenanceOptions();
         OfficeProvenanceBinary.ValidateLimits(options);
@@ -21,7 +29,7 @@ public static partial class PdfProvenance {
 
         long maximumManifestBytes = GetMaximumManifestBytes(options);
         PdfLoadOptions effectiveReadOptions = CreateReadOptionsForInspection(options, readOptions);
-        PdfReadDocument document = OpenReadDocument(pdf, effectiveReadOptions, options.CancellationToken);
+        document = OpenReadDocument(pdf, effectiveReadOptions, options.CancellationToken);
         options.CancellationToken.ThrowIfCancellationRequested();
         foreach (PdfOutputIntentInfo outputIntent in document.OutputIntents) {
             options.CancellationToken.ThrowIfCancellationRequested();
@@ -66,7 +74,11 @@ public static partial class PdfProvenance {
                 valid,
                 manifest.LongLength));
         }
-        return new OfficeProvenanceReport(OfficeProvenanceAssetFormat.Pdf, evidence.AsReadOnly());
+        return new OfficeProvenanceReport(
+            OfficeProvenanceAssetFormat.Pdf,
+            evidence.AsReadOnly(),
+            diagnostics: null,
+            expandedInspectionBytes: document.DecodedStreamBudget.UsedBytes);
     }
 
     /// <summary>Inspects a bounded PDF file.</summary>
@@ -99,7 +111,7 @@ public static partial class PdfProvenance {
             options.Limits.MaxManifestBytes,
             maximumManifestBytes,
             readOptions);
-        OfficeProvenanceReport before = Inspect(pdf, options.Limits, effectiveReadOptions);
+        OfficeProvenanceReport before = InspectCore(pdf, options.Limits, effectiveReadOptions, out PdfReadDocument document);
         if (!options.RemoveC2paManifests || before.Evidence.Count == 0) {
             return new OfficeProvenanceRemovalResult(
                 OfficeProvenanceBinary.CloneForOutput(pdf, options.EffectiveMaxOutputBytes),
@@ -109,7 +121,6 @@ public static partial class PdfProvenance {
                 false);
         }
 
-        PdfReadDocument document = OpenReadDocument(pdf, effectiveReadOptions, options.Limits.CancellationToken);
         options.Limits.CancellationToken.ThrowIfCancellationRequested();
         HashSet<int> pageTreeObjectNumbers = CollectPageTreeObjectNumbers(document, options.Limits.MaxContainerEntries);
         _ = CollectAssociationProfile(
@@ -154,7 +165,7 @@ public static partial class PdfProvenance {
                 false);
         }
 
-        PdfDocumentSecurityInfo security = PdfSyntax.ReadDocumentSecurityInfo(pdf, effectiveReadOptions);
+        PdfDocumentSecurityInfo security = document.Security;
         options.Limits.CancellationToken.ThrowIfCancellationRequested();
         if (security.HasEncryption) {
             throw new InvalidOperationException("Provenance removal does not remove or replace PDF encryption. Decrypt the document through an explicit PDF security workflow first.");
@@ -169,12 +180,26 @@ public static partial class PdfProvenance {
         byte[] output = PdfProvenanceGraphEditor.RemoveFileSpecifications(
             pdf,
             removeFileSpecifications,
+            document,
             effectiveReadOptions,
             options.EffectiveMaxOutputBytes,
             options.Limits.CancellationToken);
         options.Limits.CancellationToken.ThrowIfCancellationRequested();
+        before = new OfficeProvenanceReport(
+            before.Format,
+            before.Evidence,
+            before.Diagnostics,
+            document.DecodedStreamBudget.UsedBytes);
         PdfLoadOptions outputReadOptions = PdfLoadOptions.WithMinimumInputBytes(effectiveReadOptions, output.LongLength);
-        OfficeProvenanceOptions outputLimits = CreateOutputInspectionOptions(options.Limits, options.EffectiveMaxOutputBytes);
+        long remainingExpandedBytes = options.Limits.MaxExpandedContainerBytes - before.ExpandedInspectionBytes;
+        if (remainingExpandedBytes <= 0L) {
+            throw new InvalidDataException(
+                "The PDF provenance removal exhausted the expanded-data limit before output validation.");
+        }
+        OfficeProvenanceOptions outputLimits = CreateOutputInspectionOptions(
+            options.Limits,
+            options.EffectiveMaxOutputBytes,
+            remainingExpandedBytes);
         OfficeProvenanceReport after = Inspect(output, outputLimits, outputReadOptions);
         return new OfficeProvenanceRemovalResult(output, before, after, changes.AsReadOnly(), true);
     }
@@ -296,12 +321,15 @@ public static partial class PdfProvenance {
         return result;
     }
 
-    private static OfficeProvenanceOptions CreateOutputInspectionOptions(OfficeProvenanceOptions source, long maximumOutputBytes) => new() {
+    private static OfficeProvenanceOptions CreateOutputInspectionOptions(
+        OfficeProvenanceOptions source,
+        long maximumOutputBytes,
+        long maximumExpandedContainerBytes) => new() {
         MaxAssetBytes = maximumOutputBytes,
         MaxManifestBytes = Math.Min(source.MaxManifestBytes, maximumOutputBytes),
         MaxCarriers = source.MaxCarriers,
         MaxContainerEntries = source.MaxContainerEntries,
-        MaxExpandedContainerBytes = source.MaxExpandedContainerBytes,
+        MaxExpandedContainerBytes = maximumExpandedContainerBytes,
         CancellationToken = source.CancellationToken,
         ProcessEmbeddedAssets = source.ProcessEmbeddedAssets,
         MaxEmbeddedAssets = source.MaxEmbeddedAssets

--- a/OfficeIMO.Pdf/Provenance/PdfProvenance.cs
+++ b/OfficeIMO.Pdf/Provenance/PdfProvenance.cs
@@ -94,7 +94,12 @@ public static partial class PdfProvenance {
             readOptions);
         OfficeProvenanceReport before = Inspect(pdf, options.Limits, effectiveReadOptions);
         if (!options.RemoveC2paManifests || before.Evidence.Count == 0) {
-            return new OfficeProvenanceRemovalResult((byte[])pdf.Clone(), before, before, Array.Empty<OfficeProvenanceChange>(), false);
+            return new OfficeProvenanceRemovalResult(
+                OfficeProvenanceBinary.CloneForOutput(pdf, options.EffectiveMaxOutputBytes),
+                before,
+                before,
+                Array.Empty<OfficeProvenanceChange>(),
+                false);
         }
 
         PdfReadDocument document = PdfReadDocument.Open(pdf, effectiveReadOptions);
@@ -131,7 +136,12 @@ public static partial class PdfProvenance {
                 removedBytes: 0));
         }
         if (removeFileSpecifications.Count == 0) {
-            return new OfficeProvenanceRemovalResult((byte[])pdf.Clone(), before, before, Array.Empty<OfficeProvenanceChange>(), false);
+            return new OfficeProvenanceRemovalResult(
+                OfficeProvenanceBinary.CloneForOutput(pdf, options.EffectiveMaxOutputBytes),
+                before,
+                before,
+                Array.Empty<OfficeProvenanceChange>(),
+                false);
         }
 
         PdfDocumentSecurityInfo security = PdfSyntax.ReadDocumentSecurityInfo(pdf, effectiveReadOptions);
@@ -149,9 +159,9 @@ public static partial class PdfProvenance {
             pdf,
             removeFileSpecifications,
             effectiveReadOptions,
-            options.Limits.MaxExpandedContainerBytes);
+            options.EffectiveMaxOutputBytes);
         PdfLoadOptions outputReadOptions = PdfLoadOptions.WithMinimumInputBytes(effectiveReadOptions, output.LongLength);
-        OfficeProvenanceOptions outputLimits = CreateOutputInspectionOptions(options.Limits, output.LongLength);
+        OfficeProvenanceOptions outputLimits = CreateOutputInspectionOptions(options.Limits, options.EffectiveMaxOutputBytes);
         OfficeProvenanceReport after = Inspect(output, outputLimits, outputReadOptions);
         return new OfficeProvenanceRemovalResult(output, before, after, changes.AsReadOnly(), true);
     }
@@ -267,9 +277,9 @@ public static partial class PdfProvenance {
         return result;
     }
 
-    private static OfficeProvenanceOptions CreateOutputInspectionOptions(OfficeProvenanceOptions source, long outputBytes) => new() {
-        MaxAssetBytes = Math.Max(source.MaxAssetBytes, outputBytes),
-        MaxManifestBytes = source.MaxManifestBytes,
+    private static OfficeProvenanceOptions CreateOutputInspectionOptions(OfficeProvenanceOptions source, long maximumOutputBytes) => new() {
+        MaxAssetBytes = maximumOutputBytes,
+        MaxManifestBytes = Math.Min(source.MaxManifestBytes, maximumOutputBytes),
         MaxCarriers = source.MaxCarriers,
         MaxContainerEntries = source.MaxContainerEntries,
         MaxExpandedContainerBytes = source.MaxExpandedContainerBytes,

--- a/OfficeIMO.Pdf/Provenance/PdfProvenance.cs
+++ b/OfficeIMO.Pdf/Provenance/PdfProvenance.cs
@@ -167,7 +167,8 @@ public static partial class PdfProvenance {
             pdf,
             removeFileSpecifications,
             effectiveReadOptions,
-            options.EffectiveMaxOutputBytes);
+            options.EffectiveMaxOutputBytes,
+            options.Limits.CancellationToken);
         options.Limits.CancellationToken.ThrowIfCancellationRequested();
         PdfLoadOptions outputReadOptions = PdfLoadOptions.WithMinimumInputBytes(effectiveReadOptions, output.LongLength);
         OfficeProvenanceOptions outputLimits = CreateOutputInspectionOptions(options.Limits, options.EffectiveMaxOutputBytes);

--- a/OfficeIMO.Pdf/Provenance/PdfProvenanceGraphEditor.cs
+++ b/OfficeIMO.Pdf/Provenance/PdfProvenanceGraphEditor.cs
@@ -6,16 +6,23 @@ internal static class PdfProvenanceGraphEditor {
     internal static byte[] RemoveFileSpecifications(
         byte[] pdf,
         HashSet<int> fileSpecificationObjectNumbers,
+        PdfReadDocument document,
         PdfLoadOptions? readOptions,
         long maximumOutputBytes,
         CancellationToken cancellationToken = default) {
         Guard.NotNull(pdf, nameof(pdf));
         Guard.NotNull(fileSpecificationObjectNumbers, nameof(fileSpecificationObjectNumbers));
+        Guard.NotNull(document, nameof(document));
         cancellationToken.ThrowIfCancellationRequested();
         if (fileSpecificationObjectNumbers.Count == 0) return (byte[])pdf.Clone();
-        _ = PdfMutationPlanner.RequireFullRewrite(pdf, PdfMutationOperation.ModifyAttachments, readOptions);
+        _ = PdfMutationPlanner.RequireFullRewriteDocument(
+            pdf,
+            PdfMutationOperation.ModifyAttachments,
+            document,
+            readOptions,
+            cancellationToken: cancellationToken);
         cancellationToken.ThrowIfCancellationRequested();
-        return PdfDocumentObjectGraphRewriter.Rewrite(pdf, readOptions, null, (objects, security) => {
+        return PdfDocumentObjectGraphRewriter.Rewrite(pdf, document, readOptions, null, (objects, security) => {
             cancellationToken.ThrowIfCancellationRequested();
             RemoveFromEmbeddedFilesNameTree(objects, security, fileSpecificationObjectNumbers, cancellationToken);
             HashSet<PdfDictionary> removedDirectAnnotations = CollectFileAttachmentAnnotations(

--- a/OfficeIMO.Pdf/Provenance/PdfProvenanceGraphEditor.cs
+++ b/OfficeIMO.Pdf/Provenance/PdfProvenanceGraphEditor.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+
 namespace OfficeIMO.Pdf;
 
 internal static class PdfProvenanceGraphEditor {
@@ -5,43 +7,53 @@ internal static class PdfProvenanceGraphEditor {
         byte[] pdf,
         HashSet<int> fileSpecificationObjectNumbers,
         PdfLoadOptions? readOptions,
-        long maximumOutputBytes) {
+        long maximumOutputBytes,
+        CancellationToken cancellationToken = default) {
         Guard.NotNull(pdf, nameof(pdf));
         Guard.NotNull(fileSpecificationObjectNumbers, nameof(fileSpecificationObjectNumbers));
+        cancellationToken.ThrowIfCancellationRequested();
         if (fileSpecificationObjectNumbers.Count == 0) return (byte[])pdf.Clone();
         _ = PdfMutationPlanner.RequireFullRewrite(pdf, PdfMutationOperation.ModifyAttachments, readOptions);
+        cancellationToken.ThrowIfCancellationRequested();
         return PdfDocumentObjectGraphRewriter.Rewrite(pdf, readOptions, null, (objects, security) => {
-            RemoveFromEmbeddedFilesNameTree(objects, security, fileSpecificationObjectNumbers);
+            cancellationToken.ThrowIfCancellationRequested();
+            RemoveFromEmbeddedFilesNameTree(objects, security, fileSpecificationObjectNumbers, cancellationToken);
             HashSet<PdfDictionary> removedDirectAnnotations = CollectFileAttachmentAnnotations(
-                objects, security, fileSpecificationObjectNumbers, out HashSet<int> removedAnnotationObjectNumbers);
+                objects, security, fileSpecificationObjectNumbers, out HashSet<int> removedAnnotationObjectNumbers, cancellationToken);
             var removedObjectNumbers = new HashSet<int>(fileSpecificationObjectNumbers);
             removedObjectNumbers.UnionWith(removedAnnotationObjectNumbers);
             var visited = new HashSet<PdfObject>();
             foreach (PdfIndirectObject item in objects.Values.ToArray()) {
-                ScrubReferences(objects, item.Value, removedObjectNumbers, removedDirectAnnotations, visited);
+                cancellationToken.ThrowIfCancellationRequested();
+                ScrubReferences(objects, item.Value, removedObjectNumbers, removedDirectAnnotations, visited, cancellationToken);
             }
             visited.Clear();
             foreach (PdfIndirectObject item in objects.Values.ToArray()) {
-                RemoveEmptyAssociatedFileReferences(objects, item.Value, visited);
+                cancellationToken.ThrowIfCancellationRequested();
+                RemoveEmptyAssociatedFileReferences(objects, item.Value, visited, cancellationToken);
             }
-            foreach (int objectNumber in removedObjectNumbers) objects.Remove(objectNumber);
+            foreach (int objectNumber in removedObjectNumbers) {
+                cancellationToken.ThrowIfCancellationRequested();
+                objects.Remove(objectNumber);
+            }
             return security.InfoObjectNumber.HasValue && objects.ContainsKey(security.InfoObjectNumber.Value)
                 ? security.InfoObjectNumber
                 : null;
-        }, maximumOutputBytes);
+        }, maximumOutputBytes, cancellationToken);
     }
 
     private static void RemoveFromEmbeddedFilesNameTree(
         Dictionary<int, PdfIndirectObject> objects,
         PdfDocumentSecurityInfo security,
-        HashSet<int> targets) {
+        HashSet<int> targets,
+        CancellationToken cancellationToken) {
         if (!security.RootObjectNumber.HasValue ||
             !objects.TryGetValue(security.RootObjectNumber.Value, out PdfIndirectObject? root) ||
             root.Value is not PdfDictionary catalog ||
             PdfObjectLookup.Resolve(objects, catalog.Items.TryGetValue("Names", out PdfObject? namesValue) ? namesValue : null) is not PdfDictionary names ||
             !names.Items.TryGetValue("EmbeddedFiles", out PdfObject? embeddedFiles)) return;
         if (PdfObjectLookup.Resolve(objects, embeddedFiles) is not PdfDictionary rootTree) return;
-        if (!PruneNameTree(objects, rootTree, targets)) {
+        if (!PruneNameTree(objects, rootTree, targets, cancellationToken)) {
             names.Items.Remove("EmbeddedFiles");
         }
     }
@@ -49,7 +61,8 @@ internal static class PdfProvenanceGraphEditor {
     private static bool PruneNameTree(
         Dictionary<int, PdfIndirectObject> objects,
         PdfObject value,
-        HashSet<int> targets) {
+        HashSet<int> targets,
+        CancellationToken cancellationToken) {
         PdfObject? root = PdfObjectLookup.Resolve(objects, value);
         if (root is not PdfDictionary rootDictionary) return false;
         var visited = new HashSet<PdfObject>();
@@ -58,6 +71,7 @@ internal static class PdfProvenanceGraphEditor {
         visited.Add(rootDictionary);
         pending.Push((rootDictionary, false));
         while (pending.Count > 0) {
+            cancellationToken.ThrowIfCancellationRequested();
             (PdfDictionary dictionary, bool expanded) = pending.Pop();
             if (!expanded) {
                 pending.Push((dictionary, true));
@@ -70,7 +84,7 @@ internal static class PdfProvenanceGraphEditor {
                 }
                 continue;
             }
-            results[dictionary] = PruneNameTreeDictionary(objects, dictionary, targets, results);
+            results[dictionary] = PruneNameTreeDictionary(objects, dictionary, targets, results, cancellationToken);
         }
         return results.TryGetValue(rootDictionary, out NameTreeResult result) && result.ShouldRetain;
     }
@@ -79,7 +93,8 @@ internal static class PdfProvenanceGraphEditor {
         Dictionary<int, PdfIndirectObject> objects,
         PdfDictionary dictionary,
         HashSet<int> targets,
-        Dictionary<PdfDictionary, NameTreeResult> results) {
+        Dictionary<PdfDictionary, NameTreeResult> results,
+        CancellationToken cancellationToken) {
         bool hadLimits = dictionary.Items.ContainsKey("Limits");
         bool changed = false;
         bool hasUnresolvedRetainedChild = false;
@@ -88,6 +103,7 @@ internal static class PdfProvenanceGraphEditor {
         if (PdfObjectLookup.Resolve(objects, dictionary.Items.TryGetValue("Names", out PdfObject? namesValue) ? namesValue : null) is PdfArray names) {
             int completePairCount = names.Items.Count / 2;
             for (int pair = completePairCount - 1; pair >= 0; pair--) {
+                cancellationToken.ThrowIfCancellationRequested();
                 int index = pair * 2;
                 if (!IsTargetReference(objects, names.Items[index], targets) &&
                     !IsTargetReference(objects, names.Items[index + 1], targets)) continue;
@@ -109,6 +125,7 @@ internal static class PdfProvenanceGraphEditor {
         }
         if (PdfObjectLookup.Resolve(objects, dictionary.Items.TryGetValue("Kids", out PdfObject? kidsValue) ? kidsValue : null) is PdfArray kids) {
             for (int index = kids.Items.Count - 1; index >= 0; index--) {
+                cancellationToken.ThrowIfCancellationRequested();
                 if (PdfObjectLookup.Resolve(objects, kids.Items[index]) is PdfDictionary child &&
                     results.TryGetValue(child, out NameTreeResult childResult) &&
                     childResult.WasChanged) {
@@ -117,6 +134,7 @@ internal static class PdfProvenanceGraphEditor {
                 }
             }
             foreach (PdfObject childValue in kids.Items) {
+                cancellationToken.ThrowIfCancellationRequested();
                 if (PdfObjectLookup.Resolve(objects, childValue) is not PdfDictionary child ||
                     !results.TryGetValue(child, out NameTreeResult childResult)) {
                     hasUnresolvedRetainedChild = true;
@@ -169,7 +187,8 @@ internal static class PdfProvenanceGraphEditor {
         Dictionary<int, PdfIndirectObject> objects,
         PdfDocumentSecurityInfo security,
         HashSet<int> targets,
-        out HashSet<int> indirectObjectNumbers) {
+        out HashSet<int> indirectObjectNumbers,
+        CancellationToken cancellationToken) {
         var annotations = new HashSet<PdfDictionary>();
         var activeAnnotations = new List<(PdfObject Value, PdfDictionary Dictionary)>();
         indirectObjectNumbers = new HashSet<int>();
@@ -179,6 +198,7 @@ internal static class PdfProvenanceGraphEditor {
         var visited = new HashSet<PdfObject>();
         pending.Push(pages);
         while (pending.Count > 0) {
+            cancellationToken.ThrowIfCancellationRequested();
             PdfObject current = pending.Pop();
             PdfObject? resolved = PdfObjectLookup.Resolve(objects, current);
             if (resolved is not PdfDictionary dictionary || !visited.Add(resolved)) continue;
@@ -201,7 +221,7 @@ internal static class PdfProvenanceGraphEditor {
                 }
             }
         }
-        CollectDependentAnnotations(objects, activeAnnotations, annotations, indirectObjectNumbers);
+        CollectDependentAnnotations(objects, activeAnnotations, annotations, indirectObjectNumbers, cancellationToken);
         return annotations;
     }
 
@@ -209,9 +229,11 @@ internal static class PdfProvenanceGraphEditor {
         Dictionary<int, PdfIndirectObject> objects,
         IReadOnlyList<(PdfObject Value, PdfDictionary Dictionary)> activeAnnotations,
         HashSet<PdfDictionary> annotations,
-        HashSet<int> indirectObjectNumbers) {
+        HashSet<int> indirectObjectNumbers,
+        CancellationToken cancellationToken) {
         var dependents = new Dictionary<PdfDictionary, List<(PdfDictionary Dictionary, int? ObjectNumber)>>();
         foreach ((PdfObject value, PdfDictionary dictionary) in activeAnnotations) {
+            cancellationToken.ThrowIfCancellationRequested();
             if (dictionary.Items.TryGetValue("IRT", out PdfObject? replyTo) &&
                 PdfObjectLookup.Resolve(objects, replyTo) is PdfDictionary replyParent) {
                 AddDependent(dependents, replyParent, dictionary, value is PdfReference replyReference ? replyReference.ObjectNumber : (int?)null);
@@ -222,6 +244,7 @@ internal static class PdfProvenanceGraphEditor {
             AddDependent(dependents, dictionary, popupDictionary, popup is PdfReference popupReference ? popupReference.ObjectNumber : (int?)null);
         }
         foreach (PdfIndirectObject item in objects.Values) {
+            cancellationToken.ThrowIfCancellationRequested();
             if (item.Value is not PdfDictionary dictionary ||
                 !string.Equals(GetResolvedName(objects, dictionary, "Subtype"), "Popup", StringComparison.Ordinal) ||
                 !dictionary.Items.TryGetValue("Parent", out PdfObject? parent) ||
@@ -231,6 +254,7 @@ internal static class PdfProvenanceGraphEditor {
 
         var pending = new Queue<PdfDictionary>(annotations);
         while (pending.Count > 0) {
+            cancellationToken.ThrowIfCancellationRequested();
             PdfDictionary parent = pending.Dequeue();
             if (!dependents.TryGetValue(parent, out List<(PdfDictionary Dictionary, int? ObjectNumber)>? children)) continue;
             foreach ((PdfDictionary dictionary, int? objectNumber) in children) {
@@ -293,15 +317,17 @@ internal static class PdfProvenanceGraphEditor {
         PdfObject value,
         HashSet<int> removedObjectNumbers,
         HashSet<PdfDictionary> removedDirectAnnotations,
-        HashSet<PdfObject> visited) {
+        HashSet<PdfObject> visited,
+        CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
         if (!visited.Add(value)) return;
         PdfDictionary? dictionary = value is PdfStream stream ? stream.Dictionary : value as PdfDictionary;
         if (dictionary != null) {
             foreach (string key in dictionary.Items.Keys.ToArray()) {
                 PdfObject child = dictionary.Items[key];
                 if ((key == "Names" || key == "Nums") && PdfObjectLookup.Resolve(objects, child) is PdfArray treePairs) {
-                    RemoveTreePairs(objects, treePairs, removedObjectNumbers, removedDirectAnnotations);
-                    ScrubReferences(objects, treePairs, removedObjectNumbers, removedDirectAnnotations, visited);
+                    RemoveTreePairs(objects, treePairs, removedObjectNumbers, removedDirectAnnotations, cancellationToken);
+                    ScrubReferences(objects, treePairs, removedObjectNumbers, removedDirectAnnotations, visited, cancellationToken);
                     if (treePairs.Items.Count == 0) dictionary.Items.Remove(key);
                     continue;
                 }
@@ -309,7 +335,7 @@ internal static class PdfProvenanceGraphEditor {
                     dictionary.Items.Remove(key);
                     continue;
                 }
-                if (child is not PdfReference) ScrubReferences(objects, child, removedObjectNumbers, removedDirectAnnotations, visited);
+                if (child is not PdfReference) ScrubReferences(objects, child, removedObjectNumbers, removedDirectAnnotations, visited, cancellationToken);
                 if (key == "AF" && child is PdfArray array && array.Items.Count == 0) {
                     dictionary.Items.Remove(key);
                 }
@@ -318,9 +344,10 @@ internal static class PdfProvenanceGraphEditor {
         }
         if (value is not PdfArray values) return;
         for (int index = values.Items.Count - 1; index >= 0; index--) {
+            cancellationToken.ThrowIfCancellationRequested();
             PdfObject child = values.Items[index];
             if (IsRemoved(objects, child, removedObjectNumbers, removedDirectAnnotations)) values.Items.RemoveAt(index);
-            else if (child is not PdfReference) ScrubReferences(objects, child, removedObjectNumbers, removedDirectAnnotations, visited);
+            else if (child is not PdfReference) ScrubReferences(objects, child, removedObjectNumbers, removedDirectAnnotations, visited, cancellationToken);
         }
     }
 
@@ -328,9 +355,11 @@ internal static class PdfProvenanceGraphEditor {
         Dictionary<int, PdfIndirectObject> objects,
         PdfArray names,
         HashSet<int> removedObjectNumbers,
-        HashSet<PdfDictionary> removedDirectAnnotations) {
+        HashSet<PdfDictionary> removedDirectAnnotations,
+        CancellationToken cancellationToken) {
         int completePairCount = names.Items.Count / 2;
         for (int pair = completePairCount - 1; pair >= 0; pair--) {
+            cancellationToken.ThrowIfCancellationRequested();
             int index = pair * 2;
             if (!IsRemoved(objects, names.Items[index], removedObjectNumbers, removedDirectAnnotations) &&
                 !IsRemoved(objects, names.Items[index + 1], removedObjectNumbers, removedDirectAnnotations)) continue;
@@ -356,7 +385,9 @@ internal static class PdfProvenanceGraphEditor {
     private static void RemoveEmptyAssociatedFileReferences(
         Dictionary<int, PdfIndirectObject> objects,
         PdfObject value,
-        HashSet<PdfObject> visited) {
+        HashSet<PdfObject> visited,
+        CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
         if (!visited.Add(value)) return;
         PdfDictionary? dictionary = value is PdfStream stream ? stream.Dictionary : value as PdfDictionary;
         if (dictionary != null) {
@@ -366,13 +397,14 @@ internal static class PdfProvenanceGraphEditor {
                     dictionary.Items.Remove(key);
                     continue;
                 }
-                if (child is not PdfReference) RemoveEmptyAssociatedFileReferences(objects, child, visited);
+                if (child is not PdfReference) RemoveEmptyAssociatedFileReferences(objects, child, visited, cancellationToken);
             }
             return;
         }
         if (value is not PdfArray array) return;
         foreach (PdfObject child in array.Items) {
-            if (child is not PdfReference) RemoveEmptyAssociatedFileReferences(objects, child, visited);
+            cancellationToken.ThrowIfCancellationRequested();
+            if (child is not PdfReference) RemoveEmptyAssociatedFileReferences(objects, child, visited, cancellationToken);
         }
     }
 }

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.Provenance.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.Provenance.cs
@@ -53,8 +53,9 @@ public sealed partial class PowerPointPresentation {
         return applicationProperties?.Properties?.DigitalSignature != null;
     }
 
-    private static OfficeProvenanceSignatureStripResult StripPackageSignatures(byte[] data, OfficeProvenanceOptions limits) {
-        using var stream = new MemoryStream(data.Length);
+    private static OfficeProvenanceSignatureStripResult StripPackageSignatures(byte[] data, OfficeProvenanceRemovalOptions options) {
+        OfficeProvenanceOptions limits = options.Limits;
+        using var stream = new OfficeProvenanceBoundedMemoryStream(options.EffectiveMaxOutputBytes, data.Length);
         stream.Write(data, 0, data.Length);
         stream.Position = 0;
         bool hadSignatures;

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.Provenance.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.Provenance.cs
@@ -55,7 +55,7 @@ public sealed partial class PowerPointPresentation {
 
     private static OfficeProvenanceSignatureStripResult StripPackageSignatures(byte[] data, OfficeProvenanceRemovalOptions options) {
         OfficeProvenanceOptions limits = options.Limits;
-        using var stream = new OfficeProvenanceBoundedMemoryStream(options.EffectiveMaxOutputBytes, data.Length);
+        using var stream = new OfficeProvenanceBoundedMemoryStream(options.EffectiveMaxIntermediateBytes, data.Length);
         stream.Write(data, 0, data.Length);
         stream.Position = 0;
         bool hadSignatures;

--- a/OfficeIMO.Provenance.C2pa.Tests/C2paToolProvenanceSignerTests.cs
+++ b/OfficeIMO.Provenance.C2pa.Tests/C2paToolProvenanceSignerTests.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.IO;
 using System.Text.Json;
+using System.Threading;
 using OfficeIMO.Provenance;
 
 namespace OfficeIMO.Provenance.C2pa.Tests;
@@ -225,7 +226,7 @@ public sealed class C2paToolProvenanceSignerTests {
         internal string ManifestPath { get; private set; } = string.Empty;
         internal string StagingPath { get; private set; } = string.Empty;
 
-        public C2paToolProcessResult Run(C2paToolProcessRequest request) {
+        public C2paToolProcessResult Run(C2paToolProcessRequest request, CancellationToken cancellationToken = default) {
             if (request.Arguments.SequenceEqual(new[] { "--version" })) {
                 VersionRequest = request;
                 return new C2paToolProcessResult(0, _version, string.Empty);
@@ -252,7 +253,7 @@ public sealed class C2paToolProvenanceSignerTests {
     }
 
     private sealed class UnavailableRunner : IC2paToolProcessRunner {
-        public C2paToolProcessResult Run(C2paToolProcessRequest request) =>
+        public C2paToolProcessResult Run(C2paToolProcessRequest request, CancellationToken cancellationToken = default) =>
             throw new Win32Exception("Executable not found.");
     }
 

--- a/OfficeIMO.Provenance.C2pa.Tests/C2paToolProvenanceVerifierTests.Wave79.cs
+++ b/OfficeIMO.Provenance.C2pa.Tests/C2paToolProvenanceVerifierTests.Wave79.cs
@@ -1,0 +1,79 @@
+using System.IO;
+using System.Threading;
+
+namespace OfficeIMO.Provenance.C2pa.Tests;
+
+public sealed class C2paToolProvenanceVerifierTestsWave79 {
+    [Fact]
+    public void InterpretationBudgetReturnsAtTheDeadlineWhenWorkDoesNotCooperate() {
+        using var release = new ManualResetEventSlim();
+        var budget = new C2paToolExecutionBudget(TimeSpan.FromMilliseconds(20), CancellationToken.None);
+        try {
+            Assert.Throws<TimeoutException>(() => budget.RunInterpretation<int>(_ => {
+                release.Wait();
+                return 0;
+            }));
+        } finally {
+            release.Set();
+        }
+    }
+
+    [Fact]
+    public void CancellationRemainsActiveAfterTheProviderProcessReturns() {
+        string asset = CreateAsset();
+        using var cancellation = new CancellationTokenSource();
+        try {
+            var verifier = new C2paToolProvenanceVerifier(
+                "c2patool",
+                new CallbackRunner(() => cancellation.Cancel()));
+
+            Assert.Throws<OperationCanceledException>(() => verifier.Verify(
+                asset,
+                new OfficeProvenanceVerificationOptions(),
+                cancellation.Token));
+        } finally {
+            File.Delete(asset);
+        }
+    }
+
+    [Fact]
+    public void ProviderTimeoutIncludesReportInterpretation() {
+        string asset = CreateAsset();
+        try {
+            var verifier = new C2paToolProvenanceVerifier(
+                "c2patool",
+                new CallbackRunner(() => Thread.Sleep(30)));
+
+            OfficeProvenanceVerificationResult result = verifier.Verify(
+                asset,
+                new OfficeProvenanceVerificationOptions { Timeout = TimeSpan.FromMilliseconds(10) });
+
+            Assert.Equal(OfficeProvenanceVerificationStatus.Error, result.Status);
+            Assert.Contains(result.Findings, finding => finding.Contains("interpretation", StringComparison.OrdinalIgnoreCase));
+        } finally {
+            File.Delete(asset);
+        }
+    }
+
+    private static string CreateAsset() {
+        string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".jpg");
+        File.WriteAllBytes(path, new byte[] { 0xFF, 0xD8, 0xFF, 0xD9 });
+        return path;
+    }
+
+    private sealed class CallbackRunner : IC2paToolProcessRunner {
+        private readonly Action _callback;
+
+        internal CallbackRunner(Action callback) => _callback = callback;
+
+        public C2paToolProcessResult Run(
+            C2paToolProcessRequest request,
+            CancellationToken cancellationToken = default) {
+            _callback();
+            return new C2paToolProcessResult(
+                0,
+                "{\"active_manifest\":\"urn:c2pa:test\",\"validation_status\":[]}",
+                string.Empty);
+        }
+    }
+}

--- a/OfficeIMO.Provenance.C2pa.Tests/C2paToolProvenanceVerifierTests.cs
+++ b/OfficeIMO.Provenance.C2pa.Tests/C2paToolProvenanceVerifierTests.cs
@@ -241,6 +241,32 @@ public sealed class C2paToolProvenanceVerifierTests {
     }
 
     [Fact]
+    public void ProcessRunnerCancelsAndTerminatesTheContainedProcess() {
+        string executable;
+        IReadOnlyList<string> arguments;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            executable = Environment.GetEnvironmentVariable("ComSpec") ?? "cmd.exe";
+            arguments = new[] { "/d", "/c", "ping 127.0.0.1 -n 6" };
+        } else {
+            executable = "/bin/sh";
+            arguments = new[] { "-c", "sleep 5" };
+        }
+        var request = new C2paToolProcessRequest(
+            executable,
+            arguments,
+            Path.GetTempPath(),
+            TimeSpan.FromSeconds(10),
+            1024 * 1024);
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+        var timer = Stopwatch.StartNew();
+
+        Assert.Throws<OperationCanceledException>(() =>
+            new C2paToolProcessRunner().Run(request, cancellation.Token));
+
+        Assert.True(timer.Elapsed < TimeSpan.FromSeconds(3), $"Runner blocked for {timer.Elapsed}.");
+    }
+
+    [Fact]
     public void UnixRunnerFailsClosedWithoutSetsid() {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
         string marker = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".orphan");
@@ -274,7 +300,7 @@ public sealed class C2paToolProvenanceVerifierTests {
         internal StubRunner(C2paToolProcessResult result) => _result = result;
         internal C2paToolProcessRequest? Request { get; private set; }
         internal string SettingsJson { get; private set; } = string.Empty;
-        public C2paToolProcessResult Run(C2paToolProcessRequest request) {
+        public C2paToolProcessResult Run(C2paToolProcessRequest request, CancellationToken cancellationToken = default) {
             Request = request;
             SettingsJson = File.ReadAllText(request.Arguments[2]);
             return _result;
@@ -282,7 +308,7 @@ public sealed class C2paToolProvenanceVerifierTests {
     }
 
     private sealed class ThrowingRunner : IC2paToolProcessRunner {
-        public C2paToolProcessResult Run(C2paToolProcessRequest request) =>
+        public C2paToolProcessResult Run(C2paToolProcessRequest request, CancellationToken cancellationToken = default) =>
             throw new Win32Exception("Executable not found.");
     }
 }

--- a/OfficeIMO.Provenance.C2pa.Tests/OfficeIMO.Provenance.C2pa.Tests.csproj
+++ b/OfficeIMO.Provenance.C2pa.Tests/OfficeIMO.Provenance.C2pa.Tests.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
     <Nullable>enable</Nullable>
     <LangVersion>Latest</LangVersion>
   </PropertyGroup>

--- a/OfficeIMO.Provenance.C2pa/C2paToolExecutionBudget.cs
+++ b/OfficeIMO.Provenance.C2pa/C2paToolExecutionBudget.cs
@@ -1,0 +1,59 @@
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OfficeIMO.Provenance.C2pa;
+
+/// <summary>Applies one cancellation and timeout budget across provider execution and report interpretation.</summary>
+internal sealed class C2paToolExecutionBudget {
+    private readonly CancellationToken _cancellationToken;
+    private readonly TimeSpan _timeout;
+    private readonly Stopwatch _stopwatch = Stopwatch.StartNew();
+
+    internal C2paToolExecutionBudget(TimeSpan timeout, CancellationToken cancellationToken) {
+        _timeout = timeout;
+        _cancellationToken = cancellationToken;
+    }
+
+    internal void ThrowIfExceeded() {
+        _cancellationToken.ThrowIfCancellationRequested();
+        if (_stopwatch.Elapsed >= _timeout) {
+            throw CreateTimeoutException();
+        }
+    }
+
+    internal TimeSpan GetRemainingTimeout() {
+        ThrowIfExceeded();
+        return _timeout - _stopwatch.Elapsed;
+    }
+
+    internal T RunInterpretation<T>(Func<CancellationToken, T> interpretation) {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(interpretation);
+#else
+        if (interpretation is null) throw new ArgumentNullException(nameof(interpretation));
+#endif
+        ThrowIfExceeded();
+        TimeSpan remaining = _timeout - _stopwatch.Elapsed;
+        using var interpretationCancellation = CancellationTokenSource.CreateLinkedTokenSource(_cancellationToken);
+        Task<T> work = Task.Run(() => interpretation(interpretationCancellation.Token), CancellationToken.None);
+        Task deadline = Task.Delay(remaining, interpretationCancellation.Token);
+        Task completed = Task.WhenAny(work, deadline).GetAwaiter().GetResult();
+        if (ReferenceEquals(completed, work)) {
+            interpretationCancellation.Cancel();
+            return work.GetAwaiter().GetResult();
+        }
+
+        interpretationCancellation.Cancel();
+        _ = work.ContinueWith(
+            static task => _ = task.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnFaulted,
+            TaskScheduler.Default);
+        _cancellationToken.ThrowIfCancellationRequested();
+        throw CreateTimeoutException();
+    }
+
+    private static TimeoutException CreateTimeoutException() =>
+        new("c2patool provider execution and report interpretation exceeded the configured timeout.");
+}

--- a/OfficeIMO.Provenance.C2pa/C2paToolProvenanceVerifier.cs
+++ b/OfficeIMO.Provenance.C2pa/C2paToolProvenanceVerifier.cs
@@ -15,7 +15,7 @@ namespace OfficeIMO.Provenance.C2pa;
 /// Provides optional C2PA content-binding, signature, and trust verification through the official
 /// <c>c2patool</c> command-line application. The executable is supplied by the host and is not bundled.
 /// </summary>
-public sealed class C2paToolProvenanceVerifier : IOfficeProvenanceVerifier {
+public sealed class C2paToolProvenanceVerifier : ICancellableOfficeProvenanceVerifier {
     private static readonly string[] NonObjectReportFinding = { "c2patool returned a non-object JSON report." };
     private static readonly string[] MalformedActiveManifestFinding = { "c2patool returned malformed active_manifest data." };
     private static readonly string[] DuplicateCriticalReportFieldFinding = { "c2patool returned duplicate security-critical report fields." };
@@ -56,8 +56,16 @@ public sealed class C2paToolProvenanceVerifier : IOfficeProvenanceVerifier {
     /// <inheritdoc />
     public OfficeProvenanceVerificationResult Verify(
         string filePath,
-        OfficeProvenanceVerificationOptions? options = null,
-        CancellationToken cancellationToken = default) {
+        OfficeProvenanceVerificationOptions? options = null) => Verify(
+            filePath,
+            options,
+            CancellationToken.None);
+
+    /// <inheritdoc />
+    public OfficeProvenanceVerificationResult Verify(
+        string filePath,
+        OfficeProvenanceVerificationOptions? options,
+        CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
         if (string.IsNullOrWhiteSpace(filePath)) throw new ArgumentException("An asset path is required.", nameof(filePath));
         string fullPath = Path.GetFullPath(filePath);

--- a/OfficeIMO.Provenance.C2pa/C2paToolProvenanceVerifier.cs
+++ b/OfficeIMO.Provenance.C2pa/C2paToolProvenanceVerifier.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using OfficeIMO.Provenance;
 
@@ -53,7 +54,11 @@ public sealed class C2paToolProvenanceVerifier : IOfficeProvenanceVerifier {
     public string Name => "c2patool";
 
     /// <inheritdoc />
-    public OfficeProvenanceVerificationResult Verify(string filePath, OfficeProvenanceVerificationOptions? options = null) {
+    public OfficeProvenanceVerificationResult Verify(
+        string filePath,
+        OfficeProvenanceVerificationOptions? options = null,
+        CancellationToken cancellationToken = default) {
+        cancellationToken.ThrowIfCancellationRequested();
         if (string.IsNullOrWhiteSpace(filePath)) throw new ArgumentException("An asset path is required.", nameof(filePath));
         string fullPath = Path.GetFullPath(filePath);
         if (!File.Exists(fullPath)) throw new FileNotFoundException("The asset to verify was not found.", fullPath);
@@ -62,6 +67,7 @@ public sealed class C2paToolProvenanceVerifier : IOfficeProvenanceVerifier {
 
         string settingsPath = Path.Combine(Path.GetTempPath(), ".officeimo-c2pa-" + Guid.NewGuid().ToString("N") + ".json");
         try {
+            cancellationToken.ThrowIfCancellationRequested();
             File.WriteAllText(settingsPath, CreateSettings(options.AllowNetworkAccess), new UTF8Encoding(false));
             string workingDirectory = Path.GetDirectoryName(fullPath) ?? Directory.GetCurrentDirectory();
             var request = new C2paToolProcessRequest(
@@ -72,7 +78,7 @@ public sealed class C2paToolProvenanceVerifier : IOfficeProvenanceVerifier {
                 options.MaxReportBytes);
             C2paToolProcessResult processResult;
             try {
-                processResult = _runner.Run(request);
+                processResult = _runner.Run(request, cancellationToken);
             } catch (Win32Exception exception) {
                 return Result(OfficeProvenanceVerificationStatus.ProviderUnavailable, new[] { exception.Message }, null, options);
             } catch (TimeoutException exception) {
@@ -284,7 +290,7 @@ public sealed class C2paToolProvenanceVerifier : IOfficeProvenanceVerifier {
 }
 
 internal interface IC2paToolProcessRunner {
-    C2paToolProcessResult Run(C2paToolProcessRequest request);
+    C2paToolProcessResult Run(C2paToolProcessRequest request, CancellationToken cancellationToken = default);
 }
 
 internal sealed class C2paToolProcessRequest {
@@ -321,7 +327,10 @@ internal sealed class C2paToolProcessRunner : IC2paToolProcessRunner {
         _useExternalUnixSessionLauncher = useExternalUnixSessionLauncher;
     }
 
-    public C2paToolProcessResult Run(C2paToolProcessRequest request) {
+    public C2paToolProcessResult Run(
+        C2paToolProcessRequest request,
+        CancellationToken cancellationToken = default) {
+        cancellationToken.ThrowIfCancellationRequested();
         string targetExecutable = ResolveUnixExecutable(request.ExecutablePath, request.WorkingDirectory);
         string executable = targetExecutable;
         string arguments = string.Join(" ", request.Arguments.Select(QuoteArgument));
@@ -352,6 +361,7 @@ internal sealed class C2paToolProcessRunner : IC2paToolProcessRunner {
         Stopwatch timer = Stopwatch.StartNew();
         while (true) {
             if (process.WaitForExit(50)) break;
+            ThrowIfCancellationRequested(process, containment, cancellationToken);
             if (stdout.IsFaulted || stderr.IsFaulted) {
                 Terminate(process, containment);
                 throw stdout.Exception?.GetBaseException() ?? stderr.Exception?.GetBaseException() ?? new InvalidDataException("c2patool output failed.");
@@ -362,15 +372,31 @@ internal sealed class C2paToolProcessRunner : IC2paToolProcessRunner {
             }
         }
         try {
-            TimeSpan remaining = request.Timeout - timer.Elapsed;
-            if (remaining <= TimeSpan.Zero || !Task.WaitAll(new Task[] { stdout, stderr }, remaining)) {
-                Terminate(process, containment);
-                throw new TimeoutException($"c2patool exceeded the configured timeout of {request.Timeout}.");
+            var outputTasks = new Task[] { stdout, stderr };
+            while (true) {
+                TimeSpan remaining = request.Timeout - timer.Elapsed;
+                if (remaining <= TimeSpan.Zero) {
+                    Terminate(process, containment);
+                    throw new TimeoutException($"c2patool exceeded the configured timeout of {request.Timeout}.");
+                }
+                int waitMilliseconds = (int)Math.Min(50D, Math.Ceiling(remaining.TotalMilliseconds));
+                if (Task.WaitAll(outputTasks, waitMilliseconds, CancellationToken.None)) break;
+                ThrowIfCancellationRequested(process, containment, cancellationToken);
             }
         } catch (AggregateException exception) {
             throw exception.GetBaseException();
         }
+        cancellationToken.ThrowIfCancellationRequested();
         return new C2paToolProcessResult(process.ExitCode, stdout.Result, stderr.Result);
+    }
+
+    private static void ThrowIfCancellationRequested(
+        Process process,
+        C2paToolProcessContainment containment,
+        CancellationToken cancellationToken) {
+        if (!cancellationToken.IsCancellationRequested) return;
+        Terminate(process, containment);
+        cancellationToken.ThrowIfCancellationRequested();
     }
 
     internal static Task<string> ReadBoundedAsync(Stream stream, long maximumBytes, string streamName) => Task.Run(() => {

--- a/OfficeIMO.Provenance.C2pa/C2paToolProvenanceVerifier.cs
+++ b/OfficeIMO.Provenance.C2pa/C2paToolProvenanceVerifier.cs
@@ -72,6 +72,7 @@ public sealed class C2paToolProvenanceVerifier : ICancellableOfficeProvenanceVer
         if (!File.Exists(fullPath)) throw new FileNotFoundException("The asset to verify was not found.", fullPath);
         options ??= new OfficeProvenanceVerificationOptions();
         Validate(options);
+        var executionBudget = new C2paToolExecutionBudget(options.Timeout, cancellationToken);
 
         string settingsPath = Path.Combine(Path.GetTempPath(), ".officeimo-c2pa-" + Guid.NewGuid().ToString("N") + ".json");
         try {
@@ -82,11 +83,13 @@ public sealed class C2paToolProvenanceVerifier : ICancellableOfficeProvenanceVer
                 ExecutablePath,
                 BuildArguments(fullPath, settingsPath, workingDirectory, options),
                 workingDirectory,
-                options.Timeout,
+                executionBudget.GetRemainingTimeout(),
                 options.MaxReportBytes);
             C2paToolProcessResult processResult;
             try {
                 processResult = _runner.Run(request, cancellationToken);
+                return executionBudget.RunInterpretation(
+                    interpretationToken => Interpret(processResult, options, interpretationToken));
             } catch (Win32Exception exception) {
                 return Result(OfficeProvenanceVerificationStatus.ProviderUnavailable, new[] { exception.Message }, null, options);
             } catch (TimeoutException exception) {
@@ -98,14 +101,17 @@ public sealed class C2paToolProvenanceVerifier : ICancellableOfficeProvenanceVer
             } catch (InvalidOperationException exception) {
                 return Result(OfficeProvenanceVerificationStatus.Error, new[] { exception.Message }, null, options);
             }
-            return Interpret(processResult, options);
         } finally {
             try { if (File.Exists(settingsPath)) File.Delete(settingsPath); } catch (IOException) { }
             catch (UnauthorizedAccessException) { }
         }
     }
 
-    private static OfficeProvenanceVerificationResult Interpret(C2paToolProcessResult process, OfficeProvenanceVerificationOptions options) {
+    private static OfficeProvenanceVerificationResult Interpret(
+        C2paToolProcessResult process,
+        OfficeProvenanceVerificationOptions options,
+        CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
         if (string.IsNullOrWhiteSpace(process.StandardOutput)) {
             string message = string.IsNullOrWhiteSpace(process.StandardError)
                 ? $"c2patool exited with code {process.ExitCode} without a JSON report."
@@ -118,12 +124,13 @@ public sealed class C2paToolProvenanceVerifier : ICancellableOfficeProvenanceVer
                 CommentHandling = JsonCommentHandling.Disallow,
                 MaxDepth = 128
             });
+            cancellationToken.ThrowIfCancellationRequested();
             if (document.RootElement.ValueKind != JsonValueKind.Object) {
                 return Result(OfficeProvenanceVerificationStatus.Error,
                     NonObjectReportFinding, process.StandardOutput, options);
             }
-            if (!TryGetUniqueProperty(document.RootElement, "active_manifest", out JsonElement activeManifestElement, out bool hasActiveManifest) ||
-                !TryGetUniqueProperty(document.RootElement, "validation_status", out JsonElement validationStatus, out bool hasValidationStatus)) {
+            if (!TryGetUniqueProperty(document.RootElement, "active_manifest", cancellationToken, out JsonElement activeManifestElement, out bool hasActiveManifest) ||
+                !TryGetUniqueProperty(document.RootElement, "validation_status", cancellationToken, out JsonElement validationStatus, out bool hasValidationStatus)) {
                 return Result(OfficeProvenanceVerificationStatus.Error,
                     DuplicateCriticalReportFieldFinding, process.StandardOutput, options);
             }
@@ -148,7 +155,7 @@ public sealed class C2paToolProvenanceVerifier : ICancellableOfficeProvenanceVer
             var findings = new List<string>();
             var findingSet = new HashSet<string>(StringComparer.Ordinal);
             if (hasValidationStatus &&
-                !TryCollectValidationFindings(validationStatus, findings, findingSet)) {
+                !TryCollectValidationFindings(validationStatus, findings, findingSet, cancellationToken)) {
                 findings.Add("c2patool returned malformed validation_status data.");
                 return Result(OfficeProvenanceVerificationStatus.Error, findings, process.StandardOutput, options);
             }
@@ -188,13 +195,18 @@ public sealed class C2paToolProvenanceVerifier : ICancellableOfficeProvenanceVer
         }
     }
 
-    private static bool TryCollectValidationFindings(JsonElement validationStatus, List<string> findings, HashSet<string> findingSet) {
+    private static bool TryCollectValidationFindings(
+        JsonElement validationStatus,
+        List<string> findings,
+        HashSet<string> findingSet,
+        CancellationToken cancellationToken) {
         if (validationStatus.ValueKind != JsonValueKind.Array) return false;
         foreach (JsonElement status in validationStatus.EnumerateArray()) {
+            cancellationToken.ThrowIfCancellationRequested();
             if (status.ValueKind != JsonValueKind.Object) return false;
-            if (!TryGetUniqueProperty(status, "code", out JsonElement codeElement, out bool hasCode) ||
-                !TryGetUniqueProperty(status, "explanation", out JsonElement explanationElement, out bool hasExplanation) ||
-                !TryGetUniqueProperty(status, "success", out JsonElement successElement, out bool hasSuccess)) return false;
+            if (!TryGetUniqueProperty(status, "code", cancellationToken, out JsonElement codeElement, out bool hasCode) ||
+                !TryGetUniqueProperty(status, "explanation", cancellationToken, out JsonElement explanationElement, out bool hasExplanation) ||
+                !TryGetUniqueProperty(status, "success", cancellationToken, out JsonElement successElement, out bool hasSuccess)) return false;
             if (!hasCode || codeElement.ValueKind != JsonValueKind.String ||
                 hasExplanation && explanationElement.ValueKind != JsonValueKind.String ||
                 hasSuccess && successElement.ValueKind is not JsonValueKind.True and not JsonValueKind.False) return false;
@@ -215,11 +227,13 @@ public sealed class C2paToolProvenanceVerifier : ICancellableOfficeProvenanceVer
     private static bool TryGetUniqueProperty(
         JsonElement element,
         string propertyName,
+        CancellationToken cancellationToken,
         out JsonElement value,
         out bool found) {
         value = default;
         found = false;
         foreach (JsonProperty property in element.EnumerateObject()) {
+            cancellationToken.ThrowIfCancellationRequested();
             if (!string.Equals(property.Name, propertyName, StringComparison.Ordinal)) continue;
             if (found) return false;
             value = property.Value;

--- a/OfficeIMO.Shared.Tests/ContentSafetyContracts.cs
+++ b/OfficeIMO.Shared.Tests/ContentSafetyContracts.cs
@@ -180,6 +180,25 @@ public sealed class ContentSafetyContracts {
     }
 
     [Fact]
+    public void SignatureHandlingUsesTheContentCleanupResourcePolicy() {
+        var cleanup = new OfficeContentCleanupOptions {
+            SignatureMutationPolicy = OfficeSignatureMutationPolicy.RemoveInvalidatedSignatures
+        };
+        cleanup.Inspection.MaxInputBytes = 768L * 1024L * 1024L;
+        cleanup.Inspection.MaxPackageEntries = 1234;
+        cleanup.Inspection.MaxExpandedPackageBytes = 1536L * 1024L * 1024L;
+
+        OfficeProvenanceRemovalOptions provenance =
+            OfficeContentSafetyProvenanceOptions.CreateSignatureRemovalOptions(cleanup);
+
+        Assert.Equal(cleanup.SignatureMutationPolicy, provenance.SignatureMutationPolicy);
+        Assert.Equal(cleanup.Inspection.MaxInputBytes, provenance.Limits.MaxAssetBytes);
+        Assert.Equal(cleanup.Inspection.MaxInputBytes, provenance.MaxOutputBytes);
+        Assert.Equal(cleanup.Inspection.MaxPackageEntries, provenance.Limits.MaxContainerEntries);
+        Assert.Equal(cleanup.Inspection.MaxExpandedPackageBytes, provenance.Limits.MaxExpandedContainerBytes);
+    }
+
+    [Fact]
     public void ZeroWidthCleanupIsSelectiveAndDoesNotTreatJoinersAsAiProof() {
         const string text = "pay\u200Bload and family \U0001F469\u200D\U0001F4BB";
         OfficeTextIntegrityReport report = OfficeTextIntegrityInspector.Inspect(text);

--- a/OfficeIMO.Shared.Tests/ProvenanceAssessmentContracts.cs
+++ b/OfficeIMO.Shared.Tests/ProvenanceAssessmentContracts.cs
@@ -24,7 +24,7 @@ public sealed class ProvenanceAssessmentContracts {
                 Assert.Equal(
                     UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute,
                     File.GetUnixFileMode(snapshotDirectory));
-                Assert.Equal("snapshot.txt", Path.GetFileName(snapshotPath));
+                Assert.Equal(Path.GetFileName(source), Path.GetFileName(snapshotPath));
             }
             Assert.False(File.Exists(snapshotPath));
             Assert.False(Directory.Exists(snapshotDirectory));

--- a/OfficeIMO.Shared.Tests/ProvenanceAssessmentContracts.cs
+++ b/OfficeIMO.Shared.Tests/ProvenanceAssessmentContracts.cs
@@ -391,7 +391,10 @@ public sealed class ProvenanceAssessmentContracts {
     private sealed class StubVerifier : IOfficeProvenanceVerifier {
         public string Name => "stub-verifier";
         internal OfficeProvenanceVerificationOptions? Options { get; private set; }
-        public OfficeProvenanceVerificationResult Verify(string filePath, OfficeProvenanceVerificationOptions? options = null) =>
+        public OfficeProvenanceVerificationResult Verify(
+            string filePath,
+            OfficeProvenanceVerificationOptions? options = null,
+            CancellationToken cancellationToken = default) =>
             Create(options);
 
         private OfficeProvenanceVerificationResult Create(OfficeProvenanceVerificationOptions? options) {
@@ -405,7 +408,10 @@ public sealed class ProvenanceAssessmentContracts {
 
     private sealed class InconsistentVerifier : IOfficeProvenanceVerifier {
         public string Name => "expected";
-        public OfficeProvenanceVerificationResult Verify(string filePath, OfficeProvenanceVerificationOptions? options = null) =>
+        public OfficeProvenanceVerificationResult Verify(
+            string filePath,
+            OfficeProvenanceVerificationOptions? options = null,
+            CancellationToken cancellationToken = default) =>
             new OfficeProvenanceVerificationResult(
                 OfficeProvenanceVerificationStatus.Valid,
                 "different",
@@ -421,14 +427,14 @@ public sealed class ProvenanceAssessmentContracts {
         }
         public string Name { get; }
         public OfficeProvenanceSignalKind SignalKind { get; }
-        public OfficeProvenanceSignalResult Detect(string filePath) =>
+        public OfficeProvenanceSignalResult Detect(string filePath, CancellationToken cancellationToken = default) =>
             new OfficeProvenanceSignalResult(Name, SignalKind, _status);
     }
 
     private sealed class InconsistentDetector : IOfficeProvenanceSignalDetector {
         public string Name => "expected";
         public OfficeProvenanceSignalKind SignalKind => OfficeProvenanceSignalKind.DurableMediaWatermark;
-        public OfficeProvenanceSignalResult Detect(string filePath) =>
+        public OfficeProvenanceSignalResult Detect(string filePath, CancellationToken cancellationToken = default) =>
             new OfficeProvenanceSignalResult(
                 "different",
                 OfficeProvenanceSignalKind.DurableMediaWatermark,
@@ -444,7 +450,7 @@ public sealed class ProvenanceAssessmentContracts {
         public OfficeProvenanceSignalKind SignalKind => OfficeProvenanceSignalKind.DeterministicArtifact;
         internal string? ObservedPath { get; private set; }
 
-        public OfficeProvenanceSignalResult Detect(string filePath) {
+        public OfficeProvenanceSignalResult Detect(string filePath, CancellationToken cancellationToken = default) {
             ObservedPath = Path.GetFullPath(filePath);
             File.WriteAllText(_originalPath, "replacement", new UTF8Encoding(false));
             bool detected = File.ReadAllText(filePath).Contains("original marker", StringComparison.Ordinal);
@@ -463,7 +469,7 @@ public sealed class ProvenanceAssessmentContracts {
         public string Name => "snapshot-replacing";
         public OfficeProvenanceSignalKind SignalKind => OfficeProvenanceSignalKind.DeterministicArtifact;
 
-        public OfficeProvenanceSignalResult Detect(string filePath) {
+        public OfficeProvenanceSignalResult Detect(string filePath, CancellationToken cancellationToken = default) {
             string replacement = filePath + ".replacement";
             File.WriteAllText(replacement, "replacement", new UTF8Encoding(false));
             File.Move(replacement, filePath, overwrite: true);
@@ -483,7 +489,7 @@ public sealed class ProvenanceAssessmentContracts {
         public string Name => "cancelling";
         public OfficeProvenanceSignalKind SignalKind => OfficeProvenanceSignalKind.DeterministicArtifact;
 
-        public OfficeProvenanceSignalResult Detect(string filePath) {
+        public OfficeProvenanceSignalResult Detect(string filePath, CancellationToken cancellationToken = default) {
             _cancellation.Cancel();
             return new OfficeProvenanceSignalResult(Name, SignalKind, OfficeProvenanceSignalStatus.NotDetected);
         }

--- a/OfficeIMO.Shared.Tests/ProvenanceAssessmentContracts.cs
+++ b/OfficeIMO.Shared.Tests/ProvenanceAssessmentContracts.cs
@@ -25,6 +25,10 @@ public sealed class ProvenanceAssessmentContracts {
                     UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute,
                     File.GetUnixFileMode(snapshotDirectory));
                 Assert.Equal(Path.GetFileName(source), Path.GetFileName(snapshotPath));
+                snapshot.SealForProviderAccess();
+                Assert.Equal(
+                    UnixFileMode.UserRead | UnixFileMode.UserExecute,
+                    File.GetUnixFileMode(snapshotDirectory));
             }
             Assert.False(File.Exists(snapshotPath));
             Assert.False(Directory.Exists(snapshotDirectory));
@@ -330,6 +334,27 @@ public sealed class ProvenanceAssessmentContracts {
     }
 
     [Fact]
+    public void CoreHtmlInspectionExcludesTemplateContentsFromHeadAssociations() {
+        byte[] html = Encoding.UTF8.GetBytes(
+            "<html><head><template><link rel=\"c2pa-manifest\" href=\"ignored.c2pa\"></template>" +
+            "<link rel=\"c2pa-manifest\" href=\"claim.c2pa\"></head></html>");
+
+        OfficeProvenanceReport report = OfficeProvenanceInspector.Inspect(html, "page.html");
+
+        Assert.Equal("claim.c2pa", Assert.Single(report.Evidence).Value);
+    }
+
+    [Fact]
+    public void CoreHtmlInspectionRejectsWhitespaceAfterATagOpener() {
+        byte[] html = Encoding.UTF8.GetBytes(
+            "<html><head>< link rel=\"c2pa-manifest\" href=\"claim.c2pa\"></head></html>");
+
+        OfficeProvenanceReport report = OfficeProvenanceInspector.Inspect(html, "page.html");
+
+        Assert.Empty(report.Evidence);
+    }
+
+    [Fact]
     public void CoreHtmlInspectionKeepsManifestLinksInAnImplicitHeadAfterDoctype() {
         byte[] html = Encoding.UTF8.GetBytes(
             "<!doctype html><html><link rel=\"c2pa-manifest\" href=\"claim.c2pa\"><body>body</body></html>");
@@ -460,6 +485,30 @@ public sealed class ProvenanceAssessmentContracts {
             Assert.Throws<InvalidDataException>(() => OfficeProvenanceAssessment.InspectFile(
                 path,
                 signalDetectors: [new SnapshotReplacingDetector()]));
+        } finally {
+            File.Delete(path);
+        }
+#endif
+    }
+
+    [Fact]
+    public void AssessmentPreventsProviderSnapshotSwapAndRestore() {
+#if NET8_0_OR_GREATER
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
+        string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".txt");
+        File.WriteAllText(path, "original", new UTF8Encoding(false));
+        var detector = new SnapshotSwapRestoreDetector();
+        try {
+            OfficeProvenanceAssessmentReport report = OfficeProvenanceAssessment.InspectFile(
+                path,
+                signalDetectors: [detector]);
+
+            Assert.True(detector.NamespaceWriteBlocked);
+            Assert.False(detector.ObservedReplacement);
+            Assert.Equal(
+                UnixFileMode.UserRead | UnixFileMode.UserExecute,
+                detector.ObservedDirectoryMode);
+            Assert.Single(report.ProviderSignals);
         } finally {
             File.Delete(path);
         }
@@ -715,13 +764,44 @@ public sealed class ProvenanceAssessmentContracts {
         public OfficeProvenanceSignalKind SignalKind => OfficeProvenanceSignalKind.DeterministicArtifact;
 
         public OfficeProvenanceSignalResult Detect(string filePath) {
-            string replacement = filePath + ".replacement";
-            File.WriteAllText(replacement, "replacement", new UTF8Encoding(false));
-            File.Move(replacement, filePath, overwrite: true);
+            try {
+                string replacement = filePath + ".replacement";
+                File.WriteAllText(replacement, "replacement", new UTF8Encoding(false));
+                File.Move(replacement, filePath, overwrite: true);
+            } catch (Exception exception) when (exception is IOException or UnauthorizedAccessException) {
+                throw new InvalidDataException("The sealed snapshot namespace rejected provider mutation.", exception);
+            }
             return new OfficeProvenanceSignalResult(
                 Name,
                 SignalKind,
                 OfficeProvenanceSignalStatus.Detected);
+        }
+    }
+
+    private sealed class SnapshotSwapRestoreDetector : IOfficeProvenanceSignalDetector {
+        public string Name => "snapshot-swap-restore";
+        public OfficeProvenanceSignalKind SignalKind => OfficeProvenanceSignalKind.DeterministicArtifact;
+        internal bool NamespaceWriteBlocked { get; private set; }
+        internal bool ObservedReplacement { get; private set; }
+        internal UnixFileMode ObservedDirectoryMode { get; private set; }
+
+        public OfficeProvenanceSignalResult Detect(string filePath) {
+            string directory = Path.GetDirectoryName(filePath)!;
+            string backup = filePath + ".leased";
+            ObservedDirectoryMode = File.GetUnixFileMode(directory);
+            try {
+                File.Move(filePath, backup);
+                File.WriteAllText(filePath, "replacement", new UTF8Encoding(false));
+                ObservedReplacement = File.ReadAllText(filePath) == "replacement";
+                File.Delete(filePath);
+                File.Move(backup, filePath);
+            } catch (Exception exception) when (exception is IOException or UnauthorizedAccessException) {
+                NamespaceWriteBlocked = true;
+            }
+            return new OfficeProvenanceSignalResult(
+                Name,
+                SignalKind,
+                OfficeProvenanceSignalStatus.NotDetected);
         }
     }
 #endif

--- a/OfficeIMO.Shared.Tests/ProvenanceAssessmentContracts.cs
+++ b/OfficeIMO.Shared.Tests/ProvenanceAssessmentContracts.cs
@@ -393,8 +393,7 @@ public sealed class ProvenanceAssessmentContracts {
         internal OfficeProvenanceVerificationOptions? Options { get; private set; }
         public OfficeProvenanceVerificationResult Verify(
             string filePath,
-            OfficeProvenanceVerificationOptions? options = null,
-            CancellationToken cancellationToken = default) =>
+            OfficeProvenanceVerificationOptions? options = null) =>
             Create(options);
 
         private OfficeProvenanceVerificationResult Create(OfficeProvenanceVerificationOptions? options) {
@@ -410,8 +409,7 @@ public sealed class ProvenanceAssessmentContracts {
         public string Name => "expected";
         public OfficeProvenanceVerificationResult Verify(
             string filePath,
-            OfficeProvenanceVerificationOptions? options = null,
-            CancellationToken cancellationToken = default) =>
+            OfficeProvenanceVerificationOptions? options = null) =>
             new OfficeProvenanceVerificationResult(
                 OfficeProvenanceVerificationStatus.Valid,
                 "different",
@@ -427,14 +425,14 @@ public sealed class ProvenanceAssessmentContracts {
         }
         public string Name { get; }
         public OfficeProvenanceSignalKind SignalKind { get; }
-        public OfficeProvenanceSignalResult Detect(string filePath, CancellationToken cancellationToken = default) =>
+        public OfficeProvenanceSignalResult Detect(string filePath) =>
             new OfficeProvenanceSignalResult(Name, SignalKind, _status);
     }
 
     private sealed class InconsistentDetector : IOfficeProvenanceSignalDetector {
         public string Name => "expected";
         public OfficeProvenanceSignalKind SignalKind => OfficeProvenanceSignalKind.DurableMediaWatermark;
-        public OfficeProvenanceSignalResult Detect(string filePath, CancellationToken cancellationToken = default) =>
+        public OfficeProvenanceSignalResult Detect(string filePath) =>
             new OfficeProvenanceSignalResult(
                 "different",
                 OfficeProvenanceSignalKind.DurableMediaWatermark,
@@ -450,7 +448,7 @@ public sealed class ProvenanceAssessmentContracts {
         public OfficeProvenanceSignalKind SignalKind => OfficeProvenanceSignalKind.DeterministicArtifact;
         internal string? ObservedPath { get; private set; }
 
-        public OfficeProvenanceSignalResult Detect(string filePath, CancellationToken cancellationToken = default) {
+        public OfficeProvenanceSignalResult Detect(string filePath) {
             ObservedPath = Path.GetFullPath(filePath);
             File.WriteAllText(_originalPath, "replacement", new UTF8Encoding(false));
             bool detected = File.ReadAllText(filePath).Contains("original marker", StringComparison.Ordinal);
@@ -469,7 +467,7 @@ public sealed class ProvenanceAssessmentContracts {
         public string Name => "snapshot-replacing";
         public OfficeProvenanceSignalKind SignalKind => OfficeProvenanceSignalKind.DeterministicArtifact;
 
-        public OfficeProvenanceSignalResult Detect(string filePath, CancellationToken cancellationToken = default) {
+        public OfficeProvenanceSignalResult Detect(string filePath) {
             string replacement = filePath + ".replacement";
             File.WriteAllText(replacement, "replacement", new UTF8Encoding(false));
             File.Move(replacement, filePath, overwrite: true);
@@ -489,7 +487,7 @@ public sealed class ProvenanceAssessmentContracts {
         public string Name => "cancelling";
         public OfficeProvenanceSignalKind SignalKind => OfficeProvenanceSignalKind.DeterministicArtifact;
 
-        public OfficeProvenanceSignalResult Detect(string filePath, CancellationToken cancellationToken = default) {
+        public OfficeProvenanceSignalResult Detect(string filePath) {
             _cancellation.Cancel();
             return new OfficeProvenanceSignalResult(Name, SignalKind, OfficeProvenanceSignalStatus.NotDetected);
         }

--- a/OfficeIMO.Shared.Tests/ProvenanceAssessmentContracts.cs
+++ b/OfficeIMO.Shared.Tests/ProvenanceAssessmentContracts.cs
@@ -209,6 +209,22 @@ public sealed class ProvenanceAssessmentContracts {
     }
 
     [Fact]
+    public void AssessmentRejectsProviderMutationOfThePrimarySnapshot() {
+#if NET8_0_OR_GREATER
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
+        string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".txt");
+        File.WriteAllText(path, "original", new UTF8Encoding(false));
+        try {
+            Assert.Throws<InvalidDataException>(() => OfficeProvenanceAssessment.InspectFile(
+                path,
+                signalDetectors: [new SnapshotReplacingDetector()]));
+        } finally {
+            File.Delete(path);
+        }
+#endif
+    }
+
+    [Fact]
     public void SnapshotAppliesTheManifestLimitPerExternalDependency() {
         string directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(directory);
@@ -254,6 +270,40 @@ public sealed class ProvenanceAssessmentContracts {
                     report,
                     maximumDependencyBytes: 4,
                     maximumTotalBytes: 7));
+
+            Assert.Contains("expanded-data limit", exception.Message, StringComparison.OrdinalIgnoreCase);
+        } finally {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void SnapshotSharesTheExpandedDataLimitWithHtmlStructuralInspection() {
+        string directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        string path = Path.Combine(directory, "page.html");
+        File.WriteAllText(
+            path,
+            "<!doctype html><html><head><link rel=\"c2pa-manifest\" href=\"claim.c2pa\"></head>" +
+            "<body><img src=\"data:image/png;base64,AQIDBA==\"></body></html>",
+            new UTF8Encoding(false));
+        File.WriteAllBytes(Path.Combine(directory, "claim.c2pa"), [1, 2, 3, 4]);
+        try {
+            var options = new OfficeProvenanceOptions {
+                MaxAssetBytes = 4096,
+                MaxManifestBytes = 4096,
+                MaxExpandedContainerBytes = 7
+            };
+            OfficeProvenanceReport report = HtmlProvenance.InspectFile(path, options);
+            Assert.Equal(4, report.ExpandedInspectionBytes);
+            using OfficeProvenanceFileSnapshot snapshot = OfficeProvenanceFileSnapshot.Capture(path, 4096);
+
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+                snapshot.CaptureExternalManifestDependencies(
+                    path,
+                    report,
+                    maximumDependencyBytes: 4096,
+                    maximumTotalBytes: options.MaxExpandedContainerBytes));
 
             Assert.Contains("expanded-data limit", exception.Message, StringComparison.OrdinalIgnoreCase);
         } finally {
@@ -386,6 +436,23 @@ public sealed class ProvenanceAssessmentContracts {
                 detected ? OfficeProvenanceSignalStatus.Detected : OfficeProvenanceSignalStatus.NotDetected);
         }
     }
+
+#if NET8_0_OR_GREATER
+    private sealed class SnapshotReplacingDetector : IOfficeProvenanceSignalDetector {
+        public string Name => "snapshot-replacing";
+        public OfficeProvenanceSignalKind SignalKind => OfficeProvenanceSignalKind.DeterministicArtifact;
+
+        public OfficeProvenanceSignalResult Detect(string filePath) {
+            string replacement = filePath + ".replacement";
+            File.WriteAllText(replacement, "replacement", new UTF8Encoding(false));
+            File.Move(replacement, filePath, overwrite: true);
+            return new OfficeProvenanceSignalResult(
+                Name,
+                SignalKind,
+                OfficeProvenanceSignalStatus.Detected);
+        }
+    }
+#endif
 
     private sealed class CancellingDetector : IOfficeProvenanceSignalDetector {
         private readonly CancellationTokenSource _cancellation;

--- a/OfficeIMO.Shared.Tests/ProvenanceAssessmentContracts.cs
+++ b/OfficeIMO.Shared.Tests/ProvenanceAssessmentContracts.cs
@@ -209,6 +209,33 @@ public sealed class ProvenanceAssessmentContracts {
     }
 
     [Fact]
+    public void SnapshotDeduplicatesCaseAliasesOnACaseInsensitiveFileSystem() {
+        string directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        string path = Path.Combine(directory, "page.html");
+        string sidecar = Path.Combine(directory, "Claim.c2pa");
+        File.WriteAllText(path, "<!doctype html><html><body>body</body></html>", new UTF8Encoding(false));
+        File.WriteAllText(sidecar, "immutable claim", new UTF8Encoding(false));
+        try {
+            OfficeProvenanceReport report = CreateExternalManifestReport("Claim.c2pa", "claim.c2pa");
+            using OfficeProvenanceFileSnapshot snapshot = OfficeProvenanceFileSnapshot.Capture(path, 4096);
+            string snapshotDirectory = Path.GetDirectoryName(snapshot.FilePath)!;
+            string differentlyCasedSnapshot = Path.Combine(
+                snapshotDirectory,
+                Path.GetFileName(snapshot.FilePath).ToUpperInvariant());
+            if (!File.Exists(differentlyCasedSnapshot)) return;
+
+            snapshot.CaptureExternalManifestDependencies(path, report, 4096, 4096);
+
+            Assert.Equal(
+                "immutable claim",
+                File.ReadAllText(Path.Combine(snapshotDirectory, "Claim.c2pa")));
+        } finally {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
     public void SnapshotRejectsAUnixFifoWithoutBlockingForAWriter() {
 #if NET8_0_OR_GREATER
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;

--- a/OfficeIMO.Shared.Tests/ProvenanceAssessmentContracts.cs
+++ b/OfficeIMO.Shared.Tests/ProvenanceAssessmentContracts.cs
@@ -328,6 +328,20 @@ public sealed class ProvenanceAssessmentContracts {
         Assert.Equal("claim.c2pa", Assert.Single(report.Evidence).Value);
     }
 
+    [Theory]
+    [InlineData("&#32;")]
+    [InlineData("&#x20;")]
+    [InlineData("&Tab;")]
+    [InlineData("&NewLine;")]
+    public void CoreHtmlInspectionKeepsManifestLinksAfterEncodedHeadWhitespace(string whitespace) {
+        byte[] html = Encoding.UTF8.GetBytes(
+            "<html><head>" + whitespace + "<link rel=\"c2pa-manifest\" href=\"claim.c2pa\"></head></html>");
+
+        OfficeProvenanceReport report = OfficeProvenanceInspector.Inspect(html, "page.html");
+
+        Assert.Equal("claim.c2pa", Assert.Single(report.Evidence).Value);
+    }
+
     [Fact]
     public void PortableSnapshotFallbackCapturesPrimaryAndRelativeDependencyFiles() {
         string directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));

--- a/OfficeIMO.Shared.Tests/ProvenanceAssessmentContracts.cs
+++ b/OfficeIMO.Shared.Tests/ProvenanceAssessmentContracts.cs
@@ -196,7 +196,7 @@ public sealed class ProvenanceAssessmentContracts {
             OfficeProvenanceReport report = HtmlProvenance.InspectFile(path);
             using (OfficeProvenanceFileSnapshot snapshot = OfficeProvenanceFileSnapshot.Capture(path, 4096)) {
                 snapshotDirectory = Path.GetDirectoryName(snapshot.FilePath)!;
-                snapshot.CaptureExternalManifestDependencies(path, report, 4096);
+                snapshot.CaptureExternalManifestDependencies(path, report, 4096, 4096);
 
                 Assert.Equal(
                     "immutable claim",
@@ -206,6 +206,91 @@ public sealed class ProvenanceAssessmentContracts {
         } finally {
             Directory.Delete(directory, recursive: true);
         }
+    }
+
+    [Fact]
+    public void SnapshotAppliesTheManifestLimitPerExternalDependency() {
+        string directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        string path = Path.Combine(directory, "page.html");
+        File.WriteAllText(path, "<!doctype html><html><body>body</body></html>", new UTF8Encoding(false));
+        File.WriteAllBytes(Path.Combine(directory, "first.c2pa"), [1, 2, 3, 4]);
+        File.WriteAllBytes(Path.Combine(directory, "second.c2pa"), [5, 6, 7, 8]);
+        string? snapshotDirectory = null;
+        try {
+            OfficeProvenanceReport report = CreateExternalManifestReport("first.c2pa", "second.c2pa");
+            using (OfficeProvenanceFileSnapshot snapshot = OfficeProvenanceFileSnapshot.Capture(path, 4096)) {
+                snapshotDirectory = Path.GetDirectoryName(snapshot.FilePath)!;
+                snapshot.CaptureExternalManifestDependencies(
+                    path,
+                    report,
+                    maximumDependencyBytes: 4,
+                    maximumTotalBytes: 8);
+
+                Assert.Equal([1, 2, 3, 4], File.ReadAllBytes(Path.Combine(snapshotDirectory, "first.c2pa")));
+                Assert.Equal([5, 6, 7, 8], File.ReadAllBytes(Path.Combine(snapshotDirectory, "second.c2pa")));
+            }
+            Assert.False(Directory.Exists(snapshotDirectory));
+        } finally {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void SnapshotAppliesTheExpandedDataLimitAcrossExternalDependencies() {
+        string directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        string path = Path.Combine(directory, "page.html");
+        File.WriteAllText(path, "<!doctype html><html><body>body</body></html>", new UTF8Encoding(false));
+        File.WriteAllBytes(Path.Combine(directory, "first.c2pa"), [1, 2, 3, 4]);
+        File.WriteAllBytes(Path.Combine(directory, "second.c2pa"), [5, 6, 7, 8]);
+        try {
+            OfficeProvenanceReport report = CreateExternalManifestReport("first.c2pa", "second.c2pa");
+            using OfficeProvenanceFileSnapshot snapshot = OfficeProvenanceFileSnapshot.Capture(path, 4096);
+
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+                snapshot.CaptureExternalManifestDependencies(
+                    path,
+                    report,
+                    maximumDependencyBytes: 4,
+                    maximumTotalBytes: 7));
+
+            Assert.Contains("expanded-data limit", exception.Message, StringComparison.OrdinalIgnoreCase);
+        } finally {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void SnapshotRejectsAnExternalManifestSymlinkThatEscapesTheSourceDirectory() {
+#if NET8_0_OR_GREATER
+        string directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        string outside = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".c2pa");
+        string path = Path.Combine(directory, "page.html");
+        string sidecar = Path.Combine(directory, "claim.c2pa");
+        File.WriteAllText(path, "<!doctype html><html><body>body</body></html>", new UTF8Encoding(false));
+        File.WriteAllText(outside, "outside claim", new UTF8Encoding(false));
+        try {
+            try {
+                File.CreateSymbolicLink(sidecar, outside);
+            } catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or PlatformNotSupportedException) {
+                return;
+            }
+            OfficeProvenanceReport report = CreateExternalManifestReport("claim.c2pa");
+            using OfficeProvenanceFileSnapshot snapshot = OfficeProvenanceFileSnapshot.Capture(path, 4096);
+
+            Assert.Throws<InvalidDataException>(() => snapshot.CaptureExternalManifestDependencies(
+                path,
+                report,
+                maximumDependencyBytes: 4096,
+                maximumTotalBytes: 4096));
+        } finally {
+            File.Delete(sidecar);
+            File.Delete(outside);
+            Directory.Delete(directory, recursive: true);
+        }
+#endif
     }
 
     [Fact]
@@ -225,6 +310,15 @@ public sealed class ProvenanceAssessmentContracts {
             File.Delete(path);
         }
     }
+
+    private static OfficeProvenanceReport CreateExternalManifestReport(params string[] references) =>
+        new OfficeProvenanceReport(
+            OfficeProvenanceAssetFormat.Html,
+            references.Select(reference => new OfficeProvenanceEvidence(
+                OfficeProvenanceCarrierKind.C2paExternalManifest,
+                "html:link[rel=c2pa-manifest]",
+                isStructurallyValid: true,
+                value: reference)).ToArray());
 
     private sealed class StubVerifier : IOfficeProvenanceVerifier {
         public string Name => "stub-verifier";

--- a/OfficeIMO.Shared.Tests/ProvenanceAssessmentContracts.cs
+++ b/OfficeIMO.Shared.Tests/ProvenanceAssessmentContracts.cs
@@ -233,6 +233,29 @@ public sealed class ProvenanceAssessmentContracts {
     }
 
     [Fact]
+    public void CoreAssessmentDecodesHtmlManifestReferencesExactlyOnce() {
+        string directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        string path = Path.Combine(directory, "page.html");
+        File.WriteAllText(
+            path,
+            "<!doctype html><html><head><link rel=\"c2pa-manifest\" href=\"claim&amp;amp;v.c2pa\"></head><body>body</body></html>",
+            new UTF8Encoding(false));
+        File.WriteAllText(Path.Combine(directory, "claim&amp;v.c2pa"), "escaped claim", new UTF8Encoding(false));
+        try {
+            OfficeProvenanceAssessmentReport report = OfficeProvenanceAssessment.InspectFile(
+                path,
+                verifier: new RelativeSidecarVerifier("claim&amp;v.c2pa", "escaped claim"));
+
+            OfficeProvenanceEvidence evidence = Assert.Single(report.Structural.Evidence);
+            Assert.Equal("claim&amp;v.c2pa", evidence.Value);
+            Assert.Equal(OfficeProvenanceVerificationStatus.Valid, report.Verification!.Status);
+        } finally {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
     public void CoreHtmlInspectionResolvesRelativeBaseForManifestSnapshot() {
         string directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(Path.Combine(directory, "sub"));
@@ -333,6 +356,30 @@ public sealed class ProvenanceAssessmentContracts {
             Assert.Equal(
                 "immutable claim",
                 File.ReadAllText(Path.Combine(snapshotDirectory, "Claim.c2pa")));
+        } finally {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void SnapshotDeduplicatesUnicodeNormalizationAliasesOnMacOs() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) return;
+        string directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        string path = Path.Combine(directory, "page.html");
+        const string composed = "caf\u00E9.c2pa";
+        const string decomposed = "cafe\u0301.c2pa";
+        File.WriteAllText(path, "<!doctype html><html><body>body</body></html>", new UTF8Encoding(false));
+        File.WriteAllText(Path.Combine(directory, composed), "normalized claim", new UTF8Encoding(false));
+        try {
+            OfficeProvenanceReport report = CreateExternalManifestReport(composed, decomposed);
+            using OfficeProvenanceFileSnapshot snapshot = OfficeProvenanceFileSnapshot.Capture(path, 4096);
+            string snapshotDirectory = Path.GetDirectoryName(snapshot.FilePath)!;
+
+            snapshot.CaptureExternalManifestDependencies(path, report, 4096, 4096);
+
+            Assert.Equal("normalized claim", File.ReadAllText(Path.Combine(snapshotDirectory, composed)));
+            snapshot.VerifyExternalManifestDependencies();
         } finally {
             Directory.Delete(directory, recursive: true);
         }

--- a/OfficeIMO.Shared.Tests/ProvenanceAssessmentContracts.cs
+++ b/OfficeIMO.Shared.Tests/ProvenanceAssessmentContracts.cs
@@ -406,6 +406,26 @@ public sealed class ProvenanceAssessmentContracts {
     }
 
     [Fact]
+    public void PortableSnapshotMatchesOnlyTheCapturedSourceBytes() {
+        string directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        string path = Path.Combine(directory, "page.html");
+        string displaced = Path.Combine(directory, "displaced.html");
+        File.WriteAllText(path, "captured source", new UTF8Encoding(false));
+        try {
+            using OfficeProvenanceFileSnapshot snapshot = OfficeProvenanceFileSnapshot.CapturePortable(path, 4096);
+            File.Move(path, displaced);
+
+            Assert.True(snapshot.MatchesCapturedSource(displaced));
+
+            File.WriteAllText(displaced, "concurrent save", new UTF8Encoding(false));
+            Assert.False(snapshot.MatchesCapturedSource(displaced));
+        } finally {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
     public void SnapshotDeduplicatesCaseAliasesOnACaseInsensitiveFileSystem() {
         string directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(directory);

--- a/OfficeIMO.Shared.Tests/ProvenanceAssessmentContracts.cs
+++ b/OfficeIMO.Shared.Tests/ProvenanceAssessmentContracts.cs
@@ -324,7 +324,6 @@ public sealed class ProvenanceAssessmentContracts {
 
     [Theory]
     [InlineData("<html><body><head><link rel=\"c2pa-manifest\" href=\"claim.c2pa\"></head></body></html>")]
-    [InlineData("<html><head></head><head><link rel=\"c2pa-manifest\" href=\"claim.c2pa\"></head></html>")]
     public void CoreHtmlInspectionDoesNotReopenACompletedHead(string html) {
         OfficeProvenanceReport report = OfficeProvenanceInspector.Inspect(
             Encoding.UTF8.GetBytes(html),

--- a/OfficeIMO.Shared.Tests/ProvenanceAssessmentContracts.cs
+++ b/OfficeIMO.Shared.Tests/ProvenanceAssessmentContracts.cs
@@ -318,6 +318,17 @@ public sealed class ProvenanceAssessmentContracts {
         Assert.Empty(report.Evidence);
     }
 
+    [Theory]
+    [InlineData("<html><body><head><link rel=\"c2pa-manifest\" href=\"claim.c2pa\"></head></body></html>")]
+    [InlineData("<html><head></head><head><link rel=\"c2pa-manifest\" href=\"claim.c2pa\"></head></html>")]
+    public void CoreHtmlInspectionDoesNotReopenACompletedHead(string html) {
+        OfficeProvenanceReport report = OfficeProvenanceInspector.Inspect(
+            Encoding.UTF8.GetBytes(html),
+            "page.html");
+
+        Assert.Empty(report.Evidence);
+    }
+
     [Fact]
     public void CoreHtmlInspectionKeepsManifestLinksInAnImplicitHeadAfterDoctype() {
         byte[] html = Encoding.UTF8.GetBytes(

--- a/OfficeIMO.Shared.Tests/ProvenanceAssessmentContracts.cs
+++ b/OfficeIMO.Shared.Tests/ProvenanceAssessmentContracts.cs
@@ -209,6 +209,24 @@ public sealed class ProvenanceAssessmentContracts {
     }
 
     [Fact]
+    public void SnapshotRejectsAUnixFifoWithoutBlockingForAWriter() {
+#if NET8_0_OR_GREATER
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
+        string fifo = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".fifo");
+        try {
+            Assert.Equal(0, CreateFifoUnix(fifo, 0x180));
+
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+                OfficeProvenanceFileSnapshot.Capture(fifo, maximumBytes: 1024));
+
+            Assert.Contains("regular file", exception.Message, StringComparison.OrdinalIgnoreCase);
+        } finally {
+            File.Delete(fifo);
+        }
+#endif
+    }
+
+    [Fact]
     public void AssessmentRejectsProviderMutationOfThePrimarySnapshot() {
 #if NET8_0_OR_GREATER
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
@@ -438,6 +456,9 @@ public sealed class ProvenanceAssessmentContracts {
     }
 
 #if NET8_0_OR_GREATER
+    [DllImport("libc", EntryPoint = "mkfifo", SetLastError = true)]
+    private static extern int CreateFifoUnix(string path, uint mode);
+
     private sealed class SnapshotReplacingDetector : IOfficeProvenanceSignalDetector {
         public string Name => "snapshot-replacing";
         public OfficeProvenanceSignalKind SignalKind => OfficeProvenanceSignalKind.DeterministicArtifact;

--- a/OfficeIMO.Shared.Tests/ProvenanceAssessmentContracts.cs
+++ b/OfficeIMO.Shared.Tests/ProvenanceAssessmentContracts.cs
@@ -209,6 +209,109 @@ public sealed class ProvenanceAssessmentContracts {
     }
 
     [Fact]
+    public void CoreAssessmentPreservesRelativeHtmlManifestForVerifier() {
+        string directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(directory, "claims"));
+        string path = Path.Combine(directory, "page.html");
+        File.WriteAllText(
+            path,
+            "<!doctype html><html><head><link rel=\"c2pa-manifest\" href=\"claims/claim.c2pa\"></head><body>body</body></html>",
+            new UTF8Encoding(false));
+        File.WriteAllText(Path.Combine(directory, "claims", "claim.c2pa"), "immutable claim", new UTF8Encoding(false));
+        try {
+            OfficeProvenanceAssessmentReport report = OfficeProvenanceAssessment.InspectFile(
+                path,
+                verifier: new RelativeSidecarVerifier("claims/claim.c2pa", "immutable claim"));
+
+            OfficeProvenanceEvidence evidence = Assert.Single(report.Structural.Evidence);
+            Assert.Equal(OfficeProvenanceCarrierKind.C2paExternalManifest, evidence.Carrier);
+            Assert.True(evidence.IsStructurallyValid);
+            Assert.Equal(OfficeProvenanceVerificationStatus.Valid, report.Verification!.Status);
+        } finally {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CoreHtmlInspectionResolvesRelativeBaseForManifestSnapshot() {
+        string directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(directory, "sub"));
+        string path = Path.Combine(directory, "page.html");
+        File.WriteAllText(
+            path,
+            "<!doctype html><html><head><base href=\"sub/\"><link rel=\"c2pa-manifest\" href=\"claim.c2pa\"></head><body>body</body></html>",
+            new UTF8Encoding(false));
+        File.WriteAllText(Path.Combine(directory, "sub", "claim.c2pa"), "based claim", new UTF8Encoding(false));
+        try {
+            OfficeProvenanceAssessmentReport report = OfficeProvenanceAssessment.InspectFile(
+                path,
+                verifier: new RelativeSidecarVerifier("sub/claim.c2pa", "based claim"));
+
+            Assert.True(Assert.Single(report.Structural.Evidence).IsStructurallyValid);
+            Assert.Equal(OfficeProvenanceVerificationStatus.Valid, report.Verification!.Status);
+        } finally {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CoreHtmlInspectionReportsEmbeddedManifestAssociations() {
+        string manifest = Convert.ToBase64String(ProvenanceCoreContracts.CreateManifestStoreForLifecycleTests());
+        byte[] html = Encoding.UTF8.GetBytes(
+            $"<!doctype html><html><head><script type=\"application/c2pa\">{manifest}</script></head><body></body></html>");
+
+        OfficeProvenanceReport report = OfficeProvenanceInspector.Inspect(html, "page.html");
+
+        OfficeProvenanceEvidence evidence = Assert.Single(report.Evidence);
+        Assert.Equal(OfficeProvenanceCarrierKind.C2paManifest, evidence.Carrier);
+        Assert.True(evidence.IsStructurallyValid);
+        Assert.True(evidence.PayloadLength > 0);
+        Assert.Equal(evidence.PayloadLength, report.ExpandedInspectionBytes);
+    }
+
+    [Fact]
+    public void CoreHtmlInspectionRejectsUnsafeAndCompetingManifestAssociations() {
+        byte[] unsafeHtml = Encoding.UTF8.GetBytes(
+            "<!doctype html><html><head><link rel=\"c2pa-manifest\" href=\"java&#10;script:alert(1)\"></head></html>");
+        byte[] competingHtml = Encoding.UTF8.GetBytes(
+            "<!doctype html><html><head><link rel=\"c2pa-manifest\" href=\"first.c2pa\"><link rel=\"c2pa-manifest\" href=\"second.c2pa\"></head></html>");
+
+        Assert.False(Assert.Single(OfficeProvenanceInspector.Inspect(unsafeHtml, "unsafe.html").Evidence).IsStructurallyValid);
+        OfficeProvenanceReport competing = OfficeProvenanceInspector.Inspect(competingHtml, "competing.html");
+        Assert.Equal(2, competing.Evidence.Count);
+        Assert.All(competing.Evidence, item => Assert.False(item.IsStructurallyValid));
+        Assert.Single(competing.Diagnostics);
+    }
+
+    [Fact]
+    public void PortableSnapshotFallbackCapturesPrimaryAndRelativeDependencyFiles() {
+        string directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        string path = Path.Combine(directory, "page.html");
+        File.WriteAllText(
+            path,
+            "<!doctype html><html><head><link rel=\"c2pa-manifest\" href=\"claim.c2pa\"></head><body>portable snapshot</body></html>",
+            new UTF8Encoding(false));
+        File.WriteAllText(Path.Combine(directory, "claim.c2pa"), "portable claim", new UTF8Encoding(false));
+        string? snapshotPath = null;
+        try {
+            using (OfficeProvenanceFileSnapshot snapshot = OfficeProvenanceFileSnapshot.CapturePortable(path, 4096)) {
+                snapshotPath = snapshot.FilePath;
+                OfficeProvenanceReport report = OfficeProvenanceInspector.InspectFile(snapshot.FilePath);
+                snapshot.CaptureExternalManifestDependencies(path, report, 4096, 4096);
+
+                Assert.Contains("portable snapshot", File.ReadAllText(snapshot.FilePath), StringComparison.Ordinal);
+                Assert.Equal("portable claim", File.ReadAllText(Path.Combine(Path.GetDirectoryName(snapshot.FilePath)!, "claim.c2pa")));
+                snapshot.VerifyPrimaryFile();
+                snapshot.VerifyExternalManifestDependencies();
+            }
+            Assert.False(File.Exists(snapshotPath));
+        } finally {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
     public void SnapshotDeduplicatesCaseAliasesOnACaseInsensitiveFileSystem() {
         string directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(directory);
@@ -483,6 +586,29 @@ public sealed class ProvenanceAssessmentContracts {
                 Name,
                 SignalKind,
                 detected ? OfficeProvenanceSignalStatus.Detected : OfficeProvenanceSignalStatus.NotDetected);
+        }
+    }
+
+    private sealed class RelativeSidecarVerifier : IOfficeProvenanceVerifier {
+        private readonly string _relativePath;
+        private readonly string _expectedContent;
+
+        internal RelativeSidecarVerifier(string relativePath, string expectedContent) {
+            _relativePath = relativePath;
+            _expectedContent = expectedContent;
+        }
+
+        public string Name => "relative-sidecar";
+
+        public OfficeProvenanceVerificationResult Verify(
+            string filePath,
+            OfficeProvenanceVerificationOptions? options = null) {
+            string sidecarPath = Path.Combine(Path.GetDirectoryName(filePath)!, _relativePath);
+            bool valid = File.Exists(sidecarPath) && File.ReadAllText(sidecarPath) == _expectedContent;
+            return new OfficeProvenanceVerificationResult(
+                valid ? OfficeProvenanceVerificationStatus.Valid : OfficeProvenanceVerificationStatus.Invalid,
+                Name,
+                Array.Empty<string>());
         }
     }
 

--- a/OfficeIMO.Shared.Tests/ProvenanceAssessmentContracts.cs
+++ b/OfficeIMO.Shared.Tests/ProvenanceAssessmentContracts.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Threading;
 using OfficeIMO.Provenance;
 using Xunit;
 
@@ -70,6 +71,40 @@ public sealed class ProvenanceAssessmentContracts {
         }
     }
 
+    [Fact]
+    public void AssessmentComposesAnExistingStructuralReportWithoutChangingItsOwnerEvidence() {
+        string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".txt");
+        File.WriteAllText(path, "text\u200B", new UTF8Encoding(false));
+        try {
+            OfficeProvenanceReport structural = OfficeProvenanceInspector.InspectFile(path);
+
+            OfficeProvenanceAssessmentReport report = OfficeProvenanceAssessment.AssessFile(path, structural);
+
+            Assert.Same(structural, report.Structural);
+            Assert.Equal(OfficeTextIntegrityFindingKind.ZeroWidthSpace, Assert.Single(report.TextIntegrity!.Findings).Kind);
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void AssessmentObservesCancellationRaisedByASynchronousProvider() {
+        string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".txt");
+        File.WriteAllText(path, "text", new UTF8Encoding(false));
+        using var cancellation = new CancellationTokenSource();
+        try {
+            OfficeProvenanceReport structural = OfficeProvenanceInspector.InspectFile(path);
+
+            Assert.Throws<OperationCanceledException>(() => OfficeProvenanceAssessment.AssessFile(
+                path,
+                structural,
+                signalDetectors: [new CancellingDetector(cancellation)],
+                cancellationToken: cancellation.Token));
+        } finally {
+            File.Delete(path);
+        }
+    }
+
     private sealed class StubVerifier : IOfficeProvenanceVerifier {
         public string Name => "stub-verifier";
         internal OfficeProvenanceVerificationOptions? Options { get; private set; }
@@ -115,5 +150,19 @@ public sealed class ProvenanceAssessmentContracts {
                 "different",
                 OfficeProvenanceSignalKind.DurableMediaWatermark,
                 OfficeProvenanceSignalStatus.NotDetected);
+    }
+
+    private sealed class CancellingDetector : IOfficeProvenanceSignalDetector {
+        private readonly CancellationTokenSource _cancellation;
+
+        internal CancellingDetector(CancellationTokenSource cancellation) => _cancellation = cancellation;
+
+        public string Name => "cancelling";
+        public OfficeProvenanceSignalKind SignalKind => OfficeProvenanceSignalKind.DeterministicArtifact;
+
+        public OfficeProvenanceSignalResult Detect(string filePath) {
+            _cancellation.Cancel();
+            return new OfficeProvenanceSignalResult(Name, SignalKind, OfficeProvenanceSignalStatus.NotDetected);
+        }
     }
 }

--- a/OfficeIMO.Shared.Tests/ProvenanceAssessmentContracts.cs
+++ b/OfficeIMO.Shared.Tests/ProvenanceAssessmentContracts.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Threading;
 using System.Runtime.InteropServices;
+using OfficeIMO.Html;
 using OfficeIMO.Provenance;
 using Xunit;
 
@@ -160,6 +161,50 @@ public sealed class ProvenanceAssessmentContracts {
             Assert.Equal("replacement", File.ReadAllText(path));
         } finally {
             File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void AssessmentInspectFileReportsTheOriginalTextLocation() {
+        string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".html");
+        File.WriteAllText(path, "<!doctype html><html><body>review\u200Bthis</body></html>", new UTF8Encoding(false));
+        try {
+            OfficeProvenanceAssessmentReport report = OfficeProvenanceAssessment.InspectFile(path);
+
+            OfficeTextIntegrityFinding finding = Assert.Single(report.TextIntegrity!.Findings);
+            Assert.Equal(Path.GetFullPath(path), finding.Location);
+            Assert.DoesNotContain("officeimo-provenance-", finding.Location, StringComparison.OrdinalIgnoreCase);
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void SnapshotCapturesRelativeExternalManifestDependenciesFromFormatReports() {
+        string directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        string path = Path.Combine(directory, "page.html");
+        string sidecar = Path.Combine(directory, "manifests", "c2pa", "claim.c2pa");
+        Directory.CreateDirectory(Path.GetDirectoryName(sidecar)!);
+        File.WriteAllText(
+            path,
+            "<!doctype html><html><head><link rel=\"c2pa-manifest\" href=\"manifests/c2pa/claim.c2pa\"></head><body>body</body></html>",
+            new UTF8Encoding(false));
+        File.WriteAllText(sidecar, "immutable claim", new UTF8Encoding(false));
+        string? snapshotDirectory = null;
+        try {
+            OfficeProvenanceReport report = HtmlProvenance.InspectFile(path);
+            using (OfficeProvenanceFileSnapshot snapshot = OfficeProvenanceFileSnapshot.Capture(path, 4096)) {
+                snapshotDirectory = Path.GetDirectoryName(snapshot.FilePath)!;
+                snapshot.CaptureExternalManifestDependencies(path, report, 4096);
+
+                Assert.Equal(
+                    "immutable claim",
+                    File.ReadAllText(Path.Combine(snapshotDirectory, "manifests", "c2pa", "claim.c2pa")));
+            }
+            Assert.False(Directory.Exists(snapshotDirectory));
+        } finally {
+            Directory.Delete(directory, recursive: true);
         }
     }
 

--- a/OfficeIMO.Shared.Tests/ProvenanceAssessmentContracts.cs
+++ b/OfficeIMO.Shared.Tests/ProvenanceAssessmentContracts.cs
@@ -1,11 +1,66 @@
 using System.Text;
 using System.Threading;
+using System.Runtime.InteropServices;
 using OfficeIMO.Provenance;
 using Xunit;
 
 namespace OfficeIMO.Shared.Tests;
 
 public sealed class ProvenanceAssessmentContracts {
+    [Fact]
+    public void SnapshotUsesPrivateUnixPermissionsAndRemovesItsPayload() {
+#if NET8_0_OR_GREATER
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
+        string source = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".txt");
+        File.WriteAllText(source, "sensitive", new UTF8Encoding(false));
+        string snapshotPath;
+        string snapshotDirectory;
+        try {
+            using (OfficeProvenanceFileSnapshot snapshot = OfficeProvenanceFileSnapshot.Capture(source, 1024)) {
+                snapshotPath = snapshot.FilePath;
+                snapshotDirectory = Path.GetDirectoryName(snapshotPath)!;
+                Assert.Equal(UnixFileMode.UserRead, File.GetUnixFileMode(snapshotPath));
+                Assert.Equal(
+                    UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute,
+                    File.GetUnixFileMode(snapshotDirectory));
+                Assert.Equal("snapshot.txt", Path.GetFileName(snapshotPath));
+            }
+            Assert.False(File.Exists(snapshotPath));
+            Assert.False(Directory.Exists(snapshotDirectory));
+        } finally {
+            File.Delete(source);
+    }
+#endif
+    }
+
+    [Fact]
+    public void SnapshotCleanupCanBeRetriedAfterAWindowsSharingViolation() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
+        string input = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".txt");
+        File.WriteAllText(input, "snapshot");
+        OfficeProvenanceFileSnapshot? snapshot = null;
+        try {
+            snapshot = OfficeProvenanceFileSnapshot.Capture(input, maximumBytes: 1024);
+            string snapshotPath = snapshot.FilePath;
+            using (var blocker = new FileStream(
+                       snapshotPath,
+                       FileMode.Open,
+                       FileAccess.Read,
+                       FileShare.Read)) {
+                IOException exception = Assert.Throws<IOException>(() => snapshot.Dispose());
+                Assert.Contains(snapshotPath, exception.Message, StringComparison.Ordinal);
+                Assert.True(File.Exists(snapshotPath));
+            }
+
+            snapshot.Dispose();
+            Assert.False(File.Exists(snapshotPath));
+            snapshot = null;
+        } finally {
+            snapshot?.Dispose();
+            if (File.Exists(input)) File.Delete(input);
+        }
+    }
+
     [Fact]
     public void AssessmentKeepsStructuralVerificationTextAndProviderEvidenceDistinct() {
         string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".py");
@@ -88,6 +143,27 @@ public sealed class ProvenanceAssessmentContracts {
     }
 
     [Fact]
+    public void AssessmentInspectFileUsesOneImmutableSnapshotForEveryProvider() {
+        string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".txt");
+        File.WriteAllText(path, "original marker\u200B", new UTF8Encoding(false));
+        var detector = new ReplacingDetector(path);
+        try {
+            OfficeProvenanceAssessmentReport report = OfficeProvenanceAssessment.InspectFile(
+                path,
+                signalDetectors: [detector]);
+
+            Assert.Equal(OfficeTextIntegrityFindingKind.ZeroWidthSpace, Assert.Single(report.TextIntegrity!.Findings).Kind);
+            Assert.Equal(OfficeProvenanceSignalStatus.Detected, Assert.Single(report.ProviderSignals).Status);
+            Assert.NotNull(detector.ObservedPath);
+            Assert.NotEqual(Path.GetFullPath(path), detector.ObservedPath);
+            Assert.False(File.Exists(detector.ObservedPath));
+            Assert.Equal("replacement", File.ReadAllText(path));
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
     public void AssessmentObservesCancellationRaisedByASynchronousProvider() {
         string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".txt");
         File.WriteAllText(path, "text", new UTF8Encoding(false));
@@ -150,6 +226,26 @@ public sealed class ProvenanceAssessmentContracts {
                 "different",
                 OfficeProvenanceSignalKind.DurableMediaWatermark,
                 OfficeProvenanceSignalStatus.NotDetected);
+    }
+
+    private sealed class ReplacingDetector : IOfficeProvenanceSignalDetector {
+        private readonly string _originalPath;
+
+        internal ReplacingDetector(string originalPath) => _originalPath = originalPath;
+
+        public string Name => "replacing";
+        public OfficeProvenanceSignalKind SignalKind => OfficeProvenanceSignalKind.DeterministicArtifact;
+        internal string? ObservedPath { get; private set; }
+
+        public OfficeProvenanceSignalResult Detect(string filePath) {
+            ObservedPath = Path.GetFullPath(filePath);
+            File.WriteAllText(_originalPath, "replacement", new UTF8Encoding(false));
+            bool detected = File.ReadAllText(filePath).Contains("original marker", StringComparison.Ordinal);
+            return new OfficeProvenanceSignalResult(
+                Name,
+                SignalKind,
+                detected ? OfficeProvenanceSignalStatus.Detected : OfficeProvenanceSignalStatus.NotDetected);
+        }
     }
 
     private sealed class CancellingDetector : IOfficeProvenanceSignalDetector {

--- a/OfficeIMO.Shared.Tests/ProvenanceAssessmentContracts.cs
+++ b/OfficeIMO.Shared.Tests/ProvenanceAssessmentContracts.cs
@@ -306,6 +306,28 @@ public sealed class ProvenanceAssessmentContracts {
         Assert.Single(competing.Diagnostics);
     }
 
+    [Theory]
+    [InlineData("<html><div>body</div><link rel=\"c2pa-manifest\" href=\"claim.c2pa\">")]
+    [InlineData("<html>body<link rel=\"c2pa-manifest\" href=\"claim.c2pa\">")]
+    [InlineData("<html><head><div>body</div><link rel=\"c2pa-manifest\" href=\"claim.c2pa\"></head>")]
+    public void CoreHtmlInspectionIgnoresManifestLinksAfterAnImplicitBodyStart(string html) {
+        OfficeProvenanceReport report = OfficeProvenanceInspector.Inspect(
+            Encoding.UTF8.GetBytes(html),
+            "page.html");
+
+        Assert.Empty(report.Evidence);
+    }
+
+    [Fact]
+    public void CoreHtmlInspectionKeepsManifestLinksInAnImplicitHeadAfterDoctype() {
+        byte[] html = Encoding.UTF8.GetBytes(
+            "<!doctype html><html><link rel=\"c2pa-manifest\" href=\"claim.c2pa\"><body>body</body></html>");
+
+        OfficeProvenanceReport report = OfficeProvenanceInspector.Inspect(html, "page.html");
+
+        Assert.Equal("claim.c2pa", Assert.Single(report.Evidence).Value);
+    }
+
     [Fact]
     public void PortableSnapshotFallbackCapturesPrimaryAndRelativeDependencyFiles() {
         string directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));

--- a/OfficeIMO.Shared.Tests/ProvenanceCoreContracts.OutputLimits.cs
+++ b/OfficeIMO.Shared.Tests/ProvenanceCoreContracts.OutputLimits.cs
@@ -1,0 +1,27 @@
+using System.Text;
+using OfficeIMO.Provenance;
+using Xunit;
+
+namespace OfficeIMO.Shared.Tests;
+
+public sealed partial class ProvenanceCoreContracts {
+    [Fact]
+    public void XmpRewriteStopsAtTheOutputBoundaryDuringSerialization() {
+        byte[] xmp = CreateXmpPacket();
+        byte[] header = Encoding.ASCII.GetBytes("http://ns.adobe.com/xap/1.0/\0");
+        byte[] jpeg = Join(
+            new byte[] { 0xFF, 0xD8 },
+            CreateJpegSegment(0xE1, Join(header, xmp)),
+            new byte[] { 0xFF, 0xD9 });
+        var options = new OfficeProvenanceRemovalOptions {
+            MaxOutputBytes = 64
+        };
+        options.Limits.MaxAssetBytes = jpeg.Length;
+        options.Limits.MaxManifestBytes = jpeg.Length;
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+            OfficeProvenanceRemover.Remove(jpeg, "fixture.jpg", options));
+
+        Assert.True(OfficeProvenanceLimitException.IsOutput(exception));
+    }
+}

--- a/OfficeIMO.Shared.Tests/ProvenanceCoreContracts.Wave61.cs
+++ b/OfficeIMO.Shared.Tests/ProvenanceCoreContracts.Wave61.cs
@@ -1,5 +1,7 @@
 using System.Text;
+using System.Threading;
 using OfficeIMO.Provenance;
+using OfficeIMO.Security;
 using Xunit;
 
 namespace OfficeIMO.Shared.Tests;
@@ -40,5 +42,55 @@ public sealed partial class ProvenanceCoreContracts {
             OfficeProvenanceRemover.Remove(package, "signed.docx", options));
 
         Assert.Contains("expanded", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void RemovalResultHashObservesCancellationBeforeProcessingOwnedBytes() {
+        var report = new OfficeProvenanceReport(
+            OfficeProvenanceAssetFormat.Png,
+            Array.Empty<OfficeProvenanceEvidence>());
+        var result = new OfficeProvenanceRemovalResult(
+            new byte[1024 * 1024],
+            report,
+            report,
+            Array.Empty<OfficeProvenanceChange>(),
+            wasReserialized: false);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        Assert.Throws<OperationCanceledException>(() => result.ComputeDataSha256(cancellation.Token));
+    }
+
+    [Fact]
+    public void OpcSignatureInspectionAcceptsEquivalentDuplicateDefaultContentTypes() {
+        const string contentTypes =
+            "<Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\">" +
+            "<Default Extension=\"xml\" ContentType=\"application/xml\"/>" +
+            "<Default Extension=\"XML\" ContentType=\"application/xml\"/>" +
+            "</Types>";
+        byte[] package = CreateZip(
+            ("[Content_Types].xml", Encoding.UTF8.GetBytes(contentTypes)),
+            ("ppt/presentation.xml", Encoding.UTF8.GetBytes("<presentation/>")));
+
+        OfficePackageSignatureInfo info = OfficePackageSignatureService.Inspect(package);
+
+        Assert.False(info.HasSignatures);
+    }
+
+    [Fact]
+    public void OpcSignatureInspectionRejectsConflictingDuplicateDefaultContentTypes() {
+        const string contentTypes =
+            "<Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\">" +
+            "<Default Extension=\"xml\" ContentType=\"application/xml\"/>" +
+            "<Default Extension=\"XML\" ContentType=\"text/xml\"/>" +
+            "</Types>";
+        byte[] package = CreateZip(
+            ("[Content_Types].xml", Encoding.UTF8.GetBytes(contentTypes)),
+            ("ppt/presentation.xml", Encoding.UTF8.GetBytes("<presentation/>")));
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+            OfficePackageSignatureService.Inspect(package));
+
+        Assert.Contains("conflicting default content types", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/OfficeIMO.Shared.Tests/ProvenanceCoreContracts.Wave77.cs
+++ b/OfficeIMO.Shared.Tests/ProvenanceCoreContracts.Wave77.cs
@@ -56,4 +56,41 @@ public sealed partial class ProvenanceCoreContracts {
 
         Assert.Equal(baseline.Data, bounded.Data);
     }
+
+    [Fact]
+    public void SignatureRecheckAllowsAValidOutputAboveTheInputLimit() {
+        byte[] package = CreateCompressedZip(
+            ("keep.bin", Encoding.UTF8.GetBytes("keep")),
+            ("META-INF/content_credential.c2pa", CreateManifestStore()));
+        var options = new OfficeProvenanceRemovalOptions {
+            SignatureMutationPolicy = OfficeSignatureMutationPolicy.RemoveInvalidatedSignatures,
+            MaxOutputBytes = package.LongLength + 1024
+        };
+        options.Limits.MaxAssetBytes = package.LongLength;
+        options.Limits.MaxManifestBytes = Math.Min(package.LongLength, 1024);
+        options.Limits.MaxExpandedContainerBytes = 1024 * 1024;
+        int signatureChecks = 0;
+
+        OfficeProvenanceRemovalResult result = OfficeProvenancePackageMutation.Remove(
+            package,
+            "document.zip",
+            options,
+            (preview, _) => {
+                var expanded = new byte[checked((int)options.Limits.MaxAssetBytes + 1)];
+                Buffer.BlockCopy(preview, 0, expanded, 0, preview.Length);
+                return new OfficeProvenanceSignatureStripResult(expanded, hadSignatures: true);
+            },
+            (candidate, inspectionOptions) => {
+                signatureChecks++;
+                if (signatureChecks == 1) return true;
+                Assert.True(candidate.LongLength > options.Limits.MaxAssetBytes);
+                Assert.True(candidate.LongLength <= inspectionOptions.Limits.MaxAssetBytes);
+                return false;
+            },
+            validateOpcMetadata: false);
+
+        Assert.Equal(options.Limits.MaxAssetBytes + 1, result.DataLength);
+        Assert.Equal(2, signatureChecks);
+        Assert.True(result.WereInvalidatedSignaturesRemoved);
+    }
 }

--- a/OfficeIMO.Shared.Tests/ProvenanceCoreContracts.Wave77.cs
+++ b/OfficeIMO.Shared.Tests/ProvenanceCoreContracts.Wave77.cs
@@ -1,0 +1,59 @@
+using System.Text;
+using OfficeIMO.Provenance;
+using Xunit;
+
+namespace OfficeIMO.Shared.Tests;
+
+public sealed partial class ProvenanceCoreContracts {
+    [Fact]
+    public void OpcMetadataRewriteAppliesTheOutputLimitAfterCompression() {
+        byte[] contentTypes = Encoding.UTF8.GetBytes(
+            "<Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\">" +
+            new string(' ', 32 * 1024) +
+            "<Override PartName=\"/META-INF/content_credential.c2pa\" ContentType=\"application/c2pa\"/>" +
+            "</Types>");
+        byte[] package = CreateCompressedZip(
+            ("[Content_Types].xml", contentTypes),
+            ("META-INF/content_credential.c2pa", CreateManifestStore()));
+        var options = new OfficeProvenanceRemovalOptions();
+        options.Limits.MaxAssetBytes = 128 * 1024;
+        options.Limits.MaxManifestBytes = options.Limits.MaxAssetBytes;
+        OfficeProvenanceRemovalResult baseline = OfficeProvenanceRemover.Remove(package, "document.docx", options);
+        long finalSize = baseline.ToArray().LongLength;
+        Assert.True(contentTypes.LongLength > finalSize);
+
+        options.MaxOutputBytes = finalSize;
+        OfficeProvenanceRemovalResult bounded = OfficeProvenanceRemover.Remove(package, "document.docx", options);
+
+        Assert.Equal(finalSize, bounded.ToArray().LongLength);
+        Assert.True(bounded.WasChanged);
+    }
+
+    [Fact]
+    public void PackageMetadataReplacementAppliesTheOutputLimitAfterCompression() {
+        byte[] replacement = Encoding.UTF8.GetBytes(
+            "<metadata>" + new string(' ', 32 * 1024) + "</metadata>");
+        byte[] package = CreateCompressedZip(
+            ("remove.bin", new byte[] { 1 }),
+            ("metadata.xml", Encoding.UTF8.GetBytes("<metadata/>")));
+        OfficeProvenanceSignatureStripResult baseline = OfficeProvenanceZip.RemoveEntries(
+            package,
+            name => name == "remove.bin",
+            maximumExpandedBytes: 128 * 1024,
+            shouldReplace: name => name == "metadata.xml",
+            replace: (_, _) => replacement,
+            maximumReplacementBytes: 64 * 1024);
+        Assert.True(replacement.LongLength > baseline.Data.LongLength);
+
+        OfficeProvenanceSignatureStripResult bounded = OfficeProvenanceZip.RemoveEntries(
+            package,
+            name => name == "remove.bin",
+            maximumExpandedBytes: 128 * 1024,
+            shouldReplace: name => name == "metadata.xml",
+            replace: (_, _) => replacement,
+            maximumReplacementBytes: 64 * 1024,
+            maximumOutputBytes: baseline.Data.LongLength);
+
+        Assert.Equal(baseline.Data, bounded.Data);
+    }
+}

--- a/OfficeIMO.Shared.Tests/ProvenanceCoreContracts.Wave78.cs
+++ b/OfficeIMO.Shared.Tests/ProvenanceCoreContracts.Wave78.cs
@@ -6,6 +6,16 @@ namespace OfficeIMO.Shared.Tests;
 
 public sealed partial class ProvenanceCoreContracts {
     [Fact]
+    public void ZipInspectionReportsExpandedManifestBytes() {
+        byte[] manifest = CreateManifestStore();
+        byte[] package = CreateZip(("META-INF/content_credential.c2pa", manifest));
+
+        OfficeProvenanceReport report = OfficeProvenanceInspector.Inspect(package, "fixture.zip");
+
+        Assert.Equal(manifest.LongLength, report.ExpandedInspectionBytes);
+    }
+
+    [Fact]
     public void StructuredTextDetectionObservesCancellation() {
         using var cancellation = new CancellationTokenSource();
         cancellation.Cancel();

--- a/OfficeIMO.Shared.Tests/ProvenanceCoreContracts.Wave78.cs
+++ b/OfficeIMO.Shared.Tests/ProvenanceCoreContracts.Wave78.cs
@@ -1,0 +1,21 @@
+using OfficeIMO.Provenance;
+using System.Threading;
+using Xunit;
+
+namespace OfficeIMO.Shared.Tests;
+
+public sealed partial class ProvenanceCoreContracts {
+    [Fact]
+    public void StructuredTextDetectionObservesCancellation() {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        Assert.ThrowsAny<OperationCanceledException>(() =>
+            OfficeProvenanceText.HasStructuredDelimiter(new byte[16 * 1024], cancellation.Token));
+        Assert.ThrowsAny<OperationCanceledException>(() =>
+            OfficeProvenanceText.HasUnstructuredWrapperPrefix(
+                new byte[16 * 1024],
+                maximumContainerEntries: 16,
+                cancellation.Token));
+    }
+}

--- a/OfficeIMO.Shared.Tests/ProvenanceCoreContracts.Wave79.cs
+++ b/OfficeIMO.Shared.Tests/ProvenanceCoreContracts.Wave79.cs
@@ -1,0 +1,73 @@
+using System.Text;
+using OfficeIMO.Html;
+using OfficeIMO.Provenance;
+using Xunit;
+
+namespace OfficeIMO.Shared.Tests;
+
+public sealed partial class ProvenanceCoreContracts {
+    [Theory]
+    [InlineData(
+        "<link rel=\"c2pa-manifest\" href=\"claim.c2pa\">",
+        "claim.c2pa")]
+    [InlineData(
+        "<base href=\"https://example.test/assets/\"><link rel=\"c2pa-manifest\" href=\"claim.c2pa\">",
+        "https://example.test/assets/claim.c2pa")]
+    [InlineData(
+        "<title>parser-recovered metadata</title><link rel=\"c2pa-manifest\" href=\"claim.c2pa\">",
+        "claim.c2pa")]
+    [InlineData(
+        "<head><link rel=\"c2pa-manifest\" href=\"claim.c2pa\"></head>",
+        "claim.c2pa")]
+    public void CoreHtmlMatchesParserRecoveredAfterHeadExternalManifest(
+        string afterHead,
+        string expectedReference) {
+        string html = "<!doctype html><html><head></head>" + afterHead + "<body>body</body></html>";
+
+        OfficeProvenanceReport core = OfficeProvenanceInspector.Inspect(
+            Encoding.UTF8.GetBytes(html),
+            "fixture.html");
+        OfficeProvenanceReport owner = HtmlProvenance.Inspect(html);
+
+        OfficeProvenanceEvidence coreEvidence = Assert.Single(core.Evidence);
+        OfficeProvenanceEvidence ownerEvidence = Assert.Single(owner.Evidence);
+        Assert.Equal(OfficeProvenanceCarrierKind.C2paExternalManifest, coreEvidence.Carrier);
+        Assert.Equal(ownerEvidence.Value, coreEvidence.Value);
+        Assert.Equal(expectedReference, core.GetExternalManifestReference(coreEvidence));
+        Assert.Equal(expectedReference, owner.GetExternalManifestReference(ownerEvidence));
+    }
+
+    [Fact]
+    public void CoreHtmlMatchesParserRecoveredAfterHeadEmbeddedManifest() {
+        string manifest = Convert.ToBase64String(CreateManifestStore());
+        string html = "<!doctype html><html><head></head><script type=\"application/c2pa\">" +
+            manifest + "</script><body>body</body></html>";
+
+        OfficeProvenanceReport core = OfficeProvenanceInspector.Inspect(
+            Encoding.UTF8.GetBytes(html),
+            "fixture.html");
+        OfficeProvenanceReport owner = HtmlProvenance.Inspect(html);
+
+        OfficeProvenanceEvidence coreEvidence = Assert.Single(core.Evidence);
+        OfficeProvenanceEvidence ownerEvidence = Assert.Single(owner.Evidence);
+        Assert.Equal(OfficeProvenanceCarrierKind.C2paManifest, coreEvidence.Carrier);
+        Assert.True(coreEvidence.IsStructurallyValid);
+        Assert.Equal(ownerEvidence.IsStructurallyValid, coreEvidence.IsStructurallyValid);
+    }
+
+    [Theory]
+    [InlineData("<div>body begins</div>")]
+    [InlineData("<noscript>body begins</noscript>")]
+    public void CoreHtmlDoesNotRecoverHeadMetadataAfterBodyHasStarted(string bodyStart) {
+        string html = "<!doctype html><html><head></head>" + bodyStart +
+            "<link rel=\"c2pa-manifest\" href=\"claim.c2pa\"></html>";
+
+        OfficeProvenanceReport core = OfficeProvenanceInspector.Inspect(
+            Encoding.UTF8.GetBytes(html),
+            "fixture.html");
+        OfficeProvenanceReport owner = HtmlProvenance.Inspect(html);
+
+        Assert.Empty(core.Evidence);
+        Assert.Empty(owner.Evidence);
+    }
+}

--- a/OfficeIMO.Shared.Tests/ProvenanceDocumentContracts.Wave72.cs
+++ b/OfficeIMO.Shared.Tests/ProvenanceDocumentContracts.Wave72.cs
@@ -81,6 +81,36 @@ public sealed partial class ProvenanceDocumentContracts {
     }
 
     [Fact]
+    public void SignatureStripConsumesTheRemainingAggregateRewriteBudget() {
+        byte[] package = CreateZipPackage(
+            "odt",
+            "META-INF/documentsignatures.xml",
+            CreatePngWithManifest(CreateManifestStore()));
+        OfficeProvenanceRemovalResult preview = OdfDocument.RemoveProvenance(
+            package,
+            "document.odt",
+            new OfficeProvenanceRemovalOptions {
+                SignatureMutationPolicy = OfficeSignatureMutationPolicy.PreserveSignatureMarkup
+            });
+        OfficeProvenanceRemovalResult stripped = OdfDocument.RemoveProvenance(
+            package,
+            "document.odt",
+            new OfficeProvenanceRemovalOptions {
+                SignatureMutationPolicy = OfficeSignatureMutationPolicy.RemoveInvalidatedSignatures
+            });
+        long aggregateExpandedBytes = GetWave72ExpandedBytes(package) +
+                                     GetWave72ExpandedBytes(preview.ToArray()) +
+                                     GetWave72ExpandedBytes(stripped.ToArray());
+        var options = new OfficeProvenanceRemovalOptions {
+            SignatureMutationPolicy = OfficeSignatureMutationPolicy.RemoveInvalidatedSignatures
+        };
+        options.Limits.MaxExpandedContainerBytes = aggregateExpandedBytes - 1;
+
+        Assert.Throws<InvalidDataException>(() =>
+            OdfDocument.RemoveProvenance(package, "document.odt", options));
+    }
+
+    [Fact]
     public void SignatureRemovalAppliesTheOutputLimitToTheFinalStrippedPackage() {
         byte[] package = CreateZipPackage(
             "odt",

--- a/OfficeIMO.Shared.Tests/ProvenanceDocumentContracts.Wave72.cs
+++ b/OfficeIMO.Shared.Tests/ProvenanceDocumentContracts.Wave72.cs
@@ -1,8 +1,12 @@
 using System.IO.Compression;
+using System.IO.Packaging;
 using System.Text;
 using OfficeIMO.Excel;
 using OfficeIMO.OpenDocument;
+using OfficeIMO.PowerPoint;
 using OfficeIMO.Provenance;
+using OfficeIMO.Visio;
+using OfficeIMO.Word;
 using Xunit;
 
 namespace OfficeIMO.Shared.Tests;
@@ -117,8 +121,109 @@ public sealed partial class ProvenanceDocumentContracts {
         Assert.True(result.WereInvalidatedSignaturesRemoved);
     }
 
+    [Theory]
+    [InlineData("docx")]
+    [InlineData("xlsx")]
+    [InlineData("pptx")]
+    [InlineData("vsdx")]
+    public void OpenXmlSignatureRemovalAllowsAnIntermediateAboveTheFinalLimit(string extension) {
+        byte[] package = CreateWave73SignedOpenXmlPackage(extension);
+        OfficeProvenanceRemovalResult preview = RemoveWave73OpenXml(
+            package,
+            extension,
+            new OfficeProvenanceRemovalOptions {
+                SignatureMutationPolicy = OfficeSignatureMutationPolicy.PreserveSignatureMarkup
+            });
+        OfficeProvenanceRemovalResult baseline = RemoveWave73OpenXml(
+            package,
+            extension,
+            new OfficeProvenanceRemovalOptions {
+                SignatureMutationPolicy = OfficeSignatureMutationPolicy.RemoveInvalidatedSignatures
+            });
+        long finalSize = baseline.ToArray().LongLength;
+        Assert.True(preview.ToArray().LongLength > finalSize);
+        var bounded = new OfficeProvenanceRemovalOptions {
+            SignatureMutationPolicy = OfficeSignatureMutationPolicy.RemoveInvalidatedSignatures,
+            MaxOutputBytes = finalSize
+        };
+        bounded.Limits.MaxAssetBytes = 512 * 1024;
+        bounded.Limits.MaxManifestBytes = bounded.Limits.MaxAssetBytes;
+
+        OfficeProvenanceRemovalResult result = RemoveWave73OpenXml(package, extension, bounded);
+
+        Assert.Equal(finalSize, result.ToArray().LongLength);
+        Assert.True(result.WereInvalidatedSignaturesRemoved);
+    }
+
     private static long GetWave72ExpandedBytes(byte[] package) {
         using var archive = new ZipArchive(new MemoryStream(package), ZipArchiveMode.Read);
         return archive.Entries.Sum(entry => entry.Length);
     }
+
+    private static byte[] CreateWave73SignedOpenXmlPackage(string extension) {
+        byte[] package;
+        if (extension == "vsdx") {
+            package = CreateSignedVisioProvenancePackage(0);
+        } else {
+            string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + "." + extension);
+            try {
+                CreateOpenXmlPackage(path, extension);
+                using (Package container = Package.Open(path, FileMode.Open, FileAccess.ReadWrite)) {
+                    Uri manifestUri = PackUriHelper.CreatePartUri(new Uri("/META-INF/content_credential.c2pa", UriKind.Relative));
+                    using (Stream target = container.CreatePart(manifestUri, "application/c2pa", CompressionOption.Maximum).GetStream()) {
+                        byte[] manifest = CreateManifestStore();
+                        target.Write(manifest, 0, manifest.Length);
+                    }
+                    Uri originUri = PackUriHelper.CreatePartUri(new Uri("/_xmlsignatures/origin.sigs", UriKind.Relative));
+                    PackagePart origin = container.CreatePart(
+                        originUri,
+                        "application/vnd.openxmlformats-package.digital-signature-origin",
+                        CompressionOption.Maximum);
+                    container.CreateRelationship(
+                        originUri,
+                        TargetMode.Internal,
+                        "http://schemas.openxmlformats.org/package/2006/relationships/digital-signature/origin");
+                    Uri signatureUri = PackUriHelper.CreatePartUri(new Uri("/_xmlsignatures/sig1.xml", UriKind.Relative));
+                    _ = container.CreatePart(
+                        signatureUri,
+                        "application/vnd.openxmlformats-package.digital-signature-xmlsignature+xml",
+                        CompressionOption.Maximum);
+                    origin.CreateRelationship(
+                        signatureUri,
+                        TargetMode.Internal,
+                        "http://schemas.openxmlformats.org/package/2006/relationships/digital-signature/signature");
+                }
+                package = File.ReadAllBytes(path);
+            } finally {
+                if (File.Exists(path)) File.Delete(path);
+            }
+        }
+
+        var random = new Random(73);
+        var payload = new byte[32 * 1024];
+        random.NextBytes(payload);
+        byte[] signatureXml = Encoding.UTF8.GetBytes(
+            "<Signature xmlns=\"http://www.w3.org/2000/09/xmldsig#\"><Object>" +
+            Convert.ToBase64String(payload) + "</Object></Signature>");
+        using var output = new MemoryStream();
+        output.Write(package, 0, package.Length);
+        output.Position = 0;
+        using (Package container = Package.Open(output, FileMode.Open, FileAccess.ReadWrite)) {
+            Uri signatureUri = PackUriHelper.CreatePartUri(new Uri("/_xmlsignatures/sig1.xml", UriKind.Relative));
+            using Stream target = container.GetPart(signatureUri).GetStream(FileMode.Create, FileAccess.Write);
+            target.Write(signatureXml, 0, signatureXml.Length);
+        }
+        return output.ToArray();
+    }
+
+    private static OfficeProvenanceRemovalResult RemoveWave73OpenXml(
+        byte[] package,
+        string extension,
+        OfficeProvenanceRemovalOptions options) => extension switch {
+            "docx" => WordDocument.RemoveProvenance(package, "document.docx", options),
+            "xlsx" => ExcelDocument.RemoveProvenance(package, "workbook.xlsx", options),
+            "pptx" => PowerPointPresentation.RemoveProvenance(package, "presentation.pptx", options),
+            "vsdx" => VisioDocument.RemoveProvenance(package, "drawing.vsdx", options),
+            _ => throw new ArgumentOutOfRangeException(nameof(extension))
+        };
 }

--- a/OfficeIMO.Shared.Tests/ProvenanceDocumentContracts.Wave72.cs
+++ b/OfficeIMO.Shared.Tests/ProvenanceDocumentContracts.Wave72.cs
@@ -76,6 +76,47 @@ public sealed partial class ProvenanceDocumentContracts {
             OdfDocument.RemoveProvenance(package, "document.odt", options));
     }
 
+    [Fact]
+    public void SignatureRemovalAppliesTheOutputLimitToTheFinalStrippedPackage() {
+        byte[] package = CreateZipPackage(
+            "odt",
+            "META-INF/documentsignatures.xml",
+            CreatePngWithManifest(CreateManifestStore()));
+        var random = new Random(42);
+        var signatureBytes = new byte[16 * 1024];
+        random.NextBytes(signatureBytes);
+        package = ReplaceWave38Entry(
+            package,
+            "META-INF/documentsignatures.xml",
+            Convert.ToBase64String(signatureBytes));
+
+        OfficeProvenanceRemovalResult preview = OdfDocument.RemoveProvenance(
+            package,
+            "document.odt",
+            new OfficeProvenanceRemovalOptions {
+                SignatureMutationPolicy = OfficeSignatureMutationPolicy.PreserveSignatureMarkup
+            });
+        OfficeProvenanceRemovalResult baseline = OdfDocument.RemoveProvenance(
+            package,
+            "document.odt",
+            new OfficeProvenanceRemovalOptions {
+                SignatureMutationPolicy = OfficeSignatureMutationPolicy.RemoveInvalidatedSignatures
+            });
+        long finalSize = baseline.ToArray().LongLength;
+        Assert.True(preview.ToArray().LongLength > finalSize);
+        var bounded = new OfficeProvenanceRemovalOptions {
+            SignatureMutationPolicy = OfficeSignatureMutationPolicy.RemoveInvalidatedSignatures,
+            MaxOutputBytes = finalSize
+        };
+        bounded.Limits.MaxAssetBytes = 128 * 1024;
+        bounded.Limits.MaxManifestBytes = bounded.Limits.MaxAssetBytes;
+
+        OfficeProvenanceRemovalResult result = OdfDocument.RemoveProvenance(package, "document.odt", bounded);
+
+        Assert.Equal(finalSize, result.ToArray().LongLength);
+        Assert.True(result.WereInvalidatedSignaturesRemoved);
+    }
+
     private static long GetWave72ExpandedBytes(byte[] package) {
         using var archive = new ZipArchive(new MemoryStream(package), ZipArchiveMode.Read);
         return archive.Entries.Sum(entry => entry.Length);

--- a/OfficeIMO.Shared.Tests/ProvenanceReviewRegressionContracts.Wave73.cs
+++ b/OfficeIMO.Shared.Tests/ProvenanceReviewRegressionContracts.Wave73.cs
@@ -27,6 +27,33 @@ public sealed partial class ProvenanceReviewRegressionContracts {
     }
 
     [Theory]
+    [InlineData("utf16-le")]
+    [InlineData("utf16-be")]
+    [InlineData("utf32-le")]
+    [InlineData("utf32-be")]
+    public void HtmlAssessmentHonorsUnicodePreamblesForTextIntegrity(string encodingName) {
+        Encoding encoding = encodingName switch {
+            "utf16-le" => new UnicodeEncoding(bigEndian: false, byteOrderMark: true),
+            "utf16-be" => new UnicodeEncoding(bigEndian: true, byteOrderMark: true),
+            "utf32-le" => new UTF32Encoding(bigEndian: false, byteOrderMark: true),
+            "utf32-be" => new UTF32Encoding(bigEndian: true, byteOrderMark: true),
+            _ => throw new InvalidOperationException("Unknown test encoding.")
+        };
+        string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".html");
+        const string html = "<!doctype html><html><body>review\u200Bthis</body></html>";
+        File.WriteAllBytes(path, encoding.GetPreamble().Concat(encoding.GetBytes(html)).ToArray());
+        try {
+            OfficeProvenanceAssessmentReport report = OfficeProvenanceAssessment.InspectFile(path);
+
+            OfficeTextIntegrityFinding finding = Assert.Single(report.TextIntegrity!.Findings);
+            Assert.Equal(OfficeTextIntegrityFindingKind.ZeroWidthSpace, finding.Kind);
+            Assert.Equal(33, finding.TextOffset);
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Theory]
     [InlineData(true)]
     [InlineData(false)]
     public void ExtensionlessUtf32BigEndianSvgIsDetected(bool emitByteOrderMark) {

--- a/OfficeIMO.Shared.Tests/ProvenanceReviewRegressionContracts.Wave73.cs
+++ b/OfficeIMO.Shared.Tests/ProvenanceReviewRegressionContracts.Wave73.cs
@@ -6,6 +6,27 @@ namespace OfficeIMO.Shared.Tests;
 
 public sealed partial class ProvenanceReviewRegressionContracts {
     [Theory]
+    [InlineData("utf16-le")]
+    [InlineData("utf16-be")]
+    [InlineData("utf32-le")]
+    [InlineData("utf32-be")]
+    public void UnknownExtensionHtmlDetectionHonorsUnicodePreambles(string encodingName) {
+        Encoding encoding = encodingName switch {
+            "utf16-le" => new UnicodeEncoding(bigEndian: false, byteOrderMark: true),
+            "utf16-be" => new UnicodeEncoding(bigEndian: true, byteOrderMark: true),
+            "utf32-le" => new UTF32Encoding(bigEndian: false, byteOrderMark: true),
+            "utf32-be" => new UTF32Encoding(bigEndian: true, byteOrderMark: true),
+            _ => throw new InvalidOperationException("Unknown test encoding.")
+        };
+        const string html = "<!-- leading --><!doctype html><html><body>content</body></html>";
+        byte[] bytes = encoding.GetPreamble().Concat(encoding.GetBytes(html)).ToArray();
+
+        OfficeProvenanceReport report = OfficeProvenanceInspector.Inspect(bytes, "asset.bin");
+
+        Assert.Equal(OfficeProvenanceAssetFormat.Html, report.Format);
+    }
+
+    [Theory]
     [InlineData(true)]
     [InlineData(false)]
     public void ExtensionlessUtf32BigEndianSvgIsDetected(bool emitByteOrderMark) {

--- a/OfficeIMO.Shared.Tests/ProvenanceSnapshotConsistencyContracts.cs
+++ b/OfficeIMO.Shared.Tests/ProvenanceSnapshotConsistencyContracts.cs
@@ -1,0 +1,77 @@
+using System.Threading;
+using OfficeIMO.Provenance;
+using Xunit;
+
+namespace OfficeIMO.Shared.Tests;
+
+public sealed class ProvenanceSnapshotConsistencyContracts {
+    [Fact]
+    public void SnapshotCopyRejectsEqualLengthSourceMutationBetweenReadPasses() {
+        byte[] first = Enumerable.Repeat((byte)0x11, 4096).ToArray();
+        byte[] second = Enumerable.Repeat((byte)0x22, first.Length).ToArray();
+        using var source = new MutatingOnRewindStream(first, second);
+        using var destination = new MemoryStream();
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+            OfficeProvenanceFileSnapshot.CopyStableSource(
+                source,
+                destination,
+                maximumBytes: first.Length,
+                limitMessage: "limit",
+                CancellationToken.None,
+                out _));
+
+        Assert.Contains("changed content", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private sealed class MutatingOnRewindStream : Stream {
+        private readonly byte[] _first;
+        private readonly byte[] _second;
+        private long _position;
+        private bool _hasRead;
+        private bool _useSecond;
+
+        internal MutatingOnRewindStream(byte[] first, byte[] second) {
+            _first = first;
+            _second = second;
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => true;
+        public override bool CanWrite => false;
+        public override long Length => _first.LongLength;
+        public override long Position {
+            get => _position;
+            set {
+                if (value < 0 || value > Length) throw new ArgumentOutOfRangeException(nameof(value));
+                if (value == 0 && _hasRead) _useSecond = true;
+                _position = value;
+            }
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) {
+            byte[] active = _useSecond ? _second : _first;
+            int available = checked((int)Math.Min(count, Length - _position));
+            if (available == 0) return 0;
+            Buffer.BlockCopy(active, checked((int)_position), buffer, offset, available);
+            _position += available;
+            _hasRead = true;
+            return available;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) {
+            long target = origin switch {
+                SeekOrigin.Begin => offset,
+                SeekOrigin.Current => _position + offset,
+                SeekOrigin.End => Length + offset,
+                _ => throw new ArgumentOutOfRangeException(nameof(origin))
+            };
+            Position = target;
+            return _position;
+        }
+
+        public override void Flush() { }
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+}

--- a/OfficeIMO.Shared.Tests/TextIntegrityContracts.cs
+++ b/OfficeIMO.Shared.Tests/TextIntegrityContracts.cs
@@ -1,4 +1,6 @@
 using OfficeIMO.Provenance;
+using System.Text;
+using System.Threading;
 using Xunit;
 
 namespace OfficeIMO.Shared.Tests;
@@ -94,6 +96,36 @@ public sealed class TextIntegrityContracts {
             Assert.Throws<InvalidDataException>(() => OfficeTextIntegrityInspector.InspectFile(
                 path,
                 new OfficeTextIntegrityOptions { MaxEncodedBytes = 1 }));
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void StringInspectionObservesCancellationDuringTraversal() {
+        string text = new string('a', 16 * 1024 * 1024);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.CancelAfter(TimeSpan.FromMilliseconds(10));
+
+        Assert.Throws<OperationCanceledException>(() => OfficeTextIntegrityInspector.Inspect(
+            text,
+            new OfficeTextIntegrityOptions { MaxCharacters = text.Length },
+            "LargeText",
+            cancellation.Token));
+    }
+
+    [Fact]
+    public void FileInspectionObservesCancellationBeforeDecodeAndScan() {
+        string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".txt");
+        File.WriteAllText(path, "text", new UTF8Encoding(false));
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        try {
+            Assert.Throws<OperationCanceledException>(() => OfficeTextIntegrityInspector.InspectFile(
+                path,
+                new OfficeTextIntegrityOptions(),
+                "Text",
+                cancellation.Token));
         } finally {
             File.Delete(path);
         }

--- a/OfficeIMO.Shared.Tests/TextIntegrityContracts.cs
+++ b/OfficeIMO.Shared.Tests/TextIntegrityContracts.cs
@@ -103,15 +103,27 @@ public sealed class TextIntegrityContracts {
 
     [Fact]
     public void StringInspectionObservesCancellationDuringTraversal() {
-        string text = new string('a', 16 * 1024 * 1024);
+        string text = new string('a', 32 * 1024 * 1024);
         using var cancellation = new CancellationTokenSource();
-        cancellation.CancelAfter(TimeSpan.FromMilliseconds(10));
-
-        Assert.Throws<OperationCanceledException>(() => OfficeTextIntegrityInspector.Inspect(
-            text,
-            new OfficeTextIntegrityOptions { MaxCharacters = text.Length },
-            "LargeText",
-            cancellation.Token));
+        using var started = new ManualResetEventSlim();
+        var canceller = new Thread(() => {
+            started.Set();
+            Thread.Sleep(1);
+            cancellation.Cancel();
+        }) {
+            IsBackground = true
+        };
+        canceller.Start();
+        started.Wait();
+        try {
+            Assert.Throws<OperationCanceledException>(() => OfficeTextIntegrityInspector.Inspect(
+                text,
+                new OfficeTextIntegrityOptions { MaxCharacters = text.Length },
+                "LargeText",
+                cancellation.Token));
+        } finally {
+            canceller.Join();
+        }
     }
 
     [Fact]

--- a/OfficeIMO.Tool.Tests/OfficeImoToolAppTests.cs
+++ b/OfficeIMO.Tool.Tests/OfficeImoToolAppTests.cs
@@ -24,6 +24,7 @@ public sealed class OfficeImoToolAppTests {
         Assert.Contains("officeimo markup", help, StringComparison.Ordinal);
         Assert.Contains("officeimo tabular", help, StringComparison.Ordinal);
         Assert.Contains("officeimo workflow", help, StringComparison.Ordinal);
+        Assert.Contains("officeimo provenance", help, StringComparison.Ordinal);
         Assert.Equal(string.Empty, error.ToString());
     }
 

--- a/OfficeIMO.Tool.Tests/ProvenanceCommandTests.cs
+++ b/OfficeIMO.Tool.Tests/ProvenanceCommandTests.cs
@@ -1,0 +1,211 @@
+using System.Text.Json;
+using Xunit;
+
+namespace OfficeIMO.Tool.Tests;
+
+public sealed class ProvenanceCommandTests {
+    [Fact]
+    public async Task CapabilitiesReturnVersionedOwnerCatalog() {
+        ToolResult result = await RunAsync(["provenance", "capabilities"]);
+
+        Assert.Equal((int)OfficeImoToolExitCode.Success, result.ExitCode);
+        using JsonDocument json = JsonDocument.Parse(result.Output);
+        Assert.Equal("officeimo.provenance.capabilities.v1", json.RootElement.GetProperty("schema").GetString());
+        JsonElement capabilities = json.RootElement.GetProperty("capabilities");
+        Assert.Contains(capabilities.EnumerateArray(), item =>
+            item.GetProperty("id").GetString() == "word-openxml" &&
+            item.GetProperty("ownerPackage").GetString() == "OfficeIMO.Word");
+        Assert.Equal(string.Empty, result.Error);
+    }
+
+    [Fact]
+    public async Task InspectReturnsStableJsonWithoutChangingTopLevelInspectAlias() {
+        using var scope = new TestDirectory();
+        string input = scope.Write("page.html", HtmlWithManifest("body"));
+
+        ToolResult result = await RunAsync(["provenance", "inspect", input]);
+
+        Assert.Equal((int)OfficeImoToolExitCode.Success, result.ExitCode);
+        using JsonDocument json = JsonDocument.Parse(result.Output);
+        Assert.Equal("officeimo.provenance.result.v1", json.RootElement.GetProperty("schema").GetString());
+        Assert.Equal("Inspect", json.RootElement.GetProperty("operation").GetString());
+        Assert.Equal("OfficeIMO.Html", json.RootElement.GetProperty("ownerPackage").GetString());
+        Assert.Equal(1, json.RootElement.GetProperty("inspection").GetProperty("evidence").GetArrayLength());
+    }
+
+    [Fact]
+    public async Task AssessCanReportUnicodeIntegrityInJson() {
+        using var scope = new TestDirectory();
+        string input = scope.Write("page.html", HtmlWithManifest("review \u202Ethis"));
+
+        ToolResult result = await RunAsync(["provenance", "assess", input]);
+
+        Assert.Equal((int)OfficeImoToolExitCode.Success, result.ExitCode);
+        using JsonDocument json = JsonDocument.Parse(result.Output);
+        JsonElement findings = json.RootElement.GetProperty("assessment").GetProperty("textIntegrity");
+        Assert.Contains(findings.EnumerateArray(), item => item.GetProperty("kind").GetString() == "BidirectionalControl");
+    }
+
+    [Fact]
+    public async Task RemovePublishesVerifiedArtifactAndRefusesReplacementByDefault() {
+        using var scope = new TestDirectory();
+        string input = scope.Write("page.html", HtmlWithManifest("keep"));
+        string output = Path.Combine(scope.Path, "cleaned.html");
+
+        ToolResult first = await RunAsync(["provenance", "remove", input, "--output", output]);
+        ToolResult refused = await RunAsync(["provenance", "remove", input, "--output", output]);
+        ToolResult replaced = await RunAsync(["provenance", "remove", input, "--output", output, "--force"]);
+
+        Assert.Equal((int)OfficeImoToolExitCode.Success, first.ExitCode);
+        Assert.Equal((int)OfficeImoToolExitCode.OutputFailed, refused.ExitCode);
+        Assert.Equal((int)OfficeImoToolExitCode.Success, replaced.ExitCode);
+        Assert.DoesNotContain("c2pa-manifest", File.ReadAllText(output), StringComparison.OrdinalIgnoreCase);
+        using JsonDocument json = JsonDocument.Parse(replaced.Output);
+        Assert.True(json.RootElement.GetProperty("wasChanged").GetBoolean());
+        Assert.Equal(0, json.RootElement.GetProperty("after").GetProperty("evidence").GetArrayLength());
+    }
+
+    [Fact]
+    public async Task BatchInspectIsBoundedAndMachineReadable() {
+        using var scope = new TestDirectory();
+        string first = scope.Write("first.html", HtmlWithManifest("one"));
+        string second = scope.Write("second.html", "<html><body>two</body></html>");
+
+        ToolResult result = await RunAsync([
+            "provenance", "batch", "inspect", first, second, "--max-items", "2"
+        ]);
+
+        Assert.Equal((int)OfficeImoToolExitCode.Success, result.ExitCode);
+        using JsonDocument json = JsonDocument.Parse(result.Output);
+        Assert.Equal("officeimo.provenance.batch.v1", json.RootElement.GetProperty("schema").GetString());
+        Assert.Equal(2, json.RootElement.GetProperty("results").GetArrayLength());
+    }
+
+    [Fact]
+    public async Task BatchRemoveRejectsDuplicateBasenamesBeforeForceCanOverwrite() {
+        using var scope = new TestDirectory();
+        string firstDirectory = Path.Combine(scope.Path, "first");
+        string secondDirectory = Path.Combine(scope.Path, "second");
+        string outputDirectory = Path.Combine(scope.Path, "output");
+        Directory.CreateDirectory(firstDirectory);
+        Directory.CreateDirectory(secondDirectory);
+        string first = Path.Combine(firstDirectory, "page.html");
+        string second = Path.Combine(secondDirectory, "page.html");
+        File.WriteAllText(first, HtmlWithManifest("first"));
+        File.WriteAllText(second, HtmlWithManifest("second"));
+
+        ToolResult result = await RunAsync([
+            "provenance", "batch", "remove", first, second,
+            "--output-directory", outputDirectory, "--force"
+        ]);
+
+        Assert.Equal((int)OfficeImoToolExitCode.Usage, result.ExitCode);
+        Assert.Contains("same output path", result.Error, StringComparison.Ordinal);
+        Assert.False(Directory.Exists(outputDirectory));
+    }
+
+    [Fact]
+    public async Task PreCancelledBatchReturnsCancelledExitCodeAndResult() {
+        using var scope = new TestDirectory();
+        string first = scope.Write("first.html", "<html><body>first</body></html>");
+        string second = scope.Write("second.html", "<html><body>second</body></html>");
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        ToolResult result = await RunAsync(
+            ["provenance", "batch", "inspect", first, second],
+            cancellation.Token);
+
+        Assert.Equal((int)OfficeImoToolExitCode.Cancelled, result.ExitCode);
+        using JsonDocument json = JsonDocument.Parse(result.Output);
+        JsonElement item = Assert.Single(json.RootElement.GetProperty("results").EnumerateArray());
+        Assert.Equal("Cancelled", item.GetProperty("status").GetString());
+    }
+
+    [Fact]
+    public async Task BatchRemoveReturnsStructuredMixedResultsWhenAnInputIsMissing() {
+        using var scope = new TestDirectory();
+        string input = scope.Write("first.html", HtmlWithManifest("first"));
+        string missing = Path.Combine(scope.Path, "missing.html");
+        string outputDirectory = Path.Combine(scope.Path, "output");
+
+        ToolResult result = await RunAsync([
+            "provenance", "batch", "remove", input, missing,
+            "--output-directory", outputDirectory
+        ]);
+
+        Assert.Equal((int)OfficeImoToolExitCode.InputNotFound, result.ExitCode);
+        using JsonDocument json = JsonDocument.Parse(result.Output);
+        JsonElement.ArrayEnumerator results = json.RootElement.GetProperty("results").EnumerateArray();
+        Assert.Collection(
+            results,
+            item => Assert.Equal("Completed", item.GetProperty("status").GetString()),
+            item => Assert.Equal("InputNotFound", item.GetProperty("failureKind").GetString()));
+        Assert.True(File.Exists(Path.Combine(outputDirectory, "first.provenance-cleaned.html")));
+        Assert.False(File.Exists(Path.Combine(outputDirectory, "missing.provenance-cleaned.html")));
+    }
+
+    [Fact]
+    public async Task UnsafeOrMeaninglessRemovalOptionsReturnUsage() {
+        using var scope = new TestDirectory();
+        string input = scope.Write("page.html", HtmlWithManifest("body"));
+
+        ToolResult result = await RunAsync([
+            "provenance", "remove", input, "--keep-c2pa", "--keep-external-c2pa", "--keep-ai-source"
+        ]);
+
+        Assert.Equal((int)OfficeImoToolExitCode.Usage, result.ExitCode);
+        Assert.Contains("at least one selected carrier", result.Error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MissingInputUsesStableInputNotFoundExitCode() {
+        using var scope = new TestDirectory();
+        string missing = Path.Combine(scope.Path, "missing.html");
+
+        ToolResult result = await RunAsync(["provenance", "inspect", missing]);
+
+        Assert.Equal((int)OfficeImoToolExitCode.InputNotFound, result.ExitCode);
+        using JsonDocument json = JsonDocument.Parse(result.Output);
+        Assert.Equal("InputNotFound", json.RootElement.GetProperty("failureKind").GetString());
+    }
+
+    private static string HtmlWithManifest(string body) =>
+        "<!doctype html><html><head><link rel=\"c2pa-manifest\" href=\"claim.c2pa\"></head><body>" + body + "</body></html>";
+
+    private static async Task<ToolResult> RunAsync(string[] args, CancellationToken cancellationToken = default) {
+        await using var output = new MemoryStream();
+        using var error = new StringWriter();
+        int exitCode = await OfficeImoToolApp.RunAsync(args, Stream.Null, output, error, cancellationToken);
+        return new ToolResult(exitCode, Encoding.UTF8.GetString(output.ToArray()), error.ToString());
+    }
+
+    private sealed record ToolResult(int ExitCode, string Output, string Error);
+
+    private sealed class TestDirectory : IDisposable {
+        internal TestDirectory() {
+            Path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                "officeimo-tool-provenance-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path);
+        }
+
+        internal string Path { get; }
+
+        internal string Write(string fileName, string contents) {
+            string path = System.IO.Path.Combine(Path, fileName);
+            File.WriteAllText(path, contents, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            return path;
+        }
+
+        public void Dispose() {
+            try {
+                if (Directory.Exists(Path)) Directory.Delete(Path, recursive: true);
+            } catch (IOException) {
+                // Best-effort test cleanup.
+            } catch (UnauthorizedAccessException) {
+                // Best-effort test cleanup.
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tool.Tests/ProvenanceCommandTests.cs
+++ b/OfficeIMO.Tool.Tests/ProvenanceCommandTests.cs
@@ -74,6 +74,41 @@ public sealed class ProvenanceCommandTests {
     }
 
     [Fact]
+    public async Task TextOutputIncludesRetainedCleanupPathsFromWorkflowDiagnostics() {
+        if (!System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+                System.Runtime.InteropServices.OSPlatform.Windows)) return;
+        using var scope = new TestDirectory();
+        string input = scope.Write("page.html", HtmlWithManifest("body"));
+        string outputPath = Path.Combine(scope.Path, "cleaned.html");
+        using var cancellation = new CancellationTokenSource();
+        using var progress = new RetainingStagingProgress(scope.Path, outputPath, cancellation);
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner().RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Remove,
+                InputPath = input,
+                OutputPath = outputPath
+            },
+            progress,
+            cancellation.Token);
+        using var output = new StringWriter();
+        try {
+            await ProvenanceOutput.WriteResultAsync(output, result, ProvenanceOutputFormat.Text);
+
+            string text = output.ToString();
+            Assert.Contains(
+                "Diagnostic: Error | ProvenanceStagingCleanupFailed | stage=cleanup",
+                text,
+                StringComparison.Ordinal);
+            Assert.Contains("retainedPath: " + progress.RetainedPath, text, StringComparison.Ordinal);
+        } finally {
+            progress.Dispose();
+            if (progress.RetainedPath is not null && File.Exists(progress.RetainedPath)) {
+                File.Delete(progress.RetainedPath);
+            }
+        }
+    }
+
+    [Fact]
     public async Task RemovePublishesVerifiedArtifactAndRefusesReplacementByDefault() {
         using var scope = new TestDirectory();
         string input = scope.Write("page.html", HtmlWithManifest("keep"));
@@ -342,6 +377,39 @@ public sealed class ProvenanceCommandTests {
                 },
                 cancellationToken: cancelled.Token);
             return [failure, cancellation];
+        }
+    }
+
+    private sealed class RetainingStagingProgress : IProgress<OfficeWorkflowProgress>, IDisposable {
+        private readonly string _directory;
+        private readonly string _outputPath;
+        private readonly CancellationTokenSource _cancellation;
+        private FileStream? _lease;
+
+        internal RetainingStagingProgress(
+            string directory,
+            string outputPath,
+            CancellationTokenSource cancellation) {
+            _directory = directory;
+            _outputPath = outputPath;
+            _cancellation = cancellation;
+        }
+
+        internal string? RetainedPath { get; private set; }
+
+        public void Report(OfficeWorkflowProgress value) {
+            if (_lease != null || !string.Equals(value.Stage, "validate-output", StringComparison.Ordinal)) return;
+            RetainedPath = Directory.GetFiles(
+                    _directory,
+                    "." + Path.GetFileNameWithoutExtension(_outputPath) + ".*" + Path.GetExtension(_outputPath))
+                .Single();
+            _lease = new FileStream(RetainedPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            _cancellation.Cancel();
+        }
+
+        public void Dispose() {
+            _lease?.Dispose();
+            _lease = null;
         }
     }
 

--- a/OfficeIMO.Tool.Tests/ProvenanceCommandTests.cs
+++ b/OfficeIMO.Tool.Tests/ProvenanceCommandTests.cs
@@ -220,6 +220,20 @@ public sealed class ProvenanceCommandTests {
     }
 
     [Fact]
+    public async Task InputLimitUsesStableUnsupportedInputExitCode() {
+        using var scope = new TestDirectory();
+        string input = scope.Write("page.html", "<!doctype html><html><body>bounded input</body></html>");
+
+        ToolResult result = await RunAsync([
+            "provenance", "inspect", input, "--max-input-bytes", "16"
+        ]);
+
+        Assert.Equal((int)OfficeImoToolExitCode.UnsupportedInput, result.ExitCode);
+        using JsonDocument json = JsonDocument.Parse(result.Output);
+        Assert.Equal("UnsupportedInput", json.RootElement.GetProperty("failureKind").GetString());
+    }
+
+    [Fact]
     public void CliByteLimitsFlowIntoEveryOwningParserBoundary() {
         const long inputLimit = 768L * 1024L * 1024L;
         const long outputLimit = 1024L * 1024L * 1024L;

--- a/OfficeIMO.Tool.Tests/ProvenanceCommandTests.cs
+++ b/OfficeIMO.Tool.Tests/ProvenanceCommandTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using OfficeIMO.Provenance;
 using OfficeIMO.Tool.Commands.Provenance;
 using OfficeIMO.Workflows;
 using Xunit;
@@ -46,6 +47,30 @@ public sealed class ProvenanceCommandTests {
         using JsonDocument json = JsonDocument.Parse(result.Output);
         JsonElement findings = json.RootElement.GetProperty("assessment").GetProperty("textIntegrity");
         Assert.Contains(findings.EnumerateArray(), item => item.GetProperty("kind").GetString() == "BidirectionalControl");
+    }
+
+    [Fact]
+    public async Task AssessmentTextOutputIncludesVerificationIntegrityAndProviderEvidence() {
+        using var scope = new TestDirectory();
+        string input = scope.Write("page.html", "<!doctype html><html><body>review \u202Ethis</body></html>");
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner(
+            new InvalidVerifier(),
+            [new InconclusiveDetector()]).RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Assess,
+                InputPath = input
+            });
+        Assert.True(result.Succeeded, result.Summary);
+        using var output = new StringWriter();
+
+        await ProvenanceOutput.WriteResultAsync(output, result, ProvenanceOutputFormat.Text);
+
+        string text = output.ToString();
+        Assert.Contains("Verification: test-verifier | status=Invalid", text, StringComparison.Ordinal);
+        Assert.Contains("Verification finding: content binding failed", text, StringComparison.Ordinal);
+        Assert.Contains("PotentiallyDangerous | BidirectionalControl | U+202E", text, StringComparison.Ordinal);
+        Assert.Contains("Provider signal: test-detector | StatisticalTextWatermark | status=Inconclusive", text, StringComparison.Ordinal);
+        Assert.Contains("Provider finding: sample too short", text, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -250,6 +275,23 @@ public sealed class ProvenanceCommandTests {
     }
 
     private sealed record ToolResult(int ExitCode, string Output, string Error);
+
+    private sealed class InvalidVerifier : IOfficeProvenanceVerifier {
+        public string Name => "test-verifier";
+
+        public OfficeProvenanceVerificationResult Verify(
+            string filePath,
+            OfficeProvenanceVerificationOptions? options = null) =>
+            new(OfficeProvenanceVerificationStatus.Invalid, Name, ["content binding failed"]);
+    }
+
+    private sealed class InconclusiveDetector : IOfficeProvenanceSignalDetector {
+        public string Name => "test-detector";
+        public OfficeProvenanceSignalKind SignalKind => OfficeProvenanceSignalKind.StatisticalTextWatermark;
+
+        public OfficeProvenanceSignalResult Detect(string filePath) =>
+            new(Name, SignalKind, OfficeProvenanceSignalStatus.Inconclusive, ["sample too short"]);
+    }
 
     private sealed class FailureThenCancellationRunner : IOfficeProvenanceWorkflowRunner {
         private readonly string _missingPath;

--- a/OfficeIMO.Tool.Tests/ProvenanceCommandTests.cs
+++ b/OfficeIMO.Tool.Tests/ProvenanceCommandTests.cs
@@ -1,4 +1,6 @@
 using System.Text.Json;
+using OfficeIMO.Tool.Commands.Provenance;
+using OfficeIMO.Workflows;
 using Xunit;
 
 namespace OfficeIMO.Tool.Tests;
@@ -168,6 +170,51 @@ public sealed class ProvenanceCommandTests {
         Assert.Equal((int)OfficeImoToolExitCode.InputNotFound, result.ExitCode);
         using JsonDocument json = JsonDocument.Parse(result.Output);
         Assert.Equal("InputNotFound", json.RootElement.GetProperty("failureKind").GetString());
+    }
+
+    [Fact]
+    public void CliByteLimitsFlowIntoEveryOwningParserBoundary() {
+        const long inputLimit = 768L * 1024L * 1024L;
+        const long outputLimit = 1024L * 1024L * 1024L;
+        ProvenanceArguments parsed = ProvenanceArguments.Parse([
+            "remove", "input.html", "--max-input-bytes", inputLimit.ToString(),
+            "--max-output-bytes", outputLimit.ToString()
+        ]);
+
+        OfficeProvenanceWorkflowRequest request = ProvenanceCommand.CreateRequest(
+            parsed,
+            "input.html",
+            "output.html");
+
+        Assert.Equal(inputLimit, request.Limits.MaximumInputBytes);
+        Assert.Equal(outputLimit, request.Limits.MaximumOutputBytes);
+        Assert.Equal(inputLimit, request.Inspection.MaxAssetBytes);
+        Assert.Equal(inputLimit, request.Assessment.Structural.MaxAssetBytes);
+        Assert.Equal(inputLimit, request.Assessment.TextIntegrity.MaxEncodedBytes);
+        Assert.Equal(inputLimit, request.Removal.Limits.MaxAssetBytes);
+        Assert.Equal(outputLimit, request.Removal.MaxOutputBytes);
+    }
+
+    [Fact]
+    public void CliLongLimitsClampOnlyMaterializingParserOptions() {
+        long configured = (long)int.MaxValue + 4096L;
+        ProvenanceArguments parsed = ProvenanceArguments.Parse([
+            "remove", "input.html", "--max-input-bytes", configured.ToString(),
+            "--max-output-bytes", configured.ToString()
+        ]);
+
+        OfficeProvenanceWorkflowRequest request = ProvenanceCommand.CreateRequest(
+            parsed,
+            "input.html",
+            "output.html");
+
+        Assert.Equal(configured, request.Limits.MaximumInputBytes);
+        Assert.Equal(configured, request.Limits.MaximumOutputBytes);
+        Assert.Equal(int.MaxValue, request.Inspection.MaxAssetBytes);
+        Assert.Equal(int.MaxValue, request.Assessment.Structural.MaxAssetBytes);
+        Assert.Equal(int.MaxValue, request.Assessment.TextIntegrity.MaxEncodedBytes);
+        Assert.Equal(int.MaxValue, request.Removal.Limits.MaxAssetBytes);
+        Assert.Equal(int.MaxValue, request.Removal.MaxOutputBytes);
     }
 
     private static string HtmlWithManifest(string body) =>

--- a/OfficeIMO.Tool.Tests/ProvenanceCommandTests.cs
+++ b/OfficeIMO.Tool.Tests/ProvenanceCommandTests.cs
@@ -134,7 +134,7 @@ public sealed class ProvenanceCommandTests {
     [Fact]
     public async Task PreCancelledBatchReturnsCancelledExitCodeAndResult() {
         using var scope = new TestDirectory();
-        string first = scope.Write("first.html", "<html><body>first</body></html>");
+        string first = Path.Combine(scope.Path, "missing.html");
         string second = scope.Write("second.html", "<html><body>second</body></html>");
         using var cancellation = new CancellationTokenSource();
         cancellation.Cancel();

--- a/OfficeIMO.Tool.Tests/ProvenanceCommandTests.cs
+++ b/OfficeIMO.Tool.Tests/ProvenanceCommandTests.cs
@@ -125,6 +125,28 @@ public sealed class ProvenanceCommandTests {
     }
 
     [Fact]
+    public async Task BatchCancellationTakesExitCodePrecedenceOverAnEarlierFailure() {
+        using var scope = new TestDirectory();
+        string input = scope.Write("input.html", "<html><body>input</body></html>");
+        string missing = Path.Combine(scope.Path, "missing.html");
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+
+        int exitCode = await ProvenanceCommand.RunAsync(
+            ["batch", "inspect", input],
+            output,
+            error,
+            runner: new FailureThenCancellationRunner(missing, input));
+
+        Assert.Equal((int)OfficeImoToolExitCode.Cancelled, exitCode);
+        using JsonDocument json = JsonDocument.Parse(output.ToString());
+        Assert.Collection(
+            json.RootElement.GetProperty("results").EnumerateArray(),
+            item => Assert.Equal("Failed", item.GetProperty("status").GetString()),
+            item => Assert.Equal("Cancelled", item.GetProperty("status").GetString()));
+    }
+
+    [Fact]
     public async Task BatchRemoveReturnsStructuredMixedResultsWhenAnInputIsMissing() {
         using var scope = new TestDirectory();
         string input = scope.Write("first.html", HtmlWithManifest("first"));
@@ -228,6 +250,44 @@ public sealed class ProvenanceCommandTests {
     }
 
     private sealed record ToolResult(int ExitCode, string Output, string Error);
+
+    private sealed class FailureThenCancellationRunner : IOfficeProvenanceWorkflowRunner {
+        private readonly string _missingPath;
+        private readonly string _existingPath;
+        private readonly OfficeWorkflowRunner _inner = new OfficeWorkflowRunner();
+
+        internal FailureThenCancellationRunner(string missingPath, string existingPath) {
+            _missingPath = missingPath;
+            _existingPath = existingPath;
+        }
+
+        public Task<OfficeProvenanceWorkflowResult> RunProvenanceAsync(
+            OfficeProvenanceWorkflowRequest request,
+            IProgress<OfficeWorkflowProgress>? progress = null,
+            CancellationToken cancellationToken = default) =>
+            _inner.RunProvenanceAsync(request, progress, cancellationToken);
+
+        public async Task<IReadOnlyList<OfficeProvenanceWorkflowResult>> RunProvenanceBatchAsync(
+            IEnumerable<OfficeProvenanceWorkflowRequest> requests,
+            OfficeProvenanceWorkflowBatchOptions? options = null,
+            IProgress<OfficeWorkflowProgress>? progress = null,
+            CancellationToken cancellationToken = default) {
+            OfficeProvenanceWorkflowResult failure = await _inner.RunProvenanceAsync(
+                new OfficeProvenanceWorkflowRequest {
+                    Operation = OfficeProvenanceWorkflowOperation.Inspect,
+                    InputPath = _missingPath
+                });
+            using var cancelled = new CancellationTokenSource();
+            cancelled.Cancel();
+            OfficeProvenanceWorkflowResult cancellation = await _inner.RunProvenanceAsync(
+                new OfficeProvenanceWorkflowRequest {
+                    Operation = OfficeProvenanceWorkflowOperation.Inspect,
+                    InputPath = _existingPath
+                },
+                cancellationToken: cancelled.Token);
+            return [failure, cancellation];
+        }
+    }
 
     private sealed class TestDirectory : IDisposable {
         internal TestDirectory() {

--- a/OfficeIMO.Tool/Commands/Provenance/ProvenanceArguments.cs
+++ b/OfficeIMO.Tool/Commands/Provenance/ProvenanceArguments.cs
@@ -1,0 +1,207 @@
+using OfficeIMO;
+using OfficeIMO.Workflows;
+
+namespace OfficeIMO.Tool.Commands.Provenance;
+
+internal enum ProvenanceCommandKind {
+    Help,
+    Capabilities,
+    Inspect,
+    Assess,
+    Remove,
+    Batch
+}
+
+internal enum ProvenanceOutputFormat {
+    Json,
+    Text
+}
+
+internal sealed class ProvenanceArguments {
+    internal ProvenanceCommandKind Command { get; private set; }
+    internal OfficeProvenanceWorkflowOperation BatchOperation { get; private set; }
+    internal IReadOnlyList<string> Inputs { get; private set; } = Array.Empty<string>();
+    internal string? OutputPath { get; private set; }
+    internal string? OutputDirectory { get; private set; }
+    internal ProvenanceOutputFormat Format { get; private set; } = ProvenanceOutputFormat.Json;
+    internal bool Force { get; private set; }
+    internal bool RemoveC2paManifests { get; private set; } = true;
+    internal bool RemoveExternalC2paReferences { get; private set; } = true;
+    internal bool RemoveAiSourceMetadata { get; private set; } = true;
+    internal bool RemoveInvalidatedSignatures { get; private set; }
+    internal bool ProcessEmbeddedAssets { get; private set; } = true;
+    internal bool InspectTextIntegrity { get; private set; } = true;
+    internal long MaximumInputBytes { get; private set; } = 256L * 1024L * 1024L;
+    internal long MaximumOutputBytes { get; private set; } = 512L * 1024L * 1024L;
+    internal int MaximumItems { get; private set; } = 256;
+
+    internal static ProvenanceArguments Parse(string[] args) {
+        if (args.Length == 0 || IsHelp(args[0])) return new ProvenanceArguments { Command = ProvenanceCommandKind.Help };
+        var parsed = new ProvenanceArguments {
+            Command = args[0].ToLowerInvariant() switch {
+                "capabilities" => ProvenanceCommandKind.Capabilities,
+                "inspect" => ProvenanceCommandKind.Inspect,
+                "assess" => ProvenanceCommandKind.Assess,
+                "remove" => ProvenanceCommandKind.Remove,
+                "batch" => ProvenanceCommandKind.Batch,
+                _ => throw new ProvenanceUsageException("Unknown provenance command '" + args[0] + "'.")
+            }
+        };
+
+        int startIndex = 1;
+        if (parsed.Command == ProvenanceCommandKind.Batch) {
+            if (args.Length <= 1 || args[1].StartsWith("-", StringComparison.Ordinal)) {
+                throw new ProvenanceUsageException("batch requires inspect, assess, or remove as its operation.");
+            }
+            parsed.BatchOperation = ParseOperation(args[1]);
+            startIndex = 2;
+        }
+
+        var inputs = new List<string>();
+        for (int index = startIndex; index < args.Length; index++) {
+            string token = args[index];
+            if (IsHelp(token)) return new ProvenanceArguments { Command = ProvenanceCommandKind.Help };
+            switch (token) {
+                case "--format":
+                    parsed.Format = ParseOutputFormat(ReadValue(args, ref index, token));
+                    break;
+                case "--output":
+                    EnsureCommand(parsed.Command, token, ProvenanceCommandKind.Remove);
+                    parsed.OutputPath = ReadValue(args, ref index, token);
+                    break;
+                case "--output-directory":
+                    EnsureCommand(parsed.Command, token, ProvenanceCommandKind.Batch);
+                    parsed.OutputDirectory = ReadValue(args, ref index, token);
+                    break;
+                case "--force":
+                    EnsureMutation(parsed, token);
+                    parsed.Force = true;
+                    break;
+                case "--keep-c2pa":
+                    EnsureMutation(parsed, token);
+                    parsed.RemoveC2paManifests = false;
+                    break;
+                case "--keep-external-c2pa":
+                    EnsureMutation(parsed, token);
+                    parsed.RemoveExternalC2paReferences = false;
+                    break;
+                case "--keep-ai-source":
+                    EnsureMutation(parsed, token);
+                    parsed.RemoveAiSourceMetadata = false;
+                    break;
+                case "--remove-invalidated-signatures":
+                    EnsureMutation(parsed, token);
+                    parsed.RemoveInvalidatedSignatures = true;
+                    break;
+                case "--no-embedded":
+                    if (parsed.Command == ProvenanceCommandKind.Capabilities) {
+                        throw new ProvenanceUsageException(token + " is not valid with capabilities.");
+                    }
+                    parsed.ProcessEmbeddedAssets = false;
+                    break;
+                case "--no-text-integrity":
+                    EnsureAssessment(parsed, token);
+                    parsed.InspectTextIntegrity = false;
+                    break;
+                case "--max-input-bytes":
+                    if (parsed.Command == ProvenanceCommandKind.Capabilities) {
+                        throw new ProvenanceUsageException(token + " is not valid with capabilities.");
+                    }
+                    parsed.MaximumInputBytes = ParseLong(ReadValue(args, ref index, token), token, 1, long.MaxValue);
+                    break;
+                case "--max-output-bytes":
+                    EnsureMutation(parsed, token);
+                    parsed.MaximumOutputBytes = ParseLong(ReadValue(args, ref index, token), token, 1, long.MaxValue);
+                    break;
+                case "--max-items":
+                    EnsureCommand(parsed.Command, token, ProvenanceCommandKind.Batch);
+                    parsed.MaximumItems = checked((int)ParseLong(ReadValue(args, ref index, token), token, 1, 10_000));
+                    break;
+                default:
+                    if (token.StartsWith("-", StringComparison.Ordinal)) {
+                        throw new ProvenanceUsageException("Unknown option '" + token + "'.");
+                    }
+                    inputs.Add(token);
+                    break;
+            }
+        }
+        parsed.Inputs = inputs;
+        parsed.Validate();
+        return parsed;
+    }
+
+    private void Validate() {
+        if (Command == ProvenanceCommandKind.Capabilities) {
+            if (Inputs.Count != 0) throw new ProvenanceUsageException("capabilities does not accept input paths.");
+            return;
+        }
+        if (Command == ProvenanceCommandKind.Batch) {
+            if (Inputs.Count == 0) throw new ProvenanceUsageException("batch requires at least one input path.");
+            if (Inputs.Count > MaximumItems) {
+                throw new ProvenanceUsageException("batch input count exceeds --max-items " + MaximumItems + ".");
+            }
+            if (BatchOperation == OfficeProvenanceWorkflowOperation.Remove && string.IsNullOrWhiteSpace(OutputDirectory)) {
+                throw new ProvenanceUsageException("batch remove requires --output-directory <path>.");
+            }
+            if (BatchOperation != OfficeProvenanceWorkflowOperation.Remove && OutputDirectory is not null) {
+                throw new ProvenanceUsageException("--output-directory is valid only with batch remove.");
+            }
+        } else if (Inputs.Count != 1) {
+            throw new ProvenanceUsageException(Command.ToString().ToLowerInvariant() + " requires exactly one input path.");
+        }
+        if (IsRemoval && !RemoveC2paManifests && !RemoveExternalC2paReferences && !RemoveAiSourceMetadata) {
+            throw new ProvenanceUsageException("Removal requires at least one selected carrier class.");
+        }
+    }
+
+    internal bool IsRemoval => Command == ProvenanceCommandKind.Remove ||
+                               Command == ProvenanceCommandKind.Batch && BatchOperation == OfficeProvenanceWorkflowOperation.Remove;
+
+    private static OfficeProvenanceWorkflowOperation ParseOperation(string value) => value.ToLowerInvariant() switch {
+        "inspect" => OfficeProvenanceWorkflowOperation.Inspect,
+        "assess" => OfficeProvenanceWorkflowOperation.Assess,
+        "remove" => OfficeProvenanceWorkflowOperation.Remove,
+        _ => throw new ProvenanceUsageException("batch operation must be inspect, assess, or remove.")
+    };
+
+    private static ProvenanceOutputFormat ParseOutputFormat(string value) => value.ToLowerInvariant() switch {
+        "json" => ProvenanceOutputFormat.Json,
+        "text" => ProvenanceOutputFormat.Text,
+        _ => throw new ProvenanceUsageException("--format must be json or text.")
+    };
+
+    private static string ReadValue(string[] args, ref int index, string option) {
+        if (++index >= args.Length || string.IsNullOrWhiteSpace(args[index]) || args[index].StartsWith("-", StringComparison.Ordinal)) {
+            throw new ProvenanceUsageException(option + " requires a value.");
+        }
+        return args[index];
+    }
+
+    private static long ParseLong(string value, string option, long minimum, long maximum) {
+        if (!long.TryParse(value, System.Globalization.NumberStyles.None, System.Globalization.CultureInfo.InvariantCulture, out long parsed) ||
+            parsed < minimum || parsed > maximum) {
+            throw new ProvenanceUsageException(option + " must be between " + minimum + " and " + maximum + ".");
+        }
+        return parsed;
+    }
+
+    private static void EnsureMutation(ProvenanceArguments parsed, string option) {
+        if (!parsed.IsRemoval) throw new ProvenanceUsageException(option + " is valid only with remove or batch remove.");
+    }
+
+    private static void EnsureAssessment(ProvenanceArguments parsed, string option) {
+        bool allowed = parsed.Command == ProvenanceCommandKind.Assess ||
+                       parsed.Command == ProvenanceCommandKind.Batch && parsed.BatchOperation == OfficeProvenanceWorkflowOperation.Assess;
+        if (!allowed) throw new ProvenanceUsageException(option + " is valid only with assess or batch assess.");
+    }
+
+    private static void EnsureCommand(ProvenanceCommandKind command, string option, params ProvenanceCommandKind[] allowed) {
+        if (!allowed.Contains(command)) throw new ProvenanceUsageException(option + " is not valid with " + command.ToString().ToLowerInvariant() + ".");
+    }
+
+    private static bool IsHelp(string value) => value is "help" or "--help" or "-h";
+}
+
+internal sealed class ProvenanceUsageException : Exception {
+    internal ProvenanceUsageException(string message) : base(message) { }
+}

--- a/OfficeIMO.Tool/Commands/Provenance/ProvenanceCommand.cs
+++ b/OfficeIMO.Tool/Commands/Provenance/ProvenanceCommand.cs
@@ -1,0 +1,144 @@
+using OfficeIMO;
+using OfficeIMO.Provenance;
+using OfficeIMO.Workflows;
+
+namespace OfficeIMO.Tool.Commands.Provenance;
+
+internal static class ProvenanceCommand {
+    internal const string Usage = """
+OfficeIMO.Tool - provenance workflows
+
+Usage:
+  officeimo provenance capabilities [--format json|text]
+  officeimo provenance inspect <input> [--no-embedded] [--max-input-bytes <bytes>] [--format json|text]
+  officeimo provenance assess <input> [--no-embedded] [--no-text-integrity]
+             [--max-input-bytes <bytes>] [--format json|text]
+  officeimo provenance remove <input> [--output <path>] [--force]
+             [--keep-c2pa] [--keep-external-c2pa] [--keep-ai-source]
+             [--remove-invalidated-signatures] [--no-embedded]
+             [--max-input-bytes <bytes>] [--max-output-bytes <bytes>] [--format json|text]
+  officeimo provenance batch inspect|assess <input>... [--max-items <1-10000>] [options]
+  officeimo provenance batch remove <input>... --output-directory <path>
+             [--max-items <1-10000>] [options]
+
+JSON is the default output and carries a versioned schema identifier.
+Removal preserves the input format, refuses existing output unless --force is supplied,
+and blocks invalidating package signatures unless --remove-invalidated-signatures is explicit.
+""";
+
+    internal static async Task<int> RunAsync(
+        string[] args,
+        TextWriter standardOutput,
+        TextWriter standardError,
+        CancellationToken cancellationToken = default,
+        IOfficeProvenanceWorkflowRunner? runner = null) {
+        try {
+            ProvenanceArguments parsed = ProvenanceArguments.Parse(args);
+            if (parsed.Command == ProvenanceCommandKind.Help) {
+                await standardOutput.WriteLineAsync(Usage).ConfigureAwait(false);
+                return (int)OfficeImoToolExitCode.Success;
+            }
+            if (parsed.Command == ProvenanceCommandKind.Capabilities) {
+                await ProvenanceOutput.WriteCapabilitiesAsync(standardOutput, parsed.Format).ConfigureAwait(false);
+                return (int)OfficeImoToolExitCode.Success;
+            }
+
+            IOfficeProvenanceWorkflowRunner activeRunner = runner ?? new OfficeWorkflowRunner();
+            if (parsed.Command == ProvenanceCommandKind.Batch) {
+                IReadOnlyList<OfficeProvenanceWorkflowResult> results = await activeRunner.RunProvenanceBatchAsync(
+                    CreateBatchRequests(parsed),
+                    new OfficeProvenanceWorkflowBatchOptions { MaximumRequests = parsed.MaximumItems },
+                    cancellationToken: cancellationToken).ConfigureAwait(false);
+                await ProvenanceOutput.WriteBatchAsync(standardOutput, results, parsed.Format).ConfigureAwait(false);
+                return MapBatch(results);
+            }
+
+            OfficeProvenanceWorkflowResult result = await activeRunner.RunProvenanceAsync(
+                CreateRequest(parsed, parsed.Inputs[0], parsed.OutputPath),
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+            await ProvenanceOutput.WriteResultAsync(standardOutput, result, parsed.Format).ConfigureAwait(false);
+            return MapStatus(result.Status, result.FailureKind);
+        } catch (ProvenanceUsageException exception) {
+            await standardError.WriteLineAsync(exception.Message).ConfigureAwait(false);
+            await standardError.WriteLineAsync(Usage).ConfigureAwait(false);
+            return (int)OfficeImoToolExitCode.Usage;
+        } catch (ArgumentException exception) {
+            await standardError.WriteLineAsync(exception.Message).ConfigureAwait(false);
+            await standardError.WriteLineAsync(Usage).ConfigureAwait(false);
+            return (int)OfficeImoToolExitCode.Usage;
+        } catch (OperationCanceledException) {
+            await standardError.WriteLineAsync("Provenance workflow cancelled.").ConfigureAwait(false);
+            return (int)OfficeImoToolExitCode.Cancelled;
+        } catch (Exception exception) when (exception is not OutOfMemoryException and not StackOverflowException) {
+            await standardError.WriteLineAsync(
+                "Provenance workflow failed: " + exception.GetType().Name + ": " + exception.Message).ConfigureAwait(false);
+            return (int)OfficeImoToolExitCode.OperationFailed;
+        }
+    }
+
+    private static IEnumerable<OfficeProvenanceWorkflowRequest> CreateBatchRequests(ProvenanceArguments parsed) {
+        string? outputDirectory = parsed.OutputDirectory is null ? null : Path.GetFullPath(parsed.OutputDirectory);
+        foreach (string input in parsed.Inputs) {
+            string fullInput = Path.GetFullPath(input);
+            string? output = outputDirectory is null
+                ? null
+                : Path.Combine(
+                    outputDirectory,
+                    Path.GetFileNameWithoutExtension(fullInput) + ".provenance-cleaned" + Path.GetExtension(fullInput));
+            yield return CreateRequest(parsed, fullInput, output, parsed.BatchOperation);
+        }
+    }
+
+    private static OfficeProvenanceWorkflowRequest CreateRequest(
+        ProvenanceArguments parsed,
+        string input,
+        string? output,
+        OfficeProvenanceWorkflowOperation? operation = null) {
+        var request = new OfficeProvenanceWorkflowRequest {
+            Operation = operation ?? parsed.Command switch {
+                ProvenanceCommandKind.Inspect => OfficeProvenanceWorkflowOperation.Inspect,
+                ProvenanceCommandKind.Assess => OfficeProvenanceWorkflowOperation.Assess,
+                ProvenanceCommandKind.Remove => OfficeProvenanceWorkflowOperation.Remove,
+                _ => throw new InvalidOperationException("The command does not map to one provenance operation.")
+            },
+            InputPath = Path.GetFullPath(input),
+            OutputPath = output is null ? null : Path.GetFullPath(output),
+            ConflictPolicy = parsed.Force ? OfficeWorkflowConflictPolicy.Replace : OfficeWorkflowConflictPolicy.Fail,
+            Limits = new OfficeWorkflowLimits {
+                MaximumInputBytes = parsed.MaximumInputBytes,
+                MaximumOutputBytes = parsed.MaximumOutputBytes
+            }
+        };
+        request.Inspection.ProcessEmbeddedAssets = parsed.ProcessEmbeddedAssets;
+        request.Assessment.Structural.ProcessEmbeddedAssets = parsed.ProcessEmbeddedAssets;
+        request.Assessment.InspectTextIntegrity = parsed.InspectTextIntegrity;
+        request.Removal.RemoveC2paManifests = parsed.RemoveC2paManifests;
+        request.Removal.RemoveExternalC2paReferences = parsed.RemoveExternalC2paReferences;
+        request.Removal.RemoveAiSourceMetadata = parsed.RemoveAiSourceMetadata;
+        request.Removal.ProcessEmbeddedAssets = parsed.ProcessEmbeddedAssets;
+        request.Removal.SignatureMutationPolicy = parsed.RemoveInvalidatedSignatures
+            ? OfficeSignatureMutationPolicy.RemoveInvalidatedSignatures
+            : OfficeSignatureMutationPolicy.BlockSave;
+        return request;
+    }
+
+    private static int MapBatch(IReadOnlyList<OfficeProvenanceWorkflowResult> results) {
+        OfficeProvenanceWorkflowResult? failed = results.FirstOrDefault(result => !result.Succeeded);
+        return failed is null
+            ? (int)OfficeImoToolExitCode.Success
+            : MapStatus(failed.Status, failed.FailureKind);
+    }
+
+    private static int MapStatus(OfficeWorkflowStatus status, OfficeWorkflowFailureKind failureKind) => status switch {
+        OfficeWorkflowStatus.Completed => (int)OfficeImoToolExitCode.Success,
+        OfficeWorkflowStatus.Cancelled => (int)OfficeImoToolExitCode.Cancelled,
+        OfficeWorkflowStatus.Failed => failureKind switch {
+            OfficeWorkflowFailureKind.ValidationFailed => (int)OfficeImoToolExitCode.Usage,
+            OfficeWorkflowFailureKind.InputNotFound => (int)OfficeImoToolExitCode.InputNotFound,
+            OfficeWorkflowFailureKind.UnsupportedInput => (int)OfficeImoToolExitCode.UnsupportedInput,
+            OfficeWorkflowFailureKind.OutputFailed => (int)OfficeImoToolExitCode.OutputFailed,
+            _ => (int)OfficeImoToolExitCode.OperationFailed
+        },
+        _ => (int)OfficeImoToolExitCode.OperationFailed
+    };
+}

--- a/OfficeIMO.Tool/Commands/Provenance/ProvenanceCommand.cs
+++ b/OfficeIMO.Tool/Commands/Provenance/ProvenanceCommand.cs
@@ -130,6 +130,9 @@ and blocks invalidating package signatures unless --remove-invalidated-signature
     }
 
     private static int MapBatch(IReadOnlyList<OfficeProvenanceWorkflowResult> results) {
+        if (results.Any(result => result.Status == OfficeWorkflowStatus.Cancelled)) {
+            return (int)OfficeImoToolExitCode.Cancelled;
+        }
         OfficeProvenanceWorkflowResult? failed = results.FirstOrDefault(result => !result.Succeeded);
         return failed is null
             ? (int)OfficeImoToolExitCode.Success

--- a/OfficeIMO.Tool/Commands/Provenance/ProvenanceCommand.cs
+++ b/OfficeIMO.Tool/Commands/Provenance/ProvenanceCommand.cs
@@ -89,7 +89,7 @@ and blocks invalidating package signatures unless --remove-invalidated-signature
         }
     }
 
-    private static OfficeProvenanceWorkflowRequest CreateRequest(
+    internal static OfficeProvenanceWorkflowRequest CreateRequest(
         ProvenanceArguments parsed,
         string input,
         string? output,
@@ -109,9 +109,16 @@ and blocks invalidating package signatures unless --remove-invalidated-signature
                 MaximumOutputBytes = parsed.MaximumOutputBytes
             }
         };
+        long parserInputBytes = Math.Min(parsed.MaximumInputBytes, int.MaxValue);
+        long parserOutputBytes = Math.Min(parsed.MaximumOutputBytes, int.MaxValue);
+        request.Inspection.MaxAssetBytes = parserInputBytes;
         request.Inspection.ProcessEmbeddedAssets = parsed.ProcessEmbeddedAssets;
+        request.Assessment.Structural.MaxAssetBytes = parserInputBytes;
         request.Assessment.Structural.ProcessEmbeddedAssets = parsed.ProcessEmbeddedAssets;
+        request.Assessment.TextIntegrity.MaxEncodedBytes = parserInputBytes;
         request.Assessment.InspectTextIntegrity = parsed.InspectTextIntegrity;
+        request.Removal.Limits.MaxAssetBytes = parserInputBytes;
+        request.Removal.MaxOutputBytes = parserOutputBytes;
         request.Removal.RemoveC2paManifests = parsed.RemoveC2paManifests;
         request.Removal.RemoveExternalC2paReferences = parsed.RemoveExternalC2paReferences;
         request.Removal.RemoveAiSourceMetadata = parsed.RemoveAiSourceMetadata;

--- a/OfficeIMO.Tool/Commands/Provenance/ProvenanceCommand.cs
+++ b/OfficeIMO.Tool/Commands/Provenance/ProvenanceCommand.cs
@@ -45,6 +45,14 @@ and blocks invalidating package signatures unless --remove-invalidated-signature
 
             IOfficeProvenanceWorkflowRunner activeRunner = runner ?? new OfficeWorkflowRunner();
             if (parsed.Command == ProvenanceCommandKind.Batch) {
+                if (cancellationToken.IsCancellationRequested) {
+                    OfficeProvenanceWorkflowResult cancelled = await activeRunner.RunProvenanceAsync(
+                        CreateBatchRequest(parsed, parsed.Inputs[0]),
+                        cancellationToken: cancellationToken).ConfigureAwait(false);
+                    IReadOnlyList<OfficeProvenanceWorkflowResult> cancelledResults = new[] { cancelled };
+                    await ProvenanceOutput.WriteBatchAsync(standardOutput, cancelledResults, parsed.Format).ConfigureAwait(false);
+                    return MapBatch(cancelledResults);
+                }
                 IReadOnlyList<OfficeProvenanceWorkflowResult> results = await activeRunner.RunProvenanceBatchAsync(
                     CreateBatchRequests(parsed),
                     new OfficeProvenanceWorkflowBatchOptions { MaximumRequests = parsed.MaximumItems },
@@ -77,16 +85,20 @@ and blocks invalidating package signatures unless --remove-invalidated-signature
     }
 
     private static IEnumerable<OfficeProvenanceWorkflowRequest> CreateBatchRequests(ProvenanceArguments parsed) {
-        string? outputDirectory = parsed.OutputDirectory is null ? null : Path.GetFullPath(parsed.OutputDirectory);
         foreach (string input in parsed.Inputs) {
-            string fullInput = Path.GetFullPath(input);
-            string? output = outputDirectory is null
-                ? null
-                : Path.Combine(
-                    outputDirectory,
-                    Path.GetFileNameWithoutExtension(fullInput) + ".provenance-cleaned" + Path.GetExtension(fullInput));
-            yield return CreateRequest(parsed, fullInput, output, parsed.BatchOperation);
+            yield return CreateBatchRequest(parsed, input);
         }
+    }
+
+    private static OfficeProvenanceWorkflowRequest CreateBatchRequest(ProvenanceArguments parsed, string input) {
+        string fullInput = Path.GetFullPath(input);
+        string? outputDirectory = parsed.OutputDirectory is null ? null : Path.GetFullPath(parsed.OutputDirectory);
+        string? output = outputDirectory is null
+            ? null
+            : Path.Combine(
+                outputDirectory,
+                Path.GetFileNameWithoutExtension(fullInput) + ".provenance-cleaned" + Path.GetExtension(fullInput));
+        return CreateRequest(parsed, fullInput, output, parsed.BatchOperation);
     }
 
     internal static OfficeProvenanceWorkflowRequest CreateRequest(

--- a/OfficeIMO.Tool/Commands/Provenance/ProvenanceOutput.cs
+++ b/OfficeIMO.Tool/Commands/Provenance/ProvenanceOutput.cs
@@ -1,0 +1,184 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using OfficeIMO.Provenance;
+using OfficeIMO.Workflows;
+
+namespace OfficeIMO.Tool.Commands.Provenance;
+
+internal static class ProvenanceOutput {
+    internal static async Task WriteCapabilitiesAsync(TextWriter writer, ProvenanceOutputFormat format) {
+        ProvenanceCapabilitiesDto dto = new(
+            "officeimo.provenance.capabilities.v1",
+            OfficeProvenanceWorkflowCatalog.All.Select(ToDto).ToArray());
+        if (format == ProvenanceOutputFormat.Json) {
+            await writer.WriteLineAsync(JsonSerializer.Serialize(dto, ProvenanceJsonContext.Default.ProvenanceCapabilitiesDto)).ConfigureAwait(false);
+            return;
+        }
+        foreach (ProvenanceCapabilityDto capability in dto.Capabilities) {
+            await writer.WriteLineAsync(
+                capability.Id + " | " + capability.OwnerPackage + " | " +
+                string.Join(',', capability.Extensions) + " | remove=" + capability.CanRemove.ToString().ToLowerInvariant()).ConfigureAwait(false);
+        }
+    }
+
+    internal static async Task WriteResultAsync(
+        TextWriter writer,
+        OfficeProvenanceWorkflowResult result,
+        ProvenanceOutputFormat format) {
+        ProvenanceResultDto dto = ToDto(result);
+        if (format == ProvenanceOutputFormat.Json) {
+            await writer.WriteLineAsync(JsonSerializer.Serialize(dto, ProvenanceJsonContext.Default.ProvenanceResultDto)).ConfigureAwait(false);
+            return;
+        }
+        await WriteTextResultAsync(writer, dto).ConfigureAwait(false);
+    }
+
+    internal static async Task WriteBatchAsync(
+        TextWriter writer,
+        IReadOnlyList<OfficeProvenanceWorkflowResult> results,
+        ProvenanceOutputFormat format) {
+        ProvenanceBatchDto dto = new(
+            "officeimo.provenance.batch.v1",
+            results.Select(ToDto).ToArray());
+        if (format == ProvenanceOutputFormat.Json) {
+            await writer.WriteLineAsync(JsonSerializer.Serialize(dto, ProvenanceJsonContext.Default.ProvenanceBatchDto)).ConfigureAwait(false);
+            return;
+        }
+        foreach (ProvenanceResultDto result in dto.Results) {
+            await WriteTextResultAsync(writer, result).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task WriteTextResultAsync(TextWriter writer, ProvenanceResultDto result) {
+        await writer.WriteLineAsync(result.Status + " | " + result.Operation + " | " + result.Summary).ConfigureAwait(false);
+        await writer.WriteLineAsync("Owner: " + result.OwnerPackage).ConfigureAwait(false);
+        if (result.OutputPath is not null) await writer.WriteLineAsync("Output: " + result.OutputPath).ConfigureAwait(false);
+        ProvenanceReportDto? report = result.Inspection ?? result.Assessment?.Structural ?? result.After ?? result.Before;
+        if (report is not null) {
+            await writer.WriteLineAsync("Format: " + report.Format + "; carriers: " + report.Evidence.Count).ConfigureAwait(false);
+            foreach (ProvenanceEvidenceDto evidence in report.Evidence) {
+                await writer.WriteLineAsync("  " + evidence.Carrier + " | " + evidence.Location + " | valid=" + evidence.IsStructurallyValid.ToString().ToLowerInvariant()).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private static ProvenanceCapabilityDto ToDto(OfficeProvenanceWorkflowCapability capability) => new(
+        capability.Id,
+        capability.Label,
+        capability.Extensions,
+        capability.OwnerPackage,
+        capability.CanInspect,
+        capability.CanAssess,
+        capability.CanRemove,
+        capability.Notes);
+
+    private static ProvenanceResultDto ToDto(OfficeProvenanceWorkflowResult result) => new(
+        "officeimo.provenance.result.v1",
+        result.RequestId,
+        result.Operation.ToString(),
+        result.Status.ToString(),
+        result.FailureKind.ToString(),
+        result.OwnerPackage,
+        result.OutputPath,
+        result.InputBytes,
+        result.OutputBytes,
+        result.Duration.TotalMilliseconds,
+        result.Summary,
+        result.Inspection is null ? null : ToDto(result.Inspection),
+        result.Assessment is null ? null : ToDto(result.Assessment),
+        result.Before is null ? null : ToDto(result.Before),
+        result.After is null ? null : ToDto(result.After),
+        result.Changes.Select(change => new ProvenanceChangeDto(
+            change.Carrier.ToString(), change.Location, change.RemovedBytes)).ToArray(),
+        result.WasChanged,
+        result.WasReserialized,
+        result.WereInvalidatedSignaturesRemoved,
+        result.Diagnostics.Select(diagnostic => new ProvenanceDiagnosticDto(
+            diagnostic.Code,
+            diagnostic.Message,
+            diagnostic.Severity.ToString(),
+            diagnostic.Stage,
+            diagnostic.Details)).ToArray());
+
+    private static ProvenanceAssessmentDto ToDto(OfficeProvenanceAssessmentReport report) => new(
+        ToDto(report.Structural),
+        report.Verification is null ? null : new ProvenanceVerificationDto(
+            report.Verification.ProviderName,
+            report.Verification.Status.ToString(),
+            report.Verification.Findings,
+            report.Verification.RawReport),
+        report.TextIntegrity?.Findings.Select(finding => new ProvenanceTextFindingDto(
+            finding.Kind.ToString(),
+            finding.Risk.ToString(),
+            finding.TextOffset,
+            finding.TextLength,
+            finding.UnicodeNotation,
+            finding.Location)).ToArray(),
+        report.ProviderSignals.Select(signal => new ProvenanceSignalDto(
+            signal.ProviderName,
+            signal.SignalKind.ToString(),
+            signal.Status.ToString(),
+            signal.Findings)).ToArray());
+
+    private static ProvenanceReportDto ToDto(OfficeProvenanceReport report) => new(
+        report.Format.ToString(),
+        report.Evidence.Select(evidence => new ProvenanceEvidenceDto(
+            evidence.Carrier.ToString(),
+            evidence.Location,
+            evidence.IsStructurallyValid,
+            evidence.PayloadLength,
+            evidence.Value,
+            evidence.DigitalSourceKind.ToString())).ToArray(),
+        report.Diagnostics,
+        report.HasC2paManifest,
+        report.HasExternalC2paManifest,
+        report.HasGenerativeAiDeclaration);
+}
+
+internal sealed record ProvenanceCapabilitiesDto(string Schema, IReadOnlyList<ProvenanceCapabilityDto> Capabilities);
+internal sealed record ProvenanceCapabilityDto(string Id, string Label, IReadOnlyList<string> Extensions, string OwnerPackage, bool CanInspect, bool CanAssess, bool CanRemove, string Notes);
+internal sealed record ProvenanceBatchDto(string Schema, IReadOnlyList<ProvenanceResultDto> Results);
+internal sealed record ProvenanceResultDto(
+    string Schema,
+    string RequestId,
+    string Operation,
+    string Status,
+    string FailureKind,
+    string OwnerPackage,
+    string? OutputPath,
+    long InputBytes,
+    long OutputBytes,
+    double DurationMilliseconds,
+    string Summary,
+    ProvenanceReportDto? Inspection,
+    ProvenanceAssessmentDto? Assessment,
+    ProvenanceReportDto? Before,
+    ProvenanceReportDto? After,
+    IReadOnlyList<ProvenanceChangeDto> Changes,
+    bool WasChanged,
+    bool WasReserialized,
+    bool WereInvalidatedSignaturesRemoved,
+    IReadOnlyList<ProvenanceDiagnosticDto> Diagnostics);
+internal sealed record ProvenanceReportDto(
+    string Format,
+    IReadOnlyList<ProvenanceEvidenceDto> Evidence,
+    IReadOnlyList<string> Diagnostics,
+    bool HasC2paManifest,
+    bool HasExternalC2paManifest,
+    bool HasGenerativeAiDeclaration);
+internal sealed record ProvenanceEvidenceDto(string Carrier, string Location, bool IsStructurallyValid, long PayloadLength, string? Value, string DigitalSourceKind);
+internal sealed record ProvenanceAssessmentDto(ProvenanceReportDto Structural, ProvenanceVerificationDto? Verification, IReadOnlyList<ProvenanceTextFindingDto>? TextIntegrity, IReadOnlyList<ProvenanceSignalDto> ProviderSignals);
+internal sealed record ProvenanceVerificationDto(string ProviderName, string Status, IReadOnlyList<string> Findings, string? RawReport);
+internal sealed record ProvenanceTextFindingDto(string Kind, string Risk, int TextOffset, int TextLength, string UnicodeNotation, string Location);
+internal sealed record ProvenanceSignalDto(string ProviderName, string SignalKind, string Status, IReadOnlyList<string> Findings);
+internal sealed record ProvenanceChangeDto(string Carrier, string Location, long RemovedBytes);
+internal sealed record ProvenanceDiagnosticDto(string Code, string Message, string Severity, string? Stage, IReadOnlyDictionary<string, string> Details);
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    GenerationMode = JsonSourceGenerationMode.Metadata)]
+[JsonSerializable(typeof(ProvenanceCapabilitiesDto))]
+[JsonSerializable(typeof(ProvenanceResultDto))]
+[JsonSerializable(typeof(ProvenanceBatchDto))]
+internal sealed partial class ProvenanceJsonContext : JsonSerializerContext;

--- a/OfficeIMO.Tool/Commands/Provenance/ProvenanceOutput.cs
+++ b/OfficeIMO.Tool/Commands/Provenance/ProvenanceOutput.cs
@@ -83,6 +83,16 @@ internal static class ProvenanceOutput {
                 }
             }
         }
+        foreach (ProvenanceDiagnosticDto diagnostic in result.Diagnostics) {
+            string stage = diagnostic.Stage is null ? string.Empty : " | stage=" + diagnostic.Stage;
+            await writer.WriteLineAsync(
+                "Diagnostic: " + diagnostic.Severity + " | " + diagnostic.Code + stage + " | " + diagnostic.Message).ConfigureAwait(false);
+            foreach (KeyValuePair<string, string> detail in diagnostic.Details.OrderBy(
+                         static pair => pair.Key,
+                         StringComparer.Ordinal)) {
+                await writer.WriteLineAsync("  " + detail.Key + ": " + detail.Value).ConfigureAwait(false);
+            }
+        }
     }
 
     private static ProvenanceCapabilityDto ToDto(OfficeProvenanceWorkflowCapability capability) => new(

--- a/OfficeIMO.Tool/Commands/Provenance/ProvenanceOutput.cs
+++ b/OfficeIMO.Tool/Commands/Provenance/ProvenanceOutput.cs
@@ -60,6 +60,29 @@ internal static class ProvenanceOutput {
                 await writer.WriteLineAsync("  " + evidence.Carrier + " | " + evidence.Location + " | valid=" + evidence.IsStructurallyValid.ToString().ToLowerInvariant()).ConfigureAwait(false);
             }
         }
+        if (result.Assessment is not null) {
+            if (result.Assessment.Verification is not null) {
+                ProvenanceVerificationDto verification = result.Assessment.Verification;
+                await writer.WriteLineAsync("Verification: " + verification.ProviderName + " | status=" + verification.Status).ConfigureAwait(false);
+                foreach (string finding in verification.Findings) {
+                    await writer.WriteLineAsync("  Verification finding: " + finding).ConfigureAwait(false);
+                }
+            }
+            IReadOnlyList<ProvenanceTextFindingDto> textFindings = result.Assessment.TextIntegrity ?? Array.Empty<ProvenanceTextFindingDto>();
+            await writer.WriteLineAsync("Text integrity: " + textFindings.Count + " finding(s)").ConfigureAwait(false);
+            foreach (ProvenanceTextFindingDto finding in textFindings) {
+                await writer.WriteLineAsync(
+                    "  " + finding.Risk + " | " + finding.Kind + " | " + finding.UnicodeNotation +
+                    " | offset=" + finding.TextOffset + " | " + finding.Location).ConfigureAwait(false);
+            }
+            foreach (ProvenanceSignalDto signal in result.Assessment.ProviderSignals) {
+                await writer.WriteLineAsync(
+                    "Provider signal: " + signal.ProviderName + " | " + signal.SignalKind + " | status=" + signal.Status).ConfigureAwait(false);
+                foreach (string finding in signal.Findings) {
+                    await writer.WriteLineAsync("  Provider finding: " + finding).ConfigureAwait(false);
+                }
+            }
+        }
     }
 
     private static ProvenanceCapabilityDto ToDto(OfficeProvenanceWorkflowCapability capability) => new(

--- a/OfficeIMO.Tool/OfficeIMO.Tool.csproj
+++ b/OfficeIMO.Tool/OfficeIMO.Tool.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
-    <Description>Unified command-line interface for OfficeIMO document conversion, extraction, markup, output, intake, and capability discovery.</Description>
+    <Description>Unified command-line interface for OfficeIMO document conversion, extraction, markup, provenance, output, intake, and capability discovery.</Description>
     <AssemblyName>OfficeIMO.Tool</AssemblyName>
     <AssemblyTitle>OfficeIMO.Tool</AssemblyTitle>
     <VersionPrefix>3.3.0</VersionPrefix>
@@ -10,7 +10,7 @@
     <Company>Evotec</Company>
     <Authors>Przemyslaw Klys</Authors>
     <PackageId>OfficeIMO.Tool</PackageId>
-    <PackageTags>office;documents;html;pdf;reader;markup;cli;dotnet-tool;officeimo</PackageTags>
+    <PackageTags>office;documents;html;pdf;reader;markup;provenance;c2pa;cli;dotnet-tool;officeimo</PackageTags>
     <PackageProjectUrl>https://github.com/EvotecIT/OfficeIMO</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/EvotecIT/OfficeIMO</RepositoryUrl>

--- a/OfficeIMO.Tool/OfficeImoToolApp.cs
+++ b/OfficeIMO.Tool/OfficeImoToolApp.cs
@@ -3,6 +3,7 @@ using OfficeIMO.Tool.Commands.Convert;
 using OfficeIMO.Tool.Commands.Html;
 using OfficeIMO.Tool.Commands.Markup;
 using OfficeIMO.Tool.Commands.Mcp;
+using OfficeIMO.Tool.Commands.Provenance;
 using OfficeIMO.Tool.Commands.Reader;
 using OfficeIMO.Tool.Commands.Tabular;
 using OfficeIMO.Tool.Commands.Workflow;
@@ -25,6 +26,7 @@ Usage:
   officeimo markup <command> [options]
   officeimo tabular <command> [options]
   officeimo workflow <command> [options]
+  officeimo provenance <command> [options]
   officeimo agent <command> [options]
   officeimo mcp serve --stdio
   officeimo --version
@@ -112,6 +114,14 @@ Run 'officeimo <area> --help' for area-specific commands and options.
                     return await WorkflowCommand.RunAsync(
                         commandArguments,
                         workflowOutput,
+                        standardError,
+                        cancellationToken).ConfigureAwait(false);
+                }
+            case "provenance":
+                using (var provenanceOutput = CreateUtf8Writer(standardOutput)) {
+                    return await ProvenanceCommand.RunAsync(
+                        commandArguments,
+                        provenanceOutput,
                         standardError,
                         cancellationToken).ConfigureAwait(false);
                 }

--- a/OfficeIMO.Tool/README.md
+++ b/OfficeIMO.Tool/README.md
@@ -62,6 +62,13 @@ officeimo workflow assemble cover.png report.docx appendices .\attachments.zip -
 
 # Inspect print-sheet placement without requiring a platform printer driver
 officeimo workflow print-plan complete.pdf --paper A4 --pages-per-sheet 2 --scale fit
+
+# Inspect or assess provenance with versioned JSON output
+officeimo provenance inspect report.docx
+officeimo provenance assess page.html
+
+# Remove selected, structurally valid carriers through the owning format package
+officeimo provenance remove report.docx --output report.cleaned.docx
 ```
 
 The positional destination is optional for DOCX, XLSX, and PPTX to PDF conversion. When omitted, the tool writes a sibling `.pdf` file. `--output <path>` remains available for scripts that prefer named options.
@@ -77,6 +84,7 @@ All `convert` destinations are protected from accidental replacement. Pass `--fo
 - `officeimo inspect` is a convenient alias for `officeimo agent inspect`.
 - `officeimo tabular` lists workbook sheets, reports reader schemas, and converts CSV, TSV, XLSX, XLSB, or XLS tabular data.
 - `officeimo workflow` exports PDF pages, assembles mixed document sources, and creates deterministic print-sheet plans.
+- `officeimo provenance` discovers format owners and runs bounded inspect, assess, selective-remove, and batch workflows with versioned JSON or readable text output.
 - `officeimo html` converts HTML or MHTML to PDF and reports renderer capabilities.
 - `officeimo reader` extracts individual documents or folders as Markdown or JSON and reports supported formats.
 - `officeimo markup` parses, validates, emits, previews, and exports OfficeIMO Markup.
@@ -90,6 +98,29 @@ existing image folder or assembled PDF. Assembly preserves caller source order, 
 folders and ZIP entries in deterministic path order, and applies bounded archive entry,
 size, and compression checks before publication. Supported explicit inputs are PDF, DOCX,
 XLSX, PPTX, HTML, common raster image formats, folders, and ZIP archives.
+
+## Provenance workflows
+
+```powershell
+# Machine-readable output is the default
+officeimo provenance capabilities
+officeimo provenance inspect .\report.docx
+officeimo provenance assess .\page.html
+
+# Text output is available for interactive use
+officeimo provenance inspect .\image.png --format text
+
+# Existing output is refused unless --force is explicit
+officeimo provenance remove .\report.docx --output .\report.cleaned.docx
+
+# Batch work is sequential and bounded; removal requires an explicit destination directory
+officeimo provenance batch inspect .\one.docx .\two.pdf --max-items 20
+officeimo provenance batch remove .\one.docx .\two.pdf --output-directory .\cleaned
+```
+
+The JSON envelopes use `officeimo.provenance.capabilities.v1`, `officeimo.provenance.result.v1`, or `officeimo.provenance.batch.v1` schema identifiers. Successful inspection can still report provenance evidence; findings are data and do not change the process exit code. Execution failures use the shared exit-code table below.
+
+Removal preserves the input format, keeps malformed carriers by default, and routes package-aware changes to the owning OfficeIMO library. A mutation that would invalidate an Office package signature is blocked unless `--remove-invalidated-signatures` is supplied. Use `--keep-c2pa`, `--keep-external-c2pa`, or `--keep-ai-source` to preserve a carrier class, and `--no-embedded` to skip supported embedded assets. Generic ZIP files can be inspected but are not rewritten without a known document owner.
 
 Tabular conversion writes through an atomic sibling staging file and refuses to replace an
 existing destination unless `--force` is supplied. Workbook output is limited to `.xlsx`,

--- a/OfficeIMO.Visio/VisioDocument.Provenance.cs
+++ b/OfficeIMO.Visio/VisioDocument.Provenance.cs
@@ -81,7 +81,7 @@ public partial class VisioDocument {
 
     private static OfficeProvenanceSignatureStripResult StripPackageSignatures(byte[] data, OfficeProvenanceRemovalOptions options) {
         OfficeProvenanceOptions limits = options.Limits;
-        using var stream = new OfficeProvenanceBoundedMemoryStream(options.EffectiveMaxOutputBytes, data.Length);
+        using var stream = new OfficeProvenanceBoundedMemoryStream(options.EffectiveMaxIntermediateBytes, data.Length);
         stream.Write(data, 0, data.Length);
         stream.Position = 0;
         bool hadSignatures = false;

--- a/OfficeIMO.Visio/VisioDocument.Provenance.cs
+++ b/OfficeIMO.Visio/VisioDocument.Provenance.cs
@@ -79,8 +79,9 @@ public partial class VisioDocument {
         return false;
     }
 
-    private static OfficeProvenanceSignatureStripResult StripPackageSignatures(byte[] data, OfficeProvenanceOptions limits) {
-        using var stream = new MemoryStream(data.Length);
+    private static OfficeProvenanceSignatureStripResult StripPackageSignatures(byte[] data, OfficeProvenanceRemovalOptions options) {
+        OfficeProvenanceOptions limits = options.Limits;
+        using var stream = new OfficeProvenanceBoundedMemoryStream(options.EffectiveMaxOutputBytes, data.Length);
         stream.Write(data, 0, data.Length);
         stream.Position = 0;
         bool hadSignatures = false;

--- a/OfficeIMO.Word/WordDocument.ContentSafety.cs
+++ b/OfficeIMO.Word/WordDocument.ContentSafety.cs
@@ -236,7 +236,7 @@ public partial class WordDocument {
             throw new InvalidOperationException("Content cleanup would invalidate existing Word package signatures. Select RemoveInvalidatedSignatures or PreserveSignatureMarkup explicitly.");
         }
         return signaturePolicy == OfficeSignatureMutationPolicy.RemoveInvalidatedSignatures
-            ? StripPackageSignatures(data, provenanceOptions.Limits).Data
+            ? StripPackageSignatures(data, provenanceOptions).Data
             : (byte[])data.Clone();
     }
 

--- a/OfficeIMO.Word/WordDocument.ContentSafety.cs
+++ b/OfficeIMO.Word/WordDocument.ContentSafety.cs
@@ -45,7 +45,7 @@ public partial class WordDocument {
         IReadOnlyList<OfficeContentSafetyFinding> selected = OfficeContentSafetyBuilder.ResolveSelection(before, selection);
         if (selected.Count == 0) return new OfficeContentCleanupResult((byte[])documentBytes.Clone(), before, before, Array.Empty<OfficeContentCleanupChange>());
 
-        byte[] mutableBytes = PrepareContentSafetyMutation(documentBytes, options.SignatureMutationPolicy);
+        byte[] mutableBytes = PrepareContentSafetyMutation(documentBytes, options);
         using var stream = new MemoryStream(mutableBytes.Length + 4096);
         stream.Write(mutableBytes, 0, mutableBytes.Length);
         stream.Position = 0;
@@ -228,8 +228,10 @@ public partial class WordDocument {
         return false;
     }
 
-    private static byte[] PrepareContentSafetyMutation(byte[] data, OfficeSignatureMutationPolicy signaturePolicy) {
-        var provenanceOptions = new OfficeProvenanceRemovalOptions { SignatureMutationPolicy = signaturePolicy };
+    private static byte[] PrepareContentSafetyMutation(byte[] data, OfficeContentCleanupOptions cleanupOptions) {
+        OfficeSignatureMutationPolicy signaturePolicy = cleanupOptions.SignatureMutationPolicy;
+        OfficeProvenanceRemovalOptions provenanceOptions =
+            OfficeContentSafetyProvenanceOptions.CreateSignatureRemovalOptions(cleanupOptions);
         bool hasSignatures = HasPackageSignatures(data, provenanceOptions);
         if (!hasSignatures) return (byte[])data.Clone();
         if (signaturePolicy == OfficeSignatureMutationPolicy.BlockSave) {

--- a/OfficeIMO.Word/WordDocument.Provenance.cs
+++ b/OfficeIMO.Word/WordDocument.Provenance.cs
@@ -50,8 +50,9 @@ public partial class WordDocument {
         return applicationProperties?.Properties?.DigitalSignature != null;
     }
 
-    private static OfficeProvenanceSignatureStripResult StripPackageSignatures(byte[] data, OfficeProvenanceOptions limits) {
-        using var stream = new MemoryStream(data.Length);
+    private static OfficeProvenanceSignatureStripResult StripPackageSignatures(byte[] data, OfficeProvenanceRemovalOptions options) {
+        OfficeProvenanceOptions limits = options.Limits;
+        using var stream = new OfficeProvenanceBoundedMemoryStream(options.EffectiveMaxOutputBytes, data.Length);
         stream.Write(data, 0, data.Length);
         stream.Position = 0;
         bool hadSignatures;

--- a/OfficeIMO.Word/WordDocument.Provenance.cs
+++ b/OfficeIMO.Word/WordDocument.Provenance.cs
@@ -52,7 +52,7 @@ public partial class WordDocument {
 
     private static OfficeProvenanceSignatureStripResult StripPackageSignatures(byte[] data, OfficeProvenanceRemovalOptions options) {
         OfficeProvenanceOptions limits = options.Limits;
-        using var stream = new OfficeProvenanceBoundedMemoryStream(options.EffectiveMaxOutputBytes, data.Length);
+        using var stream = new OfficeProvenanceBoundedMemoryStream(options.EffectiveMaxIntermediateBytes, data.Length);
         stream.Write(data, 0, data.Length);
         stream.Position = 0;
         bool hadSignatures;

--- a/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.Wave74.cs
+++ b/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.Wave74.cs
@@ -1,0 +1,45 @@
+namespace OfficeIMO.Workflows.Tests;
+
+public sealed partial class OfficeProvenanceWorkflowTests {
+    [Fact]
+    public async Task SuccessfulRemovalReportsCompletionAfterPublicationFinalizes() {
+        using var scope = new TempScope();
+        string input = scope.Write("page.html", HtmlWithExternalManifest("original"));
+        string output = Path.Combine(scope.Path, "cleaned.html");
+        var stages = new List<string>();
+
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner().RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Remove,
+                InputPath = input,
+                OutputPath = output
+            },
+            new RecordingProgress(stages));
+
+        Assert.True(result.Succeeded, result.Summary);
+        Assert.Equal("complete", stages[^1]);
+        Assert.True(stages.IndexOf("finalize") < stages.IndexOf("complete"));
+        Assert.True(File.Exists(output));
+    }
+
+    private sealed class CancellingFinalizationProgress : IProgress<OfficeWorkflowProgress> {
+        private readonly string _requestId;
+        private readonly CancellationTokenSource _cancellation;
+
+        internal CancellingFinalizationProgress(string requestId, CancellationTokenSource cancellation) {
+            _requestId = requestId;
+            _cancellation = cancellation;
+        }
+
+        internal List<string> Stages { get; } = new();
+
+        public void Report(OfficeWorkflowProgress value) {
+            Stages.Add(value.Stage);
+            if (value.RequestId == _requestId && value.Stage == "finalize") _cancellation.Cancel();
+        }
+    }
+
+    private sealed class RecordingProgress(List<string> stages) : IProgress<OfficeWorkflowProgress> {
+        public void Report(OfficeWorkflowProgress value) => stages.Add(value.Stage);
+    }
+}

--- a/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.Wave75.cs
+++ b/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.Wave75.cs
@@ -1,0 +1,62 @@
+namespace OfficeIMO.Workflows.Tests;
+
+public sealed partial class OfficeProvenanceWorkflowTests {
+    [Fact]
+    public async Task EmptyBatchMaterializationPreservesEnumeratorCancellation() {
+        using var cancellation = new CancellationTokenSource();
+
+        IEnumerable<OfficeProvenanceWorkflowRequest> Requests() {
+            cancellation.Cancel();
+            yield break;
+        }
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            new OfficeWorkflowRunner().RunProvenanceBatchAsync(
+                Requests(),
+                cancellationToken: cancellation.Token));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task AssessmentRejectsAbsoluteFileManifestDependenciesEvenWhenStructurallyAmbiguous(
+        bool useBaseElement) {
+        using var scope = new TempScope();
+        string manifest = scope.Write("claim.c2pa", "mutable claim");
+        string manifestReference = new Uri(manifest).AbsoluteUri;
+        string head = useBaseElement
+            ? $"<base href=\"{new Uri(scope.Path + Path.DirectorySeparatorChar).AbsoluteUri}\"><link rel=\"c2pa-manifest\" href=\"claim.c2pa\"><link rel=\"c2pa-manifest\" href=\"claim.c2pa\">"
+            : $"<link rel=\"c2pa-manifest\" href=\"{manifestReference}\">";
+        string input = scope.Write("page.html", $"<!doctype html><html><head>{head}</head><body>body</body></html>");
+        var verifier = new NestedRelativeManifestVerifier("claim.c2pa", "mutable claim");
+
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner(verifier).RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Assess,
+                InputPath = input
+            });
+
+        Assert.False(result.Succeeded);
+        Assert.Contains("absolute file-based external provenance manifest", result.Summary, StringComparison.OrdinalIgnoreCase);
+        Assert.Null(verifier.ObservedDirectory);
+    }
+
+    [Fact]
+    public async Task AssessmentRejectsRootedFileBaseBeforeCallingProviders() {
+        using var scope = new TempScope();
+        string input = scope.Write(
+            "page.html",
+            "<!doctype html><html><head><base href=\"/outside/\"><link rel=\"c2pa-manifest\" href=\"claim.c2pa\"></head><body>body</body></html>");
+        var verifier = new NestedRelativeManifestVerifier("claim.c2pa", "unused");
+
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner(verifier).RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Assess,
+                InputPath = input
+            });
+
+        Assert.False(result.Succeeded);
+        Assert.Contains("absolute file-based external provenance manifest", result.Summary, StringComparison.OrdinalIgnoreCase);
+        Assert.Null(verifier.ObservedDirectory);
+    }
+}

--- a/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.Wave78.cs
+++ b/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.Wave78.cs
@@ -1,0 +1,117 @@
+using System.Runtime.InteropServices;
+using OfficeIMO.Provenance;
+
+namespace OfficeIMO.Workflows.Tests;
+
+public sealed partial class OfficeProvenanceWorkflowTests {
+    [Theory]
+    [InlineData("../claim.c2pa")]
+    [InlineData("%2e%2e/claim.c2pa")]
+    public async Task AssessmentRejectsParentRelativeManifestBeforeCallingProviders(string manifestReference) {
+        using var scope = new TempScope();
+        string assetDirectory = Path.Combine(scope.Path, "assets");
+        Directory.CreateDirectory(assetDirectory);
+        File.WriteAllText(Path.Combine(scope.Path, "claim.c2pa"), "outside snapshot child");
+        string input = Path.Combine(assetDirectory, "page.html");
+        File.WriteAllText(
+            input,
+            "<!doctype html><html><head><link rel=\"c2pa-manifest\" href=\"" + manifestReference +
+            "\"></head><body>body</body></html>");
+        var verifier = new NestedRelativeManifestVerifier("claim.c2pa", "unused");
+
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner(verifier).RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Assess,
+                InputPath = input
+            });
+
+        Assert.False(result.Succeeded);
+        Assert.Contains("cannot be bound within the immutable snapshot", result.Summary, StringComparison.OrdinalIgnoreCase);
+        Assert.Null(verifier.ObservedDirectory);
+    }
+
+    [Fact]
+    public async Task RemovalSharesExpandedByteBudgetAcrossWorkflowStages() {
+        using var scope = new TempScope();
+        string input = scope.Write(
+            "page.html",
+            "<!doctype html><html><head><link rel=\"c2pa-manifest\" href=\"claim.c2pa\"></head>" +
+            "<body><img src=\"data:image/png;base64,AQIDBA==\"></body></html>");
+        string output = Path.Combine(scope.Path, "cleaned.html");
+        var request = new OfficeProvenanceWorkflowRequest {
+            Operation = OfficeProvenanceWorkflowOperation.Remove,
+            InputPath = input,
+            OutputPath = output
+        };
+        request.Removal.Limits.MaxExpandedContainerBytes = 4;
+
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner().RunProvenanceAsync(request);
+
+        Assert.False(result.Succeeded);
+        Assert.Contains("expanded-container limit", result.Summary, StringComparison.OrdinalIgnoreCase);
+        Assert.False(File.Exists(output));
+    }
+
+    [Fact]
+    public void SnapshotStorageFailuresUseTheExecutionFailureContract() {
+        var exception = new IOException("snapshot storage unavailable");
+
+        OfficeWorkflowFailureKind kind = OfficeWorkflowRunner.ClassifyFailure(
+            exception,
+            OfficeWorkflowRunner.WorkflowFailureStage.Snapshot);
+
+        Assert.Equal(OfficeWorkflowFailureKind.OperationFailed, kind);
+        Assert.Equal("snapshot", OfficeWorkflowRunner.GetDiagnosticStage(
+            OfficeWorkflowRunner.WorkflowFailureStage.Snapshot));
+    }
+
+    [Fact]
+    public async Task BatchReplacementRejectsDestinationRetargetedToAnotherInput() {
+#if NET8_0_OR_GREATER
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
+        using var scope = new TempScope();
+        string firstInput = scope.Write("first.html", HtmlWithExternalManifest("first"));
+        string secondInput = scope.Write("second.html", "<!doctype html><html><body>second input</body></html>");
+        string benignDestination = scope.Write("existing.html", "existing destination");
+        string output = Path.Combine(scope.Path, "cleaned.html");
+        File.CreateSymbolicLink(output, benignDestination);
+        var progress = new RetargetingBatchOutputProgress("first", output, secondInput);
+
+        IReadOnlyList<OfficeProvenanceWorkflowResult> results = await new OfficeWorkflowRunner().RunProvenanceBatchAsync([
+            new OfficeProvenanceWorkflowRequest {
+                Id = "first",
+                Operation = OfficeProvenanceWorkflowOperation.Remove,
+                InputPath = firstInput,
+                OutputPath = output,
+                ConflictPolicy = OfficeWorkflowConflictPolicy.Replace
+            },
+            new OfficeProvenanceWorkflowRequest {
+                Id = "second",
+                Operation = OfficeProvenanceWorkflowOperation.Inspect,
+                InputPath = secondInput
+            }
+        ], progress: progress);
+
+        Assert.True(progress.Retargeted);
+        Assert.Equal(OfficeWorkflowFailureKind.OutputFailed, results[0].FailureKind);
+        Assert.Contains("overlaps another batch request", results[0].Summary, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("<!doctype html><html><body>second input</body></html>", File.ReadAllText(secondInput));
+#endif
+    }
+
+#if NET8_0_OR_GREATER
+    private sealed class RetargetingBatchOutputProgress(
+        string requestId,
+        string outputPath,
+        string targetPath) : IProgress<OfficeWorkflowProgress> {
+        internal bool Retargeted { get; private set; }
+
+        public void Report(OfficeWorkflowProgress value) {
+            if (Retargeted || value.RequestId != requestId || value.Stage != "publish") return;
+            File.Delete(outputPath);
+            File.CreateSymbolicLink(outputPath, targetPath);
+            Retargeted = true;
+        }
+    }
+#endif
+}

--- a/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.Wave78.cs
+++ b/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.Wave78.cs
@@ -1,4 +1,5 @@
 using System.Runtime.InteropServices;
+using System.Text;
 using OfficeIMO.Provenance;
 
 namespace OfficeIMO.Workflows.Tests;
@@ -99,6 +100,95 @@ public sealed partial class OfficeProvenanceWorkflowTests {
 #endif
     }
 
+    [Fact]
+    public async Task BatchReplacementWithDefaultOutputRejectsDestinationRetargetedToAnotherInput() {
+#if NET8_0_OR_GREATER
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
+        using var scope = new TempScope();
+        string firstInput = scope.Write("first.html", HtmlWithExternalManifest("first"));
+        const string secondContent = "<!doctype html><html><body>second input</body></html>";
+        string secondInput = scope.Write("second.html", secondContent);
+        string defaultOutput = Path.Combine(scope.Path, "first.provenance-cleaned.html");
+        var progress = new RetargetingBatchOutputProgress("first", defaultOutput, secondInput);
+
+        IReadOnlyList<OfficeProvenanceWorkflowResult> results = await new OfficeWorkflowRunner().RunProvenanceBatchAsync([
+            new OfficeProvenanceWorkflowRequest {
+                Id = "first",
+                Operation = OfficeProvenanceWorkflowOperation.Remove,
+                InputPath = firstInput,
+                ConflictPolicy = OfficeWorkflowConflictPolicy.Replace
+            },
+            new OfficeProvenanceWorkflowRequest {
+                Id = "second",
+                Operation = OfficeProvenanceWorkflowOperation.Inspect,
+                InputPath = secondInput
+            }
+        ], progress: progress);
+
+        Assert.True(progress.Retargeted);
+        Assert.Equal(OfficeWorkflowFailureKind.OutputFailed, results[0].FailureKind);
+        Assert.Contains("overlaps another batch request", results[0].Summary, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(secondContent, File.ReadAllText(secondInput));
+#endif
+    }
+
+    [Theory]
+    [InlineData(false, "page.html")]
+    [InlineData(true, "page.html")]
+    [InlineData(false, "asset.bin")]
+    [InlineData(true, "asset.bin")]
+    public async Task HtmlOwnerInspectionHonorsUtf32Preambles(bool bigEndian, string fileName) {
+        using var scope = new TempScope();
+        string input = Path.Combine(scope.Path, fileName);
+        var encoding = new UTF32Encoding(bigEndian, byteOrderMark: true);
+        string html = HtmlWithExternalManifest("utf32");
+        File.WriteAllBytes(input, encoding.GetPreamble().Concat(encoding.GetBytes(html)).ToArray());
+
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner().RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Inspect,
+                InputPath = input
+            });
+
+        Assert.True(result.Succeeded, result.Summary);
+        Assert.Equal("OfficeIMO.Html", result.OwnerPackage);
+        Assert.Equal(OfficeProvenanceAssetFormat.Html, result.Inspection!.Format);
+        Assert.Equal(
+            OfficeProvenanceCarrierKind.C2paExternalManifest,
+            Assert.Single(result.Inspection.Evidence).Carrier);
+    }
+
+    [Fact]
+    public async Task PublishedRemovalRemainsCompletedWhenSnapshotCleanupFails() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
+        using var scope = new TempScope();
+        string inputFileName = "cleanup-" + Guid.NewGuid().ToString("N") + ".html";
+        string input = scope.Write(inputFileName, HtmlWithExternalManifest("cleanup"));
+        string output = Path.Combine(scope.Path, "cleaned.html");
+        var progress = new SnapshotCleanupBlockingProgress(inputFileName);
+
+        try {
+            OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner().RunProvenanceAsync(
+                new OfficeProvenanceWorkflowRequest {
+                    Operation = OfficeProvenanceWorkflowOperation.Remove,
+                    InputPath = input,
+                    OutputPath = output
+                },
+                progress);
+
+            Assert.True(progress.Blocked);
+            Assert.True(result.Succeeded, result.Summary);
+            Assert.Equal(Path.GetFullPath(output), result.OutputPath);
+            Assert.True(File.Exists(output));
+            Assert.Contains(result.Diagnostics, diagnostic =>
+                diagnostic.Code == "ProvenanceSnapshotCleanupFailed" && diagnostic.Stage == "cleanup");
+        } finally {
+            if (progress.SnapshotDirectory is { } retainedDirectory && Directory.Exists(retainedDirectory)) {
+                Directory.Delete(retainedDirectory, recursive: true);
+            }
+        }
+    }
+
 #if NET8_0_OR_GREATER
     private sealed class RetargetingBatchOutputProgress(
         string requestId,
@@ -114,4 +204,18 @@ public sealed partial class OfficeProvenanceWorkflowTests {
         }
     }
 #endif
+
+    private sealed class SnapshotCleanupBlockingProgress(string inputFileName) : IProgress<OfficeWorkflowProgress> {
+        internal bool Blocked { get; private set; }
+        internal string? SnapshotDirectory { get; private set; }
+
+        public void Report(OfficeWorkflowProgress value) {
+            if (Blocked || value.Stage != "finalize") return;
+            SnapshotDirectory = Directory.EnumerateDirectories(Path.GetTempPath(), "officeimo-provenance-*")
+                .FirstOrDefault(path => File.Exists(Path.Combine(path, inputFileName)));
+            if (SnapshotDirectory is null) return;
+            File.WriteAllText(Path.Combine(SnapshotDirectory, "retain-cleanup.txt"), "force non-empty cleanup");
+            Blocked = true;
+        }
+    }
 }

--- a/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.Wave78.cs
+++ b/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.Wave78.cs
@@ -49,8 +49,40 @@ public sealed partial class OfficeProvenanceWorkflowTests {
         OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner().RunProvenanceAsync(request);
 
         Assert.False(result.Succeeded);
+        Assert.Equal(OfficeWorkflowFailureKind.UnsupportedInput, result.FailureKind);
+        Assert.NotEqual(OfficeWorkflowFailureKind.OutputFailed, result.FailureKind);
         Assert.Contains("expanded-container limit", result.Summary, StringComparison.OrdinalIgnoreCase);
         Assert.False(File.Exists(output));
+    }
+
+    [Fact]
+    public void BatchRemovalPlanningUsesPortablePathIdentitiesWhenPhysicalIdentityIsUnavailable() {
+        using var scope = new TempScope();
+        string first = scope.Write("first.html", HtmlWithExternalManifest("first"));
+        string second = scope.Write("second.html", HtmlWithExternalManifest("second"));
+
+        OfficeProvenanceWorkflowRequest[] prepared = OfficeWorkflowRunner.PrepareBatchRemovalPaths([
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Remove,
+                InputPath = first,
+                ConflictPolicy = OfficeWorkflowConflictPolicy.Replace
+            },
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Remove,
+                InputPath = second,
+                OutputPath = Path.Combine(scope.Path, "second-clean.html"),
+                ConflictPolicy = OfficeWorkflowConflictPolicy.Replace
+            }
+        ], usePhysicalIdentity: false);
+
+        Assert.Equal(Path.Combine(scope.Path, "first.provenance-cleaned.html"), prepared[0].OutputPath);
+        Assert.NotNull(prepared[0].BatchBlockedOutputIdentities);
+        Assert.Same(prepared[0].BatchBlockedOutputIdentities, prepared[1].BatchBlockedOutputIdentities);
+        Assert.All(prepared, request => Assert.NotNull(request.BatchOwnReservedOutputIdentity));
+        Assert.True(OfficeWorkflowPathIdentity.AreEquivalentWithPortableFallback(
+            prepared[0].OutputPath!,
+            Path.Combine(scope.Path, ".", "first.provenance-cleaned.html"),
+            usePhysicalIdentity: false));
     }
 
     [Fact]

--- a/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.Wave79.cs
+++ b/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.Wave79.cs
@@ -1,0 +1,63 @@
+using OfficeIMO.Provenance;
+
+namespace OfficeIMO.Workflows.Tests;
+
+public sealed partial class OfficeProvenanceWorkflowTests {
+    [Theory]
+    [InlineData("null-verifier")]
+    [InlineData("inconsistent-verifier")]
+    [InlineData("null-detector")]
+    [InlineData("inconsistent-detector")]
+    public async Task ProviderContractFailuresUseTheExecutionFailureContract(string scenario) {
+        using var scope = new TempScope();
+        string input = scope.Write("asset.txt", "provider contract input");
+        IOfficeProvenanceVerifier? verifier = scenario switch {
+            "null-verifier" => new NullResultVerifier(),
+            "inconsistent-verifier" => new InconsistentResultVerifier(),
+            _ => null
+        };
+        IOfficeProvenanceSignalDetector[] detectors = scenario switch {
+            "null-detector" => [new NullResultDetector()],
+            "inconsistent-detector" => [new InconsistentResultDetector()],
+            _ => []
+        };
+
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner(verifier, detectors)
+            .RunProvenanceAsync(new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Assess,
+                InputPath = input
+            });
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(OfficeWorkflowFailureKind.OperationFailed, result.FailureKind);
+        Assert.Contains("returned", result.Summary, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private sealed class NullResultVerifier : IOfficeProvenanceVerifier {
+        public string Name => "null-verifier";
+        public OfficeProvenanceVerificationResult Verify(
+            string filePath,
+            OfficeProvenanceVerificationOptions? options = null) => null!;
+    }
+
+    private sealed class InconsistentResultVerifier : IOfficeProvenanceVerifier {
+        public string Name => "expected-verifier";
+        public OfficeProvenanceVerificationResult Verify(
+            string filePath,
+            OfficeProvenanceVerificationOptions? options = null) =>
+            new(OfficeProvenanceVerificationStatus.Valid, "different-verifier", []);
+    }
+
+    private sealed class NullResultDetector : IOfficeProvenanceSignalDetector {
+        public string Name => "null-detector";
+        public OfficeProvenanceSignalKind SignalKind => OfficeProvenanceSignalKind.DeterministicArtifact;
+        public OfficeProvenanceSignalResult Detect(string filePath) => null!;
+    }
+
+    private sealed class InconsistentResultDetector : IOfficeProvenanceSignalDetector {
+        public string Name => "expected-detector";
+        public OfficeProvenanceSignalKind SignalKind => OfficeProvenanceSignalKind.DeterministicArtifact;
+        public OfficeProvenanceSignalResult Detect(string filePath) =>
+            new("different-detector", SignalKind, OfficeProvenanceSignalStatus.NotDetected);
+    }
+}

--- a/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.cs
+++ b/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.cs
@@ -843,6 +843,43 @@ public sealed partial class OfficeProvenanceWorkflowTests {
         Assert.Equal(existing, File.ReadAllText(output));
     }
 
+    [Fact]
+    public async Task OwnerStagingWriteAccessFailureUsesTheOutputFailureContract() {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
+        using var scope = new TempScope();
+        string input = scope.Write("page.html", HtmlWithExternalManifest("owner output"));
+        string outputDirectory = Path.Combine(scope.Path, "read-only-output");
+        Directory.CreateDirectory(outputDirectory);
+        string output = Path.Combine(outputDirectory, "cleaned.html");
+        UnixFileMode originalMode = File.GetUnixFileMode(outputDirectory);
+        try {
+            File.SetUnixFileMode(outputDirectory, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+            string permissionProbe = Path.Combine(outputDirectory, "permission-probe");
+            try {
+                File.WriteAllText(permissionProbe, "probe");
+                File.Delete(permissionProbe);
+                return;
+            } catch (Exception exception) when (exception is IOException or UnauthorizedAccessException) {
+                // The platform enforces the directory mode, so exercise the real owner staging path.
+            }
+
+            OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner().RunProvenanceAsync(
+                new OfficeProvenanceWorkflowRequest {
+                    Operation = OfficeProvenanceWorkflowOperation.Remove,
+                    InputPath = input,
+                    OutputPath = output
+                });
+
+            Assert.False(result.Succeeded);
+            Assert.Equal(OfficeWorkflowFailureKind.OutputFailed, result.FailureKind);
+            Assert.Contains(
+                result.Diagnostics,
+                diagnostic => diagnostic.Code == "ProvenanceWorkflowFailed" && diagnostic.Stage == "output");
+        } finally {
+            File.SetUnixFileMode(outputDirectory, originalMode);
+        }
+    }
+
     [Theory]
     [InlineData(typeof(IOException))]
     [InlineData(typeof(UnauthorizedAccessException))]

--- a/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.cs
+++ b/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.cs
@@ -8,6 +8,23 @@ namespace OfficeIMO.Workflows.Tests;
 
 public sealed partial class OfficeProvenanceWorkflowTests {
     [Fact]
+    public void PortableStagedArtifactFingerprintUsesLengthAndHash() {
+        using var scope = new TempScope();
+        string staged = scope.Write("staged.html", "<!doctype html><html><body>portable</body></html>");
+
+        using OfficeWorkflowRunner.StagedArtifactFingerprint fingerprint =
+            OfficeWorkflowRunner.StagedArtifactFingerprint.CapturePortable(staged, 4096);
+
+        fingerprint.VerifyStagingPath(staged, 4096, CancellationToken.None);
+        Assert.True(fingerprint.TryPinPublishedPath(staged, 4096, CancellationToken.None));
+        fingerprint.VerifyPublishedPath(staged, 4096, CancellationToken.None);
+
+        File.WriteAllText(staged, "<!doctype html><html><body>changed portable artifact</body></html>");
+        Assert.Throws<InvalidDataException>(() =>
+            fingerprint.VerifyStagingPath(staged, 4096, CancellationToken.None));
+    }
+
+    [Fact]
     public async Task RemovalCanReopenAnExpandedOutputWithinItsSeparateOutputBudget() {
         using var scope = new TempScope();
         string input = scope.Write("compact.html", "<link rel=c2pa-manifest href=x>");

--- a/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.cs
+++ b/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.cs
@@ -274,6 +274,27 @@ public sealed partial class OfficeProvenanceWorkflowTests {
     }
 
     [Fact]
+    public async Task AssessmentWithoutProvidersDoesNotCopyAnOversizedExternalManifest() {
+        using var scope = new TempScope();
+        string input = scope.Write("page.html", HtmlWithExternalManifest("body"));
+        scope.Write("claim.c2pa", new string('x', 128));
+        var assessment = new OfficeProvenanceAssessmentOptions();
+        assessment.Structural.MaxManifestBytes = 8;
+
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner().RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Assess,
+                InputPath = input,
+                Assessment = assessment
+            });
+
+        Assert.True(result.Succeeded, result.Summary);
+        Assert.Single(result.Assessment!.Structural.Evidence);
+        Assert.Null(result.Assessment.Verification);
+        Assert.Empty(result.Assessment.ProviderSignals);
+    }
+
+    [Fact]
     public async Task AssessmentSnapshotsRelativeExternalManifestDependenciesForProviders() {
         using var scope = new TempScope();
         string input = scope.Write("page.html", HtmlWithExternalManifest("body"));
@@ -399,6 +420,31 @@ public sealed partial class OfficeProvenanceWorkflowTests {
         Assert.False(result.Succeeded);
         Assert.True(progress.Deleted);
         Assert.Equal("existing destination", File.ReadAllText(output));
+    }
+
+    [Fact]
+    public async Task ReplaceRejectsAnExistingDestinationAboveTheOutputLimitWithoutHashingOrChangingIt() {
+        using var scope = new TempScope();
+        string input = scope.Write("page.html", HtmlWithExternalManifest("original"));
+        string existing = new string('x', 2048);
+        string output = scope.Write("cleaned.html", existing);
+
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner().RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Remove,
+                InputPath = input,
+                OutputPath = output,
+                ConflictPolicy = OfficeWorkflowConflictPolicy.Replace,
+                Limits = new OfficeWorkflowLimits {
+                    MaximumInputBytes = 4096,
+                    MaximumOutputBytes = 1024
+                }
+            });
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(OfficeWorkflowFailureKind.OutputFailed, result.FailureKind);
+        Assert.Contains("existing provenance destination", result.Summary, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(existing, File.ReadAllText(output));
     }
 
     [Theory]

--- a/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.cs
+++ b/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.cs
@@ -796,7 +796,7 @@ public sealed partial class OfficeProvenanceWorkflowTests {
         string input = scope.Write("page.html", HtmlWithExternalManifest("original"));
         string output = scope.Write("cleaned.html", "existing destination");
         using var cancellation = new CancellationTokenSource();
-        var progress = new CancellingProgress("replace-finalization", cancellation);
+        var progress = new CancellingFinalizationProgress("replace-finalization", cancellation);
 
         OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner().RunProvenanceAsync(
             new OfficeProvenanceWorkflowRequest {
@@ -812,6 +812,8 @@ public sealed partial class OfficeProvenanceWorkflowTests {
         Assert.Equal(OfficeWorkflowStatus.Cancelled, result.Status);
         Assert.True(cancellation.IsCancellationRequested);
         Assert.Equal("existing destination", File.ReadAllText(output));
+        Assert.Contains("finalize", progress.Stages);
+        Assert.DoesNotContain("complete", progress.Stages);
     }
 
     [Fact]
@@ -833,6 +835,8 @@ public sealed partial class OfficeProvenanceWorkflowTests {
         Assert.False(result.Succeeded);
         Assert.True(progress.Deleted);
         Assert.Equal("existing destination", File.ReadAllText(output));
+        Assert.Contains("finalize", progress.Stages);
+        Assert.DoesNotContain("complete", progress.Stages);
     }
 
     [Fact]
@@ -1177,9 +1181,11 @@ public sealed partial class OfficeProvenanceWorkflowTests {
         internal DeletingPublishedArtifactProgress(string path) => _path = path;
 
         internal bool Deleted { get; private set; }
+        internal List<string> Stages { get; } = new();
 
         public void Report(OfficeWorkflowProgress value) {
-            if (Deleted || !string.Equals(value.Stage, "complete", StringComparison.Ordinal)) return;
+            Stages.Add(value.Stage);
+            if (Deleted || !string.Equals(value.Stage, "finalize", StringComparison.Ordinal)) return;
             File.Delete(_path);
             Deleted = true;
         }

--- a/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.cs
+++ b/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.cs
@@ -24,16 +24,19 @@ public sealed partial class OfficeProvenanceWorkflowTests {
         Assert.True(outputBytes > inputBytes, $"Expected HTML normalization to expand {inputBytes} bytes, but received {outputBytes} bytes.");
 
         string output = Path.Combine(scope.Path, "cleaned.html");
+        var request = new OfficeProvenanceWorkflowRequest {
+            Operation = OfficeProvenanceWorkflowOperation.Remove,
+            InputPath = input,
+            OutputPath = output,
+            Limits = new OfficeWorkflowLimits {
+                MaximumInputBytes = inputBytes,
+                MaximumOutputBytes = outputBytes
+            }
+        };
+        request.Removal.Limits.MaxAssetBytes = inputBytes;
+        request.Removal.MaxOutputBytes = outputBytes;
         OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner().RunProvenanceAsync(
-            new OfficeProvenanceWorkflowRequest {
-                Operation = OfficeProvenanceWorkflowOperation.Remove,
-                InputPath = input,
-                OutputPath = output,
-                Limits = new OfficeWorkflowLimits {
-                    MaximumInputBytes = inputBytes,
-                    MaximumOutputBytes = outputBytes
-                }
-            });
+            request);
 
         Assert.True(result.Succeeded, result.Summary);
         Assert.Equal(outputBytes, result.OutputBytes);
@@ -757,7 +760,7 @@ public sealed partial class OfficeProvenanceWorkflowTests {
         public OfficeProvenanceSignalKind SignalKind => OfficeProvenanceSignalKind.DeterministicArtifact;
         internal string? ObservedPath { get; private set; }
 
-        public OfficeProvenanceSignalResult Detect(string filePath, CancellationToken cancellationToken = default) {
+        public OfficeProvenanceSignalResult Detect(string filePath) {
             ObservedPath = Path.GetFullPath(filePath);
             File.WriteAllText(_originalPath, "<!doctype html><html><body>replacement</body></html>");
             bool detected = File.ReadAllText(filePath).Contains("c2pa-manifest", StringComparison.OrdinalIgnoreCase);
@@ -768,13 +771,15 @@ public sealed partial class OfficeProvenanceWorkflowTests {
         }
     }
 
-    private sealed class BlockingCancellationDetector : IOfficeProvenanceSignalDetector {
+    private sealed class BlockingCancellationDetector : ICancellableOfficeProvenanceSignalDetector {
         public string Name => "blocking-cancellation";
         public OfficeProvenanceSignalKind SignalKind => OfficeProvenanceSignalKind.DeterministicArtifact;
         internal TaskCompletionSource<bool> Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
         internal bool CancellationObserved { get; private set; }
 
-        public OfficeProvenanceSignalResult Detect(string filePath, CancellationToken cancellationToken = default) {
+        public OfficeProvenanceSignalResult Detect(string filePath) => Detect(filePath, CancellationToken.None);
+
+        public OfficeProvenanceSignalResult Detect(string filePath, CancellationToken cancellationToken) {
             Started.TrySetResult(true);
             cancellationToken.WaitHandle.WaitOne();
             CancellationObserved = cancellationToken.IsCancellationRequested;
@@ -783,15 +788,22 @@ public sealed partial class OfficeProvenanceWorkflowTests {
         }
     }
 
-    private sealed class BlockingCancellationVerifier : IOfficeProvenanceVerifier {
+    private sealed class BlockingCancellationVerifier : ICancellableOfficeProvenanceVerifier {
         public string Name => "blocking-cancellation";
         internal TaskCompletionSource<bool> Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
         internal bool CancellationObserved { get; private set; }
 
         public OfficeProvenanceVerificationResult Verify(
             string filePath,
-            OfficeProvenanceVerificationOptions? options = null,
-            CancellationToken cancellationToken = default) {
+            OfficeProvenanceVerificationOptions? options = null) => Verify(
+                filePath,
+                options,
+                CancellationToken.None);
+
+        public OfficeProvenanceVerificationResult Verify(
+            string filePath,
+            OfficeProvenanceVerificationOptions? options,
+            CancellationToken cancellationToken) {
             Started.TrySetResult(true);
             cancellationToken.WaitHandle.WaitOne();
             CancellationObserved = cancellationToken.IsCancellationRequested;
@@ -807,8 +819,7 @@ public sealed partial class OfficeProvenanceWorkflowTests {
 
         public OfficeProvenanceVerificationResult Verify(
             string filePath,
-            OfficeProvenanceVerificationOptions? options = null,
-            CancellationToken cancellationToken = default) {
+            OfficeProvenanceVerificationOptions? options = null) {
             ObservedDirectory = Path.GetDirectoryName(Path.GetFullPath(filePath));
             string manifestPath = Path.Combine(ObservedDirectory!, "claim.c2pa");
             SawRelativeManifest = File.Exists(manifestPath) && File.ReadAllText(manifestPath) == "immutable claim";
@@ -827,8 +838,7 @@ public sealed partial class OfficeProvenanceWorkflowTests {
 
         public OfficeProvenanceVerificationResult Verify(
             string filePath,
-            OfficeProvenanceVerificationOptions? options = null,
-            CancellationToken cancellationToken = default) {
+            OfficeProvenanceVerificationOptions? options = null) {
             ObservedDirectory = Path.GetDirectoryName(Path.GetFullPath(filePath));
             string manifestPath = Path.Combine(ObservedDirectory!, "claim.c2pa");
             string replacementPath = manifestPath + ".replacement";
@@ -854,8 +864,7 @@ public sealed partial class OfficeProvenanceWorkflowTests {
 
         public OfficeProvenanceVerificationResult Verify(
             string filePath,
-            OfficeProvenanceVerificationOptions? options = null,
-            CancellationToken cancellationToken = default) {
+            OfficeProvenanceVerificationOptions? options = null) {
             ObservedDirectory = Path.GetDirectoryName(Path.GetFullPath(filePath));
             string manifestPath = Path.Combine(ObservedDirectory!, "sub", "claim.c2pa");
             SawRelativeManifest = File.Exists(manifestPath) &&
@@ -899,7 +908,7 @@ public sealed partial class OfficeProvenanceWorkflowTests {
         public OfficeProvenanceSignalKind SignalKind => OfficeProvenanceSignalKind.DeterministicArtifact;
         internal bool Replaced { get; private set; }
 
-        public OfficeProvenanceSignalResult Detect(string filePath, CancellationToken cancellationToken = default) {
+        public OfficeProvenanceSignalResult Detect(string filePath) {
             string replacementPath = filePath + ".replacement";
             File.WriteAllText(replacementPath, "replacement");
             File.Move(replacementPath, filePath, overwrite: true);

--- a/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.cs
+++ b/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.cs
@@ -1,4 +1,5 @@
 using System.IO.Compression;
+using System.Runtime.InteropServices;
 using System.Text;
 using OfficeIMO.OpenDocument;
 using OfficeIMO.Provenance;
@@ -338,6 +339,52 @@ public sealed partial class OfficeProvenanceWorkflowTests {
     }
 
     [Fact]
+    public async Task AssessmentFailsClosedWhenAProviderReplacesThePrimarySnapshot() {
+#if NET8_0_OR_GREATER
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
+        using var scope = new TempScope();
+        string input = scope.Write("page.html", HtmlWithExternalManifest("body"));
+        var detector = new ReplacingSnapshotDetector();
+
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner(
+            provenanceVerifier: null,
+            provenanceSignalDetectors: [detector]).RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Assess,
+                InputPath = input
+            });
+
+        Assert.True(detector.Replaced);
+        Assert.False(result.Succeeded);
+        Assert.Contains("primary provenance snapshot changed", result.Summary, StringComparison.OrdinalIgnoreCase);
+#endif
+    }
+
+    [Fact]
+    public async Task AssessmentSharesExpandedDataBudgetWithExternalManifestCapture() {
+        using var scope = new TempScope();
+        string input = scope.Write(
+            "page.html",
+            "<!doctype html><html><head><link rel=\"c2pa-manifest\" href=\"claim.c2pa\"></head>" +
+            "<body><img src=\"data:image/png;base64,AQIDBA==\"></body></html>");
+        scope.Write("claim.c2pa", "four");
+        var assessment = new OfficeProvenanceAssessmentOptions();
+        assessment.Structural.MaxExpandedContainerBytes = 7;
+        var verifier = new RelativeManifestVerifier();
+
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner(verifier).RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Assess,
+                InputPath = input,
+                Assessment = assessment
+            });
+
+        Assert.False(result.Succeeded);
+        Assert.Contains("expanded-data limit", result.Summary, StringComparison.OrdinalIgnoreCase);
+        Assert.False(verifier.SawRelativeManifest);
+    }
+
+    [Fact]
     public async Task DiskBackedSnapshotAcceptsWorkflowCeilingsAboveInt32() {
         using var scope = new TempScope();
         string input = scope.Write("page.html", HtmlWithExternalManifest("body"));
@@ -541,6 +588,25 @@ public sealed partial class OfficeProvenanceWorkflowTests {
                 Array.Empty<string>());
         }
     }
+
+#if NET8_0_OR_GREATER
+    private sealed class ReplacingSnapshotDetector : IOfficeProvenanceSignalDetector {
+        public string Name => "replacing-snapshot";
+        public OfficeProvenanceSignalKind SignalKind => OfficeProvenanceSignalKind.DeterministicArtifact;
+        internal bool Replaced { get; private set; }
+
+        public OfficeProvenanceSignalResult Detect(string filePath) {
+            string replacementPath = filePath + ".replacement";
+            File.WriteAllText(replacementPath, "replacement");
+            File.Move(replacementPath, filePath, overwrite: true);
+            Replaced = true;
+            return new OfficeProvenanceSignalResult(
+                Name,
+                SignalKind,
+                OfficeProvenanceSignalStatus.Detected);
+        }
+    }
+#endif
 
     private sealed class ReplacingStagedArtifactProgress : IProgress<OfficeWorkflowProgress> {
         private readonly string _directory;

--- a/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.cs
+++ b/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.cs
@@ -256,6 +256,164 @@ public sealed partial class OfficeProvenanceWorkflowTests {
         Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "AssessmentSnapshot");
     }
 
+    [Fact]
+    public async Task AssessmentReportsTheLogicalSourcePathWhileReadingTheSnapshot() {
+        using var scope = new TempScope();
+        string input = scope.Write("page.html", "<!doctype html><html><body>review\u200Bthis</body></html>");
+
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner().RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Assess,
+                InputPath = input
+            });
+
+        Assert.True(result.Succeeded, result.Summary);
+        OfficeTextIntegrityFinding finding = Assert.Single(result.Assessment!.TextIntegrity!.Findings);
+        Assert.Equal(Path.GetFullPath(input), finding.Location);
+        Assert.DoesNotContain("officeimo-provenance-", finding.Location, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task AssessmentSnapshotsRelativeExternalManifestDependenciesForProviders() {
+        using var scope = new TempScope();
+        string input = scope.Write("page.html", HtmlWithExternalManifest("body"));
+        scope.Write("claim.c2pa", "immutable claim");
+        var verifier = new RelativeManifestVerifier();
+
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner(verifier).RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Assess,
+                InputPath = input
+            });
+
+        Assert.True(result.Succeeded, result.Summary);
+        Assert.Equal(OfficeProvenanceVerificationStatus.Valid, result.Assessment!.Verification!.Status);
+        Assert.True(verifier.SawRelativeManifest);
+        Assert.NotEqual(Path.GetDirectoryName(input), verifier.ObservedDirectory);
+        Assert.False(Directory.Exists(verifier.ObservedDirectory));
+    }
+
+    [Fact]
+    public async Task AssessmentFailsClosedWhenAProviderReplacesACapturedExternalManifest() {
+        using var scope = new TempScope();
+        string input = scope.Write("page.html", HtmlWithExternalManifest("body"));
+        scope.Write("claim.c2pa", "immutable claim");
+        var verifier = new ReplacingRelativeManifestVerifier();
+
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner(verifier).RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Assess,
+                InputPath = input
+            });
+
+        Assert.True(verifier.Replaced || verifier.MutationBlocked);
+        if (verifier.Replaced) {
+            Assert.False(result.Succeeded);
+            Assert.Contains("external provenance manifest changed", result.Summary, StringComparison.OrdinalIgnoreCase);
+        } else {
+            Assert.True(result.Succeeded, result.Summary);
+        }
+        Assert.False(Directory.Exists(verifier.ObservedDirectory));
+    }
+
+    [Fact]
+    public async Task DiskBackedSnapshotAcceptsWorkflowCeilingsAboveInt32() {
+        using var scope = new TempScope();
+        string input = scope.Write("page.html", HtmlWithExternalManifest("body"));
+
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner().RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Assess,
+                InputPath = input,
+                Limits = new OfficeWorkflowLimits {
+                    MaximumInputBytes = (long)int.MaxValue + 4096L,
+                    MaximumOutputBytes = (long)int.MaxValue + 4096L
+                }
+            });
+
+        Assert.True(result.Succeeded, result.Summary);
+    }
+
+    [Fact]
+    public async Task PublicationRejectsAStagedArtifactChangedAfterValidation() {
+        using var scope = new TempScope();
+        string input = scope.Write("page.html", HtmlWithExternalManifest("original"));
+        string output = Path.Combine(scope.Path, "cleaned.html");
+        var progress = new ReplacingStagedArtifactProgress(scope.Path, output);
+
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner().RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Remove,
+                InputPath = input,
+                OutputPath = output
+            },
+            progress);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(OfficeWorkflowFailureKind.OutputFailed, result.FailureKind);
+        Assert.Contains("changed after output validation", result.Summary, StringComparison.OrdinalIgnoreCase);
+        Assert.True(progress.Replaced);
+        Assert.False(File.Exists(output));
+    }
+
+    [Fact]
+    public async Task ReplaceRestoresTheDisplacedDestinationWhenFinalValidationIsCancelled() {
+        using var scope = new TempScope();
+        string input = scope.Write("page.html", HtmlWithExternalManifest("original"));
+        string output = scope.Write("cleaned.html", "existing destination");
+        using var cancellation = new CancellationTokenSource();
+        var progress = new CancellingProgress("replace-finalization", cancellation);
+
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner().RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Id = "replace-finalization",
+                Operation = OfficeProvenanceWorkflowOperation.Remove,
+                InputPath = input,
+                OutputPath = output,
+                ConflictPolicy = OfficeWorkflowConflictPolicy.Replace
+            },
+            progress,
+            cancellation.Token);
+
+        Assert.Equal(OfficeWorkflowStatus.Cancelled, result.Status);
+        Assert.True(cancellation.IsCancellationRequested);
+        Assert.Equal("existing destination", File.ReadAllText(output));
+    }
+
+    [Fact]
+    public async Task ReplaceRestoresTheDisplacedDestinationWhenPublishedArtifactDisappears() {
+        using var scope = new TempScope();
+        string input = scope.Write("page.html", HtmlWithExternalManifest("original"));
+        string output = scope.Write("cleaned.html", "existing destination");
+        var progress = new DeletingPublishedArtifactProgress(output);
+
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner().RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Remove,
+                InputPath = input,
+                OutputPath = output,
+                ConflictPolicy = OfficeWorkflowConflictPolicy.Replace
+            },
+            progress);
+
+        Assert.False(result.Succeeded);
+        Assert.True(progress.Deleted);
+        Assert.Equal("existing destination", File.ReadAllText(output));
+    }
+
+    [Theory]
+    [InlineData(typeof(IOException))]
+    [InlineData(typeof(UnauthorizedAccessException))]
+    public void InputAccessFailuresUseTheInputFailureContract(Type exceptionType) {
+        var exception = (Exception)Activator.CreateInstance(exceptionType, "input unavailable")!;
+
+        OfficeWorkflowFailureKind kind = OfficeWorkflowRunner.ClassifyFailure(
+            exception,
+            OfficeWorkflowRunner.WorkflowFailureStage.Input);
+
+        Assert.Equal(OfficeWorkflowFailureKind.UnsupportedInput, kind);
+    }
+
     private static void CreateOpenDocumentPackage(string path, string mediaType) {
         using var stream = File.Create(path);
         using var archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: false);
@@ -293,6 +451,73 @@ public sealed partial class OfficeProvenanceWorkflowTests {
         }
     }
 
+    private sealed class RelativeManifestVerifier : IOfficeProvenanceVerifier {
+        public string Name => "relative-manifest";
+        internal bool SawRelativeManifest { get; private set; }
+        internal string? ObservedDirectory { get; private set; }
+
+        public OfficeProvenanceVerificationResult Verify(
+            string filePath,
+            OfficeProvenanceVerificationOptions? options = null) {
+            ObservedDirectory = Path.GetDirectoryName(Path.GetFullPath(filePath));
+            string manifestPath = Path.Combine(ObservedDirectory!, "claim.c2pa");
+            SawRelativeManifest = File.Exists(manifestPath) && File.ReadAllText(manifestPath) == "immutable claim";
+            return new OfficeProvenanceVerificationResult(
+                SawRelativeManifest ? OfficeProvenanceVerificationStatus.Valid : OfficeProvenanceVerificationStatus.Invalid,
+                Name,
+                Array.Empty<string>());
+        }
+    }
+
+    private sealed class ReplacingRelativeManifestVerifier : IOfficeProvenanceVerifier {
+        public string Name => "replacing-relative-manifest";
+        internal bool Replaced { get; private set; }
+        internal bool MutationBlocked { get; private set; }
+        internal string? ObservedDirectory { get; private set; }
+
+        public OfficeProvenanceVerificationResult Verify(
+            string filePath,
+            OfficeProvenanceVerificationOptions? options = null) {
+            ObservedDirectory = Path.GetDirectoryName(Path.GetFullPath(filePath));
+            string manifestPath = Path.Combine(ObservedDirectory!, "claim.c2pa");
+            string replacementPath = manifestPath + ".replacement";
+            try {
+                File.WriteAllText(replacementPath, "replaced claim");
+                File.Move(replacementPath, manifestPath, overwrite: true);
+                Replaced = true;
+            } catch (Exception exception) when (exception is IOException or UnauthorizedAccessException) {
+                MutationBlocked = true;
+                if (File.Exists(replacementPath)) File.Delete(replacementPath);
+            }
+            return new OfficeProvenanceVerificationResult(
+                OfficeProvenanceVerificationStatus.Valid,
+                Name,
+                Array.Empty<string>());
+        }
+    }
+
+    private sealed class ReplacingStagedArtifactProgress : IProgress<OfficeWorkflowProgress> {
+        private readonly string _directory;
+        private readonly string _outputPath;
+
+        internal ReplacingStagedArtifactProgress(string directory, string outputPath) {
+            _directory = directory;
+            _outputPath = outputPath;
+        }
+
+        internal bool Replaced { get; private set; }
+
+        public void Report(OfficeWorkflowProgress value) {
+            if (Replaced || !string.Equals(value.Stage, "publish", StringComparison.Ordinal)) return;
+            string stagingPath = Directory.GetFiles(
+                    _directory,
+                    "." + Path.GetFileNameWithoutExtension(_outputPath) + ".*" + Path.GetExtension(_outputPath))
+                .Single();
+            File.WriteAllText(stagingPath, "<!doctype html><html><body>replacement</body></html>");
+            Replaced = true;
+        }
+    }
+
     private sealed class ReplacingRemovalProgress : IProgress<OfficeWorkflowProgress> {
         private readonly string _path;
         private readonly string _replacement;
@@ -309,4 +534,19 @@ public sealed partial class OfficeProvenanceWorkflowTests {
             _replaced = true;
         }
     }
+
+    private sealed class DeletingPublishedArtifactProgress : IProgress<OfficeWorkflowProgress> {
+        private readonly string _path;
+
+        internal DeletingPublishedArtifactProgress(string path) => _path = path;
+
+        internal bool Deleted { get; private set; }
+
+        public void Report(OfficeWorkflowProgress value) {
+            if (Deleted || !string.Equals(value.Stage, "complete", StringComparison.Ordinal)) return;
+            File.Delete(_path);
+            Deleted = true;
+        }
+    }
+
 }

--- a/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.cs
+++ b/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.cs
@@ -283,7 +283,61 @@ public sealed partial class OfficeProvenanceWorkflowTests {
             [request],
             cancellation.Token);
 
-        Assert.Same(request, Assert.Single(prepared));
+        Assert.NotSame(request, Assert.Single(prepared));
+    }
+
+    [Fact]
+    public void ReportOnlyBatchPlanningDoesNotResolveInputPaths() {
+#if NET8_0_OR_GREATER
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
+        using var scope = new TempScope();
+        string loop = Path.Combine(scope.Path, "loop");
+        Directory.CreateSymbolicLink(loop, "loop");
+        var request = new OfficeProvenanceWorkflowRequest {
+            Operation = OfficeProvenanceWorkflowOperation.Inspect,
+            InputPath = Path.Combine(loop, "input.html")
+        };
+
+        OfficeProvenanceWorkflowRequest[] prepared = OfficeWorkflowRunner.PrepareBatchRemovalPaths([request]);
+
+        Assert.NotSame(request, Assert.Single(prepared));
+        Assert.Equal(request.InputPath, prepared[0].InputPath);
+#endif
+    }
+
+    [Fact]
+    public async Task BatchExecutesFrozenRequestsWhenTheCallerMutatesALaterItem() {
+        using var scope = new TempScope();
+        string firstInput = scope.Write("first.html", HtmlWithExternalManifest("first"));
+        string secondInput = scope.Write("second.html", HtmlWithExternalManifest("second"));
+        string firstOutput = Path.Combine(scope.Path, "first-clean.html");
+        string secondOutput = Path.Combine(scope.Path, "second-clean.html");
+        var second = new OfficeProvenanceWorkflowRequest {
+            Id = "second",
+            Operation = OfficeProvenanceWorkflowOperation.Remove,
+            InputPath = secondInput,
+            OutputPath = secondOutput,
+            ConflictPolicy = OfficeWorkflowConflictPolicy.Replace
+        };
+        var progress = new MutatingBatchRequestProgress(second, firstOutput);
+
+        IReadOnlyList<OfficeProvenanceWorkflowResult> results = await new OfficeWorkflowRunner().RunProvenanceBatchAsync([
+            new OfficeProvenanceWorkflowRequest {
+                Id = "first",
+                Operation = OfficeProvenanceWorkflowOperation.Remove,
+                InputPath = firstInput,
+                OutputPath = firstOutput,
+                ConflictPolicy = OfficeWorkflowConflictPolicy.Replace
+            },
+            second
+        ], progress: progress);
+
+        Assert.True(progress.Mutated);
+        Assert.All(results, result => Assert.True(result.Succeeded, result.Summary));
+        Assert.Equal(firstOutput, results[0].OutputPath);
+        Assert.Equal(secondOutput, results[1].OutputPath);
+        Assert.Contains("first", File.ReadAllText(firstOutput), StringComparison.Ordinal);
+        Assert.Contains("second", File.ReadAllText(secondOutput), StringComparison.Ordinal);
     }
 
     [Fact]
@@ -354,6 +408,29 @@ public sealed partial class OfficeProvenanceWorkflowTests {
         Assert.Equal("OfficeIMO.Html", result.OwnerPackage);
         Assert.Equal(OfficeProvenanceAssetFormat.Html, result.Inspection!.Format);
         Assert.Equal(OfficeProvenanceCarrierKind.C2paExternalManifest, Assert.Single(result.Inspection.Evidence).Carrier);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "InspectionSnapshot");
+    }
+
+    [Fact]
+    public async Task InspectRejectsAUnixFifoWithoutBlockingForAWriter() {
+#if NET8_0_OR_GREATER
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
+        string fifo = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".fifo");
+        try {
+            Assert.Equal(0, CreateWorkflowFifoUnix(fifo, 0x180));
+
+            OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner().RunProvenanceAsync(
+                new OfficeProvenanceWorkflowRequest {
+                    Operation = OfficeProvenanceWorkflowOperation.Inspect,
+                    InputPath = fifo
+                }).WaitAsync(TimeSpan.FromSeconds(2));
+
+            Assert.False(result.Succeeded);
+            Assert.Contains("regular file", result.Summary, StringComparison.OrdinalIgnoreCase);
+        } finally {
+            File.Delete(fifo);
+        }
+#endif
     }
 
     [Fact]
@@ -721,6 +798,22 @@ public sealed partial class OfficeProvenanceWorkflowTests {
         }
     }
 
+    private sealed class MutatingBatchRequestProgress(
+        OfficeProvenanceWorkflowRequest request,
+        string conflictingOutputPath) : IProgress<OfficeWorkflowProgress> {
+        internal bool Mutated { get; private set; }
+
+        public void Report(OfficeWorkflowProgress value) {
+            if (Mutated || value.RequestId != "first" || value.Stage != "validate") return;
+            request.InputPath = conflictingOutputPath;
+            request.OutputPath = conflictingOutputPath;
+            request.ConflictPolicy = OfficeWorkflowConflictPolicy.Replace;
+            request.Operation = OfficeProvenanceWorkflowOperation.Inspect;
+            request.Limits.MaximumInputBytes = 1;
+            Mutated = true;
+        }
+    }
+
 #if NET8_0_OR_GREATER
     private sealed class ReplacingSnapshotDetector : IOfficeProvenanceSignalDetector {
         public string Name => "replacing-snapshot";
@@ -792,5 +885,10 @@ public sealed partial class OfficeProvenanceWorkflowTests {
             Deleted = true;
         }
     }
+
+#if NET8_0_OR_GREATER
+    [DllImport("libc", EntryPoint = "mkfifo", SetLastError = true)]
+    private static extern int CreateWorkflowFifoUnix(string path, uint mode);
+#endif
 
 }

--- a/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.cs
+++ b/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.cs
@@ -571,6 +571,26 @@ public sealed partial class OfficeProvenanceWorkflowTests {
     }
 
     [Fact]
+    public async Task AssessmentSnapshotNamespaceDoesNotHideASiblingNamedSnapshotHtml() {
+        using var scope = new TempScope();
+        string input = scope.Write(
+            "page.html",
+            "<!doctype html><html><head><link rel=\"c2pa-manifest\" href=\"snapshot.html\"></head><body>body</body></html>");
+        scope.Write("snapshot.html", "sibling manifest");
+        var verifier = new NestedRelativeManifestVerifier("snapshot.html", "sibling manifest");
+
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner(verifier).RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Assess,
+                InputPath = input
+            });
+
+        Assert.True(result.Succeeded, result.Summary);
+        Assert.True(verifier.SawRelativeManifest);
+        Assert.False(Directory.Exists(verifier.ObservedDirectory));
+    }
+
+    [Fact]
     public async Task AssessmentResolvesRelativeManifestAgainstTheHtmlBaseElement() {
         using var scope = new TempScope();
         string input = scope.Write(
@@ -679,6 +699,56 @@ public sealed partial class OfficeProvenanceWorkflowTests {
             });
 
         Assert.True(result.Succeeded, result.Summary);
+    }
+
+    [Fact]
+    public void FirstPartyOwnerAdapterThreadsCancellationIntoHtmlInspection() {
+        using var scope = new TempScope();
+        string input = scope.Write("page.html", "<!doctype html><html><body>body</body></html>");
+        var options = new OfficeProvenanceOptions();
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        Assert.Throws<OperationCanceledException>(() => OfficeProvenanceWorkflowAdapter.Inspect(
+            OfficeProvenanceWorkflowAdapter.ProvenanceOwner.Html,
+            input,
+            options,
+            input,
+            cancellation.Token));
+    }
+
+    [Fact]
+    public async Task CancellationReportsAStagingArtifactRetainedByAWindowsLease() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
+        using var scope = new TempScope();
+        string input = scope.Write("page.html", HtmlWithExternalManifest("owner output"));
+        string output = Path.Combine(scope.Path, "cleaned.html");
+        using var cancellation = new CancellationTokenSource();
+        var progress = new CancellingStagingLeaseProgress(scope.Path, output, cancellation);
+
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner().RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Remove,
+                InputPath = input,
+                OutputPath = output
+            },
+            progress,
+            cancellation.Token);
+
+        Assert.Equal(OfficeWorkflowStatus.Cancelled, result.Status);
+        OfficeWorkflowDiagnostic cleanup = Assert.Single(
+            result.Diagnostics,
+            diagnostic => diagnostic.Code == "ProvenanceStagingCleanupFailed");
+        string retainedPath = cleanup.Details["retainedPath"];
+        Assert.Equal(progress.StagingPath, retainedPath);
+        Assert.True(File.Exists(retainedPath));
+        Assert.Contains("cleanup failed", Assert.Single(
+            result.Diagnostics,
+            diagnostic => diagnostic.Code == "Cancelled").Message,
+            StringComparison.OrdinalIgnoreCase);
+
+        progress.Dispose();
+        File.Delete(retainedPath);
     }
 
     [Fact]
@@ -1058,6 +1128,39 @@ public sealed partial class OfficeProvenanceWorkflowTests {
             if (Deleted || !string.Equals(value.Stage, "complete", StringComparison.Ordinal)) return;
             File.Delete(_path);
             Deleted = true;
+        }
+    }
+
+    private sealed class CancellingStagingLeaseProgress : IProgress<OfficeWorkflowProgress>, IDisposable {
+        private readonly string _directory;
+        private readonly string _outputPath;
+        private readonly CancellationTokenSource _cancellation;
+        private FileStream? _lease;
+
+        internal CancellingStagingLeaseProgress(
+            string directory,
+            string outputPath,
+            CancellationTokenSource cancellation) {
+            _directory = directory;
+            _outputPath = outputPath;
+            _cancellation = cancellation;
+        }
+
+        internal string? StagingPath { get; private set; }
+
+        public void Report(OfficeWorkflowProgress value) {
+            if (_lease != null || !string.Equals(value.Stage, "validate-output", StringComparison.Ordinal)) return;
+            StagingPath = Directory.GetFiles(
+                    _directory,
+                    "." + Path.GetFileNameWithoutExtension(_outputPath) + ".*" + Path.GetExtension(_outputPath))
+                .Single();
+            _lease = new FileStream(StagingPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            _cancellation.Cancel();
+        }
+
+        public void Dispose() {
+            _lease?.Dispose();
+            _lease = null;
         }
     }
 

--- a/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.cs
+++ b/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.cs
@@ -377,6 +377,50 @@ public sealed partial class OfficeProvenanceWorkflowTests {
     }
 
     [Fact]
+    public async Task AssessmentPropagatesCancellationIntoSignalDetectors() {
+        using var scope = new TempScope();
+        string input = scope.Write("page.html", "<!doctype html><html><body>body</body></html>");
+        using var cancellation = new CancellationTokenSource();
+        var detector = new BlockingCancellationDetector();
+        Task<OfficeProvenanceWorkflowResult> operation = new OfficeWorkflowRunner(
+            provenanceVerifier: null,
+            provenanceSignalDetectors: [detector]).RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Assess,
+                InputPath = input
+            },
+            cancellationToken: cancellation.Token);
+        await detector.Started.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+        cancellation.Cancel();
+        OfficeProvenanceWorkflowResult result = await operation.WaitAsync(TimeSpan.FromSeconds(2));
+
+        Assert.Equal(OfficeWorkflowStatus.Cancelled, result.Status);
+        Assert.True(detector.CancellationObserved);
+    }
+
+    [Fact]
+    public async Task AssessmentPropagatesCancellationIntoVerifiers() {
+        using var scope = new TempScope();
+        string input = scope.Write("page.html", HtmlWithExternalManifest("body"));
+        using var cancellation = new CancellationTokenSource();
+        var verifier = new BlockingCancellationVerifier();
+        Task<OfficeProvenanceWorkflowResult> operation = new OfficeWorkflowRunner(verifier).RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Assess,
+                InputPath = input
+            },
+            cancellationToken: cancellation.Token);
+        await verifier.Started.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+        cancellation.Cancel();
+        OfficeProvenanceWorkflowResult result = await operation.WaitAsync(TimeSpan.FromSeconds(2));
+
+        Assert.Equal(OfficeWorkflowStatus.Cancelled, result.Status);
+        Assert.True(verifier.CancellationObserved);
+    }
+
+    [Fact]
     public async Task AssessmentReportsTheLogicalSourcePathWhileReadingTheSnapshot() {
         using var scope = new TempScope();
         string input = scope.Write("page.html", "<!doctype html><html><body>review\u200Bthis</body></html>");
@@ -713,7 +757,7 @@ public sealed partial class OfficeProvenanceWorkflowTests {
         public OfficeProvenanceSignalKind SignalKind => OfficeProvenanceSignalKind.DeterministicArtifact;
         internal string? ObservedPath { get; private set; }
 
-        public OfficeProvenanceSignalResult Detect(string filePath) {
+        public OfficeProvenanceSignalResult Detect(string filePath, CancellationToken cancellationToken = default) {
             ObservedPath = Path.GetFullPath(filePath);
             File.WriteAllText(_originalPath, "<!doctype html><html><body>replacement</body></html>");
             bool detected = File.ReadAllText(filePath).Contains("c2pa-manifest", StringComparison.OrdinalIgnoreCase);
@@ -724,6 +768,38 @@ public sealed partial class OfficeProvenanceWorkflowTests {
         }
     }
 
+    private sealed class BlockingCancellationDetector : IOfficeProvenanceSignalDetector {
+        public string Name => "blocking-cancellation";
+        public OfficeProvenanceSignalKind SignalKind => OfficeProvenanceSignalKind.DeterministicArtifact;
+        internal TaskCompletionSource<bool> Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        internal bool CancellationObserved { get; private set; }
+
+        public OfficeProvenanceSignalResult Detect(string filePath, CancellationToken cancellationToken = default) {
+            Started.TrySetResult(true);
+            cancellationToken.WaitHandle.WaitOne();
+            CancellationObserved = cancellationToken.IsCancellationRequested;
+            cancellationToken.ThrowIfCancellationRequested();
+            throw new InvalidOperationException("The cancellation-aware detector resumed without cancellation.");
+        }
+    }
+
+    private sealed class BlockingCancellationVerifier : IOfficeProvenanceVerifier {
+        public string Name => "blocking-cancellation";
+        internal TaskCompletionSource<bool> Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        internal bool CancellationObserved { get; private set; }
+
+        public OfficeProvenanceVerificationResult Verify(
+            string filePath,
+            OfficeProvenanceVerificationOptions? options = null,
+            CancellationToken cancellationToken = default) {
+            Started.TrySetResult(true);
+            cancellationToken.WaitHandle.WaitOne();
+            CancellationObserved = cancellationToken.IsCancellationRequested;
+            cancellationToken.ThrowIfCancellationRequested();
+            throw new InvalidOperationException("The cancellation-aware verifier resumed without cancellation.");
+        }
+    }
+
     private sealed class RelativeManifestVerifier : IOfficeProvenanceVerifier {
         public string Name => "relative-manifest";
         internal bool SawRelativeManifest { get; private set; }
@@ -731,7 +807,8 @@ public sealed partial class OfficeProvenanceWorkflowTests {
 
         public OfficeProvenanceVerificationResult Verify(
             string filePath,
-            OfficeProvenanceVerificationOptions? options = null) {
+            OfficeProvenanceVerificationOptions? options = null,
+            CancellationToken cancellationToken = default) {
             ObservedDirectory = Path.GetDirectoryName(Path.GetFullPath(filePath));
             string manifestPath = Path.Combine(ObservedDirectory!, "claim.c2pa");
             SawRelativeManifest = File.Exists(manifestPath) && File.ReadAllText(manifestPath) == "immutable claim";
@@ -750,7 +827,8 @@ public sealed partial class OfficeProvenanceWorkflowTests {
 
         public OfficeProvenanceVerificationResult Verify(
             string filePath,
-            OfficeProvenanceVerificationOptions? options = null) {
+            OfficeProvenanceVerificationOptions? options = null,
+            CancellationToken cancellationToken = default) {
             ObservedDirectory = Path.GetDirectoryName(Path.GetFullPath(filePath));
             string manifestPath = Path.Combine(ObservedDirectory!, "claim.c2pa");
             string replacementPath = manifestPath + ".replacement";
@@ -776,7 +854,8 @@ public sealed partial class OfficeProvenanceWorkflowTests {
 
         public OfficeProvenanceVerificationResult Verify(
             string filePath,
-            OfficeProvenanceVerificationOptions? options = null) {
+            OfficeProvenanceVerificationOptions? options = null,
+            CancellationToken cancellationToken = default) {
             ObservedDirectory = Path.GetDirectoryName(Path.GetFullPath(filePath));
             string manifestPath = Path.Combine(ObservedDirectory!, "sub", "claim.c2pa");
             SawRelativeManifest = File.Exists(manifestPath) &&
@@ -820,7 +899,7 @@ public sealed partial class OfficeProvenanceWorkflowTests {
         public OfficeProvenanceSignalKind SignalKind => OfficeProvenanceSignalKind.DeterministicArtifact;
         internal bool Replaced { get; private set; }
 
-        public OfficeProvenanceSignalResult Detect(string filePath) {
+        public OfficeProvenanceSignalResult Detect(string filePath, CancellationToken cancellationToken = default) {
             string replacementPath = filePath + ".replacement";
             File.WriteAllText(replacementPath, "replacement");
             File.Move(replacementPath, filePath, overwrite: true);

--- a/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.cs
+++ b/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.cs
@@ -340,6 +340,23 @@ public sealed partial class OfficeProvenanceWorkflowTests {
     }
 
     [Fact]
+    public async Task InspectReentersTheDetectedHtmlOwnerForAnUnknownExtension() {
+        using var scope = new TempScope();
+        string input = scope.Write("asset.bin", HtmlWithExternalManifest("body"));
+
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner().RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Inspect,
+                InputPath = input
+            });
+
+        Assert.True(result.Succeeded, result.Summary);
+        Assert.Equal("OfficeIMO.Html", result.OwnerPackage);
+        Assert.Equal(OfficeProvenanceAssetFormat.Html, result.Inspection!.Format);
+        Assert.Equal(OfficeProvenanceCarrierKind.C2paExternalManifest, Assert.Single(result.Inspection.Evidence).Carrier);
+    }
+
+    [Fact]
     public async Task AssessmentWithoutProvidersDoesNotCopyAnOversizedExternalManifest() {
         using var scope = new TempScope();
         string input = scope.Write("page.html", HtmlWithExternalManifest("body"));
@@ -400,6 +417,27 @@ public sealed partial class OfficeProvenanceWorkflowTests {
         } else {
             Assert.True(result.Succeeded, result.Summary);
         }
+        Assert.False(Directory.Exists(verifier.ObservedDirectory));
+    }
+
+    [Fact]
+    public async Task AssessmentResolvesRelativeManifestAgainstTheHtmlBaseElement() {
+        using var scope = new TempScope();
+        string input = scope.Write(
+            "page.html",
+            "<!doctype html><html><head><base href=\"sub/\"><link rel=\"c2pa-manifest\" href=\"claim.c2pa\"></head><body>body</body></html>");
+        Directory.CreateDirectory(Path.Combine(scope.Path, "sub"));
+        File.WriteAllText(Path.Combine(scope.Path, "sub", "claim.c2pa"), "base-relative claim");
+        var verifier = new BaseRelativeManifestVerifier();
+
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner(verifier).RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Assess,
+                InputPath = input
+            });
+
+        Assert.True(result.Succeeded, result.Summary);
+        Assert.True(verifier.SawRelativeManifest);
         Assert.False(Directory.Exists(verifier.ObservedDirectory));
     }
 
@@ -649,6 +687,25 @@ public sealed partial class OfficeProvenanceWorkflowTests {
             }
             return new OfficeProvenanceVerificationResult(
                 OfficeProvenanceVerificationStatus.Valid,
+                Name,
+                Array.Empty<string>());
+        }
+    }
+
+    private sealed class BaseRelativeManifestVerifier : IOfficeProvenanceVerifier {
+        public string Name => "base-relative-manifest";
+        internal bool SawRelativeManifest { get; private set; }
+        internal string? ObservedDirectory { get; private set; }
+
+        public OfficeProvenanceVerificationResult Verify(
+            string filePath,
+            OfficeProvenanceVerificationOptions? options = null) {
+            ObservedDirectory = Path.GetDirectoryName(Path.GetFullPath(filePath));
+            string manifestPath = Path.Combine(ObservedDirectory!, "sub", "claim.c2pa");
+            SawRelativeManifest = File.Exists(manifestPath) &&
+                                  File.ReadAllText(manifestPath) == "base-relative claim";
+            return new OfficeProvenanceVerificationResult(
+                SawRelativeManifest ? OfficeProvenanceVerificationStatus.Valid : OfficeProvenanceVerificationStatus.Invalid,
                 Name,
                 Array.Empty<string>());
         }

--- a/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.cs
+++ b/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.cs
@@ -1,0 +1,312 @@
+using System.IO.Compression;
+using System.Text;
+using OfficeIMO.OpenDocument;
+using OfficeIMO.Provenance;
+
+namespace OfficeIMO.Workflows.Tests;
+
+public sealed partial class OfficeProvenanceWorkflowTests {
+    [Fact]
+    public async Task RemovalCanReopenAnExpandedOutputWithinItsSeparateOutputBudget() {
+        using var scope = new TempScope();
+        string input = scope.Write("compact.html", "<link rel=c2pa-manifest href=x>");
+        string probeOutput = Path.Combine(scope.Path, "probe.html");
+        OfficeProvenanceWorkflowResult probe = await new OfficeWorkflowRunner().RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Remove,
+                InputPath = input,
+                OutputPath = probeOutput
+            });
+        Assert.True(probe.Succeeded, probe.Summary);
+        long inputBytes = new FileInfo(input).Length;
+        long outputBytes = new FileInfo(probeOutput).Length;
+        Assert.True(outputBytes > inputBytes, $"Expected HTML normalization to expand {inputBytes} bytes, but received {outputBytes} bytes.");
+
+        string output = Path.Combine(scope.Path, "cleaned.html");
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner().RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Remove,
+                InputPath = input,
+                OutputPath = output,
+                Limits = new OfficeWorkflowLimits {
+                    MaximumInputBytes = inputBytes,
+                    MaximumOutputBytes = outputBytes
+                }
+            });
+
+        Assert.True(result.Succeeded, result.Summary);
+        Assert.Equal(outputBytes, result.OutputBytes);
+    }
+
+    [Fact]
+    public async Task RemovalRejectsAnUnchangedArtifactAboveItsIndependentOutputBudget() {
+        using var scope = new TempScope();
+        string input = scope.Write("unchanged.html", "<!doctype html><html><body>unchanged</body></html>");
+        string output = Path.Combine(scope.Path, "cleaned.html");
+        long inputBytes = new FileInfo(input).Length;
+
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner().RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Remove,
+                InputPath = input,
+                OutputPath = output,
+                Limits = new OfficeWorkflowLimits {
+                    MaximumInputBytes = inputBytes,
+                    MaximumOutputBytes = inputBytes - 1L
+                }
+            });
+
+        Assert.False(result.Succeeded);
+        Assert.Contains("output limit", result.Summary, StringComparison.OrdinalIgnoreCase);
+        Assert.False(File.Exists(output));
+    }
+
+    [Fact]
+    public async Task RemovalUsesThePreflightSnapshotWhenTheSourceIsReplaced() {
+        using var scope = new TempScope();
+        string input = scope.Write("source.html", HtmlWithExternalManifest("original"));
+        string output = Path.Combine(scope.Path, "cleaned.html");
+        long inputBytes = new FileInfo(input).Length;
+        var progress = new ReplacingRemovalProgress(
+            input,
+            "<!doctype html><html><body>replacement" + new string('x', 4096) + "</body></html>");
+
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner().RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Remove,
+                InputPath = input,
+                OutputPath = output,
+                Limits = new OfficeWorkflowLimits {
+                    MaximumInputBytes = inputBytes,
+                    MaximumOutputBytes = 16 * 1024
+                }
+            },
+            progress);
+
+        Assert.True(result.Succeeded, result.Summary);
+        string cleaned = File.ReadAllText(output);
+        Assert.Contains("original", cleaned, StringComparison.Ordinal);
+        Assert.DoesNotContain("replacement", cleaned, StringComparison.Ordinal);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "RemovalSnapshot");
+    }
+
+    [Theory]
+    [InlineData(".odt", OdfMediaTypes.Text)]
+    [InlineData(".ods", OdfMediaTypes.Spreadsheet)]
+    [InlineData(".odp", OdfMediaTypes.Presentation)]
+    [InlineData(".odg", OdfMediaTypes.Graphics)]
+    [InlineData(".ott", OdfMediaTypes.TextTemplate)]
+    [InlineData(".ots", OdfMediaTypes.SpreadsheetTemplate)]
+    [InlineData(".otp", OdfMediaTypes.PresentationTemplate)]
+    [InlineData(".otg", OdfMediaTypes.GraphicsTemplate)]
+    public async Task EveryAdvertisedOpenDocumentExtensionCanBeInspectedAndRemoved(
+        string extension,
+        string mediaType) {
+        using var scope = new TempScope();
+        string input = Path.Combine(scope.Path, "document" + extension);
+        string output = Path.Combine(scope.Path, "cleaned" + extension);
+        CreateOpenDocumentPackage(input, mediaType);
+
+        OfficeProvenanceWorkflowResult inspection = await new OfficeWorkflowRunner().RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Inspect,
+                InputPath = input
+            });
+        OfficeProvenanceWorkflowResult removal = await new OfficeWorkflowRunner().RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Remove,
+                InputPath = input,
+                OutputPath = output
+            });
+
+        Assert.True(inspection.Succeeded, inspection.Summary);
+        Assert.Equal("OfficeIMO.OpenDocument", inspection.OwnerPackage);
+        Assert.True(removal.Succeeded, removal.Summary);
+        Assert.True(File.Exists(output));
+    }
+
+    [Fact]
+    public async Task BatchReservesRenameDestinationBeforeLaterReplacementRuns() {
+        using var scope = new TempScope();
+        string first = scope.Write("first.html", HtmlWithExternalManifest("first"));
+        string second = scope.Write("second.html", HtmlWithExternalManifest("second"));
+        string requested = scope.Write("clean.html", "occupied");
+        string laterOutput = Path.Combine(scope.Path, "clean (1).html");
+
+        IReadOnlyList<OfficeProvenanceWorkflowResult> results = await new OfficeWorkflowRunner().RunProvenanceBatchAsync([
+            new OfficeProvenanceWorkflowRequest {
+                Id = "first",
+                Operation = OfficeProvenanceWorkflowOperation.Remove,
+                InputPath = first,
+                OutputPath = requested,
+                ConflictPolicy = OfficeWorkflowConflictPolicy.Rename
+            },
+            new OfficeProvenanceWorkflowRequest {
+                Id = "second",
+                Operation = OfficeProvenanceWorkflowOperation.Remove,
+                InputPath = second,
+                OutputPath = laterOutput,
+                ConflictPolicy = OfficeWorkflowConflictPolicy.Replace
+            }
+        ]);
+
+        Assert.Collection(
+            results,
+            result => Assert.Equal(Path.Combine(scope.Path, "clean (2).html"), result.OutputPath),
+            result => Assert.Equal(laterOutput, result.OutputPath));
+        Assert.Contains("first", File.ReadAllText(results[0].OutputPath!), StringComparison.Ordinal);
+        Assert.Contains("second", File.ReadAllText(results[1].OutputPath!), StringComparison.Ordinal);
+        Assert.Equal("occupied", File.ReadAllText(requested));
+    }
+
+    [Fact]
+    public async Task BatchKeepsSingleRequestInPlaceReplacementAvailable() {
+        using var scope = new TempScope();
+        string input = scope.Write("page.html", HtmlWithExternalManifest("body"));
+
+        IReadOnlyList<OfficeProvenanceWorkflowResult> results = await new OfficeWorkflowRunner().RunProvenanceBatchAsync([
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Remove,
+                InputPath = input,
+                OutputPath = input,
+                ConflictPolicy = OfficeWorkflowConflictPolicy.Replace
+            }
+        ]);
+
+        OfficeProvenanceWorkflowResult result = Assert.Single(results);
+        Assert.True(result.Succeeded, result.Summary);
+        Assert.Equal(input, result.OutputPath);
+        Assert.DoesNotContain("c2pa-manifest", File.ReadAllText(input), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BatchRenamePlanningAdvancesOneDestinationFamilyLinearly() {
+        using var scope = new TempScope();
+        string input = scope.Write("input.html", HtmlWithExternalManifest("body"));
+        string requested = Path.Combine(scope.Path, "cleaned.html");
+        OfficeProvenanceWorkflowRequest[] requests = Enumerable.Range(0, 10_000)
+            .Select(index => new OfficeProvenanceWorkflowRequest {
+                Id = "request-" + index,
+                Operation = OfficeProvenanceWorkflowOperation.Remove,
+                InputPath = input,
+                OutputPath = requested,
+                ConflictPolicy = OfficeWorkflowConflictPolicy.Rename
+            })
+            .ToArray();
+
+        OfficeProvenanceWorkflowRequest[] prepared = OfficeWorkflowRunner.PrepareBatchRemovalPaths(requests);
+
+        Assert.Equal(requested, prepared[0].OutputPath);
+        Assert.Equal(Path.Combine(scope.Path, "cleaned (9999).html"), prepared[^1].OutputPath);
+        Assert.Equal(10_000, prepared.Select(item => item.OutputPath).Distinct(StringComparer.OrdinalIgnoreCase).Count());
+        Assert.All(prepared, item => Assert.Equal(OfficeWorkflowConflictPolicy.Fail, item.ConflictPolicy));
+    }
+
+    [Fact]
+    public void BatchRenamePlanningHonorsPreCancelledWorkWithoutFilesystemScanning() {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var request = new OfficeProvenanceWorkflowRequest {
+            Operation = OfficeProvenanceWorkflowOperation.Remove,
+            InputPath = "not-inspected-input.html",
+            OutputPath = "not-inspected-output.html",
+            ConflictPolicy = OfficeWorkflowConflictPolicy.Rename
+        };
+
+        OfficeProvenanceWorkflowRequest[] prepared = OfficeWorkflowRunner.PrepareBatchRemovalPaths(
+            [request],
+            cancellation.Token);
+
+        Assert.Same(request, Assert.Single(prepared));
+    }
+
+    [Fact]
+    public void PdfOutputLimitMarkersUseTheWorkflowOutputFailureContract() {
+        InvalidDataException failure = OfficeIMO.Pdf.PdfOutputLimitErrors.Create(
+            "The rewritten PDF exceeds the configured output limit.");
+
+        OfficeWorkflowFailureKind kind = OfficeWorkflowRunner.ClassifyFailure(
+            failure,
+            OfficeWorkflowRunner.WorkflowFailureStage.Operation);
+
+        Assert.Equal(OfficeWorkflowFailureKind.OutputFailed, kind);
+    }
+
+    [Fact]
+    public async Task AssessmentComposesEverySignalFromOneImmutableSnapshot() {
+        using var scope = new TempScope();
+        string input = scope.Write("page.html", HtmlWithExternalManifest("original"));
+        var detector = new ReplacingInputDetector(input);
+
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner(
+            provenanceVerifier: null,
+            provenanceSignalDetectors: [detector]).RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Assess,
+                InputPath = input
+            });
+
+        Assert.True(result.Succeeded, result.Summary);
+        Assert.Single(result.Assessment!.Structural.Evidence);
+        Assert.Equal(OfficeProvenanceSignalStatus.Detected, Assert.Single(result.Assessment.ProviderSignals).Status);
+        Assert.NotNull(detector.ObservedPath);
+        Assert.NotEqual(Path.GetFullPath(input), detector.ObservedPath);
+        Assert.False(File.Exists(detector.ObservedPath));
+        Assert.DoesNotContain("c2pa-manifest", File.ReadAllText(input), StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "AssessmentSnapshot");
+    }
+
+    private static void CreateOpenDocumentPackage(string path, string mediaType) {
+        using var stream = File.Create(path);
+        using var archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: false);
+        WriteEntry(archive, "mimetype", mediaType, CompressionLevel.NoCompression);
+        WriteEntry(
+            archive,
+            "content.xml",
+            "<?xml version=\"1.0\"?><office:document-content xmlns:office=\"urn:oasis:names:tc:opendocument:xmlns:office:1.0\"><office:body/></office:document-content>");
+        WriteEntry(
+            archive,
+            "META-INF/manifest.xml",
+            "<?xml version=\"1.0\"?><manifest:manifest xmlns:manifest=\"urn:oasis:names:tc:opendocument:xmlns:manifest:1.0\">" +
+            "<manifest:file-entry manifest:full-path=\"/\" manifest:media-type=\"" + mediaType + "\"/>" +
+            "<manifest:file-entry manifest:full-path=\"content.xml\" manifest:media-type=\"text/xml\"/>" +
+            "</manifest:manifest>");
+    }
+
+    private sealed class ReplacingInputDetector : IOfficeProvenanceSignalDetector {
+        private readonly string _originalPath;
+
+        internal ReplacingInputDetector(string originalPath) => _originalPath = originalPath;
+
+        public string Name => "replacing-input";
+        public OfficeProvenanceSignalKind SignalKind => OfficeProvenanceSignalKind.DeterministicArtifact;
+        internal string? ObservedPath { get; private set; }
+
+        public OfficeProvenanceSignalResult Detect(string filePath) {
+            ObservedPath = Path.GetFullPath(filePath);
+            File.WriteAllText(_originalPath, "<!doctype html><html><body>replacement</body></html>");
+            bool detected = File.ReadAllText(filePath).Contains("c2pa-manifest", StringComparison.OrdinalIgnoreCase);
+            return new OfficeProvenanceSignalResult(
+                Name,
+                SignalKind,
+                detected ? OfficeProvenanceSignalStatus.Detected : OfficeProvenanceSignalStatus.NotDetected);
+        }
+    }
+
+    private sealed class ReplacingRemovalProgress : IProgress<OfficeWorkflowProgress> {
+        private readonly string _path;
+        private readonly string _replacement;
+        private bool _replaced;
+
+        internal ReplacingRemovalProgress(string path, string replacement) {
+            _path = path;
+            _replacement = replacement;
+        }
+
+        public void Report(OfficeWorkflowProgress value) {
+            if (_replaced || !string.Equals(value.Stage, "remove", StringComparison.Ordinal)) return;
+            File.WriteAllText(_path, _replacement);
+            _replaced = true;
+        }
+    }
+}

--- a/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.cs
+++ b/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.cs
@@ -200,7 +200,72 @@ public sealed partial class OfficeProvenanceWorkflowTests {
         Assert.Equal(requested, prepared[0].OutputPath);
         Assert.Equal(Path.Combine(scope.Path, "cleaned (9999).html"), prepared[^1].OutputPath);
         Assert.Equal(10_000, prepared.Select(item => item.OutputPath).Distinct(StringComparer.OrdinalIgnoreCase).Count());
-        Assert.All(prepared, item => Assert.Equal(OfficeWorkflowConflictPolicy.Fail, item.ConflictPolicy));
+        Assert.All(prepared, item => Assert.Equal(OfficeWorkflowConflictPolicy.Rename, item.ConflictPolicy));
+        Assert.Same(prepared[0].BatchBlockedOutputIdentities, prepared[^1].BatchBlockedOutputIdentities);
+        Assert.Equal(10_001, prepared[0].BatchBlockedOutputIdentities!.Count);
+    }
+
+    [Fact]
+    public async Task BatchRenameRetriesWithoutClaimingAnotherRequestsReservation() {
+        using var scope = new TempScope();
+        string first = scope.Write("first.html", HtmlWithExternalManifest("first"));
+        string second = scope.Write("second.html", HtmlWithExternalManifest("second"));
+        string requested = Path.Combine(scope.Path, "cleaned.html");
+        var progress = new CreatingOutputProgress("first", requested);
+
+        IReadOnlyList<OfficeProvenanceWorkflowResult> results = await new OfficeWorkflowRunner().RunProvenanceBatchAsync([
+            new OfficeProvenanceWorkflowRequest {
+                Id = "first",
+                Operation = OfficeProvenanceWorkflowOperation.Remove,
+                InputPath = first,
+                OutputPath = requested,
+                ConflictPolicy = OfficeWorkflowConflictPolicy.Rename
+            },
+            new OfficeProvenanceWorkflowRequest {
+                Id = "second",
+                Operation = OfficeProvenanceWorkflowOperation.Remove,
+                InputPath = second,
+                OutputPath = requested,
+                ConflictPolicy = OfficeWorkflowConflictPolicy.Rename
+            }
+        ], progress: progress);
+
+        Assert.True(progress.Created);
+        Assert.All(results, result => Assert.True(result.Succeeded, result.Summary));
+        Assert.Equal(Path.Combine(scope.Path, "cleaned (2).html"), results[0].OutputPath);
+        Assert.Equal(Path.Combine(scope.Path, "cleaned (1).html"), results[1].OutputPath);
+        Assert.Equal("occupied during execution", File.ReadAllText(requested));
+    }
+
+    [Fact]
+    public async Task BatchRejectsAncestorOutputPathsBeforePublishingAnything() {
+        using var scope = new TempScope();
+        string first = scope.Write("first.html", HtmlWithExternalManifest("first"));
+        string second = scope.Write("second.html", HtmlWithExternalManifest("second"));
+        string parentOutput = Path.Combine(scope.Path, "result.html");
+        string childOutput = Path.Combine(parentOutput, "child.html");
+
+        ArgumentException exception = await Assert.ThrowsAsync<ArgumentException>(() =>
+            new OfficeWorkflowRunner().RunProvenanceBatchAsync([
+                new OfficeProvenanceWorkflowRequest {
+                    Id = "first",
+                    Operation = OfficeProvenanceWorkflowOperation.Remove,
+                    InputPath = first,
+                    OutputPath = parentOutput,
+                    ConflictPolicy = OfficeWorkflowConflictPolicy.Replace
+                },
+                new OfficeProvenanceWorkflowRequest {
+                    Id = "second",
+                    Operation = OfficeProvenanceWorkflowOperation.Remove,
+                    InputPath = second,
+                    OutputPath = childOutput,
+                    ConflictPolicy = OfficeWorkflowConflictPolicy.Replace
+                }
+            ]));
+
+        Assert.Contains("ancestor/descendant", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.False(File.Exists(parentOutput));
+        Assert.False(Directory.Exists(parentOutput));
     }
 
     [Fact]
@@ -586,6 +651,16 @@ public sealed partial class OfficeProvenanceWorkflowTests {
                 OfficeProvenanceVerificationStatus.Valid,
                 Name,
                 Array.Empty<string>());
+        }
+    }
+
+    private sealed class CreatingOutputProgress(string requestId, string outputPath) : IProgress<OfficeWorkflowProgress> {
+        internal bool Created { get; private set; }
+
+        public void Report(OfficeWorkflowProgress value) {
+            if (Created || value.RequestId != requestId || value.Stage != "validate") return;
+            File.WriteAllText(outputPath, "occupied during execution");
+            Created = true;
         }
     }
 

--- a/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.cs
+++ b/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.cs
@@ -43,6 +43,32 @@ public sealed partial class OfficeProvenanceWorkflowTests {
     }
 
     [Fact]
+    public async Task OutputValidationRejectsAStagingPathReplacedBeforeItsFirstReadback() {
+        using var scope = new TempScope();
+        string input = scope.Write("page.html", HtmlWithExternalManifest("owner output"));
+        string output = Path.Combine(scope.Path, "cleaned.html");
+        var progress = new ReplacingStagedArtifactProgress(
+            scope.Path,
+            output,
+            "validate-output",
+            "<!doctype html><html><body>unrelated clean document</body></html>");
+
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner().RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Remove,
+                InputPath = input,
+                OutputPath = output
+            },
+            progress);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(OfficeWorkflowFailureKind.OutputFailed, result.FailureKind);
+        Assert.Contains("did not match the bytes returned", result.Summary, StringComparison.OrdinalIgnoreCase);
+        Assert.True(progress.Replaced);
+        Assert.False(File.Exists(output));
+    }
+
+    [Fact]
     public async Task RemovalRejectsAnUnchangedArtifactAboveItsIndependentOutputBudget() {
         using var scope = new TempScope();
         string input = scope.Write("unchanged.html", "<!doctype html><html><body>unchanged</body></html>");
@@ -566,6 +592,32 @@ public sealed partial class OfficeProvenanceWorkflowTests {
     }
 
     [Fact]
+    public async Task AssessmentResolvesAnAbsoluteFileBaseFromTheLogicalHtmlPath() {
+        using var scope = new TempScope();
+        string assetsDirectory = Path.Combine(scope.Path, "assets");
+        Directory.CreateDirectory(assetsDirectory);
+        File.WriteAllText(Path.Combine(assetsDirectory, "claim.c2pa"), "absolute-base claim");
+        string baseUri = new Uri(assetsDirectory + Path.DirectorySeparatorChar).AbsoluteUri;
+        string input = scope.Write(
+            "page.html",
+            "<!doctype html><html><head><base href=\"" + baseUri +
+            "\"><link rel=\"c2pa-manifest\" href=\"claim.c2pa\"></head><body>body</body></html>");
+        var verifier = new NestedRelativeManifestVerifier(
+            Path.Combine("assets", "claim.c2pa"),
+            "absolute-base claim");
+
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner(verifier).RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Assess,
+                InputPath = input
+            });
+
+        Assert.True(result.Succeeded, result.Summary);
+        Assert.True(verifier.SawRelativeManifest);
+        Assert.False(Directory.Exists(verifier.ObservedDirectory));
+    }
+
+    [Fact]
     public async Task AssessmentFailsClosedWhenAProviderReplacesThePrimarySnapshot() {
 #if NET8_0_OR_GREATER
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
@@ -876,6 +928,33 @@ public sealed partial class OfficeProvenanceWorkflowTests {
         }
     }
 
+    private sealed class NestedRelativeManifestVerifier : IOfficeProvenanceVerifier {
+        private readonly string _relativePath;
+        private readonly string _expectedContents;
+
+        internal NestedRelativeManifestVerifier(string relativePath, string expectedContents) {
+            _relativePath = relativePath;
+            _expectedContents = expectedContents;
+        }
+
+        public string Name => "nested-relative-manifest";
+        internal bool SawRelativeManifest { get; private set; }
+        internal string? ObservedDirectory { get; private set; }
+
+        public OfficeProvenanceVerificationResult Verify(
+            string filePath,
+            OfficeProvenanceVerificationOptions? options = null) {
+            ObservedDirectory = Path.GetDirectoryName(Path.GetFullPath(filePath));
+            string manifestPath = Path.Combine(ObservedDirectory!, _relativePath);
+            SawRelativeManifest = File.Exists(manifestPath) &&
+                                  File.ReadAllText(manifestPath) == _expectedContents;
+            return new OfficeProvenanceVerificationResult(
+                SawRelativeManifest ? OfficeProvenanceVerificationStatus.Valid : OfficeProvenanceVerificationStatus.Invalid,
+                Name,
+                Array.Empty<string>());
+        }
+    }
+
     private sealed class CreatingOutputProgress(string requestId, string outputPath) : IProgress<OfficeWorkflowProgress> {
         internal bool Created { get; private set; }
 
@@ -924,21 +1003,29 @@ public sealed partial class OfficeProvenanceWorkflowTests {
     private sealed class ReplacingStagedArtifactProgress : IProgress<OfficeWorkflowProgress> {
         private readonly string _directory;
         private readonly string _outputPath;
+        private readonly string _stage;
+        private readonly string _replacement;
 
-        internal ReplacingStagedArtifactProgress(string directory, string outputPath) {
+        internal ReplacingStagedArtifactProgress(
+            string directory,
+            string outputPath,
+            string stage = "publish",
+            string replacement = "<!doctype html><html><body>replacement</body></html>") {
             _directory = directory;
             _outputPath = outputPath;
+            _stage = stage;
+            _replacement = replacement;
         }
 
         internal bool Replaced { get; private set; }
 
         public void Report(OfficeWorkflowProgress value) {
-            if (Replaced || !string.Equals(value.Stage, "publish", StringComparison.Ordinal)) return;
+            if (Replaced || !string.Equals(value.Stage, _stage, StringComparison.Ordinal)) return;
             string stagingPath = Directory.GetFiles(
                     _directory,
                     "." + Path.GetFileNameWithoutExtension(_outputPath) + ".*" + Path.GetExtension(_outputPath))
                 .Single();
-            File.WriteAllText(stagingPath, "<!doctype html><html><body>replacement</body></html>");
+            File.WriteAllText(stagingPath, _replacement);
             Replaced = true;
         }
     }

--- a/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.cs
+++ b/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.cs
@@ -137,6 +137,29 @@ public sealed partial class OfficeProvenanceWorkflowTests {
         Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "RemovalSnapshot");
     }
 
+    [Fact]
+    public async Task InPlaceRemovalPreservesAConcurrentSaveMadeBeforePublication() {
+        using var scope = new TempScope();
+        string input = scope.Write("source.html", HtmlWithExternalManifest("original"));
+        const string replacement = "<!doctype html><html><body>concurrent save</body></html>";
+        var progress = new ReplacingRemovalProgress(input, replacement, "publish");
+
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner().RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Remove,
+                InputPath = input,
+                OutputPath = input,
+                ConflictPolicy = OfficeWorkflowConflictPolicy.Replace
+            },
+            progress);
+
+        Assert.True(progress.Replaced);
+        Assert.Equal(OfficeWorkflowStatus.Failed, result.Status);
+        Assert.Equal(OfficeWorkflowFailureKind.OutputFailed, result.FailureKind);
+        Assert.Contains("input changed", result.Summary, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(replacement, File.ReadAllText(input));
+    }
+
     [Theory]
     [InlineData(".odt", OdfMediaTypes.Text)]
     [InlineData(".ods", OdfMediaTypes.Spreadsheet)]
@@ -1162,15 +1185,19 @@ public sealed partial class OfficeProvenanceWorkflowTests {
     private sealed class ReplacingRemovalProgress : IProgress<OfficeWorkflowProgress> {
         private readonly string _path;
         private readonly string _replacement;
+        private readonly string _stage;
         private bool _replaced;
 
-        internal ReplacingRemovalProgress(string path, string replacement) {
+        internal ReplacingRemovalProgress(string path, string replacement, string stage = "remove") {
             _path = path;
             _replacement = replacement;
+            _stage = stage;
         }
 
+        internal bool Replaced => _replaced;
+
         public void Report(OfficeWorkflowProgress value) {
-            if (_replaced || !string.Equals(value.Stage, "remove", StringComparison.Ordinal)) return;
+            if (_replaced || !string.Equals(value.Stage, _stage, StringComparison.Ordinal)) return;
             File.WriteAllText(_path, _replacement);
             _replaced = true;
         }

--- a/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.cs
+++ b/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.cs
@@ -793,6 +793,35 @@ public sealed partial class OfficeProvenanceWorkflowTests {
     }
 
     [Fact]
+    public async Task SuccessfulReplacementReportsAnOriginalBackupRetainedByAWindowsLease() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
+        using var scope = new TempScope();
+        string input = scope.Write("page.html", HtmlWithExternalManifest("original content"));
+        using var progress = new RetainingReplacementBackupProgress(scope.Path, input);
+
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner().RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Remove,
+                InputPath = input,
+                OutputPath = input,
+                ConflictPolicy = OfficeWorkflowConflictPolicy.Replace
+            },
+            progress);
+
+        Assert.True(result.Succeeded, result.Summary);
+        OfficeWorkflowDiagnostic cleanup = Assert.Single(
+            result.Diagnostics,
+            diagnostic => diagnostic.Code == "ProvenanceBackupCleanupFailed");
+        string retainedPath = cleanup.Details["retainedPath"];
+        Assert.Equal(progress.RetainedPath, retainedPath);
+        Assert.True(File.Exists(retainedPath));
+        Assert.DoesNotContain("c2pa-manifest", File.ReadAllText(input), StringComparison.OrdinalIgnoreCase);
+
+        progress.Dispose();
+        File.Delete(retainedPath);
+    }
+
+    [Fact]
     public async Task PublicationRejectsAStagedArtifactChangedAfterValidation() {
         using var scope = new TempScope();
         string input = scope.Write("page.html", HtmlWithExternalManifest("original"));
@@ -1244,6 +1273,41 @@ public sealed partial class OfficeProvenanceWorkflowTests {
                 .Single();
             _lease = new FileStream(StagingPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             _cancellation.Cancel();
+        }
+
+        public void Dispose() {
+            _lease?.Dispose();
+            _lease = null;
+        }
+    }
+
+    private sealed class RetainingReplacementBackupProgress : IProgress<OfficeWorkflowProgress>, IDisposable {
+        private readonly string _directory;
+        private readonly string _outputPath;
+        private FileStream? _lease;
+
+        internal RetainingReplacementBackupProgress(string directory, string outputPath) {
+            _directory = directory;
+            _outputPath = outputPath;
+        }
+
+        internal string? RetainedPath { get; private set; }
+
+        public void Report(OfficeWorkflowProgress value) {
+            if (_lease != null || !string.Equals(value.Stage, "finalize", StringComparison.Ordinal)) return;
+            foreach (string candidate in Directory.EnumerateFiles(_directory, ".officeimo-*.tmp")) {
+                if (string.Equals(candidate, _outputPath, StringComparison.OrdinalIgnoreCase)) continue;
+                string contents;
+                try {
+                    contents = File.ReadAllText(candidate);
+                } catch (IOException) {
+                    continue;
+                }
+                if (!contents.Contains("c2pa-manifest", StringComparison.OrdinalIgnoreCase)) continue;
+                _lease = new FileStream(candidate, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                RetainedPath = candidate;
+                return;
+            }
         }
 
         public void Dispose() {

--- a/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.cs
+++ b/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowReviewRegressionTests.cs
@@ -629,7 +629,7 @@ public sealed partial class OfficeProvenanceWorkflowTests {
     }
 
     [Fact]
-    public async Task AssessmentResolvesAnAbsoluteFileBaseFromTheLogicalHtmlPath() {
+    public async Task AssessmentRejectsAnAbsoluteFileBaseBeforeCallingProviders() {
         using var scope = new TempScope();
         string assetsDirectory = Path.Combine(scope.Path, "assets");
         Directory.CreateDirectory(assetsDirectory);
@@ -649,9 +649,10 @@ public sealed partial class OfficeProvenanceWorkflowTests {
                 InputPath = input
             });
 
-        Assert.True(result.Succeeded, result.Summary);
-        Assert.True(verifier.SawRelativeManifest);
-        Assert.False(Directory.Exists(verifier.ObservedDirectory));
+        Assert.False(result.Succeeded);
+        Assert.Contains("absolute file-based external provenance manifest", result.Summary, StringComparison.OrdinalIgnoreCase);
+        Assert.False(verifier.SawRelativeManifest);
+        Assert.Null(verifier.ObservedDirectory);
     }
 
     [Fact]

--- a/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowTests.cs
+++ b/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowTests.cs
@@ -267,6 +267,48 @@ public sealed partial class OfficeProvenanceWorkflowTests {
     }
 
     [Fact]
+    public async Task BatchDoesNotEnumerateRequestsWhenAlreadyCancelled() {
+        int moveNextCount = 0;
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        IEnumerable<OfficeProvenanceWorkflowRequest> Requests() {
+            moveNextCount++;
+            yield return new OfficeProvenanceWorkflowRequest { InputPath = "unused" };
+        }
+
+        IReadOnlyList<OfficeProvenanceWorkflowResult> results = await new OfficeWorkflowRunner().RunProvenanceBatchAsync(
+            Requests(),
+            cancellationToken: cancellation.Token);
+
+        Assert.Equal(0, moveNextCount);
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public async Task BatchStopsMaterializingWhenEnumerationCancels() {
+        using var scope = new TempScope();
+        string input = scope.Write("page.html", "<html><body>body</body></html>");
+        int moveNextCount = 0;
+        using var cancellation = new CancellationTokenSource();
+
+        IEnumerable<OfficeProvenanceWorkflowRequest> Requests() {
+            moveNextCount++;
+            cancellation.Cancel();
+            yield return new OfficeProvenanceWorkflowRequest { InputPath = input };
+            moveNextCount++;
+            yield return new OfficeProvenanceWorkflowRequest { InputPath = input };
+        }
+
+        IReadOnlyList<OfficeProvenanceWorkflowResult> results = await new OfficeWorkflowRunner().RunProvenanceBatchAsync(
+            Requests(),
+            cancellationToken: cancellation.Token);
+
+        Assert.Equal(1, moveNextCount);
+        Assert.Equal(OfficeWorkflowStatus.Cancelled, Assert.Single(results).Status);
+    }
+
+    [Fact]
     public async Task BatchRejectsDuplicateRemovalOutputsBeforeExecution() {
         using var scope = new TempScope();
         string first = scope.Write("first.html", HtmlWithExternalManifest("first"));
@@ -371,7 +413,7 @@ public sealed partial class OfficeProvenanceWorkflowTests {
     }
 
     [Fact]
-    public async Task PreCancelledBatchReturnsOneExplicitCancelledResult() {
+    public async Task PreCancelledBatchReturnsWithoutMaterializingRequests() {
         using var scope = new TempScope();
         string first = scope.Write("first.html", "<html><body>first</body></html>");
         string second = scope.Write("second.html", "<html><body>second</body></html>");
@@ -385,9 +427,7 @@ public sealed partial class OfficeProvenanceWorkflowTests {
             ],
             cancellationToken: cancellation.Token);
 
-        OfficeProvenanceWorkflowResult result = Assert.Single(results);
-        Assert.Equal("first", result.RequestId);
-        Assert.Equal(OfficeWorkflowStatus.Cancelled, result.Status);
+        Assert.Empty(results);
     }
 
     [Fact]

--- a/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowTests.cs
+++ b/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowTests.cs
@@ -10,7 +10,7 @@ using System.Text;
 
 namespace OfficeIMO.Workflows.Tests;
 
-public sealed class OfficeProvenanceWorkflowTests {
+public sealed partial class OfficeProvenanceWorkflowTests {
     [Fact]
     public void CatalogRoutesFormatsToCanonicalOwners() {
         Assert.Equal("OfficeIMO.Word", OfficeProvenanceWorkflowCatalog.FindByPath("report.docx")?.OwnerPackage);

--- a/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowTests.cs
+++ b/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowTests.cs
@@ -250,6 +250,51 @@ public sealed class OfficeProvenanceWorkflowTests {
     }
 
     [Fact]
+    public async Task BatchRejectsRemovalOutputThatOverlapsAnotherInputBeforeExecution() {
+        using var scope = new TempScope();
+        string first = scope.Write("first.html", HtmlWithExternalManifest("first"));
+        string second = scope.Write("second.html", HtmlWithExternalManifest("second"));
+        string originalSecond = File.ReadAllText(second);
+
+        ArgumentException exception = await Assert.ThrowsAsync<ArgumentException>(() =>
+            new OfficeWorkflowRunner().RunProvenanceBatchAsync([
+                new OfficeProvenanceWorkflowRequest {
+                    Id = "first",
+                    Operation = OfficeProvenanceWorkflowOperation.Remove,
+                    InputPath = first,
+                    OutputPath = second,
+                    ConflictPolicy = OfficeWorkflowConflictPolicy.Replace
+                },
+                new OfficeProvenanceWorkflowRequest {
+                    Id = "second",
+                    Operation = OfficeProvenanceWorkflowOperation.Inspect,
+                    InputPath = second
+                }
+            ]));
+
+        Assert.Contains("overlaps another batch request's input", exception.Message, StringComparison.Ordinal);
+        Assert.Equal(originalSecond, File.ReadAllText(second));
+    }
+
+    [Fact]
+    public async Task RemovalPreflightUsesRemovalLimitsInsteadOfInspectionLimits() {
+        using var scope = new TempScope();
+        string input = scope.Write("page.html", HtmlWithExternalManifest("body"));
+        string output = Path.Combine(scope.Path, "cleaned.html");
+        var request = new OfficeProvenanceWorkflowRequest {
+            Operation = OfficeProvenanceWorkflowOperation.Remove,
+            InputPath = input,
+            OutputPath = output
+        };
+        request.Inspection.MaxAssetBytes = 1;
+
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner().RunProvenanceAsync(request);
+
+        Assert.True(result.Succeeded, result.Summary);
+        Assert.True(File.Exists(output));
+    }
+
+    [Fact]
     public async Task PreCancelledBatchReturnsOneExplicitCancelledResult() {
         using var scope = new TempScope();
         string first = scope.Write("first.html", "<html><body>first</body></html>");

--- a/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowTests.cs
+++ b/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowTests.cs
@@ -1,0 +1,532 @@
+using OfficeIMO.Provenance;
+using OfficeIMO.Epub;
+using OfficeIMO.Excel;
+using OfficeIMO.OpenDocument;
+using OfficeIMO.Pdf;
+using OfficeIMO.PowerPoint;
+using OfficeIMO.Visio;
+using OfficeIMO.Word;
+using System.Text;
+
+namespace OfficeIMO.Workflows.Tests;
+
+public sealed class OfficeProvenanceWorkflowTests {
+    [Fact]
+    public void CatalogRoutesFormatsToCanonicalOwners() {
+        Assert.Equal("OfficeIMO.Word", OfficeProvenanceWorkflowCatalog.FindByPath("report.docx")?.OwnerPackage);
+        Assert.Equal("OfficeIMO.Html", OfficeProvenanceWorkflowCatalog.FindByPath("page.HTML")?.OwnerPackage);
+        Assert.Equal("OfficeIMO.Core", OfficeProvenanceWorkflowCatalog.FindByPath("image.png")?.OwnerPackage);
+        Assert.Equal("OfficeIMO.Excel", OfficeProvenanceWorkflowCatalog.FindByPath("workbook.xlsb")?.OwnerPackage);
+        Assert.Null(OfficeProvenanceWorkflowCatalog.FindByPath("archive.zip"));
+        Assert.True(OfficeProvenanceWorkflowCatalog.All.Single(item => item.Id == "core-detected").CanRemove);
+    }
+
+    [Fact]
+    public async Task InspectUsesHtmlOwnerAndReturnsStructuralEvidence() {
+        using var scope = new TempScope();
+        string input = scope.Write("page.html", HtmlWithExternalManifest("body"));
+
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner().RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Inspect,
+                InputPath = input
+            });
+
+        Assert.True(result.Succeeded, result.Summary);
+        Assert.Equal("OfficeIMO.Html", result.OwnerPackage);
+        Assert.Equal(OfficeProvenanceAssetFormat.Html, result.Inspection?.Format);
+        Assert.Single(result.Inspection!.Evidence);
+        Assert.Null(result.OutputPath);
+    }
+
+    [Fact]
+    public async Task EmptyInputPathReturnsAStableValidationFailure() {
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner().RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Inspect,
+                InputPath = string.Empty
+            });
+
+        Assert.Equal(OfficeWorkflowStatus.Failed, result.Status);
+        Assert.Equal(OfficeWorkflowFailureKind.ValidationFailed, result.FailureKind);
+        Assert.Equal("OfficeIMO.Core", result.OwnerPackage);
+    }
+
+    [Fact]
+    public async Task InspectAcceptsRepresentativeArtifactsFromEveryRegisteredOwner() {
+        using var scope = new TempScope();
+        string word = Path.Combine(scope.Path, "report.docx");
+        using (WordDocument document = WordDocument.Create(word)) {
+            document.AddParagraph("workflow provenance");
+            document.Save();
+        }
+        string excel = Path.Combine(scope.Path, "workbook.xlsx");
+        using (ExcelDocument document = ExcelDocument.Create(excel)) {
+            document.AddWorksheet("Data").Cell(1, 1, "workflow provenance");
+            document.Save();
+        }
+        string powerPoint = Path.Combine(scope.Path, "deck.pptx");
+        using (PowerPointPresentation presentation = PowerPointPresentation.Create(powerPoint)) {
+            presentation.AddSlide().AddTextBoxPoints("workflow provenance", 20, 20, 300, 60);
+            presentation.Save();
+        }
+        string visio = Path.Combine(scope.Path, "drawing.vsdx");
+        VisioDocument visioDocument = VisioDocument.Create(visio);
+        visioDocument.AddPage("Page-1", 8.5, 11);
+        visioDocument.Save();
+        string odt = Path.Combine(scope.Path, "document.odt");
+        OdtDocument openDocument = OdtDocument.Create();
+        openDocument.AddParagraph("workflow provenance");
+        openDocument.Save(odt);
+        string epub = Path.Combine(scope.Path, "publication.epub");
+        CreateEpub(epub);
+        string pdf = Path.Combine(scope.Path, "document.pdf");
+        PdfDocument.Create(document => document.Page(page => page.Content(content =>
+            content.Item(item => item.Paragraph(paragraph => paragraph.Text("workflow provenance")))))).Save(pdf);
+        string html = scope.Write("document.html", "<!doctype html><html><body>workflow provenance</body></html>");
+        string markdown = scope.Write("document.md", "# Workflow provenance");
+        string png = Path.Combine(scope.Path, "image.png");
+        File.WriteAllBytes(png, Convert.FromBase64String(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="));
+
+        var expected = new Dictionary<string, string>(StringComparer.Ordinal) {
+            [word] = "OfficeIMO.Word",
+            [excel] = "OfficeIMO.Excel",
+            [powerPoint] = "OfficeIMO.PowerPoint",
+            [visio] = "OfficeIMO.Visio",
+            [odt] = "OfficeIMO.OpenDocument",
+            [epub] = "OfficeIMO.Epub",
+            [pdf] = "OfficeIMO.Pdf",
+            [html] = "OfficeIMO.Html",
+            [markdown] = "OfficeIMO.Markdown",
+            [png] = "OfficeIMO.Core"
+        };
+        var runner = new OfficeWorkflowRunner();
+
+        foreach ((string path, string owner) in expected) {
+            OfficeProvenanceWorkflowResult result = await runner.RunProvenanceAsync(
+                new OfficeProvenanceWorkflowRequest {
+                    Operation = OfficeProvenanceWorkflowOperation.Inspect,
+                    InputPath = path
+                });
+            Assert.True(result.Succeeded, path + ": " + result.Summary);
+            Assert.Equal(owner, result.OwnerPackage);
+        }
+    }
+
+    [Fact]
+    public async Task AssessCombinesOwnerEvidenceTextIntegrityAndInjectedProviders() {
+        using var scope = new TempScope();
+        string input = scope.Write("page.html", HtmlWithExternalManifest("review \u202Ethis"));
+        var runner = new OfficeWorkflowRunner(new TestVerifier(), [new TestDetector()]);
+
+        OfficeProvenanceWorkflowResult result = await runner.RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Assess,
+                InputPath = input
+            });
+
+        Assert.True(result.Succeeded, result.Summary);
+        OfficeProvenanceAssessmentReport assessment = Assert.IsType<OfficeProvenanceAssessmentReport>(result.Assessment);
+        Assert.Single(assessment.Structural.Evidence);
+        Assert.Equal(OfficeProvenanceVerificationStatus.Valid, assessment.Verification?.Status);
+        Assert.Contains(assessment.TextIntegrity!.Findings, finding => finding.Kind == OfficeTextIntegrityFindingKind.BidirectionalControl);
+        Assert.Equal(OfficeProvenanceSignalStatus.Detected, Assert.Single(assessment.ProviderSignals).Status);
+    }
+
+    [Fact]
+    public async Task RemoveStagesReopensAndPublishesThroughHtmlOwner() {
+        using var scope = new TempScope();
+        string input = scope.Write("page.html", HtmlWithExternalManifest("keep me"));
+        string output = Path.Combine(scope.Path, "cleaned.html");
+
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner().RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Remove,
+                InputPath = input,
+                OutputPath = output,
+                ConflictPolicy = OfficeWorkflowConflictPolicy.Fail
+            });
+
+        Assert.True(result.Succeeded, result.Summary);
+        Assert.Equal(Path.GetFullPath(output), result.OutputPath);
+        Assert.True(result.WasChanged);
+        Assert.Single(result.Before!.Evidence);
+        Assert.Empty(result.After!.Evidence);
+        Assert.Contains("keep me", File.ReadAllText(output), StringComparison.Ordinal);
+        Assert.DoesNotContain("c2pa-manifest", File.ReadAllText(output), StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "ProvenanceOutputReopened");
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "AtomicPublication");
+        Assert.Empty(Directory.EnumerateFiles(scope.Path, ".cleaned.*.html"));
+    }
+
+    [Fact]
+    public async Task FailedConflictPreservesExistingOutputAndCleansStaging() {
+        using var scope = new TempScope();
+        string input = scope.Write("page.html", HtmlWithExternalManifest("input"));
+        string output = scope.Write("cleaned.html", "existing");
+
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner().RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Remove,
+                InputPath = input,
+                OutputPath = output,
+                ConflictPolicy = OfficeWorkflowConflictPolicy.Fail
+            });
+
+        Assert.Equal(OfficeWorkflowStatus.Failed, result.Status);
+        Assert.Equal(OfficeWorkflowFailureKind.OutputFailed, result.FailureKind);
+        Assert.Equal("existing", File.ReadAllText(output));
+        Assert.Empty(Directory.EnumerateFiles(scope.Path, ".cleaned.*.html"));
+    }
+
+    [Fact]
+    public async Task GenericZipCanBeInspectedButNotMutatedWithoutAFormatOwner() {
+        using var scope = new TempScope();
+        string input = Path.Combine(scope.Path, "archive.zip");
+        using (System.IO.Compression.ZipArchive archive = System.IO.Compression.ZipFile.Open(input, System.IO.Compression.ZipArchiveMode.Create)) {
+            using StreamWriter writer = new(archive.CreateEntry("file.txt").Open());
+            writer.Write("content");
+        }
+
+        OfficeProvenanceWorkflowResult inspection = await new OfficeWorkflowRunner().RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Inspect,
+                InputPath = input
+            });
+        OfficeProvenanceWorkflowResult removal = await new OfficeWorkflowRunner().RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Remove,
+                InputPath = input
+            });
+
+        Assert.True(inspection.Succeeded, inspection.Summary);
+        Assert.Equal(OfficeProvenanceAssetFormat.ZipPackage, inspection.Inspection?.Format);
+        Assert.Equal(OfficeWorkflowFailureKind.UnsupportedInput, removal.FailureKind);
+        Assert.False(File.Exists(Path.Combine(scope.Path, "archive.provenance-cleaned.zip")));
+    }
+
+    [Fact]
+    public async Task BatchMaterializationIsBoundedBeforeExecution() {
+        using var scope = new TempScope();
+        string input = scope.Write("page.html", "<html><body>ok</body></html>");
+        OfficeProvenanceWorkflowRequest[] requests = Enumerable.Range(0, 3)
+            .Select(index => new OfficeProvenanceWorkflowRequest {
+                Id = "request-" + index,
+                Operation = OfficeProvenanceWorkflowOperation.Inspect,
+                InputPath = input
+            })
+            .ToArray();
+
+        ArgumentException exception = await Assert.ThrowsAsync<ArgumentException>(() =>
+            new OfficeWorkflowRunner().RunProvenanceBatchAsync(
+                requests,
+                new OfficeProvenanceWorkflowBatchOptions { MaximumRequests = 2 }));
+
+        Assert.Contains("limit of 2", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task BatchRejectsDuplicateRemovalOutputsBeforeExecution() {
+        using var scope = new TempScope();
+        string first = scope.Write("first.html", HtmlWithExternalManifest("first"));
+        string second = scope.Write("second.html", HtmlWithExternalManifest("second"));
+        string output = Path.Combine(scope.Path, "cleaned.html");
+        OfficeProvenanceWorkflowRequest[] requests = new[] { first, second }
+            .Select((input, index) => new OfficeProvenanceWorkflowRequest {
+                Id = "request-" + index,
+                Operation = OfficeProvenanceWorkflowOperation.Remove,
+                InputPath = input,
+                OutputPath = output,
+                ConflictPolicy = OfficeWorkflowConflictPolicy.Replace
+            })
+            .ToArray();
+
+        ArgumentException exception = await Assert.ThrowsAsync<ArgumentException>(() =>
+            new OfficeWorkflowRunner().RunProvenanceBatchAsync(requests));
+
+        Assert.Contains("same output path", exception.Message, StringComparison.Ordinal);
+        Assert.False(File.Exists(output));
+    }
+
+    [Fact]
+    public async Task PreCancelledBatchReturnsOneExplicitCancelledResult() {
+        using var scope = new TempScope();
+        string first = scope.Write("first.html", "<html><body>first</body></html>");
+        string second = scope.Write("second.html", "<html><body>second</body></html>");
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        IReadOnlyList<OfficeProvenanceWorkflowResult> results = await new OfficeWorkflowRunner().RunProvenanceBatchAsync(
+            [
+                new OfficeProvenanceWorkflowRequest { Id = "first", Operation = OfficeProvenanceWorkflowOperation.Inspect, InputPath = first },
+                new OfficeProvenanceWorkflowRequest { Id = "second", Operation = OfficeProvenanceWorkflowOperation.Inspect, InputPath = second }
+            ],
+            cancellationToken: cancellation.Token);
+
+        OfficeProvenanceWorkflowResult result = Assert.Single(results);
+        Assert.Equal("first", result.RequestId);
+        Assert.Equal(OfficeWorkflowStatus.Cancelled, result.Status);
+    }
+
+    [Fact]
+    public async Task CancellationBetweenSuccessfulItemsAddsAnExplicitCancelledResult() {
+        using var scope = new TempScope();
+        string first = scope.Write("first.html", "<html><body>first</body></html>");
+        string second = scope.Write("second.html", "<html><body>second</body></html>");
+        using var cancellation = new CancellationTokenSource();
+        var progress = new CancellingProgress("first", cancellation);
+
+        IReadOnlyList<OfficeProvenanceWorkflowResult> results = await new OfficeWorkflowRunner().RunProvenanceBatchAsync(
+            [
+                new OfficeProvenanceWorkflowRequest { Id = "first", Operation = OfficeProvenanceWorkflowOperation.Inspect, InputPath = first },
+                new OfficeProvenanceWorkflowRequest { Id = "second", Operation = OfficeProvenanceWorkflowOperation.Inspect, InputPath = second }
+            ],
+            progress: progress,
+            cancellationToken: cancellation.Token);
+
+        Assert.Collection(
+            results,
+            result => Assert.Equal(OfficeWorkflowStatus.Completed, result.Status),
+            result => Assert.Equal(OfficeWorkflowStatus.Cancelled, result.Status));
+    }
+
+    [Fact]
+    public async Task BatchKeepsPerRequestFailuresWhenContinueOnFailureIsEnabled() {
+        using var scope = new TempScope();
+        string input = scope.Write("first.html", HtmlWithExternalManifest("first"));
+        string missing = Path.Combine(scope.Path, "missing.html");
+        string firstOutput = Path.Combine(scope.Path, "first-cleaned.html");
+        string missingOutput = Path.Combine(scope.Path, "missing-cleaned.html");
+
+        IReadOnlyList<OfficeProvenanceWorkflowResult> results = await new OfficeWorkflowRunner().RunProvenanceBatchAsync([
+            new OfficeProvenanceWorkflowRequest {
+                Id = "valid",
+                Operation = OfficeProvenanceWorkflowOperation.Remove,
+                InputPath = input,
+                OutputPath = firstOutput
+            },
+            new OfficeProvenanceWorkflowRequest {
+                Id = "missing",
+                Operation = OfficeProvenanceWorkflowOperation.Remove,
+                InputPath = missing,
+                OutputPath = missingOutput
+            }
+        ]);
+
+        Assert.Collection(
+            results,
+            result => Assert.Equal(OfficeWorkflowStatus.Completed, result.Status),
+            result => Assert.Equal(OfficeWorkflowFailureKind.InputNotFound, result.FailureKind));
+        Assert.True(File.Exists(firstOutput));
+        Assert.False(File.Exists(missingOutput));
+    }
+
+    [Fact]
+    public async Task AssessmentCancellationRaisedBySynchronousDetectorIsNotReportedAsCompleted() {
+        using var scope = new TempScope();
+        string input = scope.Write("page.html", "<html><body>body</body></html>");
+        using var cancellation = new CancellationTokenSource();
+        var runner = new OfficeWorkflowRunner(null, [new CancellingDetector(cancellation)]);
+
+        OfficeProvenanceWorkflowResult result = await runner.RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Assess,
+                InputPath = input
+            },
+            cancellationToken: cancellation.Token);
+
+        Assert.Equal(OfficeWorkflowStatus.Cancelled, result.Status);
+    }
+
+    [Fact]
+    public async Task SmallWorkflowLimitsRemainValidForTinyInputsAndOutputs() {
+        using var scope = new TempScope();
+        string input = scope.Write("page.html", HtmlWithExternalManifest("tiny"));
+        string output = Path.Combine(scope.Path, "cleaned.html");
+        var limits = new OfficeWorkflowLimits {
+            MaximumInputBytes = 1024,
+            MaximumOutputBytes = 1024
+        };
+
+        OfficeProvenanceWorkflowResult inspection = await new OfficeWorkflowRunner().RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Inspect,
+                InputPath = input,
+                Limits = limits
+            });
+        OfficeProvenanceWorkflowResult removal = await new OfficeWorkflowRunner().RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Remove,
+                InputPath = input,
+                OutputPath = output,
+                Limits = limits
+            });
+
+        Assert.True(inspection.Succeeded, inspection.Summary);
+        Assert.True(removal.Succeeded, removal.Summary);
+        Assert.True(File.Exists(output));
+    }
+
+    [Fact]
+    public async Task StagedOutputLimitFailureIsClassifiedAsOutputFailure() {
+        using var scope = new TempScope();
+        string input = scope.Write("page.html", HtmlWithExternalManifest("body"));
+        string output = Path.Combine(scope.Path, "cleaned.html");
+
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner().RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Remove,
+                InputPath = input,
+                OutputPath = output,
+                Limits = new OfficeWorkflowLimits { MaximumOutputBytes = 1 }
+            });
+
+        Assert.Equal(OfficeWorkflowStatus.Failed, result.Status);
+        Assert.Equal(OfficeWorkflowFailureKind.OutputFailed, result.FailureKind);
+        Assert.False(File.Exists(output));
+        Assert.Empty(Directory.EnumerateFiles(scope.Path, ".cleaned.*.html"));
+    }
+
+    [Fact]
+    public async Task SignatureDetectedImageWithUnknownExtensionCanBeRemoved() {
+        using var scope = new TempScope();
+        string input = Path.Combine(scope.Path, "image.bin");
+        string output = Path.Combine(scope.Path, "cleaned.bin");
+        File.WriteAllBytes(input, Convert.FromBase64String(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="));
+
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner().RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Remove,
+                InputPath = input,
+                OutputPath = output
+            });
+
+        Assert.True(result.Succeeded, result.Summary);
+        Assert.Equal(OfficeProvenanceAssetFormat.Png, result.Before?.Format);
+        Assert.Equal(OfficeProvenanceAssetFormat.Png, result.After?.Format);
+        Assert.True(File.Exists(output));
+    }
+
+    [Fact]
+    public async Task PreCancelledRemovalPublishesNothing() {
+        using var scope = new TempScope();
+        string input = scope.Write("page.html", HtmlWithExternalManifest("body"));
+        string output = Path.Combine(scope.Path, "cleaned.html");
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner().RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Remove,
+                InputPath = input,
+                OutputPath = output
+            }, cancellationToken: cancellation.Token);
+
+        Assert.Equal(OfficeWorkflowStatus.Cancelled, result.Status);
+        Assert.False(File.Exists(output));
+    }
+
+    private static string HtmlWithExternalManifest(string body) =>
+        "<!doctype html><html><head><link rel=\"c2pa-manifest\" href=\"claim.c2pa\"></head><body>" + body + "</body></html>";
+
+    private static void CreateEpub(string path) {
+        using var stream = File.Create(path);
+        using var archive = new System.IO.Compression.ZipArchive(
+            stream,
+            System.IO.Compression.ZipArchiveMode.Create,
+            leaveOpen: false);
+        WriteEntry(archive, "mimetype", "application/epub+zip", System.IO.Compression.CompressionLevel.NoCompression);
+        WriteEntry(
+            archive,
+            "META-INF/container.xml",
+            "<?xml version=\"1.0\"?><container xmlns=\"urn:oasis:names:tc:opendocument:xmlns:container\"><rootfiles><rootfile full-path=\"content.opf\" media-type=\"application/oebps-package+xml\"/></rootfiles></container>");
+        WriteEntry(
+            archive,
+            "content.opf",
+            "<?xml version=\"1.0\"?><package xmlns=\"http://www.idpf.org/2007/opf\" version=\"3.0\" unique-identifier=\"id\"><metadata xmlns:dc=\"http://purl.org/dc/elements/1.1/\"><dc:identifier id=\"id\">urn:uuid:" + Guid.NewGuid() + "</dc:identifier></metadata><manifest/><spine/></package>");
+    }
+
+    private static void WriteEntry(
+        System.IO.Compression.ZipArchive archive,
+        string name,
+        string value,
+        System.IO.Compression.CompressionLevel compression = System.IO.Compression.CompressionLevel.Optimal) {
+        System.IO.Compression.ZipArchiveEntry entry = archive.CreateEntry(name, compression);
+        using var writer = new StreamWriter(
+            entry.Open(),
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        writer.Write(value);
+    }
+
+    private sealed class TestVerifier : IOfficeProvenanceVerifier {
+        public string Name => "test-verifier";
+
+        public OfficeProvenanceVerificationResult Verify(
+            string filePath,
+            OfficeProvenanceVerificationOptions? options = null) =>
+            new(OfficeProvenanceVerificationStatus.Valid, Name, ["content binding verified"]);
+    }
+
+    private sealed class TestDetector : IOfficeProvenanceSignalDetector {
+        public string Name => "test-detector";
+        public OfficeProvenanceSignalKind SignalKind => OfficeProvenanceSignalKind.DeterministicArtifact;
+
+        public OfficeProvenanceSignalResult Detect(string filePath) =>
+            new(Name, SignalKind, OfficeProvenanceSignalStatus.Detected, ["test signal"]);
+    }
+
+    private sealed class CancellingDetector : IOfficeProvenanceSignalDetector {
+        private readonly CancellationTokenSource _cancellation;
+
+        internal CancellingDetector(CancellationTokenSource cancellation) => _cancellation = cancellation;
+
+        public string Name => "cancelling-detector";
+        public OfficeProvenanceSignalKind SignalKind => OfficeProvenanceSignalKind.DeterministicArtifact;
+
+        public OfficeProvenanceSignalResult Detect(string filePath) {
+            _cancellation.Cancel();
+            return new OfficeProvenanceSignalResult(Name, SignalKind, OfficeProvenanceSignalStatus.NotDetected);
+        }
+    }
+
+    private sealed class CancellingProgress : IProgress<OfficeWorkflowProgress> {
+        private readonly string _requestId;
+        private readonly CancellationTokenSource _cancellation;
+
+        internal CancellingProgress(string requestId, CancellationTokenSource cancellation) {
+            _requestId = requestId;
+            _cancellation = cancellation;
+        }
+
+        public void Report(OfficeWorkflowProgress value) {
+            if (value.RequestId == _requestId && value.Stage == "complete") _cancellation.Cancel();
+        }
+    }
+
+    private sealed class TempScope : IDisposable {
+        internal TempScope() {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "OfficeIMO-ProvenanceWorkflow-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path);
+        }
+
+        internal string Path { get; }
+
+        internal string Write(string fileName, string contents) {
+            string path = System.IO.Path.Combine(Path, fileName);
+            File.WriteAllText(path, contents, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            return path;
+        }
+
+        public void Dispose() {
+            try {
+                if (Directory.Exists(Path)) Directory.Delete(Path, recursive: true);
+            } catch (IOException) {
+                // Best-effort test cleanup.
+            } catch (UnauthorizedAccessException) {
+                // Best-effort test cleanup.
+            }
+        }
+    }
+}

--- a/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowTests.cs
+++ b/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowTests.cs
@@ -364,6 +364,7 @@ public sealed partial class OfficeProvenanceWorkflowTests {
         OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner().RunProvenanceAsync(request);
 
         Assert.False(result.Succeeded);
+        Assert.Equal(OfficeWorkflowFailureKind.UnsupportedInput, result.FailureKind);
         Assert.Contains("above the configured", result.Summary, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("byte limit", result.Summary, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Code.EndsWith("Snapshot", StringComparison.Ordinal));

--- a/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowTests.cs
+++ b/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowTests.cs
@@ -510,8 +510,7 @@ public sealed partial class OfficeProvenanceWorkflowTests {
 
         public OfficeProvenanceVerificationResult Verify(
             string filePath,
-            OfficeProvenanceVerificationOptions? options = null,
-            CancellationToken cancellationToken = default) =>
+            OfficeProvenanceVerificationOptions? options = null) =>
             new(OfficeProvenanceVerificationStatus.Valid, Name, ["content binding verified"]);
     }
 
@@ -519,7 +518,7 @@ public sealed partial class OfficeProvenanceWorkflowTests {
         public string Name => "test-detector";
         public OfficeProvenanceSignalKind SignalKind => OfficeProvenanceSignalKind.DeterministicArtifact;
 
-        public OfficeProvenanceSignalResult Detect(string filePath, CancellationToken cancellationToken = default) =>
+        public OfficeProvenanceSignalResult Detect(string filePath) =>
             new(Name, SignalKind, OfficeProvenanceSignalStatus.Detected, ["test signal"]);
     }
 
@@ -531,7 +530,7 @@ public sealed partial class OfficeProvenanceWorkflowTests {
         public string Name => "cancelling-detector";
         public OfficeProvenanceSignalKind SignalKind => OfficeProvenanceSignalKind.DeterministicArtifact;
 
-        public OfficeProvenanceSignalResult Detect(string filePath, CancellationToken cancellationToken = default) {
+        public OfficeProvenanceSignalResult Detect(string filePath) {
             _cancellation.Cancel();
             return new OfficeProvenanceSignalResult(Name, SignalKind, OfficeProvenanceSignalStatus.NotDetected);
         }

--- a/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowTests.cs
+++ b/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowTests.cs
@@ -135,6 +135,46 @@ public sealed partial class OfficeProvenanceWorkflowTests {
     }
 
     [Fact]
+    public async Task AssessmentUsesTheHtmlOwnersDeclaredLegacyEncodingForTextIntegrity() {
+        using var scope = new TempScope();
+        string input = Path.Combine(scope.Path, "legacy.html");
+        byte[] prefix = Encoding.ASCII.GetBytes("<!doctype html><meta charset='windows-1252'><p>caf");
+        byte[] suffix = Encoding.ASCII.GetBytes("</p>");
+        File.WriteAllBytes(input, prefix.Concat(new byte[] { 0xE9, 0xA0 }).Concat(suffix).ToArray());
+
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner().RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Assess,
+                InputPath = input
+            });
+
+        Assert.True(result.Succeeded, result.Summary);
+        Assert.Contains(
+            result.Assessment!.TextIntegrity!.Findings,
+            finding => finding.Kind == OfficeTextIntegrityFindingKind.TypographicSpace && finding.CodePoint == 0x00A0);
+    }
+
+    [Fact]
+    public async Task AssessmentUsesTheSvgOwnersDeclaredXmlEncodingForTextIntegrity() {
+        using var scope = new TempScope();
+        string input = Path.Combine(scope.Path, "legacy.svg");
+        byte[] prefix = Encoding.ASCII.GetBytes("<?xml version='1.0' encoding='iso-8859-1'?><svg xmlns='http://www.w3.org/2000/svg'><text>caf");
+        byte[] suffix = Encoding.ASCII.GetBytes("</text></svg>");
+        File.WriteAllBytes(input, prefix.Concat(new byte[] { 0xE9, 0xA0 }).Concat(suffix).ToArray());
+
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner().RunProvenanceAsync(
+            new OfficeProvenanceWorkflowRequest {
+                Operation = OfficeProvenanceWorkflowOperation.Assess,
+                InputPath = input
+            });
+
+        Assert.True(result.Succeeded, result.Summary);
+        Assert.Contains(
+            result.Assessment!.TextIntegrity!.Findings,
+            finding => finding.Kind == OfficeTextIntegrityFindingKind.TypographicSpace && finding.CodePoint == 0x00A0);
+    }
+
+    [Fact]
     public async Task RemoveStagesReopensAndPublishesThroughHtmlOwner() {
         using var scope = new TempScope();
         string input = scope.Write("page.html", HtmlWithExternalManifest("keep me"));
@@ -292,6 +332,41 @@ public sealed partial class OfficeProvenanceWorkflowTests {
 
         Assert.True(result.Succeeded, result.Summary);
         Assert.True(File.Exists(output));
+    }
+
+    [Theory]
+    [InlineData(OfficeProvenanceWorkflowOperation.Inspect)]
+    [InlineData(OfficeProvenanceWorkflowOperation.Assess)]
+    [InlineData(OfficeProvenanceWorkflowOperation.Remove)]
+    public async Task OperationSpecificInputLimitRejectsBeforeSnapshotCapture(
+        OfficeProvenanceWorkflowOperation operation) {
+        using var scope = new TempScope();
+        string input = scope.Write("page.html", "<!doctype html><html><body>" + new string('x', 4096) + "</body></html>");
+        var request = new OfficeProvenanceWorkflowRequest {
+            Operation = operation,
+            InputPath = input,
+            OutputPath = operation == OfficeProvenanceWorkflowOperation.Remove
+                ? Path.Combine(scope.Path, "cleaned.html")
+                : null
+        };
+        switch (operation) {
+            case OfficeProvenanceWorkflowOperation.Inspect:
+                request.Inspection.MaxAssetBytes = 1024;
+                break;
+            case OfficeProvenanceWorkflowOperation.Assess:
+                request.Assessment.Structural.MaxAssetBytes = 1024;
+                break;
+            case OfficeProvenanceWorkflowOperation.Remove:
+                request.Removal.Limits.MaxAssetBytes = 1024;
+                break;
+        }
+
+        OfficeProvenanceWorkflowResult result = await new OfficeWorkflowRunner().RunProvenanceAsync(request);
+
+        Assert.False(result.Succeeded);
+        Assert.Contains("above the configured", result.Summary, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("byte limit", result.Summary, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Code.EndsWith("Snapshot", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowTests.cs
+++ b/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowTests.cs
@@ -277,12 +277,12 @@ public sealed partial class OfficeProvenanceWorkflowTests {
             yield return new OfficeProvenanceWorkflowRequest { InputPath = "unused" };
         }
 
-        IReadOnlyList<OfficeProvenanceWorkflowResult> results = await new OfficeWorkflowRunner().RunProvenanceBatchAsync(
-            Requests(),
-            cancellationToken: cancellation.Token);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            new OfficeWorkflowRunner().RunProvenanceBatchAsync(
+                Requests(),
+                cancellationToken: cancellation.Token));
 
         Assert.Equal(0, moveNextCount);
-        Assert.Empty(results);
     }
 
     [Fact]
@@ -413,21 +413,20 @@ public sealed partial class OfficeProvenanceWorkflowTests {
     }
 
     [Fact]
-    public async Task PreCancelledBatchReturnsWithoutMaterializingRequests() {
+    public async Task PreCancelledBatchThrowsBeforeMaterializingRequests() {
         using var scope = new TempScope();
         string first = scope.Write("first.html", "<html><body>first</body></html>");
         string second = scope.Write("second.html", "<html><body>second</body></html>");
         using var cancellation = new CancellationTokenSource();
         cancellation.Cancel();
 
-        IReadOnlyList<OfficeProvenanceWorkflowResult> results = await new OfficeWorkflowRunner().RunProvenanceBatchAsync(
-            [
-                new OfficeProvenanceWorkflowRequest { Id = "first", Operation = OfficeProvenanceWorkflowOperation.Inspect, InputPath = first },
-                new OfficeProvenanceWorkflowRequest { Id = "second", Operation = OfficeProvenanceWorkflowOperation.Inspect, InputPath = second }
-            ],
-            cancellationToken: cancellation.Token);
-
-        Assert.Empty(results);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            new OfficeWorkflowRunner().RunProvenanceBatchAsync(
+                [
+                    new OfficeProvenanceWorkflowRequest { Id = "first", Operation = OfficeProvenanceWorkflowOperation.Inspect, InputPath = first },
+                    new OfficeProvenanceWorkflowRequest { Id = "second", Operation = OfficeProvenanceWorkflowOperation.Inspect, InputPath = second }
+                ],
+                cancellationToken: cancellation.Token));
     }
 
     [Fact]

--- a/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowTests.cs
+++ b/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowTests.cs
@@ -570,9 +570,9 @@ public sealed partial class OfficeProvenanceWorkflowTests {
     }
 
     [Fact]
-    public async Task PreCancelledRemovalPublishesNothing() {
+    public async Task PreCancelledRemovalSkipsInputValidationAndPublishesNothing() {
         using var scope = new TempScope();
-        string input = scope.Write("page.html", HtmlWithExternalManifest("body"));
+        string input = Path.Combine(scope.Path, "missing.html");
         string output = Path.Combine(scope.Path, "cleaned.html");
         using var cancellation = new CancellationTokenSource();
         cancellation.Cancel();

--- a/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowTests.cs
+++ b/OfficeIMO.Workflows.Tests/OfficeProvenanceWorkflowTests.cs
@@ -510,7 +510,8 @@ public sealed partial class OfficeProvenanceWorkflowTests {
 
         public OfficeProvenanceVerificationResult Verify(
             string filePath,
-            OfficeProvenanceVerificationOptions? options = null) =>
+            OfficeProvenanceVerificationOptions? options = null,
+            CancellationToken cancellationToken = default) =>
             new(OfficeProvenanceVerificationStatus.Valid, Name, ["content binding verified"]);
     }
 
@@ -518,7 +519,7 @@ public sealed partial class OfficeProvenanceWorkflowTests {
         public string Name => "test-detector";
         public OfficeProvenanceSignalKind SignalKind => OfficeProvenanceSignalKind.DeterministicArtifact;
 
-        public OfficeProvenanceSignalResult Detect(string filePath) =>
+        public OfficeProvenanceSignalResult Detect(string filePath, CancellationToken cancellationToken = default) =>
             new(Name, SignalKind, OfficeProvenanceSignalStatus.Detected, ["test signal"]);
     }
 
@@ -530,7 +531,7 @@ public sealed partial class OfficeProvenanceWorkflowTests {
         public string Name => "cancelling-detector";
         public OfficeProvenanceSignalKind SignalKind => OfficeProvenanceSignalKind.DeterministicArtifact;
 
-        public OfficeProvenanceSignalResult Detect(string filePath) {
+        public OfficeProvenanceSignalResult Detect(string filePath, CancellationToken cancellationToken = default) {
             _cancellation.Cancel();
             return new OfficeProvenanceSignalResult(Name, SignalKind, OfficeProvenanceSignalStatus.NotDetected);
         }

--- a/OfficeIMO.Workflows/OfficeIMO.Workflows.csproj
+++ b/OfficeIMO.Workflows/OfficeIMO.Workflows.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Description>Typed local document workflows that compose first-party OfficeIMO conversion and PDF capabilities.</Description>
+    <Description>Typed local document workflows that compose first-party OfficeIMO conversion, PDF, and provenance capabilities.</Description>
     <PackageId>OfficeIMO.Workflows</PackageId>
     <AssemblyName>OfficeIMO.Workflows</AssemblyName>
     <AssemblyTitle>OfficeIMO.Workflows</AssemblyTitle>
@@ -9,7 +9,7 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Company>Evotec</Company>
     <Authors>Przemyslaw Klys</Authors>
-    <PackageTags>documents;workflow;conversion;pdf;office;officeimo</PackageTags>
+    <PackageTags>documents;workflow;conversion;pdf;provenance;c2pa;office;officeimo</PackageTags>
     <PackageProjectUrl>https://github.com/EvotecIT/OfficeIMO</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/EvotecIT/OfficeIMO</RepositoryUrl>
@@ -29,10 +29,18 @@
 
   <ItemGroup>
     <ProjectReference Include="..\OfficeIMO.Core\OfficeIMO.Core.csproj" />
+    <ProjectReference Include="..\OfficeIMO.Epub\OfficeIMO.Epub.csproj" />
+    <ProjectReference Include="..\OfficeIMO.Excel\OfficeIMO.Excel.csproj" />
     <ProjectReference Include="..\OfficeIMO.Excel.Pdf\OfficeIMO.Excel.Pdf.csproj" />
+    <ProjectReference Include="..\OfficeIMO.Html\OfficeIMO.Html.csproj" />
     <ProjectReference Include="..\OfficeIMO.Html.Pdf\OfficeIMO.Html.Pdf.csproj" />
+    <ProjectReference Include="..\OfficeIMO.Markdown\OfficeIMO.Markdown.csproj" />
+    <ProjectReference Include="..\OfficeIMO.OpenDocument\OfficeIMO.OpenDocument.csproj" />
     <ProjectReference Include="..\OfficeIMO.Pdf\OfficeIMO.Pdf.csproj" />
+    <ProjectReference Include="..\OfficeIMO.PowerPoint\OfficeIMO.PowerPoint.csproj" />
     <ProjectReference Include="..\OfficeIMO.PowerPoint.Pdf\OfficeIMO.PowerPoint.Pdf.csproj" />
+    <ProjectReference Include="..\OfficeIMO.Visio\OfficeIMO.Visio.csproj" />
+    <ProjectReference Include="..\OfficeIMO.Word\OfficeIMO.Word.csproj" />
     <ProjectReference Include="..\OfficeIMO.Word.Pdf\OfficeIMO.Word.Pdf.csproj" />
   </ItemGroup>
 

--- a/OfficeIMO.Workflows/OfficeProvenanceWorkflowAdapter.cs
+++ b/OfficeIMO.Workflows/OfficeProvenanceWorkflowAdapter.cs
@@ -8,6 +8,7 @@ using OfficeIMO.PowerPoint;
 using OfficeIMO.Provenance;
 using OfficeIMO.Visio;
 using OfficeIMO.Word;
+using System.Text;
 
 namespace OfficeIMO.Workflows;
 
@@ -90,6 +91,21 @@ internal static class OfficeProvenanceWorkflowAdapter {
             ProvenanceOwner.Markdown => MarkdownProvenance.RemoveFile(inputPath, outputPath, options),
             _ => OfficeProvenanceRemover.RemoveFile(inputPath, outputPath, options)
         };
+    }
+
+    internal static Encoding? ResolveTextEncoding(
+        ProvenanceOwner owner,
+        OfficeProvenanceAssetFormat format,
+        string path,
+        long maximumBytes,
+        CancellationToken cancellationToken) {
+        if (owner == ProvenanceOwner.Html) {
+            return HtmlProvenance.ResolveTextEncoding(path, maximumBytes, cancellationToken);
+        }
+        if (owner == ProvenanceOwner.Core && format == OfficeProvenanceAssetFormat.Svg) {
+            return OfficeProvenanceXml.ResolveTextEncoding(path, maximumBytes, cancellationToken);
+        }
+        return null;
     }
 
     internal static bool SupportsCoreRemoval(OfficeProvenanceAssetFormat format) => format is

--- a/OfficeIMO.Workflows/OfficeProvenanceWorkflowAdapter.cs
+++ b/OfficeIMO.Workflows/OfficeProvenanceWorkflowAdapter.cs
@@ -51,7 +51,8 @@ internal static class OfficeProvenanceWorkflowAdapter {
     internal static OfficeProvenanceReport Inspect(
         ProvenanceOwner owner,
         string path,
-        OfficeProvenanceOptions options) => owner switch {
+        OfficeProvenanceOptions options,
+        string? logicalFilePath = null) => owner switch {
             ProvenanceOwner.Word => WordDocument.InspectProvenance(path, options),
             ProvenanceOwner.Excel => ExcelDocument.InspectProvenance(path, options),
             ProvenanceOwner.PowerPoint => PowerPointPresentation.InspectProvenance(path, options),
@@ -59,7 +60,9 @@ internal static class OfficeProvenanceWorkflowAdapter {
             ProvenanceOwner.OpenDocument => OdfDocument.InspectProvenance(path, options),
             ProvenanceOwner.Epub => EpubDocument.InspectProvenance(path, options),
             ProvenanceOwner.Pdf => PdfProvenance.InspectFile(path, options),
-            ProvenanceOwner.Html => HtmlProvenance.InspectFile(path, options),
+            ProvenanceOwner.Html => logicalFilePath == null
+                ? HtmlProvenance.InspectFile(path, options)
+                : HtmlProvenance.InspectFile(path, logicalFilePath, options),
             ProvenanceOwner.Markdown => MarkdownProvenance.InspectFile(path, options),
             _ => OfficeProvenanceInspector.InspectFile(path, options)
         };

--- a/OfficeIMO.Workflows/OfficeProvenanceWorkflowAdapter.cs
+++ b/OfficeIMO.Workflows/OfficeProvenanceWorkflowAdapter.cs
@@ -52,7 +52,10 @@ internal static class OfficeProvenanceWorkflowAdapter {
         ProvenanceOwner owner,
         string path,
         OfficeProvenanceOptions options,
-        string? logicalFilePath = null) => owner switch {
+        string? logicalFilePath = null,
+        CancellationToken cancellationToken = default) {
+        options.CancellationToken = cancellationToken;
+        return owner switch {
             ProvenanceOwner.Word => WordDocument.InspectProvenance(path, options),
             ProvenanceOwner.Excel => ExcelDocument.InspectProvenance(path, options),
             ProvenanceOwner.PowerPoint => PowerPointPresentation.InspectProvenance(path, options),
@@ -66,12 +69,16 @@ internal static class OfficeProvenanceWorkflowAdapter {
             ProvenanceOwner.Markdown => MarkdownProvenance.InspectFile(path, options),
             _ => OfficeProvenanceInspector.InspectFile(path, options)
         };
+    }
 
     internal static OfficeProvenanceRemovalResult Remove(
         ProvenanceOwner owner,
         string inputPath,
         string outputPath,
-        OfficeProvenanceRemovalOptions options) => owner switch {
+        OfficeProvenanceRemovalOptions options,
+        CancellationToken cancellationToken = default) {
+        options.Limits.CancellationToken = cancellationToken;
+        return owner switch {
             ProvenanceOwner.Word => WordDocument.RemoveProvenance(inputPath, outputPath, options),
             ProvenanceOwner.Excel => ExcelDocument.RemoveProvenance(inputPath, outputPath, options),
             ProvenanceOwner.PowerPoint => PowerPointPresentation.RemoveProvenance(inputPath, outputPath, options),
@@ -83,6 +90,7 @@ internal static class OfficeProvenanceWorkflowAdapter {
             ProvenanceOwner.Markdown => MarkdownProvenance.RemoveFile(inputPath, outputPath, options),
             _ => OfficeProvenanceRemover.RemoveFile(inputPath, outputPath, options)
         };
+    }
 
     internal static bool SupportsCoreRemoval(OfficeProvenanceAssetFormat format) => format is
         OfficeProvenanceAssetFormat.Jpeg or

--- a/OfficeIMO.Workflows/OfficeProvenanceWorkflowAdapter.cs
+++ b/OfficeIMO.Workflows/OfficeProvenanceWorkflowAdapter.cs
@@ -1,0 +1,112 @@
+using OfficeIMO.Epub;
+using OfficeIMO.Excel;
+using OfficeIMO.Html;
+using OfficeIMO.Markdown;
+using OfficeIMO.OpenDocument;
+using OfficeIMO.Pdf;
+using OfficeIMO.PowerPoint;
+using OfficeIMO.Provenance;
+using OfficeIMO.Visio;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Workflows;
+
+internal static class OfficeProvenanceWorkflowAdapter {
+    internal static ProvenanceOwner ResolveByPath(string? path) =>
+        Path.GetExtension(path ?? string.Empty).ToLowerInvariant() switch {
+            ".docx" or ".docm" or ".dotx" or ".dotm" => ProvenanceOwner.Word,
+            ".xlsx" or ".xlsb" or ".xlsm" or ".xltx" or ".xltm" or ".xlam" => ProvenanceOwner.Excel,
+            ".pptx" or ".pptm" or ".potx" or ".potm" or ".ppsx" or ".ppsm" or ".ppam" => ProvenanceOwner.PowerPoint,
+            ".vsdx" or ".vsdm" or ".vstx" or ".vstm" or ".vssx" or ".vssm" => ProvenanceOwner.Visio,
+            ".odt" or ".ods" or ".odp" or ".odg" or ".ott" or ".ots" or ".otp" or ".otg" => ProvenanceOwner.OpenDocument,
+            ".epub" => ProvenanceOwner.Epub,
+            ".pdf" => ProvenanceOwner.Pdf,
+            ".html" or ".htm" => ProvenanceOwner.Html,
+            ".md" or ".markdown" => ProvenanceOwner.Markdown,
+            _ => ProvenanceOwner.Core
+        };
+
+    internal static ProvenanceOwner Refine(ProvenanceOwner owner, OfficeProvenanceAssetFormat format) {
+        if (owner != ProvenanceOwner.Core) return owner;
+        return format switch {
+            OfficeProvenanceAssetFormat.Pdf => ProvenanceOwner.Pdf,
+            OfficeProvenanceAssetFormat.Html => ProvenanceOwner.Html,
+            _ => owner
+        };
+    }
+
+    internal static string GetPackage(ProvenanceOwner owner) => owner switch {
+        ProvenanceOwner.Word => "OfficeIMO.Word",
+        ProvenanceOwner.Excel => "OfficeIMO.Excel",
+        ProvenanceOwner.PowerPoint => "OfficeIMO.PowerPoint",
+        ProvenanceOwner.Visio => "OfficeIMO.Visio",
+        ProvenanceOwner.OpenDocument => "OfficeIMO.OpenDocument",
+        ProvenanceOwner.Epub => "OfficeIMO.Epub",
+        ProvenanceOwner.Pdf => "OfficeIMO.Pdf",
+        ProvenanceOwner.Html => "OfficeIMO.Html",
+        ProvenanceOwner.Markdown => "OfficeIMO.Markdown",
+        _ => "OfficeIMO.Core"
+    };
+
+    internal static OfficeProvenanceReport Inspect(
+        ProvenanceOwner owner,
+        string path,
+        OfficeProvenanceOptions options) => owner switch {
+            ProvenanceOwner.Word => WordDocument.InspectProvenance(path, options),
+            ProvenanceOwner.Excel => ExcelDocument.InspectProvenance(path, options),
+            ProvenanceOwner.PowerPoint => PowerPointPresentation.InspectProvenance(path, options),
+            ProvenanceOwner.Visio => VisioDocument.InspectProvenance(path, options),
+            ProvenanceOwner.OpenDocument => OdfDocument.InspectProvenance(path, options),
+            ProvenanceOwner.Epub => EpubDocument.InspectProvenance(path, options),
+            ProvenanceOwner.Pdf => PdfProvenance.InspectFile(path, options),
+            ProvenanceOwner.Html => HtmlProvenance.InspectFile(path, options),
+            ProvenanceOwner.Markdown => MarkdownProvenance.InspectFile(path, options),
+            _ => OfficeProvenanceInspector.InspectFile(path, options)
+        };
+
+    internal static OfficeProvenanceRemovalResult Remove(
+        ProvenanceOwner owner,
+        string inputPath,
+        string outputPath,
+        OfficeProvenanceRemovalOptions options) => owner switch {
+            ProvenanceOwner.Word => WordDocument.RemoveProvenance(inputPath, outputPath, options),
+            ProvenanceOwner.Excel => ExcelDocument.RemoveProvenance(inputPath, outputPath, options),
+            ProvenanceOwner.PowerPoint => PowerPointPresentation.RemoveProvenance(inputPath, outputPath, options),
+            ProvenanceOwner.Visio => VisioDocument.RemoveProvenance(inputPath, outputPath, options),
+            ProvenanceOwner.OpenDocument => OdfDocument.RemoveProvenance(inputPath, outputPath, options),
+            ProvenanceOwner.Epub => EpubDocument.RemoveProvenance(inputPath, outputPath, options),
+            ProvenanceOwner.Pdf => PdfProvenance.RemoveFile(inputPath, outputPath, options),
+            ProvenanceOwner.Html => HtmlProvenance.RemoveFile(inputPath, outputPath, options),
+            ProvenanceOwner.Markdown => MarkdownProvenance.RemoveFile(inputPath, outputPath, options),
+            _ => OfficeProvenanceRemover.RemoveFile(inputPath, outputPath, options)
+        };
+
+    internal static bool SupportsCoreRemoval(OfficeProvenanceAssetFormat format) => format is
+        OfficeProvenanceAssetFormat.Jpeg or
+        OfficeProvenanceAssetFormat.Png or
+        OfficeProvenanceAssetFormat.Webp or
+        OfficeProvenanceAssetFormat.Gif or
+        OfficeProvenanceAssetFormat.Tiff or
+        OfficeProvenanceAssetFormat.Svg or
+        OfficeProvenanceAssetFormat.StructuredText or
+        OfficeProvenanceAssetFormat.UnstructuredText;
+
+    internal static bool IsTextLike(OfficeProvenanceAssetFormat format) => format is
+        OfficeProvenanceAssetFormat.StructuredText or
+        OfficeProvenanceAssetFormat.UnstructuredText or
+        OfficeProvenanceAssetFormat.Html or
+        OfficeProvenanceAssetFormat.Svg;
+
+    internal enum ProvenanceOwner {
+        Core,
+        Word,
+        Excel,
+        PowerPoint,
+        Visio,
+        OpenDocument,
+        Epub,
+        Pdf,
+        Html,
+        Markdown
+    }
+}

--- a/OfficeIMO.Workflows/OfficeProvenanceWorkflowContracts.cs
+++ b/OfficeIMO.Workflows/OfficeProvenanceWorkflowContracts.cs
@@ -1,0 +1,150 @@
+using System.Collections.ObjectModel;
+using OfficeIMO.Provenance;
+
+namespace OfficeIMO.Workflows;
+
+/// <summary>Operations exposed by the cross-format provenance workflow.</summary>
+public enum OfficeProvenanceWorkflowOperation {
+    /// <summary>Inspect standards-defined structural provenance carriers.</summary>
+    Inspect,
+    /// <summary>Combine structural, cryptographic, text-integrity, and provider-specific evidence.</summary>
+    Assess,
+    /// <summary>Remove selected standards-defined provenance carriers through the owning format API.</summary>
+    Remove
+}
+
+/// <summary>One typed cross-format provenance request.</summary>
+public sealed class OfficeProvenanceWorkflowRequest {
+    /// <summary>Caller-provided identifier used by progress and batch results.</summary>
+    public string Id { get; set; } = Guid.NewGuid().ToString("N");
+
+    /// <summary>Requested provenance operation.</summary>
+    public OfficeProvenanceWorkflowOperation Operation { get; set; }
+
+    /// <summary>Input asset path.</summary>
+    public required string InputPath { get; set; }
+
+    /// <summary>Output asset path for removal. When omitted, a sibling provenance-cleaned name is used.</summary>
+    public string? OutputPath { get; set; }
+
+    /// <summary>Conflict behavior used when publishing a removal artifact.</summary>
+    public OfficeWorkflowConflictPolicy ConflictPolicy { get; set; } = OfficeWorkflowConflictPolicy.Rename;
+
+    /// <summary>Structural inspection limits used by <see cref="OfficeProvenanceWorkflowOperation.Inspect"/>.</summary>
+    public OfficeProvenanceOptions Inspection { get; set; } = new();
+
+    /// <summary>Combined assessment options used by <see cref="OfficeProvenanceWorkflowOperation.Assess"/>.</summary>
+    public OfficeProvenanceAssessmentOptions Assessment { get; set; } = new();
+
+    /// <summary>Selective removal policy used by <see cref="OfficeProvenanceWorkflowOperation.Remove"/>.</summary>
+    public OfficeProvenanceRemovalOptions Removal { get; set; } = new();
+
+    /// <summary>Shared input and output byte limits.</summary>
+    public OfficeWorkflowLimits Limits { get; set; } = new();
+}
+
+/// <summary>Bounds sequential provenance batch execution.</summary>
+public sealed class OfficeProvenanceWorkflowBatchOptions {
+    /// <summary>Maximum number of materialized requests. Defaults to 256.</summary>
+    public int MaximumRequests { get; set; } = 256;
+
+    /// <summary>Whether execution continues after a failed request. Defaults to true.</summary>
+    public bool ContinueOnFailure { get; set; } = true;
+
+    internal OfficeProvenanceWorkflowBatchOptions CloneAndValidate() {
+        if (MaximumRequests <= 0 || MaximumRequests > 10_000) {
+            throw new ArgumentOutOfRangeException(nameof(MaximumRequests), "MaximumRequests must be between 1 and 10,000.");
+        }
+        return new OfficeProvenanceWorkflowBatchOptions {
+            MaximumRequests = MaximumRequests,
+            ContinueOnFailure = ContinueOnFailure
+        };
+    }
+}
+
+/// <summary>Runs reusable cross-format provenance workflows.</summary>
+public interface IOfficeProvenanceWorkflowRunner {
+    /// <summary>Runs one provenance request.</summary>
+    Task<OfficeProvenanceWorkflowResult> RunProvenanceAsync(
+        OfficeProvenanceWorkflowRequest request,
+        IProgress<OfficeWorkflowProgress>? progress = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Runs a bounded provenance batch sequentially.</summary>
+    Task<IReadOnlyList<OfficeProvenanceWorkflowResult>> RunProvenanceBatchAsync(
+        IEnumerable<OfficeProvenanceWorkflowRequest> requests,
+        OfficeProvenanceWorkflowBatchOptions? options = null,
+        IProgress<OfficeWorkflowProgress>? progress = null,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>One discoverable provenance workflow capability.</summary>
+public sealed class OfficeProvenanceWorkflowCapability {
+    internal OfficeProvenanceWorkflowCapability(
+        string id,
+        string label,
+        IEnumerable<string> extensions,
+        string ownerPackage,
+        bool canRemove,
+        string notes) {
+        Id = id;
+        Label = label;
+        Extensions = Array.AsReadOnly(extensions.OrderBy(static item => item, StringComparer.Ordinal).ToArray());
+        OwnerPackage = ownerPackage;
+        CanRemove = canRemove;
+        Notes = notes;
+    }
+
+    /// <summary>Stable capability identifier.</summary>
+    public string Id { get; }
+    /// <summary>User-facing format label.</summary>
+    public string Label { get; }
+    /// <summary>Recognized filename extensions.</summary>
+    public IReadOnlyList<string> Extensions { get; }
+    /// <summary>Package that owns format-specific inspection and mutation semantics.</summary>
+    public string OwnerPackage { get; }
+    /// <summary>Whether selected carriers can be removed.</summary>
+    public bool CanRemove { get; }
+    /// <summary>Important capability boundary.</summary>
+    public string Notes { get; }
+    /// <summary>Whether structural inspection is supported.</summary>
+    public bool CanInspect => true;
+    /// <summary>Whether combined assessment is supported.</summary>
+    public bool CanAssess => true;
+}
+
+/// <summary>Canonical format and owner catalog used by provenance workflow consumers.</summary>
+public static class OfficeProvenanceWorkflowCatalog {
+    private static readonly IReadOnlyList<OfficeProvenanceWorkflowCapability> CapabilitiesValue =
+        Array.AsReadOnly(new[] {
+            new OfficeProvenanceWorkflowCapability("word-openxml", "Word Open XML", [".docm", ".docx", ".dotm", ".dotx"], "OfficeIMO.Word", true, "Package signatures block mutation unless removal is explicitly authorized."),
+            new OfficeProvenanceWorkflowCapability("excel-package", "Excel workbook package", [".xlam", ".xlsb", ".xlsm", ".xlsx", ".xltm", ".xltx"], "OfficeIMO.Excel", true, "SpreadsheetML and XLSB package identity are validated before mutation."),
+            new OfficeProvenanceWorkflowCapability("powerpoint-openxml", "PowerPoint Open XML", [".potm", ".potx", ".ppam", ".ppsm", ".ppsx", ".pptm", ".pptx"], "OfficeIMO.PowerPoint", true, "Package signatures block mutation unless removal is explicitly authorized."),
+            new OfficeProvenanceWorkflowCapability("visio-openxml", "Visio Open XML", [".vsdm", ".vsdx", ".vssm", ".vssx", ".vstm", ".vstx"], "OfficeIMO.Visio", true, "Package signatures block mutation unless removal is explicitly authorized."),
+            new OfficeProvenanceWorkflowCapability("open-document", "OpenDocument", [".odg", ".odp", ".ods", ".odt", ".otg", ".otp", ".ots", ".ott"], "OfficeIMO.OpenDocument", true, "Encrypted OpenDocument packages cannot be rewritten."),
+            new OfficeProvenanceWorkflowCapability("epub", "EPUB", [".epub"], "OfficeIMO.Epub", true, "Package structure is validated before inspection or mutation."),
+            new OfficeProvenanceWorkflowCapability("pdf", "PDF", [".pdf"], "OfficeIMO.Pdf", true, "Removal is limited to provenance associations supported by the PDF owner."),
+            new OfficeProvenanceWorkflowCapability("html", "HTML", [".htm", ".html"], "OfficeIMO.Html", true, "External resources are not fetched during inspection."),
+            new OfficeProvenanceWorkflowCapability("markdown", "Markdown", [".markdown", ".md"], "OfficeIMO.Markdown", true, "Original BOM-aware UTF encoding is preserved by file mutation."),
+            new OfficeProvenanceWorkflowCapability("core-images", "Image provenance", [".gif", ".jpeg", ".jpg", ".png", ".svg", ".tif", ".tiff", ".webp"], "OfficeIMO.Core", true, "Inspection is signature-based; extensions are discovery hints."),
+            new OfficeProvenanceWorkflowCapability("core-text", "Structured text", [".adoc", ".asciidoc", ".bat", ".c", ".cjs", ".cmd", ".cpp", ".cs", ".css", ".go", ".h", ".hpp", ".ini", ".java", ".js", ".json", ".lua", ".mjs", ".ps1", ".py", ".rb", ".rs", ".sh", ".sql", ".tex", ".toml", ".ts", ".txt", ".vb", ".xml", ".yaml", ".yml"], "OfficeIMO.Core", true, "Only standards-defined structured or wrapped text carriers are changed."),
+            new OfficeProvenanceWorkflowCapability("core-detected", "Signature-detected asset", Array.Empty<string>(), "OfficeIMO.Core", true, "Unknown extensions may be inspected and removed when signature detection resolves to a supported non-generic format; generic ZIP mutation is not exposed.")
+        });
+
+    private static readonly IReadOnlyDictionary<string, OfficeProvenanceWorkflowCapability> ByExtension =
+        new ReadOnlyDictionary<string, OfficeProvenanceWorkflowCapability>(
+            CapabilitiesValue
+                .SelectMany(capability => capability.Extensions.Select(extension => (extension, capability)))
+                .ToDictionary(static item => item.extension, static item => item.capability, StringComparer.OrdinalIgnoreCase));
+
+    /// <summary>All cross-format provenance capabilities in stable display order.</summary>
+    public static IReadOnlyList<OfficeProvenanceWorkflowCapability> All => CapabilitiesValue;
+
+    /// <summary>Finds the configured owner by filename extension.</summary>
+    public static OfficeProvenanceWorkflowCapability? FindByPath(string? path) {
+        string extension = Path.GetExtension(path ?? string.Empty);
+        return ByExtension.TryGetValue(extension, out OfficeProvenanceWorkflowCapability? capability)
+            ? capability
+            : null;
+    }
+}

--- a/OfficeIMO.Workflows/OfficeProvenanceWorkflowContracts.cs
+++ b/OfficeIMO.Workflows/OfficeProvenanceWorkflowContracts.cs
@@ -41,6 +41,9 @@ public sealed class OfficeProvenanceWorkflowRequest {
 
     /// <summary>Shared input and output byte limits.</summary>
     public OfficeWorkflowLimits Limits { get; set; } = new();
+
+    internal SortedSet<string>? BatchBlockedOutputIdentities { get; set; }
+    internal string? BatchOwnReservedOutputIdentity { get; set; }
 }
 
 /// <summary>Bounds sequential provenance batch execution.</summary>

--- a/OfficeIMO.Workflows/OfficeProvenanceWorkflowResults.cs
+++ b/OfficeIMO.Workflows/OfficeProvenanceWorkflowResults.cs
@@ -1,0 +1,86 @@
+using OfficeIMO.Provenance;
+
+namespace OfficeIMO.Workflows;
+
+/// <summary>Completed, cancelled, or failed provenance workflow result.</summary>
+public sealed class OfficeProvenanceWorkflowResult {
+    internal OfficeProvenanceWorkflowResult(
+        string requestId,
+        OfficeProvenanceWorkflowOperation operation,
+        OfficeWorkflowStatus status,
+        OfficeWorkflowFailureKind failureKind,
+        string ownerPackage,
+        string? outputPath,
+        long inputBytes,
+        long outputBytes,
+        TimeSpan duration,
+        string summary,
+        IReadOnlyList<OfficeWorkflowDiagnostic> diagnostics,
+        OfficeProvenanceReport? inspection = null,
+        OfficeProvenanceAssessmentReport? assessment = null,
+        OfficeProvenanceReport? before = null,
+        OfficeProvenanceReport? after = null,
+        IReadOnlyList<OfficeProvenanceChange>? changes = null,
+        bool wasReserialized = false,
+        bool wereInvalidatedSignaturesRemoved = false) {
+        RequestId = requestId;
+        Operation = operation;
+        Status = status;
+        FailureKind = failureKind;
+        OwnerPackage = ownerPackage;
+        OutputPath = outputPath;
+        InputBytes = inputBytes;
+        OutputBytes = outputBytes;
+        Duration = duration;
+        Summary = summary;
+        Diagnostics = diagnostics.ToArray();
+        Inspection = inspection;
+        Assessment = assessment;
+        Before = before;
+        After = after;
+        Changes = (changes ?? Array.Empty<OfficeProvenanceChange>()).ToArray();
+        WasReserialized = wasReserialized;
+        WereInvalidatedSignaturesRemoved = wereInvalidatedSignaturesRemoved;
+    }
+
+    /// <summary>Caller-provided request identifier.</summary>
+    public string RequestId { get; }
+    /// <summary>Executed operation.</summary>
+    public OfficeProvenanceWorkflowOperation Operation { get; }
+    /// <summary>Terminal execution state.</summary>
+    public OfficeWorkflowStatus Status { get; }
+    /// <summary>Stable failure category.</summary>
+    public OfficeWorkflowFailureKind FailureKind { get; }
+    /// <summary>Package that owned format-specific behavior.</summary>
+    public string OwnerPackage { get; }
+    /// <summary>Published removal artifact, when applicable.</summary>
+    public string? OutputPath { get; }
+    /// <summary>Input file size.</summary>
+    public long InputBytes { get; }
+    /// <summary>Published output size.</summary>
+    public long OutputBytes { get; }
+    /// <summary>Elapsed workflow duration.</summary>
+    public TimeSpan Duration { get; }
+    /// <summary>User-facing outcome.</summary>
+    public string Summary { get; }
+    /// <summary>Structured orchestration diagnostics.</summary>
+    public IReadOnlyList<OfficeWorkflowDiagnostic> Diagnostics { get; }
+    /// <summary>Structural report for an inspect operation.</summary>
+    public OfficeProvenanceReport? Inspection { get; }
+    /// <summary>Combined evidence for an assess operation.</summary>
+    public OfficeProvenanceAssessmentReport? Assessment { get; }
+    /// <summary>Structural evidence before removal.</summary>
+    public OfficeProvenanceReport? Before { get; }
+    /// <summary>Reopened structural evidence after removal.</summary>
+    public OfficeProvenanceReport? After { get; }
+    /// <summary>Format-native mutations applied in source order.</summary>
+    public IReadOnlyList<OfficeProvenanceChange> Changes { get; }
+    /// <summary>Whether the owner changed at least one carrier.</summary>
+    public bool WasChanged => Changes.Count != 0;
+    /// <summary>Whether the owner serialized a container rather than copying bytes around carriers.</summary>
+    public bool WasReserialized { get; }
+    /// <summary>Whether explicitly authorized invalidated signatures were removed.</summary>
+    public bool WereInvalidatedSignaturesRemoved { get; }
+    /// <summary>Whether the workflow completed successfully.</summary>
+    public bool Succeeded => Status == OfficeWorkflowStatus.Completed;
+}

--- a/OfficeIMO.Workflows/OfficeWorkflowPathIdentity.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowPathIdentity.cs
@@ -4,6 +4,8 @@ namespace OfficeIMO.Workflows;
 
 /// <summary>Routes workflow path identity through the filesystem-aware OfficeIMO owner.</summary>
 internal static class OfficeWorkflowPathIdentity {
+    internal static bool SupportsPhysicalIdentity => OfficePathIdentity.SupportsPhysicalIdentity;
+
     internal static string Normalize(string path) => OfficePathIdentity.Normalize(path);
 
     internal static string Normalize(string path, bool caseInsensitive) =>

--- a/OfficeIMO.Workflows/OfficeWorkflowPathIdentity.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowPathIdentity.cs
@@ -11,7 +11,25 @@ internal static class OfficeWorkflowPathIdentity {
     internal static string Normalize(string path, bool caseInsensitive) =>
         OfficePathIdentity.Normalize(path, caseInsensitive);
 
+    internal static string NormalizeWithPortableFallback(
+        string path,
+        bool? usePhysicalIdentity = null) =>
+        (usePhysicalIdentity ?? SupportsPhysicalIdentity)
+            ? Normalize(path)
+            : Normalize(path, IsCaseInsensitiveFileSystem(path));
+
     internal static bool AreEquivalent(string left, string right) => OfficePathIdentity.AreEquivalent(left, right);
+
+    internal static bool AreEquivalentWithPortableFallback(
+        string left,
+        string right,
+        bool? usePhysicalIdentity = null) =>
+        (usePhysicalIdentity ?? SupportsPhysicalIdentity)
+            ? AreEquivalent(left, right)
+            : string.Equals(
+                NormalizeWithPortableFallback(left, usePhysicalIdentity: false),
+                NormalizeWithPortableFallback(right, usePhysicalIdentity: false),
+                StringComparison.Ordinal);
 
     internal static bool IsSameOrDescendant(string candidatePath, string rootPath) =>
         OfficePathIdentity.IsSameOrDescendant(candidatePath, rootPath);

--- a/OfficeIMO.Workflows/OfficeWorkflowPathIdentity.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowPathIdentity.cs
@@ -6,6 +6,9 @@ namespace OfficeIMO.Workflows;
 internal static class OfficeWorkflowPathIdentity {
     internal static string Normalize(string path) => OfficePathIdentity.Normalize(path);
 
+    internal static string Normalize(string path, bool caseInsensitive) =>
+        OfficePathIdentity.Normalize(path, caseInsensitive);
+
     internal static bool AreEquivalent(string left, string right) => OfficePathIdentity.AreEquivalent(left, right);
 
     internal static bool IsSameOrDescendant(string candidatePath, string rootPath) =>
@@ -22,4 +25,7 @@ internal static class OfficeWorkflowPathIdentity {
     internal static StringComparer GetComparer(string path) => OfficePathIdentity.GetComparer(path);
 
     internal static StringComparison GetComparison(string path) => OfficePathIdentity.GetComparison(path);
+
+    internal static bool IsCaseInsensitiveFileSystem(string path) =>
+        OfficePathIdentity.IsCaseInsensitiveFileSystem(path);
 }

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.Failures.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.Failures.cs
@@ -13,6 +13,9 @@ public sealed partial class OfficeWorkflowRunner {
         if (stage == WorkflowFailureStage.Input && exception is IOException or UnauthorizedAccessException) {
             return OfficeWorkflowFailureKind.UnsupportedInput;
         }
+        if (OfficeIMO.Provenance.OfficeProvenanceProviderContractException.Is(exception)) {
+            return OfficeWorkflowFailureKind.OperationFailed;
+        }
         if (exception is NotSupportedException or InvalidDataException) {
             return OfficeWorkflowFailureKind.UnsupportedInput;
         }

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.Failures.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.Failures.cs
@@ -10,6 +10,9 @@ public sealed partial class OfficeWorkflowRunner {
         if (exception is FileNotFoundException or DirectoryNotFoundException) {
             return OfficeWorkflowFailureKind.InputNotFound;
         }
+        if (stage == WorkflowFailureStage.Input && exception is IOException or UnauthorizedAccessException) {
+            return OfficeWorkflowFailureKind.UnsupportedInput;
+        }
         if (exception is NotSupportedException or InvalidDataException) {
             return OfficeWorkflowFailureKind.UnsupportedInput;
         }

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.Failures.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.Failures.cs
@@ -25,6 +25,7 @@ public sealed partial class OfficeWorkflowRunner {
     internal static string GetDiagnosticStage(WorkflowFailureStage stage) => stage switch {
         WorkflowFailureStage.Validation => "validate",
         WorkflowFailureStage.Input => "input",
+        WorkflowFailureStage.Snapshot => "snapshot",
         WorkflowFailureStage.Output => "output",
         WorkflowFailureStage.Operation => "execute",
         _ => "execute"
@@ -33,6 +34,7 @@ public sealed partial class OfficeWorkflowRunner {
     internal enum WorkflowFailureStage {
         Validation,
         Input,
+        Snapshot,
         Output,
         Operation
     }

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.Failures.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.Failures.cs
@@ -2,7 +2,9 @@ namespace OfficeIMO.Workflows;
 
 public sealed partial class OfficeWorkflowRunner {
     internal static OfficeWorkflowFailureKind ClassifyFailure(Exception exception, WorkflowFailureStage stage) {
-        if (stage == WorkflowFailureStage.Output) {
+        if (stage == WorkflowFailureStage.Output ||
+            OfficeIMO.Provenance.OfficeProvenanceLimitException.IsOutput(exception) ||
+            OfficeIMO.Pdf.PdfOutputLimitErrors.IsOutputLimitExceeded(exception)) {
             return OfficeWorkflowFailureKind.OutputFailed;
         }
         if (exception is FileNotFoundException or DirectoryNotFoundException) {

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
@@ -50,6 +50,7 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
             inputBytes = new FileInfo(validated.InputPath).Length;
             long operationInputLimit = GetOperationInputLimit(validated);
             EnforceInputLimit(validated.InputPath, inputBytes, operationInputLimit);
+            failureStage = WorkflowFailureStage.Snapshot;
             inputSnapshot = OfficeProvenanceFileSnapshot.Capture(
                 validated.InputPath,
                 operationInputLimit,
@@ -164,6 +165,9 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                     "Inspection is supported, but no safe mutation owner is registered for this asset format.");
             }
 
+            long remainingExpandedBytes = validated.RemovalInputInspection.MaxExpandedContainerBytes;
+            ConsumeExpandedProcessingBytes(ref remainingExpandedBytes, structural.ExpandedInspectionBytes);
+
             failureStage = WorkflowFailureStage.Output;
             string outputDirectory = Path.GetDirectoryName(validated.OutputPath!)!;
             Directory.CreateDirectory(outputDirectory);
@@ -175,14 +179,22 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
             failureStage = WorkflowFailureStage.Operation;
             OfficeProvenanceRemovalResult removal;
             try {
+                OfficeProvenanceRemovalOptions removalOptions = CloneRemovalOptions(
+                    validated.Removal,
+                    validated.Removal.Limits.MaxAssetBytes,
+                    validated.Removal.EffectiveMaxOutputBytes);
+                removalOptions.Limits.MaxExpandedContainerBytes = Math.Max(1L, remainingExpandedBytes);
                 removal = await Task.Run(
-                    () => OfficeProvenanceWorkflowAdapter.Remove(refinedOwner, operationInputPath, stagingPath, validated.Removal, cancellationToken),
+                    () => OfficeProvenanceWorkflowAdapter.Remove(
+                        refinedOwner, operationInputPath, stagingPath, removalOptions, cancellationToken),
                     cancellationToken).ConfigureAwait(false);
             } catch (Exception exception) when (exception is IOException or UnauthorizedAccessException) {
                 failureStage = WorkflowFailureStage.Output;
                 throw;
             }
             cancellationToken.ThrowIfCancellationRequested();
+            ConsumeExpandedProcessingBytes(ref remainingExpandedBytes, removal.Before.ExpandedInspectionBytes);
+            ConsumeExpandedProcessingBytes(ref remainingExpandedBytes, removal.After.ExpandedInspectionBytes);
             inputSnapshot!.VerifyPrimaryFile(cancellationToken);
             inputSnapshot!.Dispose();
             inputSnapshot = null;
@@ -201,15 +213,20 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                 removal.DataLength,
                 removal.ComputeDataSha256(cancellationToken),
                 cancellationToken);
+            OfficeProvenanceOptions outputInspectionOptions = CloneInspectionOptions(
+                validated.RemovalOutputInspection,
+                validated.RemovalOutputInspection.MaxAssetBytes);
+            outputInspectionOptions.MaxExpandedContainerBytes = Math.Max(1L, remainingExpandedBytes);
             OfficeProvenanceReport reopened = await Task.Run(
                 () => OfficeProvenanceWorkflowAdapter.Inspect(
                     refinedOwner,
                     stagingPath,
-                    validated.RemovalOutputInspection,
+                    outputInspectionOptions,
                     validated.OutputPath,
                     cancellationToken),
                 cancellationToken).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
+            ConsumeExpandedProcessingBytes(ref remainingExpandedBytes, reopened.ExpandedInspectionBytes);
             EnsureEquivalent(removal.After, reopened);
             stagedFingerprint.VerifyStagingPath(
                 stagingPath,
@@ -611,6 +628,7 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
             string publishedPath;
             switch (policy) {
                 case OfficeWorkflowConflictPolicy.Fail:
+                    EnsureBatchCandidateDoesNotOverlapAnotherRequest(requestedPath);
                     File.Move(stagingPath, requestedPath, overwrite: false);
                     publishedPath = requestedPath;
                     PinAndFinalize(publishedPath);
@@ -648,6 +666,21 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
             }
         }
 
+        void EnsureBatchCandidateDoesNotOverlapAnotherRequest(string path) {
+            if (blockedOutputIdentities is null) return;
+            string identity = OfficeWorkflowPathIdentity.Normalize(path);
+            bool isOwnReservation = string.Equals(identity, ownReservedOutputIdentity, StringComparison.Ordinal);
+            bool hasHierarchyCollision = TryFindAncestorOrDescendant(
+                identity,
+                blockedOutputIdentities,
+                out string? collisionIdentity) &&
+                !string.Equals(collisionIdentity, ownReservedOutputIdentity, StringComparison.Ordinal);
+            if ((!isOwnReservation && blockedOutputIdentities.Contains(identity)) || hasHierarchyCollision) {
+                throw new IOException(
+                    "The provenance output now overlaps another batch request path and cannot be published safely.");
+            }
+        }
+
         string PublishRenamed() {
             for (int suffix = 0; suffix < 10_000; suffix++) {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -679,6 +712,7 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
         }
 
         string PublishReplacement() {
+            EnsureBatchCandidateDoesNotOverlapAnotherRequest(requestedPath);
             if (!File.Exists(requestedPath)) {
                 bool destinationAppeared = false;
                 try {
@@ -693,6 +727,7 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                 }
             }
 
+            EnsureBatchCandidateDoesNotOverlapAnotherRequest(requestedPath);
             using StagedArtifactFingerprint destination = StagedArtifactFingerprint.Capture(
                 requestedPath,
                 maximumBytes,
@@ -838,6 +873,22 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
         OfficeProvenanceWorkflowOperation.Remove => request.RemovalInputInspection.MaxAssetBytes,
         _ => request.Limits.MaximumInputBytes
     };
+
+    private static OfficeProvenanceOptions CloneInspectionOptions(
+        OfficeProvenanceOptions source,
+        long maximumAssetBytes) {
+        var clone = new OfficeProvenanceOptions();
+        CopyInspectionOptions(source, clone, maximumAssetBytes);
+        return clone;
+    }
+
+    private static void ConsumeExpandedProcessingBytes(ref long remainingBytes, long consumedBytes) {
+        if (consumedBytes < 0 || consumedBytes > remainingBytes) {
+            throw OfficeProvenanceLimitException.Create(
+                "The provenance workflow exceeds the configured cumulative expanded-data limit.");
+        }
+        remainingBytes -= consumedBytes;
+    }
 
     private static OfficeProvenanceOptions CreateOutputInspectionOptions(
         OfficeProvenanceRemovalOptions removal) {

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
@@ -188,6 +188,8 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                 ownedStagingPath,
                 validated.OutputPath!,
                 validated.ConflictPolicy,
+                validated.BatchBlockedOutputIdentities,
+                validated.BatchOwnReservedOutputIdentity,
                 stagedFingerprint,
                 validated.Limits.MaximumOutputBytes,
                 cancellationToken,
@@ -447,6 +449,8 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
         string stagingPath,
         string requestedPath,
         OfficeWorkflowConflictPolicy policy,
+        SortedSet<string>? blockedOutputIdentities,
+        string? ownReservedOutputIdentity,
         StagedArtifactFingerprint staged,
         long maximumBytes,
         CancellationToken cancellationToken,
@@ -503,6 +507,20 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
             for (int suffix = 0; suffix < 10_000; suffix++) {
                 cancellationToken.ThrowIfCancellationRequested();
                 string candidate = suffix == 0 ? requestedPath : AddSuffix(requestedPath, suffix);
+                if (blockedOutputIdentities is not null) {
+                    string identity = OfficeWorkflowPathIdentity.Normalize(candidate);
+                    bool isOwnReservation = string.Equals(
+                        identity,
+                        ownReservedOutputIdentity,
+                        StringComparison.Ordinal);
+                    bool hasHierarchyCollision = TryFindAncestorOrDescendant(
+                        identity,
+                        blockedOutputIdentities,
+                        out string? collisionIdentity) &&
+                        !string.Equals(collisionIdentity, ownReservedOutputIdentity, StringComparison.Ordinal);
+                    if ((!isOwnReservation && blockedOutputIdentities.Contains(identity)) ||
+                        hasHierarchyCollision) continue;
+                }
                 try {
                     File.Move(stagingPath, candidate, overwrite: false);
                 } catch (IOException) when (File.Exists(candidate) || Directory.Exists(candidate)) {
@@ -600,6 +618,8 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
             outputPath,
             ResolveByPath(inputPath),
             request.ConflictPolicy,
+            request.BatchBlockedOutputIdentities,
+            request.BatchOwnReservedOutputIdentity,
             limits,
             inspection,
             assessment,
@@ -751,6 +771,8 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
         string? OutputPath,
         ProvenanceOwner Owner,
         OfficeWorkflowConflictPolicy ConflictPolicy,
+        SortedSet<string>? BatchBlockedOutputIdentities,
+        string? BatchOwnReservedOutputIdentity,
         OfficeWorkflowLimits Limits,
         OfficeProvenanceOptions Inspection,
         OfficeProvenanceAssessmentOptions Assessment,

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
@@ -252,7 +252,7 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                 validated.BatchOwnReservedOutputIdentity,
                 stagedFingerprint,
                 validated.ConflictPolicy == OfficeWorkflowConflictPolicy.Replace &&
-                OfficeWorkflowPathIdentity.AreEquivalent(validated.InputPath, validated.OutputPath!)
+                OfficeWorkflowPathIdentity.AreEquivalentWithPortableFallback(validated.InputPath, validated.OutputPath!)
                     ? inputSnapshot
                     : null,
                 validated.Limits.MaximumOutputBytes,
@@ -672,7 +672,7 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
 
         void EnsureBatchCandidateDoesNotOverlapAnotherRequest(string path) {
             if (blockedOutputIdentities is null) return;
-            string identity = OfficeWorkflowPathIdentity.Normalize(path);
+            string identity = OfficeWorkflowPathIdentity.NormalizeWithPortableFallback(path);
             bool isOwnReservation = string.Equals(identity, ownReservedOutputIdentity, StringComparison.Ordinal);
             bool hasHierarchyCollision = TryFindAncestorOrDescendant(
                 identity,
@@ -690,7 +690,7 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                 cancellationToken.ThrowIfCancellationRequested();
                 string candidate = suffix == 0 ? requestedPath : AddSuffix(requestedPath, suffix);
                 if (blockedOutputIdentities is not null) {
-                    string identity = OfficeWorkflowPathIdentity.Normalize(candidate);
+                    string identity = OfficeWorkflowPathIdentity.NormalizeWithPortableFallback(candidate);
                     bool isOwnReservation = string.Equals(
                         identity,
                         ownReservedOutputIdentity,

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
@@ -196,8 +196,6 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
             ConsumeExpandedProcessingBytes(ref remainingExpandedBytes, removal.Before.ExpandedInspectionBytes);
             ConsumeExpandedProcessingBytes(ref remainingExpandedBytes, removal.After.ExpandedInspectionBytes);
             inputSnapshot!.VerifyPrimaryFile(cancellationToken);
-            inputSnapshot!.Dispose();
-            inputSnapshot = null;
 
             failureStage = WorkflowFailureStage.Output;
             long stagedBytes = new FileInfo(stagingPath).Length;
@@ -253,6 +251,10 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                 validated.BatchBlockedOutputIdentities,
                 validated.BatchOwnReservedOutputIdentity,
                 stagedFingerprint,
+                validated.ConflictPolicy == OfficeWorkflowConflictPolicy.Replace &&
+                OfficeWorkflowPathIdentity.AreEquivalent(validated.InputPath, validated.OutputPath!)
+                    ? inputSnapshot
+                    : null,
                 validated.Limits.MaximumOutputBytes,
                 cancellationToken,
                 beforePublish: () => Report(
@@ -265,6 +267,8 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                     Report(progress, validated.Id, "finalize", "Finalizing the verified provenance artifact", 0.98D);
                     stagedFingerprint.VerifyPublishedPath(path, validated.Limits.MaximumOutputBytes, cancellationToken);
                 });
+            inputSnapshot.Dispose();
+            inputSnapshot = null;
             long outputBytes = stagedFingerprint.Length;
             diagnostics.Add(new OfficeWorkflowDiagnostic(
                 "AtomicPublication",
@@ -614,6 +618,7 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
         SortedSet<string>? blockedOutputIdentities,
         string? ownReservedOutputIdentity,
         StagedArtifactFingerprint staged,
+        OfficeProvenanceFileSnapshot? expectedDisplacedInput,
         long maximumBytes,
         CancellationToken cancellationToken,
         Action beforePublish,
@@ -714,6 +719,10 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
         string PublishReplacement() {
             EnsureBatchCandidateDoesNotOverlapAnotherRequest(requestedPath);
             if (!File.Exists(requestedPath)) {
+                if (expectedDisplacedInput != null) {
+                    throw new IOException(
+                        "The provenance input changed while its verified replacement was being published.");
+                }
                 bool destinationAppeared = false;
                 try {
                     File.Move(stagingPath, requestedPath, overwrite: false);
@@ -728,6 +737,21 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
             }
 
             EnsureBatchCandidateDoesNotOverlapAnotherRequest(requestedPath);
+            if (expectedDisplacedInput != null) {
+                bool inputCommitted = OfficeFileCommit.TryCommitTemporaryFileAtomicallyIfDestinationUnchangedAndFinalize(
+                    stagingPath,
+                    requestedPath,
+                    backupPath => expectedDisplacedInput.MatchesCapturedSource(backupPath, cancellationToken),
+                    installedPath => staged.TryPinPublishedPath(installedPath, maximumBytes, cancellationToken),
+                    beforeCommitFinalized);
+                if (!inputCommitted) {
+                    staged.ReleasePublishedLease();
+                    throw new IOException(
+                        "The provenance input changed while its verified replacement was being published.");
+                }
+                return requestedPath;
+            }
+
             using StagedArtifactFingerprint destination = StagedArtifactFingerprint.Capture(
                 requestedPath,
                 maximumBytes,

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
@@ -47,9 +47,12 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
 
             Report(progress, validated.Id, "inspect", "Inspecting through " + ownerPackage, 0.2D);
             failureStage = WorkflowFailureStage.Operation;
-            OfficeProvenanceOptions inspectionOptions = validated.Operation == OfficeProvenanceWorkflowOperation.Assess
-                ? validated.Assessment.Structural
-                : validated.Inspection;
+            OfficeProvenanceOptions inspectionOptions = validated.Operation switch {
+                OfficeProvenanceWorkflowOperation.Assess => validated.Assessment.Structural,
+                OfficeProvenanceWorkflowOperation.Remove => CreateInspectionOptions(
+                    validated.Removal, validated.Limits.MaximumInputBytes),
+                _ => validated.Inspection
+            };
             OfficeProvenanceReport structural = await Task.Run(
                 () => OfficeProvenanceWorkflowAdapter.Inspect(validated.Owner, validated.InputPath, inspectionOptions),
                 cancellationToken).ConfigureAwait(false);
@@ -116,7 +119,10 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
 
             Report(progress, validated.Id, "validate-output", "Reopening the staged artifact through " + ownerPackage, 0.72D);
             OfficeProvenanceReport reopened = await Task.Run(
-                () => OfficeProvenanceWorkflowAdapter.Inspect(refinedOwner, stagingPath, CreateInspectionOptions(validated.Removal, validated.Limits)),
+                () => OfficeProvenanceWorkflowAdapter.Inspect(
+                    refinedOwner,
+                    stagingPath,
+                    CreateInspectionOptions(validated.Removal, validated.Limits.MaximumOutputBytes)),
                 cancellationToken).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
             EnsureEquivalent(removal.After, reopened);
@@ -208,7 +214,7 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                 $"The provenance batch exceeds the configured limit of {validatedOptions.MaximumRequests:N0} requests.",
                 nameof(requests));
         }
-        EnsureDistinctBatchRemovalOutputs(materialized);
+        EnsureSafeBatchRemovalPaths(materialized);
         if (materialized.Length == 0) cancellationToken.ThrowIfCancellationRequested();
 
         var results = new List<OfficeProvenanceWorkflowResult>(materialized.Length);
@@ -231,27 +237,43 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
         return results;
     }
 
-    private static void EnsureDistinctBatchRemovalOutputs(IEnumerable<OfficeProvenanceWorkflowRequest> requests) {
+    private static void EnsureSafeBatchRemovalPaths(IReadOnlyList<OfficeProvenanceWorkflowRequest> requests) {
+        var inputIdentities = new string?[requests.Count];
+        for (int index = 0; index < requests.Count; index++) {
+            OfficeProvenanceWorkflowRequest request = requests[index] ??
+                throw new ArgumentException("Provenance batches cannot contain null requests.", nameof(requests));
+            inputIdentities[index] = TryNormalizeBatchPath(request.InputPath);
+        }
+
         var outputIdentities = new HashSet<string>(StringComparer.Ordinal);
-        foreach (OfficeProvenanceWorkflowRequest request in requests) {
-            if (request == null) throw new ArgumentException("Provenance batches cannot contain null requests.", nameof(requests));
+        for (int requestIndex = 0; requestIndex < requests.Count; requestIndex++) {
+            OfficeProvenanceWorkflowRequest request = requests[requestIndex];
             if (request.Operation != OfficeProvenanceWorkflowOperation.Remove) continue;
 
             string? outputPath = TryResolveBatchRemovalOutput(request);
             if (outputPath is null) continue;
-            string? identity = TryNormalizeBatchRemovalOutput(outputPath);
+            string? identity = TryNormalizeBatchPath(outputPath);
             if (identity is null) continue;
             if (!outputIdentities.Add(identity)) {
                 throw new ArgumentException(
                     $"Multiple provenance removal requests resolve to the same output path '{outputPath}'.",
                     nameof(requests));
             }
+
+            for (int inputIndex = 0; inputIndex < inputIdentities.Length; inputIndex++) {
+                if (inputIndex == requestIndex || inputIdentities[inputIndex] is null) continue;
+                if (string.Equals(identity, inputIdentities[inputIndex], StringComparison.Ordinal)) {
+                    throw new ArgumentException(
+                        $"Provenance removal output '{outputPath}' overlaps another batch request's input path.",
+                        nameof(requests));
+                }
+            }
         }
     }
 
-    private static string? TryNormalizeBatchRemovalOutput(string outputPath) {
+    private static string? TryNormalizeBatchPath(string? path) {
         try {
-            return OfficeWorkflowPathIdentity.Normalize(outputPath);
+            return string.IsNullOrWhiteSpace(path) ? null : OfficeWorkflowPathIdentity.Normalize(path);
         } catch (Exception exception) when (exception is ArgumentException or NotSupportedException or IOException or UnauthorizedAccessException) {
             // Defer path-access diagnostics to the item runner so batch failure behavior stays structured.
             return null;
@@ -371,9 +393,9 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
 
     private static OfficeProvenanceOptions CreateInspectionOptions(
         OfficeProvenanceRemovalOptions removal,
-        OfficeWorkflowLimits limits) {
+        long maximumAssetBytes) {
         var options = new OfficeProvenanceOptions();
-        CopyInspectionOptions(removal.Limits, options, limits.MaximumOutputBytes);
+        CopyInspectionOptions(removal.Limits, options, maximumAssetBytes);
         options.ProcessEmbeddedAssets = removal.ProcessEmbeddedAssets && removal.Limits.ProcessEmbeddedAssets;
         options.MaxEmbeddedAssets = Math.Min(removal.MaxEmbeddedAssets, removal.Limits.MaxEmbeddedAssets);
         return options;

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
@@ -266,6 +266,17 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                 beforeCommitFinalized: path => {
                     Report(progress, validated.Id, "finalize", "Finalizing the verified provenance artifact", 0.98D);
                     stagedFingerprint.VerifyPublishedPath(path, validated.Limits.MaximumOutputBytes, cancellationToken);
+                },
+                backupCleanupFailed: (path, exception) => {
+                    diagnostics.Add(new OfficeWorkflowDiagnostic(
+                        "ProvenanceBackupCleanupFailed",
+                        "The cleaned artifact was published, but the displaced original could not be deleted and remains available for operator cleanup.",
+                        OfficeWorkflowDiagnosticSeverity.Warning,
+                        "cleanup",
+                        new Dictionary<string, string>(StringComparer.Ordinal) {
+                            ["retainedPath"] = path,
+                            ["exceptionType"] = exception.GetType().Name
+                        }));
                 });
             TryDisposeSnapshot(ref inputSnapshot, diagnostics);
             long outputBytes = stagedFingerprint.Length;
@@ -621,7 +632,8 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
         long maximumBytes,
         CancellationToken cancellationToken,
         Action beforePublish,
-        Action<string> beforeCommitFinalized) {
+        Action<string> beforeCommitFinalized,
+        Action<string, Exception> backupCleanupFailed) {
         bool published = false;
         try {
             beforePublish();
@@ -742,7 +754,8 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                     requestedPath,
                     backupPath => expectedDisplacedInput.MatchesCapturedSource(backupPath, cancellationToken),
                     installedPath => staged.TryPinPublishedPath(installedPath, maximumBytes, cancellationToken),
-                    beforeCommitFinalized);
+                    beforeCommitFinalized,
+                    backupCleanupFailed);
                 if (!inputCommitted) {
                     staged.ReleasePublishedLease();
                     throw new IOException(
@@ -762,7 +775,8 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                 requestedPath,
                 backupPath => destination.MatchesPath(backupPath, maximumBytes, cancellationToken),
                 installedPath => staged.TryPinPublishedPath(installedPath, maximumBytes, cancellationToken),
-                beforeCommitFinalized);
+                beforeCommitFinalized,
+                backupCleanupFailed);
             if (!committed) {
                 staged.ReleasePublishedLease();
                 throw new IOException("The provenance destination changed while the verified artifact was being published.");

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
@@ -33,6 +33,7 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
         var diagnostics = new List<OfficeWorkflowDiagnostic>();
         ValidatedProvenanceRequest? validated = null;
         string? stagingPath = null;
+        OfficeProvenanceFileSnapshot? inputSnapshot = null;
         long inputBytes = 0;
         WorkflowFailureStage failureStage = WorkflowFailureStage.Validation;
 
@@ -44,17 +45,33 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
             failureStage = WorkflowFailureStage.Input;
             inputBytes = new FileInfo(validated.InputPath).Length;
             EnforceInputLimit(validated.InputPath, inputBytes, validated.Limits);
+            string operationInputPath = validated.InputPath;
+            if (validated.Operation is OfficeProvenanceWorkflowOperation.Assess or OfficeProvenanceWorkflowOperation.Remove) {
+                inputSnapshot = OfficeProvenanceFileSnapshot.Capture(
+                    validated.InputPath,
+                    validated.Limits.MaximumInputBytes,
+                    cancellationToken);
+                operationInputPath = inputSnapshot.FilePath;
+                inputBytes = inputSnapshot.Length;
+                diagnostics.Add(new OfficeWorkflowDiagnostic(
+                    validated.Operation == OfficeProvenanceWorkflowOperation.Assess
+                        ? "AssessmentSnapshot"
+                        : "RemovalSnapshot",
+                    validated.Operation == OfficeProvenanceWorkflowOperation.Assess
+                        ? "Structural, text-integrity, verification, and provider evidence were collected from one bounded immutable input snapshot."
+                        : "Removal preflight and mutation used one bounded immutable input snapshot.",
+                    stage: "validate"));
+            }
 
             Report(progress, validated.Id, "inspect", "Inspecting through " + ownerPackage, 0.2D);
             failureStage = WorkflowFailureStage.Operation;
             OfficeProvenanceOptions inspectionOptions = validated.Operation switch {
                 OfficeProvenanceWorkflowOperation.Assess => validated.Assessment.Structural,
-                OfficeProvenanceWorkflowOperation.Remove => CreateInspectionOptions(
-                    validated.Removal, validated.Limits.MaximumInputBytes),
+                OfficeProvenanceWorkflowOperation.Remove => validated.RemovalInputInspection,
                 _ => validated.Inspection
             };
             OfficeProvenanceReport structural = await Task.Run(
-                () => OfficeProvenanceWorkflowAdapter.Inspect(validated.Owner, validated.InputPath, inspectionOptions),
+                () => OfficeProvenanceWorkflowAdapter.Inspect(validated.Owner, operationInputPath, inspectionOptions),
                 cancellationToken).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
             ProvenanceOwner refinedOwner = Refine(validated.Owner, structural.Format);
@@ -76,7 +93,7 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                 Report(progress, validated.Id, "assess", "Collecting optional verification and signal evidence", 0.55D);
                 OfficeProvenanceAssessmentReport assessment = await Task.Run(
                     () => OfficeProvenanceAssessment.AssessFile(
-                        validated.InputPath,
+                        operationInputPath,
                         structural,
                         validated.Assessment,
                         _provenanceVerifier,
@@ -84,6 +101,8 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                         cancellationToken),
                     cancellationToken).ConfigureAwait(false);
                 cancellationToken.ThrowIfCancellationRequested();
+                inputSnapshot!.Dispose();
+                inputSnapshot = null;
                 Report(progress, validated.Id, "complete", "Provenance assessment is ready", 1D);
                 return CreateProvenanceResult(
                     validated, OfficeWorkflowStatus.Completed, OfficeWorkflowFailureKind.None,
@@ -106,9 +125,11 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
             Report(progress, validated.Id, "remove", "Removing selected carriers through " + ownerPackage, 0.48D);
             failureStage = WorkflowFailureStage.Operation;
             OfficeProvenanceRemovalResult removal = await Task.Run(
-                () => OfficeProvenanceWorkflowAdapter.Remove(refinedOwner, validated.InputPath, stagingPath, validated.Removal),
+                () => OfficeProvenanceWorkflowAdapter.Remove(refinedOwner, operationInputPath, stagingPath, validated.Removal),
                 cancellationToken).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
+            inputSnapshot!.Dispose();
+            inputSnapshot = null;
 
             failureStage = WorkflowFailureStage.Output;
             long stagedBytes = new FileInfo(stagingPath).Length;
@@ -122,7 +143,7 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                 () => OfficeProvenanceWorkflowAdapter.Inspect(
                     refinedOwner,
                     stagingPath,
-                    CreateInspectionOptions(validated.Removal, validated.Limits.MaximumOutputBytes)),
+                    validated.RemovalOutputInspection),
                 cancellationToken).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
             EnsureEquivalent(removal.After, reopened);
@@ -157,6 +178,7 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                 wasReserialized: removal.WasReserialized,
                 wereInvalidatedSignaturesRemoved: removal.WereInvalidatedSignaturesRemoved);
         } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+            TryDisposeSnapshot(ref inputSnapshot, diagnostics);
             diagnostics.Add(new OfficeWorkflowDiagnostic(
                 "Cancelled",
                 "The provenance workflow was cancelled before publication; no staged artifact was retained.",
@@ -175,6 +197,7 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                 "Cancelled",
                 diagnostics);
         } catch (Exception exception) when (exception is not OutOfMemoryException and not StackOverflowException) {
+            TryDisposeSnapshot(ref inputSnapshot, diagnostics);
             diagnostics.Add(new OfficeWorkflowDiagnostic(
                 "ProvenanceWorkflowFailed",
                 exception.Message,
@@ -196,102 +219,32 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                 "Provenance workflow failed: " + exception.Message,
                 diagnostics);
         } finally {
-            if (stagingPath is not null) TryDelete(stagingPath);
-        }
-    }
-
-    /// <summary>Runs a bounded batch sequentially so providers and parsers share one predictable resource envelope.</summary>
-    public async Task<IReadOnlyList<OfficeProvenanceWorkflowResult>> RunProvenanceBatchAsync(
-        IEnumerable<OfficeProvenanceWorkflowRequest> requests,
-        OfficeProvenanceWorkflowBatchOptions? options = null,
-        IProgress<OfficeWorkflowProgress>? progress = null,
-        CancellationToken cancellationToken = default) {
-        ArgumentNullException.ThrowIfNull(requests);
-        OfficeProvenanceWorkflowBatchOptions validatedOptions = (options ?? new OfficeProvenanceWorkflowBatchOptions()).CloneAndValidate();
-        OfficeProvenanceWorkflowRequest[] materialized = requests.Take(validatedOptions.MaximumRequests + 1).ToArray();
-        if (materialized.Length > validatedOptions.MaximumRequests) {
-            throw new ArgumentException(
-                $"The provenance batch exceeds the configured limit of {validatedOptions.MaximumRequests:N0} requests.",
-                nameof(requests));
-        }
-        EnsureSafeBatchRemovalPaths(materialized);
-        if (materialized.Length == 0) cancellationToken.ThrowIfCancellationRequested();
-
-        var results = new List<OfficeProvenanceWorkflowResult>(materialized.Length);
-        for (int index = 0; index < materialized.Length; index++) {
-            int batchIndex = index;
-            var batchProgress = progress is null
-                ? null
-                : new InlineProgress<OfficeWorkflowProgress>(item => progress.Report(new OfficeWorkflowProgress(
-                    item.RequestId,
-                    item.Stage,
-                    $"{batchIndex + 1} of {materialized.Length} · {item.Message}",
-                    item.Fraction,
-                    (batchIndex + item.Fraction) / Math.Max(1, materialized.Length))));
-            OfficeProvenanceWorkflowResult result = await RunProvenanceAsync(
-                materialized[index], batchProgress, cancellationToken).ConfigureAwait(false);
-            results.Add(result);
-            if (result.Status == OfficeWorkflowStatus.Cancelled) break;
-            if (!validatedOptions.ContinueOnFailure && !result.Succeeded) break;
-        }
-        return results;
-    }
-
-    private static void EnsureSafeBatchRemovalPaths(IReadOnlyList<OfficeProvenanceWorkflowRequest> requests) {
-        var inputIdentities = new string?[requests.Count];
-        for (int index = 0; index < requests.Count; index++) {
-            OfficeProvenanceWorkflowRequest request = requests[index] ??
-                throw new ArgumentException("Provenance batches cannot contain null requests.", nameof(requests));
-            inputIdentities[index] = TryNormalizeBatchPath(request.InputPath);
-        }
-
-        var outputIdentities = new HashSet<string>(StringComparer.Ordinal);
-        for (int requestIndex = 0; requestIndex < requests.Count; requestIndex++) {
-            OfficeProvenanceWorkflowRequest request = requests[requestIndex];
-            if (request.Operation != OfficeProvenanceWorkflowOperation.Remove) continue;
-
-            string? outputPath = TryResolveBatchRemovalOutput(request);
-            if (outputPath is null) continue;
-            string? identity = TryNormalizeBatchPath(outputPath);
-            if (identity is null) continue;
-            if (!outputIdentities.Add(identity)) {
-                throw new ArgumentException(
-                    $"Multiple provenance removal requests resolve to the same output path '{outputPath}'.",
-                    nameof(requests));
-            }
-
-            for (int inputIndex = 0; inputIndex < inputIdentities.Length; inputIndex++) {
-                if (inputIndex == requestIndex || inputIdentities[inputIndex] is null) continue;
-                if (string.Equals(identity, inputIdentities[inputIndex], StringComparison.Ordinal)) {
-                    throw new ArgumentException(
-                        $"Provenance removal output '{outputPath}' overlaps another batch request's input path.",
-                        nameof(requests));
-                }
+            try {
+                inputSnapshot?.Dispose();
+            } catch (Exception) when (inputSnapshot is not null) {
+                // Catch paths already record cleanup failures. Never let one skip staged-output cleanup.
+            } finally {
+                if (stagingPath is not null) TryDelete(stagingPath);
             }
         }
     }
 
-    private static string? TryNormalizeBatchPath(string? path) {
+    private static void TryDisposeSnapshot(
+        ref OfficeProvenanceFileSnapshot? snapshot,
+        ICollection<OfficeWorkflowDiagnostic> diagnostics) {
+        if (snapshot is null) return;
         try {
-            return string.IsNullOrWhiteSpace(path) ? null : OfficeWorkflowPathIdentity.Normalize(path);
-        } catch (Exception exception) when (exception is ArgumentException or NotSupportedException or IOException or UnauthorizedAccessException) {
-            // Defer path-access diagnostics to the item runner so batch failure behavior stays structured.
-            return null;
-        }
-    }
-
-    private static string? TryResolveBatchRemovalOutput(OfficeProvenanceWorkflowRequest request) {
-        try {
-            if (string.IsNullOrWhiteSpace(request.InputPath)) return null;
-            string inputPath = Path.GetFullPath(request.InputPath);
-            return string.IsNullOrWhiteSpace(request.OutputPath)
-                ? Path.Combine(
-                    Path.GetDirectoryName(inputPath)!,
-                    Path.GetFileNameWithoutExtension(inputPath) + ".provenance-cleaned" + Path.GetExtension(inputPath))
-                : Path.GetFullPath(request.OutputPath);
-        } catch (Exception exception) when (exception is ArgumentException or NotSupportedException or IOException or UnauthorizedAccessException) {
-            // RunProvenanceAsync owns request validation and converts invalid paths into per-item results.
-            return null;
+            snapshot.Dispose();
+            snapshot = null;
+        } catch (Exception exception) when (exception is IOException or UnauthorizedAccessException) {
+            diagnostics.Add(new OfficeWorkflowDiagnostic(
+                "ProvenanceSnapshotCleanupFailed",
+                exception.Message,
+                OfficeWorkflowDiagnosticSeverity.Error,
+                "cleanup",
+                new Dictionary<string, string>(StringComparer.Ordinal) {
+                    ["exceptionType"] = exception.GetType().Name
+                }));
         }
     }
 
@@ -313,9 +266,18 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
         OfficeProvenanceAssessmentOptions assessment = CloneAssessmentOptions(
             request.Assessment ?? throw new ArgumentException("Assessment options cannot be null.", nameof(request)),
             limits);
+        OfficeProvenanceRemovalOptions removalSource = request.Removal ??
+            throw new ArgumentException("Removal options cannot be null.", nameof(request));
         OfficeProvenanceRemovalOptions removal = CloneRemovalOptions(
-            request.Removal ?? throw new ArgumentException("Removal options cannot be null.", nameof(request)),
-            limits);
+            removalSource,
+            limits.MaximumInputBytes,
+            limits.MaximumOutputBytes);
+        OfficeProvenanceOptions removalInputInspection = CreateInspectionOptions(
+            removalSource,
+            limits.MaximumInputBytes);
+        OfficeProvenanceOptions removalOutputInspection = CreateInspectionOptions(
+            removalSource,
+            limits.MaximumOutputBytes);
         string? outputPath = string.IsNullOrWhiteSpace(request.OutputPath) ? null : Path.GetFullPath(request.OutputPath);
 
         if (request.Operation == OfficeProvenanceWorkflowOperation.Remove) {
@@ -339,7 +301,9 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
             limits,
             inspection,
             assessment,
-            removal);
+            removal,
+            removalInputInspection,
+            removalOutputInspection);
     }
 
     private static OfficeProvenanceOptions CloneInspectionOptions(OfficeProvenanceOptions source, OfficeWorkflowLimits limits) => new() {
@@ -377,7 +341,8 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
 
     private static OfficeProvenanceRemovalOptions CloneRemovalOptions(
         OfficeProvenanceRemovalOptions source,
-        OfficeWorkflowLimits limits) {
+        long maximumInputBytes,
+        long maximumOutputBytes) {
         var clone = new OfficeProvenanceRemovalOptions {
             RemoveC2paManifests = source.RemoveC2paManifests,
             RemoveExternalC2paReferences = source.RemoveExternalC2paReferences,
@@ -385,9 +350,10 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
             RequireStructurallyValidCarrier = source.RequireStructurallyValidCarrier,
             SignatureMutationPolicy = source.SignatureMutationPolicy,
             ProcessEmbeddedAssets = source.ProcessEmbeddedAssets,
-            MaxEmbeddedAssets = source.MaxEmbeddedAssets
+            MaxEmbeddedAssets = source.MaxEmbeddedAssets,
+            MaxOutputBytes = Math.Min(source.EffectiveMaxOutputBytes, maximumOutputBytes)
         };
-        CopyInspectionOptions(source.Limits, clone.Limits, limits.MaximumInputBytes);
+        CopyInspectionOptions(source.Limits, clone.Limits, maximumInputBytes);
         return clone;
     }
 
@@ -486,5 +452,7 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
         OfficeWorkflowLimits Limits,
         OfficeProvenanceOptions Inspection,
         OfficeProvenanceAssessmentOptions Assessment,
-        OfficeProvenanceRemovalOptions Removal);
+        OfficeProvenanceRemovalOptions Removal,
+        OfficeProvenanceOptions RemovalInputInspection,
+        OfficeProvenanceOptions RemovalOutputInspection);
 }

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
@@ -180,7 +180,7 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                 stagingPath,
                 validated.Limits.MaximumOutputBytes,
                 removal.DataLength,
-                removal.ComputeDataSha256(),
+                removal.ComputeDataSha256(cancellationToken),
                 cancellationToken);
             OfficeProvenanceReport reopened = await Task.Run(
                 () => OfficeProvenanceWorkflowAdapter.Inspect(

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
@@ -267,8 +267,7 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                     Report(progress, validated.Id, "finalize", "Finalizing the verified provenance artifact", 0.98D);
                     stagedFingerprint.VerifyPublishedPath(path, validated.Limits.MaximumOutputBytes, cancellationToken);
                 });
-            inputSnapshot.Dispose();
-            inputSnapshot = null;
+            TryDisposeSnapshot(ref inputSnapshot, diagnostics);
             long outputBytes = stagedFingerprint.Length;
             diagnostics.Add(new OfficeWorkflowDiagnostic(
                 "AtomicPublication",

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
@@ -359,15 +359,22 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
         }
     }
 
-    private sealed class StagedArtifactFingerprint : IDisposable {
-        private readonly string _physicalIdentity;
+    internal sealed class StagedArtifactFingerprint : IDisposable {
+        private readonly string? _physicalIdentity;
+        private readonly bool _usesPhysicalIdentity;
         private FileStream? _lease;
         private FileStream? _publishedLease;
 
-        private StagedArtifactFingerprint(long length, byte[] sha256, string physicalIdentity, FileStream lease) {
+        private StagedArtifactFingerprint(
+            long length,
+            byte[] sha256,
+            string? physicalIdentity,
+            bool usesPhysicalIdentity,
+            FileStream lease) {
             Length = length;
             Sha256 = sha256;
             _physicalIdentity = physicalIdentity;
+            _usesPhysicalIdentity = usesPhysicalIdentity;
             _lease = lease;
         }
 
@@ -384,7 +391,21 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                 expectedLength: null,
                 expectedSha256: null,
                 cancellationToken,
-                artifactDescription);
+                artifactDescription,
+                OfficeWorkflowPathIdentity.SupportsPhysicalIdentity);
+
+        /// <summary>Exercises the portable length-and-hash fingerprint path when filesystem identity is unavailable.</summary>
+        internal static StagedArtifactFingerprint CapturePortable(
+            string path,
+            long maximumBytes,
+            CancellationToken cancellationToken = default) => CaptureCore(
+                path,
+                maximumBytes,
+                expectedLength: null,
+                expectedSha256: null,
+                cancellationToken,
+                "staged provenance artifact",
+                usesPhysicalIdentity: false);
 
         internal static StagedArtifactFingerprint CaptureExpected(
             string path,
@@ -397,7 +418,8 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                 expectedLength,
                 expectedSha256 ?? throw new ArgumentNullException(nameof(expectedSha256)),
                 cancellationToken,
-                "staged provenance artifact");
+                "staged provenance artifact",
+                OfficeWorkflowPathIdentity.SupportsPhysicalIdentity);
 
         private static StagedArtifactFingerprint CaptureCore(
             string path,
@@ -405,7 +427,8 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
             long? expectedLength,
             byte[]? expectedSha256,
             CancellationToken cancellationToken,
-            string artifactDescription) {
+            string artifactDescription,
+            bool usesPhysicalIdentity) {
             var stream = OpenForIdentity(path);
             try {
                 if (stream.Length > maximumBytes) {
@@ -420,8 +443,10 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                         "The staged provenance artifact did not match the bytes returned by its format owner.");
                 }
                 stream.Position = 0;
-                string physicalIdentity = OfficeWorkflowPathIdentity.GetPhysicalIdentityKey(path, stream);
-                return new StagedArtifactFingerprint(stream.Length, sha256, physicalIdentity, stream);
+                string? physicalIdentity = usesPhysicalIdentity
+                    ? OfficeWorkflowPathIdentity.GetPhysicalIdentityKey(path, stream)
+                    : null;
+                return new StagedArtifactFingerprint(stream.Length, sha256, physicalIdentity, usesPhysicalIdentity, stream);
             } catch {
                 stream.Dispose();
                 throw;
@@ -522,8 +547,10 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
             long maximumBytes,
             CancellationToken cancellationToken) {
             if (stream.Length > maximumBytes || stream.Length != Length) return false;
-            string physicalIdentity = OfficeWorkflowPathIdentity.GetPhysicalIdentityKey(path, stream);
-            if (!string.Equals(physicalIdentity, _physicalIdentity, StringComparison.Ordinal)) return false;
+            if (_usesPhysicalIdentity) {
+                string physicalIdentity = OfficeWorkflowPathIdentity.GetPhysicalIdentityKey(path, stream);
+                if (!string.Equals(physicalIdentity, _physicalIdentity, StringComparison.Ordinal)) return false;
+            }
             byte[] currentHash = ComputeHash(stream, cancellationToken);
             return CryptographicOperations.FixedTimeEquals(currentHash, Sha256);
         }

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
@@ -80,7 +80,8 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                     validated.Owner,
                     operationInputPath,
                     inspectionOptions,
-                    validated.InputPath),
+                    validated.InputPath,
+                    cancellationToken),
                 cancellationToken).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
             ProvenanceOwner refinedOwner = Refine(validated.Owner, structural.Format);
@@ -93,7 +94,8 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                         refinedOwner,
                         operationInputPath,
                         inspectionOptions,
-                        validated.InputPath),
+                        validated.InputPath,
+                        cancellationToken),
                     cancellationToken).ConfigureAwait(false);
                 cancellationToken.ThrowIfCancellationRequested();
             }
@@ -159,7 +161,7 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
             Report(progress, validated.Id, "remove", "Removing selected carriers through " + ownerPackage, 0.48D);
             failureStage = WorkflowFailureStage.Operation;
             OfficeProvenanceRemovalResult removal = await Task.Run(
-                () => OfficeProvenanceWorkflowAdapter.Remove(refinedOwner, operationInputPath, stagingPath, validated.Removal),
+                () => OfficeProvenanceWorkflowAdapter.Remove(refinedOwner, operationInputPath, stagingPath, validated.Removal, cancellationToken),
                 cancellationToken).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
             inputSnapshot!.VerifyPrimaryFile(cancellationToken);
@@ -185,7 +187,8 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                     refinedOwner,
                     stagingPath,
                     validated.RemovalOutputInspection,
-                    validated.OutputPath),
+                    validated.OutputPath,
+                    cancellationToken),
                 cancellationToken).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
             EnsureEquivalent(removal.After, reopened);
@@ -242,9 +245,12 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                 wereInvalidatedSignaturesRemoved: removal.WereInvalidatedSignaturesRemoved);
         } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
             TryDisposeSnapshot(ref inputSnapshot, diagnostics);
+            bool stagingCleaned = TryCleanupStaging(ref stagingPath, diagnostics);
             diagnostics.Add(new OfficeWorkflowDiagnostic(
                 "Cancelled",
-                "The provenance workflow was cancelled before publication; no staged artifact was retained.",
+                stagingCleaned
+                    ? "The provenance workflow was cancelled before publication; no staged artifact was retained."
+                    : "The provenance workflow was cancelled before publication, but staging cleanup failed; the retained path is reported in diagnostics.",
                 OfficeWorkflowDiagnosticSeverity.Information,
                 "cancel"));
             return new OfficeProvenanceWorkflowResult(
@@ -261,6 +267,7 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                 diagnostics);
         } catch (Exception exception) when (exception is not OutOfMemoryException and not StackOverflowException) {
             TryDisposeSnapshot(ref inputSnapshot, diagnostics);
+            TryCleanupStaging(ref stagingPath, diagnostics);
             diagnostics.Add(new OfficeWorkflowDiagnostic(
                 "ProvenanceWorkflowFailed",
                 exception.Message,
@@ -308,6 +315,30 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                 new Dictionary<string, string>(StringComparer.Ordinal) {
                     ["exceptionType"] = exception.GetType().Name
                 }));
+        }
+    }
+
+    private static bool TryCleanupStaging(
+        ref string? stagingPath,
+        ICollection<OfficeWorkflowDiagnostic> diagnostics) {
+        if (stagingPath is null) return true;
+        string retainedPath = stagingPath;
+        try {
+            File.Delete(retainedPath);
+            stagingPath = null;
+            return true;
+        } catch (Exception exception) when (exception is IOException or UnauthorizedAccessException) {
+            stagingPath = null;
+            diagnostics.Add(new OfficeWorkflowDiagnostic(
+                "ProvenanceStagingCleanupFailed",
+                $"The staged provenance artifact could not be removed; '{retainedPath}' is retained for operator cleanup.",
+                OfficeWorkflowDiagnosticSeverity.Error,
+                "cleanup",
+                new Dictionary<string, string>(StringComparer.Ordinal) {
+                    ["retainedPath"] = retainedPath,
+                    ["exceptionType"] = exception.GetType().Name
+                }));
+            return false;
         }
     }
 

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
@@ -80,6 +80,12 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
             if (structural.Format == OfficeProvenanceAssetFormat.Unknown) {
                 throw new NotSupportedException("The input is not a supported provenance asset.");
             }
+            if (refinedOwner != validated.Owner) {
+                structural = await Task.Run(
+                    () => OfficeProvenanceWorkflowAdapter.Inspect(refinedOwner, operationInputPath, inspectionOptions),
+                    cancellationToken).ConfigureAwait(false);
+                cancellationToken.ThrowIfCancellationRequested();
+            }
             validated = validated with { Owner = refinedOwner };
             ownerPackage = GetPackage(refinedOwner);
 

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
@@ -93,11 +93,15 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
 
             if (validated.Operation == OfficeProvenanceWorkflowOperation.Assess) {
                 Report(progress, validated.Id, "assess", "Collecting optional verification and signal evidence", 0.55D);
-                inputSnapshot!.CaptureExternalManifestDependencies(
-                    validated.InputPath,
-                    structural,
-                    validated.Assessment.Structural.MaxManifestBytes,
-                    cancellationToken);
+                bool hasExternalProviders = _provenanceVerifier != null || _provenanceSignalDetectors.Count != 0;
+                if (hasExternalProviders) {
+                    inputSnapshot!.CaptureExternalManifestDependencies(
+                        validated.InputPath,
+                        structural,
+                        validated.Assessment.Structural.MaxManifestBytes,
+                        validated.Assessment.Structural.MaxExpandedContainerBytes,
+                        cancellationToken);
+                }
                 OfficeProvenanceAssessmentReport assessment = await Task.Run(
                     () => OfficeProvenanceAssessment.AssessSnapshotFile(
                         operationInputPath,
@@ -109,7 +113,7 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                         cancellationToken),
                     cancellationToken).ConfigureAwait(false);
                 cancellationToken.ThrowIfCancellationRequested();
-                inputSnapshot!.VerifyExternalManifestDependencies(cancellationToken);
+                if (hasExternalProviders) inputSnapshot!.VerifyExternalManifestDependencies(cancellationToken);
                 inputSnapshot!.Dispose();
                 inputSnapshot = null;
                 Report(progress, validated.Id, "complete", "Provenance assessment is ready", 1D);
@@ -148,6 +152,10 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
             }
 
             Report(progress, validated.Id, "validate-output", "Reopening the staged artifact through " + ownerPackage, 0.72D);
+            using StagedArtifactFingerprint stagedFingerprint = StagedArtifactFingerprint.Capture(
+                stagingPath,
+                validated.Limits.MaximumOutputBytes,
+                cancellationToken);
             OfficeProvenanceReport reopened = await Task.Run(
                 () => OfficeProvenanceWorkflowAdapter.Inspect(
                     refinedOwner,
@@ -156,6 +164,10 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                 cancellationToken).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
             EnsureEquivalent(removal.After, reopened);
+            stagedFingerprint.VerifyStagingPath(
+                stagingPath,
+                validated.Limits.MaximumOutputBytes,
+                cancellationToken);
             diagnostics.Add(new OfficeWorkflowDiagnostic(
                 "ProvenanceOutputReopened",
                 "The staged artifact was reopened through its owning format API and matched the in-memory removal report.",
@@ -166,10 +178,6 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                     ["stagedBytes"] = stagedBytes.ToString(System.Globalization.CultureInfo.InvariantCulture)
             }));
             cancellationToken.ThrowIfCancellationRequested();
-            using StagedArtifactFingerprint stagedFingerprint = StagedArtifactFingerprint.Capture(
-                stagingPath,
-                validated.Limits.MaximumOutputBytes,
-                cancellationToken);
 
             failureStage = WorkflowFailureStage.Output;
             string ownedStagingPath = stagingPath;
@@ -294,12 +302,13 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
         internal static StagedArtifactFingerprint Capture(
             string path,
             long maximumBytes,
-            CancellationToken cancellationToken) {
+            CancellationToken cancellationToken,
+            string artifactDescription = "staged provenance artifact") {
             var stream = OpenForIdentity(path);
             try {
                 if (stream.Length > maximumBytes) {
                     throw OfficeProvenanceLimitException.CreateOutput(
-                        $"The staged provenance artifact exceeds the configured output limit of {maximumBytes} bytes.");
+                        $"The {artifactDescription} exceeds the configured output limit of {maximumBytes} bytes.");
                 }
                 byte[] sha256 = ComputeHash(stream, cancellationToken);
                 stream.Position = 0;
@@ -521,13 +530,14 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
 
             using StagedArtifactFingerprint destination = StagedArtifactFingerprint.Capture(
                 requestedPath,
-                long.MaxValue,
-                cancellationToken);
+                maximumBytes,
+                cancellationToken,
+                "existing provenance destination");
             destination.ReleaseStagingLease();
             bool committed = OfficeFileCommit.TryCommitTemporaryFileAtomicallyIfDestinationUnchangedAndFinalize(
                 stagingPath,
                 requestedPath,
-                backupPath => destination.MatchesPath(backupPath, long.MaxValue, cancellationToken),
+                backupPath => destination.MatchesPath(backupPath, maximumBytes, cancellationToken),
                 installedPath => staged.TryPinPublishedPath(installedPath, maximumBytes, cancellationToken),
                 beforeCommitFinalized);
             if (!committed) {

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
@@ -113,6 +113,7 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                         cancellationToken),
                     cancellationToken).ConfigureAwait(false);
                 cancellationToken.ThrowIfCancellationRequested();
+                inputSnapshot!.VerifyPrimaryFile(cancellationToken);
                 if (hasExternalProviders) inputSnapshot!.VerifyExternalManifestDependencies(cancellationToken);
                 inputSnapshot!.Dispose();
                 inputSnapshot = null;
@@ -141,6 +142,7 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                 () => OfficeProvenanceWorkflowAdapter.Remove(refinedOwner, operationInputPath, stagingPath, validated.Removal),
                 cancellationToken).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
+            inputSnapshot!.VerifyPrimaryFile(cancellationToken);
             inputSnapshot!.Dispose();
             inputSnapshot = null;
 

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
@@ -1,4 +1,6 @@
 using System.Diagnostics;
+using System.Security.Cryptography;
+using OfficeIMO.Core.Internal;
 using OfficeIMO.Provenance;
 using static OfficeIMO.Workflows.OfficeProvenanceWorkflowAdapter;
 
@@ -91,9 +93,15 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
 
             if (validated.Operation == OfficeProvenanceWorkflowOperation.Assess) {
                 Report(progress, validated.Id, "assess", "Collecting optional verification and signal evidence", 0.55D);
+                inputSnapshot!.CaptureExternalManifestDependencies(
+                    validated.InputPath,
+                    structural,
+                    validated.Assessment.Structural.MaxManifestBytes,
+                    cancellationToken);
                 OfficeProvenanceAssessmentReport assessment = await Task.Run(
-                    () => OfficeProvenanceAssessment.AssessFile(
+                    () => OfficeProvenanceAssessment.AssessSnapshotFile(
                         operationInputPath,
+                        validated.InputPath,
                         structural,
                         validated.Assessment,
                         _provenanceVerifier,
@@ -101,6 +109,7 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                         cancellationToken),
                     cancellationToken).ConfigureAwait(false);
                 cancellationToken.ThrowIfCancellationRequested();
+                inputSnapshot!.VerifyExternalManifestDependencies(cancellationToken);
                 inputSnapshot!.Dispose();
                 inputSnapshot = null;
                 Report(progress, validated.Id, "complete", "Provenance assessment is ready", 1D);
@@ -155,19 +164,38 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                     ["ownerPackage"] = ownerPackage,
                     ["remainingCarriers"] = reopened.Evidence.Count.ToString(System.Globalization.CultureInfo.InvariantCulture),
                     ["stagedBytes"] = stagedBytes.ToString(System.Globalization.CultureInfo.InvariantCulture)
-                }));
+            }));
             cancellationToken.ThrowIfCancellationRequested();
+            using StagedArtifactFingerprint stagedFingerprint = StagedArtifactFingerprint.Capture(
+                stagingPath,
+                validated.Limits.MaximumOutputBytes,
+                cancellationToken);
 
             failureStage = WorkflowFailureStage.Output;
-            Report(progress, validated.Id, "publish", "Publishing the verified provenance artifact", 0.9D);
-            string publishedPath = Publish(stagingPath, validated.OutputPath!, validated.ConflictPolicy, cancellationToken);
+            string ownedStagingPath = stagingPath;
             stagingPath = null;
-            long outputBytes = new FileInfo(publishedPath).Length;
+            string publishedPath = PublishVerified(
+                ownedStagingPath,
+                validated.OutputPath!,
+                validated.ConflictPolicy,
+                stagedFingerprint,
+                validated.Limits.MaximumOutputBytes,
+                cancellationToken,
+                beforePublish: () => Report(
+                    progress,
+                    validated.Id,
+                    "publish",
+                    "Publishing the verified provenance artifact",
+                    0.9D),
+                beforeCommitFinalized: path => {
+                    Report(progress, validated.Id, "complete", "Provenance removal completed", 1D);
+                    stagedFingerprint.VerifyPublishedPath(path, validated.Limits.MaximumOutputBytes, cancellationToken);
+                });
+            long outputBytes = stagedFingerprint.Length;
             diagnostics.Add(new OfficeWorkflowDiagnostic(
                 "AtomicPublication",
-                "The verified artifact was staged in the destination directory and published with one filesystem move.",
+                "The verified artifact was staged in the destination directory, identity-pinned, and atomically published.",
                 stage: "publish"));
-            Report(progress, validated.Id, "complete", "Provenance removal completed", 1D);
             return CreateProvenanceResult(
                 validated, OfficeWorkflowStatus.Completed, OfficeWorkflowFailureKind.None,
                 ownerPackage, publishedPath, inputBytes, outputBytes, stopwatch.Elapsed,
@@ -245,6 +273,268 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                 new Dictionary<string, string>(StringComparer.Ordinal) {
                     ["exceptionType"] = exception.GetType().Name
                 }));
+        }
+    }
+
+    private sealed class StagedArtifactFingerprint : IDisposable {
+        private readonly string _physicalIdentity;
+        private FileStream? _lease;
+        private FileStream? _publishedLease;
+
+        private StagedArtifactFingerprint(long length, byte[] sha256, string physicalIdentity, FileStream lease) {
+            Length = length;
+            Sha256 = sha256;
+            _physicalIdentity = physicalIdentity;
+            _lease = lease;
+        }
+
+        internal long Length { get; }
+        private byte[] Sha256 { get; }
+
+        internal static StagedArtifactFingerprint Capture(
+            string path,
+            long maximumBytes,
+            CancellationToken cancellationToken) {
+            var stream = OpenForIdentity(path);
+            try {
+                if (stream.Length > maximumBytes) {
+                    throw OfficeProvenanceLimitException.CreateOutput(
+                        $"The staged provenance artifact exceeds the configured output limit of {maximumBytes} bytes.");
+                }
+                byte[] sha256 = ComputeHash(stream, cancellationToken);
+                stream.Position = 0;
+                string physicalIdentity = OfficeWorkflowPathIdentity.GetPhysicalIdentityKey(path, stream);
+                return new StagedArtifactFingerprint(stream.Length, sha256, physicalIdentity, stream);
+            } catch {
+                stream.Dispose();
+                throw;
+            }
+        }
+
+        internal void VerifyStagingPath(string path, long maximumBytes, CancellationToken cancellationToken) {
+            if (!MatchesPath(path, maximumBytes, cancellationToken)) {
+                throw new InvalidDataException(
+                    "The staged provenance artifact changed after output validation; publication was blocked.");
+            }
+        }
+
+        internal bool TryPinPublishedPath(string path, long maximumBytes, CancellationToken cancellationToken) {
+            FileStream stream = OpenForIdentity(path);
+            try {
+                if (!MatchesStream(path, stream, maximumBytes, cancellationToken)) return false;
+                _publishedLease?.Dispose();
+                _publishedLease = stream;
+                return true;
+            } catch {
+                stream.Dispose();
+                throw;
+            } finally {
+                if (!ReferenceEquals(_publishedLease, stream)) stream.Dispose();
+            }
+        }
+
+        internal void VerifyPublishedPath(string path, long maximumBytes, CancellationToken cancellationToken) {
+            if (_publishedLease is null || !MatchesPath(path, maximumBytes, cancellationToken)) {
+                throw new InvalidDataException(
+                    "The published provenance artifact changed before publication was finalized.");
+            }
+        }
+
+        internal void ReleasePublishedLease() {
+            _publishedLease?.Dispose();
+            _publishedLease = null;
+        }
+
+        internal void ReleaseStagingLease() {
+            _lease?.Dispose();
+            _lease = null;
+        }
+
+        internal void TryDeleteMatchingPath(string path, long maximumBytes, CancellationToken cancellationToken) {
+            string quarantinePath = Path.Combine(
+                Path.GetDirectoryName(Path.GetFullPath(path))!,
+                ".officeimo-provenance-rollback-" + Guid.NewGuid().ToString("N") + ".tmp");
+            bool moved = false;
+            try {
+                File.Move(path, quarantinePath, overwrite: false);
+                moved = true;
+                bool matches;
+                using (FileStream stream = OpenForIdentity(quarantinePath)) {
+                    matches = MatchesStream(quarantinePath, stream, maximumBytes, cancellationToken);
+                }
+                if (matches) {
+                    File.Delete(quarantinePath);
+                    moved = false;
+                    return;
+                }
+
+                File.Move(quarantinePath, path, overwrite: false);
+                moved = false;
+            } catch (Exception exception) when (exception is FileNotFoundException or DirectoryNotFoundException or IOException or UnauthorizedAccessException) {
+                // Never delete a known destination pathname after a failed identity check. If a
+                // different writer claimed it, retain the random quarantine rather than losing data.
+            } finally {
+                if (moved && File.Exists(quarantinePath)) {
+                    try {
+                        if (!File.Exists(path)) {
+                            File.Move(quarantinePath, path, overwrite: false);
+                            moved = false;
+                        }
+                    } catch (Exception exception) when (exception is IOException or UnauthorizedAccessException) { }
+                }
+            }
+        }
+
+        public void Dispose() {
+            ReleasePublishedLease();
+            ReleaseStagingLease();
+        }
+
+        internal bool MatchesPath(string path, long maximumBytes, CancellationToken cancellationToken) {
+            try {
+                using FileStream stream = OpenForIdentity(path);
+                return MatchesStream(path, stream, maximumBytes, cancellationToken);
+            } catch (Exception exception) when (exception is FileNotFoundException or DirectoryNotFoundException) {
+                return false;
+            }
+        }
+
+        private bool MatchesStream(
+            string path,
+            FileStream stream,
+            long maximumBytes,
+            CancellationToken cancellationToken) {
+            if (stream.Length > maximumBytes || stream.Length != Length) return false;
+            string physicalIdentity = OfficeWorkflowPathIdentity.GetPhysicalIdentityKey(path, stream);
+            if (!string.Equals(physicalIdentity, _physicalIdentity, StringComparison.Ordinal)) return false;
+            byte[] currentHash = ComputeHash(stream, cancellationToken);
+            return CryptographicOperations.FixedTimeEquals(currentHash, Sha256);
+        }
+
+        private static FileStream OpenForIdentity(string path) => new(
+            path,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.ReadWrite | FileShare.Delete,
+            81920,
+            FileOptions.SequentialScan);
+
+        private static byte[] ComputeHash(Stream stream, CancellationToken cancellationToken) {
+            stream.Position = 0;
+            using IncrementalHash algorithm = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+            var buffer = new byte[81920];
+            int read;
+            while ((read = stream.Read(buffer, 0, buffer.Length)) != 0) {
+                cancellationToken.ThrowIfCancellationRequested();
+                algorithm.AppendData(buffer, 0, read);
+            }
+            return algorithm.GetHashAndReset();
+        }
+    }
+
+    private static string PublishVerified(
+        string stagingPath,
+        string requestedPath,
+        OfficeWorkflowConflictPolicy policy,
+        StagedArtifactFingerprint staged,
+        long maximumBytes,
+        CancellationToken cancellationToken,
+        Action beforePublish,
+        Action<string> beforeCommitFinalized) {
+        bool published = false;
+        try {
+            beforePublish();
+            cancellationToken.ThrowIfCancellationRequested();
+            staged.VerifyStagingPath(stagingPath, maximumBytes, cancellationToken);
+            staged.ReleaseStagingLease();
+
+            string publishedPath;
+            switch (policy) {
+                case OfficeWorkflowConflictPolicy.Fail:
+                    File.Move(stagingPath, requestedPath, overwrite: false);
+                    publishedPath = requestedPath;
+                    PinAndFinalize(publishedPath);
+                    break;
+                case OfficeWorkflowConflictPolicy.Rename:
+                    publishedPath = PublishRenamed();
+                    break;
+                case OfficeWorkflowConflictPolicy.Replace:
+                    publishedPath = PublishReplacement();
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(policy), policy, "Unsupported conflict policy.");
+            }
+
+            published = true;
+            return publishedPath;
+        } finally {
+            if (!published) {
+                staged.ReleasePublishedLease();
+                staged.TryDeleteMatchingPath(stagingPath, maximumBytes, CancellationToken.None);
+            }
+        }
+
+        void PinAndFinalize(string path) {
+            try {
+                if (!staged.TryPinPublishedPath(path, maximumBytes, cancellationToken)) {
+                    throw new InvalidDataException(
+                        "The staged provenance artifact changed while it was being published.");
+                }
+                beforeCommitFinalized(path);
+            } catch {
+                staged.ReleasePublishedLease();
+                staged.TryDeleteMatchingPath(path, maximumBytes, CancellationToken.None);
+                throw;
+            }
+        }
+
+        string PublishRenamed() {
+            for (int suffix = 0; suffix < 10_000; suffix++) {
+                cancellationToken.ThrowIfCancellationRequested();
+                string candidate = suffix == 0 ? requestedPath : AddSuffix(requestedPath, suffix);
+                try {
+                    File.Move(stagingPath, candidate, overwrite: false);
+                } catch (IOException) when (File.Exists(candidate) || Directory.Exists(candidate)) {
+                    // Another request owns this candidate. Try the next deterministic suffix.
+                    continue;
+                }
+                PinAndFinalize(candidate);
+                return candidate;
+            }
+            throw new IOException("No available numbered output path could be reserved.");
+        }
+
+        string PublishReplacement() {
+            if (!File.Exists(requestedPath)) {
+                bool destinationAppeared = false;
+                try {
+                    File.Move(stagingPath, requestedPath, overwrite: false);
+                } catch (IOException) when (File.Exists(requestedPath)) {
+                    // The destination appeared during the claim. Validate and replace it below.
+                    destinationAppeared = true;
+                }
+                if (!destinationAppeared) {
+                    PinAndFinalize(requestedPath);
+                    return requestedPath;
+                }
+            }
+
+            using StagedArtifactFingerprint destination = StagedArtifactFingerprint.Capture(
+                requestedPath,
+                long.MaxValue,
+                cancellationToken);
+            destination.ReleaseStagingLease();
+            bool committed = OfficeFileCommit.TryCommitTemporaryFileAtomicallyIfDestinationUnchangedAndFinalize(
+                stagingPath,
+                requestedPath,
+                backupPath => destination.MatchesPath(backupPath, long.MaxValue, cancellationToken),
+                installedPath => staged.TryPinPublishedPath(installedPath, maximumBytes, cancellationToken),
+                beforeCommitFinalized);
+            if (!committed) {
+                staged.ReleasePublishedLease();
+                throw new IOException("The provenance destination changed while the verified artifact was being published.");
+            }
+            return requestedPath;
         }
     }
 

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
@@ -47,23 +47,26 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
             failureStage = WorkflowFailureStage.Input;
             inputBytes = new FileInfo(validated.InputPath).Length;
             EnforceInputLimit(validated.InputPath, inputBytes, validated.Limits);
-            string operationInputPath = validated.InputPath;
-            if (validated.Operation is OfficeProvenanceWorkflowOperation.Assess or OfficeProvenanceWorkflowOperation.Remove) {
-                inputSnapshot = OfficeProvenanceFileSnapshot.Capture(
-                    validated.InputPath,
-                    validated.Limits.MaximumInputBytes,
-                    cancellationToken);
-                operationInputPath = inputSnapshot.FilePath;
-                inputBytes = inputSnapshot.Length;
-                diagnostics.Add(new OfficeWorkflowDiagnostic(
-                    validated.Operation == OfficeProvenanceWorkflowOperation.Assess
-                        ? "AssessmentSnapshot"
-                        : "RemovalSnapshot",
-                    validated.Operation == OfficeProvenanceWorkflowOperation.Assess
-                        ? "Structural, text-integrity, verification, and provider evidence were collected from one bounded immutable input snapshot."
-                        : "Removal preflight and mutation used one bounded immutable input snapshot.",
-                    stage: "validate"));
-            }
+            inputSnapshot = OfficeProvenanceFileSnapshot.Capture(
+                validated.InputPath,
+                validated.Limits.MaximumInputBytes,
+                cancellationToken);
+            string operationInputPath = inputSnapshot.FilePath;
+            inputBytes = inputSnapshot.Length;
+            diagnostics.Add(new OfficeWorkflowDiagnostic(
+                validated.Operation switch {
+                    OfficeProvenanceWorkflowOperation.Inspect => "InspectionSnapshot",
+                    OfficeProvenanceWorkflowOperation.Assess => "AssessmentSnapshot",
+                    _ => "RemovalSnapshot"
+                },
+                validated.Operation switch {
+                    OfficeProvenanceWorkflowOperation.Inspect =>
+                        "Structural provenance was inspected from one bounded immutable input snapshot.",
+                    OfficeProvenanceWorkflowOperation.Assess =>
+                        "Structural, text-integrity, verification, and provider evidence were collected from one bounded immutable input snapshot.",
+                    _ => "Removal preflight and mutation used one bounded immutable input snapshot."
+                },
+                stage: "validate"));
 
             Report(progress, validated.Id, "inspect", "Inspecting through " + ownerPackage, 0.2D);
             failureStage = WorkflowFailureStage.Operation;
@@ -90,6 +93,9 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
             ownerPackage = GetPackage(refinedOwner);
 
             if (validated.Operation == OfficeProvenanceWorkflowOperation.Inspect) {
+                inputSnapshot.VerifyPrimaryFile(cancellationToken);
+                inputSnapshot.Dispose();
+                inputSnapshot = null;
                 Report(progress, validated.Id, "complete", "Structural provenance report is ready", 1D);
                 return CreateProvenanceResult(
                     validated, OfficeWorkflowStatus.Completed, OfficeWorkflowFailureKind.None,

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
@@ -53,6 +53,7 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                 validated.InputPath,
                 operationInputLimit,
                 cancellationToken);
+            inputSnapshot.SealForProviderAccess();
             string operationInputPath = inputSnapshot.FilePath;
             inputBytes = inputSnapshot.Length;
             diagnostics.Add(new OfficeWorkflowDiagnostic(

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
@@ -41,6 +41,7 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
         WorkflowFailureStage failureStage = WorkflowFailureStage.Validation;
 
         try {
+            cancellationToken.ThrowIfCancellationRequested();
             validated = ValidateProvenanceRequest(request);
             string ownerPackage = GetPackage(validated.Owner);
             Report(progress, validated.Id, "validate", "Validating provenance input and limits", 0.05D);
@@ -244,7 +245,7 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                     "Publishing the verified provenance artifact",
                     0.9D),
                 beforeCommitFinalized: path => {
-                    Report(progress, validated.Id, "complete", "Provenance removal completed", 1D);
+                    Report(progress, validated.Id, "finalize", "Finalizing the verified provenance artifact", 0.98D);
                     stagedFingerprint.VerifyPublishedPath(path, validated.Limits.MaximumOutputBytes, cancellationToken);
                 });
             long outputBytes = stagedFingerprint.Length;
@@ -252,6 +253,7 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                 "AtomicPublication",
                 "The verified artifact was staged in the destination directory, identity-pinned, and atomically published.",
                 stage: "publish"));
+            Report(progress, validated.Id, "complete", "Provenance removal completed", 1D);
             return CreateProvenanceResult(
                 validated, OfficeWorkflowStatus.Completed, OfficeWorkflowFailureKind.None,
                 ownerPackage, publishedPath, inputBytes, outputBytes, stopwatch.Elapsed,
@@ -276,7 +278,7 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                 validated?.Operation ?? request.Operation,
                 OfficeWorkflowStatus.Cancelled,
                 OfficeWorkflowFailureKind.None,
-                GetPackage(validated?.Owner ?? ResolveByPath(request.InputPath)),
+                GetResultPackage(validated, request),
                 null,
                 inputBytes,
                 0,
@@ -299,7 +301,7 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                 validated?.Operation ?? request.Operation,
                 OfficeWorkflowStatus.Failed,
                 ClassifyFailure(exception, failureStage),
-                GetPackage(validated?.Owner ?? ResolveByPath(request.InputPath)),
+                GetResultPackage(validated, request),
                 null,
                 inputBytes,
                 0,
@@ -314,6 +316,17 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
             } finally {
                 if (stagingPath is not null) TryDelete(stagingPath);
             }
+        }
+    }
+
+    private static string GetResultPackage(
+        ValidatedProvenanceRequest? validated,
+        OfficeProvenanceWorkflowRequest request) {
+        if (validated is not null) return GetPackage(validated.Owner);
+        try {
+            return GetPackage(ResolveByPath(request.InputPath));
+        } catch (Exception exception) when (exception is ArgumentException or NotSupportedException) {
+            return "OfficeIMO.Core";
         }
     }
 

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
@@ -76,7 +76,11 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                 _ => validated.Inspection
             };
             OfficeProvenanceReport structural = await Task.Run(
-                () => OfficeProvenanceWorkflowAdapter.Inspect(validated.Owner, operationInputPath, inspectionOptions),
+                () => OfficeProvenanceWorkflowAdapter.Inspect(
+                    validated.Owner,
+                    operationInputPath,
+                    inspectionOptions,
+                    validated.InputPath),
                 cancellationToken).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
             ProvenanceOwner refinedOwner = Refine(validated.Owner, structural.Format);
@@ -85,7 +89,11 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
             }
             if (refinedOwner != validated.Owner) {
                 structural = await Task.Run(
-                    () => OfficeProvenanceWorkflowAdapter.Inspect(refinedOwner, operationInputPath, inspectionOptions),
+                    () => OfficeProvenanceWorkflowAdapter.Inspect(
+                        refinedOwner,
+                        operationInputPath,
+                        inspectionOptions,
+                        validated.InputPath),
                     cancellationToken).ConfigureAwait(false);
                 cancellationToken.ThrowIfCancellationRequested();
             }
@@ -166,15 +174,18 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
             }
 
             Report(progress, validated.Id, "validate-output", "Reopening the staged artifact through " + ownerPackage, 0.72D);
-            using StagedArtifactFingerprint stagedFingerprint = StagedArtifactFingerprint.Capture(
+            using StagedArtifactFingerprint stagedFingerprint = StagedArtifactFingerprint.CaptureExpected(
                 stagingPath,
                 validated.Limits.MaximumOutputBytes,
+                removal.DataLength,
+                removal.ComputeDataSha256(),
                 cancellationToken);
             OfficeProvenanceReport reopened = await Task.Run(
                 () => OfficeProvenanceWorkflowAdapter.Inspect(
                     refinedOwner,
                     stagingPath,
-                    validated.RemovalOutputInspection),
+                    validated.RemovalOutputInspection,
+                    validated.OutputPath),
                 cancellationToken).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
             EnsureEquivalent(removal.After, reopened);
@@ -319,7 +330,34 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
             string path,
             long maximumBytes,
             CancellationToken cancellationToken,
-            string artifactDescription = "staged provenance artifact") {
+            string artifactDescription = "staged provenance artifact") => CaptureCore(
+                path,
+                maximumBytes,
+                expectedLength: null,
+                expectedSha256: null,
+                cancellationToken,
+                artifactDescription);
+
+        internal static StagedArtifactFingerprint CaptureExpected(
+            string path,
+            long maximumBytes,
+            long expectedLength,
+            byte[] expectedSha256,
+            CancellationToken cancellationToken) => CaptureCore(
+                path,
+                maximumBytes,
+                expectedLength,
+                expectedSha256 ?? throw new ArgumentNullException(nameof(expectedSha256)),
+                cancellationToken,
+                "staged provenance artifact");
+
+        private static StagedArtifactFingerprint CaptureCore(
+            string path,
+            long maximumBytes,
+            long? expectedLength,
+            byte[]? expectedSha256,
+            CancellationToken cancellationToken,
+            string artifactDescription) {
             var stream = OpenForIdentity(path);
             try {
                 if (stream.Length > maximumBytes) {
@@ -327,6 +365,12 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                         $"The {artifactDescription} exceeds the configured output limit of {maximumBytes} bytes.");
                 }
                 byte[] sha256 = ComputeHash(stream, cancellationToken);
+                if (expectedLength.HasValue &&
+                    (stream.Length != expectedLength.Value ||
+                     !CryptographicOperations.FixedTimeEquals(sha256, expectedSha256!))) {
+                    throw new InvalidDataException(
+                        "The staged provenance artifact did not match the bytes returned by its format owner.");
+                }
                 stream.Position = 0;
                 string physicalIdentity = OfficeWorkflowPathIdentity.GetPhysicalIdentityKey(path, stream);
                 return new StagedArtifactFingerprint(stream.Length, sha256, physicalIdentity, stream);

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
@@ -607,9 +607,7 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
         OfficeProvenanceOptions removalInputInspection = CreateInspectionOptions(
             removalSource,
             limits.MaximumInputBytes);
-        OfficeProvenanceOptions removalOutputInspection = CreateInspectionOptions(
-            removalSource,
-            limits.MaximumOutputBytes);
+        OfficeProvenanceOptions removalOutputInspection = CreateOutputInspectionOptions(removal);
         string? outputPath = string.IsNullOrWhiteSpace(request.OutputPath) ? null : Path.GetFullPath(request.OutputPath);
 
         if (request.Operation == OfficeProvenanceWorkflowOperation.Remove) {
@@ -698,6 +696,16 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
         CopyInspectionOptions(removal.Limits, options, maximumAssetBytes);
         options.ProcessEmbeddedAssets = removal.ProcessEmbeddedAssets && removal.Limits.ProcessEmbeddedAssets;
         options.MaxEmbeddedAssets = Math.Min(removal.MaxEmbeddedAssets, removal.Limits.MaxEmbeddedAssets);
+        return options;
+    }
+
+    private static OfficeProvenanceOptions CreateOutputInspectionOptions(
+        OfficeProvenanceRemovalOptions removal) {
+        OfficeProvenanceOptions options = CreateInspectionOptions(
+            removal,
+            removal.EffectiveMaxOutputBytes);
+        options.MaxAssetBytes = removal.EffectiveMaxOutputBytes;
+        options.MaxManifestBytes = Math.Min(removal.Limits.MaxManifestBytes, options.MaxAssetBytes);
         return options;
     }
 

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
@@ -1,0 +1,468 @@
+using System.Diagnostics;
+using OfficeIMO.Provenance;
+using static OfficeIMO.Workflows.OfficeProvenanceWorkflowAdapter;
+
+namespace OfficeIMO.Workflows;
+
+/// <summary>Runs cross-format provenance workflows through the owning format packages.</summary>
+public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunner {
+    private readonly IOfficeProvenanceVerifier? _provenanceVerifier;
+    private readonly IReadOnlyList<IOfficeProvenanceSignalDetector> _provenanceSignalDetectors;
+
+    /// <summary>Creates a workflow runner without optional provenance providers.</summary>
+    public OfficeWorkflowRunner() : this(null, null) { }
+
+    /// <summary>Creates a workflow runner with optional cryptographic and provider-specific provenance services.</summary>
+    public OfficeWorkflowRunner(
+        IOfficeProvenanceVerifier? provenanceVerifier,
+        IEnumerable<IOfficeProvenanceSignalDetector>? provenanceSignalDetectors = null) {
+        _provenanceVerifier = provenanceVerifier;
+        _provenanceSignalDetectors = (provenanceSignalDetectors ?? Array.Empty<IOfficeProvenanceSignalDetector>())
+            .Select(detector => detector ?? throw new ArgumentException(
+                "Signal detector collections cannot contain null entries.", nameof(provenanceSignalDetectors)))
+            .ToArray();
+    }
+
+    /// <summary>Runs one provenance request with bounded input and atomic removal publication.</summary>
+    public async Task<OfficeProvenanceWorkflowResult> RunProvenanceAsync(
+        OfficeProvenanceWorkflowRequest request,
+        IProgress<OfficeWorkflowProgress>? progress = null,
+        CancellationToken cancellationToken = default) {
+        ArgumentNullException.ThrowIfNull(request);
+        var stopwatch = Stopwatch.StartNew();
+        var diagnostics = new List<OfficeWorkflowDiagnostic>();
+        ValidatedProvenanceRequest? validated = null;
+        string? stagingPath = null;
+        long inputBytes = 0;
+        WorkflowFailureStage failureStage = WorkflowFailureStage.Validation;
+
+        try {
+            validated = ValidateProvenanceRequest(request);
+            string ownerPackage = GetPackage(validated.Owner);
+            Report(progress, validated.Id, "validate", "Validating provenance input and limits", 0.05D);
+            cancellationToken.ThrowIfCancellationRequested();
+            failureStage = WorkflowFailureStage.Input;
+            inputBytes = new FileInfo(validated.InputPath).Length;
+            EnforceInputLimit(validated.InputPath, inputBytes, validated.Limits);
+
+            Report(progress, validated.Id, "inspect", "Inspecting through " + ownerPackage, 0.2D);
+            failureStage = WorkflowFailureStage.Operation;
+            OfficeProvenanceOptions inspectionOptions = validated.Operation == OfficeProvenanceWorkflowOperation.Assess
+                ? validated.Assessment.Structural
+                : validated.Inspection;
+            OfficeProvenanceReport structural = await Task.Run(
+                () => OfficeProvenanceWorkflowAdapter.Inspect(validated.Owner, validated.InputPath, inspectionOptions),
+                cancellationToken).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+            ProvenanceOwner refinedOwner = Refine(validated.Owner, structural.Format);
+            if (structural.Format == OfficeProvenanceAssetFormat.Unknown) {
+                throw new NotSupportedException("The input is not a supported provenance asset.");
+            }
+            validated = validated with { Owner = refinedOwner };
+            ownerPackage = GetPackage(refinedOwner);
+
+            if (validated.Operation == OfficeProvenanceWorkflowOperation.Inspect) {
+                Report(progress, validated.Id, "complete", "Structural provenance report is ready", 1D);
+                return CreateProvenanceResult(
+                    validated, OfficeWorkflowStatus.Completed, OfficeWorkflowFailureKind.None,
+                    ownerPackage, null, inputBytes, 0, stopwatch.Elapsed,
+                    DescribeInspection(structural), diagnostics, inspection: structural);
+            }
+
+            if (validated.Operation == OfficeProvenanceWorkflowOperation.Assess) {
+                Report(progress, validated.Id, "assess", "Collecting optional verification and signal evidence", 0.55D);
+                OfficeProvenanceAssessmentReport assessment = await Task.Run(
+                    () => OfficeProvenanceAssessment.AssessFile(
+                        validated.InputPath,
+                        structural,
+                        validated.Assessment,
+                        _provenanceVerifier,
+                        _provenanceSignalDetectors,
+                        cancellationToken),
+                    cancellationToken).ConfigureAwait(false);
+                cancellationToken.ThrowIfCancellationRequested();
+                Report(progress, validated.Id, "complete", "Provenance assessment is ready", 1D);
+                return CreateProvenanceResult(
+                    validated, OfficeWorkflowStatus.Completed, OfficeWorkflowFailureKind.None,
+                    ownerPackage, null, inputBytes, 0, stopwatch.Elapsed,
+                    DescribeAssessment(assessment), diagnostics, assessment: assessment);
+            }
+
+            if (refinedOwner == ProvenanceOwner.Core && !SupportsCoreRemoval(structural.Format)) {
+                throw new NotSupportedException(
+                    "Inspection is supported, but no safe mutation owner is registered for this asset format.");
+            }
+
+            failureStage = WorkflowFailureStage.Output;
+            string outputDirectory = Path.GetDirectoryName(validated.OutputPath!)!;
+            Directory.CreateDirectory(outputDirectory);
+            stagingPath = Path.Combine(
+                outputDirectory,
+                "." + Path.GetFileNameWithoutExtension(validated.OutputPath) + "." +
+                Guid.NewGuid().ToString("N") + Path.GetExtension(validated.OutputPath));
+            Report(progress, validated.Id, "remove", "Removing selected carriers through " + ownerPackage, 0.48D);
+            failureStage = WorkflowFailureStage.Operation;
+            OfficeProvenanceRemovalResult removal = await Task.Run(
+                () => OfficeProvenanceWorkflowAdapter.Remove(refinedOwner, validated.InputPath, stagingPath, validated.Removal),
+                cancellationToken).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            failureStage = WorkflowFailureStage.Output;
+            long stagedBytes = new FileInfo(stagingPath).Length;
+            if (stagedBytes > validated.Limits.MaximumOutputBytes) {
+                throw new InvalidOperationException(
+                    $"Generated artifact is {stagedBytes:N0} bytes, above the configured {validated.Limits.MaximumOutputBytes:N0}-byte limit.");
+            }
+
+            Report(progress, validated.Id, "validate-output", "Reopening the staged artifact through " + ownerPackage, 0.72D);
+            OfficeProvenanceReport reopened = await Task.Run(
+                () => OfficeProvenanceWorkflowAdapter.Inspect(refinedOwner, stagingPath, CreateInspectionOptions(validated.Removal, validated.Limits)),
+                cancellationToken).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+            EnsureEquivalent(removal.After, reopened);
+            diagnostics.Add(new OfficeWorkflowDiagnostic(
+                "ProvenanceOutputReopened",
+                "The staged artifact was reopened through its owning format API and matched the in-memory removal report.",
+                stage: "validate-output",
+                details: new Dictionary<string, string>(StringComparer.Ordinal) {
+                    ["ownerPackage"] = ownerPackage,
+                    ["remainingCarriers"] = reopened.Evidence.Count.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                    ["stagedBytes"] = stagedBytes.ToString(System.Globalization.CultureInfo.InvariantCulture)
+                }));
+            cancellationToken.ThrowIfCancellationRequested();
+
+            failureStage = WorkflowFailureStage.Output;
+            Report(progress, validated.Id, "publish", "Publishing the verified provenance artifact", 0.9D);
+            string publishedPath = Publish(stagingPath, validated.OutputPath!, validated.ConflictPolicy, cancellationToken);
+            stagingPath = null;
+            long outputBytes = new FileInfo(publishedPath).Length;
+            diagnostics.Add(new OfficeWorkflowDiagnostic(
+                "AtomicPublication",
+                "The verified artifact was staged in the destination directory and published with one filesystem move.",
+                stage: "publish"));
+            Report(progress, validated.Id, "complete", "Provenance removal completed", 1D);
+            return CreateProvenanceResult(
+                validated, OfficeWorkflowStatus.Completed, OfficeWorkflowFailureKind.None,
+                ownerPackage, publishedPath, inputBytes, outputBytes, stopwatch.Elapsed,
+                DescribeRemoval(removal, reopened), diagnostics,
+                before: removal.Before,
+                after: reopened,
+                changes: removal.Changes,
+                wasReserialized: removal.WasReserialized,
+                wereInvalidatedSignaturesRemoved: removal.WereInvalidatedSignaturesRemoved);
+        } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+            diagnostics.Add(new OfficeWorkflowDiagnostic(
+                "Cancelled",
+                "The provenance workflow was cancelled before publication; no staged artifact was retained.",
+                OfficeWorkflowDiagnosticSeverity.Information,
+                "cancel"));
+            return new OfficeProvenanceWorkflowResult(
+                validated?.Id ?? request.Id,
+                validated?.Operation ?? request.Operation,
+                OfficeWorkflowStatus.Cancelled,
+                OfficeWorkflowFailureKind.None,
+                GetPackage(validated?.Owner ?? ResolveByPath(request.InputPath)),
+                null,
+                inputBytes,
+                0,
+                stopwatch.Elapsed,
+                "Cancelled",
+                diagnostics);
+        } catch (Exception exception) when (exception is not OutOfMemoryException and not StackOverflowException) {
+            diagnostics.Add(new OfficeWorkflowDiagnostic(
+                "ProvenanceWorkflowFailed",
+                exception.Message,
+                OfficeWorkflowDiagnosticSeverity.Error,
+                GetDiagnosticStage(failureStage),
+                new Dictionary<string, string>(StringComparer.Ordinal) {
+                    ["exceptionType"] = exception.GetType().Name
+                }));
+            return new OfficeProvenanceWorkflowResult(
+                validated?.Id ?? request.Id,
+                validated?.Operation ?? request.Operation,
+                OfficeWorkflowStatus.Failed,
+                ClassifyFailure(exception, failureStage),
+                GetPackage(validated?.Owner ?? ResolveByPath(request.InputPath)),
+                null,
+                inputBytes,
+                0,
+                stopwatch.Elapsed,
+                "Provenance workflow failed: " + exception.Message,
+                diagnostics);
+        } finally {
+            if (stagingPath is not null) TryDelete(stagingPath);
+        }
+    }
+
+    /// <summary>Runs a bounded batch sequentially so providers and parsers share one predictable resource envelope.</summary>
+    public async Task<IReadOnlyList<OfficeProvenanceWorkflowResult>> RunProvenanceBatchAsync(
+        IEnumerable<OfficeProvenanceWorkflowRequest> requests,
+        OfficeProvenanceWorkflowBatchOptions? options = null,
+        IProgress<OfficeWorkflowProgress>? progress = null,
+        CancellationToken cancellationToken = default) {
+        ArgumentNullException.ThrowIfNull(requests);
+        OfficeProvenanceWorkflowBatchOptions validatedOptions = (options ?? new OfficeProvenanceWorkflowBatchOptions()).CloneAndValidate();
+        OfficeProvenanceWorkflowRequest[] materialized = requests.Take(validatedOptions.MaximumRequests + 1).ToArray();
+        if (materialized.Length > validatedOptions.MaximumRequests) {
+            throw new ArgumentException(
+                $"The provenance batch exceeds the configured limit of {validatedOptions.MaximumRequests:N0} requests.",
+                nameof(requests));
+        }
+        EnsureDistinctBatchRemovalOutputs(materialized);
+        if (materialized.Length == 0) cancellationToken.ThrowIfCancellationRequested();
+
+        var results = new List<OfficeProvenanceWorkflowResult>(materialized.Length);
+        for (int index = 0; index < materialized.Length; index++) {
+            int batchIndex = index;
+            var batchProgress = progress is null
+                ? null
+                : new InlineProgress<OfficeWorkflowProgress>(item => progress.Report(new OfficeWorkflowProgress(
+                    item.RequestId,
+                    item.Stage,
+                    $"{batchIndex + 1} of {materialized.Length} · {item.Message}",
+                    item.Fraction,
+                    (batchIndex + item.Fraction) / Math.Max(1, materialized.Length))));
+            OfficeProvenanceWorkflowResult result = await RunProvenanceAsync(
+                materialized[index], batchProgress, cancellationToken).ConfigureAwait(false);
+            results.Add(result);
+            if (result.Status == OfficeWorkflowStatus.Cancelled) break;
+            if (!validatedOptions.ContinueOnFailure && !result.Succeeded) break;
+        }
+        return results;
+    }
+
+    private static void EnsureDistinctBatchRemovalOutputs(IEnumerable<OfficeProvenanceWorkflowRequest> requests) {
+        var outputIdentities = new HashSet<string>(StringComparer.Ordinal);
+        foreach (OfficeProvenanceWorkflowRequest request in requests) {
+            if (request == null) throw new ArgumentException("Provenance batches cannot contain null requests.", nameof(requests));
+            if (request.Operation != OfficeProvenanceWorkflowOperation.Remove) continue;
+
+            string? outputPath = TryResolveBatchRemovalOutput(request);
+            if (outputPath is null) continue;
+            string? identity = TryNormalizeBatchRemovalOutput(outputPath);
+            if (identity is null) continue;
+            if (!outputIdentities.Add(identity)) {
+                throw new ArgumentException(
+                    $"Multiple provenance removal requests resolve to the same output path '{outputPath}'.",
+                    nameof(requests));
+            }
+        }
+    }
+
+    private static string? TryNormalizeBatchRemovalOutput(string outputPath) {
+        try {
+            return OfficeWorkflowPathIdentity.Normalize(outputPath);
+        } catch (Exception exception) when (exception is ArgumentException or NotSupportedException or IOException or UnauthorizedAccessException) {
+            // Defer path-access diagnostics to the item runner so batch failure behavior stays structured.
+            return null;
+        }
+    }
+
+    private static string? TryResolveBatchRemovalOutput(OfficeProvenanceWorkflowRequest request) {
+        try {
+            if (string.IsNullOrWhiteSpace(request.InputPath)) return null;
+            string inputPath = Path.GetFullPath(request.InputPath);
+            return string.IsNullOrWhiteSpace(request.OutputPath)
+                ? Path.Combine(
+                    Path.GetDirectoryName(inputPath)!,
+                    Path.GetFileNameWithoutExtension(inputPath) + ".provenance-cleaned" + Path.GetExtension(inputPath))
+                : Path.GetFullPath(request.OutputPath);
+        } catch (Exception exception) when (exception is ArgumentException or NotSupportedException or IOException or UnauthorizedAccessException) {
+            // RunProvenanceAsync owns request validation and converts invalid paths into per-item results.
+            return null;
+        }
+    }
+
+    private static ValidatedProvenanceRequest ValidateProvenanceRequest(OfficeProvenanceWorkflowRequest request) {
+        if (string.IsNullOrWhiteSpace(request.Id)) throw new ArgumentException("Request id cannot be empty.", nameof(request));
+        if (!Enum.IsDefined(typeof(OfficeProvenanceWorkflowOperation), request.Operation)) {
+            throw new ArgumentOutOfRangeException(nameof(request), request.Operation, "Choose a supported provenance operation.");
+        }
+        if (!Enum.IsDefined(typeof(OfficeWorkflowConflictPolicy), request.ConflictPolicy)) {
+            throw new ArgumentOutOfRangeException(nameof(request), request.ConflictPolicy, "Choose a supported output conflict policy.");
+        }
+        if (string.IsNullOrWhiteSpace(request.InputPath)) throw new ArgumentException("Input path cannot be empty.", nameof(request));
+        string inputPath = Path.GetFullPath(request.InputPath);
+        if (!File.Exists(inputPath)) throw new FileNotFoundException("The provenance input file does not exist.", inputPath);
+        OfficeWorkflowLimits limits = (request.Limits ?? throw new ArgumentException("Workflow limits cannot be null.", nameof(request))).CloneAndValidate();
+        OfficeProvenanceOptions inspection = CloneInspectionOptions(
+            request.Inspection ?? throw new ArgumentException("Inspection options cannot be null.", nameof(request)),
+            limits);
+        OfficeProvenanceAssessmentOptions assessment = CloneAssessmentOptions(
+            request.Assessment ?? throw new ArgumentException("Assessment options cannot be null.", nameof(request)),
+            limits);
+        OfficeProvenanceRemovalOptions removal = CloneRemovalOptions(
+            request.Removal ?? throw new ArgumentException("Removal options cannot be null.", nameof(request)),
+            limits);
+        string? outputPath = string.IsNullOrWhiteSpace(request.OutputPath) ? null : Path.GetFullPath(request.OutputPath);
+
+        if (request.Operation == OfficeProvenanceWorkflowOperation.Remove) {
+            outputPath ??= Path.Combine(
+                Path.GetDirectoryName(inputPath)!,
+                Path.GetFileNameWithoutExtension(inputPath) + ".provenance-cleaned" + Path.GetExtension(inputPath));
+            if (!string.Equals(Path.GetExtension(inputPath), Path.GetExtension(outputPath), StringComparison.OrdinalIgnoreCase)) {
+                throw new ArgumentException("Provenance removal preserves the input format and requires the same output extension.", nameof(request));
+            }
+        } else if (outputPath is not null) {
+            throw new ArgumentException("Inspect and assess are report-only operations and do not publish an artifact.", nameof(request));
+        }
+
+        return new ValidatedProvenanceRequest(
+            request.Id,
+            request.Operation,
+            inputPath,
+            outputPath,
+            ResolveByPath(inputPath),
+            request.ConflictPolicy,
+            limits,
+            inspection,
+            assessment,
+            removal);
+    }
+
+    private static OfficeProvenanceOptions CloneInspectionOptions(OfficeProvenanceOptions source, OfficeWorkflowLimits limits) => new() {
+        MaxAssetBytes = Math.Min(source.MaxAssetBytes, limits.MaximumInputBytes),
+        MaxManifestBytes = Math.Min(source.MaxManifestBytes, Math.Min(source.MaxAssetBytes, limits.MaximumInputBytes)),
+        MaxCarriers = source.MaxCarriers,
+        MaxContainerEntries = source.MaxContainerEntries,
+        MaxExpandedContainerBytes = source.MaxExpandedContainerBytes,
+        ProcessEmbeddedAssets = source.ProcessEmbeddedAssets,
+        MaxEmbeddedAssets = source.MaxEmbeddedAssets
+    };
+
+    private static OfficeProvenanceAssessmentOptions CloneAssessmentOptions(
+        OfficeProvenanceAssessmentOptions source,
+        OfficeWorkflowLimits limits) {
+        var clone = new OfficeProvenanceAssessmentOptions {
+            InspectTextIntegrity = source.InspectTextIntegrity
+        };
+        CopyInspectionOptions(source.Structural, clone.Structural, limits.MaximumInputBytes);
+        clone.TextIntegrity.MaxEncodedBytes = Math.Min(source.TextIntegrity.MaxEncodedBytes, limits.MaximumInputBytes);
+        clone.TextIntegrity.MaxCharacters = source.TextIntegrity.MaxCharacters;
+        clone.TextIntegrity.MaxFindings = source.TextIntegrity.MaxFindings;
+        clone.TextIntegrity.IgnoreLeadingByteOrderMark = source.TextIntegrity.IgnoreLeadingByteOrderMark;
+        clone.TextIntegrity.IncludeTypographicSpaces = source.TextIntegrity.IncludeTypographicSpaces;
+        clone.TextIntegrity.IncludeVariationSelectors = source.TextIntegrity.IncludeVariationSelectors;
+        clone.Verification.Timeout = source.Verification.Timeout;
+        clone.Verification.MaxReportBytes = source.Verification.MaxReportBytes;
+        clone.Verification.AllowNetworkAccess = source.Verification.AllowNetworkAccess;
+        clone.Verification.IncludeRawReport = source.Verification.IncludeRawReport;
+        clone.Verification.TrustAnchorsPath = source.Verification.TrustAnchorsPath;
+        clone.Verification.AllowedListPath = source.Verification.AllowedListPath;
+        clone.Verification.TrustConfigurationPath = source.Verification.TrustConfigurationPath;
+        return clone;
+    }
+
+    private static OfficeProvenanceRemovalOptions CloneRemovalOptions(
+        OfficeProvenanceRemovalOptions source,
+        OfficeWorkflowLimits limits) {
+        var clone = new OfficeProvenanceRemovalOptions {
+            RemoveC2paManifests = source.RemoveC2paManifests,
+            RemoveExternalC2paReferences = source.RemoveExternalC2paReferences,
+            RemoveAiSourceMetadata = source.RemoveAiSourceMetadata,
+            RequireStructurallyValidCarrier = source.RequireStructurallyValidCarrier,
+            SignatureMutationPolicy = source.SignatureMutationPolicy,
+            ProcessEmbeddedAssets = source.ProcessEmbeddedAssets,
+            MaxEmbeddedAssets = source.MaxEmbeddedAssets
+        };
+        CopyInspectionOptions(source.Limits, clone.Limits, limits.MaximumInputBytes);
+        return clone;
+    }
+
+    private static OfficeProvenanceOptions CreateInspectionOptions(
+        OfficeProvenanceRemovalOptions removal,
+        OfficeWorkflowLimits limits) {
+        var options = new OfficeProvenanceOptions();
+        CopyInspectionOptions(removal.Limits, options, limits.MaximumOutputBytes);
+        options.ProcessEmbeddedAssets = removal.ProcessEmbeddedAssets && removal.Limits.ProcessEmbeddedAssets;
+        options.MaxEmbeddedAssets = Math.Min(removal.MaxEmbeddedAssets, removal.Limits.MaxEmbeddedAssets);
+        return options;
+    }
+
+    private static void CopyInspectionOptions(
+        OfficeProvenanceOptions source,
+        OfficeProvenanceOptions destination,
+        long maximumAssetBytes) {
+        destination.MaxAssetBytes = Math.Min(source.MaxAssetBytes, maximumAssetBytes);
+        destination.MaxManifestBytes = Math.Min(source.MaxManifestBytes, destination.MaxAssetBytes);
+        destination.MaxCarriers = source.MaxCarriers;
+        destination.MaxContainerEntries = source.MaxContainerEntries;
+        destination.MaxExpandedContainerBytes = source.MaxExpandedContainerBytes;
+        destination.ProcessEmbeddedAssets = source.ProcessEmbeddedAssets;
+        destination.MaxEmbeddedAssets = source.MaxEmbeddedAssets;
+    }
+
+    private static void EnsureEquivalent(OfficeProvenanceReport expected, OfficeProvenanceReport actual) {
+        bool evidenceMatches = expected.Evidence.Count == actual.Evidence.Count &&
+            expected.Evidence.Zip(actual.Evidence).All(pair =>
+                pair.First.Carrier == pair.Second.Carrier &&
+                string.Equals(pair.First.Location, pair.Second.Location, StringComparison.Ordinal) &&
+                pair.First.IsStructurallyValid == pair.Second.IsStructurallyValid &&
+                pair.First.PayloadLength == pair.Second.PayloadLength &&
+                string.Equals(pair.First.Value, pair.Second.Value, StringComparison.Ordinal) &&
+                pair.First.DigitalSourceKind == pair.Second.DigitalSourceKind);
+        if (expected.Format != actual.Format || !evidenceMatches) {
+            throw new InvalidDataException("The reopened artifact did not match the provenance removal report.");
+        }
+    }
+
+    private static string DescribeInspection(OfficeProvenanceReport report) =>
+        $"Inspected {report.Format}; found {report.Evidence.Count:N0} structural provenance carrier(s).";
+
+    private static string DescribeAssessment(OfficeProvenanceAssessmentReport report) =>
+        $"Assessed {report.Structural.Format}; found {report.Structural.Evidence.Count:N0} structural carrier(s), " +
+        $"{report.TextIntegrity?.Findings.Count ?? 0:N0} text-integrity finding(s), and " +
+        $"{report.ProviderSignals.Count:N0} provider signal result(s).";
+
+    private static string DescribeRemoval(OfficeProvenanceRemovalResult result, OfficeProvenanceReport reopened) =>
+        $"Applied {result.Changes.Count:N0} provenance change(s); {reopened.Evidence.Count:N0} carrier(s) remain after verified publication.";
+
+    private static OfficeProvenanceWorkflowResult CreateProvenanceResult(
+        ValidatedProvenanceRequest request,
+        OfficeWorkflowStatus status,
+        OfficeWorkflowFailureKind failureKind,
+        string ownerPackage,
+        string? outputPath,
+        long inputBytes,
+        long outputBytes,
+        TimeSpan duration,
+        string summary,
+        IReadOnlyList<OfficeWorkflowDiagnostic> diagnostics,
+        OfficeProvenanceReport? inspection = null,
+        OfficeProvenanceAssessmentReport? assessment = null,
+        OfficeProvenanceReport? before = null,
+        OfficeProvenanceReport? after = null,
+        IReadOnlyList<OfficeProvenanceChange>? changes = null,
+        bool wasReserialized = false,
+        bool wereInvalidatedSignaturesRemoved = false) => new(
+            request.Id,
+            request.Operation,
+            status,
+            failureKind,
+            ownerPackage,
+            outputPath,
+            inputBytes,
+            outputBytes,
+            duration,
+            summary,
+            diagnostics,
+            inspection,
+            assessment,
+            before,
+            after,
+            changes,
+            wasReserialized,
+            wereInvalidatedSignaturesRemoved);
+
+    private sealed record ValidatedProvenanceRequest(
+        string Id,
+        OfficeProvenanceWorkflowOperation Operation,
+        string InputPath,
+        string? OutputPath,
+        ProvenanceOwner Owner,
+        OfficeWorkflowConflictPolicy ConflictPolicy,
+        OfficeWorkflowLimits Limits,
+        OfficeProvenanceOptions Inspection,
+        OfficeProvenanceAssessmentOptions Assessment,
+        OfficeProvenanceRemovalOptions Removal);
+}

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.Provenance.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Security.Cryptography;
+using System.Text;
 using OfficeIMO.Core.Internal;
 using OfficeIMO.Provenance;
 using static OfficeIMO.Workflows.OfficeProvenanceWorkflowAdapter;
@@ -46,10 +47,11 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
             cancellationToken.ThrowIfCancellationRequested();
             failureStage = WorkflowFailureStage.Input;
             inputBytes = new FileInfo(validated.InputPath).Length;
-            EnforceInputLimit(validated.InputPath, inputBytes, validated.Limits);
+            long operationInputLimit = GetOperationInputLimit(validated);
+            EnforceInputLimit(validated.InputPath, inputBytes, operationInputLimit);
             inputSnapshot = OfficeProvenanceFileSnapshot.Capture(
                 validated.InputPath,
-                validated.Limits.MaximumInputBytes,
+                operationInputLimit,
                 cancellationToken);
             string operationInputPath = inputSnapshot.FilePath;
             inputBytes = inputSnapshot.Length;
@@ -115,6 +117,14 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
 
             if (validated.Operation == OfficeProvenanceWorkflowOperation.Assess) {
                 Report(progress, validated.Id, "assess", "Collecting optional verification and signal evidence", 0.55D);
+                Encoding? textEncoding = validated.Assessment.InspectTextIntegrity && IsTextLike(structural.Format)
+                    ? OfficeProvenanceWorkflowAdapter.ResolveTextEncoding(
+                        refinedOwner,
+                        structural.Format,
+                        operationInputPath,
+                        validated.Assessment.TextIntegrity.MaxEncodedBytes,
+                        cancellationToken)
+                    : null;
                 bool hasExternalProviders = _provenanceVerifier != null || _provenanceSignalDetectors.Count != 0;
                 if (hasExternalProviders) {
                     inputSnapshot!.CaptureExternalManifestDependencies(
@@ -132,7 +142,8 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                         validated.Assessment,
                         _provenanceVerifier,
                         _provenanceSignalDetectors,
-                        cancellationToken),
+                        cancellationToken,
+                        textEncoding),
                     cancellationToken).ConfigureAwait(false);
                 cancellationToken.ThrowIfCancellationRequested();
                 inputSnapshot!.VerifyPrimaryFile(cancellationToken);
@@ -160,9 +171,15 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
                 Guid.NewGuid().ToString("N") + Path.GetExtension(validated.OutputPath));
             Report(progress, validated.Id, "remove", "Removing selected carriers through " + ownerPackage, 0.48D);
             failureStage = WorkflowFailureStage.Operation;
-            OfficeProvenanceRemovalResult removal = await Task.Run(
-                () => OfficeProvenanceWorkflowAdapter.Remove(refinedOwner, operationInputPath, stagingPath, validated.Removal, cancellationToken),
-                cancellationToken).ConfigureAwait(false);
+            OfficeProvenanceRemovalResult removal;
+            try {
+                removal = await Task.Run(
+                    () => OfficeProvenanceWorkflowAdapter.Remove(refinedOwner, operationInputPath, stagingPath, validated.Removal, cancellationToken),
+                    cancellationToken).ConfigureAwait(false);
+            } catch (Exception exception) when (exception is IOException or UnauthorizedAccessException) {
+                failureStage = WorkflowFailureStage.Output;
+                throw;
+            }
             cancellationToken.ThrowIfCancellationRequested();
             inputSnapshot!.VerifyPrimaryFile(cancellationToken);
             inputSnapshot!.Dispose();
@@ -773,6 +790,13 @@ public sealed partial class OfficeWorkflowRunner : IOfficeProvenanceWorkflowRunn
         options.MaxEmbeddedAssets = Math.Min(removal.MaxEmbeddedAssets, removal.Limits.MaxEmbeddedAssets);
         return options;
     }
+
+    private static long GetOperationInputLimit(ValidatedProvenanceRequest request) => request.Operation switch {
+        OfficeProvenanceWorkflowOperation.Inspect => request.Inspection.MaxAssetBytes,
+        OfficeProvenanceWorkflowOperation.Assess => request.Assessment.Structural.MaxAssetBytes,
+        OfficeProvenanceWorkflowOperation.Remove => request.RemovalInputInspection.MaxAssetBytes,
+        _ => request.Limits.MaximumInputBytes
+    };
 
     private static OfficeProvenanceOptions CreateOutputInspectionOptions(
         OfficeProvenanceRemovalOptions removal) {

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.ProvenanceBatch.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.ProvenanceBatch.cs
@@ -11,14 +11,16 @@ public sealed partial class OfficeWorkflowRunner {
         CancellationToken cancellationToken = default) {
         ArgumentNullException.ThrowIfNull(requests);
         OfficeProvenanceWorkflowBatchOptions validatedOptions = (options ?? new OfficeProvenanceWorkflowBatchOptions()).CloneAndValidate();
-        OfficeProvenanceWorkflowRequest[] materialized = requests.Take(validatedOptions.MaximumRequests + 1).ToArray();
+        OfficeProvenanceWorkflowRequest[] materialized = MaterializeBatchRequests(
+            requests,
+            validatedOptions.MaximumRequests,
+            cancellationToken);
         if (materialized.Length > validatedOptions.MaximumRequests) {
             throw new ArgumentException(
                 $"The provenance batch exceeds the configured limit of {validatedOptions.MaximumRequests:N0} requests.",
                 nameof(requests));
         }
         materialized = PrepareBatchRemovalPaths(materialized, cancellationToken);
-        if (materialized.Length == 0) cancellationToken.ThrowIfCancellationRequested();
 
         var results = new List<OfficeProvenanceWorkflowResult>(materialized.Length);
         for (int index = 0; index < materialized.Length; index++) {
@@ -38,6 +40,22 @@ public sealed partial class OfficeWorkflowRunner {
             if (!validatedOptions.ContinueOnFailure && !result.Succeeded) break;
         }
         return results;
+    }
+
+    private static OfficeProvenanceWorkflowRequest[] MaterializeBatchRequests(
+        IEnumerable<OfficeProvenanceWorkflowRequest> requests,
+        int maximumRequests,
+        CancellationToken cancellationToken) {
+        if (cancellationToken.IsCancellationRequested) return Array.Empty<OfficeProvenanceWorkflowRequest>();
+        var materialized = new List<OfficeProvenanceWorkflowRequest>(maximumRequests + 1);
+        using IEnumerator<OfficeProvenanceWorkflowRequest> enumerator = requests.GetEnumerator();
+        while (materialized.Count <= maximumRequests) {
+            if (cancellationToken.IsCancellationRequested) break;
+            if (!enumerator.MoveNext()) break;
+            materialized.Add(enumerator.Current);
+            if (cancellationToken.IsCancellationRequested) break;
+        }
+        return materialized.ToArray();
     }
 
     internal static OfficeProvenanceWorkflowRequest[] PrepareBatchRemovalPaths(

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.ProvenanceBatch.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.ProvenanceBatch.cs
@@ -98,8 +98,7 @@ public sealed partial class OfficeWorkflowRunner {
                 cancellationToken);
             if (selectedPath is null) continue;
             nextSuffixByDestination[requestedIdentity] = nextSuffix;
-            string? selectedIdentity = pathIndex.TryNormalizeCandidate(selectedPath);
-            if (selectedIdentity is null) continue;
+            string selectedIdentity = pathIndex.NormalizeCandidate(selectedPath);
             reservedOutputIdentities.Add(selectedIdentity);
             prepared[index] = CloneBatchRequestForReservedOutput(request, selectedPath);
         }
@@ -132,8 +131,6 @@ public sealed partial class OfficeWorkflowRunner {
         BatchPathIndex pathIndex,
         ref int nextSuffix,
         CancellationToken cancellationToken) {
-        IReadOnlySet<string>? existingEntries = pathIndex.TryGetExistingEntries(requestedPath);
-        if (existingEntries is null) return null;
         for (int attempts = 0; attempts < 10_000; attempts++) {
             if (cancellationToken.IsCancellationRequested) return null;
             int suffix = nextSuffix;
@@ -142,10 +139,9 @@ public sealed partial class OfficeWorkflowRunner {
             }
             nextSuffix++;
             string candidate = suffix == 0 ? requestedPath : AddSuffix(requestedPath, suffix);
-            string? identity = pathIndex.TryNormalizeCandidate(candidate);
-            if (identity is null) return null;
+            string identity = pathIndex.NormalizeCandidate(candidate);
             if (inputRequestIndexes.ContainsKey(identity) || reservedOutputIdentities.Contains(identity) ||
-                existingEntries.Contains(identity)) continue;
+                pathIndex.CandidateExists(candidate)) continue;
             return candidate;
         }
         throw new IOException("No available numbered provenance output path could be reserved for the batch.");
@@ -182,7 +178,7 @@ public sealed partial class OfficeWorkflowRunner {
 
     private sealed class BatchPathIndex(CancellationToken cancellationToken) {
         private readonly Dictionary<string, string?> _normalizedPaths = new(StringComparer.Ordinal);
-        private readonly Dictionary<string, BatchDirectoryIndex?> _lexicalDirectories = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, BatchDirectoryIndex> _lexicalDirectories = new(StringComparer.Ordinal);
         private readonly Dictionary<string, BatchDirectoryIndex> _physicalDirectories = new(StringComparer.Ordinal);
 
         internal string? TryNormalize(string? path) {
@@ -190,49 +186,58 @@ public sealed partial class OfficeWorkflowRunner {
             string fullPath;
             try {
                 fullPath = Path.GetFullPath(path);
-            } catch (Exception exception) when (exception is ArgumentException or NotSupportedException or IOException or UnauthorizedAccessException) {
+            } catch (Exception exception) when (exception is ArgumentException or NotSupportedException) {
                 return null;
+            } catch (Exception exception) when (exception is IOException or UnauthorizedAccessException) {
+                throw new IOException($"Unable to resolve provenance batch path '{path}'.", exception);
             }
             if (_normalizedPaths.TryGetValue(fullPath, out string? cached)) return cached;
             try {
                 string identity = OfficeWorkflowPathIdentity.Normalize(fullPath);
                 _normalizedPaths.Add(fullPath, identity);
                 return identity;
-            } catch (Exception exception) when (exception is ArgumentException or NotSupportedException or IOException or UnauthorizedAccessException) {
+            } catch (ArgumentException) {
                 _normalizedPaths.Add(fullPath, null);
                 return null;
+            } catch (Exception exception) when (exception is NotSupportedException or IOException or UnauthorizedAccessException) {
+                throw new IOException($"Unable to resolve provenance batch path identity '{path}'.", exception);
             }
         }
 
-        internal string? TryNormalizeCandidate(string path) {
+        internal string NormalizeCandidate(string path) {
+            string fullPath = Path.GetFullPath(path);
+            if (_normalizedPaths.TryGetValue(fullPath, out string? cached) && cached is not null) return cached;
             try {
-                string fullPath = Path.GetFullPath(path);
-                if (_normalizedPaths.TryGetValue(fullPath, out string? cached)) return cached;
-                BatchDirectoryIndex? directory = TryGetDirectory(fullPath);
-                if (directory is null) return null;
+                BatchDirectoryIndex directory = GetDirectory(fullPath);
                 string identity = directory.NormalizeChild(Path.GetFileName(fullPath));
-                _normalizedPaths.Add(fullPath, identity);
+                _normalizedPaths[fullPath] = identity;
                 return identity;
             } catch (Exception exception) when (exception is ArgumentException or NotSupportedException or IOException or UnauthorizedAccessException) {
-                return null;
+                throw new IOException($"Unable to reserve provenance batch output '{path}'.", exception);
             }
         }
 
-        internal IReadOnlySet<string>? TryGetExistingEntries(string path) {
+        internal bool CandidateExists(string path) {
             try {
                 string fullPath = Path.GetFullPath(path);
-                return TryGetDirectory(fullPath)?.ExistingEntries;
+                _ = GetDirectory(fullPath);
+                _ = File.GetAttributes(fullPath);
+                return true;
+            } catch (FileNotFoundException) {
+                return false;
+            } catch (DirectoryNotFoundException) {
+                return false;
             } catch (Exception exception) when (exception is ArgumentException or NotSupportedException or IOException or UnauthorizedAccessException) {
-                return null;
+                throw new IOException($"Unable to inspect provenance batch output candidate '{path}'.", exception);
             }
         }
 
-        private BatchDirectoryIndex? TryGetDirectory(string fullChildPath) {
+        private BatchDirectoryIndex GetDirectory(string fullChildPath) {
             string? directoryPath = Path.GetDirectoryName(fullChildPath);
-            if (string.IsNullOrEmpty(directoryPath)) return null;
+            if (string.IsNullOrEmpty(directoryPath)) throw new IOException("The provenance batch output has no destination directory.");
             if (_lexicalDirectories.TryGetValue(directoryPath, out BatchDirectoryIndex? cached)) return cached;
             try {
-                if (cancellationToken.IsCancellationRequested) return null;
+                cancellationToken.ThrowIfCancellationRequested();
                 string physicalDirectory = OfficeWorkflowPathIdentity.ResolvePhysicalPath(directoryPath);
                 bool caseInsensitive = OfficeWorkflowPathIdentity.IsCaseInsensitiveFileSystem(physicalDirectory);
                 string physicalIdentity = OfficeWorkflowPathIdentity.Normalize(physicalDirectory, caseInsensitive);
@@ -240,32 +245,19 @@ public sealed partial class OfficeWorkflowRunner {
                     _lexicalDirectories.Add(directoryPath, shared);
                     return shared;
                 }
-                var existingEntries = new HashSet<string>(StringComparer.Ordinal);
-                if (Directory.Exists(directoryPath)) {
-                    foreach (string entry in Directory.EnumerateFileSystemEntries(directoryPath)) {
-                        if (cancellationToken.IsCancellationRequested) return null;
-                        existingEntries.Add(OfficeWorkflowPathIdentity.Normalize(
-                            Path.Combine(physicalDirectory, Path.GetFileName(entry)),
-                            caseInsensitive));
-                    }
-                }
-                var index = new BatchDirectoryIndex(physicalDirectory, caseInsensitive, existingEntries);
+                var index = new BatchDirectoryIndex(physicalDirectory, caseInsensitive);
                 _physicalDirectories.Add(physicalIdentity, index);
                 _lexicalDirectories.Add(directoryPath, index);
                 return index;
             } catch (Exception exception) when (exception is ArgumentException or NotSupportedException or IOException or UnauthorizedAccessException) {
-                _lexicalDirectories.Add(directoryPath, null);
-                return null;
+                throw new IOException($"Unable to index provenance batch destination directory '{directoryPath}'.", exception);
             }
         }
     }
 
     private sealed class BatchDirectoryIndex(
         string physicalDirectory,
-        bool caseInsensitive,
-        IReadOnlySet<string> existingEntries) {
-        internal IReadOnlySet<string> ExistingEntries { get; } = existingEntries;
-
+        bool caseInsensitive) {
         internal string NormalizeChild(string fileName) => OfficeWorkflowPathIdentity.Normalize(
             Path.Combine(physicalDirectory, fileName),
             caseInsensitive);

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.ProvenanceBatch.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.ProvenanceBatch.cs
@@ -63,6 +63,34 @@ public sealed partial class OfficeWorkflowRunner {
             }
             indexes.Add(index);
         }
+        var inputIdentities = new SortedSet<string>(inputRequestIndexes.Keys, StringComparer.Ordinal);
+
+        var removalOutputs = new BatchOutputPath?[requests.Count];
+        var outputIdentities = new SortedSet<string>(StringComparer.Ordinal);
+        var outputPathsByIdentity = new Dictionary<string, string>(StringComparer.Ordinal);
+        for (int index = 0; index < requests.Count; index++) {
+            if (cancellationToken.IsCancellationRequested) return prepared;
+            OfficeProvenanceWorkflowRequest request = requests[index];
+            if (request.Operation != OfficeProvenanceWorkflowOperation.Remove) continue;
+            string? outputPath = TryResolveBatchRemovalOutput(request);
+            string? identity = pathIndex.TryNormalize(outputPath);
+            if (outputPath is null || identity is null) continue;
+            EnsureBatchOutputDoesNotOverlapInput(
+                outputPath,
+                identity,
+                index,
+                inputRequestIndexes,
+                inputIdentities);
+            if (!outputIdentities.Contains(identity) &&
+                TryFindAncestorOrDescendant(identity, outputIdentities, out string? collisionIdentity)) {
+                throw new ArgumentException(
+                    $"Provenance removal outputs '{outputPathsByIdentity[collisionIdentity!]}' and '{outputPath}' have an ancestor/descendant path collision.",
+                    "requests");
+            }
+            outputIdentities.Add(identity);
+            outputPathsByIdentity.TryAdd(identity, outputPath);
+            removalOutputs[index] = new BatchOutputPath(outputPath, identity);
+        }
 
         var fixedOutputIdentities = new HashSet<string>(StringComparer.Ordinal);
         for (int index = 0; index < requests.Count; index++) {
@@ -70,10 +98,9 @@ public sealed partial class OfficeWorkflowRunner {
             OfficeProvenanceWorkflowRequest request = requests[index];
             if (request.Operation != OfficeProvenanceWorkflowOperation.Remove ||
                 request.ConflictPolicy == OfficeWorkflowConflictPolicy.Rename) continue;
-            string? outputPath = TryResolveBatchRemovalOutput(request);
-            string? identity = pathIndex.TryNormalize(outputPath);
-            if (outputPath is null || identity is null) continue;
-            EnsureBatchOutputIsSafe(outputPath, identity, index, inputRequestIndexes, fixedOutputIdentities);
+            BatchOutputPath? output = removalOutputs[index];
+            if (output is null) continue;
+            EnsureBatchOutputIsUnique(output.Path, output.Identity, fixedOutputIdentities);
         }
 
         var reservedOutputIdentities = new HashSet<string>(fixedOutputIdentities, StringComparer.Ordinal);
@@ -83,15 +110,16 @@ public sealed partial class OfficeWorkflowRunner {
             OfficeProvenanceWorkflowRequest request = requests[index];
             if (request.Operation != OfficeProvenanceWorkflowOperation.Remove ||
                 request.ConflictPolicy != OfficeWorkflowConflictPolicy.Rename) continue;
-            string? requestedPath = TryResolveBatchRemovalOutput(request);
-            if (requestedPath is null) continue;
-            string? requestedIdentity = pathIndex.TryNormalize(requestedPath);
-            if (requestedIdentity is null) continue;
+            BatchOutputPath? output = removalOutputs[index];
+            if (output is null) continue;
+            string requestedPath = output.Path;
+            string requestedIdentity = output.Identity;
             nextSuffixByDestination.TryGetValue(requestedIdentity, out int nextSuffix);
 
             string? selectedPath = SelectBatchRenameOutput(
                 requestedPath,
                 inputRequestIndexes,
+                inputIdentities,
                 reservedOutputIdentities,
                 pathIndex,
                 ref nextSuffix,
@@ -102,21 +130,39 @@ public sealed partial class OfficeWorkflowRunner {
             reservedOutputIdentities.Add(selectedIdentity);
             prepared[index] = CloneBatchRequestForReservedOutput(request, selectedPath);
         }
+        var blockedOutputIdentities = new SortedSet<string>(inputIdentities, StringComparer.Ordinal);
+        blockedOutputIdentities.UnionWith(reservedOutputIdentities);
+        for (int index = 0; index < requests.Count; index++) {
+            if (cancellationToken.IsCancellationRequested) return prepared;
+            OfficeProvenanceWorkflowRequest request = prepared[index];
+            if (request.Operation != OfficeProvenanceWorkflowOperation.Remove ||
+                request.ConflictPolicy != OfficeWorkflowConflictPolicy.Rename ||
+                string.IsNullOrWhiteSpace(request.OutputPath)) continue;
+            request.BatchBlockedOutputIdentities = blockedOutputIdentities;
+            request.BatchOwnReservedOutputIdentity = pathIndex.NormalizeCandidate(request.OutputPath);
+        }
         return prepared;
     }
 
-    private static void EnsureBatchOutputIsSafe(
+    private static void EnsureBatchOutputDoesNotOverlapInput(
         string outputPath,
         string identity,
         int requestIndex,
         IReadOnlyDictionary<string, List<int>> inputRequestIndexes,
-        ISet<string> outputIdentities) {
-        if (inputRequestIndexes.TryGetValue(identity, out List<int>? indexes) &&
-            indexes.Any(index => index != requestIndex)) {
+        SortedSet<string> inputIdentities) {
+        if ((inputRequestIndexes.TryGetValue(identity, out List<int>? indexes) &&
+             indexes.Any(index => index != requestIndex)) ||
+            TryFindAncestorOrDescendant(identity, inputIdentities, out _)) {
             throw new ArgumentException(
                 $"Provenance removal output '{outputPath}' overlaps another batch request's input path.",
                 "requests");
         }
+    }
+
+    private static void EnsureBatchOutputIsUnique(
+        string outputPath,
+        string identity,
+        ISet<string> outputIdentities) {
         if (!outputIdentities.Add(identity)) {
             throw new ArgumentException(
                 $"Multiple provenance removal requests resolve to the same output path '{outputPath}'.",
@@ -127,6 +173,7 @@ public sealed partial class OfficeWorkflowRunner {
     private static string? SelectBatchRenameOutput(
         string requestedPath,
         IReadOnlyDictionary<string, List<int>> inputRequestIndexes,
+        SortedSet<string> inputIdentities,
         IReadOnlySet<string> reservedOutputIdentities,
         BatchPathIndex pathIndex,
         ref int nextSuffix,
@@ -140,7 +187,9 @@ public sealed partial class OfficeWorkflowRunner {
             nextSuffix++;
             string candidate = suffix == 0 ? requestedPath : AddSuffix(requestedPath, suffix);
             string identity = pathIndex.NormalizeCandidate(candidate);
-            if (inputRequestIndexes.ContainsKey(identity) || reservedOutputIdentities.Contains(identity) ||
+            if (inputRequestIndexes.ContainsKey(identity) ||
+                TryFindAncestorOrDescendant(identity, inputIdentities, out _) ||
+                reservedOutputIdentities.Contains(identity) ||
                 pathIndex.CandidateExists(candidate)) continue;
             return candidate;
         }
@@ -154,12 +203,37 @@ public sealed partial class OfficeWorkflowRunner {
             Operation = source.Operation,
             InputPath = source.InputPath,
             OutputPath = outputPath,
-            ConflictPolicy = OfficeWorkflowConflictPolicy.Fail,
+            ConflictPolicy = OfficeWorkflowConflictPolicy.Rename,
             Inspection = source.Inspection,
             Assessment = source.Assessment,
             Removal = source.Removal,
             Limits = source.Limits
         };
+
+    private static bool TryFindAncestorOrDescendant(
+        string identity,
+        SortedSet<string> identities,
+        out string? collisionIdentity) {
+        string? parent = Path.GetDirectoryName(identity);
+        while (!string.IsNullOrEmpty(parent)) {
+            if (identities.Contains(parent)) {
+                collisionIdentity = parent;
+                return true;
+            }
+            string? next = Path.GetDirectoryName(parent);
+            if (string.Equals(next, parent, StringComparison.Ordinal)) break;
+            parent = next;
+        }
+
+        string prefix = identity.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) +
+                        Path.DirectorySeparatorChar;
+        foreach (string candidate in identities.GetViewBetween(prefix, prefix + '\uffff')) {
+            collisionIdentity = candidate;
+            return true;
+        }
+        collisionIdentity = null;
+        return false;
+    }
 
     private static string? TryResolveBatchRemovalOutput(OfficeProvenanceWorkflowRequest request) {
         try {
@@ -262,4 +336,6 @@ public sealed partial class OfficeWorkflowRunner {
             Path.Combine(physicalDirectory, fileName),
             caseInsensitive);
     }
+
+    private sealed record BatchOutputPath(string Path, string Identity);
 }

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.ProvenanceBatch.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.ProvenanceBatch.cs
@@ -1,3 +1,5 @@
+using OfficeIMO.Provenance;
+
 namespace OfficeIMO.Workflows;
 
 public sealed partial class OfficeWorkflowRunner {
@@ -15,9 +17,7 @@ public sealed partial class OfficeWorkflowRunner {
                 $"The provenance batch exceeds the configured limit of {validatedOptions.MaximumRequests:N0} requests.",
                 nameof(requests));
         }
-        if (!cancellationToken.IsCancellationRequested) {
-            materialized = PrepareBatchRemovalPaths(materialized, cancellationToken);
-        }
+        materialized = PrepareBatchRemovalPaths(materialized, cancellationToken);
         if (materialized.Length == 0) cancellationToken.ThrowIfCancellationRequested();
 
         var results = new List<OfficeProvenanceWorkflowResult>(materialized.Length);
@@ -45,16 +45,20 @@ public sealed partial class OfficeWorkflowRunner {
         CancellationToken cancellationToken = default) {
         var prepared = new OfficeProvenanceWorkflowRequest[requests.Count];
         for (int index = 0; index < requests.Count; index++) {
-            prepared[index] = requests[index] ??
+            OfficeProvenanceWorkflowRequest request = requests[index] ??
                 throw new ArgumentException("Provenance batches cannot contain null requests.", nameof(requests));
+            prepared[index] = CloneBatchRequest(request);
         }
         if (cancellationToken.IsCancellationRequested) return prepared;
+        if (!prepared.Any(static request => request.Operation == OfficeProvenanceWorkflowOperation.Remove)) {
+            return prepared;
+        }
 
         var pathIndex = new BatchPathIndex(cancellationToken);
         var inputRequestIndexes = new Dictionary<string, List<int>>(StringComparer.Ordinal);
-        for (int index = 0; index < requests.Count; index++) {
+        for (int index = 0; index < prepared.Length; index++) {
             if (cancellationToken.IsCancellationRequested) return prepared;
-            OfficeProvenanceWorkflowRequest request = requests[index];
+            OfficeProvenanceWorkflowRequest request = prepared[index];
             string? identity = pathIndex.TryNormalize(request.InputPath);
             if (identity is null) continue;
             if (!inputRequestIndexes.TryGetValue(identity, out List<int>? indexes)) {
@@ -65,12 +69,12 @@ public sealed partial class OfficeWorkflowRunner {
         }
         var inputIdentities = new SortedSet<string>(inputRequestIndexes.Keys, StringComparer.Ordinal);
 
-        var removalOutputs = new BatchOutputPath?[requests.Count];
+        var removalOutputs = new BatchOutputPath?[prepared.Length];
         var outputIdentities = new SortedSet<string>(StringComparer.Ordinal);
         var outputPathsByIdentity = new Dictionary<string, string>(StringComparer.Ordinal);
-        for (int index = 0; index < requests.Count; index++) {
+        for (int index = 0; index < prepared.Length; index++) {
             if (cancellationToken.IsCancellationRequested) return prepared;
-            OfficeProvenanceWorkflowRequest request = requests[index];
+            OfficeProvenanceWorkflowRequest request = prepared[index];
             if (request.Operation != OfficeProvenanceWorkflowOperation.Remove) continue;
             string? outputPath = TryResolveBatchRemovalOutput(request);
             string? identity = pathIndex.TryNormalize(outputPath);
@@ -93,9 +97,9 @@ public sealed partial class OfficeWorkflowRunner {
         }
 
         var fixedOutputIdentities = new HashSet<string>(StringComparer.Ordinal);
-        for (int index = 0; index < requests.Count; index++) {
+        for (int index = 0; index < prepared.Length; index++) {
             if (cancellationToken.IsCancellationRequested) return prepared;
-            OfficeProvenanceWorkflowRequest request = requests[index];
+            OfficeProvenanceWorkflowRequest request = prepared[index];
             if (request.Operation != OfficeProvenanceWorkflowOperation.Remove ||
                 request.ConflictPolicy == OfficeWorkflowConflictPolicy.Rename) continue;
             BatchOutputPath? output = removalOutputs[index];
@@ -105,9 +109,9 @@ public sealed partial class OfficeWorkflowRunner {
 
         var reservedOutputIdentities = new HashSet<string>(fixedOutputIdentities, StringComparer.Ordinal);
         var nextSuffixByDestination = new Dictionary<string, int>(StringComparer.Ordinal);
-        for (int index = 0; index < requests.Count; index++) {
+        for (int index = 0; index < prepared.Length; index++) {
             if (cancellationToken.IsCancellationRequested) return prepared;
-            OfficeProvenanceWorkflowRequest request = requests[index];
+            OfficeProvenanceWorkflowRequest request = prepared[index];
             if (request.Operation != OfficeProvenanceWorkflowOperation.Remove ||
                 request.ConflictPolicy != OfficeWorkflowConflictPolicy.Rename) continue;
             BatchOutputPath? output = removalOutputs[index];
@@ -128,11 +132,11 @@ public sealed partial class OfficeWorkflowRunner {
             nextSuffixByDestination[requestedIdentity] = nextSuffix;
             string selectedIdentity = pathIndex.NormalizeCandidate(selectedPath);
             reservedOutputIdentities.Add(selectedIdentity);
-            prepared[index] = CloneBatchRequestForReservedOutput(request, selectedPath);
+            request.OutputPath = selectedPath;
         }
         var blockedOutputIdentities = new SortedSet<string>(inputIdentities, StringComparer.Ordinal);
         blockedOutputIdentities.UnionWith(reservedOutputIdentities);
-        for (int index = 0; index < requests.Count; index++) {
+        for (int index = 0; index < prepared.Length; index++) {
             if (cancellationToken.IsCancellationRequested) return prepared;
             OfficeProvenanceWorkflowRequest request = prepared[index];
             if (request.Operation != OfficeProvenanceWorkflowOperation.Remove ||
@@ -196,19 +200,77 @@ public sealed partial class OfficeWorkflowRunner {
         throw new IOException("No available numbered provenance output path could be reserved for the batch.");
     }
 
-    private static OfficeProvenanceWorkflowRequest CloneBatchRequestForReservedOutput(
-        OfficeProvenanceWorkflowRequest source,
-        string outputPath) => new() {
-            Id = source.Id,
-            Operation = source.Operation,
-            InputPath = source.InputPath,
-            OutputPath = outputPath,
-            ConflictPolicy = OfficeWorkflowConflictPolicy.Rename,
-            Inspection = source.Inspection,
-            Assessment = source.Assessment,
-            Removal = source.Removal,
-            Limits = source.Limits
+    private static OfficeProvenanceWorkflowRequest CloneBatchRequest(OfficeProvenanceWorkflowRequest source) => new() {
+        Id = source.Id,
+        Operation = source.Operation,
+        InputPath = source.InputPath,
+        OutputPath = source.OutputPath,
+        ConflictPolicy = source.ConflictPolicy,
+        Inspection = CloneBatchInspectionOptions(source.Inspection)!,
+        Assessment = CloneBatchAssessmentOptions(source.Assessment)!,
+        Removal = CloneBatchRemovalOptions(source.Removal)!,
+        Limits = source.Limits is null
+            ? null!
+            : new OfficeWorkflowLimits {
+                MaximumInputBytes = source.Limits.MaximumInputBytes,
+                MaximumOutputBytes = source.Limits.MaximumOutputBytes
+            }
+    };
+
+    private static OfficeProvenanceOptions? CloneBatchInspectionOptions(OfficeProvenanceOptions? source) {
+        if (source is null) return null;
+        var clone = new OfficeProvenanceOptions();
+        CopyBatchInspectionOptions(source, clone);
+        return clone;
+    }
+
+    private static OfficeProvenanceAssessmentOptions? CloneBatchAssessmentOptions(OfficeProvenanceAssessmentOptions? source) {
+        if (source is null) return null;
+        var clone = new OfficeProvenanceAssessmentOptions {
+            InspectTextIntegrity = source.InspectTextIntegrity
         };
+        CopyBatchInspectionOptions(source.Structural, clone.Structural);
+        clone.TextIntegrity.MaxEncodedBytes = source.TextIntegrity.MaxEncodedBytes;
+        clone.TextIntegrity.MaxCharacters = source.TextIntegrity.MaxCharacters;
+        clone.TextIntegrity.MaxFindings = source.TextIntegrity.MaxFindings;
+        clone.TextIntegrity.IgnoreLeadingByteOrderMark = source.TextIntegrity.IgnoreLeadingByteOrderMark;
+        clone.TextIntegrity.IncludeTypographicSpaces = source.TextIntegrity.IncludeTypographicSpaces;
+        clone.TextIntegrity.IncludeVariationSelectors = source.TextIntegrity.IncludeVariationSelectors;
+        clone.Verification.Timeout = source.Verification.Timeout;
+        clone.Verification.MaxReportBytes = source.Verification.MaxReportBytes;
+        clone.Verification.AllowNetworkAccess = source.Verification.AllowNetworkAccess;
+        clone.Verification.IncludeRawReport = source.Verification.IncludeRawReport;
+        clone.Verification.TrustAnchorsPath = source.Verification.TrustAnchorsPath;
+        clone.Verification.AllowedListPath = source.Verification.AllowedListPath;
+        clone.Verification.TrustConfigurationPath = source.Verification.TrustConfigurationPath;
+        return clone;
+    }
+
+    private static OfficeProvenanceRemovalOptions? CloneBatchRemovalOptions(OfficeProvenanceRemovalOptions? source) {
+        if (source is null) return null;
+        var clone = new OfficeProvenanceRemovalOptions {
+            RemoveC2paManifests = source.RemoveC2paManifests,
+            RemoveExternalC2paReferences = source.RemoveExternalC2paReferences,
+            RemoveAiSourceMetadata = source.RemoveAiSourceMetadata,
+            RequireStructurallyValidCarrier = source.RequireStructurallyValidCarrier,
+            SignatureMutationPolicy = source.SignatureMutationPolicy,
+            ProcessEmbeddedAssets = source.ProcessEmbeddedAssets,
+            MaxEmbeddedAssets = source.MaxEmbeddedAssets,
+            MaxOutputBytes = source.MaxOutputBytes
+        };
+        CopyBatchInspectionOptions(source.Limits, clone.Limits);
+        return clone;
+    }
+
+    private static void CopyBatchInspectionOptions(OfficeProvenanceOptions source, OfficeProvenanceOptions destination) {
+        destination.MaxAssetBytes = source.MaxAssetBytes;
+        destination.MaxManifestBytes = source.MaxManifestBytes;
+        destination.MaxCarriers = source.MaxCarriers;
+        destination.MaxContainerEntries = source.MaxContainerEntries;
+        destination.MaxExpandedContainerBytes = source.MaxExpandedContainerBytes;
+        destination.ProcessEmbeddedAssets = source.ProcessEmbeddedAssets;
+        destination.MaxEmbeddedAssets = source.MaxEmbeddedAssets;
+    }
 
     private static bool TryFindAncestorOrDescendant(
         string identity,

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.ProvenanceBatch.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.ProvenanceBatch.cs
@@ -46,7 +46,7 @@ public sealed partial class OfficeWorkflowRunner {
         IEnumerable<OfficeProvenanceWorkflowRequest> requests,
         int maximumRequests,
         CancellationToken cancellationToken) {
-        if (cancellationToken.IsCancellationRequested) return Array.Empty<OfficeProvenanceWorkflowRequest>();
+        cancellationToken.ThrowIfCancellationRequested();
         var materialized = new List<OfficeProvenanceWorkflowRequest>(maximumRequests + 1);
         using IEnumerator<OfficeProvenanceWorkflowRequest> enumerator = requests.GetEnumerator();
         while (materialized.Count <= maximumRequests) {

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.ProvenanceBatch.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.ProvenanceBatch.cs
@@ -1,0 +1,273 @@
+namespace OfficeIMO.Workflows;
+
+public sealed partial class OfficeWorkflowRunner {
+    /// <summary>Runs a bounded batch sequentially so providers and parsers share one predictable resource envelope.</summary>
+    public async Task<IReadOnlyList<OfficeProvenanceWorkflowResult>> RunProvenanceBatchAsync(
+        IEnumerable<OfficeProvenanceWorkflowRequest> requests,
+        OfficeProvenanceWorkflowBatchOptions? options = null,
+        IProgress<OfficeWorkflowProgress>? progress = null,
+        CancellationToken cancellationToken = default) {
+        ArgumentNullException.ThrowIfNull(requests);
+        OfficeProvenanceWorkflowBatchOptions validatedOptions = (options ?? new OfficeProvenanceWorkflowBatchOptions()).CloneAndValidate();
+        OfficeProvenanceWorkflowRequest[] materialized = requests.Take(validatedOptions.MaximumRequests + 1).ToArray();
+        if (materialized.Length > validatedOptions.MaximumRequests) {
+            throw new ArgumentException(
+                $"The provenance batch exceeds the configured limit of {validatedOptions.MaximumRequests:N0} requests.",
+                nameof(requests));
+        }
+        if (!cancellationToken.IsCancellationRequested) {
+            materialized = PrepareBatchRemovalPaths(materialized, cancellationToken);
+        }
+        if (materialized.Length == 0) cancellationToken.ThrowIfCancellationRequested();
+
+        var results = new List<OfficeProvenanceWorkflowResult>(materialized.Length);
+        for (int index = 0; index < materialized.Length; index++) {
+            int batchIndex = index;
+            var batchProgress = progress is null
+                ? null
+                : new InlineProgress<OfficeWorkflowProgress>(item => progress.Report(new OfficeWorkflowProgress(
+                    item.RequestId,
+                    item.Stage,
+                    $"{batchIndex + 1} of {materialized.Length} · {item.Message}",
+                    item.Fraction,
+                    (batchIndex + item.Fraction) / Math.Max(1, materialized.Length))));
+            OfficeProvenanceWorkflowResult result = await RunProvenanceAsync(
+                materialized[index], batchProgress, cancellationToken).ConfigureAwait(false);
+            results.Add(result);
+            if (result.Status == OfficeWorkflowStatus.Cancelled) break;
+            if (!validatedOptions.ContinueOnFailure && !result.Succeeded) break;
+        }
+        return results;
+    }
+
+    internal static OfficeProvenanceWorkflowRequest[] PrepareBatchRemovalPaths(
+        IReadOnlyList<OfficeProvenanceWorkflowRequest> requests,
+        CancellationToken cancellationToken = default) {
+        var prepared = new OfficeProvenanceWorkflowRequest[requests.Count];
+        for (int index = 0; index < requests.Count; index++) {
+            prepared[index] = requests[index] ??
+                throw new ArgumentException("Provenance batches cannot contain null requests.", nameof(requests));
+        }
+        if (cancellationToken.IsCancellationRequested) return prepared;
+
+        var pathIndex = new BatchPathIndex(cancellationToken);
+        var inputRequestIndexes = new Dictionary<string, List<int>>(StringComparer.Ordinal);
+        for (int index = 0; index < requests.Count; index++) {
+            if (cancellationToken.IsCancellationRequested) return prepared;
+            OfficeProvenanceWorkflowRequest request = requests[index];
+            string? identity = pathIndex.TryNormalize(request.InputPath);
+            if (identity is null) continue;
+            if (!inputRequestIndexes.TryGetValue(identity, out List<int>? indexes)) {
+                indexes = new List<int>();
+                inputRequestIndexes.Add(identity, indexes);
+            }
+            indexes.Add(index);
+        }
+
+        var fixedOutputIdentities = new HashSet<string>(StringComparer.Ordinal);
+        for (int index = 0; index < requests.Count; index++) {
+            if (cancellationToken.IsCancellationRequested) return prepared;
+            OfficeProvenanceWorkflowRequest request = requests[index];
+            if (request.Operation != OfficeProvenanceWorkflowOperation.Remove ||
+                request.ConflictPolicy == OfficeWorkflowConflictPolicy.Rename) continue;
+            string? outputPath = TryResolveBatchRemovalOutput(request);
+            string? identity = pathIndex.TryNormalize(outputPath);
+            if (outputPath is null || identity is null) continue;
+            EnsureBatchOutputIsSafe(outputPath, identity, index, inputRequestIndexes, fixedOutputIdentities);
+        }
+
+        var reservedOutputIdentities = new HashSet<string>(fixedOutputIdentities, StringComparer.Ordinal);
+        var nextSuffixByDestination = new Dictionary<string, int>(StringComparer.Ordinal);
+        for (int index = 0; index < requests.Count; index++) {
+            if (cancellationToken.IsCancellationRequested) return prepared;
+            OfficeProvenanceWorkflowRequest request = requests[index];
+            if (request.Operation != OfficeProvenanceWorkflowOperation.Remove ||
+                request.ConflictPolicy != OfficeWorkflowConflictPolicy.Rename) continue;
+            string? requestedPath = TryResolveBatchRemovalOutput(request);
+            if (requestedPath is null) continue;
+            string? requestedIdentity = pathIndex.TryNormalize(requestedPath);
+            if (requestedIdentity is null) continue;
+            nextSuffixByDestination.TryGetValue(requestedIdentity, out int nextSuffix);
+
+            string? selectedPath = SelectBatchRenameOutput(
+                requestedPath,
+                inputRequestIndexes,
+                reservedOutputIdentities,
+                pathIndex,
+                ref nextSuffix,
+                cancellationToken);
+            if (selectedPath is null) continue;
+            nextSuffixByDestination[requestedIdentity] = nextSuffix;
+            string? selectedIdentity = pathIndex.TryNormalizeCandidate(selectedPath);
+            if (selectedIdentity is null) continue;
+            reservedOutputIdentities.Add(selectedIdentity);
+            prepared[index] = CloneBatchRequestForReservedOutput(request, selectedPath);
+        }
+        return prepared;
+    }
+
+    private static void EnsureBatchOutputIsSafe(
+        string outputPath,
+        string identity,
+        int requestIndex,
+        IReadOnlyDictionary<string, List<int>> inputRequestIndexes,
+        ISet<string> outputIdentities) {
+        if (inputRequestIndexes.TryGetValue(identity, out List<int>? indexes) &&
+            indexes.Any(index => index != requestIndex)) {
+            throw new ArgumentException(
+                $"Provenance removal output '{outputPath}' overlaps another batch request's input path.",
+                "requests");
+        }
+        if (!outputIdentities.Add(identity)) {
+            throw new ArgumentException(
+                $"Multiple provenance removal requests resolve to the same output path '{outputPath}'.",
+                "requests");
+        }
+    }
+
+    private static string? SelectBatchRenameOutput(
+        string requestedPath,
+        IReadOnlyDictionary<string, List<int>> inputRequestIndexes,
+        IReadOnlySet<string> reservedOutputIdentities,
+        BatchPathIndex pathIndex,
+        ref int nextSuffix,
+        CancellationToken cancellationToken) {
+        IReadOnlySet<string>? existingEntries = pathIndex.TryGetExistingEntries(requestedPath);
+        if (existingEntries is null) return null;
+        for (int attempts = 0; attempts < 10_000; attempts++) {
+            if (cancellationToken.IsCancellationRequested) return null;
+            int suffix = nextSuffix;
+            if (nextSuffix == int.MaxValue) {
+                throw new IOException("No available numbered provenance output path could be reserved for the batch.");
+            }
+            nextSuffix++;
+            string candidate = suffix == 0 ? requestedPath : AddSuffix(requestedPath, suffix);
+            string? identity = pathIndex.TryNormalizeCandidate(candidate);
+            if (identity is null) return null;
+            if (inputRequestIndexes.ContainsKey(identity) || reservedOutputIdentities.Contains(identity) ||
+                existingEntries.Contains(identity)) continue;
+            return candidate;
+        }
+        throw new IOException("No available numbered provenance output path could be reserved for the batch.");
+    }
+
+    private static OfficeProvenanceWorkflowRequest CloneBatchRequestForReservedOutput(
+        OfficeProvenanceWorkflowRequest source,
+        string outputPath) => new() {
+            Id = source.Id,
+            Operation = source.Operation,
+            InputPath = source.InputPath,
+            OutputPath = outputPath,
+            ConflictPolicy = OfficeWorkflowConflictPolicy.Fail,
+            Inspection = source.Inspection,
+            Assessment = source.Assessment,
+            Removal = source.Removal,
+            Limits = source.Limits
+        };
+
+    private static string? TryResolveBatchRemovalOutput(OfficeProvenanceWorkflowRequest request) {
+        try {
+            if (string.IsNullOrWhiteSpace(request.InputPath)) return null;
+            string inputPath = Path.GetFullPath(request.InputPath);
+            return string.IsNullOrWhiteSpace(request.OutputPath)
+                ? Path.Combine(
+                    Path.GetDirectoryName(inputPath)!,
+                    Path.GetFileNameWithoutExtension(inputPath) + ".provenance-cleaned" + Path.GetExtension(inputPath))
+                : Path.GetFullPath(request.OutputPath);
+        } catch (Exception exception) when (exception is ArgumentException or NotSupportedException or IOException or UnauthorizedAccessException) {
+            // RunProvenanceAsync owns request validation and converts invalid paths into per-item results.
+            return null;
+        }
+    }
+
+    private sealed class BatchPathIndex(CancellationToken cancellationToken) {
+        private readonly Dictionary<string, string?> _normalizedPaths = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, BatchDirectoryIndex?> _lexicalDirectories = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, BatchDirectoryIndex> _physicalDirectories = new(StringComparer.Ordinal);
+
+        internal string? TryNormalize(string? path) {
+            if (string.IsNullOrWhiteSpace(path)) return null;
+            string fullPath;
+            try {
+                fullPath = Path.GetFullPath(path);
+            } catch (Exception exception) when (exception is ArgumentException or NotSupportedException or IOException or UnauthorizedAccessException) {
+                return null;
+            }
+            if (_normalizedPaths.TryGetValue(fullPath, out string? cached)) return cached;
+            try {
+                string identity = OfficeWorkflowPathIdentity.Normalize(fullPath);
+                _normalizedPaths.Add(fullPath, identity);
+                return identity;
+            } catch (Exception exception) when (exception is ArgumentException or NotSupportedException or IOException or UnauthorizedAccessException) {
+                _normalizedPaths.Add(fullPath, null);
+                return null;
+            }
+        }
+
+        internal string? TryNormalizeCandidate(string path) {
+            try {
+                string fullPath = Path.GetFullPath(path);
+                if (_normalizedPaths.TryGetValue(fullPath, out string? cached)) return cached;
+                BatchDirectoryIndex? directory = TryGetDirectory(fullPath);
+                if (directory is null) return null;
+                string identity = directory.NormalizeChild(Path.GetFileName(fullPath));
+                _normalizedPaths.Add(fullPath, identity);
+                return identity;
+            } catch (Exception exception) when (exception is ArgumentException or NotSupportedException or IOException or UnauthorizedAccessException) {
+                return null;
+            }
+        }
+
+        internal IReadOnlySet<string>? TryGetExistingEntries(string path) {
+            try {
+                string fullPath = Path.GetFullPath(path);
+                return TryGetDirectory(fullPath)?.ExistingEntries;
+            } catch (Exception exception) when (exception is ArgumentException or NotSupportedException or IOException or UnauthorizedAccessException) {
+                return null;
+            }
+        }
+
+        private BatchDirectoryIndex? TryGetDirectory(string fullChildPath) {
+            string? directoryPath = Path.GetDirectoryName(fullChildPath);
+            if (string.IsNullOrEmpty(directoryPath)) return null;
+            if (_lexicalDirectories.TryGetValue(directoryPath, out BatchDirectoryIndex? cached)) return cached;
+            try {
+                if (cancellationToken.IsCancellationRequested) return null;
+                string physicalDirectory = OfficeWorkflowPathIdentity.ResolvePhysicalPath(directoryPath);
+                bool caseInsensitive = OfficeWorkflowPathIdentity.IsCaseInsensitiveFileSystem(physicalDirectory);
+                string physicalIdentity = OfficeWorkflowPathIdentity.Normalize(physicalDirectory, caseInsensitive);
+                if (_physicalDirectories.TryGetValue(physicalIdentity, out BatchDirectoryIndex? shared)) {
+                    _lexicalDirectories.Add(directoryPath, shared);
+                    return shared;
+                }
+                var existingEntries = new HashSet<string>(StringComparer.Ordinal);
+                if (Directory.Exists(directoryPath)) {
+                    foreach (string entry in Directory.EnumerateFileSystemEntries(directoryPath)) {
+                        if (cancellationToken.IsCancellationRequested) return null;
+                        existingEntries.Add(OfficeWorkflowPathIdentity.Normalize(
+                            Path.Combine(physicalDirectory, Path.GetFileName(entry)),
+                            caseInsensitive));
+                    }
+                }
+                var index = new BatchDirectoryIndex(physicalDirectory, caseInsensitive, existingEntries);
+                _physicalDirectories.Add(physicalIdentity, index);
+                _lexicalDirectories.Add(directoryPath, index);
+                return index;
+            } catch (Exception exception) when (exception is ArgumentException or NotSupportedException or IOException or UnauthorizedAccessException) {
+                _lexicalDirectories.Add(directoryPath, null);
+                return null;
+            }
+        }
+    }
+
+    private sealed class BatchDirectoryIndex(
+        string physicalDirectory,
+        bool caseInsensitive,
+        IReadOnlySet<string> existingEntries) {
+        internal IReadOnlySet<string> ExistingEntries { get; } = existingEntries;
+
+        internal string NormalizeChild(string fileName) => OfficeWorkflowPathIdentity.Normalize(
+            Path.Combine(physicalDirectory, fileName),
+            caseInsensitive);
+    }
+}

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.ProvenanceBatch.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.ProvenanceBatch.cs
@@ -61,7 +61,8 @@ public sealed partial class OfficeWorkflowRunner {
 
     internal static OfficeProvenanceWorkflowRequest[] PrepareBatchRemovalPaths(
         IReadOnlyList<OfficeProvenanceWorkflowRequest> requests,
-        CancellationToken cancellationToken = default) {
+        CancellationToken cancellationToken = default,
+        bool? usePhysicalIdentity = null) {
         var prepared = new OfficeProvenanceWorkflowRequest[requests.Count];
         for (int index = 0; index < requests.Count; index++) {
             OfficeProvenanceWorkflowRequest request = requests[index] ??
@@ -73,7 +74,7 @@ public sealed partial class OfficeWorkflowRunner {
             return prepared;
         }
 
-        var pathIndex = new BatchPathIndex(cancellationToken);
+        var pathIndex = new BatchPathIndex(cancellationToken, usePhysicalIdentity);
         var inputRequestIndexes = new Dictionary<string, List<int>>(StringComparer.Ordinal);
         for (int index = 0; index < prepared.Length; index++) {
             if (cancellationToken.IsCancellationRequested) return prepared;
@@ -331,7 +332,10 @@ public sealed partial class OfficeWorkflowRunner {
         }
     }
 
-    private sealed class BatchPathIndex(CancellationToken cancellationToken) {
+    private sealed class BatchPathIndex(
+        CancellationToken cancellationToken,
+        bool? usePhysicalIdentity) {
+        private readonly bool _usePhysicalIdentity = usePhysicalIdentity ?? OfficeWorkflowPathIdentity.SupportsPhysicalIdentity;
         private readonly Dictionary<string, string?> _normalizedPaths = new(StringComparer.Ordinal);
         private readonly Dictionary<string, BatchDirectoryIndex> _lexicalDirectories = new(StringComparer.Ordinal);
         private readonly Dictionary<string, BatchDirectoryIndex> _physicalDirectories = new(StringComparer.Ordinal);
@@ -348,7 +352,9 @@ public sealed partial class OfficeWorkflowRunner {
             }
             if (_normalizedPaths.TryGetValue(fullPath, out string? cached)) return cached;
             try {
-                string identity = OfficeWorkflowPathIdentity.Normalize(fullPath);
+                string identity = OfficeWorkflowPathIdentity.NormalizeWithPortableFallback(
+                    fullPath,
+                    _usePhysicalIdentity);
                 _normalizedPaths.Add(fullPath, identity);
                 return identity;
             } catch (ArgumentException) {
@@ -393,9 +399,15 @@ public sealed partial class OfficeWorkflowRunner {
             if (_lexicalDirectories.TryGetValue(directoryPath, out BatchDirectoryIndex? cached)) return cached;
             try {
                 cancellationToken.ThrowIfCancellationRequested();
-                string physicalDirectory = OfficeWorkflowPathIdentity.ResolvePhysicalPath(directoryPath);
+                string physicalDirectory = _usePhysicalIdentity
+                    ? OfficeWorkflowPathIdentity.ResolvePhysicalPath(directoryPath)
+                    : Path.GetFullPath(directoryPath);
                 bool caseInsensitive = OfficeWorkflowPathIdentity.IsCaseInsensitiveFileSystem(physicalDirectory);
-                string physicalIdentity = OfficeWorkflowPathIdentity.Normalize(physicalDirectory, caseInsensitive);
+                string physicalIdentity = _usePhysicalIdentity
+                    ? OfficeWorkflowPathIdentity.Normalize(physicalDirectory, caseInsensitive)
+                    : OfficeWorkflowPathIdentity.NormalizeWithPortableFallback(
+                        physicalDirectory,
+                        usePhysicalIdentity: false);
                 if (_physicalDirectories.TryGetValue(physicalIdentity, out BatchDirectoryIndex? shared)) {
                     _lexicalDirectories.Add(directoryPath, shared);
                     return shared;

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.ProvenanceBatch.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.ProvenanceBatch.cs
@@ -159,7 +159,6 @@ public sealed partial class OfficeWorkflowRunner {
             if (cancellationToken.IsCancellationRequested) return prepared;
             OfficeProvenanceWorkflowRequest request = prepared[index];
             if (request.Operation != OfficeProvenanceWorkflowOperation.Remove ||
-                request.ConflictPolicy != OfficeWorkflowConflictPolicy.Rename ||
                 string.IsNullOrWhiteSpace(request.OutputPath)) continue;
             request.BatchBlockedOutputIdentities = blockedOutputIdentities;
             request.BatchOwnReservedOutputIdentity = pathIndex.NormalizeCandidate(request.OutputPath);

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.ProvenanceBatch.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.ProvenanceBatch.cs
@@ -98,6 +98,7 @@ public sealed partial class OfficeWorkflowRunner {
             string? outputPath = TryResolveBatchRemovalOutput(request);
             string? identity = pathIndex.TryNormalize(outputPath);
             if (outputPath is null || identity is null) continue;
+            request.OutputPath = outputPath;
             EnsureBatchOutputDoesNotOverlapInput(
                 outputPath,
                 identity,

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.ProvenanceBatch.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.ProvenanceBatch.cs
@@ -55,6 +55,7 @@ public sealed partial class OfficeWorkflowRunner {
             materialized.Add(enumerator.Current);
             if (cancellationToken.IsCancellationRequested) break;
         }
+        if (materialized.Count == 0) cancellationToken.ThrowIfCancellationRequested();
         return materialized.ToArray();
     }
 

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.cs
@@ -804,10 +804,13 @@ public sealed partial class OfficeWorkflowRunner : IOfficeWorkflowRunner {
         }
     }
 
-    private static void EnforceInputLimit(string path, long size, OfficeWorkflowLimits limits) {
-        if (size > limits.MaximumInputBytes) {
+    private static void EnforceInputLimit(string path, long size, OfficeWorkflowLimits limits) =>
+        EnforceInputLimit(path, size, limits.MaximumInputBytes);
+
+    private static void EnforceInputLimit(string path, long size, long maximumBytes) {
+        if (size > maximumBytes) {
             throw new InvalidOperationException(
-                $"Input '{Path.GetFileName(path)}' is {size:N0} bytes, above the configured {limits.MaximumInputBytes:N0}-byte limit.");
+                $"Input '{Path.GetFileName(path)}' is {size:N0} bytes, above the configured {maximumBytes:N0}-byte limit.");
         }
     }
 

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.cs
@@ -809,7 +809,7 @@ public sealed partial class OfficeWorkflowRunner : IOfficeWorkflowRunner {
 
     private static void EnforceInputLimit(string path, long size, long maximumBytes) {
         if (size > maximumBytes) {
-            throw new InvalidOperationException(
+            throw OfficeIMO.Provenance.OfficeProvenanceLimitException.Create(
                 $"Input '{Path.GetFileName(path)}' is {size:N0} bytes, above the configured {maximumBytes:N0}-byte limit.");
         }
     }

--- a/OfficeIMO.Workflows/README.md
+++ b/OfficeIMO.Workflows/README.md
@@ -1,6 +1,6 @@
 # OfficeIMO.Workflows
 
-`OfficeIMO.Workflows` is the reusable local orchestration layer for OfficeIMO document jobs. It composes the existing first-party conversion and PDF APIs behind typed requests, bounded execution, cooperative cancellation, collision policies, atomic output publication, and post-write validation.
+`OfficeIMO.Workflows` is the reusable local orchestration layer for OfficeIMO document jobs. It composes the existing first-party conversion, PDF, and provenance APIs behind typed requests, bounded execution, cooperative cancellation, collision policies, atomic output publication, and post-write validation.
 
 The package does not add a second document or PDF engine. Desktop applications, command-line tools, and services can share this workflow contract while keeping their user-interface and hosting code thin.
 
@@ -36,3 +36,33 @@ Console.WriteLine(result.OutputPath);
 `RunAsync` also exposes PDF inspection, comparison, optimization, repair planning, repair, and sanitization through typed operations. `ExportPdfPagesAsync` exports selected PDF pages as images, `AssemblePdfAsync` combines supported PDFs, images, documents, folders, and ZIP archives, and `PdfPrintPlanner.Create` produces deterministic print-sheet placement plans.
 
 Every request runs with explicit input and output limits, cancellation, staged output validation, and a caller-selected collision policy. Passwords remain request-only values and are not copied into diagnostics or results. PDF comparison accepts a separate `ComparisonPdfPassword` when the two inputs use different credentials.
+
+## Inspect and remove provenance
+
+The provenance workflow keeps format logic in its owning package. `OfficeIMO.Word`, `OfficeIMO.Excel`, `OfficeIMO.PowerPoint`, `OfficeIMO.Visio`, `OfficeIMO.OpenDocument`, `OfficeIMO.Epub`, `OfficeIMO.Pdf`, `OfficeIMO.Html`, and `OfficeIMO.Markdown` handle their formats; `OfficeIMO.Core` handles supported images and structured text. Consumers can discover the exact extension-to-owner map through `OfficeProvenanceWorkflowCatalog.All`.
+
+```csharp
+using OfficeIMO.Workflows;
+
+var runner = new OfficeWorkflowRunner();
+
+OfficeProvenanceWorkflowResult inspection = await runner.RunProvenanceAsync(
+    new OfficeProvenanceWorkflowRequest {
+        Operation = OfficeProvenanceWorkflowOperation.Inspect,
+        InputPath = "report.docx"
+    });
+
+OfficeProvenanceWorkflowResult removal = await runner.RunProvenanceAsync(
+    new OfficeProvenanceWorkflowRequest {
+        Operation = OfficeProvenanceWorkflowOperation.Remove,
+        InputPath = "report.docx",
+        OutputPath = "report.cleaned.docx",
+        ConflictPolicy = OfficeWorkflowConflictPolicy.Fail
+    });
+```
+
+`Assess` combines the owner-specific structural report with exact Unicode findings and optional `IOfficeProvenanceVerifier` / `IOfficeProvenanceSignalDetector` services supplied to the runner. It preserves each provider's result and does not infer a universal authorship verdict.
+
+Removal is strict by default. It removes only selected, structurally valid carriers and blocks a package-signature-invalidating save unless the caller explicitly selects `OfficeSignatureMutationPolicy.RemoveInvalidatedSignatures`. The output is written to a sibling staging file, reopened through the same format owner, checked against the removal report, and only then published under the requested conflict policy. Generic ZIP packages can be inspected but are not mutated without a registered format owner.
+
+Use `RunProvenanceBatchAsync` for bounded sequential batches. Sequential execution keeps parser and provider resource use predictable, while per-request progress includes an overall batch fraction.

--- a/README.md
+++ b/README.md
@@ -765,9 +765,17 @@ _Dependency footprint:_ only OfficeIMO HTML, PDF, and Drawing packages; no brows
 
 _Dependency footprint:_ OfficeIMO Core and PDF plus HtmlTinkerX. This optional package does not change the managed `OfficeIMO.Html.Pdf` dependency graph.
 
+#### [OfficeIMO.Workflows](OfficeIMO.Workflows/README.md)
+
+- [x] Typed, bounded conversion, PDF health, page export, assembly, printing, and cross-format provenance workflows
+- [x] Canonical format-owner routing for provenance inspection, combined assessment, and strict selective removal
+- [x] Cooperative cancellation, conflict policies, staged reopen validation, atomic publication, and bounded sequential batches
+
+_Dependency footprint:_ first-party OfficeIMO format and conversion packages only; no hosted service, browser process, vendor detector, or bundled provenance executable.
+
 #### [OfficeIMO.Tool](OfficeIMO.Tool/README.md)
 
-- [x] One `officeimo` executable with explicit `html`, `reader`, `markup`, `agent`, and `mcp` command areas
+- [x] One `officeimo` executable with explicit `html`, `reader`, `markup`, `workflow`, `provenance`, `agent`, and `mcp` command areas
 - [x] Bounded HTML/MHTML-to-PDF conversion, document extraction, capability discovery, Markup validation, code emission, and Office export
 - [x] Compact inspect/search/fetch operations for documents and mail stores, plus a local STDIO MCP server for Codex and other clients
 - [x] Shared help, exit-code, packaging, NativeAOT, and stream contracts without duplicating document logic from the owning libraries


### PR DESCRIPTION
## Summary

Adds one typed provenance workflow across OfficeIMO's format owners and exposes it through OfficeIMO.Tool.

Applications can inspect provenance carriers, combine structural findings with optional verification and detector results, and remove supported carriers without duplicating format-specific routing.

## What changes

- Adds typed inspect, assess, remove, and bounded batch operations to OfficeIMO.Workflows.
- Routes Word, Excel, PowerPoint, Visio, OpenDocument, EPUB, PDF, HTML, Markdown, image, text, ZIP, and OPC inputs through their owning OfficeIMO packages.
- Publishes removal output through staging, owner reopen validation, structural comparison, and atomic destination replacement.
- Adds `officeimo provenance capabilities|inspect|assess|remove|batch` with stable JSON schemas and complete structural, verification, text-integrity, provider-signal, and workflow-diagnostic evidence in JSON and text output.
- Keeps combined assessment composition in OfficeIMO.Core so workflow, CLI, Studio, and PowerShell consumers share one result contract.
- Adds a dependency-free Core baseline for HTML C2PA links and embedded manifests, including relative base resolution for verifier sidecars.
- Refines unknown-extension UTF-16 and UTF-32 HTML inputs from their BOM and decodes HTML reference entities exactly once.
- Aligns Core HTML manifest discovery with parser head ownership, including implicit body starts, encoded head whitespace, late or duplicate head tags, template fragments, malformed tag openers, and parser-recovered metadata after an explicit head closure.
- Documents supported carriers, removal behavior, verification boundaries, and resource limits.

## Safety and compatibility

- Existing provenance inspection APIs remain available.
- Assessment and removal use one bounded, private snapshot so every provider evaluates the same immutable input bytes.
- Snapshot capture uses the selected operation's effective parser limit, preventing broader workflow defaults from bypassing inspection, assessment, or removal limits.
- Snapshot capture uses physical file identity on Windows, Linux, and macOS, with a content-stable regular-file fallback on other file-capable runtimes.
- Snapshot directories are sealed against namespace writes while path-based owners and providers consume them, then reopened only for bounded dependency capture and cleanup.
- Provider-backed HTML assessment snapshots local relative manifest dependencies and rejects absolute, rooted, parent-relative, and encoded traversal paths that cannot remain inside the immutable snapshot.
- External dependency snapshots deduplicate Unicode path aliases through the same platform-aware canonical identity.
- Text reading, decoding, Unicode traversal, Core structured-text scanning, HTML DOM parsing, PDF parsing and attachment extraction, PDF object-graph rewriting, provider execution and report interpretation, output hashing, batch materialization, and batch processing observe cancellation and time limits. Empty lazy batches cannot erase cancellation raised during enumeration.
- Pre-cancelled requests take precedence over input validation. Library batches do not enumerate lazy request sources, and the CLI emits one structured Cancelled result with exit code 130 even when the first input is missing.
- Text-integrity assessment uses BOM-aware decoding in Core and owner-resolved HTML and XML encodings in workflows, while the HTML owner preserves structural inspection and removal for UTF-32 little- and big-endian inputs.
- Input and output budgets are enforced independently, while removal carries one cumulative expanded-byte allowance through preflight, owner mutation, and staged-output validation. ZIP inspection and PDF decoded streams report their expansion into that shared budget.
- Signed or ambiguous containers continue to fail conservatively instead of being rewritten silently.
- Batch requests preflight rename and fixed destinations with a cancellation-aware physical-directory index, retain the complete reservation set for every conflict policy, and revalidate current identities immediately before publication. Other .NET-supported filesystems use a platform-aware lexical identity fallback.
- Output is reopened by its owning format package, structurally compared, and atomically promoted only after validation succeeds.
- In-place removal pins the original source identity, length, and SHA-256 and restores a concurrent save instead of publishing stale snapshot-derived output.
- Staged-output publication uses physical identity plus length and SHA-256 where available, with a length-and-hash fallback on other .NET-supported filesystems.
- Removal progress reports completion only after final published-identity validation and guarded commit finalization; cancellation or failure before that point rolls back without emitting terminal success.
- Snapshot and replacement-backup cleanup failures after atomic publication are retained as structured diagnostics without misreporting the committed output as failed. Text-mode CLI output includes retained cleanup paths for operators.
- Source-access failures retain the input contract, while private snapshot-storage failures and malformed optional-provider results use the execution-failure contract and owner staging failures use the output-failure contract.

## Validation

- OfficeIMO.Shared.Tests passed 1,009 tests on .NET Framework 4.7.2 and 1,018 tests on both .NET 8 and .NET 10.
- OfficeIMO.Workflows.Tests passed 211 tests on both .NET 8 and .NET 10.
- OfficeIMO.Pdf.Tests passed 6,109 tests on .NET Framework 4.7.2 and 6,129 tests on both .NET 8 and .NET 10.
- OfficeIMO.Html.Tests passed 2,618 tests on both .NET 8 and .NET 10 and 2,617 tests on .NET Framework 4.7.2.
- OfficeIMO.Provenance.C2pa.Tests passed 56 tests on both .NET 8 and .NET 10.
- OfficeIMO.Tool.Tests passed 156 tests on both .NET 8 and .NET 10.
- Focused contracts cover parent-relative and encoded snapshot traversal, deterministic parser cancellation at the worker boundary, cumulative ZIP and PDF expanded-byte accounting, parser-recovered after-head metadata, provider execution and interpretation cancellation/timeouts, provider-result failure classification, snapshot failure classification, concurrent in-place saves, UTF-32 HTML owner routing, retained replacement-backup and staging-cleanup diagnostics, text-mode cleanup paths, portable batch identity fallback, explicit and default batch destination retargeting, and PDF parser cancellation.
- Core, PDF, C2PA, HTML, Workflows, and Tool production builds completed with zero warnings and zero errors.
- Fresh Workflows and Tool packages were built, the CLI was installed from the local package, and provenance capability discovery was exercised.
- The Windows x64 NativeAOT tool was published and exercised against the same capability contract.

## Downstream use

OfficeIMO Studio can consume the workflow directly from this repository. After the corresponding OfficeIMO packages are published, [PSWriteOffice](https://github.com/EvotecIT/PSWriteOffice) can add a thin PowerShell surface over the same workflow contract.
