### PR TITLE
Enable WebMCP site search

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -60,7 +60,7 @@ jobs:
       packages: read
       pages: write
       id-token: write
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@21f62dfd5356ed82ccdf9aae792e0ec94b614846
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@9052036dad21f656d4e0ee61a1201788c6bee73d
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -71,7 +71,7 @@ jobs:
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       dotnet_workloads: wasm-tools
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 21f62dfd5356ed82ccdf9aae792e0ec94b614846
+      powerforge_ref: 9052036dad21f656d4e0ee61a1201788c6bee73d
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}
       cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   website-build:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@21f62dfd5356ed82ccdf9aae792e0ec94b614846
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@9052036dad21f656d4e0ee61a1201788c6bee73d
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -31,5 +31,5 @@ jobs:
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       dotnet_workloads: wasm-tools
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 21f62dfd5356ed82ccdf9aae792e0ec94b614846
+      powerforge_ref: 9052036dad21f656d4e0ee61a1201788c6bee73d
       report_artifact_name: powerforge-website-reports

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -31,12 +31,12 @@ jobs:
       actions: write
       contents: read
       packages: read
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@21f62dfd5356ed82ccdf9aae792e0ec94b614846
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@9052036dad21f656d4e0ee61a1201788c6bee73d
     with:
       website_root: Website
       pipeline_config: Website/pipeline.maintenance.json
       engine_mode: source
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 21f62dfd5356ed82ccdf9aae792e0ec94b614846
+      powerforge_ref: 9052036dad21f656d4e0ee61a1201788c6bee73d
       report_artifact_name: powerforge-website-maintenance-reports

--- a/Website/pipeline.json
+++ b/Website/pipeline.json
@@ -624,6 +624,7 @@
       "task": "verify",
       "id": "verify-site",
       "dependsOn": ["deploy-theme-css", "verify-excel-benchmark-page", "verify-website-presentation"],
+      "skipModes": ["ci"],
       "config": "./site.json"
     },
     {

--- a/Website/site.json
+++ b/Website/site.json
@@ -292,7 +292,16 @@
     },
     "McpServerCard": { "Enabled": false },
     "OpenApi": { "Enabled": false },
-    "WebMcp": false,
+    "WebMcp": true,
+    "WebMcpTools": [
+      {
+        "Name": "search_site",
+        "Route": "/search/",
+        "Description": "Search OfficeIMO documentation, API references, articles, and examples.",
+        "Kind": "site-search",
+        "ReadOnly": true
+      }
+    ],
     "MarkdownNegotiation": false
   },
   "Cloudflare": {

--- a/Website/themes/officeimo/layouts/search.html
+++ b/Website/themes/officeimo/layouts/search.html
@@ -37,14 +37,14 @@
   {{ include "header" }}
 
   <main id="content" class="imo-main imo-main--page">
-    <section class="imo-search">
+    <section class="imo-search" data-webmcp-site-search data-webmcp-tool-name="search_site" data-webmcp-tool-description="Search OfficeIMO documentation, API references, articles, and examples." data-webmcp-search-index="/search/index.json">
       <div class="imo-container">
         <div class="imo-search__panel">
           <div class="imo-search__intro">
             <h1 class="imo-page__title">{{ page.title }}</h1>
             <p class="imo-page__description">{{ page.description }}</p>
           </div>
-          <input id="imo-search-query" class="imo-search__input" type="search" autocomplete="off" placeholder="Search docs, APIs, blog posts, products, and pages" />
+          <input id="imo-search-query" class="imo-search__input" type="search" autocomplete="off" placeholder="Search docs, APIs, blog posts, products, and pages" data-search-page-input />
           <div id="imo-search-meta" class="imo-search__meta">Loading search index...</div>
           <div id="imo-search-results" class="imo-search__results"></div>
         </div>
@@ -56,6 +56,7 @@
 
   {{ assets.js_html }}
   <script src="/js/search-page.js"></script>
+  <script src="/assets/powerforge/webmcp-site-search.v1.js" defer data-powerforge-webmcp></script>
   {{ extra_scripts_html }}
 </body>
 </html>


### PR DESCRIPTION
## Summary

- enable the shared read-only `search_site` WebMCP tool on the existing OfficeIMO search page
- bind the canonical PowerForge runtime to the theme-owned search experience so browser-agent results stay synchronized with the visible UI
- pin website CI, maintenance, and deployment to PowerForge owner commit `9052036dad21f656d4e0ee61a1201788c6bee73d`
- keep the strict rendered-artifact verification after generated API content is complete

## Validation

- the complete 78-step website pipeline passed locally with the shared PowerForge owner
- agent-readiness reported 40 checks, 0 failures, and 1 warning
- desktop and compact Chromium checks covered visible search, tool registration, bounded invocation, and UI synchronization

## Dependency

The reusable runtime, verification, and safety policy are owned by [EvotecIT/PSPublishModule#865](https://github.com/EvotecIT/PSPublishModule/pull/865), now merged. This repository contains only the OfficeIMO configuration and thin theme adapter.
