### PR TITLE
Fix overlapping PDF table detection

### DIFF
--- a/OfficeIMO.Excel.Tests/Pdf/Excel.PdfTableImportTests.cs
+++ b/OfficeIMO.Excel.Tests/Pdf/Excel.PdfTableImportTests.cs
@@ -699,6 +699,7 @@ public partial class Excel {
     [InlineData("Metric", "2025")]
     [InlineData("Metric", "FY2025")]
     [InlineData("Metric", "Q1")]
+    [InlineData("Employee", "Salary")]
     public void PdfTables_BandGroupingStopsAtANewEmphasizedHeader(string headerLeft, string headerRight) {
         static PdfCore.TextLayoutEngine.TextLine Row(double y, bool emphasized, string left, string right) {
             string? baseFont = emphasized ? "Helvetica-Bold" : "Helvetica";
@@ -815,7 +816,6 @@ public partial class Excel {
     [InlineData("North", "Q1")]
     [InlineData("North Region", "Q1")]
     [InlineData("C-300", "Closed")]
-    [InlineData("North", "Closed")]
     [InlineData("Enabled", "Yes")]
     [InlineData("Central", "N/A")]
     public void PdfTables_BandGroupingKeepsEmphasizedDataRows(string label, string value) {
@@ -1017,6 +1017,40 @@ public partial class Excel {
             static table => table.Kind == "band-group" && table.Rows[0][0] == "Code");
 
         Assert.Equal(3, first.Rows.Count);
+        Assert.DoesNotContain(first.Rows, static row => row.Contains("INTERIM RESULTS", StringComparer.Ordinal));
+        Assert.DoesNotContain(first.Rows, static row => row.Contains("Alpha", StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void PdfTables_BandGroupingDoesNotUseDistantAttachedHeaderAsRowRhythm() {
+        static PdfCore.TextLayoutEngine.TextLine Row(double y, string left, string right) {
+            var spans = new List<PdfCore.PdfTextSpan> {
+                new(left, "F1", 10, 20, y, 60),
+                new(right, "F1", 10, 180, y, 40)
+            };
+            return new PdfCore.TextLayoutEngine.TextLine(y, 20, 220, left + " " + right, spans);
+        }
+
+        var headerSpans = new List<PdfCore.PdfTextSpan> {
+            new("Account", "F1", 10, 20, 900, 150, baseFont: "Helvetica-Bold"),
+            new("Total", "F1", 10, 180, 900, 40, baseFont: "Helvetica-Bold")
+        };
+        var captionSpans = new List<PdfCore.PdfTextSpan> {
+            new("INTERIM RESULTS", "F1", 10, 20, 450, 200, baseFont: "Helvetica-Bold")
+        };
+        var bands = new List<List<PdfCore.TextLayoutEngine.TextLine>> {
+            new() { new PdfCore.TextLayoutEngine.TextLine(900, 20, 220, "Account Total", headerSpans) },
+            new() { Row(700, "North", "1250") },
+            new() { new PdfCore.TextLayoutEngine.TextLine(450, 20, 220, "INTERIM RESULTS", captionSpans) },
+            new() { Row(200, "Alpha", "22") },
+            new() { Row(180, "Beta", "24") }
+        };
+
+        PdfCore.StructuredTable first = Assert.Single(
+            PdfCore.TableDetector.DetectTablesFromBands(bands),
+            static table => table.Kind == "band-group" && table.Rows[0][0] == "Account");
+
+        Assert.Equal(2, first.Rows.Count);
         Assert.DoesNotContain(first.Rows, static row => row.Contains("INTERIM RESULTS", StringComparer.Ordinal));
         Assert.DoesNotContain(first.Rows, static row => row.Contains("Alpha", StringComparer.Ordinal));
     }

--- a/OfficeIMO.Excel.Tests/Pdf/Excel.PdfTableImportTests.cs
+++ b/OfficeIMO.Excel.Tests/Pdf/Excel.PdfTableImportTests.cs
@@ -723,6 +723,32 @@ public partial class Excel {
     }
 
     [Fact]
+    public void PdfTables_BandGroupingKeepsEmphasizedSummaryRows() {
+        static PdfCore.TextLayoutEngine.TextLine Row(double y, bool emphasized, string left, string right) {
+            string? baseFont = emphasized ? "Helvetica-Bold" : "Helvetica";
+            var spans = new List<PdfCore.PdfTextSpan> {
+                new(left, "F1", 10, 20, y, 60, baseFont: baseFont),
+                new(right, "F1", 10, 180, y, 40, baseFont: baseFont)
+            };
+            return new PdfCore.TextLayoutEngine.TextLine(y, 20, 220, left + " " + right, spans);
+        }
+
+        var bands = new List<List<PdfCore.TextLayoutEngine.TextLine>> {
+            new() { Row(700, true, "Code", "Qty") },
+            new() { Row(680, false, "A-100", "12") },
+            new() { Row(660, false, "B-200", "14") },
+            new() { Row(640, true, "Total", "26") }
+        };
+
+        PdfCore.StructuredTable table = Assert.Single(
+            PdfCore.TableDetector.DetectTablesFromBands(bands),
+            static candidate => candidate.Kind == "band-group");
+
+        Assert.Equal(4, table.Rows.Count);
+        Assert.Equal(new[] { "Total", "26" }, table.Rows[3]);
+    }
+
+    [Fact]
     public void PdfTables_BandGroupingUsesRowRhythmForLargeHeaderGaps() {
         static PdfCore.TextLayoutEngine.TextLine Header(double y) {
             var spans = new List<PdfCore.PdfTextSpan> {

--- a/OfficeIMO.Excel.Tests/Pdf/Excel.PdfTableImportTests.cs
+++ b/OfficeIMO.Excel.Tests/Pdf/Excel.PdfTableImportTests.cs
@@ -723,7 +723,57 @@ public partial class Excel {
     }
 
     [Fact]
-    public void PdfTables_BandGroupingKeepsEmphasizedSummaryRows() {
+    public void PdfTables_BandGroupingStopsAtASplitlessInterveningHeader() {
+        static PdfCore.TextLayoutEngine.TextLine WideRow(double y, bool emphasized, string left, string right) {
+            string? baseFont = emphasized ? "Helvetica-Bold" : "Helvetica";
+            var spans = new List<PdfCore.PdfTextSpan> {
+                new(left, "F1", 10, 20, y, 60, baseFont: baseFont),
+                new(right, "F1", 10, 400, y, 40, baseFont: baseFont)
+            };
+            return new PdfCore.TextLayoutEngine.TextLine(y, 20, 440, left + " " + right, spans);
+        }
+
+        static PdfCore.TextLayoutEngine.TextLine NarrowRow(double y, string left, string right) {
+            var spans = new List<PdfCore.PdfTextSpan> {
+                new(left, "F1", 10, 20, y, 60),
+                new(right, "F1", 10, 180, y, 40)
+            };
+            return new PdfCore.TextLayoutEngine.TextLine(y, 20, 220, left + " " + right, spans);
+        }
+
+        static PdfCore.TextLayoutEngine.TextLine SplitlessHeader(double y) {
+            var spans = new List<PdfCore.PdfTextSpan> {
+                new("Name", "F1", 10, 20, y, 145, baseFont: "Helvetica-Bold"),
+                new("Total", "F1", 10, 180, y, 100, baseFont: "Helvetica-Bold")
+            };
+            return new PdfCore.TextLayoutEngine.TextLine(y, 20, 280, "Name Total", spans);
+        }
+
+        var bands = new List<List<PdfCore.TextLayoutEngine.TextLine>> {
+            new() { WideRow(700, true, "Code", "Qty") },
+            new() { WideRow(680, false, "A-100", "12") },
+            new() { WideRow(660, false, "B-200", "14") },
+            new() { SplitlessHeader(640) },
+            new() { NarrowRow(620, "Alpha", "22") },
+            new() { NarrowRow(600, "Beta", "24") }
+        };
+
+        PdfCore.StructuredTable[] grouped = PdfCore.TableDetector.DetectTablesFromBands(bands)
+            .Where(static table => table.Kind == "band-group")
+            .ToArray();
+
+        Assert.Equal(2, grouped.Length);
+        Assert.Equal(new[] { "Code", "Qty" }, grouped[0].Rows[0]);
+        Assert.Equal(new[] { "Name", "Total" }, grouped[1].Rows[0]);
+    }
+
+    [Theory]
+    [InlineData("Total")]
+    [InlineData("Grand Total")]
+    [InlineData("Sub Total")]
+    [InlineData("Net Subtotal")]
+    [InlineData("Overall Totals")]
+    public void PdfTables_BandGroupingKeepsEmphasizedSummaryRows(string summaryLabel) {
         static PdfCore.TextLayoutEngine.TextLine Row(double y, bool emphasized, string left, string right) {
             string? baseFont = emphasized ? "Helvetica-Bold" : "Helvetica";
             var spans = new List<PdfCore.PdfTextSpan> {
@@ -737,7 +787,7 @@ public partial class Excel {
             new() { Row(700, true, "Code", "Qty") },
             new() { Row(680, false, "A-100", "12") },
             new() { Row(660, false, "B-200", "14") },
-            new() { Row(640, true, "Total", "26") }
+            new() { Row(640, true, summaryLabel, "26") }
         };
 
         PdfCore.StructuredTable table = Assert.Single(
@@ -745,7 +795,7 @@ public partial class Excel {
             static candidate => candidate.Kind == "band-group");
 
         Assert.Equal(4, table.Rows.Count);
-        Assert.Equal(new[] { "Total", "26" }, table.Rows[3]);
+        Assert.Equal(new[] { summaryLabel, "26" }, table.Rows[3]);
     }
 
     [Fact]
@@ -779,6 +829,57 @@ public partial class Excel {
         Assert.Equal(3, table.Rows.Count);
         Assert.Equal(new[] { "Account Name", "Annual Total" }, table.Rows[0]);
         Assert.Equal(new[] { "South", "980" }, table.Rows[2]);
+    }
+
+    [Fact]
+    public void PdfTables_BandGroupingAllowsStrongTwoRowTablesAcrossLargeGaps() {
+        var headerSpans = new List<PdfCore.PdfTextSpan> {
+            new("Account", "F1", 10, 20, 700, 145, baseFont: "Helvetica-Bold"),
+            new("Total", "F1", 10, 180, 700, 70, baseFont: "Helvetica-Bold")
+        };
+        var bodySpans = new List<PdfCore.PdfTextSpan> {
+            new("North", "F1", 10, 20, 600, 60),
+            new("1250", "F1", 10, 180, 600, 40)
+        };
+        var bands = new List<List<PdfCore.TextLayoutEngine.TextLine>> {
+            new() { new PdfCore.TextLayoutEngine.TextLine(700, 20, 250, "Account Total", headerSpans) },
+            new() { new PdfCore.TextLayoutEngine.TextLine(600, 20, 220, "North 1250", bodySpans) }
+        };
+
+        PdfCore.StructuredTable table = Assert.Single(
+            PdfCore.TableDetector.DetectTablesFromBands(bands),
+            static candidate => candidate.Kind == "band-group");
+
+        Assert.Equal(2, table.Rows.Count);
+        Assert.Equal(new[] { "Account", "Total" }, table.Rows[0]);
+        Assert.Equal(new[] { "North", "1250" }, table.Rows[1]);
+    }
+
+    [Fact]
+    public void PdfTables_AlignedSplitAccumulatorRejectsAnInvalidLaterBoundary() {
+        static PdfCore.TextLayoutEngine.TextLine Row(double y, params PdfCore.PdfTextSpan[] spans) =>
+            new(y, spans.Min(static span => span.X), spans.Max(static span => span.X + span.Advance), string.Join(" ", spans.Select(static span => span.Text)), spans.ToList());
+
+        PdfCore.TextLayoutEngine.TextLine first = Row(
+            700,
+            new PdfCore.PdfTextSpan("Region", "F1", 10, 20, 700, 115),
+            new PdfCore.PdfTextSpan("Total", "F1", 10, 160, 700, 85));
+        PdfCore.TextLayoutEngine.TextLine second = Row(
+            680,
+            new PdfCore.PdfTextSpan("North", "F1", 10, 35, 680, 120),
+            new PdfCore.PdfTextSpan("1250", "F1", 10, 180, 680, 65));
+        PdfCore.TextLayoutEngine.TextLine invalid = Row(
+            660,
+            new PdfCore.PdfTextSpan("West", "F1", 10, 50, 660, 105),
+            new PdfCore.PdfTextSpan("region", "F1", 10, 160, 660, 20),
+            new PdfCore.PdfTextSpan("1430", "F1", 10, 205, 660, 40));
+
+        var accumulator = new PdfCore.TableDetector.AlignedSplitAccumulator(2, new[] { first });
+
+        Assert.True(accumulator.TryAppend(new[] { second }, requireValidSplits: true));
+        double splitBeforeInvalidRow = Assert.Single(accumulator.GetSplits()!);
+        Assert.False(accumulator.TryAppend(new[] { invalid }, requireValidSplits: true));
+        Assert.Equal(splitBeforeInvalidRow, Assert.Single(accumulator.GetSplits()!));
     }
 
     [Fact]

--- a/OfficeIMO.Excel.Tests/Pdf/Excel.PdfTableImportTests.cs
+++ b/OfficeIMO.Excel.Tests/Pdf/Excel.PdfTableImportTests.cs
@@ -695,6 +695,101 @@ public partial class Excel {
     }
 
     [Fact]
+    public void PdfTables_BandGroupingStopsAtANewEmphasizedHeader() {
+        static PdfCore.TextLayoutEngine.TextLine Row(double y, bool emphasized, string left, string right) {
+            string? baseFont = emphasized ? "Helvetica-Bold" : "Helvetica";
+            var spans = new List<PdfCore.PdfTextSpan> {
+                new(left, "F1", 10, 20, y, 60, baseFont: baseFont),
+                new(right, "F1", 10, 180, y, 40, baseFont: baseFont)
+            };
+            return new PdfCore.TextLayoutEngine.TextLine(y, 20, 220, left + " " + right, spans);
+        }
+
+        var bands = new List<List<PdfCore.TextLayoutEngine.TextLine>> {
+            new() { Row(700, true, "Code", "Qty") },
+            new() { Row(680, false, "A-100", "12") },
+            new() { Row(660, false, "B-200", "14") },
+            new() { Row(640, true, "Name", "Total") },
+            new() { Row(620, false, "Alpha", "22") },
+            new() { Row(600, false, "Beta", "24") }
+        };
+
+        List<PdfCore.StructuredTable> tables = PdfCore.TableDetector.DetectTablesFromBands(bands);
+        PdfCore.StructuredTable[] grouped = tables.Where(static table => table.Kind == "band-group").ToArray();
+
+        Assert.Equal(2, grouped.Length);
+        Assert.Equal(new[] { "Code", "Qty" }, grouped[0].Rows[0]);
+        Assert.Equal(new[] { "Name", "Total" }, grouped[1].Rows[0]);
+    }
+
+    [Fact]
+    public void PdfTables_BandGroupingUsesRowRhythmForLargeHeaderGaps() {
+        static PdfCore.TextLayoutEngine.TextLine Header(double y) {
+            var spans = new List<PdfCore.PdfTextSpan> {
+                new("Account Name", "F1", 10, 20, y, 150, baseFont: "Helvetica-Bold"),
+                new("Annual Total", "F1", 10, 180, y, 70, baseFont: "Helvetica-Bold")
+            };
+            return new PdfCore.TextLayoutEngine.TextLine(y, 20, 250, "Account Name Annual Total", spans);
+        }
+
+        static PdfCore.TextLayoutEngine.TextLine Body(double y, string left, string right) {
+            var spans = new List<PdfCore.PdfTextSpan> {
+                new(left, "F1", 10, 20, y, 60),
+                new(right, "F1", 10, 180, y, 40)
+            };
+            return new PdfCore.TextLayoutEngine.TextLine(y, 20, 220, left + " " + right, spans);
+        }
+
+        var bands = new List<List<PdfCore.TextLayoutEngine.TextLine>> {
+            new() { Header(700) },
+            new() { Body(640, "North", "1250") },
+            new() { Body(580, "South", "980") }
+        };
+
+        PdfCore.StructuredTable table = Assert.Single(
+            PdfCore.TableDetector.DetectTablesFromBands(bands),
+            static candidate => candidate.Kind == "band-group");
+
+        Assert.Equal(3, table.Rows.Count);
+        Assert.Equal(new[] { "Account Name", "Annual Total" }, table.Rows[0]);
+        Assert.Equal(new[] { "South", "980" }, table.Rows[2]);
+    }
+
+    [Fact]
+    public void PdfTables_BandGroupingRejectsDriftWithoutACommonSplit() {
+        static PdfCore.TextLayoutEngine.TextLine Row(double y, double x, bool emphasized, string left, string right) {
+            string? baseFont = emphasized ? "Helvetica-Bold" : "Helvetica";
+            var spans = new List<PdfCore.PdfTextSpan> {
+                new(left, "F1", 10, x, y, 115, baseFont: baseFont),
+                new(right, "F1", 10, x + 140, y, 245 - (x + 140), baseFont: baseFont)
+            };
+            return new PdfCore.TextLayoutEngine.TextLine(y, x, 245, left + " " + right, spans);
+        }
+
+        static PdfCore.TextLayoutEngine.TextLine DriftedRow(double y) {
+            var spans = new List<PdfCore.PdfTextSpan> {
+                new("West", "F1", 10, 50, y, 105),
+                new("region", "F1", 10, 160, y, 20),
+                new("1430", "F1", 10, 205, y, 40)
+            };
+            return new PdfCore.TextLayoutEngine.TextLine(y, 50, 245, "West region 1430", spans);
+        }
+
+        var bands = new List<List<PdfCore.TextLayoutEngine.TextLine>> {
+            new() { Row(700, 20, true, "Region", "Total") },
+            new() { Row(680, 35, false, "North", "1250") },
+            new() { DriftedRow(660) }
+        };
+
+        List<PdfCore.StructuredTable> grouped = PdfCore.TableDetector.DetectTablesFromBands(bands)
+            .Where(static table => table.Kind == "band-group")
+            .ToList();
+
+        Assert.DoesNotContain(grouped, static table =>
+            table.Rows.SelectMany(static row => row).Contains("West", StringComparer.Ordinal));
+    }
+
+    [Fact]
     public void PdfTables_PositionedCellRecoverySplitsAlignedTablesAcrossLargeVerticalGaps() {
         static PdfCore.TextLayoutEngine.TextLine Row(double y, string left, string right) {
             var spans = new List<PdfCore.PdfTextSpan> {

--- a/OfficeIMO.Excel.Tests/Pdf/Excel.PdfTableImportTests.cs
+++ b/OfficeIMO.Excel.Tests/Pdf/Excel.PdfTableImportTests.cs
@@ -743,7 +743,7 @@ public partial class Excel {
 
         static PdfCore.TextLayoutEngine.TextLine SplitlessHeader(double y) {
             var spans = new List<PdfCore.PdfTextSpan> {
-                new("Name", "F1", 10, 20, y, 145, baseFont: "Helvetica-Bold"),
+                new("Name", "F1", 10, 20, y, 150, baseFont: "Helvetica-Bold"),
                 new("Total", "F1", 10, 180, y, 100, baseFont: "Helvetica-Bold")
             };
             return new PdfCore.TextLayoutEngine.TextLine(y, 20, 280, "Name Total", spans);
@@ -854,8 +854,8 @@ public partial class Excel {
         }
 
         var sectionSpans = new List<PdfCore.PdfTextSpan> {
-            new("North", "F1", 10, 20, 640, 80, baseFont: "Helvetica-Bold"),
-            new("America", "F1", 10, 110, 640, 70, baseFont: "Helvetica-Bold")
+            new("North", "F1", 10, 20, 640, 60, baseFont: "Helvetica-Bold"),
+            new("America", "F1", 10, 90, 640, 80, baseFont: "Helvetica-Bold")
         };
         var bands = new List<List<PdfCore.TextLayoutEngine.TextLine>> {
             new() { WideRow(700, true, "Region", "Total") },
@@ -936,8 +936,8 @@ public partial class Excel {
     [Fact]
     public void PdfTables_BandGroupingKeepsSplitlessHeaderAboveMultiLineBodyBand() {
         var headerSpans = new List<PdfCore.PdfTextSpan> {
-            new("Account", "F1", 10, 20, 700, 145, baseFont: "Helvetica-Bold"),
-            new("Total", "F1", 10, 180, 700, 70, baseFont: "Helvetica-Bold")
+            new("Account", "F1", 10, 20, 800, 145, baseFont: "Helvetica-Bold"),
+            new("Total", "F1", 10, 180, 800, 70, baseFont: "Helvetica-Bold")
         };
 
         static PdfCore.TextLayoutEngine.TextLine BodyLine(double y, string left, string right) {
@@ -949,7 +949,7 @@ public partial class Excel {
         }
 
         var bands = new List<List<PdfCore.TextLayoutEngine.TextLine>> {
-            new() { new PdfCore.TextLayoutEngine.TextLine(700, 20, 250, "Account Total", headerSpans) },
+            new() { new PdfCore.TextLayoutEngine.TextLine(800, 20, 250, "Account Total", headerSpans) },
             new() { BodyLine(680, "North", "1250"), BodyLine(668, "Region", "100") },
             new() { BodyLine(640, "South", "980") }
         };
@@ -962,6 +962,68 @@ public partial class Excel {
         Assert.Equal(new[] { "Account", "Total" }, table.Rows[0]);
         Assert.Equal(new[] { "North", "1250" }, table.Rows[1]);
         Assert.Equal(new[] { "South", "980" }, table.Rows[3]);
+    }
+
+    [Fact]
+    public void PdfTables_BandGroupingStopsAtMultiLineEmphasizedHeaderBand() {
+        static PdfCore.TextLayoutEngine.TextLine Row(double y, bool emphasized, string left, string right) {
+            string? baseFont = emphasized ? "Helvetica-Bold" : "Helvetica";
+            var spans = new List<PdfCore.PdfTextSpan> {
+                new(left, "F1", 10, 20, y, 60, baseFont: baseFont),
+                new(right, "F1", 10, 180, y, 40, baseFont: baseFont)
+            };
+            return new PdfCore.TextLayoutEngine.TextLine(y, 20, 220, left + " " + right, spans);
+        }
+
+        var bands = new List<List<PdfCore.TextLayoutEngine.TextLine>> {
+            new() { Row(700, true, "Code", "Qty") },
+            new() { Row(680, false, "A-100", "12") },
+            new() { Row(660, false, "B-200", "14") },
+            new() { Row(640, true, "Account", "Annual"), Row(632, true, "Name", "Total") },
+            new() { Row(610, false, "North", "1250") },
+            new() { Row(590, false, "South", "980") }
+        };
+
+        PdfCore.StructuredTable[] grouped = PdfCore.TableDetector.DetectTablesFromBands(bands)
+            .Where(static table => table.Kind == "band-group")
+            .ToArray();
+
+        Assert.Equal(2, grouped.Length);
+        Assert.Equal(new[] { "Code", "Qty" }, grouped[0].Rows[0]);
+        Assert.Equal(new[] { "Account", "Annual" }, grouped[1].Rows[0]);
+        Assert.Equal(new[] { "Name", "Total" }, grouped[1].Rows[1]);
+    }
+
+    [Fact]
+    public void PdfTables_BandGroupingAdjustsSimilarSplitThatCrossesAColumnAnchor() {
+        static PdfCore.TextLayoutEngine.TextLine Header(double y) {
+            var spans = new List<PdfCore.PdfTextSpan> {
+                new("Region", "F1", 10, 20, y, 60, baseFont: "Helvetica-Bold"),
+                new("Total", "F1", 10, 120, y, 40, baseFont: "Helvetica-Bold")
+            };
+            return new PdfCore.TextLayoutEngine.TextLine(y, 20, 160, "Region Total", spans);
+        }
+
+        static PdfCore.TextLayoutEngine.TextLine Body(double y, string left, string right) {
+            var spans = new List<PdfCore.PdfTextSpan> {
+                new(left, "F1", 10, 20, y, 50),
+                new(right, "F1", 10, 99, y, 61)
+            };
+            return new PdfCore.TextLayoutEngine.TextLine(y, 20, 160, left + " " + right, spans);
+        }
+
+        var bands = new List<List<PdfCore.TextLayoutEngine.TextLine>> {
+            new() { Header(700) },
+            new() { Body(680, "North", "7") },
+            new() { Body(660, "South", "9") }
+        };
+
+        PdfCore.StructuredTable table = Assert.Single(
+            PdfCore.TableDetector.DetectTablesFromBands(bands),
+            static candidate => candidate.Kind == "band-group");
+
+        Assert.Equal(new[] { "North", "7" }, table.Rows[1]);
+        Assert.Equal(new[] { "South", "9" }, table.Rows[2]);
     }
 
     [Fact]

--- a/OfficeIMO.Excel.Tests/Pdf/Excel.PdfTableImportTests.cs
+++ b/OfficeIMO.Excel.Tests/Pdf/Excel.PdfTableImportTests.cs
@@ -814,6 +814,8 @@ public partial class Excel {
     [InlineData("North", "FY2025")]
     [InlineData("North", "Q1")]
     [InlineData("North Region", "Q1")]
+    [InlineData("C-300", "Closed")]
+    [InlineData("North", "Closed")]
     [InlineData("Enabled", "Yes")]
     [InlineData("Central", "N/A")]
     public void PdfTables_BandGroupingKeepsEmphasizedDataRows(string label, string value) {
@@ -952,6 +954,71 @@ public partial class Excel {
         Assert.Equal("North America", table.Rows[3][0]);
         Assert.Equal(string.Empty, table.Rows[3][1]);
         Assert.Equal(new[] { "Canada", "350" }, table.Rows[5]);
+    }
+
+    [Fact]
+    public void PdfTables_BandGroupingStopsAtNewHeaderAfterAttachedTwoRowTable() {
+        static PdfCore.TextLayoutEngine.TextLine Row(double y, bool emphasized, string left, string right) {
+            string? baseFont = emphasized ? "Helvetica-Bold" : "Helvetica";
+            var spans = new List<PdfCore.PdfTextSpan> {
+                new(left, "F1", 10, 20, y, 60, baseFont: baseFont),
+                new(right, "F1", 10, 180, y, 40, baseFont: baseFont)
+            };
+            return new PdfCore.TextLayoutEngine.TextLine(y, 20, 220, left + " " + right, spans);
+        }
+
+        var attachedHeaderSpans = new List<PdfCore.PdfTextSpan> {
+            new("Code", "F1", 10, 20, 700, 150, baseFont: "Helvetica-Bold"),
+            new("Qty", "F1", 10, 180, 700, 40, baseFont: "Helvetica-Bold")
+        };
+        var bands = new List<List<PdfCore.TextLayoutEngine.TextLine>> {
+            new() { new PdfCore.TextLayoutEngine.TextLine(700, 20, 220, "Code Qty", attachedHeaderSpans) },
+            new() { Row(680, false, "A-100", "12") },
+            new() { Row(660, true, "Name", "Total") },
+            new() { Row(640, false, "Alpha", "22") },
+            new() { Row(620, false, "Beta", "24") }
+        };
+
+        PdfCore.StructuredTable[] grouped = PdfCore.TableDetector.DetectTablesFromBands(bands)
+            .Where(static table => table.Kind == "band-group")
+            .ToArray();
+
+        Assert.Equal(2, grouped.Length);
+        Assert.Equal(2, grouped[0].Rows.Count);
+        Assert.Equal(new[] { "Code", "Qty" }, grouped[0].Rows[0]);
+        Assert.Equal(new[] { "Name", "Total" }, grouped[1].Rows[0]);
+    }
+
+    [Fact]
+    public void PdfTables_BandGroupingDoesNotBridgeDistantCaptionByProportionAlone() {
+        static PdfCore.TextLayoutEngine.TextLine Row(double y, bool emphasized, string left, string right) {
+            string? baseFont = emphasized ? "Helvetica-Bold" : "Helvetica";
+            var spans = new List<PdfCore.PdfTextSpan> {
+                new(left, "F1", 10, 20, y, 60, baseFont: baseFont),
+                new(right, "F1", 10, 180, y, 40, baseFont: baseFont)
+            };
+            return new PdfCore.TextLayoutEngine.TextLine(y, 20, 220, left + " " + right, spans);
+        }
+
+        var captionSpans = new List<PdfCore.PdfTextSpan> {
+            new("INTERIM RESULTS", "F1", 10, 20, 400, 200, baseFont: "Helvetica-Bold")
+        };
+        var bands = new List<List<PdfCore.TextLayoutEngine.TextLine>> {
+            new() { Row(700, true, "Code", "Qty") },
+            new() { Row(680, false, "A-100", "12") },
+            new() { Row(660, false, "B-200", "14") },
+            new() { new PdfCore.TextLayoutEngine.TextLine(400, 20, 220, "INTERIM RESULTS", captionSpans) },
+            new() { Row(140, false, "Alpha", "22") },
+            new() { Row(120, false, "Beta", "24") }
+        };
+
+        PdfCore.StructuredTable first = Assert.Single(
+            PdfCore.TableDetector.DetectTablesFromBands(bands),
+            static table => table.Kind == "band-group" && table.Rows[0][0] == "Code");
+
+        Assert.Equal(3, first.Rows.Count);
+        Assert.DoesNotContain(first.Rows, static row => row.Contains("INTERIM RESULTS", StringComparer.Ordinal));
+        Assert.DoesNotContain(first.Rows, static row => row.Contains("Alpha", StringComparer.Ordinal));
     }
 
     [Fact]

--- a/OfficeIMO.Excel.Tests/Pdf/Excel.PdfTableImportTests.cs
+++ b/OfficeIMO.Excel.Tests/Pdf/Excel.PdfTableImportTests.cs
@@ -803,6 +803,37 @@ public partial class Excel {
         Assert.Equal(new[] { summaryLabel, summaryValue }, table.Rows[3]);
     }
 
+    [Theory]
+    [InlineData("North", "1250")]
+    [InlineData("Enabled", "Yes")]
+    [InlineData("Central", "N/A")]
+    public void PdfTables_BandGroupingKeepsEmphasizedDataRows(string label, string value) {
+        static PdfCore.TextLayoutEngine.TextLine Row(double y, bool emphasized, string left, string right) {
+            string? baseFont = emphasized ? "Helvetica-Bold" : "Helvetica";
+            var spans = new List<PdfCore.PdfTextSpan> {
+                new(left, "F1", 10, 20, y, 60, baseFont: baseFont),
+                new(right, "F1", 10, 180, y, 40, baseFont: baseFont)
+            };
+            return new PdfCore.TextLayoutEngine.TextLine(y, 20, 220, left + " " + right, spans);
+        }
+
+        var bands = new List<List<PdfCore.TextLayoutEngine.TextLine>> {
+            new() { Row(700, true, "Code", "Qty") },
+            new() { Row(680, false, "A-100", "12") },
+            new() { Row(660, false, "B-200", "14") },
+            new() { Row(640, true, label, value) },
+            new() { Row(620, false, "South", "980") }
+        };
+
+        PdfCore.StructuredTable table = Assert.Single(
+            PdfCore.TableDetector.DetectTablesFromBands(bands),
+            static candidate => candidate.Kind == "band-group");
+
+        Assert.Equal(5, table.Rows.Count);
+        Assert.Equal(new[] { label, value }, table.Rows[3]);
+        Assert.Equal(new[] { "South", "980" }, table.Rows[4]);
+    }
+
     [Fact]
     public void PdfTables_BandGroupingUsesStableLargeRowRhythmWhileExtending() {
         static PdfCore.TextLayoutEngine.TextLine Row(

--- a/OfficeIMO.Excel.Tests/Pdf/Excel.PdfTableImportTests.cs
+++ b/OfficeIMO.Excel.Tests/Pdf/Excel.PdfTableImportTests.cs
@@ -694,8 +694,11 @@ public partial class Excel {
             table.Rows.SelectMany(static row => row).Contains("Name", StringComparer.Ordinal));
     }
 
-    [Fact]
-    public void PdfTables_BandGroupingStopsAtANewEmphasizedHeader() {
+    [Theory]
+    [InlineData("Name", "Total")]
+    [InlineData("Metric", "2025")]
+    [InlineData("Metric", "FY2025")]
+    public void PdfTables_BandGroupingStopsAtANewEmphasizedHeader(string headerLeft, string headerRight) {
         static PdfCore.TextLayoutEngine.TextLine Row(double y, bool emphasized, string left, string right) {
             string? baseFont = emphasized ? "Helvetica-Bold" : "Helvetica";
             var spans = new List<PdfCore.PdfTextSpan> {
@@ -709,7 +712,7 @@ public partial class Excel {
             new() { Row(700, true, "Code", "Qty") },
             new() { Row(680, false, "A-100", "12") },
             new() { Row(660, false, "B-200", "14") },
-            new() { Row(640, true, "Name", "Total") },
+            new() { Row(640, true, headerLeft, headerRight) },
             new() { Row(620, false, "Alpha", "22") },
             new() { Row(600, false, "Beta", "24") }
         };
@@ -719,7 +722,7 @@ public partial class Excel {
 
         Assert.Equal(2, grouped.Length);
         Assert.Equal(new[] { "Code", "Qty" }, grouped[0].Rows[0]);
-        Assert.Equal(new[] { "Name", "Total" }, grouped[1].Rows[0]);
+        Assert.Equal(new[] { headerLeft, headerRight }, grouped[1].Rows[0]);
     }
 
     [Fact]
@@ -805,6 +808,7 @@ public partial class Excel {
 
     [Theory]
     [InlineData("North", "1250")]
+    [InlineData("North", "7")]
     [InlineData("Enabled", "Yes")]
     [InlineData("Central", "N/A")]
     public void PdfTables_BandGroupingKeepsEmphasizedDataRows(string label, string value) {

--- a/OfficeIMO.Excel.Tests/Pdf/Excel.PdfTableImportTests.cs
+++ b/OfficeIMO.Excel.Tests/Pdf/Excel.PdfTableImportTests.cs
@@ -770,6 +770,9 @@ public partial class Excel {
     [Theory]
     [InlineData("Total", "0")]
     [InlineData("Total", "7")]
+    [InlineData("Total", "N/A")]
+    [InlineData("Total", "—")]
+    [InlineData("Grand Total", "TBD")]
     [InlineData("Total", "26")]
     [InlineData("Grand Total", "26")]
     [InlineData("Sub Total", "26")]
@@ -931,30 +934,34 @@ public partial class Excel {
     }
 
     [Fact]
-    public void PdfTables_AlignedSplitAccumulatorRejectsAnInvalidLaterBoundary() {
-        static PdfCore.TextLayoutEngine.TextLine Row(double y, params PdfCore.PdfTextSpan[] spans) =>
-            new(y, spans.Min(static span => span.X), spans.Max(static span => span.X + span.Advance), string.Join(" ", spans.Select(static span => span.Text)), spans.ToList());
+    public void PdfTables_BandGroupingKeepsSplitlessHeaderAboveMultiLineBodyBand() {
+        var headerSpans = new List<PdfCore.PdfTextSpan> {
+            new("Account", "F1", 10, 20, 700, 145, baseFont: "Helvetica-Bold"),
+            new("Total", "F1", 10, 180, 700, 70, baseFont: "Helvetica-Bold")
+        };
 
-        PdfCore.TextLayoutEngine.TextLine first = Row(
-            700,
-            new PdfCore.PdfTextSpan("Region", "F1", 10, 20, 700, 115),
-            new PdfCore.PdfTextSpan("Total", "F1", 10, 160, 700, 85));
-        PdfCore.TextLayoutEngine.TextLine second = Row(
-            680,
-            new PdfCore.PdfTextSpan("North", "F1", 10, 35, 680, 120),
-            new PdfCore.PdfTextSpan("1250", "F1", 10, 180, 680, 65));
-        PdfCore.TextLayoutEngine.TextLine invalid = Row(
-            660,
-            new PdfCore.PdfTextSpan("West", "F1", 10, 50, 660, 105),
-            new PdfCore.PdfTextSpan("region", "F1", 10, 160, 660, 20),
-            new PdfCore.PdfTextSpan("1430", "F1", 10, 205, 660, 40));
+        static PdfCore.TextLayoutEngine.TextLine BodyLine(double y, string left, string right) {
+            var spans = new List<PdfCore.PdfTextSpan> {
+                new(left, "F1", 10, 20, y, 60),
+                new(right, "F1", 10, 180, y, 40)
+            };
+            return new PdfCore.TextLayoutEngine.TextLine(y, 20, 220, left + " " + right, spans);
+        }
 
-        var accumulator = new PdfCore.TableDetector.AlignedSplitAccumulator(2, new[] { first });
+        var bands = new List<List<PdfCore.TextLayoutEngine.TextLine>> {
+            new() { new PdfCore.TextLayoutEngine.TextLine(700, 20, 250, "Account Total", headerSpans) },
+            new() { BodyLine(680, "North", "1250"), BodyLine(668, "Region", "100") },
+            new() { BodyLine(640, "South", "980") }
+        };
 
-        Assert.True(accumulator.TryAppend(new[] { second }, requireValidSplits: true));
-        double splitBeforeInvalidRow = Assert.Single(accumulator.GetSplits()!);
-        Assert.False(accumulator.TryAppend(new[] { invalid }, requireValidSplits: true));
-        Assert.Equal(splitBeforeInvalidRow, Assert.Single(accumulator.GetSplits()!));
+        PdfCore.StructuredTable table = Assert.Single(
+            PdfCore.TableDetector.DetectTablesFromBands(bands),
+            static candidate => candidate.Kind == "band-group");
+
+        Assert.Equal(4, table.Rows.Count);
+        Assert.Equal(new[] { "Account", "Total" }, table.Rows[0]);
+        Assert.Equal(new[] { "North", "1250" }, table.Rows[1]);
+        Assert.Equal(new[] { "South", "980" }, table.Rows[3]);
     }
 
     [Fact]

--- a/OfficeIMO.Excel.Tests/Pdf/Excel.PdfTableImportTests.cs
+++ b/OfficeIMO.Excel.Tests/Pdf/Excel.PdfTableImportTests.cs
@@ -1000,6 +1000,43 @@ public partial class Excel {
     }
 
     [Fact]
+    public void PdfTables_BandGroupingKeepsBaseSplitForAttachedSplitlessHeader() {
+        var headerSpans = new List<PdfCore.PdfTextSpan> {
+            new("Account", "F1", 10, 20, 700, 140, baseFont: "Helvetica-Bold"),
+            new("Total", "F1", 10, 165, 700, 80, baseFont: "Helvetica-Bold")
+        };
+
+        static PdfCore.TextLayoutEngine.TextLine Body(
+            double y,
+            string left,
+            double leftAdvance,
+            double rightX,
+            double rightAdvance,
+            string right) {
+            var spans = new List<PdfCore.PdfTextSpan> {
+                new(left, "F1", 10, 20, y, leftAdvance),
+                new(right, "F1", 10, rightX, y, rightAdvance)
+            };
+            return new PdfCore.TextLayoutEngine.TextLine(y, 20, rightX + rightAdvance, left + " " + right, spans);
+        }
+
+        var bands = new List<List<PdfCore.TextLayoutEngine.TextLine>> {
+            new() { new PdfCore.TextLayoutEngine.TextLine(700, 20, 245, "Account Total", headerSpans) },
+            new() { Body(680, "North", 80, 220, 40, "1250") },
+            new() { Body(660, "Western Europe", 155, 201, 59, "980") }
+        };
+
+        PdfCore.StructuredTable table = Assert.Single(
+            PdfCore.TableDetector.DetectTablesFromBands(bands),
+            static candidate => candidate.Kind == "band-group");
+
+        Assert.Equal(3, table.Rows.Count);
+        Assert.True(table.Columns[0].To > 165);
+        Assert.Equal(new[] { "Account", "Total" }, table.Rows[0]);
+        Assert.Equal(new[] { "Western Europe", "980" }, table.Rows[2]);
+    }
+
+    [Fact]
     public void PdfTables_BandGroupingStopsAtMultiLineEmphasizedHeaderBand() {
         static PdfCore.TextLayoutEngine.TextLine Row(double y, bool emphasized, string left, string right) {
             string? baseFont = emphasized ? "Helvetica-Bold" : "Helvetica";

--- a/OfficeIMO.Excel.Tests/Pdf/Excel.PdfTableImportTests.cs
+++ b/OfficeIMO.Excel.Tests/Pdf/Excel.PdfTableImportTests.cs
@@ -698,6 +698,7 @@ public partial class Excel {
     [InlineData("Name", "Total")]
     [InlineData("Metric", "2025")]
     [InlineData("Metric", "FY2025")]
+    [InlineData("Metric", "Q1")]
     public void PdfTables_BandGroupingStopsAtANewEmphasizedHeader(string headerLeft, string headerRight) {
         static PdfCore.TextLayoutEngine.TextLine Row(double y, bool emphasized, string left, string right) {
             string? baseFont = emphasized ? "Helvetica-Bold" : "Helvetica";
@@ -809,6 +810,10 @@ public partial class Excel {
     [Theory]
     [InlineData("North", "1250")]
     [InlineData("North", "7")]
+    [InlineData("North", "2025")]
+    [InlineData("North", "FY2025")]
+    [InlineData("North", "Q1")]
+    [InlineData("North Region", "Q1")]
     [InlineData("Enabled", "Yes")]
     [InlineData("Central", "N/A")]
     public void PdfTables_BandGroupingKeepsEmphasizedDataRows(string label, string value) {
@@ -899,6 +904,44 @@ public partial class Excel {
             new() { new PdfCore.TextLayoutEngine.TextLine(640, 20, 180, "North America", sectionSpans) },
             new() { NarrowRow(620, "United States", "900") },
             new() { NarrowRow(600, "Canada", "350") }
+        };
+
+        PdfCore.StructuredTable table = Assert.Single(
+            PdfCore.TableDetector.DetectTablesFromBands(bands),
+            static candidate => candidate.Kind == "band-group");
+
+        Assert.Equal(6, table.Rows.Count);
+        Assert.Equal("North America", table.Rows[3][0]);
+        Assert.Equal(string.Empty, table.Rows[3][1]);
+        Assert.Equal(new[] { "Canada", "350" }, table.Rows[5]);
+    }
+
+    [Fact]
+    public void PdfTables_BandGroupingUsesPhysicalRhythmAcrossSpanningSection() {
+        static PdfCore.TextLayoutEngine.TextLine Row(
+            double y,
+            bool emphasized,
+            string left,
+            double leftAdvance,
+            string right) {
+            string? baseFont = emphasized ? "Helvetica-Bold" : "Helvetica";
+            var spans = new List<PdfCore.PdfTextSpan> {
+                new(left, "F1", 10, 20, y, leftAdvance, baseFont: baseFont),
+                new(right, "F1", 10, 200, y, 40, baseFont: baseFont)
+            };
+            return new PdfCore.TextLayoutEngine.TextLine(y, 20, 240, left + " " + right, spans);
+        }
+
+        var sectionSpans = new List<PdfCore.PdfTextSpan> {
+            new("North America", "F1", 10, 20, 520, 170, baseFont: "Helvetica-Bold")
+        };
+        var bands = new List<List<PdfCore.TextLayoutEngine.TextLine>> {
+            new() { Row(700, true, "Region", 100, "Total") },
+            new() { Row(640, false, "Global", 100, "2230") },
+            new() { Row(580, false, "Europe", 100, "980") },
+            new() { new PdfCore.TextLayoutEngine.TextLine(520, 20, 190, "North America", sectionSpans) },
+            new() { Row(460, false, "United States", 155, "900") },
+            new() { Row(400, false, "Canada", 150, "350") }
         };
 
         PdfCore.StructuredTable table = Assert.Single(

--- a/OfficeIMO.Excel.Tests/Pdf/Excel.PdfTableImportTests.cs
+++ b/OfficeIMO.Excel.Tests/Pdf/Excel.PdfTableImportTests.cs
@@ -768,12 +768,14 @@ public partial class Excel {
     }
 
     [Theory]
-    [InlineData("Total")]
-    [InlineData("Grand Total")]
-    [InlineData("Sub Total")]
-    [InlineData("Net Subtotal")]
-    [InlineData("Overall Totals")]
-    public void PdfTables_BandGroupingKeepsEmphasizedSummaryRows(string summaryLabel) {
+    [InlineData("Total", "0")]
+    [InlineData("Total", "7")]
+    [InlineData("Total", "26")]
+    [InlineData("Grand Total", "26")]
+    [InlineData("Sub Total", "26")]
+    [InlineData("Net Subtotal", "26")]
+    [InlineData("Overall Totals", "26")]
+    public void PdfTables_BandGroupingKeepsEmphasizedSummaryRows(string summaryLabel, string summaryValue) {
         static PdfCore.TextLayoutEngine.TextLine Row(double y, bool emphasized, string left, string right) {
             string? baseFont = emphasized ? "Helvetica-Bold" : "Helvetica";
             var spans = new List<PdfCore.PdfTextSpan> {
@@ -787,7 +789,7 @@ public partial class Excel {
             new() { Row(700, true, "Code", "Qty") },
             new() { Row(680, false, "A-100", "12") },
             new() { Row(660, false, "B-200", "14") },
-            new() { Row(640, true, summaryLabel, "26") }
+            new() { Row(640, true, summaryLabel, summaryValue) }
         };
 
         PdfCore.StructuredTable table = Assert.Single(
@@ -795,7 +797,80 @@ public partial class Excel {
             static candidate => candidate.Kind == "band-group");
 
         Assert.Equal(4, table.Rows.Count);
-        Assert.Equal(new[] { summaryLabel, "26" }, table.Rows[3]);
+        Assert.Equal(new[] { summaryLabel, summaryValue }, table.Rows[3]);
+    }
+
+    [Fact]
+    public void PdfTables_BandGroupingUsesStableLargeRowRhythmWhileExtending() {
+        static PdfCore.TextLayoutEngine.TextLine Row(
+            double y,
+            bool emphasized,
+            string left,
+            double leftAdvance,
+            string right) {
+            string? baseFont = emphasized ? "Helvetica-Bold" : "Helvetica";
+            var spans = new List<PdfCore.PdfTextSpan> {
+                new(left, "F1", 10, 20, y, leftAdvance, baseFont: baseFont),
+                new(right, "F1", 10, 200, y, 40, baseFont: baseFont)
+            };
+            return new PdfCore.TextLayoutEngine.TextLine(y, 20, 240, left + " " + right, spans);
+        }
+
+        var bands = new List<List<PdfCore.TextLayoutEngine.TextLine>> {
+            new() { Row(700, true, "Region", 100, "Total") },
+            new() { Row(640, false, "North", 110, "1250") },
+            new() { Row(580, false, "South East", 130, "980") },
+            new() { Row(520, false, "Western Europe", 145, "1430") }
+        };
+
+        PdfCore.StructuredTable table = Assert.Single(
+            PdfCore.TableDetector.DetectTablesFromBands(bands),
+            static candidate => candidate.Kind == "band-group");
+
+        Assert.Equal(4, table.Rows.Count);
+        Assert.Equal(new[] { "Western Europe", "1430" }, table.Rows[3]);
+    }
+
+    [Fact]
+    public void PdfTables_BandGroupingKeepsNaturalSpanningSectionRowsAcrossSplitDrift() {
+        static PdfCore.TextLayoutEngine.TextLine WideRow(double y, bool emphasized, string left, string right) {
+            string? baseFont = emphasized ? "Helvetica-Bold" : "Helvetica";
+            var spans = new List<PdfCore.PdfTextSpan> {
+                new(left, "F1", 10, 20, y, 100, baseFont: baseFont),
+                new(right, "F1", 10, 200, y, 40, baseFont: baseFont)
+            };
+            return new PdfCore.TextLayoutEngine.TextLine(y, 20, 240, left + " " + right, spans);
+        }
+
+        static PdfCore.TextLayoutEngine.TextLine NarrowRow(double y, string left, string right) {
+            var spans = new List<PdfCore.PdfTextSpan> {
+                new(left, "F1", 10, 20, y, 50),
+                new(right, "F1", 10, 110, y, 130)
+            };
+            return new PdfCore.TextLayoutEngine.TextLine(y, 20, 240, left + " " + right, spans);
+        }
+
+        var sectionSpans = new List<PdfCore.PdfTextSpan> {
+            new("North", "F1", 10, 20, 640, 80, baseFont: "Helvetica-Bold"),
+            new("America", "F1", 10, 110, 640, 70, baseFont: "Helvetica-Bold")
+        };
+        var bands = new List<List<PdfCore.TextLayoutEngine.TextLine>> {
+            new() { WideRow(700, true, "Region", "Total") },
+            new() { WideRow(680, false, "Global", "2230") },
+            new() { WideRow(660, false, "Europe", "980") },
+            new() { new PdfCore.TextLayoutEngine.TextLine(640, 20, 180, "North America", sectionSpans) },
+            new() { NarrowRow(620, "United States", "900") },
+            new() { NarrowRow(600, "Canada", "350") }
+        };
+
+        PdfCore.StructuredTable table = Assert.Single(
+            PdfCore.TableDetector.DetectTablesFromBands(bands),
+            static candidate => candidate.Kind == "band-group");
+
+        Assert.Equal(6, table.Rows.Count);
+        Assert.Equal("North America", table.Rows[3][0]);
+        Assert.Equal(string.Empty, table.Rows[3][1]);
+        Assert.Equal(new[] { "Canada", "350" }, table.Rows[5]);
     }
 
     [Fact]

--- a/OfficeIMO.Excel.Tests/Pdf/Excel.PdfTableImportTests.cs
+++ b/OfficeIMO.Excel.Tests/Pdf/Excel.PdfTableImportTests.cs
@@ -22,7 +22,7 @@ public partial class Excel {
             })
             .ToBytes();
 
-        PdfCore.PdfDocumentReadResult logical = LoadTables(pdf);
+        PdfCore.PdfDocumentReadResult logical = PdfCore.PdfDocument.Load(pdf).Read();
         PdfCore.PdfLogicalTable table = Assert.Single(logical.Pages.SelectMany(static page => page.Tables));
         Assert.Equal(4, table.Rows.Count);
 

--- a/OfficeIMO.Excel.Tests/Pdf/Excel.PdfTableImportTests.cs
+++ b/OfficeIMO.Excel.Tests/Pdf/Excel.PdfTableImportTests.cs
@@ -10,6 +10,40 @@ namespace OfficeIMO.Tests;
 
 public partial class Excel {
     [Fact]
+    public void PdfTables_SaveTablesAsExcel_PreservesHeaderWhenNarrativePrecedesAutoSizedTable() {
+        byte[] pdf = PdfCore.PdfDocument.Create()
+            .H1("Quarterly results")
+            .Paragraph(paragraph => paragraph.Text("Revenue improved in the current quarter."))
+            .Table(new[] {
+                new[] { "Region", "Revenue", "Active" },
+                new[] { "North", "1250", "True" },
+                new[] { "South", "980", "False" },
+                new[] { "West", "1430", "True" }
+            })
+            .ToBytes();
+
+        PdfCore.PdfDocumentReadResult logical = LoadTables(pdf);
+        PdfCore.PdfLogicalTable table = Assert.Single(logical.Pages.SelectMany(static page => page.Tables));
+        Assert.Equal(4, table.Rows.Count);
+
+        using var workbook = new MemoryStream();
+        PdfExcelTableImportEntry result = Assert.Single(logical.SaveTablesAsExcel(
+            workbook,
+            new PdfExcelTableImportOptions {
+                AutoFitColumns = false
+            }).Entries);
+
+        Assert.Equal(3, result.RowCount);
+        using ExcelDocumentReader reader = ExcelDocumentReader.Open(workbook.ToArray());
+        ExcelTableInfo excelTable = Assert.Single(reader.GetTables());
+        Assert.Equal(new[] { "Region", "Revenue", "Active" }, excelTable.Columns.Select(static column => column.Name).ToArray());
+        object?[,] values = reader.GetSheet(result.SheetName).ReadRange(result.Range);
+        Assert.Equal("North", values[1, 0]);
+        Assert.Equal(1250d, Convert.ToDouble(values[1, 1], CultureInfo.InvariantCulture));
+        Assert.Equal("West", values[3, 0]);
+    }
+
+    [Fact]
     public void PdfTables_SaveTablesAsExcel_ImportsDetectedTablesAsWorkbookTables() {
         byte[] pdf = PdfCore.PdfDocument.Create(new PdfCore.PdfOptions {
                 PageWidth = 420,

--- a/OfficeIMO.Pdf/Reading/Layout/TableDetector.AlignedSplits.cs
+++ b/OfficeIMO.Pdf/Reading/Layout/TableDetector.AlignedSplits.cs
@@ -5,7 +5,7 @@ using System.Linq;
 namespace OfficeIMO.Pdf;
 
 internal static partial class TableDetector {
-    internal sealed class AlignedSplitAccumulator {
+    private sealed class AlignedSplitAccumulator {
         private readonly int _expectedColumnCount;
         private double[] _maximumInkEnds;
         private double[] _maximumLastSpanStarts;

--- a/OfficeIMO.Pdf/Reading/Layout/TableDetector.AlignedSplits.cs
+++ b/OfficeIMO.Pdf/Reading/Layout/TableDetector.AlignedSplits.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OfficeIMO.Pdf;
+
+internal static partial class TableDetector {
+    internal sealed class AlignedSplitAccumulator {
+        private readonly int _expectedColumnCount;
+        private double[] _maximumInkEnds;
+        private double[] _maximumLastSpanStarts;
+        private double[] _minimumNextStarts;
+        private int _rowCount;
+
+        internal AlignedSplitAccumulator(
+            int expectedColumnCount,
+            IReadOnlyList<TextLayoutEngine.TextLine> initialLines) {
+            _expectedColumnCount = expectedColumnCount;
+            int boundaryCount = Math.Max(0, expectedColumnCount - 1);
+            _maximumInkEnds = Enumerable.Repeat(double.NegativeInfinity, boundaryCount).ToArray();
+            _maximumLastSpanStarts = Enumerable.Repeat(double.NegativeInfinity, boundaryCount).ToArray();
+            _minimumNextStarts = Enumerable.Repeat(double.PositiveInfinity, boundaryCount).ToArray();
+            TryAppend(initialLines, requireValidSplits: false);
+        }
+
+        internal bool TryAppend(
+            IReadOnlyList<TextLayoutEngine.TextLine> lines,
+            bool requireValidSplits) {
+            double[] maximumInkEnds = (double[])_maximumInkEnds.Clone();
+            double[] maximumLastSpanStarts = (double[])_maximumLastSpanStarts.Clone();
+            double[] minimumNextStarts = (double[])_minimumNextStarts.Clone();
+            int rowCount = _rowCount;
+
+            for (int lineIndex = 0; lineIndex < lines.Count; lineIndex++) {
+                PositionedRow? row = TryCreatePositionedRow(lines[lineIndex]);
+                if (row == null || row.Cells.Count != _expectedColumnCount) continue;
+                rowCount++;
+                for (int columnIndex = 0; columnIndex < _expectedColumnCount - 1; columnIndex++) {
+                    maximumInkEnds[columnIndex] = Math.Max(
+                        maximumInkEnds[columnIndex],
+                        row.Cells[columnIndex].To);
+                    maximumLastSpanStarts[columnIndex] = Math.Max(
+                        maximumLastSpanStarts[columnIndex],
+                        row.Cells[columnIndex].LastSpanStart);
+                    minimumNextStarts[columnIndex] = Math.Min(
+                        minimumNextStarts[columnIndex],
+                        row.Cells[columnIndex + 1].From);
+                }
+            }
+
+            if (requireValidSplits &&
+                !TryBuildSplits(
+                    rowCount,
+                    maximumInkEnds,
+                    maximumLastSpanStarts,
+                    minimumNextStarts,
+                    out _)) {
+                return false;
+            }
+
+            _rowCount = rowCount;
+            _maximumInkEnds = maximumInkEnds;
+            _maximumLastSpanStarts = maximumLastSpanStarts;
+            _minimumNextStarts = minimumNextStarts;
+            return true;
+        }
+
+        internal List<double>? GetSplits() => TryBuildSplits(
+            _rowCount,
+            _maximumInkEnds,
+            _maximumLastSpanStarts,
+            _minimumNextStarts,
+            out List<double>? splits)
+            ? splits
+            : null;
+
+        private static bool TryBuildSplits(
+            int rowCount,
+            double[] maximumInkEnds,
+            double[] maximumLastSpanStarts,
+            double[] minimumNextStarts,
+            out List<double>? splits) {
+            splits = null;
+            if (rowCount < 2) return false;
+
+            var candidate = new List<double>(maximumInkEnds.Length);
+            for (int boundaryIndex = 0; boundaryIndex < maximumInkEnds.Length; boundaryIndex++) {
+                double leftEdge = maximumInkEnds[boundaryIndex];
+                double rightEdge = minimumNextStarts[boundaryIndex];
+                if (rightEdge <= leftEdge + 1D) {
+                    // Text ink may overlap the next column even though every span start remains
+                    // separable. SplitBySplits assigns spans by their start coordinate, so this
+                    // narrower boundary is still safe and retains prose-heavy table cells.
+                    leftEdge = maximumLastSpanStarts[boundaryIndex];
+                    if (rightEdge <= leftEdge + 1D) return false;
+                }
+                candidate.Add(leftEdge + (rightEdge - leftEdge) / 2D);
+            }
+
+            splits = candidate;
+            return true;
+        }
+    }
+}

--- a/OfficeIMO.Pdf/Reading/Layout/TableDetector.BandGeometry.cs
+++ b/OfficeIMO.Pdf/Reading/Layout/TableDetector.BandGeometry.cs
@@ -40,23 +40,6 @@ internal static partial class TableDetector {
         return true;
     }
 
-    private static bool LooksLikeNaturalSpanningPhrase(TextLayoutEngine.TextLine line) {
-        PdfTextSpan[] spans = line.Spans
-            .Where(static span => !string.IsNullOrWhiteSpace(span.Text))
-            .OrderBy(static span => span.X)
-            .ToArray();
-        if (spans.Length < 2 || spans.Any(static span => span.Text.Any(char.IsDigit))) return false;
-
-        for (int index = 1; index < spans.Length; index++) {
-            PdfTextSpan previous = spans[index - 1];
-            PdfTextSpan current = spans[index];
-            double gap = current.X - (previous.X + Math.Max(0D, previous.Advance));
-            double wordSpacing = Math.Max(4D, Math.Max(previous.FontSize, current.FontSize) * 1.25D);
-            if (gap < -1D || gap > wordSpacing) return false;
-        }
-        return true;
-    }
-
     private static List<(double From, double To)>? GetSplitCellBounds(
         TextLayoutEngine.TextLine line,
         List<double> splits) {
@@ -76,6 +59,63 @@ internal static partial class TableDetector {
         for (int columnIndex = 0; columnIndex < columnCount; columnIndex++) {
             if (double.IsPositiveInfinity(from[columnIndex])) return null;
             cells.Add((from[columnIndex], to[columnIndex]));
+        }
+        return cells;
+    }
+
+    private static bool BandsContainAlignedCells(
+        List<TextLayoutEngine.TextLine> firstBand,
+        List<TextLayoutEngine.TextLine> secondBand) {
+        var firstRowsByColumnCount = new Dictionary<int, PositionedRow>();
+        for (int firstIndex = 0; firstIndex < firstBand.Count; firstIndex++) {
+            PositionedRow? first = TryCreatePositionedRow(firstBand[firstIndex]);
+            if (first is not null && !firstRowsByColumnCount.ContainsKey(first.Cells.Count)) {
+                firstRowsByColumnCount.Add(first.Cells.Count, first);
+            }
+        }
+        for (int secondIndex = 0; secondIndex < secondBand.Count; secondIndex++) {
+            PositionedRow? second = TryCreatePositionedRow(secondBand[secondIndex]);
+            if (second is not null &&
+                firstRowsByColumnCount.TryGetValue(second.Cells.Count, out PositionedRow? first) &&
+                PositionedRowsAlign(first, second)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static bool SplitsSeparatePositionedCells(
+        List<TextLayoutEngine.TextLine> lines,
+        List<double> splits,
+        int expectedColumnCount) {
+        for (int lineIndex = 0; lineIndex < lines.Count; lineIndex++) {
+            PositionedRow? row = TryCreatePositionedRow(lines[lineIndex]);
+            if (row is null || row.Cells.Count != expectedColumnCount) continue;
+            for (int boundaryIndex = 0; boundaryIndex < splits.Count; boundaryIndex++) {
+                double split = splits[boundaryIndex];
+                if (split <= row.Cells[boundaryIndex].LastSpanStart ||
+                    split > row.Cells[boundaryIndex + 1].From) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private static string[] MergeBandCellsBySplits(
+        List<TextLayoutEngine.TextLine> band,
+        List<double> splits) {
+        var cells = new string[splits.Count + 1];
+        for (int columnIndex = 0; columnIndex < cells.Length; columnIndex++) cells[columnIndex] = string.Empty;
+        for (int lineIndex = 0; lineIndex < band.Count; lineIndex++) {
+            string[] lineCells = SplitBySplits(band[lineIndex], splits);
+            for (int columnIndex = 0; columnIndex < cells.Length; columnIndex++) {
+                string value = lineCells[columnIndex].Trim();
+                if (value.Length == 0) continue;
+                cells[columnIndex] = string.IsNullOrEmpty(cells[columnIndex])
+                    ? value
+                    : cells[columnIndex] + " " + value;
+            }
         }
         return cells;
     }

--- a/OfficeIMO.Pdf/Reading/Layout/TableDetector.BandGeometry.cs
+++ b/OfficeIMO.Pdf/Reading/Layout/TableDetector.BandGeometry.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OfficeIMO.Pdf;
+
+internal static partial class TableDetector {
+    private static bool BandsHaveCompatibleVerticalRhythm(
+        List<TextLayoutEngine.TextLine> previousBand,
+        List<TextLayoutEngine.TextLine> currentBand,
+        List<TextLayoutEngine.TextLine> nextBand) {
+        if (previousBand.Count != 1 || currentBand.Count != 1 || nextBand.Count != 1) return false;
+        double previousGap = previousBand[0].Y - currentBand[0].Y;
+        double nextGap = currentBand[0].Y - nextBand[0].Y;
+        if (previousGap <= 0D || nextGap <= 0D) return false;
+        double smallerGap = Math.Min(previousGap, nextGap);
+        double largerGap = Math.Max(previousGap, nextGap);
+        return largerGap <= smallerGap * 1.75D;
+    }
+
+    private static bool BandsAlignUsingSplits(
+        List<TextLayoutEngine.TextLine> firstBand,
+        List<TextLayoutEngine.TextLine> secondBand,
+        List<double> splits) {
+        if (firstBand.Count != 1 || secondBand.Count != 1 || splits.Count == 0) return false;
+        List<(double From, double To)>? firstCells = GetSplitCellBounds(firstBand[0], splits);
+        List<(double From, double To)>? secondCells = GetSplitCellBounds(secondBand[0], splits);
+        if (firstCells is null || secondCells is null || firstCells.Count != secondCells.Count) return false;
+
+        for (int index = 0; index < firstCells.Count; index++) {
+            (double firstFrom, double firstTo) = firstCells[index];
+            (double secondFrom, double secondTo) = secondCells[index];
+            bool leftAligned = Math.Abs(firstFrom - secondFrom) <= 16D;
+            bool centerAligned = Math.Abs(
+                (firstFrom + firstTo) / 2D -
+                (secondFrom + secondTo) / 2D) <= 16D;
+            bool rightAligned = Math.Abs(firstTo - secondTo) <= 16D;
+            if (!leftAligned && !centerAligned && !rightAligned) return false;
+        }
+        return true;
+    }
+
+    private static bool LooksLikeNaturalSpanningPhrase(TextLayoutEngine.TextLine line) {
+        PdfTextSpan[] spans = line.Spans
+            .Where(static span => !string.IsNullOrWhiteSpace(span.Text))
+            .OrderBy(static span => span.X)
+            .ToArray();
+        if (spans.Length < 2 || spans.Any(static span => span.Text.Any(char.IsDigit))) return false;
+
+        for (int index = 1; index < spans.Length; index++) {
+            PdfTextSpan previous = spans[index - 1];
+            PdfTextSpan current = spans[index];
+            double gap = current.X - (previous.X + Math.Max(0D, previous.Advance));
+            double wordSpacing = Math.Max(4D, Math.Max(previous.FontSize, current.FontSize) * 1.25D);
+            if (gap < -1D || gap > wordSpacing) return false;
+        }
+        return true;
+    }
+
+    private static List<(double From, double To)>? GetSplitCellBounds(
+        TextLayoutEngine.TextLine line,
+        List<double> splits) {
+        int columnCount = splits.Count + 1;
+        var from = Enumerable.Repeat(double.PositiveInfinity, columnCount).ToArray();
+        var to = Enumerable.Repeat(double.NegativeInfinity, columnCount).ToArray();
+        for (int spanIndex = 0; spanIndex < line.Spans.Count; spanIndex++) {
+            PdfTextSpan span = line.Spans[spanIndex];
+            if (string.IsNullOrWhiteSpace(span.Text)) continue;
+            int columnIndex = 0;
+            while (columnIndex < splits.Count && span.X >= splits[columnIndex]) columnIndex++;
+            from[columnIndex] = Math.Min(from[columnIndex], span.X);
+            to[columnIndex] = Math.Max(to[columnIndex], span.X + Math.Max(0D, span.Advance));
+        }
+
+        var cells = new List<(double From, double To)>(columnCount);
+        for (int columnIndex = 0; columnIndex < columnCount; columnIndex++) {
+            if (double.IsPositiveInfinity(from[columnIndex])) return null;
+            cells.Add((from[columnIndex], to[columnIndex]));
+        }
+        return cells;
+    }
+}

--- a/OfficeIMO.Pdf/Reading/Layout/TableDetector.cs
+++ b/OfficeIMO.Pdf/Reading/Layout/TableDetector.cs
@@ -16,10 +16,10 @@ internal static partial class TableDetector {
     private const int MaximumPositionedRecoveryLines = 4096;
     private const int MaximumPositionedRecoveryColumns = 64;
     private const int MaximumPositionedRecoveryCells = 65536;
-    private static readonly HashSet<string> ReportingPeriodHeaderLabels = new(StringComparer.OrdinalIgnoreCase) {
-        "account", "amount", "category", "code", "date", "department", "description", "id", "item",
-        "fiscal year", "measure", "metric", "month", "name", "period", "project", "quarter", "region",
-        "reporting period", "status", "type", "value", "year"
+    private static readonly HashSet<string> ColumnHeaderWords = new(StringComparer.OrdinalIgnoreCase) {
+        "account", "amount", "annual", "category", "code", "date", "department", "description", "fiscal",
+        "id", "item", "measure", "metric", "month", "name", "period", "project", "qty", "quantity",
+        "quarter", "region", "reporting", "status", "total", "type", "value", "year"
     };
     public static List<string[]> Detect(List<TextLayoutEngine.TextLine> lines, double? pageHeight = null) {
         var rows = new List<string[]>();
@@ -453,13 +453,20 @@ internal static partial class TableDetector {
             var alignedSplitAccumulator = new AlignedSplitAccumulator(
                 baseSplits.Count + 1,
                 bandSplits[start].lines);
+            int precedingBandIndex = bandSplits[start].idx - 1;
+            List<TextLayoutEngine.TextLine>? headerLines = claimedBandIndexes.Contains(precedingBandIndex)
+                ? null
+                : TryGetPrecedingHeaderLines(
+                    bands,
+                    bandSplits[start].idx,
+                    baseSplits);
             // Extend while splits remain similar. An intervening band without
             // detectable splits is either retained as a strongly evidenced
             // spanning row or skipped when it belongs to an adjacent region.
             while (end + 1 < bandSplits.Count) {
                 (int idx, List<TextLayoutEngine.TextLine> lines, List<double> splits) current = bandSplits[end];
                 (int idx, List<TextLayoutEngine.TextLine> lines, List<double> splits) next = bandSplits[end + 1];
-                bool startsNewEmphasizedHeader = end > start &&
+                bool startsNewEmphasizedHeader = (end > start || headerLines is not null) &&
                                                   LooksLikeEmphasizedHeaderBand(next.lines, next.splits);
                 if (startsNewEmphasizedHeader) {
                     break;
@@ -497,7 +504,10 @@ internal static partial class TableDetector {
                     bands,
                     current.idx,
                     next.idx,
-                    baseSplits);
+                    baseSplits,
+                    current.idx > bandSplits[start].idx
+                        ? bands[current.idx - 1]
+                        : headerLines);
                 if (bridgeDecision == InterveningBandDecision.Reject) {
                     break;
                 }
@@ -528,13 +538,6 @@ internal static partial class TableDetector {
             }
             // Build table for [start..end], including a compatible header-only band immediately above it.
             var groupLines = new List<TextLayoutEngine.TextLine>();
-            int precedingBandIndex = bandSplits[start].idx - 1;
-            List<TextLayoutEngine.TextLine>? headerLines = claimedBandIndexes.Contains(precedingBandIndex)
-                ? null
-                : TryGetPrecedingHeaderLines(
-                    bands,
-                    bandSplits[start].idx,
-                    baseSplits);
             if (headerLines is not null) {
                 groupLines.AddRange(headerLines);
             }
@@ -599,7 +602,8 @@ internal static partial class TableDetector {
         List<List<TextLayoutEngine.TextLine>> bands,
         int currentBandIndex,
         int nextBandIndex,
-        List<double> splits) {
+        List<double> splits,
+        List<TextLayoutEngine.TextLine>? establishedPreviousBand) {
         if (nextBandIndex == currentBandIndex + 1) return InterveningBandDecision.Skip;
         if (nextBandIndex != currentBandIndex + 2 || splits.Count == 0) {
             return InterveningBandDecision.Reject;
@@ -608,7 +612,11 @@ internal static partial class TableDetector {
         List<TextLayoutEngine.TextLine> intervening = bands[currentBandIndex + 1];
         if (intervening.Count != 1) return InterveningBandDecision.Reject;
         TextLayoutEngine.TextLine line = intervening[0];
-        if (!HasCompatibleRowRhythm(bands[currentBandIndex], line, bands[nextBandIndex])) {
+        if (!HasCompatibleRowRhythm(
+                establishedPreviousBand,
+                bands[currentBandIndex],
+                line,
+                bands[nextBandIndex])) {
             return InterveningBandDecision.Reject;
         }
         if (!HasMeaningfulHorizontalOverlap(line, bands[currentBandIndex], bands[nextBandIndex])) {
@@ -739,6 +747,7 @@ internal static partial class TableDetector {
     }
 
     private static bool HasCompatibleRowRhythm(
+        List<TextLayoutEngine.TextLine>? establishedPreviousBand,
         List<TextLayoutEngine.TextLine> previousBand,
         TextLayoutEngine.TextLine intervening,
         List<TextLayoutEngine.TextLine> nextBand) {
@@ -749,7 +758,16 @@ internal static partial class TableDetector {
         if (upperGap <= 0D || lowerGap <= 0D) return false;
         double smaller = Math.Min(upperGap, lowerGap);
         double larger = Math.Max(upperGap, lowerGap);
-        return larger <= smaller * 1.75D;
+        if (larger > smaller * 1.75D) return false;
+
+        if (establishedPreviousBand is null || establishedPreviousBand.Count == 0) {
+            return larger <= 36D;
+        }
+
+        double establishedPreviousY = establishedPreviousBand.Average(static candidate => candidate.Y);
+        double establishedCurrentY = previousBand.Average(static candidate => candidate.Y);
+        double establishedGap = establishedPreviousY - establishedCurrentY;
+        return establishedGap > 0D && larger <= Math.Max(36D, establishedGap * 1.75D);
     }
 
     private static bool IsCompactNonNarrativeRow(string text) {
@@ -887,21 +905,30 @@ internal static partial class TableDetector {
     }
 
     private static bool LooksLikeEmphasizedDataRow(string[] cells) {
+        string firstValue = ContentStructureExtractor.NormalizeShattered(cells[0]).Trim();
         bool reportingPeriodHeader = LooksLikeColumnHeaderLabel(cells[0]) &&
                                      cells.Skip(1).Any(static cell => LooksLikeReportingPeriodHeaderValue(
                                          ContentStructureExtractor.NormalizeShattered(cell).Trim()));
+        if (!reportingPeriodHeader &&
+            LooksLikeSummaryValue(firstValue) &&
+            cells.Skip(1).Any(static cell => !string.IsNullOrWhiteSpace(cell))) {
+            return true;
+        }
         return cells.Skip(1).Any(cell => {
             string value = ContentStructureExtractor.NormalizeShattered(cell).Trim();
             return LooksLikeSummaryValue(value) &&
                    (!reportingPeriodHeader || !LooksLikeReportingPeriodHeaderValue(value));
-        });
+        }) || (!reportingPeriodHeader &&
+               !cells.All(static cell => LooksLikeColumnHeaderLabel(cell)));
     }
 
     private static bool LooksLikeColumnHeaderLabel(string cell) {
         string value = ContentStructureExtractor.NormalizeShattered(cell)
             .Trim()
             .Trim(':', '-', '_', '/', '\\');
-        return ReportingPeriodHeaderLabels.Contains(value);
+        string[] words = value.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+        return words.Length > 0 && words.All(static word => ColumnHeaderWords.Contains(
+            word.Trim(':', '-', '_', '/', '\\')));
     }
 
     private static bool LooksLikeReportingPeriodHeaderValue(string value) {

--- a/OfficeIMO.Pdf/Reading/Layout/TableDetector.cs
+++ b/OfficeIMO.Pdf/Reading/Layout/TableDetector.cs
@@ -540,12 +540,17 @@ internal static partial class TableDetector {
                 }
                 effectiveSplits = alignedSplits;
             }
-            Dictionary<TextLayoutEngine.TextLine, List<double>>? bridgeSplits = null;
-            if (includedBridgeBandIndexes.Count > 0) {
-                bridgeSplits = new Dictionary<TextLayoutEngine.TextLine, List<double>>();
+            Dictionary<TextLayoutEngine.TextLine, List<double>>? lineSplitOverrides = null;
+            if (headerLines is not null || includedBridgeBandIndexes.Count > 0) {
+                lineSplitOverrides = new Dictionary<TextLayoutEngine.TextLine, List<double>>();
+                if (headerLines is not null) {
+                    foreach (TextLayoutEngine.TextLine headerLine in headerLines) {
+                        lineSplitOverrides[headerLine] = baseSplits;
+                    }
+                }
                 foreach (int bridgeBandIndex in includedBridgeBandIndexes) {
                     foreach (TextLayoutEngine.TextLine bridgeLine in bands[bridgeBandIndex]) {
-                        bridgeSplits[bridgeLine] = baseSplits;
+                        lineSplitOverrides[bridgeLine] = baseSplits;
                     }
                 }
             }
@@ -553,7 +558,7 @@ internal static partial class TableDetector {
                 groupLines,
                 effectiveSplits,
                 "band-group",
-                bridgeSplits);
+                lineSplitOverrides);
             if (table != null &&
                 (table.Rows.Count >= 3 || HasStrongTwoRowEvidence(table, groupLines)) &&
                 HasValidatedRows(table, groupLines)) {

--- a/OfficeIMO.Pdf/Reading/Layout/TableDetector.cs
+++ b/OfficeIMO.Pdf/Reading/Layout/TableDetector.cs
@@ -461,9 +461,14 @@ internal static partial class TableDetector {
                 }
 
                 bool hasNonLeftAlignedCells = BandsHaveNonLeftAlignedCells(current.lines, next.lines);
+                List<TextLayoutEngine.TextLine>? previous = end > start
+                    ? bandSplits[end - 1].lines
+                    : null;
                 bool hasContinuousAlignedCells = HasEmphasizedText(bandSplits[start].lines[0]) &&
                                                  BandsHaveAlignedCells(current.lines, next.lines) &&
-                                                 BandsHaveCompatibleVerticalGap(current.lines, next.lines);
+                                                 (BandsHaveCompatibleVerticalGap(current.lines, next.lines) ||
+                                                  (previous is not null &&
+                                                   BandsHaveCompatibleVerticalRhythm(previous, current.lines, next.lines)));
                 if (next.idx > current.idx + 2 ||
                     (!AreSplitsSimilar(baseSplits, next.splits) &&
                      !hasNonLeftAlignedCells &&
@@ -479,7 +484,9 @@ internal static partial class TableDetector {
                     break;
                 }
                 if (bridgeDecision == InterveningBandDecision.Include &&
-                    LooksLikeEmphasizedHeaderBand(bands[current.idx + 1], next.splits)) {
+                    LooksLikeEmphasizedHeaderBand(bands[current.idx + 1], next.splits) &&
+                    !LooksLikeNaturalSpanningPhrase(bands[current.idx + 1][0]) &&
+                    BandsAlignUsingSplits(bands[current.idx + 1], next.lines, next.splits)) {
                     break;
                 }
 
@@ -527,7 +534,20 @@ internal static partial class TableDetector {
                 }
                 effectiveSplits = alignedSplits;
             }
-            var table = BuildTableFromLinesAndSplits(groupLines, effectiveSplits, "band-group");
+            Dictionary<TextLayoutEngine.TextLine, List<double>>? bridgeSplits = null;
+            if (includedBridgeBandIndexes.Count > 0) {
+                bridgeSplits = new Dictionary<TextLayoutEngine.TextLine, List<double>>();
+                foreach (int bridgeBandIndex in includedBridgeBandIndexes) {
+                    foreach (TextLayoutEngine.TextLine bridgeLine in bands[bridgeBandIndex]) {
+                        bridgeSplits[bridgeLine] = baseSplits;
+                    }
+                }
+            }
+            var table = BuildTableFromLinesAndSplits(
+                groupLines,
+                effectiveSplits,
+                "band-group",
+                bridgeSplits);
             if (table != null &&
                 (table.Rows.Count >= 3 || HasStrongTwoRowEvidence(table, groupLines)) &&
                 HasValidatedRows(table, groupLines)) {
@@ -785,9 +805,16 @@ internal static partial class TableDetector {
         if (cells.Length < 2) return false;
         string label = ContentStructureExtractor.NormalizeShattered(cells[0]).Trim();
         if (!LooksLikeSummaryLabel(label)) return false;
-        return cells.Skip(1).Any(static cell => IsTabularValue(
+        return cells.Skip(1).Any(static cell => LooksLikeSummaryValue(
             ContentStructureExtractor.NormalizeShattered(cell).Trim()));
     }
+
+    private static bool LooksLikeSummaryValue(string value) =>
+        value.Any(char.IsDigit) ||
+        string.Equals(value, "yes", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(value, "no", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(value, "true", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(value, "false", StringComparison.OrdinalIgnoreCase);
 
     private static bool LooksLikeSummaryLabel(string label) {
         string value = label.Trim().TrimEnd(':').Trim();
@@ -816,7 +843,11 @@ internal static partial class TableDetector {
         return true;
     }
 
-    private static StructuredTable? BuildTableFromLinesAndSplits(List<TextLayoutEngine.TextLine> lines, List<double> splits, string kind) {
+    private static StructuredTable? BuildTableFromLinesAndSplits(
+        List<TextLayoutEngine.TextLine> lines,
+        List<double> splits,
+        string kind,
+        Dictionary<TextLayoutEngine.TextLine, List<double>>? lineSplitOverrides = null) {
         if (splits.Count == 0) return null;
         double minX = double.MaxValue, maxX = double.MinValue;
         foreach (var ln in lines) { minX = Math.Min(minX, ln.XStart); maxX = Math.Max(maxX, ln.XEnd); }
@@ -833,7 +864,11 @@ internal static partial class TableDetector {
         }
         int cols = table.Columns.Count;
         foreach (var ln in lines) {
-            var cells = SplitBySplits(ln, splits);
+            List<double> lineSplits = lineSplitOverrides is not null &&
+                                      lineSplitOverrides.TryGetValue(ln, out List<double>? splitOverride)
+                ? splitOverride
+                : splits;
+            var cells = SplitBySplits(ln, lineSplits);
             if (cells.Length != cols) continue;
             bool anyContent = false; for (int i = 0; i < cells.Length; i++) if (!string.IsNullOrWhiteSpace(cells[i])) { anyContent = true; break; }
             if (!anyContent) continue;

--- a/OfficeIMO.Pdf/Reading/Layout/TableDetector.cs
+++ b/OfficeIMO.Pdf/Reading/Layout/TableDetector.cs
@@ -452,10 +452,12 @@ internal static class TableDetector {
             while (end + 1 < bandSplits.Count) {
                 (int idx, List<TextLayoutEngine.TextLine> lines, List<double> splits) current = bandSplits[end];
                 (int idx, List<TextLayoutEngine.TextLine> lines, List<double> splits) next = bandSplits[end + 1];
+                string[] nextCells = SplitBySplits(next.lines[0], baseSplits);
                 bool startsNewEmphasizedHeader = end > start &&
                                                   next.lines.Count == 1 &&
                                                   HasEmphasizedText(next.lines[0]) &&
-                                                  LooksLikeHeaderRow(SplitBySplits(next.lines[0], baseSplits));
+                                                  LooksLikeHeaderRow(nextCells) &&
+                                                  !LooksLikeSummaryRow(nextCells);
                 if (startsNewEmphasizedHeader) {
                     break;
                 }
@@ -785,6 +787,14 @@ internal static class TableDetector {
         }
 
         return true;
+    }
+
+    private static bool LooksLikeSummaryRow(string[] cells) {
+        if (cells.Length < 2) return false;
+        string label = ContentStructureExtractor.NormalizeShattered(cells[0]).Trim();
+        if (!HasSpanningRowQualifier(label)) return false;
+        return cells.Skip(1).Any(static cell => IsTabularValue(
+            ContentStructureExtractor.NormalizeShattered(cell).Trim()));
     }
 
     private static bool AreSplitsSimilar(List<double> a, List<double> b) {

--- a/OfficeIMO.Pdf/Reading/Layout/TableDetector.cs
+++ b/OfficeIMO.Pdf/Reading/Layout/TableDetector.cs
@@ -469,8 +469,9 @@ internal static partial class TableDetector {
                                                  (BandsHaveCompatibleVerticalGap(current.lines, next.lines) ||
                                                   (previous is not null &&
                                                    BandsHaveCompatibleVerticalRhythm(previous, current.lines, next.lines)));
+                bool splitsAreSimilar = AreSplitsSimilar(baseSplits, next.splits);
                 if (next.idx > current.idx + 2 ||
-                    (!AreSplitsSimilar(baseSplits, next.splits) &&
+                    (!splitsAreSimilar &&
                      !hasNonLeftAlignedCells &&
                      !hasContinuousAlignedCells)) {
                     break;
@@ -490,7 +491,8 @@ internal static partial class TableDetector {
                     break;
                 }
 
-                bool nextRequiresAlignedCellSplits = hasNonLeftAlignedCells || hasContinuousAlignedCells;
+                bool nextRequiresAlignedCellSplits = !splitsAreSimilar &&
+                                                     (hasNonLeftAlignedCells || hasContinuousAlignedCells);
                 if (!alignedSplitAccumulator.TryAppend(
                     next.lines,
                     requiresAlignedCellSplits || nextRequiresAlignedCellSplits)) {

--- a/OfficeIMO.Pdf/Reading/Layout/TableDetector.cs
+++ b/OfficeIMO.Pdf/Reading/Layout/TableDetector.cs
@@ -12,7 +12,7 @@ namespace OfficeIMO.Pdf;
 /// - Splits when gap exceeds max(2*em, 18pt)
 /// - Emits a row when at least two cells are produced and one cell is numeric-ish
 /// </summary>
-internal static class TableDetector {
+internal static partial class TableDetector {
     private const int MaximumPositionedRecoveryLines = 4096;
     private const int MaximumPositionedRecoveryColumns = 64;
     private const int MaximumPositionedRecoveryCells = 65536;
@@ -445,19 +445,17 @@ internal static class TableDetector {
             int end = k;
             var includedBridgeBandIndexes = new HashSet<int>();
             bool requiresAlignedCellSplits = false;
-            var groupedSplitLines = new List<TextLayoutEngine.TextLine>(bandSplits[start].lines);
+            var alignedSplitAccumulator = new AlignedSplitAccumulator(
+                baseSplits.Count + 1,
+                bandSplits[start].lines);
             // Extend while splits remain similar. An intervening band without
             // detectable splits is either retained as a strongly evidenced
             // spanning row or skipped when it belongs to an adjacent region.
             while (end + 1 < bandSplits.Count) {
                 (int idx, List<TextLayoutEngine.TextLine> lines, List<double> splits) current = bandSplits[end];
                 (int idx, List<TextLayoutEngine.TextLine> lines, List<double> splits) next = bandSplits[end + 1];
-                string[] nextCells = SplitBySplits(next.lines[0], baseSplits);
                 bool startsNewEmphasizedHeader = end > start &&
-                                                  next.lines.Count == 1 &&
-                                                  HasEmphasizedText(next.lines[0]) &&
-                                                  LooksLikeHeaderRow(nextCells) &&
-                                                  !LooksLikeSummaryRow(nextCells);
+                                                  LooksLikeEmphasizedHeaderBand(next.lines, next.splits);
                 if (startsNewEmphasizedHeader) {
                     break;
                 }
@@ -480,16 +478,18 @@ internal static class TableDetector {
                 if (bridgeDecision == InterveningBandDecision.Reject) {
                     break;
                 }
-                int priorSplitLineCount = groupedSplitLines.Count;
-                groupedSplitLines.AddRange(next.lines);
-                if ((hasNonLeftAlignedCells || hasContinuousAlignedCells) &&
-                    InferAlignedCellSplits(groupedSplitLines, baseSplits.Count + 1) is null) {
-                    groupedSplitLines.RemoveRange(
-                        priorSplitLineCount,
-                        groupedSplitLines.Count - priorSplitLineCount);
+                if (bridgeDecision == InterveningBandDecision.Include &&
+                    LooksLikeEmphasizedHeaderBand(bands[current.idx + 1], next.splits)) {
                     break;
                 }
-                requiresAlignedCellSplits |= hasNonLeftAlignedCells || hasContinuousAlignedCells;
+
+                bool nextRequiresAlignedCellSplits = hasNonLeftAlignedCells || hasContinuousAlignedCells;
+                if (!alignedSplitAccumulator.TryAppend(
+                    next.lines,
+                    requiresAlignedCellSplits || nextRequiresAlignedCellSplits)) {
+                    break;
+                }
+                requiresAlignedCellSplits |= nextRequiresAlignedCellSplits;
 
                 if (bridgeDecision == InterveningBandDecision.Include) {
                     includedBridgeBandIndexes.Add(current.idx + 1);
@@ -518,9 +518,15 @@ internal static class TableDetector {
                     groupLines.AddRange(bands[bandIndex]);
                 }
             }
-            List<double> effectiveSplits = requiresAlignedCellSplits
-                ? InferAlignedCellSplits(groupedSplitLines, baseSplits.Count + 1) ?? baseSplits
-                : baseSplits;
+            List<double> effectiveSplits = baseSplits;
+            if (requiresAlignedCellSplits) {
+                List<double>? alignedSplits = alignedSplitAccumulator.GetSplits();
+                if (alignedSplits is null) {
+                    k = end + 1;
+                    continue;
+                }
+                effectiveSplits = alignedSplits;
+            }
             var table = BuildTableFromLinesAndSplits(groupLines, effectiveSplits, "band-group");
             if (table != null &&
                 (table.Rows.Count >= 3 || HasStrongTwoRowEvidence(table, groupLines)) &&
@@ -683,32 +689,6 @@ internal static class TableDetector {
         return hasNonLeftAlignment;
     }
 
-    private static List<double>? InferAlignedCellSplits(
-        List<TextLayoutEngine.TextLine> lines,
-        int expectedColumnCount) {
-        var rows = new List<PositionedRow>();
-        for (int index = 0; index < lines.Count; index++) {
-            PositionedRow? row = TryCreatePositionedRow(lines[index]);
-            if (row != null && row.Cells.Count == expectedColumnCount) rows.Add(row);
-        }
-        if (rows.Count < 2) return null;
-
-        var splits = new List<double>(expectedColumnCount - 1);
-        for (int columnIndex = 0; columnIndex < expectedColumnCount - 1; columnIndex++) {
-            double leftEdge = rows.Max(row => row.Cells[columnIndex].To);
-            double rightEdge = rows.Min(row => row.Cells[columnIndex + 1].From);
-            if (rightEdge <= leftEdge + 1D) {
-                // Text ink may overlap the next column even though every span start remains
-                // separable. SplitBySplits assigns spans by their start coordinate, so this
-                // narrower boundary is still safe and retains prose-heavy table cells.
-                leftEdge = rows.Max(row => row.Cells[columnIndex].LastSpanStart);
-                if (rightEdge <= leftEdge + 1D) return null;
-            }
-            splits.Add(leftEdge + (rightEdge - leftEdge) / 2D);
-        }
-        return splits;
-    }
-
     private static bool HasCompatibleRowRhythm(
         List<TextLayoutEngine.TextLine> previousBand,
         TextLayoutEngine.TextLine intervening,
@@ -758,8 +738,7 @@ internal static class TableDetector {
         List<TextLayoutEngine.TextLine>? followingBodyBand = bodyBandIndex + 1 < bands.Count
             ? bands[bodyBandIndex + 1]
             : null;
-        if (!BandsHaveCompatibleVerticalGap(headerBand, bands[bodyBandIndex], followingBodyBand) ||
-            !IsCompactNonNarrativeRow(headerBand[0].Text.Trim()) ||
+        if (!IsCompactNonNarrativeRow(headerBand[0].Text.Trim()) ||
             (!BandsHaveAlignedCells(headerBand, bands[bodyBandIndex]) &&
              !HasEmphasizedText(headerBand[0]))) {
             return null;
@@ -768,6 +747,19 @@ internal static class TableDetector {
         string[] headerCells = SplitBySplits(headerBand[0], bodySplits);
         if (!LooksLikeHeaderRow(headerCells)) {
             return null;
+        }
+
+        if (!BandsHaveCompatibleVerticalGap(headerBand, bands[bodyBandIndex], followingBodyBand)) {
+            var twoRowLines = new List<TextLayoutEngine.TextLine>(headerBand.Count + bands[bodyBandIndex].Count);
+            twoRowLines.AddRange(headerBand);
+            twoRowLines.AddRange(bands[bodyBandIndex]);
+            StructuredTable? twoRowTable = BuildTableFromLinesAndSplits(
+                twoRowLines,
+                bodySplits,
+                "band-group");
+            if (twoRowTable is null || !HasStrongTwoRowEvidence(twoRowTable, twoRowLines)) {
+                return null;
+            }
         }
 
         return headerBand;
@@ -792,9 +784,29 @@ internal static class TableDetector {
     private static bool LooksLikeSummaryRow(string[] cells) {
         if (cells.Length < 2) return false;
         string label = ContentStructureExtractor.NormalizeShattered(cells[0]).Trim();
-        if (!HasSpanningRowQualifier(label)) return false;
+        if (!LooksLikeSummaryLabel(label)) return false;
         return cells.Skip(1).Any(static cell => IsTabularValue(
             ContentStructureExtractor.NormalizeShattered(cell).Trim()));
+    }
+
+    private static bool LooksLikeSummaryLabel(string label) {
+        string value = label.Trim().TrimEnd(':').Trim();
+        return value.Equals("total", StringComparison.OrdinalIgnoreCase) ||
+               value.Equals("totals", StringComparison.OrdinalIgnoreCase) ||
+               value.Equals("subtotal", StringComparison.OrdinalIgnoreCase) ||
+               value.Equals("sub total", StringComparison.OrdinalIgnoreCase) ||
+               value.EndsWith(" total", StringComparison.OrdinalIgnoreCase) ||
+               value.EndsWith(" totals", StringComparison.OrdinalIgnoreCase) ||
+               value.EndsWith(" subtotal", StringComparison.OrdinalIgnoreCase) ||
+               value.EndsWith(" sub total", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool LooksLikeEmphasizedHeaderBand(
+        List<TextLayoutEngine.TextLine> band,
+        List<double> splits) {
+        if (band.Count != 1 || splits.Count == 0 || !HasEmphasizedText(band[0])) return false;
+        string[] cells = SplitBySplits(band[0], splits);
+        return LooksLikeHeaderRow(cells) && !LooksLikeSummaryRow(cells);
     }
 
     private static bool AreSplitsSimilar(List<double> a, List<double> b) {

--- a/OfficeIMO.Pdf/Reading/Layout/TableDetector.cs
+++ b/OfficeIMO.Pdf/Reading/Layout/TableDetector.cs
@@ -447,11 +447,16 @@ internal static class TableDetector {
                 (int idx, List<TextLayoutEngine.TextLine> lines, List<double> splits) current = bandSplits[end];
                 (int idx, List<TextLayoutEngine.TextLine> lines, List<double> splits) next = bandSplits[end + 1];
                 bool hasNonLeftAlignedCells = BandsHaveNonLeftAlignedCells(current.lines, next.lines);
+                bool hasContinuousAlignedCells = HasEmphasizedText(bandSplits[start].lines[0]) &&
+                                                 BandsHaveAlignedCells(current.lines, next.lines) &&
+                                                 BandsHaveCompactVerticalGap(current.lines, next.lines);
                 if (next.idx > current.idx + 2 ||
-                    (!AreSplitsSimilar(baseSplits, next.splits) && !hasNonLeftAlignedCells)) {
+                    (!AreSplitsSimilar(baseSplits, next.splits) &&
+                     !hasNonLeftAlignedCells &&
+                     !hasContinuousAlignedCells)) {
                     break;
                 }
-                requiresAlignedCellSplits |= hasNonLeftAlignedCells;
+                requiresAlignedCellSplits |= hasNonLeftAlignedCells || hasContinuousAlignedCells;
 
                 InterveningBandDecision bridgeDecision = ClassifyInterveningBand(
                     bands,
@@ -594,6 +599,14 @@ internal static class TableDetector {
         return first != null && second != null && PositionedRowsAlign(first, second);
     }
 
+    private static bool BandsHaveCompactVerticalGap(
+        List<TextLayoutEngine.TextLine> firstBand,
+        List<TextLayoutEngine.TextLine> secondBand) {
+        if (firstBand.Count != 1 || secondBand.Count != 1) return false;
+        double gap = firstBand[0].Y - secondBand[0].Y;
+        return gap > 0D && gap <= 36D;
+    }
+
     private static bool BandsHaveNonLeftAlignedCells(
         List<TextLayoutEngine.TextLine> firstBand,
         List<TextLayoutEngine.TextLine> secondBand) {
@@ -683,7 +696,8 @@ internal static class TableDetector {
             return null;
         }
 
-        if (!IsCompactNonNarrativeRow(headerBand[0].Text.Trim()) ||
+        if (!BandsHaveCompactVerticalGap(headerBand, bands[bodyBandIndex]) ||
+            !IsCompactNonNarrativeRow(headerBand[0].Text.Trim()) ||
             (!BandsHaveAlignedCells(headerBand, bands[bodyBandIndex]) &&
              !HasEmphasizedText(headerBand[0]))) {
             return null;

--- a/OfficeIMO.Pdf/Reading/Layout/TableDetector.cs
+++ b/OfficeIMO.Pdf/Reading/Layout/TableDetector.cs
@@ -664,12 +664,13 @@ internal static partial class TableDetector {
         List<TextLayoutEngine.TextLine> firstBand,
         List<TextLayoutEngine.TextLine> secondBand,
         List<TextLayoutEngine.TextLine>? followingBand = null) {
-        if (firstBand.Count != 1 || secondBand.Count != 1) return false;
-        double gap = firstBand[0].Y - secondBand[0].Y;
+        if (firstBand.Count != 1 || secondBand.Count == 0) return false;
+        double secondBandTop = secondBand.Max(static line => line.Y);
+        double gap = firstBand[0].Y - secondBandTop;
         if (gap <= 0D) return false;
 
         double largestFontSize = firstBand[0].Spans
-            .Concat(secondBand[0].Spans)
+            .Concat(secondBand.SelectMany(static line => line.Spans))
             .Select(static span => span.FontSize)
             .DefaultIfEmpty(0D)
             .Max();
@@ -813,6 +814,25 @@ internal static partial class TableDetector {
 
     private static bool LooksLikeSummaryValue(string value) =>
         value.Any(char.IsDigit) ||
+        string.Equals(value, "n/a", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(value, "n.a.", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(value, "na", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(value, "#n/a", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(value, "none", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(value, "null", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(value, "tbd", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(value, "tbc", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(value, "pending", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(value, "unknown", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(value, "unavailable", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(value, "missing", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(value, "no data", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(value, "not reported", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(value, "not provided", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(value, "redacted", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(value, "not applicable", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(value, "not available", StringComparison.OrdinalIgnoreCase) ||
+        value is "-" or "–" or "—" ||
         string.Equals(value, "yes", StringComparison.OrdinalIgnoreCase) ||
         string.Equals(value, "no", StringComparison.OrdinalIgnoreCase) ||
         string.Equals(value, "true", StringComparison.OrdinalIgnoreCase) ||

--- a/OfficeIMO.Pdf/Reading/Layout/TableDetector.cs
+++ b/OfficeIMO.Pdf/Reading/Layout/TableDetector.cs
@@ -486,13 +486,17 @@ internal static partial class TableDetector {
                 }
                 if (bridgeDecision == InterveningBandDecision.Include &&
                     LooksLikeEmphasizedHeaderBand(bands[current.idx + 1], next.splits) &&
-                    !LooksLikeNaturalSpanningPhrase(bands[current.idx + 1][0]) &&
                     BandsAlignUsingSplits(bands[current.idx + 1], next.lines, next.splits)) {
                     break;
                 }
 
-                bool nextRequiresAlignedCellSplits = !splitsAreSimilar &&
-                                                     (hasNonLeftAlignedCells || hasContinuousAlignedCells);
+                bool baseSplitsSeparateNextCells = SplitsSeparatePositionedCells(
+                    next.lines,
+                    baseSplits,
+                    baseSplits.Count + 1);
+                bool nextRequiresAlignedCellSplits = !baseSplitsSeparateNextCells ||
+                                                     (!splitsAreSimilar &&
+                                                      (hasNonLeftAlignedCells || hasContinuousAlignedCells));
                 if (!alignedSplitAccumulator.TryAppend(
                     next.lines,
                     requiresAlignedCellSplits || nextRequiresAlignedCellSplits)) {
@@ -677,12 +681,12 @@ internal static partial class TableDetector {
         if (gap <= Math.Max(36D, largestFontSize * 3D)) return true;
 
         if (followingBand == null ||
-            followingBand.Count != 1 ||
-            !BandsHaveAlignedCells(secondBand, followingBand)) {
+            followingBand.Count == 0 ||
+            !BandsContainAlignedCells(secondBand, followingBand)) {
             return false;
         }
 
-        double followingGap = secondBand[0].Y - followingBand[0].Y;
+        double followingGap = secondBandTop - followingBand.Max(static line => line.Y);
         if (followingGap <= 0D) return false;
         double smallerGap = Math.Min(gap, followingGap);
         double largerGap = Math.Max(gap, followingGap);
@@ -780,7 +784,7 @@ internal static partial class TableDetector {
                 twoRowLines,
                 bodySplits,
                 "band-group");
-            if (twoRowTable is null || !HasStrongTwoRowEvidence(twoRowTable, twoRowLines)) {
+            if (twoRowTable is null || !HasStrongHeaderAndBodyEvidence(twoRowTable, twoRowLines)) {
                 return null;
             }
         }
@@ -853,8 +857,8 @@ internal static partial class TableDetector {
     private static bool LooksLikeEmphasizedHeaderBand(
         List<TextLayoutEngine.TextLine> band,
         List<double> splits) {
-        if (band.Count != 1 || splits.Count == 0 || !HasEmphasizedText(band[0])) return false;
-        string[] cells = SplitBySplits(band[0], splits);
+        if (band.Count == 0 || splits.Count == 0 || band.Any(static line => !HasEmphasizedText(line))) return false;
+        string[] cells = MergeBandCellsBySplits(band, splits);
         return LooksLikeHeaderRow(cells) && !LooksLikeSummaryRow(cells);
     }
 
@@ -996,8 +1000,15 @@ internal static partial class TableDetector {
         StructuredTable table,
         List<TextLayoutEngine.TextLine> sourceLines) {
         if (table.Rows.Count != 2 || sourceLines.Count != 2) return false;
+        return HasStrongHeaderAndBodyEvidence(table, sourceLines);
+    }
+
+    private static bool HasStrongHeaderAndBodyEvidence(
+        StructuredTable table,
+        List<TextLayoutEngine.TextLine> sourceLines) {
+        if (table.Rows.Count < 2 || sourceLines.Count < 2) return false;
         if (!LooksLikeHeaderRow(table.Rows[0])) return false;
-        return table.Rows[1].Any(IsTabularValue) ||
+        return table.Rows.Skip(1).Any(static row => row.Any(IsTabularValue)) ||
                (HasStableColumnAnchors(table, sourceLines) && HasEmphasizedHeader(sourceLines));
     }
 

--- a/OfficeIMO.Pdf/Reading/Layout/TableDetector.cs
+++ b/OfficeIMO.Pdf/Reading/Layout/TableDetector.cs
@@ -207,6 +207,7 @@ internal static class TableDetector {
         var builder = new System.Text.StringBuilder();
         double from = 0D;
         double to = 0D;
+        double lastSpanStart = 0D;
         for (int index = 0; index < line.Spans.Count; index++) {
             PdfTextSpan span = line.Spans[index];
             bool split = false;
@@ -219,7 +220,7 @@ internal static class TableDetector {
             }
 
             if (split) {
-                cells.Add(new PositionedCell(from, to, builder.ToString().Trim()));
+                cells.Add(new PositionedCell(from, to, lastSpanStart, builder.ToString().Trim()));
                 builder.Clear();
             } else if (gap > 1D && builder.Length > 0 && builder[builder.Length - 1] != ' ') {
                 builder.Append(' ');
@@ -228,10 +229,11 @@ internal static class TableDetector {
             if (builder.Length == 0) from = span.X;
             builder.Append(span.Text);
             to = span.X + Math.Max(0D, span.Advance);
+            lastSpanStart = span.X;
             if (cells.Count == MaximumPositionedRecoveryColumns) return null;
         }
 
-        if (builder.Length > 0) cells.Add(new PositionedCell(from, to, builder.ToString().Trim()));
+        if (builder.Length > 0) cells.Add(new PositionedCell(from, to, lastSpanStart, builder.ToString().Trim()));
         return cells.Count is >= 2 and <= MaximumPositionedRecoveryColumns
             ? new PositionedRow(line.Y, cells)
             : null;
@@ -370,13 +372,15 @@ internal static class TableDetector {
     }
 
     private readonly struct PositionedCell {
-        internal PositionedCell(double from, double to, string text) {
+        internal PositionedCell(double from, double to, double lastSpanStart, string text) {
             From = from;
             To = to;
+            LastSpanStart = lastSpanStart;
             Text = text;
         }
         internal double From { get; }
         internal double To { get; }
+        internal double LastSpanStart { get; }
         internal string Text { get; }
     }
 
@@ -432,6 +436,7 @@ internal static class TableDetector {
             bandSplits.Add((i, b, sp));
         }
         int k = 0;
+        var claimedBandIndexes = new HashSet<int>();
         while (k < bandSplits.Count) {
             cancellationCheck?.Invoke();
             consumeWork?.Invoke(1);
@@ -440,24 +445,31 @@ internal static class TableDetector {
             int end = k;
             var includedBridgeBandIndexes = new HashSet<int>();
             bool requiresAlignedCellSplits = false;
+            var groupedSplitLines = new List<TextLayoutEngine.TextLine>(bandSplits[start].lines);
             // Extend while splits remain similar. An intervening band without
             // detectable splits is either retained as a strongly evidenced
             // spanning row or skipped when it belongs to an adjacent region.
             while (end + 1 < bandSplits.Count) {
                 (int idx, List<TextLayoutEngine.TextLine> lines, List<double> splits) current = bandSplits[end];
                 (int idx, List<TextLayoutEngine.TextLine> lines, List<double> splits) next = bandSplits[end + 1];
+                bool startsNewEmphasizedHeader = end > start &&
+                                                  next.lines.Count == 1 &&
+                                                  HasEmphasizedText(next.lines[0]) &&
+                                                  LooksLikeHeaderRow(SplitBySplits(next.lines[0], baseSplits));
+                if (startsNewEmphasizedHeader) {
+                    break;
+                }
+
                 bool hasNonLeftAlignedCells = BandsHaveNonLeftAlignedCells(current.lines, next.lines);
                 bool hasContinuousAlignedCells = HasEmphasizedText(bandSplits[start].lines[0]) &&
                                                  BandsHaveAlignedCells(current.lines, next.lines) &&
-                                                 BandsHaveCompactVerticalGap(current.lines, next.lines);
+                                                 BandsHaveCompatibleVerticalGap(current.lines, next.lines);
                 if (next.idx > current.idx + 2 ||
                     (!AreSplitsSimilar(baseSplits, next.splits) &&
                      !hasNonLeftAlignedCells &&
                      !hasContinuousAlignedCells)) {
                     break;
                 }
-                requiresAlignedCellSplits |= hasNonLeftAlignedCells || hasContinuousAlignedCells;
-
                 InterveningBandDecision bridgeDecision = ClassifyInterveningBand(
                     bands,
                     current.idx,
@@ -466,6 +478,17 @@ internal static class TableDetector {
                 if (bridgeDecision == InterveningBandDecision.Reject) {
                     break;
                 }
+                int priorSplitLineCount = groupedSplitLines.Count;
+                groupedSplitLines.AddRange(next.lines);
+                if ((hasNonLeftAlignedCells || hasContinuousAlignedCells) &&
+                    InferAlignedCellSplits(groupedSplitLines, baseSplits.Count + 1) is null) {
+                    groupedSplitLines.RemoveRange(
+                        priorSplitLineCount,
+                        groupedSplitLines.Count - priorSplitLineCount);
+                    break;
+                }
+                requiresAlignedCellSplits |= hasNonLeftAlignedCells || hasContinuousAlignedCells;
+
                 if (bridgeDecision == InterveningBandDecision.Include) {
                     includedBridgeBandIndexes.Add(current.idx + 1);
                 }
@@ -473,10 +496,13 @@ internal static class TableDetector {
             }
             // Build table for [start..end], including a compatible header-only band immediately above it.
             var groupLines = new List<TextLayoutEngine.TextLine>();
-            List<TextLayoutEngine.TextLine>? headerLines = TryGetPrecedingHeaderLines(
-                bands,
-                bandSplits[start].idx,
-                baseSplits);
+            int precedingBandIndex = bandSplits[start].idx - 1;
+            List<TextLayoutEngine.TextLine>? headerLines = claimedBandIndexes.Contains(precedingBandIndex)
+                ? null
+                : TryGetPrecedingHeaderLines(
+                    bands,
+                    bandSplits[start].idx,
+                    baseSplits);
             if (headerLines is not null) {
                 groupLines.AddRange(headerLines);
             }
@@ -491,12 +517,17 @@ internal static class TableDetector {
                 }
             }
             List<double> effectiveSplits = requiresAlignedCellSplits
-                ? InferAlignedCellSplits(groupLines, baseSplits.Count + 1) ?? baseSplits
+                ? InferAlignedCellSplits(groupedSplitLines, baseSplits.Count + 1) ?? baseSplits
                 : baseSplits;
             var table = BuildTableFromLinesAndSplits(groupLines, effectiveSplits, "band-group");
             if (table != null &&
                 (table.Rows.Count >= 3 || HasStrongTwoRowEvidence(table, groupLines)) &&
-                HasValidatedRows(table, groupLines)) result.Add(table);
+                HasValidatedRows(table, groupLines)) {
+                result.Add(table);
+                claimedBandIndexes.UnionWith(splitBandIndexes);
+                claimedBandIndexes.UnionWith(includedBridgeBandIndexes);
+                if (headerLines is not null) claimedBandIndexes.Add(precedingBandIndex);
+            }
             k = end + 1;
         }
         return result;
@@ -599,12 +630,32 @@ internal static class TableDetector {
         return first != null && second != null && PositionedRowsAlign(first, second);
     }
 
-    private static bool BandsHaveCompactVerticalGap(
+    private static bool BandsHaveCompatibleVerticalGap(
         List<TextLayoutEngine.TextLine> firstBand,
-        List<TextLayoutEngine.TextLine> secondBand) {
+        List<TextLayoutEngine.TextLine> secondBand,
+        List<TextLayoutEngine.TextLine>? followingBand = null) {
         if (firstBand.Count != 1 || secondBand.Count != 1) return false;
         double gap = firstBand[0].Y - secondBand[0].Y;
-        return gap > 0D && gap <= 36D;
+        if (gap <= 0D) return false;
+
+        double largestFontSize = firstBand[0].Spans
+            .Concat(secondBand[0].Spans)
+            .Select(static span => span.FontSize)
+            .DefaultIfEmpty(0D)
+            .Max();
+        if (gap <= Math.Max(36D, largestFontSize * 3D)) return true;
+
+        if (followingBand == null ||
+            followingBand.Count != 1 ||
+            !BandsHaveAlignedCells(secondBand, followingBand)) {
+            return false;
+        }
+
+        double followingGap = secondBand[0].Y - followingBand[0].Y;
+        if (followingGap <= 0D) return false;
+        double smallerGap = Math.Min(gap, followingGap);
+        double largerGap = Math.Max(gap, followingGap);
+        return largerGap <= smallerGap * 1.75D;
     }
 
     private static bool BandsHaveNonLeftAlignedCells(
@@ -644,7 +695,13 @@ internal static class TableDetector {
         for (int columnIndex = 0; columnIndex < expectedColumnCount - 1; columnIndex++) {
             double leftEdge = rows.Max(row => row.Cells[columnIndex].To);
             double rightEdge = rows.Min(row => row.Cells[columnIndex + 1].From);
-            if (rightEdge <= leftEdge + 1D) return null;
+            if (rightEdge <= leftEdge + 1D) {
+                // Text ink may overlap the next column even though every span start remains
+                // separable. SplitBySplits assigns spans by their start coordinate, so this
+                // narrower boundary is still safe and retains prose-heavy table cells.
+                leftEdge = rows.Max(row => row.Cells[columnIndex].LastSpanStart);
+                if (rightEdge <= leftEdge + 1D) return null;
+            }
             splits.Add(leftEdge + (rightEdge - leftEdge) / 2D);
         }
         return splits;
@@ -696,7 +753,10 @@ internal static class TableDetector {
             return null;
         }
 
-        if (!BandsHaveCompactVerticalGap(headerBand, bands[bodyBandIndex]) ||
+        List<TextLayoutEngine.TextLine>? followingBodyBand = bodyBandIndex + 1 < bands.Count
+            ? bands[bodyBandIndex + 1]
+            : null;
+        if (!BandsHaveCompatibleVerticalGap(headerBand, bands[bodyBandIndex], followingBodyBand) ||
             !IsCompactNonNarrativeRow(headerBand[0].Text.Trim()) ||
             (!BandsHaveAlignedCells(headerBand, bands[bodyBandIndex]) &&
              !HasEmphasizedText(headerBand[0]))) {

--- a/OfficeIMO.Pdf/Reading/Layout/TableDetector.cs
+++ b/OfficeIMO.Pdf/Reading/Layout/TableDetector.cs
@@ -16,10 +16,10 @@ internal static partial class TableDetector {
     private const int MaximumPositionedRecoveryLines = 4096;
     private const int MaximumPositionedRecoveryColumns = 64;
     private const int MaximumPositionedRecoveryCells = 65536;
-    private static readonly HashSet<string> ColumnHeaderWords = new(StringComparer.OrdinalIgnoreCase) {
-        "account", "amount", "annual", "category", "code", "date", "department", "description", "fiscal",
-        "id", "item", "measure", "metric", "month", "name", "period", "project", "qty", "quantity",
-        "quarter", "region", "reporting", "status", "total", "type", "value", "year"
+    private static readonly HashSet<string> ReportingPeriodHeaderLabels = new(StringComparer.OrdinalIgnoreCase) {
+        "account", "amount", "category", "code", "date", "department", "description", "id", "item",
+        "fiscal year", "measure", "metric", "month", "name", "period", "project", "quarter", "region",
+        "reporting period", "status", "type", "value", "year"
     };
     public static List<string[]> Detect(List<TextLayoutEngine.TextLine> lines, double? pageHeight = null) {
         var rows = new List<string[]>();
@@ -507,7 +507,7 @@ internal static partial class TableDetector {
                     baseSplits,
                     current.idx > bandSplits[start].idx
                         ? bands[current.idx - 1]
-                        : headerLines);
+                        : null);
                 if (bridgeDecision == InterveningBandDecision.Reject) {
                     break;
                 }
@@ -918,17 +918,14 @@ internal static partial class TableDetector {
             string value = ContentStructureExtractor.NormalizeShattered(cell).Trim();
             return LooksLikeSummaryValue(value) &&
                    (!reportingPeriodHeader || !LooksLikeReportingPeriodHeaderValue(value));
-        }) || (!reportingPeriodHeader &&
-               !cells.All(static cell => LooksLikeColumnHeaderLabel(cell)));
+        });
     }
 
     private static bool LooksLikeColumnHeaderLabel(string cell) {
         string value = ContentStructureExtractor.NormalizeShattered(cell)
             .Trim()
             .Trim(':', '-', '_', '/', '\\');
-        string[] words = value.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
-        return words.Length > 0 && words.All(static word => ColumnHeaderWords.Contains(
-            word.Trim(':', '-', '_', '/', '\\')));
+        return ReportingPeriodHeaderLabels.Contains(value);
     }
 
     private static bool LooksLikeReportingPeriodHeaderValue(string value) {

--- a/OfficeIMO.Pdf/Reading/Layout/TableDetector.cs
+++ b/OfficeIMO.Pdf/Reading/Layout/TableDetector.cs
@@ -16,6 +16,11 @@ internal static partial class TableDetector {
     private const int MaximumPositionedRecoveryLines = 4096;
     private const int MaximumPositionedRecoveryColumns = 64;
     private const int MaximumPositionedRecoveryCells = 65536;
+    private static readonly HashSet<string> ReportingPeriodHeaderLabels = new(StringComparer.OrdinalIgnoreCase) {
+        "account", "amount", "category", "code", "date", "department", "description", "id", "item",
+        "fiscal year", "measure", "metric", "month", "name", "period", "project", "quarter", "region",
+        "reporting period", "status", "type", "value", "year"
+    };
     public static List<string[]> Detect(List<TextLayoutEngine.TextLine> lines, double? pageHeight = null) {
         var rows = new List<string[]>();
         foreach (var match in DetectLineRows(lines, pageHeight)) {
@@ -464,11 +469,23 @@ internal static partial class TableDetector {
                 List<TextLayoutEngine.TextLine>? previous = end > start
                     ? bandSplits[end - 1].lines
                     : null;
+                List<TextLayoutEngine.TextLine> rhythmMiddle = current.lines;
+                List<TextLayoutEngine.TextLine>? rhythmPrevious = previous;
+                if (includedBridgeBandIndexes.Contains(current.idx - 1)) {
+                    rhythmPrevious = bands[current.idx - 1];
+                }
+                if (next.idx == current.idx + 2) {
+                    rhythmPrevious = current.lines;
+                    rhythmMiddle = bands[current.idx + 1];
+                }
                 bool hasContinuousAlignedCells = HasEmphasizedText(bandSplits[start].lines[0]) &&
                                                  BandsHaveAlignedCells(current.lines, next.lines) &&
                                                  (BandsHaveCompatibleVerticalGap(current.lines, next.lines) ||
-                                                  (previous is not null &&
-                                                   BandsHaveCompatibleVerticalRhythm(previous, current.lines, next.lines)));
+                                                  (rhythmPrevious is not null &&
+                                                   BandsHaveCompatibleVerticalRhythm(
+                                                       rhythmPrevious,
+                                                       rhythmMiddle,
+                                                       next.lines)));
                 bool splitsAreSimilar = AreSplitsSimilar(baseSplits, next.splits);
                 if (next.idx > current.idx + 2 ||
                     (!splitsAreSimilar &&
@@ -732,7 +749,7 @@ internal static partial class TableDetector {
         if (upperGap <= 0D || lowerGap <= 0D) return false;
         double smaller = Math.Min(upperGap, lowerGap);
         double larger = Math.Max(upperGap, lowerGap);
-        return larger <= 36D && larger <= smaller * 1.75D;
+        return larger <= smaller * 1.75D;
     }
 
     private static bool IsCompactNonNarrativeRow(string text) {
@@ -869,11 +886,23 @@ internal static partial class TableDetector {
                !LooksLikeEmphasizedDataRow(cells);
     }
 
-    private static bool LooksLikeEmphasizedDataRow(string[] cells) =>
-        cells.Skip(1).Any(static cell => {
+    private static bool LooksLikeEmphasizedDataRow(string[] cells) {
+        bool reportingPeriodHeader = LooksLikeColumnHeaderLabel(cells[0]) &&
+                                     cells.Skip(1).Any(static cell => LooksLikeReportingPeriodHeaderValue(
+                                         ContentStructureExtractor.NormalizeShattered(cell).Trim()));
+        return cells.Skip(1).Any(cell => {
             string value = ContentStructureExtractor.NormalizeShattered(cell).Trim();
-            return LooksLikeSummaryValue(value) && !LooksLikeReportingPeriodHeaderValue(value);
+            return LooksLikeSummaryValue(value) &&
+                   (!reportingPeriodHeader || !LooksLikeReportingPeriodHeaderValue(value));
         });
+    }
+
+    private static bool LooksLikeColumnHeaderLabel(string cell) {
+        string value = ContentStructureExtractor.NormalizeShattered(cell)
+            .Trim()
+            .Trim(':', '-', '_', '/', '\\');
+        return ReportingPeriodHeaderLabels.Contains(value);
+    }
 
     private static bool LooksLikeReportingPeriodHeaderValue(string value) {
         string compact = new string(value.Where(static character => !char.IsWhiteSpace(character)).ToArray());

--- a/OfficeIMO.Pdf/Reading/Layout/TableDetector.cs
+++ b/OfficeIMO.Pdf/Reading/Layout/TableDetector.cs
@@ -865,8 +865,43 @@ internal static partial class TableDetector {
     }
 
     private static bool LooksLikeEmphasizedDataRow(string[] cells) =>
-        cells.Skip(1).Any(static cell => LooksLikeSummaryValue(
-            ContentStructureExtractor.NormalizeShattered(cell).Trim()));
+        cells.Skip(1).Any(static cell => {
+            string value = ContentStructureExtractor.NormalizeShattered(cell).Trim();
+            return LooksLikeSummaryValue(value) && !LooksLikeReportingPeriodHeaderValue(value);
+        });
+
+    private static bool LooksLikeReportingPeriodHeaderValue(string value) {
+        string compact = new string(value.Where(static character => !char.IsWhiteSpace(character)).ToArray());
+        if (int.TryParse(compact, out int year)) return year is >= 1900 and <= 2200;
+        if (compact.Length == 6 &&
+            compact.StartsWith("FY", StringComparison.OrdinalIgnoreCase) &&
+            TryParseFourDigitYear(compact, 2, out year)) {
+            return year is >= 1900 and <= 2200;
+        }
+        if (compact.Length == 2 &&
+            (compact[0] is 'Q' or 'q' && compact[1] is >= '1' and <= '4' ||
+             compact[0] is 'H' or 'h' && compact[1] is >= '1' and <= '2')) {
+            return true;
+        }
+        if (compact.Length > 5 &&
+            TryParseFourDigitYear(compact, 0, out year) &&
+            year is >= 1900 and <= 2200 &&
+            compact[4] is '/' or '-' or '–' or '—') {
+            return true;
+        }
+        return false;
+    }
+
+    private static bool TryParseFourDigitYear(string value, int offset, out int year) {
+        year = 0;
+        if (offset < 0 || value.Length - offset < 4) return false;
+        for (int index = offset; index < offset + 4; index++) {
+            char character = value[index];
+            if (character is < '0' or > '9') return false;
+            year = year * 10 + character - '0';
+        }
+        return true;
+    }
 
     private static bool AreSplitsSimilar(List<double> a, List<double> b) {
         if (a.Count != b.Count) return false;

--- a/OfficeIMO.Pdf/Reading/Layout/TableDetector.cs
+++ b/OfficeIMO.Pdf/Reading/Layout/TableDetector.cs
@@ -859,8 +859,14 @@ internal static partial class TableDetector {
         List<double> splits) {
         if (band.Count == 0 || splits.Count == 0 || band.Any(static line => !HasEmphasizedText(line))) return false;
         string[] cells = MergeBandCellsBySplits(band, splits);
-        return LooksLikeHeaderRow(cells) && !LooksLikeSummaryRow(cells);
+        return LooksLikeHeaderRow(cells) &&
+               !LooksLikeSummaryRow(cells) &&
+               !LooksLikeEmphasizedDataRow(cells);
     }
+
+    private static bool LooksLikeEmphasizedDataRow(string[] cells) =>
+        cells.Skip(1).Any(static cell => LooksLikeSummaryValue(
+            ContentStructureExtractor.NormalizeShattered(cell).Trim()));
 
     private static bool AreSplitsSimilar(List<double> a, List<double> b) {
         if (a.Count != b.Count) return false;


### PR DESCRIPTION
## Summary

- keep auto-sized table rows together when content-derived split points drift but cell anchors and vertical rhythm remain continuous
- preserve headed tables that follow normal heading and paragraph content without emitting overlapping table candidates
- separate adjacent emphasized table headers, including tightly spaced splitless, multi-line, attached two-row, year, fiscal-year, quarter, half-year, and year-range header bands, while retaining emphasized data, subtotal, and total rows
- distinguish reporting-period headers contextually, so labels such as `Metric | Q1` start a header while emphasized values such as `North | Q1`, `North | FY2025`, and `North | 2025` remain data
- retain categorical emphasized code rows such as `C-300 | Closed` while keeping arbitrary all-text labels such as `Employee | Salary` eligible as adjacent headers
- recognize numeric, Boolean, placeholder, compound-label, and single-digit body or summary values without dropping highlighted rows
- scale preceding-header and body-row continuity using font geometry, stable physical row rhythm, strong multi-line header/body evidence, and the top line of wrapped body bands
- preserve natural spanning section rows under their established table geometry, including uniformly spaced large-gap rows with later split drift, while bounding bridge rhythm to the established table so distant captions cannot join unrelated regions
- retain established split geometry only while each split safely separates the positioned cells, preserving rotated table-border semantics while correcting unsafe within-tolerance anchors

## Why this matters

PSWriteOffice consumes the OfficeIMO PDF read and PDF-to-Excel contracts through thin cmdlets. A normal generated report with narrative followed by an auto-sized table could be exposed as overlapping or truncated tables, losing headers, highlighted data, summary rows, section labels, or trailing data. This fixes the reusable OfficeIMO owner so C# and PowerShell consumers receive one complete logical table across those layouts.

## Validation

- PdfTableDetectionValidationTests: 25 passed on net472, net8.0, and net10.0
- all PdfTables_ tests: 66 passed on net472, net8.0, and net10.0
- rotated pure-table semantic-border regression: passed on net472, net8.0, and net10.0
- Bibliography net472 suite: 917 passed locally after one unrelated CI job failure
- extended .NET 8 logical-table suite: 49 passed on the earlier closure candidate
- focused end-to-end regression proves one logical table, preserved headers, three data rows, and numeric Excel output
- regression coverage includes adjacent, splitless, multi-line, attached two-row, arbitrary all-text, and contextual reporting-period headers; emphasized numeric, Boolean, placeholder, categorical, and reporting-period data rows; wrapped first-body bands; compound and placeholder-valued summaries; large-gap headers and body rows; physical rhythm across natural spanning sections; distant-caption rejection, including after a large-gap attached two-row table; unsafe later column drift; attached splitless headers under shifted body geometry; and stable border geometry

## Release ordering

Merge and publish this OfficeIMO patch before completing the dependent PSWriteOffice OCR/PDF API update.
