### PR TITLE
Add typed PDF action sanitization

### DIFF
--- a/OfficeIMO.Pdf.Tests/Pdf/PdfSanitizerTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfSanitizerTests.cs
@@ -123,6 +123,73 @@ public class PdfSanitizerTests {
     }
 
     [Fact]
+    public void InspectSanitization_BoundsNamedJavaScriptReferenceChains() {
+        byte[] source = BuildNamedJavaScriptReferenceChainPdf(referenceCount: 8);
+        var readOptions = new PdfLoadOptions {
+            Limits = new PdfReadLimits { MaxNameTreeDepth = 4 }
+        };
+
+        PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() =>
+            PdfDocument.Load(source, readOptions).InspectSanitization());
+
+        Assert.Equal(PdfReadLimitKind.NameTreeDepth, exception.Kind);
+    }
+
+    [Fact]
+    public void InspectSanitization_CountsDanglingNamedJavaScriptReferencesAgainstNodeLimit() {
+        byte[] source = Encoding.ASCII.GetBytes(string.Join("\n", new[] {
+            "%PDF-1.7",
+            "1 0 obj", "<< /Type /Catalog /Pages 2 0 R /Names << /JavaScript << /Kids [100 0 R 101 0 R 102 0 R] >> >> >>", "endobj",
+            "2 0 obj", "<< /Type /Pages /Count 1 /Kids [3 0 R] >>", "endobj",
+            "3 0 obj", "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R >>", "endobj",
+            "4 0 obj", "<< /Length 0 >>", "stream", string.Empty, "endstream", "endobj",
+            "trailer", "<< /Root 1 0 R /Size 5 >>", "%%EOF"
+        }));
+        var readOptions = new PdfLoadOptions {
+            Limits = new PdfReadLimits { MaxNameTreeNodes = 2 }
+        };
+
+        PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() =>
+            PdfDocument.Load(source, readOptions).InspectSanitization());
+
+        Assert.Equal(PdfReadLimitKind.NameTreeNodes, exception.Kind);
+    }
+
+    [Fact]
+    public void InspectSanitization_CachesSharedNamedJavaScriptRootsAcrossTheScan() {
+        byte[] source = BuildSharedNamedJavaScriptRootPdf();
+        var readOptions = new PdfLoadOptions {
+            Limits = new PdfReadLimits { MaxNameTreeNodes = 2 }
+        };
+
+        PdfSanitizationReport report = PdfDocument.Load(source, readOptions).InspectSanitization();
+
+        Assert.Equal(2, report.ActionCounts.JavaScript);
+    }
+
+    [Fact]
+    public void InspectSanitization_DoesNotChargeActionPayloadsToTheNameTreeNodeLimit() {
+        byte[] source = Encoding.ASCII.GetBytes(string.Join("\n", new[] {
+            "%PDF-1.7",
+            "1 0 obj", "<< /Type /Catalog /Pages 2 0 R /Names << /JavaScript 5 0 R >> >>", "endobj",
+            "2 0 obj", "<< /Type /Pages /Count 1 /Kids [3 0 R] >>", "endobj",
+            "3 0 obj", "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R >>", "endobj",
+            "4 0 obj", "<< /Length 0 >>", "stream", string.Empty, "endstream", "endobj",
+            "5 0 obj", "<< /Names [(Run) 6 0 R] >>", "endobj",
+            "6 0 obj", "<< /S /JavaScript /JS 7 0 R >>", "endobj",
+            "7 0 obj", "(app.alert\\('test'\\);)", "endobj",
+            "trailer", "<< /Root 1 0 R /Size 8 >>", "%%EOF"
+        }));
+        var readOptions = new PdfLoadOptions {
+            Limits = new PdfReadLimits { MaxNameTreeNodes = 1 }
+        };
+
+        PdfSanitizationReport report = PdfDocument.Load(source, readOptions).InspectSanitization();
+
+        Assert.Equal(1, report.ActionCounts.JavaScript);
+    }
+
+    [Fact]
     public void SanitizationOptions_RejectUnsupportedActionKindBits() {
         Assert.Throws<ArgumentOutOfRangeException>(() => new PdfSanitizationOptions {
             ActionKindsToRemove = (PdfSanitizationActionKind)(1 << 20)
@@ -605,6 +672,41 @@ public class PdfSanitizerTests {
             "3 0 obj", "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R >>", "endobj",
             "4 0 obj", "<< /Length 0 >>", "stream", string.Empty, "endstream", "endobj",
             "trailer", "<< /Root 1 0 R /Size 5 >>", "%%EOF"
+        }));
+    }
+
+    private static byte[] BuildNamedJavaScriptReferenceChainPdf(int referenceCount) {
+        var lines = new List<string> {
+            "%PDF-1.7",
+            "1 0 obj", "<< /Type /Catalog /Pages 2 0 R /Names << /JavaScript 5 0 R >> >>", "endobj",
+            "2 0 obj", "<< /Type /Pages /Count 1 /Kids [3 0 R] >>", "endobj",
+            "3 0 obj", "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R >>", "endobj",
+            "4 0 obj", "<< /Length 0 >>", "stream", string.Empty, "endstream", "endobj"
+        };
+        for (int index = 0; index < referenceCount; index++) {
+            int objectNumber = 5 + index;
+            lines.Add(objectNumber.ToString(System.Globalization.CultureInfo.InvariantCulture) + " 0 obj");
+            lines.Add(index + 1 < referenceCount
+                ? "<< /Kids [" + (objectNumber + 1).ToString(System.Globalization.CultureInfo.InvariantCulture) + " 0 R] >>"
+                : "<< /Names [] >>");
+            lines.Add("endobj");
+        }
+        lines.Add("trailer");
+        lines.Add("<< /Root 1 0 R /Size " + (5 + referenceCount).ToString(System.Globalization.CultureInfo.InvariantCulture) + " >>");
+        lines.Add("%%EOF");
+        return Encoding.ASCII.GetBytes(string.Join("\n", lines));
+    }
+
+    private static byte[] BuildSharedNamedJavaScriptRootPdf() {
+        return Encoding.ASCII.GetBytes(string.Join("\n", new[] {
+            "%PDF-1.7",
+            "1 0 obj", "<< /Type /Catalog /Pages 2 0 R /Names << /JavaScript 5 0 R /Also << /JavaScript 5 0 R >> >> >>", "endobj",
+            "2 0 obj", "<< /Type /Pages /Count 1 /Kids [3 0 R] >>", "endobj",
+            "3 0 obj", "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R >>", "endobj",
+            "4 0 obj", "<< /Length 0 >>", "stream", string.Empty, "endstream", "endobj",
+            "5 0 obj", "<< /Kids [6 0 R] >>", "endobj",
+            "6 0 obj", "<< /Names [] >>", "endobj",
+            "trailer", "<< /Root 1 0 R /Size 7 >>", "%%EOF"
         }));
     }
 

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfSanitizerTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfSanitizerTests.cs
@@ -94,6 +94,35 @@ public class PdfSanitizerTests {
     }
 
     [Fact]
+    public void Sanitize_DefaultUriSchemePolicyOverridesTheActionTypeAllowList() {
+        var policy = new PdfSanitizationOptions();
+        policy.AllowedActionTypes.Add("URI");
+
+        PdfSanitizationReport preview = PdfDocument.Load(BuildUnsafeWidgetUriPdf()).InspectSanitization(policy);
+        PdfSanitizationResult result = PdfSanitizer.Sanitize(BuildUnsafeWidgetUriPdf(), policy);
+
+        Assert.Equal(1, preview.ActionCounts.Uri);
+        Assert.Equal(1, result.RemovedActionCounts.Uri);
+        Assert.DoesNotContain("javascript:unsafe", PdfEncoding.Latin1GetString(result.ToBytes()), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void InspectSanitization_InventoriesMalformedNamedJavaScriptContainer() {
+        byte[] source = BuildMalformedNamedJavaScriptPdf();
+        var policy = new PdfSanitizationOptions {
+            ActionKindsToRemove = PdfSanitizationActionKind.JavaScript
+        };
+
+        PdfSanitizationReport preview = PdfDocument.Load(source).InspectSanitization(policy);
+        PdfSanitizationResult result = PdfSanitizer.Sanitize(source, policy);
+
+        Assert.Equal(1, preview.ActionCounts.JavaScript);
+        Assert.Equal(1, result.RemovedActionCounts.JavaScript);
+        Assert.True(result.IsSanitized);
+        Assert.DoesNotContain("/JavaScript", PdfEncoding.Latin1GetString(result.ToBytes()), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void SanitizationOptions_RejectUnsupportedActionKindBits() {
         Assert.Throws<ArgumentOutOfRangeException>(() => new PdfSanitizationOptions {
             ActionKindsToRemove = (PdfSanitizationActionKind)(1 << 20)
@@ -565,6 +594,17 @@ public class PdfSanitizerTests {
             "5 0 obj", "<< /Fields [6 0 R] >>", "endobj",
             "6 0 obj", "<< /Type /Annot /Subtype /Widget /FT /Btn /Ff 65536 /T (run) /Rect [20 20 120 44] /P 3 0 R /A << /S /URI /URI (javascript:unsafe) >> >>", "endobj",
             "trailer", "<< /Root 1 0 R /Size 7 >>", "%%EOF"
+        }));
+    }
+
+    private static byte[] BuildMalformedNamedJavaScriptPdf() {
+        return Encoding.ASCII.GetBytes(string.Join("\n", new[] {
+            "%PDF-1.7",
+            "1 0 obj", "<< /Type /Catalog /Pages 2 0 R /Names << /JavaScript << /Names [] >> >> >>", "endobj",
+            "2 0 obj", "<< /Type /Pages /Count 1 /Kids [3 0 R] >>", "endobj",
+            "3 0 obj", "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R >>", "endobj",
+            "4 0 obj", "<< /Length 0 >>", "stream", string.Empty, "endstream", "endobj",
+            "trailer", "<< /Root 1 0 R /Size 5 >>", "%%EOF"
         }));
     }
 

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfSanitizerTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfSanitizerTests.cs
@@ -6,6 +6,101 @@ namespace OfficeIMO.Tests.Pdf;
 
 public class PdfSanitizerTests {
     [Fact]
+    public void InspectSanitization_ReportsTypedActionCountsForTheDefaultPolicy() {
+        PdfSanitizationReport report = PdfDocument.Load(BuildActiveContentPdf()).InspectSanitization();
+
+        Assert.Equal(2, report.ActionCounts.JavaScript);
+        Assert.Equal(1, report.ActionCounts.Uri);
+        Assert.Equal(1, report.ActionCounts.Launch);
+        Assert.Equal(1, report.ActionCounts.SubmitForm);
+        Assert.Equal(1, report.ActionCounts.GoToR);
+        Assert.Equal(1, report.ActionCounts.GoToE);
+        Assert.Equal(1, report.ActionCounts.ImportData);
+        Assert.Equal(8, report.ActionCounts.Total);
+        Assert.Equal(report.Findings.Count, report.TotalCount);
+    }
+
+    [Theory]
+    [InlineData(PdfSanitizationActionKind.JavaScript, 2)]
+    [InlineData(PdfSanitizationActionKind.Launch, 1)]
+    [InlineData(PdfSanitizationActionKind.SubmitForm, 1)]
+    [InlineData(PdfSanitizationActionKind.GoToR, 1)]
+    [InlineData(PdfSanitizationActionKind.GoToE, 1)]
+    [InlineData(PdfSanitizationActionKind.ImportData, 1)]
+    public void InspectSanitization_UsesAnExactActionKindSelection(PdfSanitizationActionKind selected, int expectedCount) {
+        var policy = new PdfSanitizationOptions { ActionKindsToRemove = selected };
+
+        PdfSanitizationReport report = PdfDocument.Load(BuildActiveContentPdf()).InspectSanitization(policy);
+
+        Assert.Equal(expectedCount, report.ActionCounts.GetCount(selected));
+        Assert.Equal(expectedCount, report.ActionCounts.Total);
+        Assert.All(report.Findings.Where(static finding => finding.ActionKind.HasValue),
+            finding => Assert.Equal(selected, finding.ActionKind));
+    }
+
+    [Fact]
+    public void Sanitize_CanRemoveJavaScriptWithoutRemovingOtherActionKinds() {
+        var policy = new PdfSanitizationOptions {
+            ActionKindsToRemove = PdfSanitizationActionKind.JavaScript
+        };
+
+        PdfSanitizationResult result = PdfSanitizer.Sanitize(BuildActiveContentPdf(), policy);
+        IReadOnlyList<PdfSanitizationFinding> preservedActions = PdfSanitizer.Analyze(result.ToBytes());
+
+        Assert.True(result.IsSanitized);
+        Assert.Equal(2, result.RemovedActionCounts.JavaScript);
+        Assert.DoesNotContain("JavaScript", PdfEncoding.Latin1GetString(result.ToBytes()), StringComparison.Ordinal);
+        Assert.Contains(preservedActions, static finding => finding.ActionKind == PdfSanitizationActionKind.Launch);
+        Assert.Contains(preservedActions, static finding => finding.ActionKind == PdfSanitizationActionKind.SubmitForm);
+        Assert.Contains(preservedActions, static finding => finding.ActionKind == PdfSanitizationActionKind.GoToR);
+    }
+
+    [Fact]
+    public void Sanitize_CanRemoveEveryUriActionWithoutRemovingOtherActionKinds() {
+        var policy = new PdfSanitizationOptions {
+            ActionKindsToRemove = PdfSanitizationActionKind.Uri
+        };
+
+        PdfSanitizationResult result = PdfSanitizer.Sanitize(BuildActiveContentPdf(), policy);
+        PdfDocumentInfo info = PdfInspector.Inspect(result.ToBytes());
+        IReadOnlyList<PdfSanitizationFinding> preservedActions = PdfSanitizer.Analyze(result.ToBytes());
+
+        Assert.True(result.IsSanitized);
+        Assert.Equal(3, result.RemovedActionCounts.Uri);
+        Assert.Empty(info.LinkAnnotations.Where(static link => link.Uri != null));
+        Assert.DoesNotContain("base.example", PdfEncoding.Latin1GetString(result.ToBytes()), StringComparison.Ordinal);
+        Assert.Contains(preservedActions, static finding => finding.ActionKind == PdfSanitizationActionKind.JavaScript);
+        Assert.Contains(preservedActions, static finding => finding.ActionKind == PdfSanitizationActionKind.Launch);
+    }
+
+    [Fact]
+    public void Sanitize_ExplicitAllowListOverridesAnExactActionKindSelection() {
+        var policy = new PdfSanitizationOptions {
+            ActionKindsToRemove = PdfSanitizationActionKind.JavaScript |
+                                  PdfSanitizationActionKind.Launch
+        };
+        policy.AllowedActionTypes.Add("JavaScript");
+
+        PdfSanitizationReport preview = PdfDocument.Load(BuildActiveContentPdf()).InspectSanitization(policy);
+        PdfSanitizationResult result = PdfSanitizer.Sanitize(BuildActiveContentPdf(), policy);
+        IReadOnlyList<PdfSanitizationFinding> defaultPolicyFindings = PdfSanitizer.Analyze(result.ToBytes());
+
+        Assert.Equal(0, preview.ActionCounts.JavaScript);
+        Assert.Equal(1, preview.ActionCounts.Launch);
+        Assert.Equal(0, result.RemovedActionCounts.JavaScript);
+        Assert.Equal(1, result.RemovedActionCounts.Launch);
+        Assert.Contains(defaultPolicyFindings, static finding => finding.ActionKind == PdfSanitizationActionKind.JavaScript);
+        Assert.DoesNotContain(defaultPolicyFindings, static finding => finding.ActionKind == PdfSanitizationActionKind.Launch);
+    }
+
+    [Fact]
+    public void SanitizationOptions_RejectUnsupportedActionKindBits() {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new PdfSanitizationOptions {
+            ActionKindsToRemove = (PdfSanitizationActionKind)(1 << 20)
+        });
+    }
+
+    [Fact]
     public void Analyze_HonorsPolicyCancellation() {
         byte[] source = BuildActiveContentPdf();
         using var cancellation = new System.Threading.CancellationTokenSource();
@@ -391,7 +486,7 @@ public class PdfSanitizerTests {
         string pdf = string.Join("\n", new[] {
             "%PDF-1.7",
             "1 0 obj",
-            "<< /Type /Catalog /Pages 2 0 R /Names << /JavaScript << /Names [(Open) 6 0 R] >> >> /AA << /WC 12 0 R /WS 13 0 R /WP 14 0 R >> >>",
+            "<< /Type /Catalog /Pages 2 0 R /Names << /JavaScript << /Names [(Open) 6 0 R] >> >> /URI << /Base (https://base.example/) >> /AA << /WC 12 0 R /WS 13 0 R /WP 14 0 R >> >>",
             "endobj",
             "2 0 obj",
             "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",

--- a/OfficeIMO.Pdf/Core/PdfDocument.Operations.cs
+++ b/OfficeIMO.Pdf/Core/PdfDocument.Operations.cs
@@ -657,6 +657,11 @@ public sealed partial class PdfDocument {
         return PdfSanitizer.Sanitize(GetBytesForOperation(), options, ReadOptions);
     }
 
+    /// <summary>Inspects what the supplied sanitization policy would remove without modifying the PDF.</summary>
+    public PdfSanitizationReport InspectSanitization(PdfSanitizationOptions? options = null) {
+        return PdfSanitizer.Inspect(GetBytesForOperation(), options, ReadOptions);
+    }
+
     /// <summary>
     /// Attempts to create a new PDF with updated metadata, returning diagnostics when blocked or failed.
     /// </summary>

--- a/OfficeIMO.Pdf/Manipulation/PdfSanitizationActionCounts.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfSanitizationActionCounts.cs
@@ -1,0 +1,43 @@
+namespace OfficeIMO.Pdf;
+
+/// <summary>Typed counts of action findings in a PDF sanitization preview or result.</summary>
+public sealed class PdfSanitizationActionCounts {
+    internal PdfSanitizationActionCounts(IReadOnlyList<PdfSanitizationFinding> findings) {
+        for (int i = 0; i < findings.Count; i++) {
+            PdfSanitizationActionKind? kind = findings[i].ActionKind;
+            if (!kind.HasValue) continue;
+            _counts.TryGetValue(kind.Value, out int count);
+            _counts[kind.Value] = count + 1;
+            Total++;
+        }
+    }
+
+    private readonly Dictionary<PdfSanitizationActionKind, int> _counts = new();
+
+    /// <summary>Total number of action findings.</summary>
+    public int Total { get; private set; }
+
+    /// <summary>Number of JavaScript action findings.</summary>
+    public int JavaScript => GetCount(PdfSanitizationActionKind.JavaScript);
+    /// <summary>Number of URI action or catalog URI-base findings.</summary>
+    public int Uri => GetCount(PdfSanitizationActionKind.Uri);
+    /// <summary>Number of Launch action findings.</summary>
+    public int Launch => GetCount(PdfSanitizationActionKind.Launch);
+    /// <summary>Number of SubmitForm action findings.</summary>
+    public int SubmitForm => GetCount(PdfSanitizationActionKind.SubmitForm);
+    /// <summary>Number of GoToR action findings.</summary>
+    public int GoToR => GetCount(PdfSanitizationActionKind.GoToR);
+    /// <summary>Number of GoToE action findings.</summary>
+    public int GoToE => GetCount(PdfSanitizationActionKind.GoToE);
+    /// <summary>Number of ImportData action findings.</summary>
+    public int ImportData => GetCount(PdfSanitizationActionKind.ImportData);
+    /// <summary>Number of Movie action findings.</summary>
+    public int Movie => GetCount(PdfSanitizationActionKind.Movie);
+    /// <summary>Number of Rendition action findings.</summary>
+    public int Rendition => GetCount(PdfSanitizationActionKind.Rendition);
+    /// <summary>Number of RichMedia action findings.</summary>
+    public int RichMedia => GetCount(PdfSanitizationActionKind.RichMedia);
+
+    /// <summary>Returns the count for one atomic action kind.</summary>
+    public int GetCount(PdfSanitizationActionKind kind) => _counts.TryGetValue(kind, out int count) ? count : 0;
+}

--- a/OfficeIMO.Pdf/Manipulation/PdfSanitizationActionKind.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfSanitizationActionKind.cs
@@ -1,0 +1,32 @@
+namespace OfficeIMO.Pdf;
+
+/// <summary>Selectable PDF action categories understood by the sanitization engine.</summary>
+[System.Flags]
+public enum PdfSanitizationActionKind {
+    /// <summary>Do not select any action category.</summary>
+    None = 0,
+    /// <summary>JavaScript actions and document-level JavaScript name trees.</summary>
+    JavaScript = 1 << 0,
+    /// <summary>URI actions and catalog URI base targets.</summary>
+    Uri = 1 << 1,
+    /// <summary>Launch actions that open a file or application.</summary>
+    Launch = 1 << 2,
+    /// <summary>SubmitForm actions.</summary>
+    SubmitForm = 1 << 3,
+    /// <summary>GoToR actions that navigate to another PDF.</summary>
+    GoToR = 1 << 4,
+    /// <summary>GoToE actions that navigate into an embedded PDF.</summary>
+    GoToE = 1 << 5,
+    /// <summary>ImportData actions.</summary>
+    ImportData = 1 << 6,
+    /// <summary>Movie actions.</summary>
+    Movie = 1 << 7,
+    /// <summary>Rendition actions.</summary>
+    Rendition = 1 << 8,
+    /// <summary>RichMedia actions.</summary>
+    RichMedia = 1 << 9,
+    /// <summary>All active action kinds removed by the legacy default policy, excluding URI actions.</summary>
+    DefaultActiveContent = JavaScript | Launch | SubmitForm | GoToR | GoToE | ImportData | Movie | Rendition | RichMedia,
+    /// <summary>Every selectable action kind, including all URI targets.</summary>
+    All = DefaultActiveContent | Uri
+}

--- a/OfficeIMO.Pdf/Manipulation/PdfSanitizationFinding.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfSanitizationFinding.cs
@@ -2,11 +2,12 @@ namespace OfficeIMO.Pdf;
 
 /// <summary>A bounded, reviewable item discovered by the PDF sanitization engine.</summary>
 public sealed class PdfSanitizationFinding {
-    internal PdfSanitizationFinding(PdfSanitizationFindingKind kind, int objectNumber, string path, string detail) {
+    internal PdfSanitizationFinding(PdfSanitizationFindingKind kind, int objectNumber, string path, string detail, PdfSanitizationActionKind? actionKind = null) {
         Kind = kind;
         ObjectNumber = objectNumber;
         Path = path;
         Detail = detail;
+        ActionKind = actionKind;
     }
 
     /// <summary>Finding category.</summary>
@@ -20,4 +21,7 @@ public sealed class PdfSanitizationFinding {
 
     /// <summary>Action type, URI, or payload marker that caused the finding.</summary>
     public string Detail { get; }
+
+    /// <summary>Typed action category when this finding represents an action or URI target.</summary>
+    public PdfSanitizationActionKind? ActionKind { get; }
 }

--- a/OfficeIMO.Pdf/Manipulation/PdfSanitizationOptions.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfSanitizationOptions.cs
@@ -2,6 +2,8 @@ namespace OfficeIMO.Pdf;
 
 /// <summary>Explicit policy for removing active content and embedded payloads from a PDF.</summary>
 public sealed class PdfSanitizationOptions {
+    private PdfSanitizationActionKind? _actionKindsToRemove;
+
     /// <summary>Cancellation observed between inventory, object-graph rewrite, and verification stages.</summary>
     public System.Threading.CancellationToken CancellationToken { get; set; }
 
@@ -10,6 +12,21 @@ public sealed class PdfSanitizationOptions {
 
     /// <summary>Action types that may remain. Values are PDF action names without a leading slash.</summary>
     public ISet<string> AllowedActionTypes { get; } = new HashSet<string>(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Exact action kinds to remove. When null, the existing default policy removes known active-content
+    /// actions and only URI targets whose schemes are not allowed. When set, unselected action kinds are
+    /// preserved and selecting <see cref="PdfSanitizationActionKind.Uri"/> removes every URI target.
+    /// </summary>
+    public PdfSanitizationActionKind? ActionKindsToRemove {
+        get => _actionKindsToRemove;
+        set {
+            if (value.HasValue && (value.Value & ~PdfSanitizationActionKind.All) != 0) {
+                throw new ArgumentOutOfRangeException(nameof(ActionKindsToRemove), value, "Unsupported PDF sanitization action kind.");
+            }
+            _actionKindsToRemove = value;
+        }
+    }
 
     /// <summary>Absolute URI schemes that may remain. Relative URI targets are preserved.</summary>
     public ISet<string> AllowedUriSchemes { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
@@ -23,6 +40,34 @@ public sealed class PdfSanitizationOptions {
     public bool RemoveRichMedia { get; set; } = true;
 
     internal bool IsActionAllowed(string actionType) => AllowedActionTypes.Contains(actionType);
+
+    internal bool ShouldRemoveAction(string actionType, string? uri = null) {
+        if (IsActionAllowed(actionType)) return false;
+        PdfSanitizationActionKind kind = GetActionKind(actionType);
+        if (ActionKindsToRemove.HasValue) {
+            return kind != PdfSanitizationActionKind.None && (ActionKindsToRemove.Value & kind) == kind;
+        }
+        if (kind == PdfSanitizationActionKind.Uri) return uri != null && !IsUriAllowed(uri);
+        return PdfActiveContentPolicy.IsUnsafeActionType(actionType);
+    }
+
+    internal bool ShouldRemoveCatalogUriBase(string value) => ActionKindsToRemove.HasValue
+        ? (ActionKindsToRemove.Value & PdfSanitizationActionKind.Uri) != 0
+        : !IsUriAllowed(value);
+
+    internal static PdfSanitizationActionKind GetActionKind(string actionType) => actionType switch {
+        "JavaScript" => PdfSanitizationActionKind.JavaScript,
+        "URI" => PdfSanitizationActionKind.Uri,
+        "Launch" => PdfSanitizationActionKind.Launch,
+        "SubmitForm" => PdfSanitizationActionKind.SubmitForm,
+        "GoToR" => PdfSanitizationActionKind.GoToR,
+        "GoToE" => PdfSanitizationActionKind.GoToE,
+        "ImportData" => PdfSanitizationActionKind.ImportData,
+        "Movie" => PdfSanitizationActionKind.Movie,
+        "Rendition" => PdfSanitizationActionKind.Rendition,
+        "RichMedia" => PdfSanitizationActionKind.RichMedia,
+        _ => PdfSanitizationActionKind.None
+    };
 
     internal bool IsUriAllowed(string value) {
         if (!Uri.TryCreate(value, UriKind.RelativeOrAbsolute, out Uri? uri) || !uri.IsAbsoluteUri) {

--- a/OfficeIMO.Pdf/Manipulation/PdfSanitizationOptions.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfSanitizationOptions.cs
@@ -42,12 +42,13 @@ public sealed class PdfSanitizationOptions {
     internal bool IsActionAllowed(string actionType) => AllowedActionTypes.Contains(actionType);
 
     internal bool ShouldRemoveAction(string actionType, string? uri = null) {
-        if (IsActionAllowed(actionType)) return false;
         PdfSanitizationActionKind kind = GetActionKind(actionType);
         if (ActionKindsToRemove.HasValue) {
+            if (IsActionAllowed(actionType)) return false;
             return kind != PdfSanitizationActionKind.None && (ActionKindsToRemove.Value & kind) == kind;
         }
         if (kind == PdfSanitizationActionKind.Uri) return uri != null && !IsUriAllowed(uri);
+        if (IsActionAllowed(actionType)) return false;
         return PdfActiveContentPolicy.IsUnsafeActionType(actionType);
     }
 

--- a/OfficeIMO.Pdf/Manipulation/PdfSanitizationReport.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfSanitizationReport.cs
@@ -1,0 +1,18 @@
+namespace OfficeIMO.Pdf;
+
+/// <summary>Typed preview of items that the supplied PDF sanitization policy would remove.</summary>
+public sealed class PdfSanitizationReport {
+    internal PdfSanitizationReport(IReadOnlyList<PdfSanitizationFinding> findings) {
+        Findings = findings;
+        ActionCounts = new PdfSanitizationActionCounts(findings);
+    }
+
+    /// <summary>Items selected for removal by the inspected policy.</summary>
+    public IReadOnlyList<PdfSanitizationFinding> Findings { get; }
+
+    /// <summary>Per-kind action counts for the selected policy.</summary>
+    public PdfSanitizationActionCounts ActionCounts { get; }
+
+    /// <summary>Total number of selected findings.</summary>
+    public int TotalCount => Findings.Count;
+}

--- a/OfficeIMO.Pdf/Manipulation/PdfSanitizationResult.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfSanitizationResult.cs
@@ -20,6 +20,8 @@ public sealed class PdfSanitizationResult {
         RemovedFindings = removedFindings;
         RemainingFindings = remainingFindings;
         QuarantinedAttachments = quarantinedAttachments;
+        RemovedActionCounts = new PdfSanitizationActionCounts(removedFindings);
+        RemainingActionCounts = new PdfSanitizationActionCounts(remainingFindings);
     }
 
     /// <summary>Shared mutation plan used for the full rewrite.</summary>
@@ -33,6 +35,12 @@ public sealed class PdfSanitizationResult {
 
     /// <summary>Forbidden items found after save. A successful operation always returns an empty list.</summary>
     public IReadOnlyList<PdfSanitizationFinding> RemainingFindings { get; }
+
+    /// <summary>Per-kind counts of actions removed by the policy.</summary>
+    public PdfSanitizationActionCounts RemovedActionCounts { get; }
+
+    /// <summary>Per-kind counts of selected actions found after the rewrite.</summary>
+    public PdfSanitizationActionCounts RemainingActionCounts { get; }
 
     /// <summary>Decoded attachments retained in memory when quarantine mode was requested.</summary>
     public IReadOnlyList<PdfExtractedAttachment> QuarantinedAttachments { get; }

--- a/OfficeIMO.Pdf/Manipulation/PdfSanitizer.Traversal.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfSanitizer.Traversal.cs
@@ -7,11 +7,23 @@ internal static partial class PdfSanitizer {
 
     private static IReadOnlyList<PdfSanitizationFinding> Scan(
         Dictionary<int, PdfIndirectObject> objects,
-        PdfSanitizationOptions policy) {
+        PdfSanitizationOptions policy,
+        PdfReadLimits readLimits) {
         var findings = new List<PdfSanitizationFinding>();
+        var namedJavaScriptScan = new PdfSanitizerNamedJavaScriptScan(
+            readLimits.MaxNameTreeDepth,
+            readLimits.MaxNameTreeNodes,
+            readLimits.MaxIndirectObjects);
         foreach (KeyValuePair<int, PdfIndirectObject> item in objects.OrderBy(static item => item.Key)) {
             policy.CancellationToken.ThrowIfCancellationRequested();
-            ScanObject(objects, item.Value.Value, policy, item.Key, "Object[" + item.Key + "]", findings);
+            ScanObject(
+                objects,
+                item.Value.Value,
+                policy,
+                item.Key,
+                "Object[" + item.Key + "]",
+                findings,
+                namedJavaScriptScan);
         }
 
         return findings.Count == 0 ? Array.Empty<PdfSanitizationFinding>() : findings.AsReadOnly();
@@ -23,16 +35,17 @@ internal static partial class PdfSanitizer {
         PdfSanitizationOptions policy,
         int objectNumber,
         string path,
-        List<PdfSanitizationFinding> findings) {
+        List<PdfSanitizationFinding> findings,
+        PdfSanitizerNamedJavaScriptScan namedJavaScriptScan) {
         policy.CancellationToken.ThrowIfCancellationRequested();
         if (value is PdfStream stream) {
-            ScanDictionary(objects, stream.Dictionary, policy, objectNumber, path, findings);
+            ScanDictionary(objects, stream.Dictionary, policy, objectNumber, path, findings, namedJavaScriptScan);
         } else if (value is PdfDictionary dictionary) {
-            ScanDictionary(objects, dictionary, policy, objectNumber, path, findings);
+            ScanDictionary(objects, dictionary, policy, objectNumber, path, findings, namedJavaScriptScan);
         } else if (value is PdfArray array) {
             for (int i = 0; i < array.Items.Count; i++) {
                 if (array.Items[i] is not PdfReference) {
-                    ScanObject(objects, array.Items[i], policy, objectNumber, path + "[" + i + "]", findings);
+                    ScanObject(objects, array.Items[i], policy, objectNumber, path + "[" + i + "]", findings, namedJavaScriptScan);
                 }
             }
         }
@@ -44,7 +57,8 @@ internal static partial class PdfSanitizer {
         PdfSanitizationOptions policy,
         int objectNumber,
         string path,
-        List<PdfSanitizationFinding> findings) {
+        List<PdfSanitizationFinding> findings,
+        PdfSanitizerNamedJavaScriptScan namedJavaScriptScan) {
         policy.CancellationToken.ThrowIfCancellationRequested();
         if (TryGetForbiddenAction(objects, dictionary, policy, out PdfSanitizationFindingKind findingKind, out PdfSanitizationActionKind actionKind, out string? actionDetail)) {
             findings.Add(new PdfSanitizationFinding(findingKind, objectNumber, path, actionDetail!, actionKind));
@@ -63,7 +77,11 @@ internal static partial class PdfSanitizer {
 
             if (item.Key == "JavaScript" &&
                 policy.ShouldRemoveAction("JavaScript") &&
-                !ContainsSelectedJavaScriptAction(objects, item.Value, policy, new HashSet<PdfObject>())) {
+                !ContainsSelectedJavaScriptAction(
+                    objects,
+                    item.Value,
+                    policy,
+                    namedJavaScriptScan)) {
                 findings.Add(new PdfSanitizationFinding(
                     PdfSanitizationFindingKind.ActiveAction,
                     objectNumber,
@@ -81,7 +99,7 @@ internal static partial class PdfSanitizer {
             }
 
             if (item.Value is not PdfReference) {
-                ScanObject(objects, item.Value, policy, objectNumber, itemPath, findings);
+                ScanObject(objects, item.Value, policy, objectNumber, itemPath, findings, namedJavaScriptScan);
             }
         }
     }
@@ -110,6 +128,7 @@ internal static partial class PdfSanitizer {
         PdfSanitizationOptions policy,
         int maximumActionDepth,
         PdfSanitizerActionBudget actionBudget) {
+        policy.CancellationToken.ThrowIfCancellationRequested();
         if (value is PdfStream stream) {
             SanitizeDictionary(objects, stream.Dictionary, policy, maximumActionDepth, actionBudget);
         } else if (value is PdfDictionary dictionary) {
@@ -190,6 +209,7 @@ internal static partial class PdfSanitizer {
         int maximumActionDepth,
         PdfSanitizerActionBudget actionBudget) {
         for (int i = 0; i < actions.Items.Count; i++) {
+            policy.CancellationToken.ThrowIfCancellationRequested();
             if (actions.Items[i] is PdfDictionary action) {
                 SanitizeNormalizedActionDictionary(objects, action, policy, maximumActionDepth, actionBudget);
             }
@@ -202,6 +222,7 @@ internal static partial class PdfSanitizer {
         PdfSanitizationOptions policy,
         int maximumActionDepth,
         PdfSanitizerActionBudget actionBudget) {
+        policy.CancellationToken.ThrowIfCancellationRequested();
         if (action.Items.TryGetValue("Next", out PdfObject? nextObject)) {
             if (nextObject is PdfDictionary nextAction) {
                 SanitizeNormalizedActionDictionary(objects, nextAction, policy, maximumActionDepth, actionBudget);
@@ -224,6 +245,7 @@ internal static partial class PdfSanitizer {
         int depth,
         HashSet<(int ObjectNumber, int Generation)> pathReferences,
         PdfSanitizerActionBudget actionBudget) {
+        policy.CancellationToken.ThrowIfCancellationRequested();
         if (depth > maximumDepth) throw PdfReadLimitException.Create(PdfReadLimitKind.ObjectNestingDepth, maximumDepth, depth);
 
         if (actionObject is PdfReference reference) {
@@ -454,28 +476,104 @@ internal static partial class PdfSanitizer {
         Dictionary<int, PdfIndirectObject> objects,
         PdfObject value,
         PdfSanitizationOptions policy,
-        HashSet<PdfObject> visited) {
-        PdfObject? resolved = Resolve(objects, value);
-        if (resolved is null || !visited.Add(resolved)) return false;
-        if (resolved is PdfStream stream) {
-            return ContainsSelectedJavaScriptAction(objects, stream.Dictionary, policy, visited);
-        }
-        if (resolved is PdfDictionary dictionary) {
-            if (TryGetForbiddenAction(objects, dictionary, policy, out _, out PdfSanitizationActionKind actionKind, out _) &&
-                actionKind == PdfSanitizationActionKind.JavaScript) {
-                return true;
+        PdfSanitizerNamedJavaScriptScan scan) {
+        if (scan.TryGetCached(value, out bool cached)) return cached;
+
+        var pending = new Stack<(PdfObject Value, int NameTreeDepth, bool CountReferenceAsNameTreeNode, bool ArrayItemsAreNameTreeNodes)>();
+        var visitedObjects = new HashSet<PdfObject>();
+        var visitedReferences = new HashSet<(int ObjectNumber, int Generation)>();
+        pending.Push((value, 0, true, false));
+
+        while (pending.Count > 0) {
+            policy.CancellationToken.ThrowIfCancellationRequested();
+            (PdfObject current, int nameTreeDepth, bool countReferenceAsNameTreeNode, bool arrayItemsAreNameTreeNodes) = pending.Pop();
+            scan.EnsureDepth(nameTreeDepth);
+
+            if (current is PdfReference reference) {
+                var key = (reference.ObjectNumber, reference.Generation);
+                if (!visitedReferences.Add(key)) continue;
+                scan.ConsumeWorkNode();
+                if (countReferenceAsNameTreeNode) scan.ConsumeNameTreeNode();
+                if (!PdfObjectLookup.TryGet(objects, reference, out PdfIndirectObject? indirect)) continue;
+                pending.Push((indirect.Value, nameTreeDepth, false, arrayItemsAreNameTreeNodes));
+                continue;
             }
-            foreach (PdfObject child in dictionary.Items.Values) {
-                if (ContainsSelectedJavaScriptAction(objects, child, policy, visited)) return true;
+
+            if (!visitedObjects.Add(current)) continue;
+            if (current is PdfStream stream) {
+                pending.Push((stream.Dictionary, nameTreeDepth, false, false));
+                continue;
             }
-            return false;
-        }
-        if (resolved is PdfArray array) {
-            for (int i = 0; i < array.Items.Count; i++) {
-                if (ContainsSelectedJavaScriptAction(objects, array.Items[i], policy, visited)) return true;
+            if (current is PdfDictionary dictionary) {
+                if (TryGetForbiddenAction(objects, dictionary, policy, out _, out PdfSanitizationActionKind actionKind, out _) &&
+                    actionKind == PdfSanitizationActionKind.JavaScript) {
+                    scan.Cache(value, true);
+                    return true;
+                }
+                foreach (KeyValuePair<string, PdfObject> child in dictionary.Items) {
+                    bool isKids = string.Equals(child.Key, "Kids", StringComparison.Ordinal);
+                    pending.Push((child.Value, isKids ? nameTreeDepth + 1 : nameTreeDepth, false, isKids));
+                }
+                continue;
+            }
+            if (current is PdfArray array) {
+                for (int i = 0; i < array.Items.Count; i++) {
+                    pending.Push((array.Items[i], nameTreeDepth, arrayItemsAreNameTreeNodes, false));
+                }
             }
         }
+        scan.Cache(value, false);
         return false;
+    }
+
+    private sealed class PdfSanitizerNamedJavaScriptScan {
+        private readonly int _maximumDepth;
+        private readonly int _maximumNameTreeNodes;
+        private readonly int _maximumWorkNodes;
+        private readonly Dictionary<(int ObjectNumber, int Generation), bool> _referenceRootResults = new();
+        private readonly Dictionary<PdfObject, bool> _directRootResults = new();
+        private int _traversedNameTreeNodes;
+        private int _traversedWorkNodes;
+
+        internal PdfSanitizerNamedJavaScriptScan(int maximumDepth, int maximumNameTreeNodes, int maximumWorkNodes) {
+            _maximumDepth = maximumDepth;
+            _maximumNameTreeNodes = maximumNameTreeNodes;
+            _maximumWorkNodes = maximumWorkNodes;
+        }
+
+        internal bool TryGetCached(PdfObject root, out bool result) {
+            return root is PdfReference reference
+                ? _referenceRootResults.TryGetValue((reference.ObjectNumber, reference.Generation), out result)
+                : _directRootResults.TryGetValue(root, out result);
+        }
+
+        internal void Cache(PdfObject root, bool result) {
+            if (root is PdfReference reference) {
+                _referenceRootResults[(reference.ObjectNumber, reference.Generation)] = result;
+            } else {
+                _directRootResults[root] = result;
+            }
+        }
+
+        internal void EnsureDepth(int depth) {
+            if (depth > _maximumDepth) {
+                throw PdfReadLimitException.Create(PdfReadLimitKind.NameTreeDepth, _maximumDepth, depth);
+            }
+        }
+
+        internal void ConsumeNameTreeNode() {
+            _traversedNameTreeNodes++;
+            if (_traversedNameTreeNodes > _maximumNameTreeNodes) {
+                throw PdfReadLimitException.Create(PdfReadLimitKind.NameTreeNodes, _maximumNameTreeNodes, _traversedNameTreeNodes);
+            }
+        }
+
+        internal void ConsumeWorkNode() {
+            _traversedWorkNodes++;
+            if (_traversedWorkNodes > _maximumWorkNodes) {
+                throw PdfReadLimitException.Create(PdfReadLimitKind.IndirectObjects, _maximumWorkNodes, _traversedWorkNodes);
+            }
+        }
     }
 
     private static PdfObject? Resolve(Dictionary<int, PdfIndirectObject> objects, PdfObject? value) {

--- a/OfficeIMO.Pdf/Manipulation/PdfSanitizer.Traversal.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfSanitizer.Traversal.cs
@@ -46,8 +46,8 @@ internal static partial class PdfSanitizer {
         string path,
         List<PdfSanitizationFinding> findings) {
         policy.CancellationToken.ThrowIfCancellationRequested();
-        if (TryGetForbiddenAction(objects, dictionary, policy, out PdfSanitizationFindingKind actionKind, out string? actionDetail)) {
-            findings.Add(new PdfSanitizationFinding(actionKind, objectNumber, path, actionDetail!));
+        if (TryGetForbiddenAction(objects, dictionary, policy, out PdfSanitizationFindingKind findingKind, out PdfSanitizationActionKind actionKind, out string? actionDetail)) {
+            findings.Add(new PdfSanitizationFinding(findingKind, objectNumber, path, actionDetail!, actionKind));
         }
 
         if (IsRichAnnotation(objects, dictionary, policy, out string? annotationSubtype)) {
@@ -62,8 +62,11 @@ internal static partial class PdfSanitizer {
             }
 
             if (item.Key == "URI" && Resolve(objects, item.Value) is PdfDictionary uriDictionary &&
-                TryGetString(objects, uriDictionary, "Base", out string? baseUri) && !policy.IsUriAllowed(baseUri!)) {
-                findings.Add(new PdfSanitizationFinding(PdfSanitizationFindingKind.UnsafeUri, objectNumber, itemPath + "/Base", baseUri!));
+                TryGetString(objects, uriDictionary, "Base", out string? baseUri) && policy.ShouldRemoveCatalogUriBase(baseUri!)) {
+                PdfSanitizationFindingKind uriFindingKind = policy.ActionKindsToRemove.HasValue
+                    ? PdfSanitizationFindingKind.ActiveAction
+                    : PdfSanitizationFindingKind.UnsafeUri;
+                findings.Add(new PdfSanitizationFinding(uriFindingKind, objectNumber, itemPath + "/Base", baseUri!, PdfSanitizationActionKind.Uri));
             }
 
             if (item.Value is not PdfReference) {
@@ -115,7 +118,7 @@ internal static partial class PdfSanitizer {
         PdfSanitizationOptions policy,
         int maximumActionDepth,
         PdfSanitizerActionBudget actionBudget) {
-        if (!policy.IsActionAllowed("JavaScript")) {
+        if (policy.ShouldRemoveAction("JavaScript")) {
             dictionary.Items.Remove("JavaScript");
         }
 
@@ -138,7 +141,7 @@ internal static partial class PdfSanitizer {
             if (actionTraversalAlreadyNormalized && string.Equals(key, "Next", StringComparison.Ordinal)) continue;
 
             PdfObject? resolved = Resolve(objects, item);
-            if (resolved is PdfDictionary action && TryGetForbiddenAction(objects, action, policy, out _, out _)) {
+            if (resolved is PdfDictionary action && TryGetForbiddenAction(objects, action, policy, out _, out _, out _)) {
                 List<PdfDictionary> retained = action.Items.TryGetValue("Next", out PdfObject? next)
                     ? CollectRetainedActions(objects, next, policy, maximumActionDepth, 0, new HashSet<(int ObjectNumber, int Generation)>(), actionBudget)
                     : new List<PdfDictionary>();
@@ -159,7 +162,7 @@ internal static partial class PdfSanitizer {
             }
 
             if (key == "URI" && resolved is PdfDictionary uriDictionary &&
-                TryGetString(objects, uriDictionary, "Base", out string? baseUri) && !policy.IsUriAllowed(baseUri!)) {
+                TryGetString(objects, uriDictionary, "Base", out string? baseUri) && policy.ShouldRemoveCatalogUriBase(baseUri!)) {
                 uriDictionary.Items.Remove("Base");
             }
 
@@ -235,7 +238,7 @@ internal static partial class PdfSanitizer {
         action.Items.Remove("Next");
         AttachNextActions(action, children);
         actionBudget.MarkNormalized(action);
-        if (TryGetForbiddenAction(objects, action, policy, out _, out _)) return children;
+        if (TryGetForbiddenAction(objects, action, policy, out _, out _, out _)) return children;
 
         var clone = new PdfDictionary();
         foreach (KeyValuePair<string, PdfObject> item in action.Items) {
@@ -376,25 +379,31 @@ internal static partial class PdfSanitizer {
         PdfDictionary dictionary,
         PdfSanitizationOptions policy,
         out PdfSanitizationFindingKind kind,
+        out PdfSanitizationActionKind actionKind,
         out string? detail) {
         kind = PdfSanitizationFindingKind.ActiveAction;
+        actionKind = PdfSanitizationActionKind.None;
         detail = null;
         if (Resolve(objects, dictionary.Get<PdfObject>("S")) is not PdfName actionName) {
             return false;
         }
 
         string actionType = actionName.Name;
+        actionKind = PdfSanitizationOptions.GetActionKind(actionType);
         if (actionType == "URI") {
-            if (TryGetString(objects, dictionary, "URI", out string? uri) && !policy.IsUriAllowed(uri!)) {
-                kind = PdfSanitizationFindingKind.UnsafeUri;
-                detail = uri;
+            bool hasUri = TryGetString(objects, dictionary, "URI", out string? uri);
+            if (policy.ShouldRemoveAction(actionType, hasUri ? uri : null)) {
+                kind = policy.ActionKindsToRemove.HasValue
+                    ? PdfSanitizationFindingKind.ActiveAction
+                    : PdfSanitizationFindingKind.UnsafeUri;
+                detail = hasUri ? uri : actionType;
                 return true;
             }
 
             return false;
         }
 
-        if (!PdfActiveContentPolicy.IsUnsafeActionType(actionType) || policy.IsActionAllowed(actionType)) {
+        if (!policy.ShouldRemoveAction(actionType)) {
             return false;
         }
 

--- a/OfficeIMO.Pdf/Manipulation/PdfSanitizer.Traversal.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfSanitizer.Traversal.cs
@@ -61,6 +61,17 @@ internal static partial class PdfSanitizer {
                 findings.Add(new PdfSanitizationFinding(PdfSanitizationFindingKind.EmbeddedFile, objectNumber, itemPath, item.Key));
             }
 
+            if (item.Key == "JavaScript" &&
+                policy.ShouldRemoveAction("JavaScript") &&
+                !ContainsSelectedJavaScriptAction(objects, item.Value, policy, new HashSet<PdfObject>())) {
+                findings.Add(new PdfSanitizationFinding(
+                    PdfSanitizationFindingKind.ActiveAction,
+                    objectNumber,
+                    itemPath,
+                    "JavaScript",
+                    PdfSanitizationActionKind.JavaScript));
+            }
+
             if (item.Key == "URI" && Resolve(objects, item.Value) is PdfDictionary uriDictionary &&
                 TryGetString(objects, uriDictionary, "Base", out string? baseUri) && policy.ShouldRemoveCatalogUriBase(baseUri!)) {
                 PdfSanitizationFindingKind uriFindingKind = policy.ActionKindsToRemove.HasValue
@@ -436,6 +447,34 @@ internal static partial class PdfSanitizer {
         }
 
         value = null;
+        return false;
+    }
+
+    private static bool ContainsSelectedJavaScriptAction(
+        Dictionary<int, PdfIndirectObject> objects,
+        PdfObject value,
+        PdfSanitizationOptions policy,
+        HashSet<PdfObject> visited) {
+        PdfObject? resolved = Resolve(objects, value);
+        if (resolved is null || !visited.Add(resolved)) return false;
+        if (resolved is PdfStream stream) {
+            return ContainsSelectedJavaScriptAction(objects, stream.Dictionary, policy, visited);
+        }
+        if (resolved is PdfDictionary dictionary) {
+            if (TryGetForbiddenAction(objects, dictionary, policy, out _, out PdfSanitizationActionKind actionKind, out _) &&
+                actionKind == PdfSanitizationActionKind.JavaScript) {
+                return true;
+            }
+            foreach (PdfObject child in dictionary.Items.Values) {
+                if (ContainsSelectedJavaScriptAction(objects, child, policy, visited)) return true;
+            }
+            return false;
+        }
+        if (resolved is PdfArray array) {
+            for (int i = 0; i < array.Items.Count; i++) {
+                if (ContainsSelectedJavaScriptAction(objects, array.Items[i], policy, visited)) return true;
+            }
+        }
         return false;
     }
 

--- a/OfficeIMO.Pdf/Manipulation/PdfSanitizer.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfSanitizer.cs
@@ -17,7 +17,8 @@ internal static partial class PdfSanitizer {
         cancellationToken.ThrowIfCancellationRequested();
         var parsed = PdfSyntax.ParseObjects(pdf, readOptions, out _, out _, cancellationToken);
         cancellationToken.ThrowIfCancellationRequested();
-        return Scan(parsed.Map, policy);
+        PdfReadLimits readLimits = readOptions?.Limits ?? new PdfReadLimits();
+        return Scan(parsed.Map, policy, readLimits);
     }
 
     /// <summary>

--- a/OfficeIMO.Pdf/Manipulation/PdfSanitizer.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfSanitizer.cs
@@ -2,6 +2,9 @@ namespace OfficeIMO.Pdf;
 
 /// <summary>Removes or quarantines active content and embedded payloads through a proven full rewrite.</summary>
 internal static partial class PdfSanitizer {
+    internal static PdfSanitizationReport Inspect(byte[] pdf, PdfSanitizationOptions? options, PdfLoadOptions? readOptions) =>
+        new PdfSanitizationReport(Analyze(pdf, options, readOptions));
+
     /// <summary>Returns the forbidden-content inventory that the supplied policy would remove.</summary>
     public static IReadOnlyList<PdfSanitizationFinding> Analyze(byte[] pdf, PdfSanitizationOptions? options = null) {
         return Analyze(pdf, options, readOptions: null);
@@ -101,11 +104,11 @@ internal static partial class PdfSanitizer {
         PdfDocumentInfo originalInfo = PdfInspector.Inspect(pdf, sourceDocument, cancellationToken);
         for (int i = 0; i < originalInfo.LinkAnnotations.Count; i++) {
             string? uri = originalInfo.LinkAnnotations[i].Uri;
-            if (uri is not null && !policy.IsUriAllowed(uri)) preservationOptions.ExcludedLinkAnnotationUris.Add(uri);
+            if (uri is not null && policy.ShouldRemoveAction("URI", uri)) preservationOptions.ExcludedLinkAnnotationUris.Add(uri);
         }
         AddPolicyRetainedActionTypes(originalInfo, policy, preservationOptions.PreservedActionTypes);
         for (int i = 0; i < before.Count; i++) {
-            if (before[i].Kind == PdfSanitizationFindingKind.UnsafeUri) {
+            if (before[i].ActionKind == PdfSanitizationActionKind.Uri) {
                 preservationOptions.ExcludedActionUris.Add(before[i].Detail);
             }
         }
@@ -139,7 +142,7 @@ internal static partial class PdfSanitizer {
     }
 
     private static void AddPolicyRetainedActionType(string actionType, PdfSanitizationOptions policy, ISet<string> preservedActionTypes) {
-        if (!PdfActiveContentPolicy.IsUnsafeActionType(actionType) || policy.IsActionAllowed(actionType)) preservedActionTypes.Add(actionType);
+        if (!policy.ShouldRemoveAction(actionType)) preservedActionTypes.Add(actionType);
     }
 
     /// <summary>Sanitizes a PDF from the current position of a readable stream.</summary>

--- a/OfficeIMO.Pdf/README.md
+++ b/OfficeIMO.Pdf/README.md
@@ -104,6 +104,30 @@ returning it. Per-script, script-count, and aggregate-byte limits come from
 sanitizer removes it, and full-rewrite edits are blocked for encrypted or signed
 inputs rather than weakening their security or revision contracts.
 
+### Preview and select active-content removal
+
+```csharp
+PdfDocument incoming = PdfDocument.Load("incoming.pdf");
+var policy = new PdfSanitizationOptions {
+    ActionKindsToRemove = PdfSanitizationActionKind.JavaScript |
+        PdfSanitizationActionKind.Launch |
+        PdfSanitizationActionKind.SubmitForm
+};
+
+PdfSanitizationReport preview = incoming.InspectSanitization(policy);
+Console.WriteLine($"Scripts: {preview.ActionCounts.JavaScript}");
+Console.WriteLine($"Launch actions: {preview.ActionCounts.Launch}");
+
+PdfSanitizationResult result = incoming.Sanitize(policy);
+File.WriteAllBytes("sanitized.pdf", result.ToBytes());
+```
+
+`ActionKindsToRemove` is an exact opt-in selection, so unselected action kinds
+remain. Selecting `Uri` removes every URI action and catalog URI base, including
+ordinary web links. Leave the property null for the established default policy:
+known active-content actions are removed, allowed `http`, `https`, `mailto`, and
+`tel` links remain, and URI schemes outside `AllowedUriSchemes` are removed.
+
 ### Add interactive fields to an existing PDF
 
 ```csharp


### PR DESCRIPTION
## Summary

- add exact, composable action-kind selection to the existing `PdfSanitizationOptions`
- add a non-mutating `InspectSanitization` preview with typed per-action counts
- expose typed removed and remaining action counts on sanitization results
- preserve the established default URI scheme policy and explicit action allow-list behavior
- treat explicit URI selection as all URI actions and catalog URI bases, including ordinary links
- inventory malformed named-JavaScript containers when the same policy will remove them
- bound named-JavaScript inspection with iterative, cancellation-aware traversal, scan-wide caching, canonical name-tree limits, and a separate indirect-object work budget
- document the preview-and-apply workflow

## Validation

- focused `PdfSanitizerTests`: 49 passed on .NET 10 and .NET Framework 4.7.2
- `OfficeIMO.Pdf.Tests` on .NET 8 and .NET 10: 6,155 passed per target
- independent local review covered cyclic, shared, deep, dangling, and action-payload reference graphs plus limit and cancellation behavior

Closes #2430