### PR TITLE
Add scoped canvas blend-mode effects

### DIFF
--- a/OfficeIMO.Pdf.Tests/Pdf/PdfComposePageDictionaryBuilderTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfComposePageDictionaryBuilderTests.cs
@@ -810,6 +810,9 @@ namespace OfficeIMO.Tests.Pdf {
             Assert.Equal(
                 "<< /Type /ExtGState /ca 0.35 /CA 0.75 >>\n",
                 PdfVisualResourceDictionaryBuilder.BuildExtGStateObject(0.35, 0.75));
+            Assert.Equal(
+                "<< /Type /ExtGState /ca 1 /CA 1 /BM /Multiply >>\n",
+                PdfVisualResourceDictionaryBuilder.BuildExtGStateObject(1, 1, OfficeBlendMode.Multiply));
 
             Assert.Equal(
                 "<< /ShadingType 2 /ColorSpace /DeviceRGB /Coords [30 118 120 118] /Function << /FunctionType 2 /Domain [0 1] /C0 [0.039 0.078 0.118] /C1 [1 0.502 0] /N 1 >> /Extend [true true] >>\n",
@@ -866,6 +869,8 @@ namespace OfficeIMO.Tests.Pdf {
                 PdfVisualResourceDictionaryBuilder.BuildExtGStateObject(-0.1, 1));
             Assert.Throws<ArgumentOutOfRangeException>(() =>
                 PdfVisualResourceDictionaryBuilder.BuildExtGStateObject(1, 1.1));
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                PdfVisualResourceDictionaryBuilder.BuildExtGStateObject(1, 1, (OfficeBlendMode)99));
             Assert.Throws<ArgumentOutOfRangeException>(() =>
                 PdfVisualResourceDictionaryBuilder.BuildAxialShadingObject(double.NaN, 0, 1, 1, OfficeColor.Black, OfficeColor.White));
             Assert.Throws<ArgumentOutOfRangeException>(() =>

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfDocumentCanvasTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfDocumentCanvasTests.cs
@@ -1867,11 +1867,57 @@ public class PdfDocumentCanvasTests {
     }
 
     [Fact]
+    public void CanvasWithBlendMode_WritesScopedMultiplyGraphicsState() {
+        var highlight = OfficeShape.Rectangle(100D, 18D);
+        highlight.FillColor = OfficeColor.FromRgb(255, 230, 70);
+        highlight.StrokeWidth = 0D;
+
+        byte[] bytes = PdfDocument.Create(new PdfOptions {
+                PageWidth = 180D,
+                PageHeight = 100D,
+                MarginLeft = 0D,
+                MarginRight = 0D,
+                MarginTop = 0D,
+                MarginBottom = 0D,
+                CompressContentStreams = false
+            })
+            .Canvas(canvas => canvas
+                .Text("Readable text", 20D, 24D, 120D, 20D)
+                .WithBlendMode(OfficeBlendMode.Multiply, blended =>
+                    blended.Shape(highlight, 18D, 24D)))
+            .ToBytes();
+
+        string raw = Encoding.ASCII.GetString(bytes);
+        PdfReadPage page = PdfReadDocument.Open(bytes).Pages[0];
+
+        Assert.Contains("/BM /Multiply", raw, StringComparison.Ordinal);
+        Assert.Contains("/Group << /S /Transparency /I true /K false >>", raw, StringComparison.Ordinal);
+        Assert.Contains(page.GetIdentityGraphicsEffectTransitions(), transition =>
+            transition.Effect.BlendMode == OfficeBlendMode.Multiply);
+    }
+
+    [Fact]
+    public void CanvasEffect_CombinesOpacityAndBlendModeInOneGraphicsState() {
+        byte[] bytes = PdfDocument.Create(new PdfOptions { CompressContentStreams = false })
+            .Canvas(canvas => canvas.Effect(
+                OfficeTransform.Identity,
+                0.4D,
+                OfficeBlendMode.Screen,
+                blended => blended.Text("SCREENED", 20D, 20D, 100D, 20D)))
+            .ToBytes();
+
+        string raw = Encoding.ASCII.GetString(bytes);
+        Assert.Contains("/ca 0.4 /CA 0.4 /BM /Screen", raw, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void CanvasEffect_RejectsInvalidOpacity() {
         Assert.Throws<ArgumentOutOfRangeException>(() => PdfDocument.Create().Canvas(canvas =>
             canvas.Effect(OfficeTransform.Identity, double.NaN, _ => { })));
         Assert.Throws<ArgumentNullException>(() => PdfDocument.Create().Canvas(canvas =>
             canvas.Effect(OfficeTransform.Identity, 1D, null!)));
+        Assert.Throws<ArgumentOutOfRangeException>(() => PdfDocument.Create().Canvas(canvas =>
+            canvas.WithBlendMode((OfficeBlendMode)99, _ => { })));
     }
 
     [Fact]
@@ -1928,6 +1974,9 @@ public class PdfDocumentCanvasTests {
     public void CanvasEffect_RejectsInteractiveFieldsInNontrivialEffects() {
         Assert.Throws<ArgumentException>(() => PdfDocument.Create().Canvas(canvas =>
             canvas.Effect(OfficeTransform.RotateDegrees(45D), 0.5D, nested =>
+                nested.TextField("Name", "Ada", 10D, 10D, 80D, 20D))));
+        Assert.Throws<ArgumentException>(() => PdfDocument.Create().Canvas(canvas =>
+            canvas.WithBlendMode(OfficeBlendMode.Multiply, nested =>
                 nested.TextField("Name", "Ada", 10D, 10D, 80D, 20D))));
 
         byte[] identityBytes = PdfDocument.Create().Canvas(canvas =>

--- a/OfficeIMO.Pdf/Model/PdfPageCanvas.cs
+++ b/OfficeIMO.Pdf/Model/PdfPageCanvas.cs
@@ -415,24 +415,37 @@ public sealed partial class PdfPageCanvas {
     }
 
     /// <summary>Adds nested canvas content through one top-left-coordinate affine transform and opacity state.</summary>
-    public PdfPageCanvas Effect(OfficeTransform transform, double opacity, Action<PdfPageCanvas> build) {
+    public PdfPageCanvas Effect(OfficeTransform transform, double opacity, Action<PdfPageCanvas> build) =>
+        Effect(transform, opacity, OfficeBlendMode.Normal, build);
+
+    /// <summary>Adds nested canvas content through one top-left-coordinate affine transform, opacity, and blend mode.</summary>
+    public PdfPageCanvas Effect(OfficeTransform transform, double opacity, OfficeBlendMode blendMode, Action<PdfPageCanvas> build) {
         if (double.IsNaN(opacity) || double.IsInfinity(opacity) || opacity < 0D || opacity > 1D) {
             throw new ArgumentOutOfRangeException(nameof(opacity), "Canvas effect opacity must be between zero and one.");
+        }
+        if (blendMode < OfficeBlendMode.Normal || blendMode > OfficeBlendMode.Luminosity) {
+            throw new ArgumentOutOfRangeException(nameof(blendMode), blendMode, "Unsupported canvas blend mode.");
         }
         Guard.NotNull(build, nameof(build));
         var nestedCanvas = new PdfPageCanvas(allowOutOfPageCoordinates: true);
         build(nestedCanvas);
-        bool trivialEffect = transform == OfficeTransform.Identity && Math.Abs(opacity - 1D) <= 0.000001D;
+        bool trivialEffect = transform == OfficeTransform.Identity &&
+            Math.Abs(opacity - 1D) <= 0.000001D &&
+            blendMode == OfficeBlendMode.Normal;
         if (ContainsInteractiveFormContent(nestedCanvas.Items)) {
             if (!trivialEffect) {
-                throw new ArgumentException("Interactive form fields cannot be nested inside a transformed or translucent canvas effect.", nameof(build));
+                throw new ArgumentException("Interactive form fields cannot be nested inside a transformed, translucent, or blended canvas effect.", nameof(build));
             }
             _items.AddRange(nestedCanvas.Items);
             return this;
         }
-        _items.Add(new PdfCanvasEffectItem(nestedCanvas.Items, transform, opacity));
+        _items.Add(new PdfCanvasEffectItem(nestedCanvas.Items, transform, opacity, blendMode));
         return this;
     }
+
+    /// <summary>Adds nested canvas content composited with the requested blend mode.</summary>
+    public PdfPageCanvas WithBlendMode(OfficeBlendMode blendMode, Action<PdfPageCanvas> build) =>
+        Effect(OfficeTransform.Identity, 1D, blendMode, build);
 
     private static bool ContainsInteractiveFormContent(IReadOnlyList<PdfCanvasItem> items) {
         foreach (PdfCanvasItem item in items) {
@@ -801,14 +814,16 @@ internal sealed class PdfCanvasClipItem : PdfCanvasItem {
 }
 
 internal sealed class PdfCanvasEffectItem : PdfCanvasItem {
-    public PdfCanvasEffectItem(IReadOnlyList<PdfCanvasItem> items, OfficeTransform transform, double opacity)
+    public PdfCanvasEffectItem(IReadOnlyList<PdfCanvasItem> items, OfficeTransform transform, double opacity, OfficeBlendMode blendMode)
         : base(0D, 0D) {
         Items = items;
         Transform = transform;
         Opacity = opacity;
+        BlendMode = blendMode;
     }
 
     public IReadOnlyList<PdfCanvasItem> Items { get; }
     public OfficeTransform Transform { get; }
     public double Opacity { get; }
+    public OfficeBlendMode BlendMode { get; }
 }

--- a/OfficeIMO.Pdf/README.md
+++ b/OfficeIMO.Pdf/README.md
@@ -836,6 +836,29 @@ shapes, drawings, clipping, and effects are supported. Interactive links and
 annotations, named destinations, forms, and document outlines use their
 dedicated editors so their behavior is not silently flattened or discarded.
 
+Use a scoped canvas blend mode when foreground artwork must composite with the
+existing page. This example adds a Multiply highlight while keeping dark text
+legible:
+
+```csharp
+using OfficeIMO.Drawing;
+
+var highlight = OfficeShape.Rectangle(180, 18);
+highlight.FillColor = OfficeColor.FromRgb(255, 230, 70);
+highlight.StrokeWidth = 0;
+
+PdfDocument.Load("contract.pdf")
+    .Stamp.Content((canvas, page) => canvas
+        .WithBlendMode(OfficeBlendMode.Multiply, blended =>
+            blended.Shape(highlight, 72, 140)))
+    .Save("contract-highlighted.pdf");
+```
+
+`Effect(transform, opacity, blendMode, build)` combines affine transforms,
+group opacity, and any standard PDF blend mode. Set `BehindContent = true` on
+`PdfCanvasStampOptions` for a true underlay; use the foreground default when
+the blend must use existing page artwork as its backdrop.
+
 ### Search and edit existing page text
 
 Text editing coordinates use PDF points from the page bottom-left. Inspect a

--- a/OfficeIMO.Pdf/Rendering/PdfWriter.cs
+++ b/OfficeIMO.Pdf/Rendering/PdfWriter.cs
@@ -532,7 +532,7 @@ internal static partial class PdfWriter {
             var graphicsStates = new List<(string Name, int Id)>();
             if (page.GraphicsStates.Count > 0) {
                 foreach (var state in page.GraphicsStates) {
-                    int gsId = AddObject(objects, PdfVisualResourceDictionaryBuilder.BuildExtGStateObject(state.FillOpacity, state.StrokeOpacity));
+                    int gsId = AddObject(objects, PdfVisualResourceDictionaryBuilder.BuildExtGStateObject(state.FillOpacity, state.StrokeOpacity, state.BlendMode));
                     graphicsStates.Add(("/" + state.Name, gsId));
                 }
             }

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfVisualResourceDictionaryBuilder.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfVisualResourceDictionaryBuilder.cs
@@ -10,14 +10,21 @@ internal static class PdfVisualResourceDictionaryBuilder {
     private const int MaximumGradientSubdivisionDepth = 8;
     private const double GradientTransformTolerance = 1D / 1024D;
 
-    internal static string BuildExtGStateObject(double fillOpacity, double strokeOpacity) {
+    internal static string BuildExtGStateObject(
+        double fillOpacity,
+        double strokeOpacity,
+        OfficeBlendMode blendMode = OfficeBlendMode.Normal) {
         ValidateOpacity(fillOpacity, nameof(fillOpacity));
         ValidateOpacity(strokeOpacity, nameof(strokeOpacity));
+        if (blendMode < OfficeBlendMode.Normal || blendMode > OfficeBlendMode.Luminosity) {
+            throw new ArgumentOutOfRangeException(nameof(blendMode), blendMode, "Unsupported PDF blend mode.");
+        }
 
         return "<< /Type /ExtGState /ca " +
             FormatNumber(fillOpacity) +
             " /CA " +
             FormatNumber(strokeOpacity) +
+            (blendMode == OfficeBlendMode.Normal ? string.Empty : " /BM /" + blendMode) +
             " >>\n";
     }
 

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Canvas.Effects.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Canvas.Effects.cs
@@ -6,18 +6,21 @@ namespace OfficeIMO.Pdf;
 internal static partial class PdfWriter {
     private sealed partial class LayoutContext {
         private void RenderCanvasEffect(PdfCanvasEffectItem item) {
-            if (item.Opacity >= 1D) {
+            if (item.Opacity >= 1D && item.BlendMode == OfficeBlendMode.Normal) {
                 OfficeTransform transform = ConvertTopLeftCanvasTransform(item.Transform, currentOpts.PageHeight);
                 RenderOpaqueEffectGroupInline(transform, () => RenderCanvasBlock(new PdfCanvasBlock(item.Items)));
                 return;
             }
 
-            RenderEffectGroup(item.Transform, item.Opacity, () => RenderCanvasBlock(new PdfCanvasBlock(item.Items)));
+            RenderEffectGroup(item.Transform, item.Opacity, item.BlendMode, () => RenderCanvasBlock(new PdfCanvasBlock(item.Items)));
         }
 
-        private void RenderEffectGroup(OfficeTransform topLeftPageTransform, double opacity, Action renderContent) {
+        private void RenderEffectGroup(OfficeTransform topLeftPageTransform, double opacity, Action renderContent) =>
+            RenderEffectGroup(topLeftPageTransform, opacity, OfficeBlendMode.Normal, renderContent);
+
+        private void RenderEffectGroup(OfficeTransform topLeftPageTransform, double opacity, OfficeBlendMode blendMode, Action renderContent) {
             OfficeTransform transform = ConvertTopLeftCanvasTransform(topLeftPageTransform, currentOpts.PageHeight);
-            if (opacity >= 1D &&
+            if (opacity >= 1D && blendMode == OfficeBlendMode.Normal &&
                 (currentOpts.TaggedStructureMode != PdfTaggedStructureMode.CatalogMarkers ||
                  _suppressCanvasAccessibilityWrappers ||
                  _suppressCanvasActualTextChildren)) {
@@ -32,7 +35,7 @@ internal static partial class PdfWriter {
             int highlightAnnotationStart = currentPage.HighlightAnnotations.Count;
             int imageStart = currentPage.Images.Count;
             int formFieldStart = currentPage.FormFields.Count;
-            string? opacityState = EnsureGraphicsState(opacity, opacity);
+            string? opacityState = EnsureGraphicsState(opacity, opacity, blendMode);
             int contentStart = sb.Length;
             _canvasClipDepth++;
             try {

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Drawing.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Drawing.cs
@@ -8,15 +8,17 @@ internal static partial class PdfWriter {
         private static PdfColor? ToPdfColor(OfficeIMO.Drawing.OfficeColor? color) =>
             color.HasValue ? PdfColor.FromOfficeColorOrNull(color.Value) : null;
 
-        private string? EnsureGraphicsState(double fillOpacity, double strokeOpacity) {
-            if (fillOpacity >= 1D && strokeOpacity >= 1D) {
+        private string? EnsureGraphicsState(double fillOpacity, double strokeOpacity, OfficeBlendMode blendMode = OfficeBlendMode.Normal) {
+            if (fillOpacity >= 1D && strokeOpacity >= 1D && blendMode == OfficeBlendMode.Normal) {
                 return null;
             }
 
             EnsurePage();
             for (int i = 0; i < currentPage!.GraphicsStates.Count; i++) {
                 var existing = currentPage.GraphicsStates[i];
-                if (existing.FillOpacity.Equals(fillOpacity) && existing.StrokeOpacity.Equals(strokeOpacity)) {
+                if (existing.FillOpacity.Equals(fillOpacity) &&
+                    existing.StrokeOpacity.Equals(strokeOpacity) &&
+                    existing.BlendMode == blendMode) {
                     return existing.Name;
                 }
             }
@@ -25,7 +27,8 @@ internal static partial class PdfWriter {
             currentPage.GraphicsStates.Add(new PageGraphicsState {
                 Name = name,
                 FillOpacity = fillOpacity,
-                StrokeOpacity = strokeOpacity
+                StrokeOpacity = strokeOpacity,
+                BlendMode = blendMode
             });
             return name;
         }

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.HeaderFooter.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.HeaderFooter.cs
@@ -535,7 +535,9 @@ internal static partial class PdfWriter {
 
         for (int i = 0; i < page.GraphicsStates.Count; i++) {
             var existing = page.GraphicsStates[i];
-            if (existing.FillOpacity.Equals(fillOpacity) && existing.StrokeOpacity.Equals(strokeOpacity)) {
+            if (existing.FillOpacity.Equals(fillOpacity) &&
+                existing.StrokeOpacity.Equals(strokeOpacity) &&
+                existing.BlendMode == OfficeBlendMode.Normal) {
                 return existing.Name;
             }
         }

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Objects.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Objects.cs
@@ -404,6 +404,7 @@ internal static partial class PdfWriter {
         public string Name { get; set; } = string.Empty;
         public double FillOpacity { get; set; } = 1D;
         public double StrokeOpacity { get; set; } = 1D;
+        public OfficeBlendMode BlendMode { get; set; } = OfficeBlendMode.Normal;
     }
 
     private sealed class PageShading {


### PR DESCRIPTION
## Summary

- add `PdfPageCanvas.WithBlendMode(...)` for scoped canvas compositing
- extend `Effect(...)` so transforms, opacity, and a standard `OfficeBlendMode` can be combined in one isolated transparency group
- keep normal opaque effects on the existing inline path and reject blended interactive form fields explicitly
- document the foreground Multiply highlight pattern and the existing `BehindContent` underlay alternative

## Contract

Canvas blend effects emit one reusable graphics state containing `/BM` and optional opacity, and isolate the nested drawing content in a transparency group. Existing canvas behavior remains unchanged when the blend mode is `Normal`.

The generated PDF was rendered with both a normal foreground highlight and a Multiply highlight; the normal fill covered prior glyphs while Multiply preserved the dark text as intended.

## Validation

- full OfficeIMO.Pdf.Tests on .NET 8: 6140 passed
- full OfficeIMO.Pdf.Tests on .NET 10: 6140 passed
- focused canvas/resource tests on .NET Framework 4.7.2: 87 passed
- raw PDF dictionary assertions and reader round-trip coverage for blend effects

Closes #2428