### PR TITLE
Add browser-local document conversion Website Tool

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -60,7 +60,7 @@ jobs:
       packages: read
       pages: write
       id-token: write
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@9052036dad21f656d4e0ee61a1201788c6bee73d
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@2540d97039f41bae9bf79ae337f6be6bf8f7a44d
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -71,7 +71,7 @@ jobs:
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       dotnet_workloads: wasm-tools
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 9052036dad21f656d4e0ee61a1201788c6bee73d
+      powerforge_ref: 2540d97039f41bae9bf79ae337f6be6bf8f7a44d
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}
       cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   website-build:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@9052036dad21f656d4e0ee61a1201788c6bee73d
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@2540d97039f41bae9bf79ae337f6be6bf8f7a44d
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -31,5 +31,5 @@ jobs:
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       dotnet_workloads: wasm-tools
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 9052036dad21f656d4e0ee61a1201788c6bee73d
+      powerforge_ref: 2540d97039f41bae9bf79ae337f6be6bf8f7a44d
       report_artifact_name: powerforge-website-reports

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -31,12 +31,12 @@ jobs:
       actions: write
       contents: read
       packages: read
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@9052036dad21f656d4e0ee61a1201788c6bee73d
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@2540d97039f41bae9bf79ae337f6be6bf8f7a44d
     with:
       website_root: Website
       pipeline_config: Website/pipeline.maintenance.json
       engine_mode: source
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 9052036dad21f656d4e0ee61a1201788c6bee73d
+      powerforge_ref: 2540d97039f41bae9bf79ae337f6be6bf8f7a44d
       report_artifact_name: powerforge-website-maintenance-reports

--- a/Website/Apps/OfficeIMO.Web.Converter/Components/ConverterWorkspace.razor.cs
+++ b/Website/Apps/OfficeIMO.Web.Converter/Components/ConverterWorkspace.razor.cs
@@ -39,6 +39,7 @@ This **Markdown** becomes a browser preview or an editable Word document.
     [Inject] private BrowserConversionService ConversionService { get; set; } = null!;
 
     private ConverterInterop? _interop;
+    private DotNetObjectReference<ConverterWorkspace>? _webMcpReference;
     private ConversionRoute ActiveRoute { get; set; } = ConversionRouteCatalog.Default;
     private SelectedDocument? SelectedFile { get; set; }
     private ConversionResult? Output { get; set; }
@@ -91,6 +92,15 @@ This **Markdown** becomes a browser preview or an editable Word document.
         _interop = new ConverterInterop(JS);
         ActiveRoute = ConversionRouteCatalog.Find(GetQueryValue("route"));
         TextInput = IsHtmlInputRoute(ActiveRoute) ? DefaultHtml : DefaultMarkdown;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender) {
+        if (!firstRender || _interop is null) {
+            return;
+        }
+
+        _webMcpReference = DotNetObjectReference.Create(this);
+        await _interop.RegisterWebMcpToolAsync(_webMcpReference);
     }
 
     private async Task SelectRouteAsync(ConversionRoute route) {
@@ -210,11 +220,65 @@ This **Markdown** becomes a browser preview or an editable Word document.
             Diagnostics.Add(new($"{fidelity} conversion", $"Created {Output.FileName} locally in {ElapsedLabel}. {Output.ProvenanceSummary}", tone));
         } catch (Exception ex) {
             stopwatch.Stop();
+            ElapsedMilliseconds = stopwatch.ElapsedMilliseconds;
             Output = null;
             Diagnostics.Add(new("Conversion failed", DescribeFailure(ex), "ocx-dot--bad"));
         } finally {
             IsBusy = false;
         }
+    }
+
+    [JSInvokable]
+    public async Task<WebMcpConversionResult> ConvertSelectedDocumentForWebMcpAsync() {
+        if (ActiveRoute.InputKind != ConversionInputKind.File) {
+            return new(false, ActiveRoute.Id, ActiveRoute.Source, ActiveRoute.Target, null, 0, 0, 0,
+                "This tool converts a file already selected in the visible workspace; choose a file-based route first.");
+        }
+        if (SelectedFile is null) {
+            Diagnostics.Clear();
+            Diagnostics.Add(new("Select a document", "Choose or load a sample document in the visible workspace before using the Website Tool.", "ocx-dot--warn"));
+            await InvokeAsync(StateHasChanged);
+            return new(false, ActiveRoute.Id, ActiveRoute.Source, ActiveRoute.Target, null, 0, 0, 0,
+                "No document is selected. Choose or load a sample document in the visible workspace, then try again.");
+        }
+        if (IsBusy) {
+            return new(false, ActiveRoute.Id, ActiveRoute.Source, ActiveRoute.Target, null, 0, 0, 0,
+                "A conversion is already running in this browser tab.");
+        }
+
+        await ConvertAsync();
+        await InvokeAsync(StateHasChanged);
+        if (Output is null) {
+            return new(false, ActiveRoute.Id, ActiveRoute.Source, ActiveRoute.Target, null, 0, 0, ElapsedMilliseconds,
+                BoundWebMcpText(Diagnostics.LastOrDefault()?.Message ?? "The browser-local conversion did not produce an output.", 300));
+        }
+
+        return new(
+            true,
+            ActiveRoute.Id,
+            ActiveRoute.Source,
+            ActiveRoute.Target,
+            BoundWebMcpText(Output.FileName, 180),
+            Output.Bytes.LongLength,
+            ReviewWarnings.Count,
+            ElapsedMilliseconds,
+            "Conversion completed locally. Review the visible preview, warnings, and download action before saving the result.");
+    }
+
+    private static string BoundWebMcpText(string? value, int maximumCharacters) {
+        string text = value?.Trim() ?? string.Empty;
+        if (text.Length <= maximumCharacters) {
+            return text;
+        }
+
+        int length = maximumCharacters;
+        if (length > 0 &&
+            char.IsHighSurrogate(text[length - 1]) &&
+            length < text.Length &&
+            char.IsLowSurrogate(text[length])) {
+            length--;
+        }
+        return text[..length];
     }
 
     private static bool IsHtmlInputRoute(ConversionRoute route) =>
@@ -330,11 +394,13 @@ This **Markdown** becomes a browser preview or an editable Word document.
 
     public async ValueTask DisposeAsync() {
         if (_interop is not null) {
+            await _interop.UnregisterWebMcpToolAsync();
             await _interop.RevokeObjectUrlAsync(OutputUrl);
             await _interop.RevokeObjectUrlAsync(OutputReportUrl);
             await _interop.RevokeObjectUrlAsync(OutputOverlayUrl);
             await _interop.RevokeObjectUrlAsync(OutputSupportUrl);
             await _interop.DisposeAsync();
         }
+        _webMcpReference?.Dispose();
     }
 }

--- a/Website/Apps/OfficeIMO.Web.Converter/Components/ConverterWorkspace.razor.js
+++ b/Website/Apps/OfficeIMO.Web.Converter/Components/ConverterWorkspace.razor.js
@@ -8,3 +8,64 @@ export function revokeObjectUrl(url) {
     URL.revokeObjectURL(url);
   }
 }
+
+const toolName = "convert_selected_document";
+let activeConverter = null;
+let registered = false;
+let registrationController = null;
+
+export async function registerWebMcpTool(converter) {
+  activeConverter = converter;
+  if (registered || !document.modelContext || typeof document.modelContext.registerTool !== "function") {
+    document.body.setAttribute("data-webmcp-status", registered ? "registered" : "unsupported");
+    return false;
+  }
+
+  try {
+    registrationController = new AbortController();
+    await document.modelContext.registerTool({
+      name: toolName,
+      description: "Convert the document already selected in the visible OfficeIMO workspace using the current browser-local route and settings.",
+      inputSchema: {
+        type: "object",
+        properties: {},
+        additionalProperties: false
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
+        untrustedContentHint: true
+      },
+      execute: async (_input, context) => {
+        if (!activeConverter) {
+          throw new Error("The OfficeIMO converter is no longer available on this page.");
+        }
+        if (context?.signal?.aborted) {
+          return {
+            success: false,
+            message: "Conversion was cancelled before it started."
+          };
+        }
+        return activeConverter.invokeMethodAsync("ConvertSelectedDocumentForWebMcpAsync");
+      }
+    }, { signal: registrationController.signal });
+    registered = true;
+    document.body.setAttribute("data-webmcp-status", "registered");
+    return true;
+  } catch {
+    registrationController?.abort();
+    registrationController = null;
+    document.body.setAttribute("data-webmcp-status", "failed");
+    return false;
+  }
+}
+
+export async function unregisterWebMcpTool() {
+  activeConverter = null;
+  registrationController?.abort();
+  registrationController = null;
+  registered = false;
+  document.body.setAttribute("data-webmcp-status", "disposed");
+}

--- a/Website/Apps/OfficeIMO.Web.Converter/Models/ConversionModels.cs
+++ b/Website/Apps/OfficeIMO.Web.Converter/Models/ConversionModels.cs
@@ -76,3 +76,14 @@ public sealed record ConversionResult(
     public BrowserPdfProfile? Profile { get; init; }
     public SelectedDocument? SourceSnapshot { get; init; }
 }
+
+public sealed record WebMcpConversionResult(
+    bool Success,
+    string Route,
+    string SourceFormat,
+    string TargetFormat,
+    string? OutputFileName,
+    long OutputBytes,
+    int WarningCount,
+    long ElapsedMilliseconds,
+    string Message);

--- a/Website/Apps/OfficeIMO.Web.Converter/Services/ConverterInterop.cs
+++ b/Website/Apps/OfficeIMO.Web.Converter/Services/ConverterInterop.cs
@@ -6,6 +6,8 @@ public sealed class ConverterInterop(IJSRuntime js) : IAsyncDisposable {
     internal const string ModulePath = "./Components/ConverterWorkspace.razor.js";
     internal const string CreateObjectUrlMethod = "createObjectUrl";
     internal const string RevokeObjectUrlMethod = "revokeObjectUrl";
+    internal const string RegisterWebMcpToolMethod = "registerWebMcpTool";
+    internal const string UnregisterWebMcpToolMethod = "unregisterWebMcpTool";
 
     private IJSObjectReference? _module;
 
@@ -23,6 +25,21 @@ public sealed class ConverterInterop(IJSRuntime js) : IAsyncDisposable {
         }
         IJSObjectReference module = await GetModuleAsync();
         await module.InvokeVoidAsync(RevokeObjectUrlMethod, url);
+    }
+
+    public async ValueTask RegisterWebMcpToolAsync<T>(DotNetObjectReference<T> converter) where T : class {
+        IJSObjectReference module = await GetModuleAsync();
+        await module.InvokeVoidAsync(RegisterWebMcpToolMethod, converter);
+    }
+
+    public async ValueTask UnregisterWebMcpToolAsync() {
+        if (_module is null) {
+            return;
+        }
+        try {
+            await _module.InvokeVoidAsync(UnregisterWebMcpToolMethod);
+        } catch (JSDisconnectedException) {
+        }
     }
 
     public async ValueTask DisposeAsync() {

--- a/Website/Apps/OfficeIMO.Web.Converter/wwwroot/index.html
+++ b/Website/Apps/OfficeIMO.Web.Converter/wwwroot/index.html
@@ -20,7 +20,11 @@
     <script type="importmap"></script>
 </head>
 
-<body class="imo-body officeimo-converter-standalone">
+<body class="imo-body officeimo-converter-standalone"
+      data-webmcp-page-tool
+      data-webmcp-tool-name="convert_selected_document"
+      data-webmcp-tool-description="Convert the document already selected in the visible OfficeIMO workspace using the current browser-local route and settings."
+      data-webmcp-read-only="false">
     <div id="app">
         <main class="ocx-shell">
             <div class="ocx-container">
@@ -34,6 +38,7 @@
         <a href="." class="reload">Reload</a>
         <span class="dismiss">x</span>
     </div>
+    <script type="module" src="Components/ConverterWorkspace.razor.js" data-powerforge-webmcp data-webmcp-tool-name="convert_selected_document"></script>
     <script src="_framework/blazor.webassembly#[.{fingerprint}].js"></script>
 </body>
 

--- a/Website/content/docs/converters/browser-playground/index.md
+++ b/Website/content/docs/converters/browser-playground/index.md
@@ -6,6 +6,12 @@ order: 90
 
 The [browser document workspace](/convert/) is a static Blazor WebAssembly application. Supported conversions and PDF operations execute inside the current tab; selected file bytes are not uploaded to OfficeIMO.
 
+## ChatGPT Website Tool
+
+Open the [full-screen browser workspace](/apps/officeimo-converter/) in a browser that supports Website Tools to make `convert_selected_document` available on that page. Choose or drop a document and select the route and settings in the visible workspace first. ChatGPT can then invoke the same **Convert** action, and the generated download, warnings, and diagnostics remain visible on the page.
+
+The tool has no file, path, URL, or format arguments. It can act only on the document and settings already selected by the user, and processing remains browser-local. It returns bounded metadata rather than document contents. Closing or navigating away from the workspace unregisters the tool. Cancellation is honored before conversion starts; once the synchronous browser-local conversion has started, it completes atomically.
+
 ## Supported browser routes
 
 | Source | Output | Engine |

--- a/Website/scripts/Test-ConverterPerformance.ps1
+++ b/Website/scripts/Test-ConverterPerformance.ps1
@@ -114,6 +114,38 @@ try {
             throw "Repeated route '$($route.routeId)' did not produce fail-closed in-flight browser heap evidence."
         }
     }
+    if (-not $result.webMcp) {
+        throw 'The browser run did not capture the convert_selected_document Website Tool.'
+    }
+    if (-not [bool] $result.webMcpLifecycle.removedOutsideConverter -or -not [bool] $result.webMcpLifecycle.restoredWithConverter) {
+        throw 'The converter Website Tool did not follow the visible converter workspace lifecycle.'
+    }
+    if (-not [bool] $result.webMcp.output.success -or [string] $result.webMcp.output.route -ne 'docx-pdf') {
+        throw 'The convert_selected_document Website Tool did not complete the visible DOCX-to-PDF route.'
+    }
+    if ([long] $result.webMcp.outputCharacters -gt 1500) {
+        throw "The converter Website Tool returned $($result.webMcp.outputCharacters) characters; the limit is 1500."
+    }
+    if ([bool] $result.webMcp.annotations.readOnlyHint -or [bool] $result.webMcp.annotations.destructiveHint -or -not [bool] $result.webMcp.annotations.untrustedContentHint) {
+        throw 'The converter Website Tool annotations do not describe a local, non-destructive conversion of user-provided content.'
+    }
+    if ([bool] $result.webMcp.cancelled.success -or [string] $result.webMcp.cancelled.message -ne 'Conversion was cancelled before it started.') {
+        throw 'The converter Website Tool did not honor a caller cancellation before conversion.'
+    }
+    if ($null -ne $result.webMcp.schema.properties.PSObject.Properties -and @($result.webMcp.schema.properties.PSObject.Properties).Count -gt 0) {
+        throw 'The converter Website Tool must not accept file paths, bytes, or other input parameters.'
+    }
+    if (-not [bool] $result.longNameWebMcp.output.success -or
+        [long] $result.longNameWebMcp.outputCharacters -gt 1500 -or
+        [long] $result.longNameWebMcp.outputFileNameCharacters -gt 180 -or
+        [bool] $result.longNameWebMcp.hasUnpairedSurrogate) {
+        $longNameEvidence = $result.longNameWebMcp | ConvertTo-Json -Depth 6 -Compress
+        throw "The converter Website Tool did not return a Unicode-safe bounded filename. Evidence: $longNameEvidence"
+    }
+    if ([bool] $result.malformedWebMcp.output.success -or [long] $result.malformedWebMcp.outputCharacters -gt 1500 -or [string] $result.malformedWebMcp.visibleDiagnostics -notmatch 'Conversion failed') {
+        $malformedEvidence = $result.malformedWebMcp | ConvertTo-Json -Depth 6 -Compress
+        throw "The converter Website Tool did not return a bounded failure synchronized with the visible workspace. Evidence: $malformedEvidence"
+    }
     if (@($result.consoleErrors).Count -gt 0) {
         throw "Browser converter emitted console errors: $($result.consoleErrors -join ' | ')"
     }
@@ -127,6 +159,10 @@ try {
         playwrightCliVersion = [string] $budgets.playwrightCliVersion
         browserEngine = $browserEngine
         routes = $result.routes
+        webMcp = $result.webMcp
+        webMcpLifecycle = $result.webMcpLifecycle
+        longNameWebMcp = $result.longNameWebMcp
+        malformedWebMcp = $result.malformedWebMcp
         budgets = $budgets
     }
     $reportDirectory = Split-Path -Parent $ReportPath

--- a/Website/scripts/converter-performance.playwright.js
+++ b/Website/scripts/converter-performance.playwright.js
@@ -1,4 +1,18 @@
 async (page) => {
+  await page.addInitScript(() => {
+    const tools = Object.create(null);
+    Object.defineProperty(window, '__officeImoWebMcpTools', { value: tools, configurable: true });
+    Object.defineProperty(document, 'modelContext', {
+      configurable: true,
+      value: {
+        registerTool: async (tool, options) => {
+          tools[tool.name] = tool;
+          options?.signal?.addEventListener('abort', () => { delete tools[tool.name]; }, { once: true });
+        }
+      }
+    });
+  });
+  await page.reload({ waitUntil: 'domcontentloaded' });
   const routeIds = ['docx-pdf', 'xlsx-pdf', 'pptx-pdf'];
   const consoleErrors = [];
   page.on('console', message => {
@@ -17,7 +31,15 @@ async (page) => {
   if (await page.locator('#blazor-error-ui').isVisible()) {
     consoleErrors.push('Blazor error UI became visible during startup.');
   }
+  await page.waitForFunction(() => Boolean(window.__officeImoWebMcpTools?.convert_selected_document), null, { timeout: 60000 });
+  await page.getByRole('button', { name: 'PDF tools', exact: true }).click();
+  await page.waitForFunction(() => !window.__officeImoWebMcpTools?.convert_selected_document, null, { timeout: 60000 });
+  const removedOutsideConverter = await page.evaluate(() => !window.__officeImoWebMcpTools?.convert_selected_document);
+  await page.getByRole('button', { name: 'Convert', exact: true }).click();
+  await page.waitForFunction(() => Boolean(window.__officeImoWebMcpTools?.convert_selected_document), null, { timeout: 60000 });
+  const restoredWithConverter = await page.evaluate(() => Boolean(window.__officeImoWebMcpTools?.convert_selected_document));
   let maximumBrowserHeapBytes = 0;
+  let webMcp = null;
 
   const readBrowserHeap = async () => page.evaluate(() => {
     const memory = performance.memory;
@@ -38,7 +60,7 @@ async (page) => {
     await page.locator('.ocx-diagnostic').filter({ hasText: 'Sample ready' }).waitFor({ state: 'visible', timeout: 60000 });
     const summary = page.locator(`[data-performance-result="true"][data-route="${routeId}"]`);
     const downloadLink = page.getByRole('link', { name: 'Download result', exact: true });
-    const measureConversion = async previousDownloadUrl => {
+    const measureConversion = async (previousDownloadUrl, useWebMcp) => {
       let sampling = true;
       let memorySamples = 0;
       let peakBrowserHeapBytes = 0;
@@ -58,7 +80,27 @@ async (page) => {
         }
       })();
 
-      await page.locator(`[data-convert-route="${routeId}"]`).click();
+      let webMcpOutput = null;
+      if (useWebMcp) {
+        await page.waitForFunction(() => Boolean(window.__officeImoWebMcpTools?.convert_selected_document), null, { timeout: 60000 });
+        webMcpOutput = await page.evaluate(async () => {
+          const tool = window.__officeImoWebMcpTools.convert_selected_document;
+          const cancelledSignal = new AbortController();
+          cancelledSignal.abort();
+          const cancelled = await tool.execute({}, { signal: cancelledSignal.signal });
+          const output = await tool.execute({}, { signal: new AbortController().signal });
+          return {
+            registeredTools: Object.keys(window.__officeImoWebMcpTools).sort(),
+            schema: tool.inputSchema,
+            annotations: tool.annotations,
+            cancelled,
+            output,
+            outputCharacters: JSON.stringify(output).length
+          };
+        });
+      } else {
+        await page.locator(`[data-convert-route="${routeId}"]`).click();
+      }
       await page.waitForFunction(previousUrl => {
         const link = Array.from(document.querySelectorAll('a'))
           .find(element => element.textContent?.trim() === 'Download result');
@@ -79,11 +121,12 @@ async (page) => {
         peakRetainedBytes: Number(element.getAttribute('data-peak-retained-bytes') || '0'),
         resultBytes: Number(element.getAttribute('data-result-bytes') || '0')
       }));
-      return { downloadUrl, pdfMagic, memorySamples, peakBrowserHeapBytes, peakBrowserUsedHeapBytes, ...metrics };
+      return { downloadUrl, pdfMagic, memorySamples, peakBrowserHeapBytes, peakBrowserUsedHeapBytes, webMcpOutput, ...metrics };
     };
 
-    const first = await measureConversion('');
-    const repeat = await measureConversion(first.downloadUrl);
+    const first = await measureConversion('', index === 0);
+    const repeat = await measureConversion(first.downloadUrl, false);
+    if (first.webMcpOutput) webMcp = first.webMcpOutput;
     maximumBrowserHeapBytes = Math.max(
       maximumBrowserHeapBytes,
       first.peakBrowserHeapBytes,
@@ -107,5 +150,70 @@ async (page) => {
     });
   }
 
-  return JSON.stringify({ startupMilliseconds, maximumBrowserHeapBytes, routes: results, consoleErrors });
+  await page.goto(`${baseUrl}?route=docx-pdf`, { waitUntil: 'domcontentloaded' });
+  await page.locator('[data-converter-ready="true"]').waitFor({ state: 'visible', timeout: 60000 });
+  await page.waitForFunction(() => Boolean(window.__officeImoWebMcpTools?.convert_selected_document), null, { timeout: 60000 });
+  await page.getByLabel('Choose a DOCX file', { exact: true }).evaluate(async input => {
+    const bytes = new Uint8Array(await (await fetch('samples/basic.docx')).arrayBuffer());
+    const file = new File(
+      [bytes],
+      `${'a'.repeat(179)}🚀.docx`,
+      { type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' }
+    );
+    const transfer = new DataTransfer();
+    transfer.items.add(file);
+    input.files = transfer.files;
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+  });
+  await page.locator('.ocx-diagnostic').filter({ hasText: 'is loaded in this browser tab' })
+    .waitFor({ state: 'visible', timeout: 60000 });
+  const longNameWebMcp = await page.evaluate(async () => {
+    const tool = window.__officeImoWebMcpTools.convert_selected_document;
+    const output = await tool.execute({}, { signal: new AbortController().signal });
+    const fileName = String(output.outputFileName || '');
+    const hasUnpairedSurrogate = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:^|[^\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(fileName);
+    return {
+      output,
+      outputCharacters: JSON.stringify(output).length,
+      outputFileNameCharacters: fileName.length,
+      hasUnpairedSurrogate
+    };
+  });
+  await page.getByLabel('Choose a DOCX file', { exact: true }).evaluate(input => {
+    const bytes = new Uint8Array([
+      110, 111, 116, 45, 97, 110, 45, 111, 112, 101, 110,
+      45, 120, 109, 108, 45, 112, 97, 99, 107, 97, 103, 101
+    ]);
+    const file = new File(
+      [bytes],
+      `${'malformed-'.repeat(18)}document.docx`,
+      { type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' }
+    );
+    const transfer = new DataTransfer();
+    transfer.items.add(file);
+    input.files = transfer.files;
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+  });
+  await page.locator('.ocx-diagnostic').filter({ hasText: 'is loaded in this browser tab' })
+    .waitFor({ state: 'visible', timeout: 60000 });
+  const malformedWebMcp = await page.evaluate(async () => {
+    const tool = window.__officeImoWebMcpTools.convert_selected_document;
+    const output = await tool.execute({}, { signal: new AbortController().signal });
+    return {
+      output,
+      outputCharacters: JSON.stringify(output).length,
+      visibleDiagnostics: Array.from(document.querySelectorAll('.ocx-diagnostic')).map(element => element.textContent || '').join(' ')
+    };
+  });
+
+  return JSON.stringify({
+    startupMilliseconds,
+    maximumBrowserHeapBytes,
+    routes: results,
+    webMcp,
+    webMcpLifecycle: { removedOutsideConverter, restoredWithConverter },
+    longNameWebMcp,
+    malformedWebMcp,
+    consoleErrors
+  });
 }

--- a/Website/site.json
+++ b/Website/site.json
@@ -300,6 +300,13 @@
         "Description": "Search OfficeIMO documentation, API references, articles, and examples.",
         "Kind": "site-search",
         "ReadOnly": true
+      },
+      {
+        "Name": "convert_selected_document",
+        "Route": "/apps/officeimo-converter/",
+        "Description": "Convert the document already selected in the visible OfficeIMO workspace using the current browser-local route and settings.",
+        "Kind": "page-tool",
+        "ReadOnly": false
       }
     ],
     "MarkdownNegotiation": false


### PR DESCRIPTION
## Summary

- expose `convert_selected_document` on the existing OfficeIMO WebAssembly converter page
- convert only the document already selected in the visible workspace, using its current browser-local route and settings
- keep document bytes local to the browser; the tool does not add an upload service, account, credit system, or server queue
- bound success/failure responses, preserve exact output filenames safely, synchronize the visible conversion/download state, and unregister on component disposal
- associate the adapter explicitly with its tool and pin website CI/deployment/maintenance to the merged PowerForge.Web owner

## Ownership and dependency

OfficeIMO owns the document conversion behavior; PowerForge.Web owns Website Tool discovery and readiness verification. [EvotecIT/PSPublishModule#870](https://github.com/EvotecIT/PSPublishModule/pull/870) is merged, and this PR consumes commit `2540d97039f41bae9bf79ae337f6be6bf8f7a44d`.

## Safety boundary

This pilot performs a user-visible, browser-local conversion on an already selected file. It adds no authenticated, administrative, licensing, tenant, or server-side action.

## Validation

- full 78-step website pipeline passed against the exact PowerForge revision
- agent readiness: 40 checks, 0 failures
- converter asset graph: 98 fingerprinted resources
- Playwright browser acceptance: 85,802,336-byte published app, 365 ms startup, three representative conversion routes
- registration lifecycle, cancellation, long filename, bounded output, malformed-input failure, and visible result state passed