### PR TITLE
Validate live conversion and bounded WebMCP search visibility

### DIFF
--- a/Website/scripts/converter-performance.playwright.js
+++ b/Website/scripts/converter-performance.playwright.js
@@ -1,7 +1,20 @@
 async (page) => {
   await page.addInitScript(() => {
     const tools = Object.create(null);
+    const objectUrlBlobs = new Map();
+    const createObjectURL = URL.createObjectURL.bind(URL);
+    const revokeObjectURL = URL.revokeObjectURL.bind(URL);
     Object.defineProperty(window, '__officeImoWebMcpTools', { value: tools, configurable: true });
+    Object.defineProperty(window, '__officeImoObjectUrlBlobs', { value: objectUrlBlobs, configurable: true });
+    URL.createObjectURL = blob => {
+      const url = createObjectURL(blob);
+      objectUrlBlobs.set(url, blob);
+      return url;
+    };
+    URL.revokeObjectURL = url => {
+      objectUrlBlobs.delete(url);
+      revokeObjectURL(url);
+    };
     Object.defineProperty(document, 'modelContext', {
       configurable: true,
       value: {
@@ -113,7 +126,9 @@ async (page) => {
 
       const downloadUrl = await downloadLink.getAttribute('href');
       const pdfMagic = await page.evaluate(async url => {
-        const bytes = new Uint8Array(await (await fetch(url)).arrayBuffer());
+        const blob = window.__officeImoObjectUrlBlobs?.get(url);
+        if (!(blob instanceof Blob)) throw new Error(`Generated output blob is unavailable for ${url}.`);
+        const bytes = new Uint8Array(await blob.arrayBuffer());
         return String.fromCharCode(...bytes.slice(0, 4));
       }, downloadUrl);
       const metrics = await summary.evaluate(element => ({

--- a/Website/static/js/search-page.js
+++ b/Website/static/js/search-page.js
@@ -7,6 +7,15 @@
     return;
   }
 
+  let entries = [];
+  let indexLoadError = null;
+  let resolveIndexReady;
+  const indexReady = new Promise(function (resolve) {
+    resolveIndexReady = resolve;
+  });
+  const webMcpSearch = window.PowerForgeWebMcpSearch || {};
+  window.PowerForgeWebMcpSearch = webMcpSearch;
+
   const params = new URLSearchParams(window.location.search);
   const seededQuery = (params.get('q') || '').trim();
   if (seededQuery) {
@@ -63,7 +72,47 @@
     }).join('');
   }
 
-  let entries = [];
+  function awaitIndex(signal) {
+    if (!signal) {
+      return indexReady;
+    }
+    if (signal.aborted) {
+      return Promise.reject(new DOMException('The OfficeIMO search was cancelled.', 'AbortError'));
+    }
+
+    return new Promise(function (resolve, reject) {
+      function cleanup() {
+        signal.removeEventListener('abort', abort);
+      }
+      function abort() {
+        cleanup();
+        reject(new DOMException('The OfficeIMO search was cancelled.', 'AbortError'));
+      }
+      signal.addEventListener('abort', abort, { once: true });
+      indexReady.then(function () {
+        cleanup();
+        resolve();
+      });
+    });
+  }
+
+  webMcpSearch.adapter = {
+    search: async function (request) {
+      await awaitIndex(request.signal);
+      if (indexLoadError) {
+        throw indexLoadError;
+      }
+      if (typeof webMcpSearch.searchEntries !== 'function') {
+        throw new Error('The PowerForge WebMCP search runtime is unavailable.');
+      }
+
+      const result = webMcpSearch.searchEntries(entries, request.query, request.limit);
+      input.value = request.query;
+      render(result.results, request.query);
+      return result;
+    }
+  };
+
   try {
     let indexPath = '/search/index.json';
     const manifestResponse = await fetch('/search/manifest.json', { cache: 'no-cache' });
@@ -81,10 +130,13 @@
 
     entries = await indexResponse.json();
   } catch (error) {
+    indexLoadError = error instanceof Error ? error : new Error(String(error));
     meta.textContent = 'Search index unavailable.';
     results.innerHTML = '<p>' + escapeHtml(error && error.message ? error.message : error) + '</p>';
+    resolveIndexReady();
     return;
   }
+  resolveIndexReady();
 
   function runSearch() {
     const query = input.value.trim().toLowerCase();

--- a/Website/static/js/search-page.js
+++ b/Website/static/js/search-page.js
@@ -8,11 +8,8 @@
   }
 
   let entries = [];
-  let indexLoadError = null;
-  let resolveIndexReady;
-  const indexReady = new Promise(function (resolve) {
-    resolveIndexReady = resolve;
-  });
+  let indexLoaded = false;
+  let webMcpResultsVisible = false;
   const webMcpSearch = window.PowerForgeWebMcpSearch || {};
   window.PowerForgeWebMcpSearch = webMcpSearch;
 
@@ -72,46 +69,18 @@
     }).join('');
   }
 
-  function awaitIndex(signal) {
-    if (!signal) {
-      return indexReady;
-    }
-    if (signal.aborted) {
-      return Promise.reject(new DOMException('The OfficeIMO search was cancelled.', 'AbortError'));
-    }
-
-    return new Promise(function (resolve, reject) {
-      function cleanup() {
-        signal.removeEventListener('abort', abort);
-      }
-      function abort() {
-        cleanup();
-        reject(new DOMException('The OfficeIMO search was cancelled.', 'AbortError'));
-      }
-      signal.addEventListener('abort', abort, { once: true });
-      indexReady.then(function () {
-        cleanup();
-        resolve();
-      });
-    });
-  }
-
-  webMcpSearch.adapter = {
-    search: async function (request) {
-      await awaitIndex(request.signal);
-      if (indexLoadError) {
-        throw indexLoadError;
-      }
-      if (typeof webMcpSearch.searchEntries !== 'function') {
-        throw new Error('The PowerForge WebMCP search runtime is unavailable.');
-      }
-
-      const result = webMcpSearch.searchEntries(entries, request.query, request.limit);
-      input.value = request.query;
-      render(result.results, request.query);
-      return result;
-    }
+  webMcpSearch.renderVisibleResults = function (response) {
+    webMcpResultsVisible = true;
+    input.value = response.query;
+    render(response.results, response.query);
   };
+
+  input.addEventListener('input', function () {
+    webMcpResultsVisible = false;
+    if (indexLoaded) {
+      runSearch();
+    }
+  });
 
   try {
     let indexPath = '/search/index.json';
@@ -129,14 +98,14 @@
     }
 
     entries = await indexResponse.json();
+    indexLoaded = true;
   } catch (error) {
-    indexLoadError = error instanceof Error ? error : new Error(String(error));
-    meta.textContent = 'Search index unavailable.';
-    results.innerHTML = '<p>' + escapeHtml(error && error.message ? error.message : error) + '</p>';
-    resolveIndexReady();
+    if (!webMcpResultsVisible) {
+      meta.textContent = 'Search index unavailable.';
+      results.innerHTML = '<p>' + escapeHtml(error && error.message ? error.message : error) + '</p>';
+    }
     return;
   }
-  resolveIndexReady();
 
   function runSearch() {
     const query = input.value.trim().toLowerCase();
@@ -166,6 +135,7 @@
     render(matches, query);
   }
 
-  input.addEventListener('input', runSearch);
-  runSearch();
+  if (!webMcpResultsVisible) {
+    runSearch();
+  }
 })();

--- a/Website/themes/officeimo/layouts/search.html
+++ b/Website/themes/officeimo/layouts/search.html
@@ -46,7 +46,7 @@
           </div>
           <input id="imo-search-query" class="imo-search__input" type="search" autocomplete="off" placeholder="Search docs, APIs, blog posts, products, and pages" data-search-page-input />
           <div id="imo-search-meta" class="imo-search__meta">Loading search index...</div>
-          <div id="imo-search-results" class="imo-search__results"></div>
+          <div id="imo-search-results" class="imo-search__results" data-search-page-results></div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary

- validate generated converter downloads from the Blob already created by the browser application, without weakening the live `connect-src 'self'` policy
- expose the search result region to the shared Website Tool acceptance check
- render only the normalized, bounded PowerForge search response and preserve it across late OfficeIMO index initialization
- return normal search ownership to the page as soon as the user types

## Why

The converter's live CSP correctly blocks `fetch(blob:)`, so the performance harness could not inspect a completed PDF even though the visible download and Website Tool conversion had succeeded. The harness now observes `URL.createObjectURL`, reads the same generated Blob directly, and releases captured references when the application revokes them.

For site search, [PowerForge](https://github.com/EvotecIT/PSPublishModule) remains the index, ranking, bounds, normalization, and cancellation owner. This page consumes the bounded renderer added by PowerForge PR [#875](https://github.com/EvotecIT/PSPublishModule/pull/875); merge and deploy that owner first, then this PR.

## Validation

- converter acceptance passed for representative DOCX, XLSX, and PPTX routes on the live production build
- converter Website Tool lifecycle, cancellation, Unicode filename bounds, failure visibility, download validation, and workspace synchronization passed with zero console errors
- search Website Tool returned three of 189 matches and the visible page showed exactly the same three URLs
- a forced 2.5-second OfficeIMO index delay did not overwrite the bounded tool-rendered results after initialization
- manual input after tool execution restored the page's normal 47-result search behavior
- empty search results rendered visibly; immediate pre-render cancellation returned `AbortError` without changing the page