### PR TITLE
Add combined PDF before-sharing sanitization

### DIFF
--- a/OfficeIMO.Pdf.Tests/Pdf/PdfSanitizerTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfSanitizerTests.cs
@@ -155,6 +155,188 @@ public class PdfSanitizerTests {
         Assert.DoesNotContain("PRIVATE-INDIRECT-LAYER", raw, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void UserMetadataSanitizationRemovesCustomInfoFieldsButKeepsTechnicalFields() {
+        byte[] source = BuildCustomInfoMetadataPdf();
+        var policy = new PdfSanitizationOptions {
+            ContentKindsToRemove = PdfSanitizationContentKind.UserMetadata
+        };
+
+        PdfSanitizationReport preview = PdfDocument.Load(source).InspectSanitization(policy);
+        PdfSanitizationResult result = PdfDocument.Load(source).Sanitize(policy);
+        string raw = PdfEncoding.Latin1GetString(result.ToBytes());
+
+        Assert.Equal(3, preview.CategoryCounts.UserMetadata);
+        Assert.DoesNotContain("PRIVATE-COMPANY", raw, StringComparison.Ordinal);
+        Assert.DoesNotContain("PRIVATE-CUSTOM", raw, StringComparison.Ordinal);
+        Assert.Null(ReadInfoString(result.ToBytes(), "Company"));
+        Assert.Null(ReadInfoString(result.ToBytes(), "CustomField"));
+        Assert.Equal("OfficeIMO-Test", ReadInfoString(result.ToBytes(), "Producer"));
+        Assert.Contains("/CreationDate", raw, StringComparison.Ordinal);
+        Assert.Contains("/ModDate", raw, StringComparison.Ordinal);
+        Assert.Contains("/Trapped /False", raw, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UserMetadataSelectionPreservesComponentLevelXmpOutsideTheCatalogScope() {
+        byte[] source = BuildComponentXmpMetadataPdf();
+        var policy = new PdfSanitizationOptions {
+            ContentKindsToRemove = PdfSanitizationContentKind.UserMetadata
+        };
+
+        PdfSanitizationReport preview = PdfDocument.Load(source).InspectSanitization(policy);
+        PdfSanitizationResult result = PdfDocument.Load(source).Sanitize(policy);
+
+        Assert.Equal(0, preview.CategoryCounts.UserMetadata);
+        Assert.Contains("COMPONENT-XMP", PdfEncoding.Latin1GetString(result.ToBytes()), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BookmarkSanitizationClearsReverseLinkedAliasedOutlineItems() {
+        byte[] source = BuildReverseLinkedAliasedOutlinePdf();
+        var policy = new PdfSanitizationOptions {
+            ContentKindsToRemove = PdfSanitizationContentKind.Bookmarks
+        };
+
+        PdfSanitizationReport preview = PdfDocument.Load(source).InspectSanitization(policy);
+        PdfSanitizationResult result = PdfDocument.Load(source).Sanitize(policy);
+
+        Assert.Equal(2, preview.CategoryCounts.Bookmarks);
+        Assert.DoesNotContain("PRIVATE-REVERSE-BOOKMARK", PdfEncoding.Latin1GetString(result.ToBytes()), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EmbeddedFileSanitizationClearsAliasedFileSpecificationMetadata() {
+        byte[] source = BuildAliasedFileSpecificationPdf();
+        var policy = new PdfSanitizationOptions {
+            ContentKindsToRemove = PdfSanitizationContentKind.EmbeddedFiles
+        };
+
+        PdfSanitizationResult result = PdfDocument.Load(source).Sanitize(policy);
+        string raw = PdfEncoding.Latin1GetString(result.ToBytes());
+
+        Assert.DoesNotContain("PRIVATE-FILENAME", raw, StringComparison.Ordinal);
+        Assert.DoesNotContain("PRIVATE-FILE-DESCRIPTION", raw, StringComparison.Ordinal);
+        Assert.DoesNotContain("PRIVATE-FILE-PAYLOAD", raw, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EmbeddedFileSelectionPreservesExternalFileSpecificationsUsedByActions() {
+        byte[] source = BuildExternalFileSpecificationActionPdf();
+        var policy = new PdfSanitizationOptions {
+            ContentKindsToRemove = PdfSanitizationContentKind.EmbeddedFiles
+        };
+
+        PdfSanitizationResult result = PdfDocument.Load(source).Sanitize(policy);
+        var (objects, _) = PdfSyntax.ParseObjects(result.ToBytes());
+        PdfDictionary fileSpecification = Assert.Single(
+            objects.Values.Select(static item => item.Value as PdfDictionary),
+            static dictionary => dictionary?.Get<PdfName>("Type")?.Name == "Filespec")!;
+        PdfDictionary catalog = Assert.IsType<PdfDictionary>(objects[1].Value);
+        PdfReference openActionReference = Assert.IsType<PdfReference>(catalog.Items["OpenAction"]);
+        PdfDictionary openAction = Assert.IsType<PdfDictionary>(objects[openActionReference.ObjectNumber].Value);
+        PdfReference actionFileReference = Assert.IsType<PdfReference>(openAction.Items["F"]);
+
+        Assert.Equal("remote.pdf", fileSpecification.Get<PdfStringObj>("F")?.Value);
+        Assert.Equal("GoToR", openAction.Get<PdfName>("S")?.Name);
+        Assert.Same(fileSpecification, objects[actionFileReference.ObjectNumber].Value);
+    }
+
+    [Fact]
+    public void OptionalContentSanitizationClearsAliasedConfigurationMetadata() {
+        byte[] source = BuildAliasedOptionalContentConfigurationPdf();
+        var policy = new PdfSanitizationOptions {
+            ContentKindsToRemove = PdfSanitizationContentKind.OptionalContent
+        };
+
+        PdfSanitizationResult result = PdfDocument.Load(source).Sanitize(policy);
+        string raw = PdfEncoding.Latin1GetString(result.ToBytes());
+
+        Assert.DoesNotContain("PRIVATE-LAYER-CONFIG", raw, StringComparison.Ordinal);
+        Assert.DoesNotContain("PRIVATE-LAYER-CREATOR", raw, StringComparison.Ordinal);
+        Assert.DoesNotContain("PRIVATE-LAYER-NAME", raw, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LegacyPolicyCanRetainFileAttachmentAnnotationWhileRemovingItsPayload() {
+        byte[] source = BuildBeforeSharingPdf();
+        var policy = new PdfSanitizationOptions { RemoveRichMedia = false };
+
+        PdfSanitizationResult result = PdfDocument.Load(source).Sanitize(policy);
+        PdfDocumentInfo info = result.ToDocument().Inspect();
+
+        Assert.Contains(info.Annotations, static annotation => annotation.Subtype == "FileAttachment");
+        Assert.Empty(info.Attachments);
+        Assert.DoesNotContain("PRIVATE-ATTACHMENT-PAYLOAD", PdfEncoding.Latin1GetString(result.ToBytes()), StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(PdfSanitizationContentKind.EmbeddedFiles, "UseAttachments")]
+    [InlineData(PdfSanitizationContentKind.OptionalContent, "UseOC")]
+    public void SanitizationResetsPageModesWhosePanelsWereRemoved(PdfSanitizationContentKind kind, string pageMode) {
+        byte[] source = BuildCategoryPageModePdf(kind, pageMode);
+        var policy = new PdfSanitizationOptions { ContentKindsToRemove = kind };
+
+        PdfSanitizationResult result = PdfDocument.Load(source).Sanitize(policy);
+
+        Assert.NotEqual(pageMode, result.ToDocument().Inspect().CatalogPageMode);
+    }
+
+    [Theory]
+    [InlineData(PdfSanitizationContentKind.EmbeddedFiles, "UseAttachments")]
+    [InlineData(PdfSanitizationContentKind.OptionalContent, "UseOC")]
+    [InlineData(PdfSanitizationContentKind.Bookmarks, "UseOutlines")]
+    public void SanitizationResetsIndirectPageModesWhosePanelsWereRemoved(PdfSanitizationContentKind kind, string pageMode) {
+        byte[] source = BuildIndirectCategoryPageModePdf(kind, pageMode);
+        var policy = new PdfSanitizationOptions { ContentKindsToRemove = kind };
+
+        PdfSanitizationResult result = PdfDocument.Load(source).Sanitize(policy);
+
+        Assert.NotEqual(pageMode, result.ToDocument().Inspect().CatalogPageMode);
+    }
+
+    [Fact]
+    public void BookmarkSanitizationCountsAndClearsALastOnlyReverseLinkedTree() {
+        byte[] source = BuildLastOnlyOutlinePdf();
+        var policy = new PdfSanitizationOptions {
+            ContentKindsToRemove = PdfSanitizationContentKind.Bookmarks
+        };
+
+        PdfSanitizationReport preview = PdfDocument.Load(source).InspectSanitization(policy);
+        PdfSanitizationResult result = PdfDocument.Load(source).Sanitize(policy);
+
+        Assert.Equal(2, preview.CategoryCounts.Bookmarks);
+        Assert.DoesNotContain("PRIVATE-LAST-ONLY", PdfEncoding.Latin1GetString(result.ToBytes()), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ExactActionInspectionDoesNotTraverseAnUnselectedAttachmentNameTree() {
+        byte[] source = BuildDeepAttachmentNameTreeWithActionPdf();
+        var readOptions = new PdfLoadOptions {
+            Limits = new PdfReadLimits { MaxNameTreeDepth = 1 }
+        };
+        var policy = new PdfSanitizationOptions {
+            ContentKindsToRemove = PdfSanitizationContentKind.Actions,
+            ActionKindsToRemove = PdfSanitizationActionKind.JavaScript
+        };
+
+        PdfSanitizationReport report = PdfDocument.Load(source, readOptions).InspectSanitization(policy);
+
+        Assert.Equal(1, report.ActionCounts.JavaScript);
+        Assert.Equal(0, report.CategoryCounts.EmbeddedFiles);
+    }
+
+    [Fact]
+    public void LegacyRichMediaScanAndRewriteShareTheSameReachableDictionaryScope() {
+        byte[] source = BuildAliasedUntypedRichMediaPdf();
+
+        PdfSanitizationResult result = PdfDocument.Load(source).Sanitize();
+
+        Assert.True(result.IsSanitized);
+        Assert.Empty(result.RemainingFindings);
+        Assert.DoesNotContain("PRIVATE-UNTYPED-RICH-MEDIA", PdfEncoding.Latin1GetString(result.ToBytes()), StringComparison.Ordinal);
+    }
+
     [Theory]
     [InlineData(PdfSanitizationContentKind.UserMetadata)]
     [InlineData(PdfSanitizationContentKind.EmbeddedFiles)]
@@ -829,6 +1011,168 @@ public class PdfSanitizerTests {
         }) + "\n";
 
         return Encoding.ASCII.GetBytes(pdf);
+    }
+
+    private static byte[] BuildCustomInfoMetadataPdf() {
+        return Encoding.ASCII.GetBytes(string.Join("\n", new[] {
+            "%PDF-1.7",
+            "1 0 obj", "<< /Type /Catalog /Pages 2 0 R >>", "endobj",
+            "2 0 obj", "<< /Type /Pages /Count 1 /Kids [3 0 R] >>", "endobj",
+            "3 0 obj", "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R >>", "endobj",
+            StreamObject(4, string.Empty, string.Empty),
+            "5 0 obj", "<< /Title (PRIVATE-TITLE) /Company (PRIVATE-COMPANY) /CustomField (PRIVATE-CUSTOM) /Producer (OfficeIMO-Test) /CreationDate (D:20260102030405Z) /ModDate (D:20260203040506Z) /Trapped /False >>", "endobj",
+            "trailer", "<< /Root 1 0 R /Info 5 0 R /Size 6 >>", "%%EOF"
+        }));
+    }
+
+    private static byte[] BuildComponentXmpMetadataPdf() {
+        const string xmp = "<?xpacket begin=''?><x:xmpmeta xmlns:x='adobe:ns:meta/'>COMPONENT-XMP</x:xmpmeta><?xpacket end='w'?>";
+        return Encoding.ASCII.GetBytes(string.Join("\n", new[] {
+            "%PDF-1.7",
+            "1 0 obj", "<< /Type /Catalog /Pages 2 0 R >>", "endobj",
+            "2 0 obj", "<< /Type /Pages /Count 1 /Kids [3 0 R] >>", "endobj",
+            "3 0 obj", "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R /Metadata 5 0 R >>", "endobj",
+            StreamObject(4, string.Empty, string.Empty),
+            StreamObject(5, "/Type /Metadata /Subtype /XML", xmp),
+            "trailer", "<< /Root 1 0 R /Size 6 >>", "%%EOF"
+        }));
+    }
+
+    private static byte[] BuildReverseLinkedAliasedOutlinePdf() {
+        return Encoding.ASCII.GetBytes(string.Join("\n", new[] {
+            "%PDF-1.7",
+            "1 0 obj", "<< /Type /Catalog /Pages 2 0 R /Outlines 10 0 R /PieceInfo << /Private 12 0 R >> >>", "endobj",
+            "2 0 obj", "<< /Type /Pages /Count 1 /Kids [3 0 R] >>", "endobj",
+            "3 0 obj", "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R >>", "endobj",
+            StreamObject(4, string.Empty, string.Empty),
+            "10 0 obj", "<< /Type /Outlines /First 11 0 R /Last 12 0 R /Count 2 >>", "endobj",
+            "11 0 obj", "<< /Title (FIRST-BOOKMARK) /Parent 10 0 R >>", "endobj",
+            "12 0 obj", "<< /Title (PRIVATE-REVERSE-BOOKMARK) /Parent 10 0 R /Prev 11 0 R >>", "endobj",
+            "trailer", "<< /Root 1 0 R /Size 13 >>", "%%EOF"
+        }));
+    }
+
+    private static byte[] BuildAliasedFileSpecificationPdf() {
+        return Encoding.ASCII.GetBytes(string.Join("\n", new[] {
+            "%PDF-1.7",
+            "1 0 obj", "<< /Type /Catalog /Pages 2 0 R /Names << /EmbeddedFiles << /Names [(PRIVATE-FILENAME.txt) 6 0 R] >> >> /PieceInfo << /Private 6 0 R >> >>", "endobj",
+            "2 0 obj", "<< /Type /Pages /Count 1 /Kids [3 0 R] >>", "endobj",
+            "3 0 obj", "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R >>", "endobj",
+            StreamObject(4, string.Empty, string.Empty),
+            StreamObject(5, "/Type /EmbeddedFile", "PRIVATE-FILE-PAYLOAD"),
+            "6 0 obj", "<< /Type /Filespec /F (PRIVATE-FILENAME.txt) /UF (PRIVATE-FILENAME.txt) /Desc (PRIVATE-FILE-DESCRIPTION) /EF << /F 5 0 R >> >>", "endobj",
+            "trailer", "<< /Root 1 0 R /Size 7 >>", "%%EOF"
+        }));
+    }
+
+    private static byte[] BuildAliasedOptionalContentConfigurationPdf() {
+        return Encoding.ASCII.GetBytes(string.Join("\n", new[] {
+            "%PDF-1.7",
+            "1 0 obj", "<< /Type /Catalog /Pages 2 0 R /OCProperties 6 0 R /PieceInfo << /Private 7 0 R >> >>", "endobj",
+            "2 0 obj", "<< /Type /Pages /Count 1 /Kids [3 0 R] >>", "endobj",
+            "3 0 obj", "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Resources << /Properties << /Layer 8 0 R >> >> /Contents 4 0 R >>", "endobj",
+            StreamObject(4, string.Empty, string.Empty),
+            "6 0 obj", "<< /OCGs [8 0 R] /D 7 0 R >>", "endobj",
+            "7 0 obj", "<< /Name (PRIVATE-LAYER-CONFIG) /Creator (PRIVATE-LAYER-CREATOR) /ON [8 0 R] >>", "endobj",
+            "8 0 obj", "<< /Type /OCG /Name (PRIVATE-LAYER-NAME) >>", "endobj",
+            "trailer", "<< /Root 1 0 R /Size 9 >>", "%%EOF"
+        }));
+    }
+
+    private static byte[] BuildCategoryPageModePdf(PdfSanitizationContentKind kind, string pageMode) {
+        string catalog = kind switch {
+            PdfSanitizationContentKind.EmbeddedFiles =>
+                "<< /Type /Catalog /Pages 2 0 R /PageMode /" + pageMode + " /Names << /EmbeddedFiles << /Names [(payload.txt) 6 0 R] >> >> >>",
+            PdfSanitizationContentKind.OptionalContent =>
+                "<< /Type /Catalog /Pages 2 0 R /PageMode /" + pageMode + " /OCProperties << /OCGs [6 0 R] /D << /ON [6 0 R] >> >> >>",
+            PdfSanitizationContentKind.Bookmarks =>
+                "<< /Type /Catalog /Pages 2 0 R /PageMode /" + pageMode + " /Outlines 6 0 R >>",
+            _ => throw new ArgumentOutOfRangeException(nameof(kind))
+        };
+        var lines = new List<string> {
+            "%PDF-1.7",
+            "1 0 obj",
+            catalog,
+            "endobj",
+            "2 0 obj", "<< /Type /Pages /Count 1 /Kids [3 0 R] >>", "endobj",
+            "3 0 obj", "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R >>", "endobj",
+            StreamObject(4, string.Empty, string.Empty)
+        };
+        if (kind == PdfSanitizationContentKind.EmbeddedFiles) {
+            lines.Add(StreamObject(5, "/Type /EmbeddedFile", "payload"));
+            lines.Add("6 0 obj\n<< /Type /Filespec /F (payload.txt) /EF << /F 5 0 R >> >>\nendobj");
+        } else if (kind == PdfSanitizationContentKind.OptionalContent) {
+            lines.Add("6 0 obj\n<< /Type /OCG /Name (Layer) >>\nendobj");
+        } else {
+            lines.Add("6 0 obj\n<< /Type /Outlines >>\nendobj");
+        }
+        lines.Add("trailer");
+        lines.Add("<< /Root 1 0 R /Size 7 >>");
+        lines.Add("%%EOF");
+        return Encoding.ASCII.GetBytes(string.Join("\n", lines));
+    }
+
+    private static byte[] BuildIndirectCategoryPageModePdf(PdfSanitizationContentKind kind, string pageMode) {
+        string pdf = Encoding.ASCII.GetString(BuildCategoryPageModePdf(kind, pageMode));
+        pdf = pdf.Replace("/PageMode /" + pageMode, "/PageMode 9 0 R")
+            .Replace(
+                "trailer\n<< /Root 1 0 R /Size 7 >>",
+                "9 0 obj\n/" + pageMode + "\nendobj\ntrailer\n<< /Root 1 0 R /Size 10 >>");
+        return Encoding.ASCII.GetBytes(pdf);
+    }
+
+    private static byte[] BuildExternalFileSpecificationActionPdf() {
+        return Encoding.ASCII.GetBytes(string.Join("\n", new[] {
+            "%PDF-1.7",
+            "1 0 obj", "<< /Type /Catalog /Pages 2 0 R /OpenAction 5 0 R >>", "endobj",
+            "2 0 obj", "<< /Type /Pages /Count 1 /Kids [3 0 R] >>", "endobj",
+            "3 0 obj", "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R >>", "endobj",
+            StreamObject(4, string.Empty, string.Empty),
+            "5 0 obj", "<< /S /GoToR /F 6 0 R /D [0 /Fit] >>", "endobj",
+            "6 0 obj", "<< /Type /Filespec /F (remote.pdf) >>", "endobj",
+            "trailer", "<< /Root 1 0 R /Size 7 >>", "%%EOF"
+        }));
+    }
+
+    private static byte[] BuildLastOnlyOutlinePdf() {
+        return Encoding.ASCII.GetBytes(string.Join("\n", new[] {
+            "%PDF-1.7",
+            "1 0 obj", "<< /Type /Catalog /Pages 2 0 R /Outlines 10 0 R >>", "endobj",
+            "2 0 obj", "<< /Type /Pages /Count 1 /Kids [3 0 R] >>", "endobj",
+            "3 0 obj", "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R >>", "endobj",
+            StreamObject(4, string.Empty, string.Empty),
+            "10 0 obj", "<< /Type /Outlines /Last 12 0 R /Count 2 >>", "endobj",
+            "11 0 obj", "<< /Title (PRIVATE-LAST-ONLY-FIRST) /Parent 10 0 R >>", "endobj",
+            "12 0 obj", "<< /Title (PRIVATE-LAST-ONLY-SECOND) /Parent 10 0 R /Prev 11 0 R >>", "endobj",
+            "trailer", "<< /Root 1 0 R /Size 13 >>", "%%EOF"
+        }));
+    }
+
+    private static byte[] BuildDeepAttachmentNameTreeWithActionPdf() {
+        return Encoding.ASCII.GetBytes(string.Join("\n", new[] {
+            "%PDF-1.7",
+            "1 0 obj", "<< /Type /Catalog /Pages 2 0 R /Names << /EmbeddedFiles 5 0 R >> /OpenAction 8 0 R >>", "endobj",
+            "2 0 obj", "<< /Type /Pages /Count 1 /Kids [3 0 R] >>", "endobj",
+            "3 0 obj", "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R >>", "endobj",
+            StreamObject(4, string.Empty, string.Empty),
+            "5 0 obj", "<< /Kids [6 0 R] >>", "endobj",
+            "6 0 obj", "<< /Kids [7 0 R] >>", "endobj",
+            "7 0 obj", "<< /Names [] >>", "endobj",
+            "8 0 obj", "<< /S /JavaScript /JS (app.alert('selected')) >>", "endobj",
+            "trailer", "<< /Root 1 0 R /Size 9 >>", "%%EOF"
+        }));
+    }
+
+    private static byte[] BuildAliasedUntypedRichMediaPdf() {
+        return Encoding.ASCII.GetBytes(string.Join("\n", new[] {
+            "%PDF-1.7",
+            "1 0 obj", "<< /Type /Catalog /Pages 2 0 R /PieceInfo << /Private 5 0 R >> >>", "endobj",
+            "2 0 obj", "<< /Type /Pages /Count 1 /Kids [3 0 R] >>", "endobj",
+            "3 0 obj", "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R >>", "endobj",
+            StreamObject(4, string.Empty, string.Empty),
+            "5 0 obj", "<< /Subtype /RichMedia /Contents (PRIVATE-UNTYPED-RICH-MEDIA) >>", "endobj",
+            "trailer", "<< /Root 1 0 R /Size 6 >>", "%%EOF"
+        }));
     }
 
     private static byte[] BuildBeforeSharingPdf() {

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfSanitizerTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfSanitizerTests.cs
@@ -6,6 +6,115 @@ namespace OfficeIMO.Tests.Pdf;
 
 public class PdfSanitizerTests {
     [Fact]
+    public void InspectAndSanitizeBeforeSharingUsesOneTypedPolicyAndVerifiedRewrite() {
+        byte[] source = BuildBeforeSharingPdf();
+        var policy = new PdfSanitizationOptions {
+            ContentKindsToRemove = PdfSanitizationContentKind.All,
+            ActionKindsToRemove = PdfSanitizationActionKind.All
+        };
+
+        PdfSanitizationReport preview = PdfDocument.Load(source).InspectSanitization(policy);
+
+        Assert.Equal(6, preview.CategoryCounts.UserMetadata);
+        Assert.Equal(1, preview.CategoryCounts.EmbeddedFiles);
+        Assert.Equal(2, preview.CategoryCounts.Actions);
+        Assert.Equal(1, preview.CategoryCounts.CommentsAndMarkup);
+        Assert.Equal(1, preview.CategoryCounts.Bookmarks);
+        Assert.Equal(1, preview.CategoryCounts.OptionalContent);
+        Assert.Equal(12, preview.TotalCount);
+
+        PdfSanitizationResult result = PdfDocument.Load(source).Sanitize(policy);
+        PdfDocumentInfo info = result.ToDocument().Inspect();
+        string raw = PdfEncoding.Latin1GetString(result.ToBytes());
+
+        Assert.True(result.IsSanitized);
+        Assert.Equal(12, result.RemovedCategoryCounts.Total);
+        Assert.Equal(0, result.RemainingCategoryCounts.Total);
+        Assert.Null(info.Metadata.Title);
+        Assert.Null(info.Metadata.Author);
+        Assert.Null(info.Metadata.Subject);
+        Assert.Null(info.Metadata.Keywords);
+        Assert.False(info.HasXmpMetadata);
+        Assert.Empty(info.Attachments);
+        Assert.Empty(info.Outlines);
+        Assert.False(info.HasOptionalContent);
+        Assert.DoesNotContain(info.Annotations, static annotation => annotation.Subtype == "Text" || annotation.Subtype == "FileAttachment");
+        Assert.Contains(info.Annotations, static annotation => annotation.Subtype == "Link");
+        Assert.Contains(info.Annotations, static annotation => annotation.Subtype == "Widget");
+        Assert.Equal("OfficeIMO-Test", ReadInfoString(result.ToBytes(), "Producer"));
+        Assert.Equal(new DateTimeOffset(2026, 1, 2, 3, 4, 5, TimeSpan.Zero), info.Metadata.CreationDate);
+        Assert.Equal(new DateTimeOffset(2026, 2, 3, 4, 5, 6, TimeSpan.Zero), info.Metadata.ModificationDate);
+        Assert.Equal(PdfTrappingStatus.False, info.Metadata.TrappingStatus);
+        Assert.DoesNotContain("PRIVATE-", raw, StringComparison.Ordinal);
+        Assert.Contains("VISIBLE-PAGE-CONTENT", result.ToDocument().Read().Text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SanitizeBeforeSharingCanRemoveOnlyUserMetadata() {
+        byte[] source = BuildBeforeSharingPdf();
+        var policy = new PdfSanitizationOptions {
+            ContentKindsToRemove = PdfSanitizationContentKind.UserMetadata,
+            ActionKindsToRemove = PdfSanitizationActionKind.All
+        };
+
+        PdfSanitizationResult result = PdfDocument.Load(source).Sanitize(policy);
+        PdfDocumentInfo info = result.ToDocument().Inspect();
+
+        Assert.True(result.IsSanitized);
+        Assert.Equal(6, result.RemovedCategoryCounts.UserMetadata);
+        Assert.Equal(0, result.RemovedCategoryCounts.Actions);
+        Assert.Single(info.Attachments);
+        Assert.Single(info.Outlines);
+        Assert.True(info.HasOptionalContent);
+        Assert.Contains(info.Annotations, static annotation => annotation.Subtype == "Text");
+        Assert.Contains(PdfSanitizer.Analyze(result.ToBytes()), static finding => finding.ActionKind == PdfSanitizationActionKind.JavaScript);
+    }
+
+    [Theory]
+    [InlineData(PdfSanitizationContentKind.UserMetadata)]
+    [InlineData(PdfSanitizationContentKind.EmbeddedFiles)]
+    [InlineData(PdfSanitizationContentKind.Actions)]
+    [InlineData(PdfSanitizationContentKind.CommentsAndMarkup)]
+    [InlineData(PdfSanitizationContentKind.Bookmarks)]
+    [InlineData(PdfSanitizationContentKind.OptionalContent)]
+    public void SanitizeBeforeSharingUsesAnExactContentCategorySelection(PdfSanitizationContentKind selected) {
+        byte[] source = BuildBeforeSharingPdf();
+        var allCategories = new PdfSanitizationOptions {
+            ContentKindsToRemove = PdfSanitizationContentKind.All,
+            ActionKindsToRemove = PdfSanitizationActionKind.All
+        };
+        var selectedCategory = new PdfSanitizationOptions {
+            ContentKindsToRemove = selected,
+            ActionKindsToRemove = PdfSanitizationActionKind.All
+        };
+
+        PdfSanitizationReport before = PdfDocument.Load(source).InspectSanitization(allCategories);
+        PdfSanitizationResult result = PdfDocument.Load(source).Sanitize(selectedCategory);
+        PdfSanitizationReport after = result.ToDocument().InspectSanitization(allCategories);
+
+        Assert.True(result.IsSanitized);
+        Assert.Equal(before.CategoryCounts.GetCount(selected), result.RemovedCategoryCounts.GetCount(selected));
+        Assert.Equal(0, after.CategoryCounts.GetCount(selected));
+        foreach (PdfSanitizationContentKind unselected in new[] {
+                     PdfSanitizationContentKind.UserMetadata,
+                     PdfSanitizationContentKind.EmbeddedFiles,
+                     PdfSanitizationContentKind.Actions,
+                     PdfSanitizationContentKind.CommentsAndMarkup,
+                     PdfSanitizationContentKind.Bookmarks,
+                     PdfSanitizationContentKind.OptionalContent
+                 }.Where(kind => kind != selected)) {
+            Assert.Equal(before.CategoryCounts.GetCount(unselected), after.CategoryCounts.GetCount(unselected));
+        }
+    }
+
+    [Fact]
+    public void SanitizationOptionsRejectUnsupportedContentKindBits() {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new PdfSanitizationOptions {
+            ContentKindsToRemove = (PdfSanitizationContentKind)(1 << 20)
+        });
+    }
+
+    [Fact]
     public void InspectSanitization_ReportsTypedActionCountsForTheDefaultPolicy() {
         PdfSanitizationReport report = PdfDocument.Load(BuildActiveContentPdf()).InspectSanitization();
 
@@ -637,6 +746,40 @@ public class PdfSanitizerTests {
         return Encoding.ASCII.GetBytes(pdf);
     }
 
+    private static byte[] BuildBeforeSharingPdf() {
+        const string pageContent = "BT /F1 12 Tf 20 150 Td (VISIBLE-PAGE-CONTENT) Tj ET\n/OC /Layer BDC BT /F1 12 Tf 20 120 Td (VISIBLE-AFTER-LAYER-FLATTEN) Tj ET EMC";
+        const string xmp = "<?xpacket begin=''?><x:xmpmeta xmlns:x='adobe:ns:meta/'><rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'><rdf:Description rdf:about='' xmlns:dc='http://purl.org/dc/elements/1.1/'><dc:title><rdf:Alt><rdf:li xml:lang='x-default'>PRIVATE-XMP-TITLE</rdf:li></rdf:Alt></dc:title></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end='w'?>";
+        const string payload = "PRIVATE-ATTACHMENT-PAYLOAD";
+        string pdf = string.Join("\n", new[] {
+            "%PDF-1.7",
+            "1 0 obj",
+            "<< /Type /Catalog /Pages 2 0 R /Outlines 10 0 R /PageMode /UseOutlines /Names << /EmbeddedFiles << /Names [(payload.txt) 14 0 R] >> /JavaScript << /Names [(startup) 17 0 R] >> >> /Metadata 12 0 R /OCProperties << /OCGs [16 0 R] /D << /ON [16 0 R] /Order [16 0 R] >> >> >>",
+            "endobj",
+            "2 0 obj", "<< /Type /Pages /Count 1 /Kids [3 0 R] >>", "endobj",
+            "3 0 obj",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 240 180] /Resources << /Font << /F1 8 0 R >> /Properties << /Layer 16 0 R >> >> /Contents 4 0 R /Annots [5 0 R 6 0 R 7 0 R 15 0 R] >>",
+            "endobj",
+            StreamObject(4, string.Empty, pageContent),
+            "5 0 obj", "<< /Type /Annot /Subtype /Text /Rect [20 20 40 40] /Contents (PRIVATE-COMMENT) >>", "endobj",
+            "6 0 obj", "<< /Type /Annot /Subtype /Link /Rect [50 20 100 40] /A << /S /URI /URI (https://example.com/) >> >>", "endobj",
+            "7 0 obj", "<< /Type /Annot /Subtype /Widget /Rect [110 20 180 40] >>", "endobj",
+            "8 0 obj", "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>", "endobj",
+            "10 0 obj", "<< /Type /Outlines /First 11 0 R /Last 11 0 R /Count 1 >>", "endobj",
+            "11 0 obj", "<< /Title (PRIVATE-BOOKMARK) /Parent 10 0 R /Dest [3 0 R /Fit] >>", "endobj",
+            StreamObject(12, "/Type /Metadata /Subtype /XML", xmp),
+            StreamObject(13, "/Type /EmbeddedFile /Subtype /text#2Fplain", payload),
+            "14 0 obj", "<< /Type /Filespec /F (payload.txt) /UF (payload.txt) /EF << /F 13 0 R /UF 13 0 R >> >>", "endobj",
+            "15 0 obj", "<< /Type /Annot /Subtype /FileAttachment /Rect [190 20 210 40] /FS 14 0 R /Contents (PRIVATE-ATTACHMENT-COMMENT) >>", "endobj",
+            "16 0 obj", "<< /Type /OCG /Name (PRIVATE-LAYER) >>", "endobj",
+            "17 0 obj", "<< /S /JavaScript /JS (app.alert('PRIVATE-SCRIPT')) >>", "endobj",
+            "20 0 obj",
+            "<< /Title (PRIVATE-TITLE) /Author (PRIVATE-AUTHOR) /Subject (PRIVATE-SUBJECT) /Keywords (PRIVATE-KEYWORDS) /Creator (PRIVATE-CREATOR) /Producer (OfficeIMO-Test) /CreationDate (D:20260102030405Z) /ModDate (D:20260203040506Z) /Trapped /False >>",
+            "endobj",
+            "trailer", "<< /Root 1 0 R /Info 20 0 R /Size 21 >>", "%%EOF"
+        }) + "\n";
+        return Encoding.ASCII.GetBytes(pdf);
+    }
+
     private static byte[] BuildForbiddenWidgetRootWithRetainedNextPdf() {
         string pdf = string.Join("\n", new[] {
             "%PDF-1.7",
@@ -863,5 +1006,21 @@ public class PdfSanitizerTests {
             "4 0 obj\n<< /Length 0 >>\nstream\n\nendstream\nendobj\n" +
             "trailer\n<< /Root 1 0 R /Size 5 >>\n%%EOF\n";
         return Encoding.ASCII.GetBytes(pdf);
+    }
+
+    private static string StreamObject(int objectNumber, string dictionaryEntries, string content) =>
+        objectNumber.ToString(System.Globalization.CultureInfo.InvariantCulture) + " 0 obj\n<< " + dictionaryEntries +
+        " /Length " + Encoding.ASCII.GetByteCount(content).ToString(System.Globalization.CultureInfo.InvariantCulture) +
+        " >>\nstream\n" + content + "\nendstream\nendobj";
+
+    private static string? ReadInfoString(byte[] pdf, string key) {
+        var (objects, trailerRaw) = PdfSyntax.ParseObjects(pdf);
+        if (!PdfSyntax.TryGetTrailerReference(trailerRaw, "Info", limits: null, out PdfReference infoReference) ||
+            !objects.TryGetValue(infoReference.ObjectNumber, out PdfIndirectObject? infoObject) ||
+            infoObject.Value is not PdfDictionary info ||
+            info.Get<PdfStringObj>(key) is not PdfStringObj value) {
+            return null;
+        }
+        return value.Value;
     }
 }

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfSanitizerTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfSanitizerTests.cs
@@ -21,7 +21,7 @@ public class PdfSanitizerTests {
         Assert.Equal(1, preview.CategoryCounts.CommentsAndMarkup);
         Assert.Equal(1, preview.CategoryCounts.Bookmarks);
         Assert.Equal(1, preview.CategoryCounts.OptionalContent);
-        Assert.Equal(12, preview.TotalCount);
+        Assert.Equal(preview.Findings.Count, preview.TotalCount);
 
         PdfSanitizationResult result = PdfDocument.Load(source).Sanitize(policy);
         PdfDocumentInfo info = result.ToDocument().Inspect();
@@ -68,6 +68,91 @@ public class PdfSanitizerTests {
         Assert.True(info.HasOptionalContent);
         Assert.Contains(info.Annotations, static annotation => annotation.Subtype == "Text");
         Assert.Contains(PdfSanitizer.Analyze(result.ToBytes()), static finding => finding.ActionKind == PdfSanitizationActionKind.JavaScript);
+    }
+
+    [Fact]
+    public void UserMetadataSanitizationNeutralizesAnXmpStreamRetainedByASecondaryReference() {
+        byte[] source = BuildAliasedXmpMetadataPdf();
+        var policy = new PdfSanitizationOptions {
+            ContentKindsToRemove = PdfSanitizationContentKind.UserMetadata
+        };
+
+        PdfSanitizationResult result = PdfDocument.Load(source).Sanitize(policy);
+        string raw = PdfEncoding.Latin1GetString(result.ToBytes());
+
+        Assert.True(result.IsSanitized);
+        Assert.Equal(1, result.RemovedCategoryCounts.UserMetadata);
+        Assert.False(result.ToDocument().Inspect().HasXmpMetadata);
+        Assert.DoesNotContain("PRIVATE-XMP-ALIAS", raw, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EmbeddedFileSanitizationNeutralizesAPayloadStreamRetainedByASecondaryReference() {
+        byte[] source = BuildAliasedEmbeddedFilePdf();
+        var policy = new PdfSanitizationOptions {
+            ContentKindsToRemove = PdfSanitizationContentKind.EmbeddedFiles
+        };
+
+        PdfSanitizationReport preview = PdfDocument.Load(source).InspectSanitization(policy);
+        PdfSanitizationResult result = PdfDocument.Load(source).Sanitize(policy);
+        string raw = PdfEncoding.Latin1GetString(result.ToBytes());
+
+        Assert.Equal(1, preview.CategoryCounts.EmbeddedFiles);
+        Assert.True(result.IsSanitized);
+        Assert.Equal(1, result.RemovedCategoryCounts.EmbeddedFiles);
+        Assert.Empty(result.ToDocument().Inspect().Attachments);
+        Assert.DoesNotContain("PRIVATE-ATTACHMENT-ALIAS", raw, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CommentSanitizationCountsAndNeutralizesAnUnplacedAnnotationRetainedByASecondaryReference() {
+        byte[] source = BuildAliasedUnplacedCommentPdf();
+        var policy = new PdfSanitizationOptions {
+            ContentKindsToRemove = PdfSanitizationContentKind.CommentsAndMarkup
+        };
+
+        PdfSanitizationReport preview = PdfDocument.Load(source).InspectSanitization(policy);
+        PdfSanitizationResult result = PdfDocument.Load(source).Sanitize(policy);
+        string raw = PdfEncoding.Latin1GetString(result.ToBytes());
+
+        Assert.Equal(1, preview.CategoryCounts.CommentsAndMarkup);
+        Assert.True(result.IsSanitized);
+        Assert.Equal(1, result.RemovedCategoryCounts.CommentsAndMarkup);
+        Assert.DoesNotContain("PRIVATE-UNPLACED-COMMENT", raw, StringComparison.Ordinal);
+        Assert.Empty(result.ToDocument().Inspect().Annotations);
+    }
+
+    [Fact]
+    public void BookmarkSanitizationCountsTheCompleteOutlineTreeBeyondTheLogicalReaderDepth() {
+        byte[] source = BuildDeepOutlinePdf(depth: 65);
+        var policy = new PdfSanitizationOptions {
+            ContentKindsToRemove = PdfSanitizationContentKind.Bookmarks
+        };
+
+        PdfSanitizationReport preview = PdfDocument.Load(source).InspectSanitization(policy);
+        PdfSanitizationResult result = PdfDocument.Load(source).Sanitize(policy);
+
+        Assert.Equal(65, preview.CategoryCounts.Bookmarks);
+        Assert.True(result.IsSanitized);
+        Assert.Equal(65, result.RemovedCategoryCounts.Bookmarks);
+        Assert.Empty(result.ToDocument().Inspect().Outlines);
+        Assert.DoesNotContain("PRIVATE-BOOKMARK-", PdfEncoding.Latin1GetString(result.ToBytes()), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void OptionalContentSanitizationResolvesAnIndirectGroupType() {
+        byte[] source = BuildIndirectOptionalContentTypePdf();
+        var policy = new PdfSanitizationOptions {
+            ContentKindsToRemove = PdfSanitizationContentKind.OptionalContent
+        };
+
+        PdfSanitizationResult result = PdfDocument.Load(source).Sanitize(policy);
+        string raw = PdfEncoding.Latin1GetString(result.ToBytes());
+
+        Assert.True(result.IsSanitized);
+        Assert.Equal(1, result.RemovedCategoryCounts.OptionalContent);
+        Assert.False(result.ToDocument().Inspect().HasOptionalContent);
+        Assert.DoesNotContain("PRIVATE-INDIRECT-LAYER", raw, StringComparison.Ordinal);
     }
 
     [Theory]
@@ -778,6 +863,83 @@ public class PdfSanitizerTests {
             "trailer", "<< /Root 1 0 R /Info 20 0 R /Size 21 >>", "%%EOF"
         }) + "\n";
         return Encoding.ASCII.GetBytes(pdf);
+    }
+
+    private static byte[] BuildAliasedXmpMetadataPdf() {
+        const string xmp = "<?xpacket begin=''?><x:xmpmeta xmlns:x='adobe:ns:meta/'>PRIVATE-XMP-ALIAS</x:xmpmeta><?xpacket end='w'?>";
+        return Encoding.ASCII.GetBytes(string.Join("\n", new[] {
+            "%PDF-1.7",
+            "1 0 obj", "<< /Type /Catalog /Pages 2 0 R /Metadata 5 0 R >>", "endobj",
+            "2 0 obj", "<< /Type /Pages /Count 1 /Kids [3 0 R] >>", "endobj",
+            "3 0 obj", "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R /Metadata 5 0 R >>", "endobj",
+            StreamObject(4, string.Empty, string.Empty),
+            StreamObject(5, "/Type /Metadata /Subtype /XML", xmp),
+            "trailer", "<< /Root 1 0 R /Size 6 >>", "%%EOF"
+        }));
+    }
+
+    private static byte[] BuildAliasedEmbeddedFilePdf() {
+        return Encoding.ASCII.GetBytes(string.Join("\n", new[] {
+            "%PDF-1.7",
+            "1 0 obj", "<< /Type /Catalog /Pages 2 0 R /Names << /EmbeddedFiles << /Names [(payload.txt) 6 0 R] >> >> /PieceInfo << /Private 5 0 R >> >>", "endobj",
+            "2 0 obj", "<< /Type /Pages /Count 1 /Kids [3 0 R] >>", "endobj",
+            "3 0 obj", "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R >>", "endobj",
+            StreamObject(4, string.Empty, string.Empty),
+            StreamObject(5, "/Type /EmbeddedFile /Subtype /text#2Fplain", "PRIVATE-ATTACHMENT-ALIAS"),
+            "6 0 obj", "<< /Type /Filespec /F (payload.txt) /UF (payload.txt) /EF << /F 5 0 R /UF 5 0 R >> >>", "endobj",
+            "trailer", "<< /Root 1 0 R /Size 7 >>", "%%EOF"
+        }));
+    }
+
+    private static byte[] BuildAliasedUnplacedCommentPdf() {
+        return Encoding.ASCII.GetBytes(string.Join("\n", new[] {
+            "%PDF-1.7",
+            "1 0 obj", "<< /Type /Catalog /Pages 2 0 R /PieceInfo << /Private 5 0 R >> >>", "endobj",
+            "2 0 obj", "<< /Type /Pages /Count 1 /Kids [3 0 R] >>", "endobj",
+            "3 0 obj", "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R /Annots [5 0 R] >>", "endobj",
+            StreamObject(4, string.Empty, string.Empty),
+            "5 0 obj", "<< /Type /Annot /Subtype /Text /Contents (PRIVATE-UNPLACED-COMMENT) >>", "endobj",
+            "trailer", "<< /Root 1 0 R /Size 6 >>", "%%EOF"
+        }));
+    }
+
+    private static byte[] BuildDeepOutlinePdf(int depth) {
+        var lines = new List<string> {
+            "%PDF-1.7",
+            "1 0 obj", "<< /Type /Catalog /Pages 2 0 R /Outlines 10 0 R >>", "endobj",
+            "2 0 obj", "<< /Type /Pages /Count 1 /Kids [3 0 R] >>", "endobj",
+            "3 0 obj", "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R >>", "endobj",
+            StreamObject(4, string.Empty, string.Empty),
+            "10 0 obj", "<< /Type /Outlines /First 11 0 R /Last 11 0 R /Count " + depth.ToString(System.Globalization.CultureInfo.InvariantCulture) + " >>", "endobj"
+        };
+        for (int index = 0; index < depth; index++) {
+            int objectNumber = 11 + index;
+            int parentObjectNumber = index == 0 ? 10 : objectNumber - 1;
+            string child = index + 1 < depth
+                ? " /First " + (objectNumber + 1).ToString(System.Globalization.CultureInfo.InvariantCulture) + " 0 R"
+                : string.Empty;
+            lines.Add(objectNumber.ToString(System.Globalization.CultureInfo.InvariantCulture) + " 0 obj");
+            lines.Add("<< /Title (PRIVATE-BOOKMARK-" + index.ToString(System.Globalization.CultureInfo.InvariantCulture) + ") /Parent " +
+                      parentObjectNumber.ToString(System.Globalization.CultureInfo.InvariantCulture) + " 0 R" + child + " >>");
+            lines.Add("endobj");
+        }
+        lines.Add("trailer");
+        lines.Add("<< /Root 1 0 R /Size " + (11 + depth).ToString(System.Globalization.CultureInfo.InvariantCulture) + " >>");
+        lines.Add("%%EOF");
+        return Encoding.ASCII.GetBytes(string.Join("\n", lines));
+    }
+
+    private static byte[] BuildIndirectOptionalContentTypePdf() {
+        return Encoding.ASCII.GetBytes(string.Join("\n", new[] {
+            "%PDF-1.7",
+            "1 0 obj", "<< /Type /Catalog /Pages 2 0 R /OCProperties << /OCGs [6 0 R] /D << /ON [6 0 R] >> >> >>", "endobj",
+            "2 0 obj", "<< /Type /Pages /Count 1 /Kids [3 0 R] >>", "endobj",
+            "3 0 obj", "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Resources << /Properties << /Layer 6 0 R >> >> /Contents 4 0 R >>", "endobj",
+            StreamObject(4, string.Empty, string.Empty),
+            "6 0 obj", "<< /Type 7 0 R /Name (PRIVATE-INDIRECT-LAYER) >>", "endobj",
+            "7 0 obj", "/OCG", "endobj",
+            "trailer", "<< /Root 1 0 R /Size 8 >>", "%%EOF"
+        }));
     }
 
     private static byte[] BuildForbiddenWidgetRootWithRetainedNextPdf() {

--- a/OfficeIMO.Pdf/Manipulation/PdfSanitizationCategoryCounts.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfSanitizationCategoryCounts.cs
@@ -1,0 +1,46 @@
+namespace OfficeIMO.Pdf;
+
+/// <summary>Typed counts for a PDF sanitization preview or verified result.</summary>
+public sealed class PdfSanitizationCategoryCounts {
+    internal PdfSanitizationCategoryCounts(
+        int userMetadata,
+        int embeddedFiles,
+        int actions,
+        int commentsAndMarkup,
+        int bookmarks,
+        int optionalContent) {
+        UserMetadata = userMetadata;
+        EmbeddedFiles = embeddedFiles;
+        Actions = actions;
+        CommentsAndMarkup = commentsAndMarkup;
+        Bookmarks = bookmarks;
+        OptionalContent = optionalContent;
+    }
+
+    /// <summary>Number of selected user-authored Info fields and XMP packets.</summary>
+    public int UserMetadata { get; }
+    /// <summary>Number of selected logical file attachments.</summary>
+    public int EmbeddedFiles { get; }
+    /// <summary>Number of selected action findings.</summary>
+    public int Actions { get; }
+    /// <summary>Number of selected comment and markup annotations.</summary>
+    public int CommentsAndMarkup { get; }
+    /// <summary>Number of selected outline/bookmark entries.</summary>
+    public int Bookmarks { get; }
+    /// <summary>Number of selected optional-content layer definitions.</summary>
+    public int OptionalContent { get; }
+    /// <summary>Total number of selected logical items.</summary>
+    public int Total => UserMetadata + EmbeddedFiles + Actions + CommentsAndMarkup + Bookmarks + OptionalContent;
+
+    /// <summary>Returns the count for one atomic content category.</summary>
+    public int GetCount(PdfSanitizationContentKind kind) => kind switch {
+        PdfSanitizationContentKind.None => 0,
+        PdfSanitizationContentKind.UserMetadata => UserMetadata,
+        PdfSanitizationContentKind.EmbeddedFiles => EmbeddedFiles,
+        PdfSanitizationContentKind.Actions => Actions,
+        PdfSanitizationContentKind.CommentsAndMarkup => CommentsAndMarkup,
+        PdfSanitizationContentKind.Bookmarks => Bookmarks,
+        PdfSanitizationContentKind.OptionalContent => OptionalContent,
+        _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, "A single PDF sanitization content category is required.")
+    };
+}

--- a/OfficeIMO.Pdf/Manipulation/PdfSanitizationContentKind.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfSanitizationContentKind.cs
@@ -1,0 +1,22 @@
+namespace OfficeIMO.Pdf;
+
+/// <summary>Selectable document-content categories understood by the PDF sanitization engine.</summary>
+[System.Flags]
+public enum PdfSanitizationContentKind {
+    /// <summary>Do not select any document-content category.</summary>
+    None = 0,
+    /// <summary>User-authored Info fields and the catalog XMP metadata packet.</summary>
+    UserMetadata = 1 << 0,
+    /// <summary>Embedded and associated file attachments.</summary>
+    EmbeddedFiles = 1 << 1,
+    /// <summary>JavaScript, URI, launch, submit, remote-navigation, and other selected actions.</summary>
+    Actions = 1 << 2,
+    /// <summary>Comment and markup annotations, excluding Link, Widget, and FileAttachment annotations.</summary>
+    CommentsAndMarkup = 1 << 3,
+    /// <summary>The document outline/bookmark tree.</summary>
+    Bookmarks = 1 << 4,
+    /// <summary>Optional-content layer definitions and associations.</summary>
+    OptionalContent = 1 << 5,
+    /// <summary>Every selectable before-sharing category.</summary>
+    All = UserMetadata | EmbeddedFiles | Actions | CommentsAndMarkup | Bookmarks | OptionalContent
+}

--- a/OfficeIMO.Pdf/Manipulation/PdfSanitizationOptions.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfSanitizationOptions.cs
@@ -3,6 +3,7 @@ namespace OfficeIMO.Pdf;
 /// <summary>Explicit policy for removing active content and embedded payloads from a PDF.</summary>
 public sealed class PdfSanitizationOptions {
     private PdfSanitizationActionKind? _actionKindsToRemove;
+    private PdfSanitizationContentKind? _contentKindsToRemove;
 
     /// <summary>Cancellation observed between inventory, object-graph rewrite, and verification stages.</summary>
     public System.Threading.CancellationToken CancellationToken { get; set; }
@@ -28,6 +29,21 @@ public sealed class PdfSanitizationOptions {
         }
     }
 
+    /// <summary>
+    /// Exact before-sharing content categories to remove. When null, the established sanitizer behavior is
+    /// retained. When set, unselected categories remain. Action selection is further narrowed by
+    /// <see cref="ActionKindsToRemove"/> when the <see cref="PdfSanitizationContentKind.Actions"/> category is selected.
+    /// </summary>
+    public PdfSanitizationContentKind? ContentKindsToRemove {
+        get => _contentKindsToRemove;
+        set {
+            if (value.HasValue && (value.Value & ~PdfSanitizationContentKind.All) != 0) {
+                throw new ArgumentOutOfRangeException(nameof(ContentKindsToRemove), value, "Unsupported PDF sanitization content kind.");
+            }
+            _contentKindsToRemove = value;
+        }
+    }
+
     /// <summary>Absolute URI schemes that may remain. Relative URI targets are preserved.</summary>
     public ISet<string> AllowedUriSchemes { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
         "http", "https", "mailto", "tel"
@@ -41,7 +57,12 @@ public sealed class PdfSanitizationOptions {
 
     internal bool IsActionAllowed(string actionType) => AllowedActionTypes.Contains(actionType);
 
+    internal bool ShouldRemoveContent(PdfSanitizationContentKind kind) => ContentKindsToRemove.HasValue
+        ? (ContentKindsToRemove.Value & kind) == kind
+        : kind == PdfSanitizationContentKind.EmbeddedFiles || kind == PdfSanitizationContentKind.Actions;
+
     internal bool ShouldRemoveAction(string actionType, string? uri = null) {
+        if (!ShouldRemoveContent(PdfSanitizationContentKind.Actions)) return false;
         PdfSanitizationActionKind kind = GetActionKind(actionType);
         if (ActionKindsToRemove.HasValue) {
             if (IsActionAllowed(actionType)) return false;
@@ -52,9 +73,25 @@ public sealed class PdfSanitizationOptions {
         return PdfActiveContentPolicy.IsUnsafeActionType(actionType);
     }
 
-    internal bool ShouldRemoveCatalogUriBase(string value) => ActionKindsToRemove.HasValue
-        ? (ActionKindsToRemove.Value & PdfSanitizationActionKind.Uri) != 0
-        : !IsUriAllowed(value);
+    internal bool ShouldRemoveCatalogUriBase(string value) =>
+        ShouldRemoveContent(PdfSanitizationContentKind.Actions) &&
+        (ActionKindsToRemove.HasValue
+            ? (ActionKindsToRemove.Value & PdfSanitizationActionKind.Uri) != 0
+            : !IsUriAllowed(value));
+
+    internal bool ShouldRemoveEmbeddedFiles => ShouldRemoveContent(PdfSanitizationContentKind.EmbeddedFiles);
+    internal bool ShouldRemoveUserMetadata => ShouldRemoveContent(PdfSanitizationContentKind.UserMetadata);
+    internal bool ShouldRemoveCommentsAndMarkup => ShouldRemoveContent(PdfSanitizationContentKind.CommentsAndMarkup);
+    internal bool ShouldRemoveBookmarks => ShouldRemoveContent(PdfSanitizationContentKind.Bookmarks);
+    internal bool ShouldRemoveOptionalContent => ShouldRemoveContent(PdfSanitizationContentKind.OptionalContent);
+
+    internal bool ShouldRemoveCommentAnnotation(string subtype) => ShouldRemoveCommentsAndMarkup &&
+        !string.Equals(subtype, "Link", StringComparison.Ordinal) &&
+        !string.Equals(subtype, "Widget", StringComparison.Ordinal) &&
+        !string.Equals(subtype, "FileAttachment", StringComparison.Ordinal);
+
+    internal bool ShouldRemoveLegacyRichAnnotation(string subtype) =>
+        !ContentKindsToRemove.HasValue && RemoveRichMedia && PdfSanitizer.IsRichAnnotationSubtype(subtype);
 
     internal static PdfSanitizationActionKind GetActionKind(string actionType) => actionType switch {
         "JavaScript" => PdfSanitizationActionKind.JavaScript,

--- a/OfficeIMO.Pdf/Manipulation/PdfSanitizationReport.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfSanitizationReport.cs
@@ -29,6 +29,6 @@ public sealed class PdfSanitizationReport {
     /// <summary>Logical per-category counts for the selected sanitization policy.</summary>
     public PdfSanitizationCategoryCounts CategoryCounts { get; }
 
-    /// <summary>Total number of selected logical items.</summary>
-    public int TotalCount => CategoryCounts.Total;
+    /// <summary>Total number of low-level findings selected by the policy.</summary>
+    public int TotalCount => Findings.Count;
 }

--- a/OfficeIMO.Pdf/Manipulation/PdfSanitizationReport.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfSanitizationReport.cs
@@ -2,17 +2,33 @@ namespace OfficeIMO.Pdf;
 
 /// <summary>Typed preview of items that the supplied PDF sanitization policy would remove.</summary>
 public sealed class PdfSanitizationReport {
-    internal PdfSanitizationReport(IReadOnlyList<PdfSanitizationFinding> findings) {
+    internal PdfSanitizationReport(
+        IReadOnlyList<PdfSanitizationFinding> findings,
+        int userMetadata = 0,
+        int embeddedFiles = 0,
+        int commentsAndMarkup = 0,
+        int bookmarks = 0,
+        int optionalContent = 0) {
         Findings = findings;
         ActionCounts = new PdfSanitizationActionCounts(findings);
+        CategoryCounts = new PdfSanitizationCategoryCounts(
+            userMetadata,
+            embeddedFiles,
+            ActionCounts.Total,
+            commentsAndMarkup,
+            bookmarks,
+            optionalContent);
     }
 
-    /// <summary>Items selected for removal by the inspected policy.</summary>
+    /// <summary>Low-level active-content and embedded-payload findings selected by the policy.</summary>
     public IReadOnlyList<PdfSanitizationFinding> Findings { get; }
 
     /// <summary>Per-kind action counts for the selected policy.</summary>
     public PdfSanitizationActionCounts ActionCounts { get; }
 
-    /// <summary>Total number of selected findings.</summary>
-    public int TotalCount => Findings.Count;
+    /// <summary>Logical per-category counts for the selected sanitization policy.</summary>
+    public PdfSanitizationCategoryCounts CategoryCounts { get; }
+
+    /// <summary>Total number of selected logical items.</summary>
+    public int TotalCount => CategoryCounts.Total;
 }

--- a/OfficeIMO.Pdf/Manipulation/PdfSanitizationResult.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfSanitizationResult.cs
@@ -9,19 +9,21 @@ public sealed class PdfSanitizationResult {
         byte[] pdfBytes,
         PdfMutationPlan mutationPlan,
         PdfRewritePreservationReport preservationReport,
-        IReadOnlyList<PdfSanitizationFinding> removedFindings,
-        IReadOnlyList<PdfSanitizationFinding> remainingFindings,
+        PdfSanitizationReport removedReport,
+        PdfSanitizationReport remainingReport,
         IReadOnlyList<PdfExtractedAttachment> quarantinedAttachments,
         PdfLoadOptions readOptions) {
         _pdfBytes = (byte[])pdfBytes.Clone();
         _readOptions = readOptions;
         MutationPlan = mutationPlan;
         PreservationReport = preservationReport;
-        RemovedFindings = removedFindings;
-        RemainingFindings = remainingFindings;
+        RemovedReport = removedReport;
+        RemainingReport = remainingReport;
+        RemovedFindings = removedReport.Findings;
+        RemainingFindings = remainingReport.Findings;
         QuarantinedAttachments = quarantinedAttachments;
-        RemovedActionCounts = new PdfSanitizationActionCounts(removedFindings);
-        RemainingActionCounts = new PdfSanitizationActionCounts(remainingFindings);
+        RemovedActionCounts = removedReport.ActionCounts;
+        RemainingActionCounts = remainingReport.ActionCounts;
     }
 
     /// <summary>Shared mutation plan used for the full rewrite.</summary>
@@ -36,6 +38,18 @@ public sealed class PdfSanitizationResult {
     /// <summary>Forbidden items found after save. A successful operation always returns an empty list.</summary>
     public IReadOnlyList<PdfSanitizationFinding> RemainingFindings { get; }
 
+    /// <summary>Typed inventory selected before the rewrite.</summary>
+    public PdfSanitizationReport RemovedReport { get; }
+
+    /// <summary>Typed selected inventory found after the rewrite.</summary>
+    public PdfSanitizationReport RemainingReport { get; }
+
+    /// <summary>Logical per-category counts removed by the policy.</summary>
+    public PdfSanitizationCategoryCounts RemovedCategoryCounts => RemovedReport.CategoryCounts;
+
+    /// <summary>Logical per-category counts still selected after the rewrite.</summary>
+    public PdfSanitizationCategoryCounts RemainingCategoryCounts => RemainingReport.CategoryCounts;
+
     /// <summary>Per-kind counts of actions removed by the policy.</summary>
     public PdfSanitizationActionCounts RemovedActionCounts { get; }
 
@@ -46,7 +60,7 @@ public sealed class PdfSanitizationResult {
     public IReadOnlyList<PdfExtractedAttachment> QuarantinedAttachments { get; }
 
     /// <summary>True when post-save inventory proves that no forbidden item remains.</summary>
-    public bool IsSanitized => RemainingFindings.Count == 0;
+    public bool IsSanitized => RemainingReport.TotalCount == 0;
 
     /// <summary>Returns a defensive copy of the sanitized PDF bytes.</summary>
     public byte[] ToBytes() => (byte[])_pdfBytes.Clone();

--- a/OfficeIMO.Pdf/Manipulation/PdfSanitizationResult.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfSanitizationResult.cs
@@ -60,7 +60,7 @@ public sealed class PdfSanitizationResult {
     public IReadOnlyList<PdfExtractedAttachment> QuarantinedAttachments { get; }
 
     /// <summary>True when post-save inventory proves that no forbidden item remains.</summary>
-    public bool IsSanitized => RemainingReport.CategoryCounts.Total == 0;
+    public bool IsSanitized => RemainingFindings.Count == 0 && RemainingReport.CategoryCounts.Total == 0;
 
     /// <summary>Returns a defensive copy of the sanitized PDF bytes.</summary>
     public byte[] ToBytes() => (byte[])_pdfBytes.Clone();

--- a/OfficeIMO.Pdf/Manipulation/PdfSanitizationResult.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfSanitizationResult.cs
@@ -60,7 +60,7 @@ public sealed class PdfSanitizationResult {
     public IReadOnlyList<PdfExtractedAttachment> QuarantinedAttachments { get; }
 
     /// <summary>True when post-save inventory proves that no forbidden item remains.</summary>
-    public bool IsSanitized => RemainingReport.TotalCount == 0;
+    public bool IsSanitized => RemainingReport.CategoryCounts.Total == 0;
 
     /// <summary>Returns a defensive copy of the sanitized PDF bytes.</summary>
     public byte[] ToBytes() => (byte[])_pdfBytes.Clone();

--- a/OfficeIMO.Pdf/Manipulation/PdfSanitizer.HiddenData.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfSanitizer.HiddenData.cs
@@ -1,0 +1,121 @@
+namespace OfficeIMO.Pdf;
+
+internal static partial class PdfSanitizer {
+    private static readonly string[] UserMetadataKeys = { "Title", "Author", "Subject", "Keywords", "Creator" };
+
+    private static PdfSanitizationReport BuildReport(
+        byte[] pdf,
+        PdfSanitizationOptions policy,
+        PdfLoadOptions? readOptions,
+        IReadOnlyList<PdfSanitizationFinding> findings) {
+        policy.CancellationToken.ThrowIfCancellationRequested();
+        PdfDocumentInfo info = PdfInspector.Inspect(pdf, readOptions);
+        int userMetadata = policy.ShouldRemoveUserMetadata
+            ? CountUserMetadataEntries(pdf, readOptions, policy.CancellationToken)
+            : 0;
+        int embeddedFiles = policy.ShouldRemoveEmbeddedFiles ? info.Attachments.Count : 0;
+        int commentsAndMarkup = 0;
+        for (int i = 0; i < info.Annotations.Count; i++) {
+            string subtype = info.Annotations[i].Subtype;
+            if (policy.ShouldRemoveCommentAnnotation(subtype) || policy.ShouldRemoveLegacyRichAnnotation(subtype)) {
+                commentsAndMarkup++;
+            }
+        }
+        int bookmarks = policy.ShouldRemoveBookmarks ? CountOutlines(info.Outlines) : 0;
+        int optionalContent = policy.ShouldRemoveOptionalContent && info.HasOptionalContent
+            ? Math.Max(1, info.OptionalContentGroupCount)
+            : 0;
+        return new PdfSanitizationReport(
+            findings,
+            userMetadata,
+            embeddedFiles,
+            commentsAndMarkup,
+            bookmarks,
+            optionalContent);
+    }
+
+    private static int CountUserMetadataEntries(
+        byte[] pdf,
+        PdfLoadOptions? readOptions,
+        System.Threading.CancellationToken cancellationToken) {
+        var parsed = PdfSyntax.ParseObjects(pdf, readOptions, out _, out _, cancellationToken);
+        PdfDocumentSecurityInfo baseline = PdfSyntax.ReadDocumentSecurityInfo(
+            pdf,
+            readOptions,
+            includeParsedDetails: false,
+            cancellationToken: cancellationToken);
+        PdfDocumentSecurityInfo security = PdfSyntax.ReadDocumentSecurityInfo(
+            pdf,
+            parsed.Map,
+            parsed.TrailerRaw,
+            baseline,
+            readOptions,
+            cancellationToken);
+        int count = 0;
+        if (security.InfoObjectNumber.HasValue &&
+            parsed.Map.TryGetValue(security.InfoObjectNumber.Value, out PdfIndirectObject? infoObject) &&
+            infoObject.Value is PdfDictionary info) {
+            for (int i = 0; i < UserMetadataKeys.Length; i++) {
+                if (info.Items.ContainsKey(UserMetadataKeys[i])) count++;
+            }
+        }
+        if (security.RootObjectNumber.HasValue &&
+            parsed.Map.TryGetValue(security.RootObjectNumber.Value, out PdfIndirectObject? rootObject) &&
+            rootObject.Value is PdfDictionary catalog &&
+            catalog.Items.ContainsKey("Metadata")) {
+            count++;
+        }
+        return count;
+    }
+
+    private static int CountOutlines(IReadOnlyList<PdfOutlineItem> outlines) {
+        int count = 0;
+        for (int i = 0; i < outlines.Count; i++) {
+            count = checked(count + 1 + CountOutlines(outlines[i].Children));
+        }
+        return count;
+    }
+
+    private static void SanitizeDocumentContainers(
+        Dictionary<int, PdfIndirectObject> objects,
+        PdfDocumentSecurityInfo security,
+        PdfSanitizationOptions policy) {
+        if (policy.ShouldRemoveUserMetadata && security.InfoObjectNumber.HasValue &&
+            objects.TryGetValue(security.InfoObjectNumber.Value, out PdfIndirectObject? infoObject) &&
+            infoObject.Value is PdfDictionary info) {
+            for (int i = 0; i < UserMetadataKeys.Length; i++) info.Items.Remove(UserMetadataKeys[i]);
+        }
+
+        if (!security.RootObjectNumber.HasValue ||
+            !objects.TryGetValue(security.RootObjectNumber.Value, out PdfIndirectObject? rootObject) ||
+            rootObject.Value is not PdfDictionary catalog) {
+            throw new InvalidOperationException("The active PDF trailer does not reference a readable catalog object.");
+        }
+
+        if (policy.ShouldRemoveUserMetadata) catalog.Items.Remove("Metadata");
+        if (policy.ShouldRemoveBookmarks) {
+            catalog.Items.Remove("Outlines");
+            if (catalog.Get<PdfName>("PageMode")?.Name == "UseOutlines") catalog.Items.Remove("PageMode");
+        }
+        if (policy.ShouldRemoveOptionalContent) catalog.Items.Remove("OCProperties");
+    }
+
+    private static bool ShouldRemoveAnnotation(
+        Dictionary<int, PdfIndirectObject> objects,
+        PdfDictionary annotation,
+        PdfSanitizationOptions policy) {
+        if (Resolve(objects, annotation.Get<PdfObject>("Subtype")) is not PdfName subtype) return false;
+        if (string.Equals(subtype.Name, "FileAttachment", StringComparison.Ordinal) && policy.ShouldRemoveEmbeddedFiles) return true;
+        return policy.ShouldRemoveCommentAnnotation(subtype.Name) || policy.ShouldRemoveLegacyRichAnnotation(subtype.Name);
+    }
+
+    private static void RemoveOptionalContentAssociation(PdfDictionary dictionary) {
+        string? type = dictionary.Get<PdfName>("Type")?.Name;
+        if (string.Equals(type, "OCG", StringComparison.Ordinal) || string.Equals(type, "OCMD", StringComparison.Ordinal)) {
+            dictionary.Items.Clear();
+            return;
+        }
+        dictionary.Items.Remove("OC");
+        dictionary.Items.Remove("OCGs");
+    }
+}

--- a/OfficeIMO.Pdf/Manipulation/PdfSanitizer.HiddenData.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfSanitizer.HiddenData.cs
@@ -10,18 +10,27 @@ internal static partial class PdfSanitizer {
         IReadOnlyList<PdfSanitizationFinding> findings) {
         policy.CancellationToken.ThrowIfCancellationRequested();
         PdfDocumentInfo info = PdfInspector.Inspect(pdf, readOptions);
-        int userMetadata = policy.ShouldRemoveUserMetadata
-            ? CountUserMetadataEntries(pdf, readOptions, policy.CancellationToken)
-            : 0;
+        var parsed = PdfSyntax.ParseObjects(pdf, readOptions, out _, out _, policy.CancellationToken);
+        PdfDocumentSecurityInfo baseline = PdfSyntax.ReadDocumentSecurityInfo(
+            pdf,
+            readOptions,
+            includeParsedDetails: false,
+            cancellationToken: policy.CancellationToken);
+        PdfDocumentSecurityInfo security = PdfSyntax.ReadDocumentSecurityInfo(
+            pdf,
+            parsed.Map,
+            parsed.TrailerRaw,
+            baseline,
+            readOptions,
+            policy.CancellationToken);
+        int userMetadata = policy.ShouldRemoveUserMetadata ? CountUserMetadataEntries(parsed.Map, security) : 0;
         int embeddedFiles = policy.ShouldRemoveEmbeddedFiles ? info.Attachments.Count : 0;
-        int commentsAndMarkup = 0;
-        for (int i = 0; i < info.Annotations.Count; i++) {
-            string subtype = info.Annotations[i].Subtype;
-            if (policy.ShouldRemoveCommentAnnotation(subtype) || policy.ShouldRemoveLegacyRichAnnotation(subtype)) {
-                commentsAndMarkup++;
-            }
-        }
-        int bookmarks = policy.ShouldRemoveBookmarks ? CountOutlines(info.Outlines) : 0;
+        int commentsAndMarkup = policy.ShouldRemoveCommentsAndMarkup
+            ? CountSelectedCommentAnnotations(parsed.Map, policy)
+            : 0;
+        int bookmarks = policy.ShouldRemoveBookmarks
+            ? CountOutlineItems(parsed.Map, security, policy.CancellationToken)
+            : 0;
         int optionalContent = policy.ShouldRemoveOptionalContent && info.HasOptionalContent
             ? Math.Max(1, info.OptionalContentGroupCount)
             : 0;
@@ -35,32 +44,18 @@ internal static partial class PdfSanitizer {
     }
 
     private static int CountUserMetadataEntries(
-        byte[] pdf,
-        PdfLoadOptions? readOptions,
-        System.Threading.CancellationToken cancellationToken) {
-        var parsed = PdfSyntax.ParseObjects(pdf, readOptions, out _, out _, cancellationToken);
-        PdfDocumentSecurityInfo baseline = PdfSyntax.ReadDocumentSecurityInfo(
-            pdf,
-            readOptions,
-            includeParsedDetails: false,
-            cancellationToken: cancellationToken);
-        PdfDocumentSecurityInfo security = PdfSyntax.ReadDocumentSecurityInfo(
-            pdf,
-            parsed.Map,
-            parsed.TrailerRaw,
-            baseline,
-            readOptions,
-            cancellationToken);
+        Dictionary<int, PdfIndirectObject> objects,
+        PdfDocumentSecurityInfo security) {
         int count = 0;
         if (security.InfoObjectNumber.HasValue &&
-            parsed.Map.TryGetValue(security.InfoObjectNumber.Value, out PdfIndirectObject? infoObject) &&
+            objects.TryGetValue(security.InfoObjectNumber.Value, out PdfIndirectObject? infoObject) &&
             infoObject.Value is PdfDictionary info) {
             for (int i = 0; i < UserMetadataKeys.Length; i++) {
                 if (info.Items.ContainsKey(UserMetadataKeys[i])) count++;
             }
         }
         if (security.RootObjectNumber.HasValue &&
-            parsed.Map.TryGetValue(security.RootObjectNumber.Value, out PdfIndirectObject? rootObject) &&
+            objects.TryGetValue(security.RootObjectNumber.Value, out PdfIndirectObject? rootObject) &&
             rootObject.Value is PdfDictionary catalog &&
             catalog.Items.ContainsKey("Metadata")) {
             count++;
@@ -68,12 +63,91 @@ internal static partial class PdfSanitizer {
         return count;
     }
 
-    private static int CountOutlines(IReadOnlyList<PdfOutlineItem> outlines) {
+    private static int CountSelectedCommentAnnotations(
+        Dictionary<int, PdfIndirectObject> objects,
+        PdfSanitizationOptions policy) {
         int count = 0;
-        for (int i = 0; i < outlines.Count; i++) {
-            count = checked(count + 1 + CountOutlines(outlines[i].Children));
+        var visited = new HashSet<PdfDictionary>();
+        var counted = new HashSet<PdfDictionary>();
+        foreach (PdfIndirectObject indirect in objects.Values) {
+            CountSelectedCommentAnnotations(objects, indirect.Value, policy, visited, counted, ref count);
         }
         return count;
+    }
+
+    private static void CountSelectedCommentAnnotations(
+        Dictionary<int, PdfIndirectObject> objects,
+        PdfObject value,
+        PdfSanitizationOptions policy,
+        HashSet<PdfDictionary> visited,
+        HashSet<PdfDictionary> counted,
+        ref int count) {
+        policy.CancellationToken.ThrowIfCancellationRequested();
+        if (value is PdfStream stream) value = stream.Dictionary;
+        if (value is PdfArray array) {
+            for (int i = 0; i < array.Items.Count; i++) {
+                if (array.Items[i] is not PdfReference) {
+                    CountSelectedCommentAnnotations(objects, array.Items[i], policy, visited, counted, ref count);
+                }
+            }
+            return;
+        }
+        if (value is not PdfDictionary dictionary || !visited.Add(dictionary)) return;
+        if (Resolve(objects, dictionary.Get<PdfObject>("Type")) is PdfName type &&
+            string.Equals(type.Name, "Annot", StringComparison.Ordinal) &&
+            IsSelectedCommentAnnotation(objects, dictionary, policy) &&
+            counted.Add(dictionary)) {
+            count = checked(count + 1);
+        }
+        if (dictionary.Items.TryGetValue("Annots", out PdfObject? annotationsObject) &&
+            Resolve(objects, annotationsObject) is PdfArray annotations) {
+            for (int i = 0; i < annotations.Items.Count; i++) {
+                if (Resolve(objects, annotations.Items[i]) is PdfDictionary annotation &&
+                    IsSelectedCommentAnnotation(objects, annotation, policy) &&
+                    counted.Add(annotation)) {
+                    count = checked(count + 1);
+                }
+            }
+        }
+        foreach (PdfObject child in dictionary.Items.Values) {
+            if (child is not PdfReference) {
+                CountSelectedCommentAnnotations(objects, child, policy, visited, counted, ref count);
+            }
+        }
+    }
+
+    private static int CountOutlineItems(
+        Dictionary<int, PdfIndirectObject> objects,
+        PdfDocumentSecurityInfo security,
+        System.Threading.CancellationToken cancellationToken) {
+        if (!security.RootObjectNumber.HasValue ||
+            !objects.TryGetValue(security.RootObjectNumber.Value, out PdfIndirectObject? rootObject) ||
+            rootObject.Value is not PdfDictionary catalog ||
+            !catalog.Items.TryGetValue("Outlines", out PdfObject? outlinesObject) ||
+            Resolve(objects, outlinesObject) is not PdfDictionary outlines) {
+            return 0;
+        }
+        if (!outlines.Items.TryGetValue("First", out PdfObject? first)) return 1;
+
+        int count = 0;
+        var pending = new Stack<PdfObject>();
+        var visitedReferences = new HashSet<(int ObjectNumber, int Generation)>();
+        var visitedDictionaries = new HashSet<PdfDictionary>();
+        pending.Push(first);
+        while (pending.Count > 0) {
+            cancellationToken.ThrowIfCancellationRequested();
+            PdfObject current = pending.Pop();
+            if (current is PdfReference reference) {
+                if (!visitedReferences.Add((reference.ObjectNumber, reference.Generation)) ||
+                    !PdfObjectLookup.TryGet(objects, reference, out PdfIndirectObject? indirect)) continue;
+                current = indirect.Value;
+            }
+            if (current is not PdfDictionary item || !visitedDictionaries.Add(item)) continue;
+            count = checked(count + 1);
+            if (item.Items.TryGetValue("Next", out PdfObject? next)) pending.Push(next);
+            if (item.Items.TryGetValue("First", out PdfObject? child)) pending.Push(child);
+        }
+        return count == 0 ? 1 : count;
     }
 
     private static void SanitizeDocumentContainers(
@@ -92,8 +166,12 @@ internal static partial class PdfSanitizer {
             throw new InvalidOperationException("The active PDF trailer does not reference a readable catalog object.");
         }
 
-        if (policy.ShouldRemoveUserMetadata) catalog.Items.Remove("Metadata");
+        if (policy.ShouldRemoveUserMetadata && catalog.Items.TryGetValue("Metadata", out PdfObject? metadata)) {
+            NeutralizeReferencedStream(objects, metadata);
+            catalog.Items.Remove("Metadata");
+        }
         if (policy.ShouldRemoveBookmarks) {
+            if (catalog.Items.TryGetValue("Outlines", out PdfObject? outlines)) ClearOutlineTree(objects, outlines, policy.CancellationToken);
             catalog.Items.Remove("Outlines");
             if (catalog.Get<PdfName>("PageMode")?.Name == "UseOutlines") catalog.Items.Remove("PageMode");
         }
@@ -109,13 +187,61 @@ internal static partial class PdfSanitizer {
         return policy.ShouldRemoveCommentAnnotation(subtype.Name) || policy.ShouldRemoveLegacyRichAnnotation(subtype.Name);
     }
 
-    private static void RemoveOptionalContentAssociation(PdfDictionary dictionary) {
-        string? type = dictionary.Get<PdfName>("Type")?.Name;
+    private static bool IsSelectedCommentAnnotation(
+        Dictionary<int, PdfIndirectObject> objects,
+        PdfDictionary annotation,
+        PdfSanitizationOptions policy) {
+        if (Resolve(objects, annotation.Get<PdfObject>("Subtype")) is not PdfName subtype) return false;
+        return policy.ShouldRemoveCommentAnnotation(subtype.Name) || policy.ShouldRemoveLegacyRichAnnotation(subtype.Name);
+    }
+
+    private static void RemoveOptionalContentAssociation(
+        Dictionary<int, PdfIndirectObject> objects,
+        PdfDictionary dictionary) {
+        string? type = Resolve(objects, dictionary.Get<PdfObject>("Type")) is PdfName typeName ? typeName.Name : null;
         if (string.Equals(type, "OCG", StringComparison.Ordinal) || string.Equals(type, "OCMD", StringComparison.Ordinal)) {
             dictionary.Items.Clear();
             return;
         }
         dictionary.Items.Remove("OC");
         dictionary.Items.Remove("OCGs");
+    }
+
+    private static void NeutralizeReferencedStream(Dictionary<int, PdfIndirectObject> objects, PdfObject value) {
+        var visited = new HashSet<(int ObjectNumber, int Generation)>();
+        while (value is PdfReference reference && visited.Add((reference.ObjectNumber, reference.Generation)) &&
+               PdfObjectLookup.TryGet(objects, reference, out PdfIndirectObject? indirect)) {
+            if (indirect.Value is PdfStream) {
+                objects[reference.ObjectNumber] = new PdfIndirectObject(
+                    indirect.ObjectNumber,
+                    indirect.Generation,
+                    new PdfStream(new PdfDictionary(), Array.Empty<byte>()));
+                return;
+            }
+            value = indirect.Value;
+        }
+    }
+
+    private static void ClearOutlineTree(
+        Dictionary<int, PdfIndirectObject> objects,
+        PdfObject outlines,
+        System.Threading.CancellationToken cancellationToken) {
+        var pending = new Stack<PdfObject>();
+        var visitedReferences = new HashSet<(int ObjectNumber, int Generation)>();
+        var visitedDictionaries = new HashSet<PdfDictionary>();
+        pending.Push(outlines);
+        while (pending.Count > 0) {
+            cancellationToken.ThrowIfCancellationRequested();
+            PdfObject current = pending.Pop();
+            if (current is PdfReference reference) {
+                if (!visitedReferences.Add((reference.ObjectNumber, reference.Generation)) ||
+                    !PdfObjectLookup.TryGet(objects, reference, out PdfIndirectObject? indirect)) continue;
+                current = indirect.Value;
+            }
+            if (current is not PdfDictionary dictionary || !visitedDictionaries.Add(dictionary)) continue;
+            if (dictionary.Items.TryGetValue("First", out PdfObject? first)) pending.Push(first);
+            if (dictionary.Items.TryGetValue("Next", out PdfObject? next)) pending.Push(next);
+            dictionary.Items.Clear();
+        }
     }
 }

--- a/OfficeIMO.Pdf/Manipulation/PdfSanitizer.HiddenData.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfSanitizer.HiddenData.cs
@@ -1,7 +1,9 @@
 namespace OfficeIMO.Pdf;
 
 internal static partial class PdfSanitizer {
-    private static readonly string[] UserMetadataKeys = { "Title", "Author", "Subject", "Keywords", "Creator" };
+    private static readonly HashSet<string> TechnicalInfoKeys = new HashSet<string>(StringComparer.Ordinal) {
+        "Producer", "CreationDate", "ModDate", "Trapped"
+    };
 
     private static PdfSanitizationReport BuildReport(
         byte[] pdf,
@@ -9,7 +11,6 @@ internal static partial class PdfSanitizer {
         PdfLoadOptions? readOptions,
         IReadOnlyList<PdfSanitizationFinding> findings) {
         policy.CancellationToken.ThrowIfCancellationRequested();
-        PdfDocumentInfo info = PdfInspector.Inspect(pdf, readOptions);
         var parsed = PdfSyntax.ParseObjects(pdf, readOptions, out _, out _, policy.CancellationToken);
         PdfDocumentSecurityInfo baseline = PdfSyntax.ReadDocumentSecurityInfo(
             pdf,
@@ -24,15 +25,21 @@ internal static partial class PdfSanitizer {
             readOptions,
             policy.CancellationToken);
         int userMetadata = policy.ShouldRemoveUserMetadata ? CountUserMetadataEntries(parsed.Map, security) : 0;
-        int embeddedFiles = policy.ShouldRemoveEmbeddedFiles ? info.Attachments.Count : 0;
+        int embeddedFiles = policy.ShouldRemoveEmbeddedFiles
+            ? PdfAttachmentExtractor.InspectAttachments(
+                parsed.Map,
+                parsed.TrailerRaw,
+                readOptions?.Limits,
+                policy.CancellationToken).Count
+            : 0;
         int commentsAndMarkup = policy.ShouldRemoveCommentsAndMarkup
             ? CountSelectedCommentAnnotations(parsed.Map, policy)
             : 0;
         int bookmarks = policy.ShouldRemoveBookmarks
             ? CountOutlineItems(parsed.Map, security, policy.CancellationToken)
             : 0;
-        int optionalContent = policy.ShouldRemoveOptionalContent && info.HasOptionalContent
-            ? Math.Max(1, info.OptionalContentGroupCount)
+        int optionalContent = policy.ShouldRemoveOptionalContent
+            ? CountOptionalContentGroups(parsed.Map, security)
             : 0;
         return new PdfSanitizationReport(
             findings,
@@ -50,8 +57,8 @@ internal static partial class PdfSanitizer {
         if (security.InfoObjectNumber.HasValue &&
             objects.TryGetValue(security.InfoObjectNumber.Value, out PdfIndirectObject? infoObject) &&
             infoObject.Value is PdfDictionary info) {
-            for (int i = 0; i < UserMetadataKeys.Length; i++) {
-                if (info.Items.ContainsKey(UserMetadataKeys[i])) count++;
+            foreach (string key in info.Items.Keys) {
+                if (!TechnicalInfoKeys.Contains(key)) count++;
             }
         }
         if (security.RootObjectNumber.HasValue &&
@@ -127,13 +134,16 @@ internal static partial class PdfSanitizer {
             Resolve(objects, outlinesObject) is not PdfDictionary outlines) {
             return 0;
         }
-        if (!outlines.Items.TryGetValue("First", out PdfObject? first)) return 1;
+        bool hasFirst = outlines.Items.TryGetValue("First", out PdfObject? first);
+        bool hasLast = outlines.Items.TryGetValue("Last", out PdfObject? last);
+        if (!hasFirst && !hasLast) return 1;
 
         int count = 0;
         var pending = new Stack<PdfObject>();
         var visitedReferences = new HashSet<(int ObjectNumber, int Generation)>();
         var visitedDictionaries = new HashSet<PdfDictionary>();
-        pending.Push(first);
+        if (first is not null) pending.Push(first);
+        if (last is not null) pending.Push(last);
         while (pending.Count > 0) {
             cancellationToken.ThrowIfCancellationRequested();
             PdfObject current = pending.Pop();
@@ -144,10 +154,32 @@ internal static partial class PdfSanitizer {
             }
             if (current is not PdfDictionary item || !visitedDictionaries.Add(item)) continue;
             count = checked(count + 1);
-            if (item.Items.TryGetValue("Next", out PdfObject? next)) pending.Push(next);
-            if (item.Items.TryGetValue("First", out PdfObject? child)) pending.Push(child);
+            PushOutlineLinks(item, pending);
         }
         return count == 0 ? 1 : count;
+    }
+
+    private static int CountOptionalContentGroups(
+        Dictionary<int, PdfIndirectObject> objects,
+        PdfDocumentSecurityInfo security) {
+        if (!security.RootObjectNumber.HasValue ||
+            !objects.TryGetValue(security.RootObjectNumber.Value, out PdfIndirectObject? rootObject) ||
+            rootObject.Value is not PdfDictionary catalog ||
+            !catalog.Items.TryGetValue("OCProperties", out PdfObject? optionalContentObject) ||
+            Resolve(objects, optionalContentObject) is not PdfDictionary optionalContent) {
+            return 0;
+        }
+
+        if (!optionalContent.Items.TryGetValue("OCGs", out PdfObject? groupsObject) ||
+            Resolve(objects, groupsObject) is not PdfArray groups) {
+            return 1;
+        }
+
+        var counted = new HashSet<PdfDictionary>();
+        for (int index = 0; index < groups.Items.Count; index++) {
+            if (Resolve(objects, groups.Items[index]) is PdfDictionary group) counted.Add(group);
+        }
+        return Math.Max(1, counted.Count);
     }
 
     private static void SanitizeDocumentContainers(
@@ -157,7 +189,9 @@ internal static partial class PdfSanitizer {
         if (policy.ShouldRemoveUserMetadata && security.InfoObjectNumber.HasValue &&
             objects.TryGetValue(security.InfoObjectNumber.Value, out PdfIndirectObject? infoObject) &&
             infoObject.Value is PdfDictionary info) {
-            for (int i = 0; i < UserMetadataKeys.Length; i++) info.Items.Remove(UserMetadataKeys[i]);
+            foreach (string key in info.Items.Keys.Where(static key => !TechnicalInfoKeys.Contains(key)).ToArray()) {
+                info.Items.Remove(key);
+            }
         }
 
         if (!security.RootObjectNumber.HasValue ||
@@ -167,23 +201,42 @@ internal static partial class PdfSanitizer {
         }
 
         if (policy.ShouldRemoveUserMetadata && catalog.Items.TryGetValue("Metadata", out PdfObject? metadata)) {
+            RemoveSelectedMetadataAliases(objects, metadata);
             NeutralizeReferencedStream(objects, metadata);
             catalog.Items.Remove("Metadata");
         }
         if (policy.ShouldRemoveBookmarks) {
             if (catalog.Items.TryGetValue("Outlines", out PdfObject? outlines)) ClearOutlineTree(objects, outlines, policy.CancellationToken);
             catalog.Items.Remove("Outlines");
-            if (catalog.Get<PdfName>("PageMode")?.Name == "UseOutlines") catalog.Items.Remove("PageMode");
+            if (HasCatalogPageMode(objects, catalog, "UseOutlines")) catalog.Items.Remove("PageMode");
         }
-        if (policy.ShouldRemoveOptionalContent) catalog.Items.Remove("OCProperties");
+        if (policy.ShouldRemoveEmbeddedFiles && HasCatalogPageMode(objects, catalog, "UseAttachments")) {
+            catalog.Items.Remove("PageMode");
+        }
+        if (policy.ShouldRemoveOptionalContent) {
+            if (catalog.Items.TryGetValue("OCProperties", out PdfObject? optionalContent)) {
+                NeutralizeObjectGraph(objects, optionalContent, policy.CancellationToken);
+            }
+            catalog.Items.Remove("OCProperties");
+            if (HasCatalogPageMode(objects, catalog, "UseOC")) catalog.Items.Remove("PageMode");
+        }
     }
+
+    private static bool HasCatalogPageMode(
+        Dictionary<int, PdfIndirectObject> objects,
+        PdfDictionary catalog,
+        string expected) =>
+        Resolve(objects, catalog.Get<PdfObject>("PageMode")) is PdfName pageMode &&
+        string.Equals(pageMode.Name, expected, StringComparison.Ordinal);
 
     private static bool ShouldRemoveAnnotation(
         Dictionary<int, PdfIndirectObject> objects,
         PdfDictionary annotation,
         PdfSanitizationOptions policy) {
         if (Resolve(objects, annotation.Get<PdfObject>("Subtype")) is not PdfName subtype) return false;
-        if (string.Equals(subtype.Name, "FileAttachment", StringComparison.Ordinal) && policy.ShouldRemoveEmbeddedFiles) return true;
+        if (string.Equals(subtype.Name, "FileAttachment", StringComparison.Ordinal) && policy.ShouldRemoveEmbeddedFiles) {
+            return policy.ContentKindsToRemove.HasValue || policy.RemoveRichMedia;
+        }
         return policy.ShouldRemoveCommentAnnotation(subtype.Name) || policy.ShouldRemoveLegacyRichAnnotation(subtype.Name);
     }
 
@@ -239,9 +292,71 @@ internal static partial class PdfSanitizer {
                 current = indirect.Value;
             }
             if (current is not PdfDictionary dictionary || !visitedDictionaries.Add(dictionary)) continue;
-            if (dictionary.Items.TryGetValue("First", out PdfObject? first)) pending.Push(first);
-            if (dictionary.Items.TryGetValue("Next", out PdfObject? next)) pending.Push(next);
+            PushOutlineLinks(dictionary, pending);
             dictionary.Items.Clear();
+        }
+    }
+
+    private static void RemoveSelectedMetadataAliases(
+        Dictionary<int, PdfIndirectObject> objects,
+        PdfObject selectedMetadata) {
+        foreach (PdfIndirectObject indirect in objects.Values) {
+            PdfDictionary? dictionary = indirect.Value is PdfStream stream
+                ? stream.Dictionary
+                : indirect.Value as PdfDictionary;
+            if (dictionary is null ||
+                !dictionary.Items.TryGetValue("Metadata", out PdfObject? candidate)) continue;
+            if (ReferencesSameObject(objects, candidate, selectedMetadata)) dictionary.Items.Remove("Metadata");
+        }
+    }
+
+    private static bool ReferencesSameObject(
+        Dictionary<int, PdfIndirectObject> objects,
+        PdfObject left,
+        PdfObject right) {
+        if (left is PdfReference leftReference && right is PdfReference rightReference) {
+            return leftReference.ObjectNumber == rightReference.ObjectNumber &&
+                leftReference.Generation == rightReference.Generation;
+        }
+        return ReferenceEquals(Resolve(objects, left), Resolve(objects, right));
+    }
+
+    private static void NeutralizeObjectGraph(
+        Dictionary<int, PdfIndirectObject> objects,
+        PdfObject root,
+        System.Threading.CancellationToken cancellationToken) {
+        var pending = new Stack<PdfObject>();
+        var visitedReferences = new HashSet<(int ObjectNumber, int Generation)>();
+        var visitedObjects = new HashSet<PdfObject>();
+        pending.Push(root);
+        while (pending.Count > 0) {
+            cancellationToken.ThrowIfCancellationRequested();
+            PdfObject current = pending.Pop();
+            if (current is PdfReference reference) {
+                if (!visitedReferences.Add((reference.ObjectNumber, reference.Generation)) ||
+                    !PdfObjectLookup.TryGet(objects, reference, out PdfIndirectObject? indirect)) continue;
+                current = indirect.Value;
+            }
+            if (!visitedObjects.Add(current)) continue;
+            if (current is PdfStream stream) {
+                foreach (PdfObject child in stream.Dictionary.Items.Values) pending.Push(child);
+                stream.Dictionary.Items.Clear();
+                continue;
+            }
+            if (current is PdfArray array) {
+                for (int index = 0; index < array.Items.Count; index++) pending.Push(array.Items[index]);
+                array.Items.Clear();
+                continue;
+            }
+            if (current is not PdfDictionary dictionary) continue;
+            foreach (PdfObject child in dictionary.Items.Values) pending.Push(child);
+            dictionary.Items.Clear();
+        }
+    }
+
+    private static void PushOutlineLinks(PdfDictionary dictionary, Stack<PdfObject> pending) {
+        foreach (string key in new[] { "First", "Last", "Next", "Prev" }) {
+            if (dictionary.Items.TryGetValue(key, out PdfObject? linked)) pending.Push(linked);
         }
     }
 }

--- a/OfficeIMO.Pdf/Manipulation/PdfSanitizer.Traversal.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfSanitizer.Traversal.cs
@@ -5,6 +5,8 @@ internal static partial class PdfSanitizer {
         "RichMedia", "Movie", "Sound", "Screen", "3D", "FileAttachment"
     };
 
+    internal static bool IsRichAnnotationSubtype(string subtype) => RichAnnotationSubtypes.Contains(subtype);
+
     private static IReadOnlyList<PdfSanitizationFinding> Scan(
         Dictionary<int, PdfIndirectObject> objects,
         PdfSanitizationOptions policy,
@@ -71,7 +73,7 @@ internal static partial class PdfSanitizer {
         foreach (KeyValuePair<string, PdfObject> item in dictionary.Items) {
             policy.CancellationToken.ThrowIfCancellationRequested();
             string itemPath = path + "/" + item.Key;
-            if (item.Key == "EmbeddedFiles" || item.Key == "AF" || item.Key == "EF") {
+            if (policy.ShouldRemoveEmbeddedFiles && (item.Key == "EmbeddedFiles" || item.Key == "AF" || item.Key == "EF")) {
                 findings.Add(new PdfSanitizationFinding(PdfSanitizationFindingKind.EmbeddedFile, objectNumber, itemPath, item.Key));
             }
 
@@ -106,10 +108,12 @@ internal static partial class PdfSanitizer {
 
     private static void SanitizeObjectGraph(
         Dictionary<int, PdfIndirectObject> objects,
+        PdfDocumentSecurityInfo security,
         PdfSanitizationOptions policy,
         int maximumActionDepth,
         int maximumActionNodes) {
         policy.CancellationToken.ThrowIfCancellationRequested();
+        SanitizeDocumentContainers(objects, security, policy);
         var actionBudget = new PdfSanitizerActionBudget(maximumActionNodes);
         foreach (PdfIndirectObject item in objects.Values.OrderBy(static item => item.ObjectNumber)) {
             policy.CancellationToken.ThrowIfCancellationRequested();
@@ -152,9 +156,14 @@ internal static partial class PdfSanitizer {
             dictionary.Items.Remove("JavaScript");
         }
 
-        dictionary.Items.Remove("EmbeddedFiles");
-        dictionary.Items.Remove("AF");
-        dictionary.Items.Remove("EF");
+        if (policy.ShouldRemoveEmbeddedFiles) {
+            dictionary.Items.Remove("EmbeddedFiles");
+            dictionary.Items.Remove("AF");
+            dictionary.Items.Remove("EF");
+        }
+        if (policy.ShouldRemoveOptionalContent) {
+            RemoveOptionalContentAssociation(dictionary);
+        }
         bool actionTraversalAlreadyNormalized = actionBudget.WasNormalized(dictionary);
 
         if (dictionary.Items.TryGetValue("Annots", out PdfObject? annotationsObject) &&
@@ -365,7 +374,7 @@ internal static partial class PdfSanitizer {
         PdfSanitizationOptions policy) {
         for (int i = annotations.Items.Count - 1; i >= 0; i--) {
             if (Resolve(objects, annotations.Items[i]) is PdfDictionary annotation &&
-                IsRichAnnotation(objects, annotation, policy, out _)) {
+                ShouldRemoveAnnotation(objects, annotation, policy)) {
                 annotations.Items.RemoveAt(i);
             }
         }
@@ -450,7 +459,8 @@ internal static partial class PdfSanitizer {
         PdfSanitizationOptions policy,
         out string? subtype) {
         subtype = null;
-        if (!policy.RemoveRichMedia || Resolve(objects, dictionary.Get<PdfObject>("Subtype")) is not PdfName name) {
+        if (Resolve(objects, dictionary.Get<PdfObject>("Subtype")) is not PdfName name ||
+            !policy.ShouldRemoveLegacyRichAnnotation(name.Name)) {
             return false;
         }
 

--- a/OfficeIMO.Pdf/Manipulation/PdfSanitizer.Traversal.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfSanitizer.Traversal.cs
@@ -114,11 +114,15 @@ internal static partial class PdfSanitizer {
         int maximumActionNodes) {
         policy.CancellationToken.ThrowIfCancellationRequested();
         SanitizeDocumentContainers(objects, security, policy);
+        HashSet<PdfDictionary> selectedAnnotations = CollectSelectedAnnotations(objects, policy);
+        NeutralizeSelectedPayloadObjects(objects, policy);
         var actionBudget = new PdfSanitizerActionBudget(maximumActionNodes);
         foreach (PdfIndirectObject item in objects.Values.OrderBy(static item => item.ObjectNumber)) {
             policy.CancellationToken.ThrowIfCancellationRequested();
-            SanitizeObject(objects, item.Value, policy, maximumActionDepth, actionBudget);
+            SanitizeObject(objects, item.Value, policy, maximumActionDepth, actionBudget, selectedAnnotations);
         }
+
+        foreach (PdfDictionary annotation in selectedAnnotations) annotation.Items.Clear();
 
         foreach (PdfIndirectObject item in objects.Values.OrderBy(static item => item.ObjectNumber)) {
             policy.CancellationToken.ThrowIfCancellationRequested();
@@ -131,16 +135,17 @@ internal static partial class PdfSanitizer {
         PdfObject value,
         PdfSanitizationOptions policy,
         int maximumActionDepth,
-        PdfSanitizerActionBudget actionBudget) {
+        PdfSanitizerActionBudget actionBudget,
+        HashSet<PdfDictionary> selectedAnnotations) {
         policy.CancellationToken.ThrowIfCancellationRequested();
         if (value is PdfStream stream) {
-            SanitizeDictionary(objects, stream.Dictionary, policy, maximumActionDepth, actionBudget);
+            SanitizeDictionary(objects, stream.Dictionary, policy, maximumActionDepth, actionBudget, selectedAnnotations);
         } else if (value is PdfDictionary dictionary) {
-            SanitizeDictionary(objects, dictionary, policy, maximumActionDepth, actionBudget);
+            SanitizeDictionary(objects, dictionary, policy, maximumActionDepth, actionBudget, selectedAnnotations);
         } else if (value is PdfArray array) {
             for (int i = 0; i < array.Items.Count; i++) {
                 if (array.Items[i] is not PdfReference) {
-                    SanitizeObject(objects, array.Items[i], policy, maximumActionDepth, actionBudget);
+                    SanitizeObject(objects, array.Items[i], policy, maximumActionDepth, actionBudget, selectedAnnotations);
                 }
             }
         }
@@ -151,7 +156,8 @@ internal static partial class PdfSanitizer {
         PdfDictionary dictionary,
         PdfSanitizationOptions policy,
         int maximumActionDepth,
-        PdfSanitizerActionBudget actionBudget) {
+        PdfSanitizerActionBudget actionBudget,
+        HashSet<PdfDictionary> selectedAnnotations) {
         if (policy.ShouldRemoveAction("JavaScript")) {
             dictionary.Items.Remove("JavaScript");
         }
@@ -161,14 +167,17 @@ internal static partial class PdfSanitizer {
             dictionary.Items.Remove("AF");
             dictionary.Items.Remove("EF");
         }
+        if (policy.ShouldRemoveUserMetadata) {
+            dictionary.Items.Remove("Metadata");
+        }
         if (policy.ShouldRemoveOptionalContent) {
-            RemoveOptionalContentAssociation(dictionary);
+            RemoveOptionalContentAssociation(objects, dictionary);
         }
         bool actionTraversalAlreadyNormalized = actionBudget.WasNormalized(dictionary);
 
         if (dictionary.Items.TryGetValue("Annots", out PdfObject? annotationsObject) &&
             Resolve(objects, annotationsObject) is PdfArray annotations) {
-            FilterAnnotations(objects, annotations, policy);
+            FilterAnnotations(objects, annotations, selectedAnnotations);
         }
 
         string[] keys = dictionary.Items.Keys.ToArray();
@@ -188,7 +197,7 @@ internal static partial class PdfSanitizer {
                     dictionary.Items.Remove(key);
                 } else {
                     PdfDictionary promoted = CreatePromotedActionRoot(retained);
-                    SanitizeNormalizedActionDictionary(objects, promoted, policy, maximumActionDepth, actionBudget);
+                    SanitizeNormalizedActionDictionary(objects, promoted, policy, maximumActionDepth, actionBudget, selectedAnnotations);
                     dictionary.Items[key] = promoted;
                 }
                 continue;
@@ -196,7 +205,7 @@ internal static partial class PdfSanitizer {
 
             if (key == "Next" && resolved is PdfArray nextActions) {
                 FilterActions(objects, nextActions, policy, maximumActionDepth, actionBudget);
-                SanitizeNormalizedActionArray(objects, nextActions, policy, maximumActionDepth, actionBudget);
+                SanitizeNormalizedActionArray(objects, nextActions, policy, maximumActionDepth, actionBudget, selectedAnnotations);
                 continue;
             }
 
@@ -206,7 +215,7 @@ internal static partial class PdfSanitizer {
             }
 
             if (item is not PdfReference) {
-                SanitizeObject(objects, item, policy, maximumActionDepth, actionBudget);
+                SanitizeObject(objects, item, policy, maximumActionDepth, actionBudget, selectedAnnotations);
             }
         }
     }
@@ -216,11 +225,12 @@ internal static partial class PdfSanitizer {
         PdfArray actions,
         PdfSanitizationOptions policy,
         int maximumActionDepth,
-        PdfSanitizerActionBudget actionBudget) {
+        PdfSanitizerActionBudget actionBudget,
+        HashSet<PdfDictionary> selectedAnnotations) {
         for (int i = 0; i < actions.Items.Count; i++) {
             policy.CancellationToken.ThrowIfCancellationRequested();
             if (actions.Items[i] is PdfDictionary action) {
-                SanitizeNormalizedActionDictionary(objects, action, policy, maximumActionDepth, actionBudget);
+                SanitizeNormalizedActionDictionary(objects, action, policy, maximumActionDepth, actionBudget, selectedAnnotations);
             }
         }
     }
@@ -230,19 +240,20 @@ internal static partial class PdfSanitizer {
         PdfDictionary action,
         PdfSanitizationOptions policy,
         int maximumActionDepth,
-        PdfSanitizerActionBudget actionBudget) {
+        PdfSanitizerActionBudget actionBudget,
+        HashSet<PdfDictionary> selectedAnnotations) {
         policy.CancellationToken.ThrowIfCancellationRequested();
         if (action.Items.TryGetValue("Next", out PdfObject? nextObject)) {
             if (nextObject is PdfDictionary nextAction) {
-                SanitizeNormalizedActionDictionary(objects, nextAction, policy, maximumActionDepth, actionBudget);
+                SanitizeNormalizedActionDictionary(objects, nextAction, policy, maximumActionDepth, actionBudget, selectedAnnotations);
             } else if (nextObject is PdfArray nextActions) {
-                SanitizeNormalizedActionArray(objects, nextActions, policy, maximumActionDepth, actionBudget);
+                SanitizeNormalizedActionArray(objects, nextActions, policy, maximumActionDepth, actionBudget, selectedAnnotations);
             }
         }
 
         foreach (KeyValuePair<string, PdfObject> item in action.Items.ToArray()) {
             if (string.Equals(item.Key, "Next", StringComparison.Ordinal) || item.Value is PdfReference) continue;
-            SanitizeObject(objects, item.Value, policy, maximumActionDepth, actionBudget);
+            SanitizeObject(objects, item.Value, policy, maximumActionDepth, actionBudget, selectedAnnotations);
         }
     }
 
@@ -371,12 +382,75 @@ internal static partial class PdfSanitizer {
     private static void FilterAnnotations(
         Dictionary<int, PdfIndirectObject> objects,
         PdfArray annotations,
-        PdfSanitizationOptions policy) {
+        HashSet<PdfDictionary> selectedAnnotations) {
         for (int i = annotations.Items.Count - 1; i >= 0; i--) {
             if (Resolve(objects, annotations.Items[i]) is PdfDictionary annotation &&
-                ShouldRemoveAnnotation(objects, annotation, policy)) {
+                selectedAnnotations.Contains(annotation)) {
                 annotations.Items.RemoveAt(i);
             }
+        }
+    }
+
+    private static HashSet<PdfDictionary> CollectSelectedAnnotations(
+        Dictionary<int, PdfIndirectObject> objects,
+        PdfSanitizationOptions policy) {
+        var selected = new HashSet<PdfDictionary>();
+        var visited = new HashSet<PdfObject>();
+        foreach (PdfIndirectObject indirect in objects.Values) {
+            CollectSelectedAnnotations(objects, indirect.Value, policy, selected, visited);
+        }
+        return selected;
+    }
+
+    private static void CollectSelectedAnnotations(
+        Dictionary<int, PdfIndirectObject> objects,
+        PdfObject value,
+        PdfSanitizationOptions policy,
+        HashSet<PdfDictionary> selected,
+        HashSet<PdfObject> visited) {
+        policy.CancellationToken.ThrowIfCancellationRequested();
+        if (!visited.Add(value)) return;
+        if (value is PdfStream stream) value = stream.Dictionary;
+        if (value is PdfArray array) {
+            for (int i = 0; i < array.Items.Count; i++) {
+                if (array.Items[i] is not PdfReference) {
+                    CollectSelectedAnnotations(objects, array.Items[i], policy, selected, visited);
+                }
+            }
+            return;
+        }
+        if (value is not PdfDictionary dictionary) return;
+        if (Resolve(objects, dictionary.Get<PdfObject>("Type")) is PdfName type &&
+            string.Equals(type.Name, "Annot", StringComparison.Ordinal) &&
+            ShouldRemoveAnnotation(objects, dictionary, policy)) {
+            selected.Add(dictionary);
+        }
+        if (dictionary.Items.TryGetValue("Annots", out PdfObject? annotationsObject) &&
+            Resolve(objects, annotationsObject) is PdfArray annotations) {
+            for (int i = 0; i < annotations.Items.Count; i++) {
+                if (Resolve(objects, annotations.Items[i]) is PdfDictionary annotation &&
+                    ShouldRemoveAnnotation(objects, annotation, policy)) {
+                    selected.Add(annotation);
+                }
+            }
+        }
+        foreach (PdfObject child in dictionary.Items.Values) {
+            if (child is not PdfReference) CollectSelectedAnnotations(objects, child, policy, selected, visited);
+        }
+    }
+
+    private static void NeutralizeSelectedPayloadObjects(
+        Dictionary<int, PdfIndirectObject> objects,
+        PdfSanitizationOptions policy) {
+        if (!policy.ShouldRemoveEmbeddedFiles) return;
+        foreach (KeyValuePair<int, PdfIndirectObject> item in objects.ToArray()) {
+            if (item.Value.Value is not PdfStream stream ||
+                Resolve(objects, stream.Dictionary.Get<PdfObject>("Type")) is not PdfName type ||
+                !string.Equals(type.Name, "EmbeddedFile", StringComparison.Ordinal)) continue;
+            objects[item.Key] = new PdfIndirectObject(
+                item.Value.ObjectNumber,
+                item.Value.Generation,
+                new PdfStream(new PdfDictionary(), Array.Empty<byte>()));
         }
     }
 

--- a/OfficeIMO.Pdf/Manipulation/PdfSanitizer.Traversal.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfSanitizer.Traversal.cs
@@ -113,9 +113,11 @@ internal static partial class PdfSanitizer {
         int maximumActionDepth,
         int maximumActionNodes) {
         policy.CancellationToken.ThrowIfCancellationRequested();
-        SanitizeDocumentContainers(objects, security, policy);
         HashSet<PdfDictionary> selectedAnnotations = CollectSelectedAnnotations(objects, policy);
+        HashSet<PdfDictionary> selectedFileSpecifications = CollectSelectedFileSpecifications(objects, policy);
+        SanitizeDocumentContainers(objects, security, policy);
         NeutralizeSelectedPayloadObjects(objects, policy);
+        foreach (PdfDictionary fileSpecification in selectedFileSpecifications) fileSpecification.Items.Clear();
         var actionBudget = new PdfSanitizerActionBudget(maximumActionNodes);
         foreach (PdfIndirectObject item in objects.Values.OrderBy(static item => item.ObjectNumber)) {
             policy.CancellationToken.ThrowIfCancellationRequested();
@@ -166,9 +168,6 @@ internal static partial class PdfSanitizer {
             dictionary.Items.Remove("EmbeddedFiles");
             dictionary.Items.Remove("AF");
             dictionary.Items.Remove("EF");
-        }
-        if (policy.ShouldRemoveUserMetadata) {
-            dictionary.Items.Remove("Metadata");
         }
         if (policy.ShouldRemoveOptionalContent) {
             RemoveOptionalContentAssociation(objects, dictionary);
@@ -420,9 +419,10 @@ internal static partial class PdfSanitizer {
             return;
         }
         if (value is not PdfDictionary dictionary) return;
-        if (Resolve(objects, dictionary.Get<PdfObject>("Type")) is PdfName type &&
-            string.Equals(type.Name, "Annot", StringComparison.Ordinal) &&
-            ShouldRemoveAnnotation(objects, dictionary, policy)) {
+        bool isTypedAnnotation = Resolve(objects, dictionary.Get<PdfObject>("Type")) is PdfName type &&
+            string.Equals(type.Name, "Annot", StringComparison.Ordinal);
+        if ((isTypedAnnotation && ShouldRemoveAnnotation(objects, dictionary, policy)) ||
+            (!isTypedAnnotation && IsRichAnnotation(objects, dictionary, policy, out _))) {
             selected.Add(dictionary);
         }
         if (dictionary.Items.TryGetValue("Annots", out PdfObject? annotationsObject) &&
@@ -436,6 +436,44 @@ internal static partial class PdfSanitizer {
         }
         foreach (PdfObject child in dictionary.Items.Values) {
             if (child is not PdfReference) CollectSelectedAnnotations(objects, child, policy, selected, visited);
+        }
+    }
+
+    private static HashSet<PdfDictionary> CollectSelectedFileSpecifications(
+        Dictionary<int, PdfIndirectObject> objects,
+        PdfSanitizationOptions policy) {
+        var selected = new HashSet<PdfDictionary>();
+        if (!policy.ShouldRemoveEmbeddedFiles) return selected;
+        var visited = new HashSet<PdfObject>();
+        foreach (PdfIndirectObject indirect in objects.Values) {
+            CollectSelectedFileSpecifications(objects, indirect.Value, policy, selected, visited);
+        }
+        return selected;
+    }
+
+    private static void CollectSelectedFileSpecifications(
+        Dictionary<int, PdfIndirectObject> objects,
+        PdfObject value,
+        PdfSanitizationOptions policy,
+        HashSet<PdfDictionary> selected,
+        HashSet<PdfObject> visited) {
+        policy.CancellationToken.ThrowIfCancellationRequested();
+        if (!visited.Add(value)) return;
+        if (value is PdfStream stream) value = stream.Dictionary;
+        if (value is PdfArray array) {
+            for (int index = 0; index < array.Items.Count; index++) {
+                if (array.Items[index] is not PdfReference) {
+                    CollectSelectedFileSpecifications(objects, array.Items[index], policy, selected, visited);
+                }
+            }
+            return;
+        }
+        if (value is not PdfDictionary dictionary) return;
+        if (dictionary.Items.ContainsKey("EF")) selected.Add(dictionary);
+        foreach (PdfObject child in dictionary.Items.Values) {
+            if (child is not PdfReference) {
+                CollectSelectedFileSpecifications(objects, child, policy, selected, visited);
+            }
         }
     }
 

--- a/OfficeIMO.Pdf/Manipulation/PdfSanitizer.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfSanitizer.cs
@@ -2,8 +2,12 @@ namespace OfficeIMO.Pdf;
 
 /// <summary>Removes or quarantines active content and embedded payloads through a proven full rewrite.</summary>
 internal static partial class PdfSanitizer {
-    internal static PdfSanitizationReport Inspect(byte[] pdf, PdfSanitizationOptions? options, PdfLoadOptions? readOptions) =>
-        new PdfSanitizationReport(Analyze(pdf, options, readOptions));
+    internal static PdfSanitizationReport Inspect(byte[] pdf, PdfSanitizationOptions? options, PdfLoadOptions? readOptions) {
+        Guard.NotNull(pdf, nameof(pdf));
+        PdfSanitizationOptions policy = options ?? new PdfSanitizationOptions();
+        IReadOnlyList<PdfSanitizationFinding> findings = Analyze(pdf, policy, readOptions);
+        return BuildReport(pdf, policy, readOptions, findings);
+    }
 
     /// <summary>Returns the forbidden-content inventory that the supplied policy would remove.</summary>
     public static IReadOnlyList<PdfSanitizationFinding> Analyze(byte[] pdf, PdfSanitizationOptions? options = null) {
@@ -42,10 +46,10 @@ internal static partial class PdfSanitizer {
             PdfMutationOperation.Sanitize,
             readOptions,
             cancellationToken: cancellationToken);
-        IReadOnlyList<PdfSanitizationFinding> before = Analyze(pdf, policy, readOptions);
+        PdfSanitizationReport before = BuildReport(pdf, policy, readOptions, Analyze(pdf, policy, readOptions));
         cancellationToken.ThrowIfCancellationRequested();
         IReadOnlyList<PdfExtractedAttachment> quarantined;
-        if (policy.EmbeddedFiles == PdfEmbeddedFileSanitizationMode.Quarantine) {
+        if (policy.ShouldRemoveEmbeddedFiles && policy.EmbeddedFiles == PdfEmbeddedFileSanitizationMode.Quarantine) {
             quarantined = sourceDocument.ExtractAttachments(cancellationToken);
         } else {
             quarantined = Array.Empty<PdfExtractedAttachment>();
@@ -63,7 +67,7 @@ internal static partial class PdfSanitizer {
                 outputEncryption: null,
                 (objects, security) => {
                     cancellationToken.ThrowIfCancellationRequested();
-                    SanitizeObjectGraph(objects, policy, maximumActionDepth, maximumActionNodes);
+                    SanitizeObjectGraph(objects, security, policy, maximumActionDepth, maximumActionNodes);
                     return security.InfoObjectNumber.HasValue && objects.ContainsKey(security.InfoObjectNumber.Value)
                         ? security.InfoObjectNumber
                         : null;
@@ -77,20 +81,30 @@ internal static partial class PdfSanitizer {
         }
         cancellationToken.ThrowIfCancellationRequested();
         PdfLoadOptions rewrittenReadOptions = PdfLoadOptions.WithMinimumInputBytes(readOptions, sanitized.LongLength);
-        IReadOnlyList<PdfSanitizationFinding> remaining = Analyze(sanitized, policy, rewrittenReadOptions);
+        PdfSanitizationReport remaining = BuildReport(
+            sanitized,
+            policy,
+            rewrittenReadOptions,
+            Analyze(sanitized, policy, rewrittenReadOptions));
         cancellationToken.ThrowIfCancellationRequested();
-        if (remaining.Count > 0) {
+        if (remaining.TotalCount > 0) {
             throw new InvalidOperationException(
-                "PDF sanitization post-save validation found " + remaining.Count.ToString(System.Globalization.CultureInfo.InvariantCulture) +
+                "PDF sanitization post-save validation found " + remaining.TotalCount.ToString(System.Globalization.CultureInfo.InvariantCulture) +
                 " forbidden item(s); the artifact was not returned.");
         }
 
+        PdfDocumentInfo originalInfo = PdfInspector.Inspect(pdf, sourceDocument, cancellationToken);
         var preservationOptions = new PdfRewritePreservationOptions {
             OriginalReadOptions = readOptions,
             RewrittenReadOptions = rewrittenReadOptions,
+            PreserveMetadata = !policy.ShouldRemoveUserMetadata,
+            PreserveOutlines = !policy.ShouldRemoveBookmarks,
             PreserveLinkAnnotations = true,
             PreserveAnnotations = true,
-            PreserveEmbeddedFiles = false,
+            PreserveEmbeddedFiles = !policy.ShouldRemoveEmbeddedFiles,
+            PreserveXmpMetadata = !policy.ShouldRemoveUserMetadata,
+            PreserveOptionalContent = !policy.ShouldRemoveOptionalContent,
+            PreserveCatalogViewSettings = !policy.ShouldRemoveBookmarks,
             PreserveCatalogActions = true,
             PreservePageActions = true,
             PreserveOpenAction = true,
@@ -99,18 +113,22 @@ internal static partial class PdfSanitizer {
             PreserveRevisionStructure = false,
             PreserveSecurityState = !sourceDocument.Security.HasEncryption
         };
-        if (policy.RemoveRichMedia) {
+        if (policy.ShouldRemoveEmbeddedFiles) preservationOptions.ExcludedAnnotationSubtypes.Add("FileAttachment");
+        if (policy.ShouldRemoveCommentsAndMarkup) {
+            foreach (string subtype in originalInfo.AnnotationSubtypeCounts.Keys) {
+                if (policy.ShouldRemoveCommentAnnotation(subtype)) preservationOptions.ExcludedAnnotationSubtypes.Add(subtype);
+            }
+        } else if (!policy.ContentKindsToRemove.HasValue && policy.RemoveRichMedia) {
             foreach (string subtype in RichAnnotationSubtypes) preservationOptions.ExcludedAnnotationSubtypes.Add(subtype);
         }
-        PdfDocumentInfo originalInfo = PdfInspector.Inspect(pdf, sourceDocument, cancellationToken);
         for (int i = 0; i < originalInfo.LinkAnnotations.Count; i++) {
             string? uri = originalInfo.LinkAnnotations[i].Uri;
             if (uri is not null && policy.ShouldRemoveAction("URI", uri)) preservationOptions.ExcludedLinkAnnotationUris.Add(uri);
         }
         AddPolicyRetainedActionTypes(originalInfo, policy, preservationOptions.PreservedActionTypes);
-        for (int i = 0; i < before.Count; i++) {
-            if (before[i].ActionKind == PdfSanitizationActionKind.Uri) {
-                preservationOptions.ExcludedActionUris.Add(before[i].Detail);
+        for (int i = 0; i < before.Findings.Count; i++) {
+            if (before.Findings[i].ActionKind == PdfSanitizationActionKind.Uri) {
+                preservationOptions.ExcludedActionUris.Add(before.Findings[i].Detail);
             }
         }
         PdfRewritePreservationReport preservation = PdfRewritePreservation.AssertPreserved(

--- a/OfficeIMO.Pdf/Manipulation/PdfSanitizer.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfSanitizer.cs
@@ -87,9 +87,10 @@ internal static partial class PdfSanitizer {
             rewrittenReadOptions,
             Analyze(sanitized, policy, rewrittenReadOptions));
         cancellationToken.ThrowIfCancellationRequested();
-        if (remaining.CategoryCounts.Total > 0) {
+        int remainingCount = Math.Max(remaining.TotalCount, remaining.CategoryCounts.Total);
+        if (remainingCount > 0) {
             throw new InvalidOperationException(
-                "PDF sanitization post-save validation found " + remaining.CategoryCounts.Total.ToString(System.Globalization.CultureInfo.InvariantCulture) +
+                "PDF sanitization post-save validation found " + remainingCount.ToString(System.Globalization.CultureInfo.InvariantCulture) +
                 " forbidden item(s); the artifact was not returned.");
         }
 
@@ -104,7 +105,9 @@ internal static partial class PdfSanitizer {
             PreserveEmbeddedFiles = !policy.ShouldRemoveEmbeddedFiles,
             PreserveXmpMetadata = !policy.ShouldRemoveUserMetadata,
             PreserveOptionalContent = !policy.ShouldRemoveOptionalContent,
-            PreserveCatalogViewSettings = !policy.ShouldRemoveBookmarks,
+            PreserveCatalogViewSettings = !policy.ShouldRemoveBookmarks &&
+                !policy.ShouldRemoveEmbeddedFiles &&
+                !policy.ShouldRemoveOptionalContent,
             PreserveCatalogActions = true,
             PreservePageActions = true,
             PreserveOpenAction = true,
@@ -113,7 +116,9 @@ internal static partial class PdfSanitizer {
             PreserveRevisionStructure = false,
             PreserveSecurityState = !sourceDocument.Security.HasEncryption
         };
-        if (policy.ShouldRemoveEmbeddedFiles) preservationOptions.ExcludedAnnotationSubtypes.Add("FileAttachment");
+        if (policy.ShouldRemoveEmbeddedFiles && (policy.ContentKindsToRemove.HasValue || policy.RemoveRichMedia)) {
+            preservationOptions.ExcludedAnnotationSubtypes.Add("FileAttachment");
+        }
         if (policy.ShouldRemoveCommentsAndMarkup) {
             foreach (string subtype in originalInfo.AnnotationSubtypeCounts.Keys) {
                 if (policy.ShouldRemoveCommentAnnotation(subtype)) preservationOptions.ExcludedAnnotationSubtypes.Add(subtype);

--- a/OfficeIMO.Pdf/Manipulation/PdfSanitizer.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfSanitizer.cs
@@ -87,9 +87,9 @@ internal static partial class PdfSanitizer {
             rewrittenReadOptions,
             Analyze(sanitized, policy, rewrittenReadOptions));
         cancellationToken.ThrowIfCancellationRequested();
-        if (remaining.TotalCount > 0) {
+        if (remaining.CategoryCounts.Total > 0) {
             throw new InvalidOperationException(
-                "PDF sanitization post-save validation found " + remaining.TotalCount.ToString(System.Globalization.CultureInfo.InvariantCulture) +
+                "PDF sanitization post-save validation found " + remaining.CategoryCounts.Total.ToString(System.Globalization.CultureInfo.InvariantCulture) +
                 " forbidden item(s); the artifact was not returned.");
         }
 

--- a/OfficeIMO.Pdf/README.md
+++ b/OfficeIMO.Pdf/README.md
@@ -128,6 +128,39 @@ ordinary web links. Leave the property null for the established default policy:
 known active-content actions are removed, allowed `http`, `https`, `mailto`, and
 `tel` links remain, and URI schemes outside `AllowedUriSchemes` are removed.
 
+### Inspect and sanitize before sharing
+
+```csharp
+PdfDocument incoming = PdfDocument.Load("incoming.pdf");
+var policy = new PdfSanitizationOptions {
+    ContentKindsToRemove = PdfSanitizationContentKind.All,
+    ActionKindsToRemove = PdfSanitizationActionKind.All
+};
+
+PdfSanitizationReport preview = incoming.InspectSanitization(policy);
+Console.WriteLine($"User metadata: {preview.CategoryCounts.UserMetadata}");
+Console.WriteLine($"Attachments: {preview.CategoryCounts.EmbeddedFiles}");
+Console.WriteLine($"Actions: {preview.CategoryCounts.Actions}");
+Console.WriteLine($"Comments and markup: {preview.CategoryCounts.CommentsAndMarkup}");
+Console.WriteLine($"Bookmarks: {preview.CategoryCounts.Bookmarks}");
+Console.WriteLine($"Layer definitions: {preview.CategoryCounts.OptionalContent}");
+
+PdfSanitizationResult result = incoming.Sanitize(policy);
+File.WriteAllBytes("shared.pdf", result.ToBytes());
+```
+
+`ContentKindsToRemove` is an exact selection of user-authored Info fields and
+XMP, embedded files, actions, comments and markup, bookmarks, and optional-content
+definitions. Unselected categories remain. Link and Widget annotations remain
+when comments are selected; selecting URI actions can still remove a link's URI.
+Producer, creation and modification dates, and trapping status are not classified
+as user metadata and remain in the output.
+
+Selecting optional content removes layer definitions and associations. Drawing
+and text operators that belonged to a layer remain as ordinary page content, so
+they no longer depend on viewer layer state. Use content-safety inspection and
+verified redaction when the page content itself must be removed.
+
 ### Add interactive fields to an existing PDF
 
 ```csharp


### PR DESCRIPTION
## Summary

- extend the canonical `PdfSanitizer` workflow with selectable before-sharing categories for user metadata, embedded files, actions, comments and markup, bookmarks, and optional-content definitions
- add typed per-category counts to preview and result reports while preserving the existing total finding count contract
- keep inspection and rewrite scopes aligned across aliased metadata, embedded payloads, annotations, optional-content graphs, outline links, and catalog view modes
- preserve unselected content, including component-level XMP, external file specifications, retained actions, and the legacy file-attachment annotation policy
- verify the rewritten artifact against both low-level findings and typed category counts before returning it

## Usage boundary

Optional-content sanitization removes layer definitions and leaves the page content visible. It does not delete the page operators that were previously controlled by those definitions. Callers that need physical content removal should use the redaction workflow before sharing.

## Validation

- `OfficeIMO.Pdf.Tests` on .NET 8 and .NET 10: 6,184 passed per target
- focused sanitizer contracts on .NET Framework 4.7.2 and .NET 10: 78 passed per target
- targeted read-only confirmation covered external file specifications, indirect page modes, and reverse-only outline trees with no remaining findings

## Dependency

This PR is intentionally based on #2437, which owns typed action selection and URI policy. Merge #2437 first, then retarget this PR to `master`.

Closes #2431