### PR TITLE
Make PDF table reconstruction language-independent

### DIFF
--- a/OfficeIMO.Excel.Tests/Pdf/Excel.PdfTableImportTests.cs
+++ b/OfficeIMO.Excel.Tests/Pdf/Excel.PdfTableImportTests.cs
@@ -700,7 +700,9 @@ public partial class Excel {
     [InlineData("Metric", "FY2025")]
     [InlineData("Metric", "Q1")]
     [InlineData("Employee", "Salary")]
-    public void PdfTables_BandGroupingStopsAtANewEmphasizedHeader(string headerLeft, string headerRight) {
+    [InlineData("Kwartał", "Wartość")]
+    [InlineData("指標", "年度")]
+    public void PdfTables_BandGroupingStopsAtAStructurallySeparatedEmphasizedHeader(string headerLeft, string headerRight) {
         static PdfCore.TextLayoutEngine.TextLine Row(double y, bool emphasized, string left, string right) {
             string? baseFont = emphasized ? "Helvetica-Bold" : "Helvetica";
             var spans = new List<PdfCore.PdfTextSpan> {
@@ -714,9 +716,9 @@ public partial class Excel {
             new() { Row(700, true, "Code", "Qty") },
             new() { Row(680, false, "A-100", "12") },
             new() { Row(660, false, "B-200", "14") },
-            new() { Row(640, true, headerLeft, headerRight) },
-            new() { Row(620, false, "Alpha", "22") },
-            new() { Row(600, false, "Beta", "24") }
+            new() { Row(625, true, headerLeft, headerRight) },
+            new() { Row(605, false, "Alpha", "22") },
+            new() { Row(585, false, "Beta", "24") }
         };
 
         List<PdfCore.StructuredTable> tables = PdfCore.TableDetector.DetectTablesFromBands(bands);
@@ -818,7 +820,12 @@ public partial class Excel {
     [InlineData("C-300", "Closed")]
     [InlineData("Enabled", "Yes")]
     [InlineData("Central", "N/A")]
-    public void PdfTables_BandGroupingKeepsEmphasizedDataRows(string label, string value) {
+    [InlineData("2025", "North")]
+    [InlineData("4100", "North")]
+    [InlineData("Q1", "Metric")]
+    [InlineData("٢٠٢٥", "المنطقة")]
+    [InlineData("年度", "東京")]
+    public void PdfTables_BandGroupingKeepsStructurallyAmbiguousEmphasizedRows(string label, string value) {
         static PdfCore.TextLayoutEngine.TextLine Row(double y, bool emphasized, string left, string right) {
             string? baseFont = emphasized ? "Helvetica-Bold" : "Helvetica";
             var spans = new List<PdfCore.PdfTextSpan> {
@@ -974,9 +981,9 @@ public partial class Excel {
         var bands = new List<List<PdfCore.TextLayoutEngine.TextLine>> {
             new() { new PdfCore.TextLayoutEngine.TextLine(700, 20, 220, "Code Qty", attachedHeaderSpans) },
             new() { Row(680, false, "A-100", "12") },
-            new() { Row(660, true, "Name", "Total") },
-            new() { Row(640, false, "Alpha", "22") },
-            new() { Row(620, false, "Beta", "24") }
+            new() { Row(645, true, "Name", "Total") },
+            new() { Row(625, false, "Alpha", "22") },
+            new() { Row(605, false, "Beta", "24") }
         };
 
         PdfCore.StructuredTable[] grouped = PdfCore.TableDetector.DetectTablesFromBands(bands)
@@ -1195,9 +1202,9 @@ public partial class Excel {
             new() { Row(700, true, "Code", "Qty") },
             new() { Row(680, false, "A-100", "12") },
             new() { Row(660, false, "B-200", "14") },
-            new() { Row(640, true, "Account", "Annual"), Row(632, true, "Name", "Total") },
-            new() { Row(610, false, "North", "1250") },
-            new() { Row(590, false, "South", "980") }
+            new() { Row(625, true, "Account", "Annual"), Row(617, true, "Name", "Total") },
+            new() { Row(595, false, "North", "1250") },
+            new() { Row(575, false, "South", "980") }
         };
 
         PdfCore.StructuredTable[] grouped = PdfCore.TableDetector.DetectTablesFromBands(bands)
@@ -1373,6 +1380,7 @@ public partial class Excel {
         Assert.Equal(new[] { "Code", "Qty" }, tables[0].Rows[0]);
         Assert.Equal(new[] { "Name", "Total" }, tables[1].Rows[0]);
         Assert.All(tables, table => Assert.Equal("positioned-cells-bounded", table.Kind));
+        Assert.Empty(tables[0].SourceRuns.Intersect(tables[1].SourceRuns));
     }
 
     [Fact]

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfLogicalTableContinuationContractTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfLogicalTableContinuationContractTests.cs
@@ -207,6 +207,64 @@ public sealed class PdfLogicalTableContinuationContractTests {
             tolerance: 4D));
     }
 
+    [Fact]
+    public void TableContinuations_UseOcrVisualBoundsForPageEdgeInference() {
+        PdfDocumentReadResult source = PdfDocumentReadResult.Load(
+            PdfDocument.Create()
+                .Paragraph(paragraph => paragraph.Text("First page"))
+                .PageBreak()
+                .Paragraph(paragraph => paragraph.Text("Second page"))
+                .ToBytes());
+        PdfLogicalPage firstSource = source.Pages[0];
+        PdfLogicalPage secondSource = source.Pages[1];
+        double firstHeight = firstSource.GetVisualPageSize().Height;
+        IReadOnlyList<IReadOnlyList<string>> firstRows = [
+            new[] { "Code", "Amount" },
+            new[] { "A-1", "10" },
+            new[] { "A-2", "20" }
+        ];
+        IReadOnlyList<IReadOnlyList<string>> secondRows = [
+            new[] { "Code", "Amount" },
+            new[] { "A-3", "30" },
+            new[] { "A-4", "40" }
+        ];
+        PdfUnderstandingTableCandidate firstCandidate = CreateOcrCandidate(firstHeight - 90D, firstHeight - 10D, firstRows);
+        PdfUnderstandingTableCandidate secondCandidate = CreateOcrCandidate(10D, 90D, secondRows);
+        PdfLogicalPage first = AddOcrTable(firstSource, firstCandidate);
+        PdfLogicalPage second = AddOcrTable(secondSource, secondCandidate);
+        PdfDocumentReadResult enriched = source.WithPages(new[] { first, second });
+
+        PdfLogicalTableContinuationGroup group = Assert.Single(enriched.GetTableContinuationGroups());
+
+        Assert.True(group.SpansPages);
+        Assert.Equal(new[] { 1, 2 }, group.Segments.Select(static segment => segment.PageNumber));
+        Assert.True(group.Evidence.HasFlag(PdfLogicalTableContinuationEvidence.PageEdges));
+    }
+
+    private static PdfLogicalPage AddOcrTable(
+        PdfLogicalPage page,
+        PdfUnderstandingTableCandidate candidate) =>
+        page.WithOcrContent(
+            Array.Empty<PdfLogicalTextBlock>(),
+            Array.Empty<PdfLogicalHeading>(),
+            Array.Empty<PdfLogicalParagraph>(),
+            Array.Empty<PdfLogicalListItem>(),
+            new[] { candidate });
+
+    private static PdfUnderstandingTableCandidate CreateOcrCandidate(
+        double top,
+        double bottom,
+        IReadOnlyList<IReadOnlyList<string>> rows) =>
+        PdfUnderstandingTableCandidate.FromOcr(
+            "OcrAlignedColumns",
+            top,
+            bottom,
+            new PdfLogicalVisualBounds(30D, top, 230D, bottom),
+            [(30D, 130D), (130D, 230D)],
+            rows,
+            0.9D,
+            new[] { new PdfInferenceEvidence("test.ocr-table", "Test OCR table geometry.", 1D) });
+
     private static byte[] BuildMultiPageTablePdf() {
         var rows = new List<string[]> {
             new[] { "Group", "State" },

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfOcrTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfOcrTests.cs
@@ -461,6 +461,49 @@ public class PdfOcrTests {
     }
 
     [Fact]
+    public void EnrichedDocument_PreservesRicherOverlappingOcrTable() {
+        byte[] pdf = PdfDocument.Create()
+            .Table(new[] {
+                new[] { "Item", "Value" },
+                new[] { "Alpha", "10" }
+            })
+            .ToBytes();
+        PdfLogicalPage page = Assert.Single(PdfDocumentReadResult.Load(pdf).Pages);
+        PdfUnderstandingTableCandidate native = Assert.Single(page.Analysis.TableCandidates);
+        double left = native.Columns.Min(static column => column.From);
+        double right = native.Columns.Max(static column => column.To);
+        PdfVisualBounds visual = page.TransformBoundsToVisual(
+            left,
+            Math.Min(native.YBottom, native.YTop),
+            right,
+            Math.Max(native.YBottom, native.YTop));
+        var richerRows = native.Rows
+            .Concat(new IReadOnlyList<string>[] { new[] { "Beta", "20" }, new[] { "Gamma", "30" } })
+            .ToArray();
+        PdfUnderstandingTableCandidate ocr = PdfUnderstandingTableCandidate.FromOcr(
+            "OcrAlignedColumns",
+            visual.Top - 2D,
+            visual.Bottom + 40D,
+            new PdfLogicalVisualBounds(visual.Left - 2D, visual.Top - 2D, visual.Right + 2D, visual.Bottom + 40D),
+            native.Columns.Select(column => (column.From, column.To)).ToArray(),
+            richerRows,
+            0.99D,
+            new[] { new PdfInferenceEvidence("test.ocr-richer", "OCR candidate contains additional rows.", 1D) });
+
+        PdfLogicalPage enriched = page.WithOcrContent(
+            Array.Empty<PdfLogicalTextBlock>(),
+            Array.Empty<PdfLogicalHeading>(),
+            Array.Empty<PdfLogicalParagraph>(),
+            Array.Empty<PdfLogicalListItem>(),
+            new[] { ocr });
+
+        PdfLogicalTable ocrTable = Assert.Single(enriched.Tables, table => table.SourceKind == PdfLogicalContentSourceKind.Ocr);
+        Assert.Equal(4, ocrTable.Rows.Count);
+        Assert.Contains(ocrTable.Rows, row => row.SequenceEqual(new[] { "Gamma", "30" }));
+        Assert.Equal(2, enriched.Analysis.TableCandidates.Count);
+    }
+
+    [Fact]
     public async Task EnrichedDocument_KeepsAlignedNarrativeColumnsOutOfTableInference() {
         byte[] pdf = PdfDocument.Create()
             .Image(PdfPngTestImages.CreateRgbPng(245, 245, 245), 220, 120)

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfOcrTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfOcrTests.cs
@@ -395,6 +395,11 @@ public class PdfOcrTests {
         PdfOcrMergeResult result = await PdfDocument.Load(pdf).Ocr.ReadAsync(provider);
         PdfLogicalTable table = Assert.Single(result.EnrichedDocument.Tables, candidate => candidate.SourceKind == PdfLogicalContentSourceKind.Ocr);
         Assert.Equal("OcrAlignedColumns", table.DetectionKind);
+        Assert.Equal(PdfTableCoordinateSpace.VisualTopLeft, table.CoordinateSpace);
+        PdfUnderstandingTableCandidate candidate = Assert.Single(
+            result.EnrichedDocument.Pages[0].Analysis.TableCandidates,
+            candidate => candidate.SourceKind == PdfLogicalContentSourceKind.Ocr);
+        Assert.Equal(table.Rows.Select(static row => row.ToArray()), candidate.Rows.Select(static row => row.ToArray()));
         Assert.Equal(3, table.Rows.Count);
         Assert.Equal(new[] { "Alpha", "10" }, table.Rows[1]);
         Assert.DoesNotContain(table.Rows, row => row.Contains("Narrative"));
@@ -413,6 +418,46 @@ public class PdfOcrTests {
 
         string html = result.EnrichedDocument.ToHtml();
         Assert.Equal(1, html.Split(new[] { "Alpha" }, StringSplitOptions.None).Length - 1);
+    }
+
+    [Fact]
+    public void EnrichedDocument_DoesNotDuplicateNativeTableWithOverlappingOcrCandidate() {
+        byte[] pdf = PdfDocument.Create()
+            .Table(new[] {
+                new[] { "Item", "Value" },
+                new[] { "Alpha", "10" },
+                new[] { "Beta", "20" }
+            })
+            .ToBytes();
+        PdfLogicalPage page = Assert.Single(PdfDocumentReadResult.Load(pdf).Pages);
+        PdfUnderstandingTableCandidate native = Assert.Single(page.Analysis.TableCandidates);
+        double left = native.Columns.Min(static column => column.From);
+        double right = native.Columns.Max(static column => column.To);
+        PdfVisualBounds visual = page.TransformBoundsToVisual(
+            left,
+            Math.Min(native.YBottom, native.YTop),
+            right,
+            Math.Max(native.YBottom, native.YTop));
+        PdfUnderstandingTableCandidate ocr = PdfUnderstandingTableCandidate.FromOcr(
+            "OcrAlignedColumns",
+            visual.Top - 2D,
+            visual.Bottom + 2D,
+            new PdfLogicalVisualBounds(visual.Left - 2D, visual.Top - 2D, visual.Right + 2D, visual.Bottom + 2D),
+            native.Columns.Select(column => (column.From, column.To)).ToArray(),
+            native.Rows,
+            0.99D,
+            new[] { new PdfInferenceEvidence("test.ocr-duplicate", "Overlapping OCR candidate.", 1D) });
+
+        PdfLogicalPage enriched = page.WithOcrContent(
+            Array.Empty<PdfLogicalTextBlock>(),
+            Array.Empty<PdfLogicalHeading>(),
+            Array.Empty<PdfLogicalParagraph>(),
+            Array.Empty<PdfLogicalListItem>(),
+            new[] { ocr });
+
+        Assert.Single(enriched.Tables);
+        Assert.Single(enriched.Analysis.TableCandidates);
+        Assert.All(enriched.Tables, table => Assert.Equal(PdfLogicalContentSourceKind.Native, table.SourceKind));
     }
 
     [Fact]

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfOcrTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfOcrTests.cs
@@ -511,10 +511,10 @@ public class PdfOcrTests {
         var provider = new StubOcrProvider(request => new PdfOcrResponse(new[] {
             At(request, "Alpha", 30, 50, 30, 10), At(request, "project", 65, 50, 42, 10), At(request, "overview", 112, 50, 48, 10),
             At(request, "Delta", 300, 50, 30, 10), At(request, "project", 335, 50, 42, 10), At(request, "overview", 382, 50, 48, 10),
-            At(request, "continues", 30, 90, 48, 10), At(request, "with", 83, 90, 24, 10), At(request, "details", 112, 90, 36, 10),
-            At(request, "continues", 300, 90, 48, 10), At(request, "with", 353, 90, 24, 10), At(request, "details", 382, 90, 36, 10),
-            At(request, "for", 30, 130, 18, 10), At(request, "each", 53, 130, 24, 10), At(request, "audience", 82, 130, 48, 10),
-            At(request, "for", 300, 130, 18, 10), At(request, "each", 323, 130, 24, 10), At(request, "audience", 352, 130, 48, 10)
+            At(request, "continues", 30, 66, 48, 10), At(request, "with", 83, 66, 24, 10), At(request, "details", 112, 66, 36, 10),
+            At(request, "continues", 300, 66, 48, 10), At(request, "with", 353, 66, 24, 10), At(request, "details", 382, 66, 36, 10),
+            At(request, "for", 30, 82, 18, 10), At(request, "each", 53, 82, 24, 10), At(request, "audience", 82, 82, 48, 10),
+            At(request, "for", 300, 82, 18, 10), At(request, "each", 323, 82, 24, 10), At(request, "audience", 352, 82, 48, 10)
         }));
 
         PdfOcrMergeResult result = await PdfDocument.Load(pdf).Ocr.ReadAsync(provider);
@@ -534,6 +534,25 @@ public class PdfOcrTests {
             PdfLogicalReadingOrderAnalysis.Analyze(page)
                 .Where(static item => item.Kind == PdfLogicalReadingOrderKind.Paragraph)
                 .Select(item => page.Paragraphs[item.SourceIndex].Text));
+    }
+
+    [Fact]
+    public async Task EnrichedDocument_InfersCompactTextOnlyOcrTablesWithoutLanguageTokens() {
+        byte[] pdf = PdfDocument.Create()
+            .Image(PdfPngTestImages.CreateRgbPng(245, 245, 245), 220, 120)
+            .ToBytes();
+        var provider = new StubOcrProvider(request => new PdfOcrResponse(new[] {
+            At(request, "Pole", 30, 50, 34, 10), At(request, "Stan", 150, 50, 30, 10),
+            At(request, "Szukaj", 30, 66, 42, 10), At(request, "Włączone", 150, 66, 54, 10),
+            At(request, "Eksport", 30, 82, 46, 10), At(request, "Wyłączone", 150, 82, 60, 10)
+        }));
+
+        PdfOcrMergeResult result = await PdfDocument.Load(pdf).Ocr.ReadAsync(provider);
+        PdfLogicalTable table = Assert.Single(result.EnrichedDocument.Tables);
+
+        Assert.Equal(PdfLogicalContentSourceKind.Ocr, table.SourceKind);
+        Assert.Equal(3, table.Rows.Count);
+        Assert.Equal(new[] { "Eksport", "Wyłączone" }, table.Rows[2]);
     }
 
     [Fact]

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfTableDetectionValidationTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfTableDetectionValidationTests.cs
@@ -108,22 +108,6 @@ public sealed class PdfTableDetectionValidationTests {
     }
 
     [Fact]
-    public void LogicalTables_RetainSparseSpanningRowsWhenTheTableHasStrongEvidence() {
-        byte[] pdf = PdfDocument.Create()
-            .Table(new[] {
-                new[] { "Account", "Owner", "Amount", "Status" },
-                new[] { "SECTION-A", "", "", "" },
-                new[] { "ACC-01", "Owner 01", "1037.25", "Approved" }
-            }, style: new PdfTableStyle { HeaderRowCount = 1 })
-            .ToBytes();
-
-        PdfLogicalTable table = Assert.Single(PdfDocumentReadResult.Load(pdf).Tables);
-        PdfLogicalTableData data = PdfLogicalTableAnalysis.Extract(table);
-        Assert.Contains("SECTION-A", data.Rows.SelectMany(static row => row));
-        Assert.Contains("1037.25", data.Rows.SelectMany(static row => row));
-    }
-
-    [Fact]
     public void TableDetector_RetainsSparseResponseFormsWithShatteredCompactHeaders() {
         List<List<TextLayoutEngine.TextLine>> bands = new() {
             new() { CreateLine(520D,
@@ -167,6 +151,29 @@ public sealed class PdfTableDetectionValidationTests {
         Assert.Contains("Client owner", table.Rows.SelectMany(static row => row));
     }
 
+    [Fact]
+    public void TableDetector_RetainsSparseFormsWhenLabelsAreNotInTheFirstColumn() {
+        List<List<TextLayoutEngine.TextLine>> bands = new() {
+            new() { CreateLine(520D,
+                ("Notes", 50D, 40D, "Helvetica"), ("Date", 150D, 40D, "Helvetica"),
+                ("Decision", 250D, 50D, "Helvetica"), ("Name", 350D, 40D, "Helvetica"),
+                ("Role", 450D, 40D, "Helvetica")) },
+            new() { CreateLine(500D,
+                (" ", 50D, 40D, "Helvetica"), (" ", 150D, 40D, "Helvetica"),
+                (" ", 250D, 40D, "Helvetica"), (" ", 350D, 40D, "Helvetica"),
+                ("Lead auditor", 450D, 40D, "Helvetica")) },
+            new() { CreateLine(480D,
+                (" ", 50D, 40D, "Helvetica"), (" ", 150D, 40D, "Helvetica"),
+                (" ", 250D, 40D, "Helvetica"), (" ", 350D, 40D, "Helvetica"),
+                ("Client owner", 450D, 40D, "Helvetica")) }
+        };
+
+        StructuredTable table = Assert.Single(TableDetector.DetectTablesFromBands(bands));
+        Assert.Equal(5, table.Columns.Count);
+        Assert.Contains("Lead auditor", table.Rows.SelectMany(static row => row));
+        Assert.Contains("Client owner", table.Rows.SelectMany(static row => row));
+    }
+
     [Theory]
     [InlineData("Intervening narrative text must remain a paragraph.")]
     [InlineData("Intervening narrative remains independent")]
@@ -198,6 +205,24 @@ public sealed class PdfTableDetectionValidationTests {
         Assert.Equal(2, logical.Tables.Count);
         Assert.Contains(logical.Paragraphs,
             paragraph => paragraph.Text.Contains(narrative, StringComparison.Ordinal));
+        Assert.All(logical.Pages[0].Analysis.TableCandidates, candidate =>
+            Assert.DoesNotContain(candidate.SourceLines, line => line.Text.Contains(narrative, StringComparison.Ordinal)));
+    }
+
+    [Fact]
+    public void LogicalTables_RetainCompactSparseRowsUsingStructuralEvidence() {
+        byte[] pdf = PdfDocument.Create()
+            .Table(new[] {
+                new[] { "Code", "Owner", "Amount", "State" },
+                new[] { "AREA-77", "", "", "" },
+                new[] { "ACC-01", "Owner 01", "4100.25", "Accepted" }
+            }, style: new PdfTableStyle { HeaderRowCount = 1 })
+            .ToBytes();
+
+        PdfLogicalTable table = Assert.Single(PdfDocumentReadResult.Load(pdf).Tables);
+        PdfLogicalTableData data = PdfLogicalTableAnalysis.Extract(table);
+        Assert.Contains("AREA-77", data.Rows.SelectMany(static row => row));
+        Assert.Contains("4100.25", data.Rows.SelectMany(static row => row));
     }
 
     [Fact]
@@ -337,7 +362,7 @@ public sealed class PdfTableDetectionValidationTests {
         List<List<TextLayoutEngine.TextLine>> bands = new() {
             new() { CreateLine(520D, ("Account", 50D, 55D, "Helvetica"), ("Amount", 220D, 48D, "Helvetica")) },
             new() { CreateLine(500D, ("A-1", 50D, 24D, "Helvetica"), ("100", 220D, 24D, "Helvetica")) },
-            new() { CreateLine(480D, ("Amounts exclude tax.", 50D, 250D, "Helvetica")) },
+            new() { CreateLine(480D, ("Amounts exclude tax.", 50D, 250D, "Helvetica-Bold")) },
             new() { CreateLine(460D, ("A-2", 50D, 24D, "Helvetica"), ("200", 220D, 24D, "Helvetica")) }
         };
 
@@ -430,7 +455,7 @@ public sealed class PdfTableDetectionValidationTests {
         double y,
         params (string Text, double X, double Advance, string Font)[] values) {
         var spans = values
-            .Select(value => new PdfTextSpan(value.Text, value.Font, 11D, value.X, y, value.Advance))
+            .Select(value => new PdfTextSpan(value.Text, value.Font, 11D, value.X, y, value.Advance, baseFont: value.Font))
             .ToList();
         return new TextLayoutEngine.TextLine(
             y,

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfTableDetectionValidationTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfTableDetectionValidationTests.cs
@@ -108,6 +108,22 @@ public sealed class PdfTableDetectionValidationTests {
     }
 
     [Fact]
+    public void PositionedRecovery_RetainsTextOnlyCategoricalTablesFromStructuralEvidence() {
+        TextLayoutEngine.TextLine[] lines = {
+            CreateLine(520D, ("Feature", 50D, 50D, "Helvetica"), ("Enabled", 220D, 52D, "Helvetica")),
+            CreateLine(500D, ("Search", 50D, 42D, "Helvetica"), ("Yes", 220D, 24D, "Helvetica")),
+            CreateLine(480D, ("Export", 50D, 42D, "Helvetica"), ("No", 220D, 18D, "Helvetica")),
+            CreateLine(460D, ("Archive", 50D, 46D, "Helvetica"), ("Yes", 220D, 24D, "Helvetica"))
+        };
+
+        StructuredTable table = Assert.Single(TableDetector.DetectPositionedCellTables(lines));
+
+        Assert.Equal("positioned-cells-bounded", table.Kind);
+        Assert.Equal(4, table.Rows.Count);
+        Assert.Contains("Archive", table.Rows.SelectMany(static row => row));
+    }
+
+    [Fact]
     public void TableDetector_RetainsSparseResponseFormsWithShatteredCompactHeaders() {
         List<List<TextLayoutEngine.TextLine>> bands = new() {
             new() { CreateLine(520D,

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfUnderstandingPipelineTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfUnderstandingPipelineTests.cs
@@ -1131,6 +1131,7 @@ public class PdfUnderstandingPipelineTests {
         options.PageSegmentation = new FirstLineOnlySegmentationStage();
         options.ReadingOrder = new IdentityReadingOrderStage();
         options.SemanticClassification = new ParagraphClassificationStage();
+        options.TableDetection = new CountingTableDetectionStage();
 
         PdfDocumentReadResult result = Read(pdf, options);
         PdfLogicalPage page = Assert.Single(result.Pages);
@@ -1142,6 +1143,46 @@ public class PdfUnderstandingPipelineTests {
         Assert.Contains("Retained by segmentation", result.Text, StringComparison.Ordinal);
         Assert.DoesNotContain("Excluded", result.Text, StringComparison.Ordinal);
         Assert.DoesNotContain("Excluded", result.ToMarkdown(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LogicalTableProjection_SizesCellsFromSparseAggregateCount() {
+        PdfUnderstandingTableColumn[] columns = Enumerable.Range(0, 50_000)
+            .Select(static index => new PdfUnderstandingTableColumn(index, index + 1D))
+            .ToArray();
+        IReadOnlyList<string>[] rows = Enumerable.Range(0, 50_000)
+            .Select(static index => index == 0
+                ? (IReadOnlyList<string>)new[] { "Only populated cell" }
+                : Array.Empty<string>())
+            .ToArray();
+        var candidate = new PdfUnderstandingTableCandidate(
+            "sparse-capacity-test",
+            700D,
+            680D,
+            columns,
+            rows,
+            Array.Empty<PdfUnderstandingLine>());
+
+        PdfLogicalTable table = PdfLogicalTable.From(1, candidate);
+
+        Assert.Equal(50_000, table.Columns.Count);
+        Assert.Equal(50_000, table.Rows.Count);
+        Assert.Equal("Only populated cell", Assert.Single(table.Cells).Text);
+    }
+
+    [Fact]
+    public void AdvancedTableDetection_PreservesSingleRowLeaderCandidate() {
+        byte[] pdf = PdfDocument.Create()
+            .Paragraph(paragraph => paragraph.Text("Section").Tab(PdfTabLeaderStyle.Dots).Text("7"))
+            .ToBytes();
+
+        PdfLogicalPage page = Assert.Single(Read(pdf, PdfUnderstandingPipelineOptions.Structured()).Pages);
+        PdfUnderstandingTableCandidate candidate = Assert.Single(page.Analysis.TableCandidates);
+
+        Assert.Equal("leaders", candidate.DetectionKind);
+        Assert.Single(candidate.Rows);
+        Assert.Equal(new[] { "Section", "7" }, candidate.Rows[0]);
+        Assert.Single(page.Tables);
     }
 
     [Fact]

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfUnderstandingPipelineTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfUnderstandingPipelineTests.cs
@@ -37,10 +37,109 @@ public class PdfUnderstandingPipelineTests {
             Assert.All(page.Regions, region => { Assert.InRange(region.Confidence, 0D, 1D); Assert.NotEmpty(region.Evidence); });
             Assert.All(page.ReadingOrderEvidence, order => { Assert.InRange(order.Confidence, 0D, 1D); Assert.NotEmpty(order.Evidence); });
             Assert.All(page.Elements, element => { Assert.InRange(element.Confidence, 0D, 1D); Assert.NotEmpty(element.Evidence); });
-            Assert.Equal(new[] { "glyph-decoding", "word-grouping", "line-grouping", "page-segmentation", "reading-order", "semantic-classification" }, page.Trace.Select(static trace => trace.Stage));
+            Assert.Equal(new[] { "glyph-decoding", "word-grouping", "line-grouping", "table-detection", "page-segmentation", "reading-order", "semantic-classification" }, page.Trace.Select(static trace => trace.Stage));
         });
         Assert.All(pages.SelectMany(static page => page.Trace), trace =>
             Assert.Equal(typeof(PdfAdvancedUnderstandingStages).Assembly, trace.ProviderType.Assembly));
+    }
+
+    [Fact]
+    public void Pipeline_DetectsTablesOnceAndReusesFirstClassCandidatesForLogicalProjection() {
+        byte[] pdf = PdfDocument.Create().Paragraph(p => p.Text("placeholder")).ToBytes();
+        var tableDetection = new CountingTableDetectionStage();
+        PdfUnderstandingPipelineOptions options = PdfUnderstandingPipelineOptions.Structured();
+        options.GlyphDecoding = new FixedGlyphStage(new[] {
+            new PdfTextSpan("Klucz Wartość", "F1", 12D, 40D, 700D, 180D),
+            new PdfTextSpan("Żółć 東京", "F1", 12D, 40D, 680D, 180D)
+        });
+        options.TableDetection = tableDetection;
+
+        PdfLogicalPage page = Assert.Single(Read(pdf, options).Pages);
+        PdfUnderstandingTableCandidate candidate = Assert.Single(page.Analysis.TableCandidates);
+        PdfLogicalTable table = Assert.Single(page.Tables);
+
+        Assert.Equal(1, tableDetection.CallCount);
+        Assert.Equal("test-aligned-geometry", candidate.DetectionKind);
+        Assert.Equal(candidate.DetectionKind, table.DetectionKind);
+        Assert.Equal(PdfLogicalContentSourceKind.Native, table.SourceKind);
+        Assert.Equal(new[] { "Żółć", "東京" }, table.Rows[1]);
+        Assert.Equal(
+            typeof(CountingTableDetectionStage),
+            Assert.Single(page.Analysis.Trace, static trace => trace.Stage == "table-detection").ProviderType);
+    }
+
+    [Fact]
+    public void Pipeline_SegmentsSharedBaselineTableFragmentsIndependently() {
+        byte[] pdf = PdfDocument.Create().Paragraph(p => p.Text("placeholder")).ToBytes();
+        PdfUnderstandingPipelineOptions options = PdfUnderstandingPipelineOptions.Structured();
+        options.GlyphDecoding = new FixedGlyphStage(new[] {
+            new PdfTextSpan("Left", "F1", 10D, 40D, 700D, 35D),
+            new PdfTextSpan("L1", "F1", 10D, 140D, 700D, 20D),
+            new PdfTextSpan("Right", "F1", 10D, 320D, 700D, 40D),
+            new PdfTextSpan("R1", "F1", 10D, 430D, 700D, 20D),
+            new PdfTextSpan("Alpha", "F1", 10D, 40D, 680D, 35D),
+            new PdfTextSpan("10", "F1", 10D, 140D, 680D, 20D),
+            new PdfTextSpan("Gamma", "F1", 10D, 320D, 680D, 40D),
+            new PdfTextSpan("30", "F1", 10D, 430D, 680D, 20D),
+            new PdfTextSpan("Beta", "F1", 10D, 40D, 660D, 35D),
+            new PdfTextSpan("20", "F1", 10D, 140D, 660D, 20D),
+            new PdfTextSpan("Delta", "F1", 10D, 320D, 660D, 40D),
+            new PdfTextSpan("40", "F1", 10D, 430D, 660D, 20D)
+        });
+        options.LineGrouping = new BaselineLineGroupingStage();
+        options.TableDetection = new TwoTableFragmentDetectionStage();
+
+        PdfUnderstandingPageResult page = Assert.Single(Read(pdf, options).Pages).Analysis;
+        PdfUnderstandingTableCandidate[] candidates = page.TableCandidates.ToArray();
+        PdfUnderstandingSemanticElement[] regions = page.Elements
+            .Where(static element => element.Kind == PdfUnderstandingSemanticKind.Table)
+            .ToArray();
+
+        Assert.Equal(2, candidates.Length);
+        Assert.Equal(2, regions.Length);
+        Assert.Empty(candidates[0].SourceLines.Intersect(candidates[1].SourceLines));
+        Assert.Contains(regions, region => region.Region.Text.Contains("Alpha", StringComparison.Ordinal) &&
+                                          !region.Region.Text.Contains("Gamma", StringComparison.Ordinal));
+        Assert.Contains(regions, region => region.Region.Text.Contains("Gamma", StringComparison.Ordinal) &&
+                                          !region.Region.Text.Contains("Alpha", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void StructuredPipeline_PromotesTableBeforeGeneralSegmentation() {
+        byte[] pdf = PdfDocument.Create(new PdfOptions {
+                PageWidth = 420,
+                PageHeight = 320,
+                MarginLeft = 36,
+                MarginRight = 36,
+                MarginTop = 36,
+                MarginBottom = 36,
+                DefaultFontSize = 10
+            })
+            .Table(new[] {
+                new[] { "Year", "Region", "Value" },
+                new[] { "2025", "North", "1250" },
+                new[] { "2024", "West", "980" }
+            }, style: new PdfTableStyle {
+                ColumnWidthPoints = new List<double?> { 70, 120, 90 },
+                HeaderRowCount = 1,
+                CellPaddingX = 6,
+                CellPaddingY = 4
+            })
+            .ToBytes();
+
+        PdfLogicalPage page = Assert.Single(Read(pdf, PdfUnderstandingPipelineOptions.Structured()).Pages);
+        PdfUnderstandingTableCandidate candidate = Assert.Single(
+            page.Analysis.TableCandidates,
+            static table => table.Rows.Count >= 3 && table.Columns.Count >= 3);
+        PdfLogicalTable table = Assert.Single(
+            page.Tables,
+            static table => table.Rows.Count >= 3 && table.Columns.Count >= 3);
+
+        Assert.Equal(PdfTableCoordinateSpace.PdfUserSpace, candidate.CoordinateSpace);
+        Assert.Equal(new[] { "2025", "North", "1250" }, candidate.Rows[1]);
+        Assert.Equal(candidate.Rows.Select(static row => row.ToArray()), table.Rows.Select(static row => row.ToArray()));
+        Assert.Contains(page.Analysis.Regions, region =>
+            region.Evidence.Any(static evidence => evidence.Code == "region.canonical-table"));
     }
 
     [Fact]
@@ -79,6 +178,42 @@ public class PdfUnderstandingPipelineTests {
 
         Assert.Equal(PdfReadLimitKind.UnderstandingArtifacts, exception.Kind);
         Assert.Equal(1, exception.Limit);
+    }
+
+    [Fact]
+    public void Pipeline_RejectsOversizedCustomTableCandidateSets() {
+        byte[] pdf = PdfDocument.Create().Paragraph(p => p.Text("placeholder")).ToBytes();
+        PdfUnderstandingPipelineOptions options = PdfUnderstandingPipelineOptions.Structured();
+        options.GlyphDecoding = new FixedGlyphStage(new[] {
+            new PdfTextSpan("first", "F1", 12D, 40D, 700D, 80D),
+            new PdfTextSpan("second", "F1", 12D, 40D, 680D, 80D)
+        });
+        options.TableDetection = new CountingTableDetectionStage(candidateCount: 2);
+        options.MaxTableCandidatesPerPage = 1;
+
+        PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() => Read(pdf, options));
+
+        Assert.Equal(PdfReadLimitKind.UnderstandingArtifacts, exception.Kind);
+        Assert.Equal(1, exception.Limit);
+        Assert.Equal(2, exception.Actual);
+    }
+
+    [Fact]
+    public void Pipeline_RejectsOversizedNestedTableCandidateArtifacts() {
+        byte[] pdf = PdfDocument.Create().Paragraph(p => p.Text("placeholder")).ToBytes();
+        PdfUnderstandingPipelineOptions options = PdfUnderstandingPipelineOptions.Structured();
+        options.GlyphDecoding = new FixedGlyphStage(new[] {
+            new PdfTextSpan("first", "F1", 12D, 40D, 700D, 80D),
+            new PdfTextSpan("second", "F1", 12D, 40D, 680D, 80D)
+        });
+        options.TableDetection = new CountingTableDetectionStage();
+        options.MaxWordsPerPage = 3;
+
+        PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() => Read(pdf, options));
+
+        Assert.Equal(PdfReadLimitKind.UnderstandingArtifacts, exception.Kind);
+        Assert.Equal(3, exception.Limit);
+        Assert.Equal(4, exception.Actual);
     }
 
     [Fact]
@@ -1670,15 +1805,6 @@ public class PdfUnderstandingPipelineTests {
     }
 
     [Fact]
-    public void AdvancedPipeline_TableOwnershipRequiresMeaningfulHorizontalOverlap() {
-        PdfUnderstandingLine clipped = CreateUnderstandingLine("Adjacent prose", 249.5D, 339.5D, 475D);
-        PdfUnderstandingLine owned = CreateUnderstandingLine("Table prose", 100D, 190D, 475D);
-
-        Assert.False(PdfAdvancedUnderstandingStages.HasMeaningfulTableOverlap(clipped, 500D, 450D, 50D, 250D));
-        Assert.True(PdfAdvancedUnderstandingStages.HasMeaningfulTableOverlap(owned, 500D, 450D, 50D, 250D));
-    }
-
-    [Fact]
     public void AdvancedReadingOrder_UsesRotatedSourceRunExtents() {
         var sourceRun = new PdfTextSpan("Vertical section label", "Helvetica", 11D, 280D, 200D, 400D, rotationDegrees: 90D);
         var word = new PdfUnderstandingWord(
@@ -2177,6 +2303,82 @@ public class PdfUnderstandingPipelineTests {
         public IReadOnlyList<PdfUnderstandingLine> GroupLines(
             PdfUnderstandingPageContext context,
             IReadOnlyList<PdfUnderstandingWord> words) => _lines;
+    }
+
+    private sealed class BaselineLineGroupingStage : IPdfLineGroupingStage {
+        public IReadOnlyList<PdfUnderstandingLine> GroupLines(
+            PdfUnderstandingPageContext context,
+            IReadOnlyList<PdfUnderstandingWord> words) =>
+            words.GroupBy(static word => word.BaselineY)
+                .OrderByDescending(static group => group.Key)
+                .Select(group => new PdfUnderstandingLine(group.OrderBy(static word => word.XStart).ToArray()))
+                .ToArray();
+    }
+
+    private sealed class TwoTableFragmentDetectionStage : IPdfTableDetectionStage {
+        public IReadOnlyList<PdfUnderstandingTableCandidate> DetectTables(
+            PdfUnderstandingPageContext context,
+            IReadOnlyList<PdfUnderstandingLine> lines) =>
+            new[] {
+                Create("left-test-table", lines, static word => word.XStart < 250D, 40D, 160D,
+                    new IReadOnlyList<string>[] { new[] { "Left", "L1" }, new[] { "Alpha", "10" }, new[] { "Beta", "20" } }),
+                Create("right-test-table", lines, static word => word.XStart >= 250D, 320D, 450D,
+                    new IReadOnlyList<string>[] { new[] { "Right", "R1" }, new[] { "Gamma", "30" }, new[] { "Delta", "40" } })
+            };
+
+        private static PdfUnderstandingTableCandidate Create(
+            string kind,
+            IReadOnlyList<PdfUnderstandingLine> lines,
+            Func<PdfUnderstandingWord, bool> selector,
+            double from,
+            double to,
+            IReadOnlyList<IReadOnlyList<string>> rows) {
+            PdfUnderstandingLine[] fragments = lines
+                .Select(line => new PdfUnderstandingLine(line.Words.Where(selector).ToArray(), line.Confidence, line.Evidence))
+                .ToArray();
+            return new PdfUnderstandingTableCandidate(
+                kind,
+                700D,
+                660D,
+                new[] { new PdfUnderstandingTableColumn(from, (from + to) / 2D), new PdfUnderstandingTableColumn((from + to) / 2D, to) },
+                rows,
+                fragments,
+                0.9D,
+                new[] { new PdfInferenceEvidence("test.table-fragment", "Independent table fragment.", 1D) });
+        }
+    }
+
+    private sealed class CountingTableDetectionStage : IPdfTableDetectionStage {
+        private readonly int _candidateCount;
+
+        internal CountingTableDetectionStage(int candidateCount = 1) {
+            _candidateCount = candidateCount;
+        }
+
+        internal int CallCount { get; private set; }
+
+        public IReadOnlyList<PdfUnderstandingTableCandidate> DetectTables(
+            PdfUnderstandingPageContext context,
+            IReadOnlyList<PdfUnderstandingLine> lines) {
+            CallCount++;
+            return Enumerable.Range(0, _candidateCount)
+                .Select(_ => new PdfUnderstandingTableCandidate(
+                    "test-aligned-geometry",
+                    700D,
+                    680D,
+                    new[] {
+                        new PdfUnderstandingTableColumn(40D, 120D),
+                        new PdfUnderstandingTableColumn(120D, 220D)
+                    },
+                    new IReadOnlyList<string>[] {
+                        new[] { "Klucz", "Wartość" },
+                        new[] { "Żółć", "東京" }
+                    },
+                    lines,
+                    0.95D,
+                    new[] { new PdfInferenceEvidence("test.table", "Test table candidate.", 1D) }))
+                .ToArray();
+        }
     }
 
     private sealed class CombinedLineGroupingStage : IPdfLineGroupingStage {

--- a/OfficeIMO.Pdf/Reading/Layout/ContentStructureExtractor.cs
+++ b/OfficeIMO.Pdf/Reading/Layout/ContentStructureExtractor.cs
@@ -84,6 +84,7 @@ public sealed class StructuredTable {
     public List<StructuredTableColumn> Columns { get; } = new();
     /// <summary>Extracted row values aligned to Columns.</summary>
     public List<string[]> Rows { get; } = new();
+    internal IReadOnlyList<PdfTextSpan> SourceRuns { get; set; } = Array.Empty<PdfTextSpan>();
 }
 
 /// <summary>Column geometry for a detected table.</summary>
@@ -287,7 +288,8 @@ internal static class ContentStructureExtractor {
         TextLayoutEngine.Options opts,
         double? pageHeight,
         Action<long>? consumeWork,
-        Action? cancellationCheck) {
+        Action? cancellationCheck,
+        IReadOnlyList<StructuredTable>? precomputedTables = null) {
         cancellationCheck?.Invoke();
         var page = new StructuredPage();
         var fallbackTableLines = new HashSet<TextLayoutEngine.TextLine>();
@@ -349,11 +351,13 @@ internal static class ContentStructureExtractor {
         }
 
         // Table detection: prefer banded column inference; fallback to per-line
-        var tables = TableDetector.DetectTablesFromBands(
-            bands,
-            pageHeight,
-            consumeWork,
-            cancellationCheck);
+        var tables = precomputedTables is null
+            ? TableDetector.DetectTablesFromBands(
+                bands,
+                pageHeight,
+                consumeWork,
+                cancellationCheck)
+            : precomputedTables.ToList();
         if (tables.Count > 0) {
             // Clean leaders and add
             foreach (var t in tables) {
@@ -385,7 +389,7 @@ internal static class ContentStructureExtractor {
                 page.TablesDetailed.Add(t);
                 page.Tables.AddRange(t.Rows);
             }
-        } else {
+        } else if (precomputedTables is null) {
             // Try a page-level leader-based table (TOC-like)
             var leaderTbl = TableDetector.DetectLeaderTable(
                 nonEmpty,

--- a/OfficeIMO.Pdf/Reading/Layout/TableDetector.cs
+++ b/OfficeIMO.Pdf/Reading/Layout/TableDetector.cs
@@ -16,11 +16,6 @@ internal static partial class TableDetector {
     private const int MaximumPositionedRecoveryLines = 4096;
     private const int MaximumPositionedRecoveryColumns = 64;
     private const int MaximumPositionedRecoveryCells = 65536;
-    private static readonly HashSet<string> ReportingPeriodHeaderLabels = new(StringComparer.OrdinalIgnoreCase) {
-        "account", "amount", "category", "code", "date", "department", "description", "id", "item",
-        "fiscal year", "measure", "metric", "month", "name", "period", "project", "quarter", "region",
-        "reporting period", "status", "type", "value", "year"
-    };
     public static List<string[]> Detect(List<TextLayoutEngine.TextLine> lines, double? pageHeight = null) {
         var rows = new List<string[]>();
         foreach (var match in DetectLineRows(lines, pageHeight)) {
@@ -210,6 +205,7 @@ internal static partial class TableDetector {
         if (line.Spans.Count < 2) return null;
         var cells = new List<PositionedCell>();
         var builder = new System.Text.StringBuilder();
+        var sourceRuns = new List<PdfTextSpan>();
         double from = 0D;
         double to = 0D;
         double lastSpanStart = 0D;
@@ -225,20 +221,22 @@ internal static partial class TableDetector {
             }
 
             if (split) {
-                cells.Add(new PositionedCell(from, to, lastSpanStart, builder.ToString().Trim()));
+                cells.Add(new PositionedCell(from, to, lastSpanStart, builder.ToString().Trim(), sourceRuns.ToArray()));
                 builder.Clear();
+                sourceRuns.Clear();
             } else if (gap > 1D && builder.Length > 0 && builder[builder.Length - 1] != ' ') {
                 builder.Append(' ');
             }
 
             if (builder.Length == 0) from = span.X;
             builder.Append(span.Text);
+            sourceRuns.Add(span);
             to = span.X + Math.Max(0D, span.Advance);
             lastSpanStart = span.X;
             if (cells.Count == MaximumPositionedRecoveryColumns) return null;
         }
 
-        if (builder.Length > 0) cells.Add(new PositionedCell(from, to, lastSpanStart, builder.ToString().Trim()));
+        if (builder.Length > 0) cells.Add(new PositionedCell(from, to, lastSpanStart, builder.ToString().Trim(), sourceRuns.ToArray()));
         return cells.Count is >= 2 and <= MaximumPositionedRecoveryColumns
             ? new PositionedRow(line.Y, cells)
             : null;
@@ -296,6 +294,11 @@ internal static partial class TableDetector {
         for (int rowIndex = 0; rowIndex < rows.Count; rowIndex++) {
             table.Rows.Add(rows[rowIndex].Cells.Select(static cell => cell.Text).ToArray());
         }
+        table.SourceRuns = rows
+            .SelectMany(static row => row.Cells)
+            .SelectMany(static cell => cell.SourceRuns)
+            .Distinct()
+            .ToArray();
         result.Add(table);
     }
 
@@ -357,11 +360,7 @@ internal static partial class TableDetector {
         for (int rowIndex = 1; rowIndex < rows.Count; rowIndex++) {
             for (int columnIndex = 0; columnIndex < rows[rowIndex].Cells.Count; columnIndex++) {
                 string value = rows[rowIndex].Cells[columnIndex].Text;
-                if (HasManyDigits(value) ||
-                    string.Equals(value, "yes", StringComparison.OrdinalIgnoreCase) ||
-                    string.Equals(value, "no", StringComparison.OrdinalIgnoreCase) ||
-                    string.Equals(value, "true", StringComparison.OrdinalIgnoreCase) ||
-                    string.Equals(value, "false", StringComparison.OrdinalIgnoreCase)) return true;
+                if (HasManyDigits(value)) return true;
             }
         }
         return false;
@@ -377,16 +376,23 @@ internal static partial class TableDetector {
     }
 
     private readonly struct PositionedCell {
-        internal PositionedCell(double from, double to, double lastSpanStart, string text) {
+        internal PositionedCell(
+            double from,
+            double to,
+            double lastSpanStart,
+            string text,
+            IReadOnlyList<PdfTextSpan> sourceRuns) {
             From = from;
             To = to;
             LastSpanStart = lastSpanStart;
             Text = text;
+            SourceRuns = sourceRuns;
         }
         internal double From { get; }
         internal double To { get; }
         internal double LastSpanStart { get; }
         internal string Text { get; }
+        internal IReadOnlyList<PdfTextSpan> SourceRuns { get; }
     }
 
     private static bool IsLeaderBand(List<TextLayoutEngine.TextLine> band) {
@@ -406,11 +412,13 @@ internal static partial class TableDetector {
 
     private static StructuredTable? BuildLeaderTableForBand(List<TextLayoutEngine.TextLine> band) {
         var rows = new List<string[]>();
+        var sourceRuns = new List<PdfTextSpan>();
         double leftMin = double.MaxValue, leftMax = double.MinValue;
         double rightMin = double.MaxValue, rightMax = double.MinValue;
         foreach (var ln in band) {
             if (TryLeaderRowFromLine(ln, out var row, out var left, out var right)) {
                 rows.Add(row);
+                sourceRuns.AddRange(ln.Spans);
                 leftMin = Math.Min(leftMin, left.From);
                 leftMax = Math.Max(leftMax, left.To);
                 rightMin = Math.Min(rightMin, right.From);
@@ -422,6 +430,7 @@ internal static partial class TableDetector {
         t.Columns.Add(new StructuredTableColumn { From = leftMin, To = leftMax });
         t.Columns.Add(new StructuredTableColumn { From = rightMin, To = rightMax });
         t.Rows.AddRange(rows);
+        t.SourceRuns = sourceRuns.Distinct().ToArray();
         return t;
     }
 
@@ -466,16 +475,19 @@ internal static partial class TableDetector {
             while (end + 1 < bandSplits.Count) {
                 (int idx, List<TextLayoutEngine.TextLine> lines, List<double> splits) current = bandSplits[end];
                 (int idx, List<TextLayoutEngine.TextLine> lines, List<double> splits) next = bandSplits[end + 1];
-                bool startsNewEmphasizedHeader = (end > start || headerLines is not null) &&
-                                                  LooksLikeEmphasizedHeaderBand(next.lines, next.splits);
-                if (startsNewEmphasizedHeader) {
+                List<TextLayoutEngine.TextLine>? previous = end > start
+                    ? bandSplits[end - 1].lines
+                    : headerLines;
+                List<TextLayoutEngine.TextLine>? following = end + 2 < bandSplits.Count &&
+                                                              bandSplits[end + 2].idx == next.idx + 1
+                    ? bandSplits[end + 2].lines
+                    : null;
+                if ((end > start || headerLines is not null) &&
+                    StartsStructurallySeparatedTable(current.lines, next.lines, previous, following)) {
                     break;
                 }
 
                 bool hasNonLeftAlignedCells = BandsHaveNonLeftAlignedCells(current.lines, next.lines);
-                List<TextLayoutEngine.TextLine>? previous = end > start
-                    ? bandSplits[end - 1].lines
-                    : null;
                 List<TextLayoutEngine.TextLine> rhythmMiddle = current.lines;
                 List<TextLayoutEngine.TextLine>? rhythmPrevious = previous;
                 if (includedBridgeBandIndexes.Contains(current.idx - 1)) {
@@ -512,7 +524,7 @@ internal static partial class TableDetector {
                     break;
                 }
                 if (bridgeDecision == InterveningBandDecision.Include &&
-                    LooksLikeEmphasizedHeaderBand(bands[current.idx + 1], next.splits) &&
+                    IsUniformlyEmphasizedBand(bands[current.idx + 1]) &&
                     BandsAlignUsingSplits(bands[current.idx + 1], next.lines, next.splits)) {
                     break;
                 }
@@ -627,16 +639,26 @@ internal static partial class TableDetector {
         if (cells.Count(static cell => !string.IsNullOrWhiteSpace(cell)) != 1) {
             return InterveningBandDecision.Reject;
         }
-        string text = line.Text.Trim();
         bool crossesColumnBoundary = CrossesColumnBoundary(line, splits);
-        bool hasSectionLabelEvidence = HasEmphasizedText(line) || IsUppercaseSectionLabel(text);
+        bool hasSectionLabelEvidence = HasEmphasizedText(line);
+        bool hasCompactRowShape = LooksLikeCompactSpanningRow(cells);
         bool followsEmphasizedHeader = bands[currentBandIndex].Count == 1 &&
                                        HasEmphasizedText(bands[currentBandIndex][0]);
-        return (crossesColumnBoundary &&
-                (hasSectionLabelEvidence || HasSpanningRowQualifier(text))) ||
-               (!crossesColumnBoundary && followsEmphasizedHeader && hasSectionLabelEvidence)
+        if (crossesColumnBoundary) {
+            return hasSectionLabelEvidence || hasCompactRowShape
+                ? InterveningBandDecision.Include
+                : InterveningBandDecision.Skip;
+        }
+        return followsEmphasizedHeader && (hasSectionLabelEvidence || hasCompactRowShape)
             ? InterveningBandDecision.Include
             : InterveningBandDecision.Reject;
+    }
+
+    private static bool LooksLikeCompactSpanningRow(IReadOnlyList<string> cells) {
+        string value = ContentStructureExtractor.NormalizeShattered(
+            cells.First(static cell => !string.IsNullOrWhiteSpace(cell))).Trim();
+        int words = value.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries).Length;
+        return words is >= 1 and <= 3 && value[value.Length - 1] is not ('.' or '!' or '?');
     }
 
     private static bool HasMeaningfulHorizontalOverlap(
@@ -656,33 +678,6 @@ internal static partial class TableDetector {
         double left = Math.Min(line.XStart, line.XEnd);
         double right = Math.Max(line.XStart, line.XEnd);
         return splits.Any(split => left < split - 1D && right > split + 1D);
-    }
-
-    private static bool HasSpanningRowQualifier(string text) {
-        if (text.Length is 0 or > 80) return false;
-        string firstWord = text.Split((char[]?)null, 2, StringSplitOptions.RemoveEmptyEntries)[0].TrimEnd(':');
-        return firstWord.Equals("amount", StringComparison.OrdinalIgnoreCase) ||
-               firstWord.Equals("amounts", StringComparison.OrdinalIgnoreCase) ||
-               firstWord.Equals("figure", StringComparison.OrdinalIgnoreCase) ||
-               firstWord.Equals("figures", StringComparison.OrdinalIgnoreCase) ||
-               firstWord.Equals("note", StringComparison.OrdinalIgnoreCase) ||
-               firstWord.Equals("notes", StringComparison.OrdinalIgnoreCase) ||
-               firstWord.Equals("subtotal", StringComparison.OrdinalIgnoreCase) ||
-               firstWord.Equals("total", StringComparison.OrdinalIgnoreCase) ||
-               firstWord.Equals("totals", StringComparison.OrdinalIgnoreCase) ||
-               firstWord.Equals("value", StringComparison.OrdinalIgnoreCase) ||
-               firstWord.Equals("values", StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static bool IsUppercaseSectionLabel(string text) {
-        bool hasLetter = false;
-        for (int index = 0; index < text.Length; index++) {
-            char value = text[index];
-            if (!char.IsLetter(value)) continue;
-            hasLetter = true;
-            if (char.IsLower(value)) return false;
-        }
-        return hasLetter;
     }
 
     private static bool BandsHaveAlignedCells(
@@ -770,17 +765,6 @@ internal static partial class TableDetector {
         return establishedGap > 0D && larger <= Math.Max(36D, establishedGap * 1.75D);
     }
 
-    private static bool IsCompactNonNarrativeRow(string text) {
-        if (text.Length is 0 or > 80 ||
-            text[text.Length - 1] is '.' or '!' or '?' ||
-            text.StartsWith("Figure ", StringComparison.OrdinalIgnoreCase) ||
-            text.StartsWith("Fig. ", StringComparison.OrdinalIgnoreCase) ||
-            text.StartsWith("Table ", StringComparison.OrdinalIgnoreCase)) {
-            return false;
-        }
-        return text.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries).Length <= 8;
-    }
-
     private static bool HasEmphasizedText(TextLayoutEngine.TextLine line) {
         PdfTextSpan[] spans = line.Spans
             .Where(static span => !string.IsNullOrWhiteSpace(span.Text))
@@ -805,8 +789,7 @@ internal static partial class TableDetector {
         List<TextLayoutEngine.TextLine>? followingBodyBand = bodyBandIndex + 1 < bands.Count
             ? bands[bodyBandIndex + 1]
             : null;
-        if (!IsCompactNonNarrativeRow(headerBand[0].Text.Trim()) ||
-            (!BandsHaveAlignedCells(headerBand, bands[bodyBandIndex]) &&
+        if ((!BandsHaveAlignedCells(headerBand, bands[bodyBandIndex]) &&
              !HasEmphasizedText(headerBand[0]))) {
             return null;
         }
@@ -848,117 +831,38 @@ internal static partial class TableDetector {
         return true;
     }
 
-    private static bool LooksLikeSummaryRow(string[] cells) {
-        if (cells.Length < 2) return false;
-        string label = ContentStructureExtractor.NormalizeShattered(cells[0]).Trim();
-        if (!LooksLikeSummaryLabel(label)) return false;
-        return cells.Skip(1).Any(static cell => LooksLikeSummaryValue(
-            ContentStructureExtractor.NormalizeShattered(cell).Trim()));
-    }
+    private static bool IsUniformlyEmphasizedBand(List<TextLayoutEngine.TextLine> band) =>
+        band.Count > 0 && band.All(static line => HasEmphasizedText(line));
 
-    private static bool LooksLikeSummaryValue(string value) =>
-        value.Any(char.IsDigit) ||
-        string.Equals(value, "n/a", StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(value, "n.a.", StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(value, "na", StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(value, "#n/a", StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(value, "none", StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(value, "null", StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(value, "tbd", StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(value, "tbc", StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(value, "pending", StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(value, "unknown", StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(value, "unavailable", StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(value, "missing", StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(value, "no data", StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(value, "not reported", StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(value, "not provided", StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(value, "redacted", StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(value, "not applicable", StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(value, "not available", StringComparison.OrdinalIgnoreCase) ||
-        value is "-" or "–" or "—" ||
-        string.Equals(value, "yes", StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(value, "no", StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(value, "true", StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(value, "false", StringComparison.OrdinalIgnoreCase);
-
-    private static bool LooksLikeSummaryLabel(string label) {
-        string value = label.Trim().TrimEnd(':').Trim();
-        return value.Equals("total", StringComparison.OrdinalIgnoreCase) ||
-               value.Equals("totals", StringComparison.OrdinalIgnoreCase) ||
-               value.Equals("subtotal", StringComparison.OrdinalIgnoreCase) ||
-               value.Equals("sub total", StringComparison.OrdinalIgnoreCase) ||
-               value.EndsWith(" total", StringComparison.OrdinalIgnoreCase) ||
-               value.EndsWith(" totals", StringComparison.OrdinalIgnoreCase) ||
-               value.EndsWith(" subtotal", StringComparison.OrdinalIgnoreCase) ||
-               value.EndsWith(" sub total", StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static bool LooksLikeEmphasizedHeaderBand(
-        List<TextLayoutEngine.TextLine> band,
-        List<double> splits) {
-        if (band.Count == 0 || splits.Count == 0 || band.Any(static line => !HasEmphasizedText(line))) return false;
-        string[] cells = MergeBandCellsBySplits(band, splits);
-        return LooksLikeHeaderRow(cells) &&
-               !LooksLikeSummaryRow(cells) &&
-               !LooksLikeEmphasizedDataRow(cells);
-    }
-
-    private static bool LooksLikeEmphasizedDataRow(string[] cells) {
-        string firstValue = ContentStructureExtractor.NormalizeShattered(cells[0]).Trim();
-        bool reportingPeriodHeader = LooksLikeColumnHeaderLabel(cells[0]) &&
-                                     cells.Skip(1).Any(static cell => LooksLikeReportingPeriodHeaderValue(
-                                         ContentStructureExtractor.NormalizeShattered(cell).Trim()));
-        if (!reportingPeriodHeader &&
-            LooksLikeSummaryValue(firstValue) &&
-            cells.Skip(1).Any(static cell => !string.IsNullOrWhiteSpace(cell))) {
-            return true;
+    private static bool StartsStructurallySeparatedTable(
+        List<TextLayoutEngine.TextLine> current,
+        List<TextLayoutEngine.TextLine> candidateHeader,
+        List<TextLayoutEngine.TextLine>? previous,
+        List<TextLayoutEngine.TextLine>? following) {
+        if (!IsUniformlyEmphasizedBand(candidateHeader) ||
+            current.Count == 0 ||
+            candidateHeader.Count == 0 ||
+            following is null ||
+            following.Count == 0 ||
+            !BandsContainAlignedCells(candidateHeader, following)) {
+            return false;
         }
-        return cells.Skip(1).Any(cell => {
-            string value = ContentStructureExtractor.NormalizeShattered(cell).Trim();
-            return LooksLikeSummaryValue(value) &&
-                   (!reportingPeriodHeader || !LooksLikeReportingPeriodHeaderValue(value));
-        });
-    }
 
-    private static bool LooksLikeColumnHeaderLabel(string cell) {
-        string value = ContentStructureExtractor.NormalizeShattered(cell)
-            .Trim()
-            .Trim(':', '-', '_', '/', '\\');
-        return ReportingPeriodHeaderLabels.Contains(value);
-    }
+        double boundaryGap = current.Average(static line => line.Y) - candidateHeader.Average(static line => line.Y);
+        if (boundaryGap <= 0D) return false;
+        double referenceGap = previous is null || previous.Count == 0
+            ? candidateHeader.Average(static line => line.Y) - following.Average(static line => line.Y)
+            : previous.Average(static line => line.Y) - current.Average(static line => line.Y);
+        if (referenceGap <= 0D) return false;
 
-    private static bool LooksLikeReportingPeriodHeaderValue(string value) {
-        string compact = new string(value.Where(static character => !char.IsWhiteSpace(character)).ToArray());
-        if (int.TryParse(compact, out int year)) return year is >= 1900 and <= 2200;
-        if (compact.Length == 6 &&
-            compact.StartsWith("FY", StringComparison.OrdinalIgnoreCase) &&
-            TryParseFourDigitYear(compact, 2, out year)) {
-            return year is >= 1900 and <= 2200;
-        }
-        if (compact.Length == 2 &&
-            (compact[0] is 'Q' or 'q' && compact[1] is >= '1' and <= '4' ||
-             compact[0] is 'H' or 'h' && compact[1] is >= '1' and <= '2')) {
-            return true;
-        }
-        if (compact.Length > 5 &&
-            TryParseFourDigitYear(compact, 0, out year) &&
-            year is >= 1900 and <= 2200 &&
-            compact[4] is '/' or '-' or '–' or '—') {
-            return true;
-        }
-        return false;
-    }
-
-    private static bool TryParseFourDigitYear(string value, int offset, out int year) {
-        year = 0;
-        if (offset < 0 || value.Length - offset < 4) return false;
-        for (int index = offset; index < offset + 4; index++) {
-            char character = value[index];
-            if (character is < '0' or > '9') return false;
-            year = year * 10 + character - '0';
-        }
-        return true;
+        double fontSize = current
+            .Concat(candidateHeader)
+            .Concat(following)
+            .SelectMany(static line => line.Spans)
+            .Select(static span => span.FontSize)
+            .DefaultIfEmpty(0D)
+            .Max();
+        return boundaryGap >= Math.Max(referenceGap * 1.35D, referenceGap + Math.Max(2D, fontSize * 0.35D));
     }
 
     private static bool AreSplitsSimilar(List<double> a, List<double> b) {
@@ -988,6 +892,7 @@ internal static partial class TableDetector {
             prev = next;
         }
         int cols = table.Columns.Count;
+        var sourceRuns = new List<PdfTextSpan>();
         foreach (var ln in lines) {
             List<double> lineSplits = lineSplitOverrides is not null &&
                                       lineSplitOverrides.TryGetValue(ln, out List<double>? splitOverride)
@@ -998,7 +903,9 @@ internal static partial class TableDetector {
             bool anyContent = false; for (int i = 0; i < cells.Length; i++) if (!string.IsNullOrWhiteSpace(cells[i])) { anyContent = true; break; }
             if (!anyContent) continue;
             table.Rows.Add(cells);
+            sourceRuns.AddRange(ln.Spans);
         }
+        table.SourceRuns = sourceRuns.Distinct().ToArray();
         return table.Rows.Count > 0 ? table : null;
     }
 
@@ -1044,7 +951,7 @@ internal static partial class TableDetector {
     private static bool LooksLikeSparseFormGrid(StructuredTable table) {
         if (table.Rows.Count < 3 || !LooksLikeCompactHeaderRow(table.Rows[0])) return false;
 
-        int sparseLabelRows = 0;
+        var sparseRowsByColumn = new int[table.Columns.Count];
         for (int rowIndex = 1; rowIndex < table.Rows.Count; rowIndex++) {
             string[] row = table.Rows[rowIndex];
             int populatedCells = 0;
@@ -1054,15 +961,15 @@ internal static partial class TableDetector {
                 populatedCells++;
                 populatedColumn = columnIndex;
             }
-            if (populatedCells != 1 || populatedColumn != 0) continue;
+            if (populatedCells != 1 || populatedColumn < 0) continue;
 
-            string label = ContentStructureExtractor.NormalizeShattered(row[0]).Trim();
+            string label = ContentStructureExtractor.NormalizeShattered(row[populatedColumn]).Trim();
             int words = label.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries).Length;
             if (words is >= 1 and <= 5 && label[label.Length - 1] is not ('.' or '!' or '?')) {
-                sparseLabelRows++;
+                sparseRowsByColumn[populatedColumn]++;
             }
         }
-        return sparseLabelRows >= 2;
+        return sparseRowsByColumn.Any(static count => count >= 2);
     }
 
     private static bool HasPageColumnLikeGutters(IReadOnlyList<TextLayoutEngine.TextLine> sourceLines) {
@@ -1181,12 +1088,7 @@ internal static partial class TableDetector {
         baseFont?.IndexOf("Demi", StringComparison.OrdinalIgnoreCase) >= 0 ||
         baseFont?.IndexOf("SemiBold", StringComparison.OrdinalIgnoreCase) >= 0;
 
-    private static bool IsTabularValue(string value) =>
-        HasManyDigits(value) ||
-        string.Equals(value, "yes", StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(value, "no", StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(value, "true", StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(value, "false", StringComparison.OrdinalIgnoreCase);
+    private static bool IsTabularValue(string value) => HasManyDigits(value);
 
     public static StructuredTable? DetectLeaderTable(
         List<TextLayoutEngine.TextLine> lines,
@@ -1202,12 +1104,14 @@ internal static partial class TableDetector {
             .ToList();
         if (candidates.Count == 0) return null;
         var rows = new List<string[]>();
+        var sourceRuns = new List<PdfTextSpan>();
         double leftMin = double.MaxValue, leftMax = double.MinValue;
         double rightMin = double.MaxValue, rightMax = double.MinValue;
         foreach (var ln in candidates) {
             cancellationCheck?.Invoke();
             if (TryLeaderRowFromLine(ln, out var row, out var leftBounds, out var rightBounds)) {
                 rows.Add(row);
+                sourceRuns.AddRange(ln.Spans);
                 leftMin = Math.Min(leftMin, leftBounds.From);
                 leftMax = Math.Max(leftMax, leftBounds.To);
                 rightMin = Math.Min(rightMin, rightBounds.From);
@@ -1223,6 +1127,7 @@ internal static partial class TableDetector {
         table.Columns.Add(new StructuredTableColumn { From = leftMin, To = leftMax });
         table.Columns.Add(new StructuredTableColumn { From = rightMin, To = rightMax });
         table.Rows.AddRange(rows);
+        table.SourceRuns = sourceRuns.Distinct().ToArray();
         return table;
     }
 

--- a/OfficeIMO.Pdf/Reading/Layout/TableDetector.cs
+++ b/OfficeIMO.Pdf/Reading/Layout/TableDetector.cs
@@ -363,7 +363,35 @@ internal static partial class TableDetector {
                 if (HasManyDigits(value)) return true;
             }
         }
-        return false;
+        return HasTextualGridEvidence(rows);
+    }
+
+    private static bool HasTextualGridEvidence(List<PositionedRow> rows) {
+        // Header plus at least three compact, consistently aligned body rows is
+        // language-neutral evidence for categorical tables without numeric cells.
+        if (rows.Count < 4) return false;
+        int columnCount = rows[0].Cells.Count;
+        if (columnCount < 2 || rows.Any(row => row.Cells.Count != columnCount)) return false;
+
+        for (int rowIndex = 0; rowIndex < rows.Count; rowIndex++) {
+            for (int columnIndex = 0; columnIndex < columnCount; columnIndex++) {
+                string value = ContentStructureExtractor.NormalizeShattered(rows[rowIndex].Cells[columnIndex].Text).Trim();
+                if (value.Length == 0 ||
+                    value.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries).Length > 4) {
+                    return false;
+                }
+            }
+        }
+
+        var gaps = new List<double>(rows.Count - 1);
+        for (int rowIndex = 1; rowIndex < rows.Count; rowIndex++) {
+            double gap = rows[rowIndex - 1].Y - rows[rowIndex].Y;
+            if (gap <= 0D) return false;
+            gaps.Add(gap);
+        }
+        double medianGap = Median(gaps);
+        double tolerance = Math.Max(3D, medianGap * 0.35D);
+        return gaps.All(gap => Math.Abs(gap - medianGap) <= tolerance);
     }
 
     private sealed class PositionedRow {

--- a/OfficeIMO.Pdf/Reading/Layout/TextLayoutEngine.cs
+++ b/OfficeIMO.Pdf/Reading/Layout/TextLayoutEngine.cs
@@ -569,7 +569,8 @@ public static class PdfReadPageExtensions {
         PdfTextLayoutOptions? options,
         CancellationToken cancellationToken,
         Action<long>? consumeWork = null,
-        Action? cancellationCheck = null) {
+        Action? cancellationCheck = null,
+        IReadOnlyList<StructuredTable>? precomputedTables = null) {
         cancellationToken.ThrowIfCancellationRequested();
         cancellationCheck?.Invoke();
         var (_, pageHeight) = page.GetPageSize();
@@ -588,7 +589,8 @@ public static class PdfReadPageExtensions {
             engineOpts ?? new TextLayoutEngine.Options(),
             pageHeight,
             consumeWork,
-            cancellationCheck ?? cancellationToken.ThrowIfCancellationRequested);
+            cancellationCheck ?? cancellationToken.ThrowIfCancellationRequested,
+            precomputedTables);
         cancellationToken.ThrowIfCancellationRequested();
         cancellationCheck?.Invoke();
         return result;

--- a/OfficeIMO.Pdf/Reading/Logical/PdfLogicalPage.Ocr.cs
+++ b/OfficeIMO.Pdf/Reading/Logical/PdfLogicalPage.Ocr.cs
@@ -6,8 +6,13 @@ public sealed partial class PdfLogicalPage {
         IReadOnlyList<PdfLogicalHeading> ocrHeadings,
         IReadOnlyList<PdfLogicalParagraph> ocrParagraphs,
         IReadOnlyList<PdfLogicalListItem> ocrListItems,
-        IReadOnlyList<PdfLogicalTable> ocrTables) {
-        var elements = new List<IPdfLogicalElement>(Elements.Count + ocrTextBlocks.Count + ocrTables.Count);
+        IReadOnlyList<PdfUnderstandingTableCandidate> ocrTableCandidates) {
+        IReadOnlyList<PdfUnderstandingTableCandidate> acceptedOcrTableCandidates =
+            PdfUnderstandingTableCandidateReconciler.FilterAdditions(this, Analysis.TableCandidates, ocrTableCandidates);
+        PdfLogicalTable[] ocrTables = acceptedOcrTableCandidates
+            .Select(candidate => PdfLogicalTable.From(PageNumber, candidate))
+            .ToArray();
+        var elements = new List<IPdfLogicalElement>(Elements.Count + ocrTextBlocks.Count + ocrTables.Length);
         elements.AddRange(Elements);
         elements.AddRange(ocrTextBlocks);
         elements.AddRange(ocrTables);
@@ -16,6 +21,7 @@ public sealed partial class PdfLogicalPage {
         PdfLogicalParagraph[] paragraphs = Paragraphs.Concat(ocrParagraphs).ToArray();
         PdfLogicalListItem[] listItems = ListItems.Concat(ocrListItems).ToArray();
         PdfLogicalTable[] tables = Tables.Concat(ocrTables).ToArray();
+        PdfUnderstandingPageResult analysis = Analysis.WithAdditionalTableCandidates(acceptedOcrTableCandidates);
         var merged = new PdfLogicalPage(
             PageNumber,
             Width,
@@ -36,7 +42,7 @@ public sealed partial class PdfLogicalPage {
             LinkAnnotations,
             FormWidgets,
             PageActions,
-            Analysis);
+            analysis);
         IReadOnlyList<PdfLogicalTextBlock> orderedTextBlocks = OrderTextBlocks(merged);
         if (orderedTextBlocks.SequenceEqual(textBlocks)) return merged;
         var orderedElements = new List<IPdfLogicalElement>(elements.Count);
@@ -62,7 +68,7 @@ public sealed partial class PdfLogicalPage {
             LinkAnnotations,
             FormWidgets,
             PageActions,
-            Analysis);
+            analysis);
     }
 
     private static System.Collections.ObjectModel.ReadOnlyCollection<PdfLogicalTextBlock> OrderTextBlocks(PdfLogicalPage page) {

--- a/OfficeIMO.Pdf/Reading/Logical/PdfLogicalPage.cs
+++ b/OfficeIMO.Pdf/Reading/Logical/PdfLogicalPage.cs
@@ -282,7 +282,10 @@ public sealed partial class PdfLogicalPage {
                 options,
                 cancellationToken,
                 analysis.ConsumeWork,
-                analysis.CancellationCheck);
+                analysis.CancellationCheck,
+                analysis.TableCandidates
+                    .Select(table => table.ToStructuredTable(analysis.ConsumeWork, analysis.CancellationCheck))
+                    .ToArray());
         if (analysis is not null) {
             ReplaceProjectionLines(page, structured, retainedLines!, cancellationToken);
         }
@@ -339,8 +342,10 @@ public sealed partial class PdfLogicalPage {
             elements.Add(leader);
         }
 
-        foreach (var table in structured.TablesDetailed) {
-            var logicalTable = PdfLogicalTable.From(pageNumber, table);
+        IEnumerable<PdfLogicalTable> logicalTables = analysis is null
+            ? structured.TablesDetailed.Select(table => PdfLogicalTable.From(pageNumber, table))
+            : analysis.TableCandidates.Select(table => PdfLogicalTable.From(pageNumber, table));
+        foreach (PdfLogicalTable logicalTable in logicalTables) {
             tables.Add(logicalTable);
             elements.Add(logicalTable);
         }

--- a/OfficeIMO.Pdf/Reading/Logical/PdfLogicalPage.cs
+++ b/OfficeIMO.Pdf/Reading/Logical/PdfLogicalPage.cs
@@ -275,6 +275,9 @@ public sealed partial class PdfLogicalPage {
             : analysis.RestrictLogicalProjectionToReadingOrder
                 ? GetRetainedProjectionRuns(retainedLines!, cancellationToken)
                 : analysis.DecodedRuns;
+        IReadOnlyList<PdfUnderstandingTableCandidate>? projectedTableCandidates = analysis is null
+            ? null
+            : GetProjectedTableCandidates(analysis, retainedRuns!, cancellationToken);
         var structured = analysis is null
             ? page.ExtractStructured(options)
             : page.ExtractStructured(
@@ -283,7 +286,7 @@ public sealed partial class PdfLogicalPage {
                 cancellationToken,
                 analysis.ConsumeWork,
                 analysis.CancellationCheck,
-                analysis.TableCandidates
+                projectedTableCandidates!
                     .Select(table => table.ToStructuredTable(analysis.ConsumeWork, analysis.CancellationCheck))
                     .ToArray());
         if (analysis is not null) {
@@ -344,7 +347,7 @@ public sealed partial class PdfLogicalPage {
 
         IEnumerable<PdfLogicalTable> logicalTables = analysis is null
             ? structured.TablesDetailed.Select(table => PdfLogicalTable.From(pageNumber, table))
-            : analysis.TableCandidates.Select(table => PdfLogicalTable.From(pageNumber, table));
+            : projectedTableCandidates!.Select(table => PdfLogicalTable.From(pageNumber, table));
         foreach (PdfLogicalTable logicalTable in logicalTables) {
             tables.Add(logicalTable);
             elements.Add(logicalTable);
@@ -435,6 +438,42 @@ public sealed partial class PdfLogicalPage {
             }
         }
         return retained.AsReadOnly();
+    }
+
+    private static IReadOnlyList<PdfUnderstandingTableCandidate> GetProjectedTableCandidates(
+        PdfUnderstandingPageResult analysis,
+        IReadOnlyList<PdfTextSpan> retainedRuns,
+        CancellationToken cancellationToken) {
+        if (!analysis.RestrictLogicalProjectionToReadingOrder || analysis.TableCandidates.Count == 0) {
+            return analysis.TableCandidates;
+        }
+
+        var retained = new HashSet<PdfTextSpan>(retainedRuns);
+        var candidates = new List<PdfUnderstandingTableCandidate>(analysis.TableCandidates.Count);
+        for (int candidateIndex = 0; candidateIndex < analysis.TableCandidates.Count; candidateIndex++) {
+            cancellationToken.ThrowIfCancellationRequested();
+            PdfUnderstandingTableCandidate candidate = analysis.TableCandidates[candidateIndex];
+            bool hasSourceRun = false;
+            bool isRetained = true;
+            for (int lineIndex = 0; lineIndex < candidate.SourceLines.Count && isRetained; lineIndex++) {
+                IReadOnlyList<PdfUnderstandingWord> words = candidate.SourceLines[lineIndex].Words;
+                for (int wordIndex = 0; wordIndex < words.Count && isRetained; wordIndex++) {
+                    IReadOnlyList<PdfTextSpan> sourceRuns = words[wordIndex].SourceRuns;
+                    for (int runIndex = 0; runIndex < sourceRuns.Count; runIndex++) {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        hasSourceRun = true;
+                        if (!retained.Contains(sourceRuns[runIndex])) {
+                            isRetained = false;
+                            break;
+                        }
+                    }
+                }
+            }
+            if (hasSourceRun && isRetained) candidates.Add(candidate);
+        }
+        return candidates.Count == analysis.TableCandidates.Count
+            ? analysis.TableCandidates
+            : candidates.AsReadOnly();
     }
 
     private static void ReplaceProjectionLines(

--- a/OfficeIMO.Pdf/Reading/Logical/PdfLogicalTableContinuations.cs
+++ b/OfficeIMO.Pdf/Reading/Logical/PdfLogicalTableContinuations.cs
@@ -241,6 +241,15 @@ public static class PdfLogicalTableContinuations {
 
     private static bool TryGetVisualBounds(PdfLogicalTable table, PdfLogicalPage page, out PdfVisualBounds bounds) {
         if (table.Columns.Count == 0) { bounds = default; return false; }
+        if (table.CoordinateSpace == PdfTableCoordinateSpace.VisualTopLeft) {
+            PdfLogicalVisualBounds? visual = table.VisualBounds;
+            double visualLeft = visual?.Left ?? table.Columns.Min(static column => Math.Min(column.From, column.To));
+            double visualRight = visual?.Right ?? table.Columns.Max(static column => Math.Max(column.From, column.To));
+            double visualTop = visual?.Top ?? Math.Min(table.YTop, table.YBottom);
+            double visualBottom = visual?.Bottom ?? Math.Max(table.YTop, table.YBottom);
+            bounds = new PdfVisualBounds(visualLeft, visualTop, visualRight, visualBottom);
+            return bounds.Right > bounds.Left && bounds.Bottom > bounds.Top;
+        }
         double left = table.Columns.Min(static column => Math.Min(column.From, column.To));
         double right = table.Columns.Max(static column => Math.Max(column.From, column.To));
         double bottom = Math.Min(table.YBottom, table.YTop);
@@ -286,7 +295,7 @@ public static class PdfLogicalTableContinuations {
         PdfLogicalTable table,
         PdfLogicalPage page,
         CancellationToken cancellationToken) {
-        if (table.SourceKind == PdfLogicalContentSourceKind.Ocr) {
+        if (table.CoordinateSpace == PdfTableCoordinateSpace.VisualTopLeft) {
             var visualColumns = new VisualColumn[table.Columns.Count];
             for (int index = 0; index < table.Columns.Count; index++) {
                 cancellationToken.ThrowIfCancellationRequested();

--- a/OfficeIMO.Pdf/Reading/Logical/PdfLogicalTableElements.cs
+++ b/OfficeIMO.Pdf/Reading/Logical/PdfLogicalTableElements.cs
@@ -36,7 +36,10 @@ public sealed class PdfLogicalTable : IPdfLogicalElement {
         IReadOnlyList<IReadOnlyList<string>> rows,
         IReadOnlyList<PdfLogicalTableCell> cells,
         PdfLogicalContentSourceKind sourceKind = PdfLogicalContentSourceKind.Native,
-        PdfLogicalVisualBounds? visualBounds = null) {
+        PdfTableCoordinateSpace coordinateSpace = PdfTableCoordinateSpace.PdfUserSpace,
+        PdfLogicalVisualBounds? visualBounds = null,
+        double? confidence = null,
+        IReadOnlyList<PdfInferenceEvidence>? evidence = null) {
         PageNumber = pageNumber;
         DetectionKind = kind;
         YTop = yTop;
@@ -45,12 +48,13 @@ public sealed class PdfLogicalTable : IPdfLogicalElement {
         Rows = rows;
         Cells = cells;
         SourceKind = sourceKind;
+        CoordinateSpace = coordinateSpace;
         VisualBounds = visualBounds;
         int expectedCells = rows.Count * columns.Count;
         int filledCells = rows.Sum(static row => row.Count(static cell => !string.IsNullOrWhiteSpace(cell)));
         double completeness = expectedCells == 0 ? 0D : (double)filledCells / expectedCells;
-        Confidence = PdfInference.Clamp((columns.Count > 1 ? 0.45D : 0.2D) + (completeness * 0.45D) + (visualBounds is not null || yTop > yBottom ? 0.1D : 0D));
-        Evidence = new[] {
+        Confidence = PdfInference.Clamp(confidence ?? ((columns.Count > 1 ? 0.45D : 0.2D) + (completeness * 0.45D) + (visualBounds is not null || yTop > yBottom ? 0.1D : 0D)));
+        Evidence = evidence ?? new[] {
             new PdfInferenceEvidence("table.detection-kind", "The table was produced by the " + kind + " detector.", 0.5D),
             new PdfInferenceEvidence("table.cell-completeness", "Filled-cell completeness is " + completeness.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture) + ".", (completeness * 2D) - 1D),
             new PdfInferenceEvidence("table.column-geometry", columns.Count > 1 ? "Multiple column boundaries were detected." : "Fewer than two column boundaries were detected.", columns.Count > 1 ? 0.7D : -0.5D)
@@ -66,13 +70,13 @@ public sealed class PdfLogicalTable : IPdfLogicalElement {
     /// <summary>Detection heuristic that produced the table.</summary>
     public string DetectionKind { get; }
 
-    /// <summary>Top Y coordinate of the detected table band.</summary>
+    /// <summary>Top Y coordinate in <see cref="CoordinateSpace"/>.</summary>
     public double YTop { get; }
 
-    /// <summary>Bottom Y coordinate of the detected table band.</summary>
+    /// <summary>Bottom Y coordinate in <see cref="CoordinateSpace"/>.</summary>
     public double YBottom { get; }
 
-    /// <summary>Detected table columns.</summary>
+    /// <summary>Detected table columns in <see cref="CoordinateSpace"/>.</summary>
     public IReadOnlyList<PdfLogicalTableColumn> Columns { get; }
 
     /// <summary>Extracted table rows.</summary>
@@ -82,6 +86,8 @@ public sealed class PdfLogicalTable : IPdfLogicalElement {
     public IReadOnlyList<PdfLogicalTableCell> Cells { get; }
     /// <summary>Whether table evidence came from native PDF operations or accepted OCR geometry.</summary>
     public PdfLogicalContentSourceKind SourceKind { get; }
+    /// <summary>Coordinate system used by the table bounds and columns.</summary>
+    public PdfTableCoordinateSpace CoordinateSpace { get; }
     /// <summary>Direct top-left visual geometry when the detector operates on rendered OCR coordinates.</summary>
     public PdfLogicalVisualBounds? VisualBounds { get; }
     /// <summary>Normalized table-detection confidence.</summary>
@@ -116,33 +122,60 @@ public sealed class PdfLogicalTable : IPdfLogicalElement {
             cells.AsReadOnly());
     }
 
+    internal static PdfLogicalTable From(int pageNumber, PdfUnderstandingTableCandidate table) {
+        var columns = table.Columns
+            .Select(static column => new PdfLogicalTableColumn(column.From, column.To))
+            .ToArray();
+        var rows = table.Rows
+            .Select(static row => (IReadOnlyList<string>)Array.AsReadOnly(row.ToArray()))
+            .ToArray();
+        var cells = new List<PdfLogicalTableCell>(rows.Length * columns.Length);
+        for (int rowIndex = 0; rowIndex < rows.Length; rowIndex++) {
+            for (int columnIndex = 0; columnIndex < rows[rowIndex].Count; columnIndex++) {
+                PdfLogicalTableColumn? column = columnIndex < columns.Length ? columns[columnIndex] : null;
+                cells.Add(new PdfLogicalTableCell(pageNumber, rowIndex, columnIndex, rows[rowIndex][columnIndex], column));
+            }
+        }
+        return new PdfLogicalTable(
+            pageNumber,
+            table.DetectionKind,
+            table.YTop,
+            table.YBottom,
+            columns,
+            rows,
+            cells.AsReadOnly(),
+            table.SourceKind,
+            table.CoordinateSpace,
+            table.VisualBounds,
+            table.Confidence,
+            table.Evidence);
+    }
+
     internal static PdfLogicalTable FromOcr(
         int pageNumber,
         double top,
         double bottom,
         IReadOnlyList<(double From, double To)> columnBounds,
         IReadOnlyList<IReadOnlyList<string>> sourceRows) {
-        var columns = columnBounds.Select(static column => new PdfLogicalTableColumn(column.From, column.To)).ToArray();
-        var rows = sourceRows.Select(static row => (IReadOnlyList<string>)Array.AsReadOnly(row.ToArray())).ToArray();
-        var cells = new List<PdfLogicalTableCell>(rows.Length * columns.Length);
-        for (int rowIndex = 0; rowIndex < rows.Length; rowIndex++) {
-            for (int columnIndex = 0; columnIndex < rows[rowIndex].Count; columnIndex++) {
-                cells.Add(new PdfLogicalTableCell(pageNumber, rowIndex, columnIndex, rows[rowIndex][columnIndex], columns[columnIndex]));
-            }
-        }
         double left = columnBounds.Min(static column => column.From);
         double right = columnBounds.Max(static column => column.To);
-        return new PdfLogicalTable(
-            pageNumber,
+        PdfUnderstandingTableCandidate candidate = PdfUnderstandingTableCandidate.FromOcr(
             "OcrAlignedColumns",
             top,
             bottom,
-            columns,
-            rows,
-            cells.AsReadOnly(),
-            PdfLogicalContentSourceKind.Ocr,
-            new PdfLogicalVisualBounds(left, top, right, bottom));
+            new PdfLogicalVisualBounds(left, top, right, bottom),
+            columnBounds,
+            sourceRows,
+            0.8D,
+            new[] {
+                new PdfInferenceEvidence(
+                    "table.ocr-aligned-geometry",
+                    "Accepted OCR words form repeated aligned columns.",
+                    0.8D)
+            });
+        return From(pageNumber, candidate);
     }
+
 }
 
 /// <summary>
@@ -182,9 +215,9 @@ public sealed class PdfLogicalTableColumn {
         To = to;
     }
 
-    /// <summary>Left X coordinate in PDF points.</summary>
+    /// <summary>Left X coordinate in the owning table's coordinate space.</summary>
     public double From { get; }
 
-    /// <summary>Right X coordinate in PDF points.</summary>
+    /// <summary>Right X coordinate in the owning table's coordinate space.</summary>
     public double To { get; }
 }

--- a/OfficeIMO.Pdf/Reading/Logical/PdfLogicalTableElements.cs
+++ b/OfficeIMO.Pdf/Reading/Logical/PdfLogicalTableElements.cs
@@ -129,7 +129,11 @@ public sealed class PdfLogicalTable : IPdfLogicalElement {
         var rows = table.Rows
             .Select(static row => (IReadOnlyList<string>)Array.AsReadOnly(row.ToArray()))
             .ToArray();
-        var cells = new List<PdfLogicalTableCell>(rows.Length * columns.Length);
+        int cellCount = 0;
+        for (int rowIndex = 0; rowIndex < rows.Length; rowIndex++) {
+            cellCount = checked(cellCount + rows[rowIndex].Count);
+        }
+        var cells = new List<PdfLogicalTableCell>(cellCount);
         for (int rowIndex = 0; rowIndex < rows.Length; rowIndex++) {
             for (int columnIndex = 0; columnIndex < rows[rowIndex].Count; columnIndex++) {
                 PdfLogicalTableColumn? column = columnIndex < columns.Length ? columns[columnIndex] : null;

--- a/OfficeIMO.Pdf/Reading/Ocr/PdfOcrLogicalDocumentBuilder.cs
+++ b/OfficeIMO.Pdf/Reading/Ocr/PdfOcrLogicalDocumentBuilder.cs
@@ -64,9 +64,9 @@ internal static class PdfOcrLogicalDocumentBuilder {
         CancellationToken cancellationToken) {
         List<OcrLine> sourceLines = BuildLines(words, cancellationToken);
         HashSet<int> tableLineIndexes = new HashSet<int>();
-        IReadOnlyList<PdfLogicalTable> tables = options.DetectAlignedTables
+        IReadOnlyList<PdfUnderstandingTableCandidate> tableCandidates = options.DetectAlignedTables
             ? DetectTables(page, sourceLines, tableLineIndexes, options, cancellationToken)
-            : Array.Empty<PdfLogicalTable>();
+            : Array.Empty<PdfUnderstandingTableCandidate>();
         List<(OcrLine Line, bool IsTableLine)> lines = BuildSemanticLines(
             sourceLines,
             tableLineIndexes,
@@ -122,7 +122,12 @@ internal static class PdfOcrLogicalDocumentBuilder {
         }
         FlushParagraph();
 
-        return page.WithOcrContent(textBlocks.AsReadOnly(), headings.AsReadOnly(), paragraphs.AsReadOnly(), listItems.AsReadOnly(), tables);
+        return page.WithOcrContent(
+            textBlocks.AsReadOnly(),
+            headings.AsReadOnly(),
+            paragraphs.AsReadOnly(),
+            listItems.AsReadOnly(),
+            tableCandidates);
 
         void FlushParagraph() {
             if (paragraphLines.Count == 0) return;
@@ -214,7 +219,7 @@ internal static class PdfOcrLogicalDocumentBuilder {
         return result;
     }
 
-    private static IReadOnlyList<PdfLogicalTable> DetectTables(
+    private static IReadOnlyList<PdfUnderstandingTableCandidate> DetectTables(
         PdfLogicalPage page,
         IReadOnlyList<OcrLine> lines,
         HashSet<int> tableLineIndexes,
@@ -226,7 +231,7 @@ internal static class PdfOcrLogicalDocumentBuilder {
             IReadOnlyList<OcrCell> cells = SplitCells(lines[lineIndex].Words, options.MinimumTableColumnGapPoints);
             if (cells.Count >= 2) candidates.Add((lineIndex, cells));
         }
-        if (candidates.Count < options.MinimumAlignedTableRows) return Array.Empty<PdfLogicalTable>();
+        if (candidates.Count < options.MinimumAlignedTableRows) return Array.Empty<PdfUnderstandingTableCandidate>();
 
         var groups = new List<List<(int Index, IReadOnlyList<OcrCell> Cells)>>();
         foreach ((int index, IReadOnlyList<OcrCell> cells) in candidates) {
@@ -239,53 +244,59 @@ internal static class PdfOcrLogicalDocumentBuilder {
             group.Add((index, cells));
         }
 
-        var result = new List<PdfLogicalTable>();
+        var result = new List<PdfUnderstandingTableCandidate>();
         foreach (List<(int Index, IReadOnlyList<OcrCell> Cells)> group in groups.Where(group => group.Count >= options.MinimumAlignedTableRows)) {
             cancellationToken.ThrowIfCancellationRequested();
-            if (!HasConservativeTableEvidence(group)) continue;
+            if (!HasConservativeTableEvidence(group, lines)) continue;
             if (result.Count >= options.MaxInferredTablesPerPage) {
                 throw PdfReadLimitException.Create(PdfReadLimitKind.OcrArtifacts, options.MaxInferredTablesPerPage, result.Count + 1L);
             }
             int columnCount = group[0].Cells.Count;
-            var columnBounds = new List<(double From, double To)>(columnCount);
+            var visualColumnBounds = new List<(double From, double To)>(columnCount);
             for (int column = 0; column < columnCount; column++) {
-                columnBounds.Add((group.Min(row => row.Cells[column].Left), group.Max(row => row.Cells[column].Right)));
+                visualColumnBounds.Add((group.Min(row => row.Cells[column].Left), group.Max(row => row.Cells[column].Right)));
             }
             var rows = group.Select(row => (IReadOnlyList<string>)row.Cells.Select(static cell => cell.Text).ToArray()).ToArray();
             double top = group.Min(row => lines[row.Index].Top);
             double bottom = group.Max(row => lines[row.Index].Bottom);
-            result.Add(PdfLogicalTable.FromOcr(page.PageNumber, top, bottom, columnBounds, rows));
+            double left = visualColumnBounds.Min(static column => column.From);
+            double right = visualColumnBounds.Max(static column => column.To);
+            double confidence = PdfInference.Clamp(group.Average(row => lines[row.Index].Confidence));
+            result.Add(PdfUnderstandingTableCandidate.FromOcr(
+                "OcrAlignedColumns",
+                top,
+                bottom,
+                new PdfLogicalVisualBounds(left, top, right, bottom),
+                visualColumnBounds,
+                rows,
+                confidence,
+                new[] {
+                    new PdfInferenceEvidence(
+                        "table.ocr-aligned-geometry",
+                        "Accepted OCR words form repeated columns with compact row rhythm.",
+                        0.85D)
+                }));
             foreach ((int index, IReadOnlyList<OcrCell> _) in group) tableLineIndexes.Add(index);
         }
         return result.AsReadOnly();
     }
 
     private static bool HasConservativeTableEvidence(
-        IReadOnlyList<(int Index, IReadOnlyList<OcrCell> Cells)> rows) {
-        int columnCount = rows[0].Cells.Count;
-        if (columnCount >= 3 && rows.Count >= 4) return true;
-        for (int columnIndex = 0; columnIndex < columnCount; columnIndex++) {
-            int nonEmptyCount = 0;
-            int typedValueCount = 0;
-            for (int rowIndex = 1; rowIndex < rows.Count; rowIndex++) {
-                string value = rows[rowIndex].Cells[columnIndex].Text.Trim();
-                if (value.Length == 0) continue;
-                nonEmptyCount++;
-                if (LooksLikeTypedTableValue(value)) typedValueCount++;
-            }
-            if (nonEmptyCount >= 2 && typedValueCount >= 2 && typedValueCount * 4 >= nonEmptyCount * 3) return true;
+        IReadOnlyList<(int Index, IReadOnlyList<OcrCell> Cells)> rows,
+        IReadOnlyList<OcrLine> lines) {
+        if (rows.Count < 3 || rows[0].Cells.Count < 2) return false;
+        double[] verticalSteps = new double[rows.Count - 1];
+        for (int rowIndex = 1; rowIndex < rows.Count; rowIndex++) {
+            verticalSteps[rowIndex - 1] = lines[rows[rowIndex].Index].CenterY - lines[rows[rowIndex - 1].Index].CenterY;
+            if (verticalSteps[rowIndex - 1] <= 0D) return false;
         }
-        return false;
+        double medianStep = Median(verticalSteps);
+        double medianHeight = Median(rows.Select(row => lines[row.Index].Height));
+        if (medianHeight <= 0D || medianStep > Math.Max(24D, medianHeight * 3D)) return false;
+        double smallestStep = verticalSteps.Min();
+        double largestStep = verticalSteps.Max();
+        return smallestStep > 0D && largestStep <= smallestStep * 1.75D;
     }
-
-    private static bool LooksLikeTypedTableValue(string value) =>
-        PdfLogicalTableAnalysis.LooksLikeNumericValue(value) ||
-        bool.TryParse(value, out _) ||
-        DateTime.TryParse(
-            value,
-            System.Globalization.CultureInfo.InvariantCulture,
-            System.Globalization.DateTimeStyles.AllowWhiteSpaces,
-            out _);
 
     private static IReadOnlyList<OcrCell> SplitCells(List<PdfRecognizedWord> words, double minimumGap) {
         if (words.Count == 0) return Array.Empty<OcrCell>();

--- a/OfficeIMO.Pdf/Reading/Ocr/PdfOcrLogicalDocumentBuilder.cs
+++ b/OfficeIMO.Pdf/Reading/Ocr/PdfOcrLogicalDocumentBuilder.cs
@@ -285,6 +285,7 @@ internal static class PdfOcrLogicalDocumentBuilder {
         IReadOnlyList<(int Index, IReadOnlyList<OcrCell> Cells)> rows,
         IReadOnlyList<OcrLine> lines) {
         if (rows.Count < 3 || rows[0].Cells.Count < 2) return false;
+        if (!HasCompactCellStructure(rows)) return false;
         double[] verticalSteps = new double[rows.Count - 1];
         for (int rowIndex = 1; rowIndex < rows.Count; rowIndex++) {
             verticalSteps[rowIndex - 1] = lines[rows[rowIndex].Index].CenterY - lines[rows[rowIndex - 1].Index].CenterY;
@@ -296,6 +297,22 @@ internal static class PdfOcrLogicalDocumentBuilder {
         double smallestStep = verticalSteps.Min();
         double largestStep = verticalSteps.Max();
         return smallestStep > 0D && largestStep <= smallestStep * 1.75D;
+    }
+
+    private static bool HasCompactCellStructure(
+        IReadOnlyList<(int Index, IReadOnlyList<OcrCell> Cells)> rows) {
+        long cellCount = 0L;
+        long wordCount = 0L;
+        for (int rowIndex = 0; rowIndex < rows.Count; rowIndex++) {
+            IReadOnlyList<OcrCell> cells = rows[rowIndex].Cells;
+            for (int cellIndex = 0; cellIndex < cells.Count; cellIndex++) {
+                int words = cells[cellIndex].Words.Count;
+                if (words == 0 || words > 4) return false;
+                cellCount++;
+                wordCount += words;
+            }
+        }
+        return cellCount > 0L && wordCount <= cellCount * 2L;
     }
 
     private static IReadOnlyList<OcrCell> SplitCells(List<PdfRecognizedWord> words, double minimumGap) {

--- a/OfficeIMO.Pdf/Reading/Options/PdfReadOptions.cs
+++ b/OfficeIMO.Pdf/Reading/Options/PdfReadOptions.cs
@@ -79,6 +79,7 @@ public sealed class PdfReadOptions {
             GlyphDecoding = options.GlyphDecoding,
             WordGrouping = options.WordGrouping,
             LineGrouping = options.LineGrouping,
+            TableDetection = options.TableDetection,
             PageSegmentation = options.PageSegmentation,
             ReadingOrder = options.ReadingOrder,
             SemanticClassification = options.SemanticClassification,
@@ -87,6 +88,7 @@ public sealed class PdfReadOptions {
             MaxTextCharactersPerPage = options.MaxTextCharactersPerPage,
             MaxWordsPerPage = options.MaxWordsPerPage,
             MaxLinesPerPage = options.MaxLinesPerPage,
+            MaxTableCandidatesPerPage = options.MaxTableCandidatesPerPage,
             MaxRegionsPerPage = options.MaxRegionsPerPage,
             MaxWorkUnitsPerPage = options.MaxWorkUnitsPerPage,
             MaxDocumentWorkUnits = options.MaxDocumentWorkUnits

--- a/OfficeIMO.Pdf/Reading/Understanding/PdfAdvancedUnderstandingStages.cs
+++ b/OfficeIMO.Pdf/Reading/Understanding/PdfAdvancedUnderstandingStages.cs
@@ -12,6 +12,8 @@ public static class PdfAdvancedUnderstandingStages {
     public static IPdfWordGroupingStage WordGrouping { get; } = new AdvancedWordGroupingStage();
     /// <summary>Arbitrary-baseline line grouping.</summary>
     public static IPdfLineGroupingStage LineGrouping { get; } = new AdvancedLineGroupingStage();
+    /// <summary>Language-neutral table candidate detection.</summary>
+    public static IPdfTableDetectionStage TableDetection { get; } = new AdvancedTableDetectionStage();
     /// <summary>Spatial connected-region segmentation.</summary>
     public static IPdfPageSegmentationStage PageSegmentation { get; } = new AdvancedPageSegmentationStage();
     /// <summary>Spanning-band and multi-column reading order.</summary>
@@ -323,8 +325,84 @@ public static class PdfAdvancedUnderstandingStages {
         }
     }
 
+    private sealed class AdvancedTableDetectionStage : IPdfTableDetectionStage {
+        public IReadOnlyList<PdfUnderstandingTableCandidate> DetectTables(
+            PdfUnderstandingPageContext context,
+            IReadOnlyList<PdfUnderstandingLine> lines) {
+            if (context.DecodedRuns.Count == 0 || lines.Count == 0) {
+                return Array.Empty<PdfUnderstandingTableCandidate>();
+            }
+
+            StructuredPage structure = ContentStructureExtractor.Extract(
+                context.DecodedRuns,
+                context.LayoutOptions.ToEngineOptions(),
+                context.Height,
+                context.ConsumeWork,
+                context.ThrowIfCancellationRequested);
+            var result = new List<PdfUnderstandingTableCandidate>(structure.TablesDetailed.Count);
+            foreach (StructuredTable table in structure.TablesDetailed) {
+                context.ConsumeWork();
+                if (table.Columns.Count < 2 || table.SourceRuns.Count == 0) continue;
+
+                var ownedRuns = new HashSet<PdfTextSpan>();
+                for (int runIndex = 0; runIndex < table.SourceRuns.Count; runIndex++) {
+                    context.ConsumeWork();
+                    ownedRuns.Add(table.SourceRuns[runIndex]);
+                }
+                var matchedLines = new List<PdfUnderstandingLine>();
+                for (int lineIndex = 0; lineIndex < lines.Count; lineIndex++) {
+                    context.ConsumeWork();
+                    PdfUnderstandingLine line = lines[lineIndex];
+                    var ownedWords = new List<PdfUnderstandingWord>();
+                    for (int wordIndex = 0; wordIndex < line.Words.Count; wordIndex++) {
+                        PdfUnderstandingWord word = line.Words[wordIndex];
+                        IReadOnlyList<PdfTextSpan> sourceRuns = word.SourceRuns;
+                        bool owned = false;
+                        for (int runIndex = 0; runIndex < sourceRuns.Count; runIndex++) {
+                            context.ConsumeWork();
+                            if (!ownedRuns.Contains(sourceRuns[runIndex])) continue;
+                            owned = true;
+                            break;
+                        }
+                        if (owned) ownedWords.Add(word);
+                    }
+                    if (ownedWords.Count > 0) {
+                        matchedLines.Add(new PdfUnderstandingLine(
+                            ownedWords.AsReadOnly(),
+                            line.Confidence,
+                            line.Evidence));
+                    }
+                }
+                PdfUnderstandingLine[] sourceLines = CopyAndSort(
+                    context,
+                    matchedLines,
+                    static (first, second) => {
+                        int baseline = second.BaselineY.CompareTo(first.BaselineY);
+                        return baseline != 0 ? baseline : first.XStart.CompareTo(second.XStart);
+                    });
+                if (sourceLines.Length < 2) continue;
+
+                double confidence = PdfInference.Clamp(sourceLines.Average(static line => line.Confidence));
+                result.Add(PdfUnderstandingTableCandidate.FromStructured(
+                    table,
+                    sourceLines,
+                    confidence,
+                    new[] {
+                        new PdfInferenceEvidence(
+                            "table.aligned-geometry",
+                            "Repeated column geometry and row alignment form a bounded table candidate.",
+                            0.9D)
+                    },
+                    context.ConsumeWork,
+                    context.ThrowIfCancellationRequested));
+            }
+            return result.Count == 0 ? Array.Empty<PdfUnderstandingTableCandidate>() : result.AsReadOnly();
+        }
+    }
+
     private sealed class AdvancedPageSegmentationStage : IPdfPageSegmentationStage {
         public IReadOnlyList<PdfUnderstandingRegion> Segment(PdfUnderstandingPageContext context, IReadOnlyList<PdfUnderstandingLine> lines) {
+            lines = BuildSegmentationLines(context, lines);
             var remaining = new HashSet<int>(Enumerable.Range(0, lines.Count));
             var regions = new List<PdfUnderstandingRegion>();
             AddCanonicalTableRegions(context, lines, remaining, regions);
@@ -365,31 +443,83 @@ public static class PdfAdvancedUnderstandingStages {
             return regions.Count == 0 ? Array.Empty<PdfUnderstandingRegion>() : regions.AsReadOnly();
         }
 
+        private static IReadOnlyList<PdfUnderstandingLine> BuildSegmentationLines(
+            PdfUnderstandingPageContext context,
+            IReadOnlyList<PdfUnderstandingLine> lines) {
+            PdfUnderstandingTableCandidate[] tables = context.TableCandidates
+                .Where(static table => !string.Equals(table.DetectionKind, "leaders", StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+            if (tables.Length == 0) return lines;
+
+            var ownedRuns = new HashSet<PdfTextSpan>();
+            var tableLines = new HashSet<PdfUnderstandingLine>();
+            for (int tableIndex = 0; tableIndex < tables.Length; tableIndex++) {
+                IReadOnlyList<PdfUnderstandingLine> sourceLines = tables[tableIndex].SourceLines;
+                for (int lineIndex = 0; lineIndex < sourceLines.Count; lineIndex++) {
+                    context.ConsumeWork();
+                    PdfUnderstandingLine sourceLine = sourceLines[lineIndex];
+                    tableLines.Add(sourceLine);
+                    for (int wordIndex = 0; wordIndex < sourceLine.Words.Count; wordIndex++) {
+                        IReadOnlyList<PdfTextSpan> sourceRuns = sourceLine.Words[wordIndex].SourceRuns;
+                        for (int runIndex = 0; runIndex < sourceRuns.Count; runIndex++) {
+                            context.ConsumeWork();
+                            ownedRuns.Add(sourceRuns[runIndex]);
+                        }
+                    }
+                }
+            }
+
+            var result = new List<PdfUnderstandingLine>(lines.Count + tableLines.Count);
+            result.AddRange(tableLines);
+            for (int lineIndex = 0; lineIndex < lines.Count; lineIndex++) {
+                context.ConsumeWork();
+                PdfUnderstandingLine line = lines[lineIndex];
+                var unownedWords = new List<PdfUnderstandingWord>(line.Words.Count);
+                for (int wordIndex = 0; wordIndex < line.Words.Count; wordIndex++) {
+                    PdfUnderstandingWord word = line.Words[wordIndex];
+                    bool owned = false;
+                    for (int runIndex = 0; runIndex < word.SourceRuns.Count; runIndex++) {
+                        context.ConsumeWork();
+                        if (!ownedRuns.Contains(word.SourceRuns[runIndex])) continue;
+                        owned = true;
+                        break;
+                    }
+                    if (!owned) unownedWords.Add(word);
+                }
+                if (unownedWords.Count == line.Words.Count) {
+                    result.Add(line);
+                } else if (unownedWords.Count > 0) {
+                    result.Add(new PdfUnderstandingLine(
+                        unownedWords.AsReadOnly(),
+                        line.Confidence,
+                        line.Evidence));
+                }
+            }
+            PdfUnderstandingLine[] ordered = CopyAndSort(
+                context,
+                result.Distinct().ToArray(),
+                static (left, right) => {
+                    int baseline = right.BaselineY.CompareTo(left.BaselineY);
+                    return baseline != 0 ? baseline : left.XStart.CompareTo(right.XStart);
+                });
+            return ordered.Length == 0 ? Array.Empty<PdfUnderstandingLine>() : Array.AsReadOnly(ordered);
+        }
+
         private static void AddCanonicalTableRegions(
             PdfUnderstandingPageContext context,
             IReadOnlyList<PdfUnderstandingLine> lines,
             HashSet<int> remaining,
             List<PdfUnderstandingRegion> regions) {
-            if (context.DecodedRuns.Count == 0 || lines.Count == 0) return;
+            if (context.TableCandidates.Count == 0 || lines.Count == 0) return;
 
-            StructuredPage structure = ContentStructureExtractor.Extract(
-                context.DecodedRuns,
-                context.LayoutOptions.ToEngineOptions(),
-                context.Height,
-                context.ConsumeWork,
-                context.ThrowIfCancellationRequested);
-            foreach (StructuredTable table in structure.TablesDetailed) {
+            foreach (PdfUnderstandingTableCandidate table in context.TableCandidates) {
                 context.ConsumeWork();
-                if (string.Equals(table.Kind, "leaders", StringComparison.OrdinalIgnoreCase) || table.Columns.Count < 2) continue;
-
-                double top = Math.Max(table.YTop, table.YBottom);
-                double bottom = Math.Min(table.YTop, table.YBottom);
-                double left = table.Columns.Min(static column => Math.Min(column.From, column.To));
-                double right = table.Columns.Max(static column => Math.Max(column.From, column.To));
+                if (string.Equals(table.DetectionKind, "leaders", StringComparison.OrdinalIgnoreCase)) continue;
+                var sourceLines = new HashSet<PdfUnderstandingLine>(table.SourceLines);
                 var matchedIndexes = new List<int>();
                 foreach (int index in remaining) {
                     context.ConsumeWork();
-                    if (HasMeaningfulTableOverlap(lines[index], top, bottom, left, right)) matchedIndexes.Add(index);
+                    if (sourceLines.Contains(lines[index])) matchedIndexes.Add(index);
                 }
                 int[] tableLineIndexes = CopyAndSort(
                     context,
@@ -406,7 +536,7 @@ public static class PdfAdvancedUnderstandingStages {
                 regions.Add(new PdfUnderstandingRegion(tableLines, confidence, new[] {
                     new PdfInferenceEvidence(
                         "region.canonical-table",
-                        "The canonical layout engine recovered these aligned lines as one validated table.",
+                        "The page table-detection stage owns these aligned source lines.",
                         0.9D)
                 }));
             }
@@ -551,21 +681,6 @@ public static class PdfAdvancedUnderstandingStages {
         internal double Angle { get; }
         internal double Normal { get; set; }
         internal List<PdfUnderstandingWord> Words { get; } = new();
-    }
-
-    internal static bool HasMeaningfulTableOverlap(
-        PdfUnderstandingLine line,
-        double top,
-        double bottom,
-        double left,
-        double right) {
-        double verticalTolerance = Math.Max(1D, line.FontSize * 0.5D);
-        if (line.BaselineY > top + verticalTolerance || line.BaselineY < bottom - verticalTolerance) return false;
-        double lineLeft = Math.Min(line.XStart, line.XEnd);
-        double lineRight = Math.Max(line.XStart, line.XEnd);
-        double overlap = Math.Max(0D, Math.Min(lineRight, right) - Math.Max(lineLeft, left));
-        double narrowerWidth = Math.Min(lineRight - lineLeft, right - left);
-        return narrowerWidth > 0.001D && overlap + 0.001D >= narrowerWidth * 0.5D;
     }
 
     private static double WordAnchorX(PdfUnderstandingWord word) => (word.XStart + word.XEnd) / 2D;

--- a/OfficeIMO.Pdf/Reading/Understanding/PdfAdvancedUnderstandingStages.cs
+++ b/OfficeIMO.Pdf/Reading/Understanding/PdfAdvancedUnderstandingStages.cs
@@ -380,7 +380,8 @@ public static class PdfAdvancedUnderstandingStages {
                         int baseline = second.BaselineY.CompareTo(first.BaselineY);
                         return baseline != 0 ? baseline : first.XStart.CompareTo(second.XStart);
                     });
-                if (sourceLines.Length < 2) continue;
+                if (sourceLines.Length == 0 ||
+                    (sourceLines.Length < 2 && !string.Equals(table.Kind, "leaders", StringComparison.Ordinal))) continue;
 
                 double confidence = PdfInference.Clamp(sourceLines.Average(static line => line.Confidence));
                 result.Add(PdfUnderstandingTableCandidate.FromStructured(

--- a/OfficeIMO.Pdf/Reading/Understanding/PdfDocumentSemanticEnricher.cs
+++ b/OfficeIMO.Pdf/Reading/Understanding/PdfDocumentSemanticEnricher.cs
@@ -66,7 +66,8 @@ internal static class PdfDocumentSemanticEnricher {
                 page.CancellationCheck,
                 page.CompleteOperation,
                 page.LogicalProjectionLines,
-                page.RestrictLogicalProjectionToReadingOrder);
+                page.RestrictLogicalProjectionToReadingOrder,
+                page.TableCandidates);
         }
         return Array.AsReadOnly(result);
     }

--- a/OfficeIMO.Pdf/Reading/Understanding/PdfUnderstandingContracts.cs
+++ b/OfficeIMO.Pdf/Reading/Understanding/PdfUnderstandingContracts.cs
@@ -69,6 +69,8 @@ public sealed class PdfUnderstandingPageContext {
     public void ThrowIfCancellationRequested() => _workBudget.ThrowIfCancellationRequested();
     internal void CompleteOperation() => _workBudget.CompleteOperation();
     internal IReadOnlyList<PdfTextSpan> DecodedRuns { get; set; } = Array.Empty<PdfTextSpan>();
+    /// <summary>Table candidates available to page segmentation and later stages.</summary>
+    public IReadOnlyList<PdfUnderstandingTableCandidate> TableCandidates { get; internal set; } = Array.Empty<PdfUnderstandingTableCandidate>();
 }
 
 /// <summary>One decoded word candidate with source-run traceability.</summary>
@@ -232,7 +234,8 @@ public sealed class PdfUnderstandingPageResult {
         Action? cancellationCheck = null,
         Action? completeOperation = null,
         IReadOnlyList<PdfUnderstandingLine>? logicalProjectionLines = null,
-        bool restrictLogicalProjectionToReadingOrder = false) {
+        bool restrictLogicalProjectionToReadingOrder = false,
+        IReadOnlyList<PdfUnderstandingTableCandidate>? tableCandidates = null) {
         PageNumber = pageNumber;
         DecodedRuns = runs;
         Words = words;
@@ -242,6 +245,7 @@ public sealed class PdfUnderstandingPageResult {
         ReadingOrderEvidence = readingOrderEvidence;
         Elements = elements;
         Trace = trace;
+        TableCandidates = tableCandidates ?? Array.Empty<PdfUnderstandingTableCandidate>();
         LogicalProjectionLines = logicalProjectionLines ?? CollectLogicalProjectionLines(readingOrder);
         RestrictLogicalProjectionToReadingOrder = restrictLogicalProjectionToReadingOrder;
         ConsumeWork = consumeWork;
@@ -264,6 +268,8 @@ public sealed class PdfUnderstandingPageResult {
     public IReadOnlyList<PdfReadingOrderEvidence> ReadingOrderEvidence { get; }
     /// <summary>Semantically classified ordered regions.</summary>
     public IReadOnlyList<PdfUnderstandingSemanticElement> Elements { get; }
+    /// <summary>Tables recovered before general page segmentation.</summary>
+    public IReadOnlyList<PdfUnderstandingTableCandidate> TableCandidates { get; }
     /// <summary>Stage execution trace.</summary>
     public IReadOnlyList<PdfUnderstandingStageTrace> Trace { get; }
     internal Action<long>? ConsumeWork { get; }
@@ -273,6 +279,27 @@ public sealed class PdfUnderstandingPageResult {
     /// <summary>Whether caller-supplied structural stages make the retained sequence an extraction boundary.</summary>
     internal bool RestrictLogicalProjectionToReadingOrder { get; }
     internal void CompleteOperation() => _completeOperation?.Invoke();
+
+    internal PdfUnderstandingPageResult WithAdditionalTableCandidates(
+        IReadOnlyList<PdfUnderstandingTableCandidate> candidates) {
+        if (candidates.Count == 0) return this;
+        return new PdfUnderstandingPageResult(
+            PageNumber,
+            DecodedRuns,
+            Words,
+            Lines,
+            Regions,
+            ReadingOrder,
+            ReadingOrderEvidence,
+            Elements,
+            Trace,
+            ConsumeWork,
+            CancellationCheck,
+            _completeOperation,
+            LogicalProjectionLines,
+            RestrictLogicalProjectionToReadingOrder,
+            TableCandidates.Concat(candidates).ToArray());
+    }
 
     private static IReadOnlyList<PdfUnderstandingLine> CollectLogicalProjectionLines(
         IReadOnlyList<PdfUnderstandingRegion> readingOrder) {
@@ -313,6 +340,11 @@ public interface IPdfWordGroupingStage {
 public interface IPdfLineGroupingStage {
     /// <summary>Groups words into line artifacts.</summary>
     IReadOnlyList<PdfUnderstandingLine> GroupLines(PdfUnderstandingPageContext context, IReadOnlyList<PdfUnderstandingWord> words);
+}
+/// <summary>Detects table candidates before general page segmentation.</summary>
+public interface IPdfTableDetectionStage {
+    /// <summary>Returns table candidates and the source lines owned by each table.</summary>
+    IReadOnlyList<PdfUnderstandingTableCandidate> DetectTables(PdfUnderstandingPageContext context, IReadOnlyList<PdfUnderstandingLine> lines);
 }
 /// <summary>Segments page lines into regions.</summary>
 public interface IPdfPageSegmentationStage {

--- a/OfficeIMO.Pdf/Reading/Understanding/PdfUnderstandingPipeline.cs
+++ b/OfficeIMO.Pdf/Reading/Understanding/PdfUnderstandingPipeline.cs
@@ -12,6 +12,7 @@ public sealed class PdfUnderstandingPipelineOptions {
         GlyphDecoding = PdfAdvancedUnderstandingStages.GlyphDecoding,
         WordGrouping = PdfAdvancedUnderstandingStages.WordGrouping,
         LineGrouping = PdfAdvancedUnderstandingStages.LineGrouping,
+        TableDetection = PdfAdvancedUnderstandingStages.TableDetection,
         PageSegmentation = PdfAdvancedUnderstandingStages.PageSegmentation,
         ReadingOrder = PdfAdvancedUnderstandingStages.ReadingOrder,
         SemanticClassification = PdfAdvancedUnderstandingStages.SemanticClassification
@@ -23,6 +24,8 @@ public sealed class PdfUnderstandingPipelineOptions {
     public IPdfWordGroupingStage? WordGrouping { get; set; }
     /// <summary>Line grouping stage.</summary>
     public IPdfLineGroupingStage? LineGrouping { get; set; }
+    /// <summary>Table detection stage run before general page segmentation.</summary>
+    public IPdfTableDetectionStage? TableDetection { get; set; }
     /// <summary>Page segmentation stage.</summary>
     public IPdfPageSegmentationStage? PageSegmentation { get; set; }
     /// <summary>Reading-order stage.</summary>
@@ -39,6 +42,8 @@ public sealed class PdfUnderstandingPipelineOptions {
     public int MaxWordsPerPage { get; set; } = 100_000;
     /// <summary>Maximum grouped lines retained for one page.</summary>
     public int MaxLinesPerPage { get; set; } = 50_000;
+    /// <summary>Maximum table candidates retained for one page.</summary>
+    public int MaxTableCandidatesPerPage { get; set; } = 1_024;
     /// <summary>Maximum regions and semantic elements retained for one page.</summary>
     public int MaxRegionsPerPage { get; set; } = 10_000;
     /// <summary>Maximum comparison and traversal work performed by built-in stages for one page.</summary>
@@ -52,6 +57,7 @@ public sealed class PdfUnderstandingPipelineOptions {
             GlyphDecoding = source.GlyphDecoding ?? PdfAdvancedUnderstandingStages.GlyphDecoding,
             WordGrouping = source.WordGrouping ?? PdfAdvancedUnderstandingStages.WordGrouping,
             LineGrouping = source.LineGrouping ?? PdfAdvancedUnderstandingStages.LineGrouping,
+            TableDetection = source.TableDetection ?? PdfAdvancedUnderstandingStages.TableDetection,
             PageSegmentation = source.PageSegmentation ?? PdfAdvancedUnderstandingStages.PageSegmentation,
             ReadingOrder = source.ReadingOrder ?? PdfAdvancedUnderstandingStages.ReadingOrder,
             SemanticClassification = source.SemanticClassification ?? PdfAdvancedUnderstandingStages.SemanticClassification,
@@ -60,6 +66,7 @@ public sealed class PdfUnderstandingPipelineOptions {
             MaxTextCharactersPerPage = source.MaxTextCharactersPerPage,
             MaxWordsPerPage = source.MaxWordsPerPage,
             MaxLinesPerPage = source.MaxLinesPerPage,
+            MaxTableCandidatesPerPage = source.MaxTableCandidatesPerPage,
             MaxRegionsPerPage = source.MaxRegionsPerPage,
             MaxWorkUnitsPerPage = source.MaxWorkUnitsPerPage,
             MaxDocumentWorkUnits = source.MaxDocumentWorkUnits
@@ -72,6 +79,7 @@ internal sealed class PdfUnderstandingPipeline {
     private readonly IPdfGlyphDecodingStage _glyphDecoding;
     private readonly IPdfWordGroupingStage _wordGrouping;
     private readonly IPdfLineGroupingStage _lineGrouping;
+    private readonly IPdfTableDetectionStage _tableDetection;
     private readonly IPdfPageSegmentationStage _pageSegmentation;
     private readonly IPdfReadingOrderStage _readingOrder;
     private readonly IPdfSemanticClassificationStage _semanticClassification;
@@ -86,12 +94,14 @@ internal sealed class PdfUnderstandingPipeline {
         _glyphDecoding = effective.GlyphDecoding!;
         _wordGrouping = effective.WordGrouping!;
         _lineGrouping = effective.LineGrouping!;
+        _tableDetection = effective.TableDetection!;
         _pageSegmentation = effective.PageSegmentation!;
         _readingOrder = effective.ReadingOrder!;
         _semanticClassification = effective.SemanticClassification!;
         _restrictLogicalProjectionToReadingOrder =
             !ReferenceEquals(_wordGrouping, PdfAdvancedUnderstandingStages.WordGrouping) ||
             !ReferenceEquals(_lineGrouping, PdfAdvancedUnderstandingStages.LineGrouping) ||
+            !ReferenceEquals(_tableDetection, PdfAdvancedUnderstandingStages.TableDetection) ||
             !ReferenceEquals(_pageSegmentation, PdfAdvancedUnderstandingStages.PageSegmentation) ||
             !ReferenceEquals(_readingOrder, PdfAdvancedUnderstandingStages.ReadingOrder);
         _layout = layout ?? throw new ArgumentNullException(nameof(layout));
@@ -102,6 +112,7 @@ internal sealed class PdfUnderstandingPipeline {
         ValidateLimit(effective.MaxTextCharactersPerPage, nameof(effective.MaxTextCharactersPerPage));
         ValidateLimit(effective.MaxWordsPerPage, nameof(effective.MaxWordsPerPage));
         ValidateLimit(effective.MaxLinesPerPage, nameof(effective.MaxLinesPerPage));
+        ValidateLimit(effective.MaxTableCandidatesPerPage, nameof(effective.MaxTableCandidatesPerPage));
         ValidateLimit(effective.MaxRegionsPerPage, nameof(effective.MaxRegionsPerPage));
         ValidateLimit(effective.MaxWorkUnitsPerPage, nameof(effective.MaxWorkUnitsPerPage));
         ValidateLimit(effective.MaxDocumentWorkUnits, nameof(effective.MaxDocumentWorkUnits));
@@ -132,7 +143,7 @@ internal sealed class PdfUnderstandingPipeline {
             _limits.MaxWordsPerPage,
             _limits.MaxWorkUnitsPerPage,
             cancellationToken);
-        var trace = new List<PdfUnderstandingStageTrace>(6);
+        var trace = new List<PdfUnderstandingStageTrace>(7);
         IReadOnlyList<PdfTextSpan> runs = NotNull(_glyphDecoding.Decode(context), nameof(IPdfGlyphDecodingStage));
         cancellationToken.ThrowIfCancellationRequested();
         EnsureCount(runs.Count, _limits.MaxRunsPerPage);
@@ -157,6 +168,19 @@ internal sealed class PdfUnderstandingPipeline {
         EnsureCount(lines.Count, _limits.MaxLinesPerPage);
         cancellationToken.ThrowIfCancellationRequested();
         trace.Add(new PdfUnderstandingStageTrace("line-grouping", _lineGrouping.GetType(), words.Count, lines.Count));
+        IReadOnlyList<PdfUnderstandingTableCandidate> tableCandidates = NotNull(
+            _tableDetection.DetectTables(context, lines),
+            nameof(IPdfTableDetectionStage));
+        EnsureCount(tableCandidates.Count, _limits.MaxTableCandidatesPerPage);
+        EnsureTableCandidateArtifacts(
+            context,
+            tableCandidates,
+            _limits.MaxLinesPerPage,
+            _limits.MaxWordsPerPage,
+            _limits.MaxTextCharactersPerPage);
+        context.TableCandidates = tableCandidates;
+        cancellationToken.ThrowIfCancellationRequested();
+        trace.Add(new PdfUnderstandingStageTrace("table-detection", _tableDetection.GetType(), lines.Count, tableCandidates.Count));
         IReadOnlyList<PdfUnderstandingRegion> regions = NotNull(_pageSegmentation.Segment(context, lines), nameof(IPdfPageSegmentationStage));
         EnsureCount(regions.Count, _limits.MaxRegionsPerPage);
         cancellationToken.ThrowIfCancellationRequested();
@@ -184,7 +208,8 @@ internal sealed class PdfUnderstandingPipeline {
             context.ThrowIfCancellationRequested,
             context.CompleteOperation,
             logicalProjectionLines: null,
-            restrictLogicalProjectionToReadingOrder: _restrictLogicalProjectionToReadingOrder);
+            restrictLogicalProjectionToReadingOrder: _restrictLogicalProjectionToReadingOrder,
+            tableCandidates: tableCandidates);
     }
 
     private static System.Collections.ObjectModel.ReadOnlyCollection<PdfReadingOrderEvidence> BuildReadingOrderEvidence(IReadOnlyList<PdfUnderstandingRegion> ordered, Type providerType) {
@@ -221,5 +246,57 @@ internal sealed class PdfUnderstandingPipeline {
             total = checked(total + (value?.Length ?? 0));
             if (total > maximum) throw PdfReadLimitException.Create(PdfReadLimitKind.UnderstandingArtifacts, maximum, total);
         }
+    }
+
+    private static void EnsureTableCandidateArtifacts(
+        PdfUnderstandingPageContext context,
+        IReadOnlyList<PdfUnderstandingTableCandidate> candidates,
+        int maximumLines,
+        int maximumCells,
+        int maximumCharacters) {
+        long rows = 0;
+        long cells = 0;
+        long sourceLines = 0;
+        long characters = 0;
+        for (int candidateIndex = 0; candidateIndex < candidates.Count; candidateIndex++) {
+            context.ConsumeWork();
+            PdfUnderstandingTableCandidate candidate = candidates[candidateIndex]
+                ?? throw new InvalidOperationException(nameof(IPdfTableDetectionStage) + " returned a null table candidate.");
+            AddCharacters(candidate.DetectionKind);
+            EnsureCount(candidate.Columns.Count, maximumCells);
+            context.ConsumeWork(candidate.Columns.Count);
+            rows = AddAndEnsure(rows, candidate.Rows.Count, maximumLines);
+            sourceLines = AddAndEnsure(sourceLines, candidate.SourceLines.Count, maximumLines);
+            context.ConsumeWork(candidate.SourceLines.Count + 1L);
+            for (int rowIndex = 0; rowIndex < candidate.Rows.Count; rowIndex++) {
+                context.ConsumeWork();
+                IReadOnlyList<string> row = candidate.Rows[rowIndex];
+                cells = AddAndEnsure(cells, row.Count, maximumCells);
+                context.ConsumeWork(row.Count + 1L);
+                for (int cellIndex = 0; cellIndex < row.Count; cellIndex++) AddCharacters(row[cellIndex]);
+            }
+            for (int evidenceIndex = 0; evidenceIndex < candidate.Evidence.Count; evidenceIndex++) {
+                context.ConsumeWork();
+                AddCharacters(candidate.Evidence[evidenceIndex].Code);
+                AddCharacters(candidate.Evidence[evidenceIndex].Message);
+            }
+        }
+
+        void AddCharacters(string? value) {
+            characters = AddAndEnsure(characters, value?.Length ?? 0, maximumCharacters);
+        }
+    }
+
+    private static long AddAndEnsure(long current, long additional, long maximum) {
+        long total;
+        try {
+            total = checked(current + additional);
+        } catch (OverflowException) {
+            throw PdfReadLimitException.Create(PdfReadLimitKind.UnderstandingArtifacts, maximum, long.MaxValue);
+        }
+        if (total > maximum) {
+            throw PdfReadLimitException.Create(PdfReadLimitKind.UnderstandingArtifacts, maximum, total);
+        }
+        return total;
     }
 }

--- a/OfficeIMO.Pdf/Reading/Understanding/PdfUnderstandingTableCandidate.cs
+++ b/OfficeIMO.Pdf/Reading/Understanding/PdfUnderstandingTableCandidate.cs
@@ -1,0 +1,277 @@
+namespace OfficeIMO.Pdf;
+
+/// <summary>Coordinate system used by table bounds and columns.</summary>
+public enum PdfTableCoordinateSpace {
+    /// <summary>PDF user space with the Y axis increasing from bottom to top.</summary>
+    PdfUserSpace,
+    /// <summary>Top-left visual page space used by rendered OCR input.</summary>
+    VisualTopLeft
+}
+
+/// <summary>Immutable column geometry recovered by a PDF table-detection stage.</summary>
+public sealed class PdfUnderstandingTableColumn {
+    /// <summary>Creates one table column in the owning candidate's coordinate space.</summary>
+    public PdfUnderstandingTableColumn(double from, double to) {
+        if (!IsFinite(from)) throw new ArgumentOutOfRangeException(nameof(from));
+        if (!IsFinite(to)) throw new ArgumentOutOfRangeException(nameof(to));
+        From = Math.Min(from, to);
+        To = Math.Max(from, to);
+    }
+
+    private static bool IsFinite(double value) => !double.IsNaN(value) && !double.IsInfinity(value);
+
+    /// <summary>Left X coordinate in the owning candidate's coordinate space.</summary>
+    public double From { get; }
+
+    /// <summary>Right X coordinate in the owning candidate's coordinate space.</summary>
+    public double To { get; }
+}
+
+/// <summary>
+/// A table candidate recovered before general page segmentation. The candidate owns its
+/// source lines so later stages can treat the table as one structural object.
+/// </summary>
+public sealed class PdfUnderstandingTableCandidate {
+    private readonly PdfLogicalVisualBounds? _visualBounds;
+
+    /// <summary>Creates a table candidate for a custom table-detection stage.</summary>
+    public PdfUnderstandingTableCandidate(
+        string detectionKind,
+        double yTop,
+        double yBottom,
+        IReadOnlyList<PdfUnderstandingTableColumn> columns,
+        IReadOnlyList<IReadOnlyList<string>> rows,
+        IReadOnlyList<PdfUnderstandingLine> sourceLines,
+        double confidence = 0.5D,
+        IEnumerable<PdfInferenceEvidence>? evidence = null)
+        : this(
+            detectionKind,
+            yTop,
+            yBottom,
+            columns,
+            rows,
+            sourceLines,
+            PdfLogicalContentSourceKind.Native,
+            PdfTableCoordinateSpace.PdfUserSpace,
+            null,
+            confidence,
+            evidence,
+            null,
+            null) {
+    }
+
+    private PdfUnderstandingTableCandidate(
+        string detectionKind,
+        double yTop,
+        double yBottom,
+        IReadOnlyList<PdfUnderstandingTableColumn> columns,
+        IReadOnlyList<IReadOnlyList<string>> rows,
+        IReadOnlyList<PdfUnderstandingLine> sourceLines,
+        PdfLogicalContentSourceKind sourceKind,
+        PdfTableCoordinateSpace coordinateSpace,
+        PdfLogicalVisualBounds? visualBounds,
+        double confidence,
+        IEnumerable<PdfInferenceEvidence>? evidence,
+        Action<long>? consumeWork,
+        Action? cancellationCheck) {
+        cancellationCheck?.Invoke();
+        Guard.NotNull(detectionKind, nameof(detectionKind));
+        Guard.NotNull(columns, nameof(columns));
+        Guard.NotNull(rows, nameof(rows));
+        Guard.NotNull(sourceLines, nameof(sourceLines));
+        if (string.IsNullOrWhiteSpace(detectionKind)) throw new ArgumentException("Detection kind cannot be empty.", nameof(detectionKind));
+        if (!IsFinite(yTop)) throw new ArgumentOutOfRangeException(nameof(yTop));
+        if (!IsFinite(yBottom)) throw new ArgumentOutOfRangeException(nameof(yBottom));
+        if (columns.Count < 2) throw new ArgumentException("A table candidate requires at least two columns.", nameof(columns));
+        if (!IsFinite(confidence)) throw new ArgumentOutOfRangeException(nameof(confidence));
+
+        DetectionKind = detectionKind;
+        YTop = coordinateSpace == PdfTableCoordinateSpace.VisualTopLeft
+            ? Math.Min(yTop, yBottom)
+            : Math.Max(yTop, yBottom);
+        YBottom = coordinateSpace == PdfTableCoordinateSpace.VisualTopLeft
+            ? Math.Max(yTop, yBottom)
+            : Math.Min(yTop, yBottom);
+        Columns = SnapshotColumns(columns, consumeWork, cancellationCheck);
+        Rows = SnapshotRows(rows, consumeWork, cancellationCheck);
+        SourceLines = SnapshotSourceLines(sourceLines, consumeWork, cancellationCheck);
+        SourceKind = sourceKind;
+        CoordinateSpace = coordinateSpace;
+        Confidence = PdfInference.Clamp(confidence);
+        Evidence = PdfInference.Snapshot(evidence);
+        _visualBounds = visualBounds;
+    }
+
+    /// <summary>Stable detector identifier that produced this candidate.</summary>
+    public string DetectionKind { get; }
+
+    /// <summary>Top Y coordinate in <see cref="CoordinateSpace"/>.</summary>
+    public double YTop { get; private set; }
+
+    /// <summary>Bottom Y coordinate in <see cref="CoordinateSpace"/>.</summary>
+    public double YBottom { get; private set; }
+
+    /// <summary>Detected columns in <see cref="CoordinateSpace"/>.</summary>
+    public IReadOnlyList<PdfUnderstandingTableColumn> Columns { get; }
+
+    /// <summary>Extracted row values aligned to <see cref="Columns"/>.</summary>
+    public IReadOnlyList<IReadOnlyList<string>> Rows { get; }
+
+    /// <summary>Exact native understanding-line fragments owned by this table.</summary>
+    public IReadOnlyList<PdfUnderstandingLine> SourceLines { get; }
+
+    /// <summary>Whether the candidate came from native PDF operations or accepted OCR geometry.</summary>
+    public PdfLogicalContentSourceKind SourceKind { get; }
+
+    /// <summary>Coordinate system used by <see cref="YTop"/>, <see cref="YBottom"/>, and <see cref="Columns"/>.</summary>
+    public PdfTableCoordinateSpace CoordinateSpace { get; } = PdfTableCoordinateSpace.PdfUserSpace;
+
+    /// <summary>Normalized table-detection confidence from 0 to 1.</summary>
+    public double Confidence { get; }
+
+    /// <summary>Evidence supporting the table candidate.</summary>
+    public IReadOnlyList<PdfInferenceEvidence> Evidence { get; }
+
+    internal PdfLogicalVisualBounds? VisualBounds => _visualBounds;
+
+    internal static PdfUnderstandingTableCandidate FromStructured(
+        StructuredTable table,
+        IReadOnlyList<PdfUnderstandingLine> sourceLines,
+        double confidence,
+        IEnumerable<PdfInferenceEvidence> evidence,
+        Action<long> consumeWork,
+        Action cancellationCheck) {
+        var columns = new PdfUnderstandingTableColumn[table.Columns.Count];
+        for (int columnIndex = 0; columnIndex < table.Columns.Count; columnIndex++) {
+            cancellationCheck();
+            consumeWork(1);
+            StructuredTableColumn column = table.Columns[columnIndex];
+            columns[columnIndex] = new PdfUnderstandingTableColumn(column.From, column.To);
+        }
+        var rows = new IReadOnlyList<string>[table.Rows.Count];
+        for (int rowIndex = 0; rowIndex < table.Rows.Count; rowIndex++) {
+            cancellationCheck();
+            consumeWork(1);
+            rows[rowIndex] = table.Rows[rowIndex];
+        }
+        return new PdfUnderstandingTableCandidate(
+            table.Kind,
+            table.YTop,
+            table.YBottom,
+            columns,
+            rows,
+            sourceLines,
+            PdfLogicalContentSourceKind.Native,
+            PdfTableCoordinateSpace.PdfUserSpace,
+            null,
+            confidence,
+            evidence,
+            consumeWork,
+            cancellationCheck);
+    }
+
+    internal static PdfUnderstandingTableCandidate FromOcr(
+        string detectionKind,
+        double top,
+        double bottom,
+        PdfLogicalVisualBounds visualBounds,
+        IReadOnlyList<(double From, double To)> visualColumnBounds,
+        IReadOnlyList<IReadOnlyList<string>> rows,
+        double confidence,
+        IEnumerable<PdfInferenceEvidence> evidence) {
+        var columns = visualColumnBounds
+            .Select(static column => new PdfUnderstandingTableColumn(column.From, column.To))
+            .ToArray();
+        return new PdfUnderstandingTableCandidate(
+            detectionKind,
+            top,
+            bottom,
+            columns,
+            rows,
+            Array.Empty<PdfUnderstandingLine>(),
+            PdfLogicalContentSourceKind.Ocr,
+            PdfTableCoordinateSpace.VisualTopLeft,
+            visualBounds,
+            confidence,
+            evidence,
+            null,
+            null);
+    }
+
+    internal StructuredTable ToStructuredTable(Action<long>? consumeWork = null, Action? cancellationCheck = null) {
+        cancellationCheck?.Invoke();
+        consumeWork?.Invoke(1);
+        var table = new StructuredTable {
+            Kind = DetectionKind,
+            YTop = YTop,
+            YBottom = YBottom
+        };
+        for (int columnIndex = 0; columnIndex < Columns.Count; columnIndex++) {
+            cancellationCheck?.Invoke();
+            consumeWork?.Invoke(1);
+            PdfUnderstandingTableColumn column = Columns[columnIndex];
+            table.Columns.Add(new StructuredTableColumn { From = column.From, To = column.To });
+        }
+        for (int rowIndex = 0; rowIndex < Rows.Count; rowIndex++) {
+            cancellationCheck?.Invoke();
+            consumeWork?.Invoke(1);
+            IReadOnlyList<string> row = Rows[rowIndex];
+            var cells = new string[row.Count];
+            for (int columnIndex = 0; columnIndex < row.Count; columnIndex++) {
+                cancellationCheck?.Invoke();
+                consumeWork?.Invoke(1);
+                cells[columnIndex] = row[columnIndex];
+            }
+            table.Rows.Add(cells);
+        }
+        return table;
+    }
+
+    private static bool IsFinite(double value) => !double.IsNaN(value) && !double.IsInfinity(value);
+
+    private static System.Collections.ObjectModel.ReadOnlyCollection<PdfUnderstandingTableColumn> SnapshotColumns(
+        IReadOnlyList<PdfUnderstandingTableColumn> columns,
+        Action<long>? consumeWork,
+        Action? cancellationCheck) {
+        var result = new PdfUnderstandingTableColumn[columns.Count];
+        for (int index = 0; index < columns.Count; index++) {
+            cancellationCheck?.Invoke();
+            consumeWork?.Invoke(1);
+            result[index] = columns[index] ?? throw new ArgumentException("Columns cannot contain null values.", nameof(columns));
+        }
+        return Array.AsReadOnly(result);
+    }
+
+    private static System.Collections.ObjectModel.ReadOnlyCollection<IReadOnlyList<string>> SnapshotRows(
+        IReadOnlyList<IReadOnlyList<string>> rows,
+        Action<long>? consumeWork,
+        Action? cancellationCheck) {
+        var result = new IReadOnlyList<string>[rows.Count];
+        for (int rowIndex = 0; rowIndex < rows.Count; rowIndex++) {
+            cancellationCheck?.Invoke();
+            consumeWork?.Invoke(1);
+            IReadOnlyList<string> row = rows[rowIndex] ?? throw new ArgumentException("Rows cannot contain null values.", nameof(rows));
+            var cells = new string[row.Count];
+            for (int columnIndex = 0; columnIndex < row.Count; columnIndex++) {
+                cancellationCheck?.Invoke();
+                consumeWork?.Invoke(1);
+                cells[columnIndex] = row[columnIndex] ?? string.Empty;
+            }
+            result[rowIndex] = Array.AsReadOnly(cells);
+        }
+        return Array.AsReadOnly(result);
+    }
+
+    private static System.Collections.ObjectModel.ReadOnlyCollection<PdfUnderstandingLine> SnapshotSourceLines(
+        IReadOnlyList<PdfUnderstandingLine> sourceLines,
+        Action<long>? consumeWork,
+        Action? cancellationCheck) {
+        var result = new PdfUnderstandingLine[sourceLines.Count];
+        for (int index = 0; index < sourceLines.Count; index++) {
+            cancellationCheck?.Invoke();
+            consumeWork?.Invoke(1);
+            result[index] = sourceLines[index] ?? throw new ArgumentException("Source lines cannot contain null values.", nameof(sourceLines));
+        }
+        return Array.AsReadOnly(result);
+    }
+}

--- a/OfficeIMO.Pdf/Reading/Understanding/PdfUnderstandingTableCandidateReconciler.cs
+++ b/OfficeIMO.Pdf/Reading/Understanding/PdfUnderstandingTableCandidateReconciler.cs
@@ -1,0 +1,102 @@
+namespace OfficeIMO.Pdf;
+
+internal static class PdfUnderstandingTableCandidateReconciler {
+    internal static IReadOnlyList<PdfUnderstandingTableCandidate> FilterAdditions(
+        PdfLogicalPage page,
+        IReadOnlyList<PdfUnderstandingTableCandidate> existing,
+        IReadOnlyList<PdfUnderstandingTableCandidate> additions) {
+        if (additions.Count == 0) return Array.Empty<PdfUnderstandingTableCandidate>();
+
+        var accepted = new List<PdfUnderstandingTableCandidate>(additions.Count);
+        for (int additionIndex = 0; additionIndex < additions.Count; additionIndex++) {
+            PdfUnderstandingTableCandidate candidate = additions[additionIndex];
+            bool duplicate = existing.Any(current => RepresentsSameVisualTable(page, current, candidate)) ||
+                             accepted.Any(current => RepresentsSameVisualTable(page, current, candidate));
+            if (!duplicate) accepted.Add(candidate);
+        }
+        return accepted.Count == 0 ? Array.Empty<PdfUnderstandingTableCandidate>() : accepted.AsReadOnly();
+    }
+
+    private static bool RepresentsSameVisualTable(
+        PdfLogicalPage page,
+        PdfUnderstandingTableCandidate left,
+        PdfUnderstandingTableCandidate right) {
+        if (!TryGetVisualBounds(page, left, out PdfVisualBounds leftBounds) ||
+            !TryGetVisualBounds(page, right, out PdfVisualBounds rightBounds)) {
+            return false;
+        }
+
+        double horizontalOverlap = Math.Max(0D, Math.Min(leftBounds.Right, rightBounds.Right) - Math.Max(leftBounds.Left, rightBounds.Left));
+        double verticalOverlap = Math.Max(0D, Math.Min(leftBounds.Bottom, rightBounds.Bottom) - Math.Max(leftBounds.Top, rightBounds.Top));
+        double narrowerWidth = Math.Min(leftBounds.Width, rightBounds.Width);
+        double shorterHeight = Math.Min(leftBounds.Height, rightBounds.Height);
+        if (narrowerWidth <= 0D || shorterHeight <= 0D) return false;
+
+        double horizontalRatio = horizontalOverlap / narrowerWidth;
+        double verticalRatio = verticalOverlap / shorterHeight;
+        if (horizontalRatio >= 0.65D && verticalRatio >= 0.6D) return true;
+        if (horizontalRatio < 0.5D || verticalRatio < 0.3D) return false;
+
+        HashSet<string> leftCells = GetCellSignatures(left);
+        HashSet<string> rightCells = GetCellSignatures(right);
+        if (leftCells.Count == 0 || rightCells.Count == 0) return false;
+        int shared = leftCells.Count <= rightCells.Count
+            ? leftCells.Count(rightCells.Contains)
+            : rightCells.Count(leftCells.Contains);
+        return shared >= 2 && shared * 2 >= Math.Min(leftCells.Count, rightCells.Count);
+    }
+
+    private static bool TryGetVisualBounds(
+        PdfLogicalPage page,
+        PdfUnderstandingTableCandidate candidate,
+        out PdfVisualBounds bounds) {
+        if (candidate.Columns.Count == 0) {
+            bounds = default;
+            return false;
+        }
+        if (candidate.CoordinateSpace == PdfTableCoordinateSpace.VisualTopLeft) {
+            PdfLogicalVisualBounds? visual = candidate.VisualBounds;
+            double left = visual?.Left ?? candidate.Columns.Min(static column => Math.Min(column.From, column.To));
+            double right = visual?.Right ?? candidate.Columns.Max(static column => Math.Max(column.From, column.To));
+            double top = visual?.Top ?? Math.Min(candidate.YTop, candidate.YBottom);
+            double bottom = visual?.Bottom ?? Math.Max(candidate.YTop, candidate.YBottom);
+            bounds = new PdfVisualBounds(left, top, right, bottom);
+        } else {
+            double left = candidate.Columns.Min(static column => Math.Min(column.From, column.To));
+            double right = candidate.Columns.Max(static column => Math.Max(column.From, column.To));
+            double bottom = Math.Min(candidate.YBottom, candidate.YTop);
+            double top = Math.Max(candidate.YBottom, candidate.YTop);
+            bounds = page.TransformBoundsToVisual(left, bottom, right, top);
+        }
+        return bounds.Right > bounds.Left && bounds.Bottom > bounds.Top;
+    }
+
+    private static HashSet<string> GetCellSignatures(PdfUnderstandingTableCandidate candidate) {
+        var result = new HashSet<string>(StringComparer.Ordinal);
+        for (int rowIndex = 0; rowIndex < candidate.Rows.Count; rowIndex++) {
+            IReadOnlyList<string> row = candidate.Rows[rowIndex];
+            for (int columnIndex = 0; columnIndex < row.Count; columnIndex++) {
+                string signature = NormalizeCell(row[columnIndex]);
+                if (signature.Length > 0) result.Add(signature);
+            }
+        }
+        return result;
+    }
+
+    private static string NormalizeCell(string value) {
+        if (string.IsNullOrWhiteSpace(value)) return string.Empty;
+        var result = new System.Text.StringBuilder(value.Length);
+        bool pendingSpace = false;
+        for (int index = 0; index < value.Length; index++) {
+            char character = value[index];
+            if (char.IsWhiteSpace(character)) {
+                pendingSpace = result.Length > 0;
+                continue;
+            }
+            if (pendingSpace) result.Append(' ');
+            result.Append(char.ToUpperInvariant(character));
+            pendingSpace = false;
+        }
+        return result.ToString();
+    }
+}

--- a/OfficeIMO.Pdf/Reading/Understanding/PdfUnderstandingTableCandidateReconciler.cs
+++ b/OfficeIMO.Pdf/Reading/Understanding/PdfUnderstandingTableCandidateReconciler.cs
@@ -34,16 +34,37 @@ internal static class PdfUnderstandingTableCandidateReconciler {
 
         double horizontalRatio = horizontalOverlap / narrowerWidth;
         double verticalRatio = verticalOverlap / shorterHeight;
-        if (horizontalRatio >= 0.65D && verticalRatio >= 0.6D) return true;
         if (horizontalRatio < 0.5D || verticalRatio < 0.3D) return false;
 
         HashSet<string> leftCells = GetCellSignatures(left);
         HashSet<string> rightCells = GetCellSignatures(right);
-        if (leftCells.Count == 0 || rightCells.Count == 0) return false;
+        if (HasStrictlyRicherContent(right, left)) return false;
+        if (leftCells.Count == 0 || rightCells.Count == 0) {
+            return horizontalRatio >= 0.65D && verticalRatio >= 0.6D &&
+                   left.Rows.Count == right.Rows.Count;
+        }
         int shared = leftCells.Count <= rightCells.Count
             ? leftCells.Count(rightCells.Contains)
             : rightCells.Count(leftCells.Contains);
         return shared >= 2 && shared * 2 >= Math.Min(leftCells.Count, rightCells.Count);
+    }
+
+    private static bool HasStrictlyRicherContent(
+        PdfUnderstandingTableCandidate candidate,
+        PdfUnderstandingTableCandidate existing) {
+        if (candidate.Rows.Count <= existing.Rows.Count) return false;
+        return CountPopulatedCells(candidate) > CountPopulatedCells(existing);
+    }
+
+    private static int CountPopulatedCells(PdfUnderstandingTableCandidate candidate) {
+        int count = 0;
+        for (int rowIndex = 0; rowIndex < candidate.Rows.Count; rowIndex++) {
+            IReadOnlyList<string> row = candidate.Rows[rowIndex];
+            for (int columnIndex = 0; columnIndex < row.Count; columnIndex++) {
+                if (!string.IsNullOrWhiteSpace(row[columnIndex])) count++;
+            }
+        }
+        return count;
     }
 
     private static bool TryGetVisualBounds(


### PR DESCRIPTION
## Summary

- add a first-class table-detection stage before general page segmentation, with public table candidates, confidence, evidence, source ownership, and explicit coordinate space
- reuse the detected candidates for logical projection instead of running native table detection a second time
- replace reporting-period, summary-word, and typed-value heuristics with geometry, alignment, row rhythm, typography, and compact-shape evidence that does not depend on a particular language or column order
- project OCR tables through the same candidate model, reconcile overlapping native/OCR candidates before export, and preserve visual coordinates for continuation detection
- bound nested candidate artifacts and charge source matching and projection work to the understanding work budget

## Behavioral notes

`PdfUnderstandingPipelineOptions.TableDetection` can replace the built-in detector. Its candidates are available to segmentation through `PdfUnderstandingPageContext.TableCandidates` and in the final `PdfUnderstandingPageResult.TableCandidates` collection.

Native table source ownership is carried at source-run/word-fragment granularity. This keeps intervening prose out of table regions and lets side-by-side tables sharing a baseline remain independent.

The change is additive at the public API level. It does not add a runtime package or OCR-engine dependency.

## Validation

- `OfficeIMO.Pdf.Tests` on .NET 8: 6,133 passed
- PDF-to-Excel table tests on .NET 8: 73 passed
- `OfficeIMO.Pdf` Release build: `net472`, `netstandard2.0`, `net8.0`, and `net10.0`, with zero warnings
