### PR TITLE
Consume the final PowerForge WebMCP runtime

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -60,7 +60,7 @@ jobs:
       packages: read
       pages: write
       id-token: write
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@2c554894d3c40a704af3babb5c5334a386b1b131
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@9f2d36a18c8334d9a27587f04b38ad0dc9bd515d
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -71,7 +71,7 @@ jobs:
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       dotnet_workloads: wasm-tools
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 2c554894d3c40a704af3babb5c5334a386b1b131
+      powerforge_ref: 9f2d36a18c8334d9a27587f04b38ad0dc9bd515d
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}
       cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -60,7 +60,7 @@ jobs:
       packages: read
       pages: write
       id-token: write
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@2540d97039f41bae9bf79ae337f6be6bf8f7a44d
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@2c554894d3c40a704af3babb5c5334a386b1b131
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -71,7 +71,7 @@ jobs:
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       dotnet_workloads: wasm-tools
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 2540d97039f41bae9bf79ae337f6be6bf8f7a44d
+      powerforge_ref: 2c554894d3c40a704af3babb5c5334a386b1b131
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}
       cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   website-build:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@2c554894d3c40a704af3babb5c5334a386b1b131
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@9f2d36a18c8334d9a27587f04b38ad0dc9bd515d
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -31,5 +31,5 @@ jobs:
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       dotnet_workloads: wasm-tools
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 2c554894d3c40a704af3babb5c5334a386b1b131
+      powerforge_ref: 9f2d36a18c8334d9a27587f04b38ad0dc9bd515d
       report_artifact_name: powerforge-website-reports

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   website-build:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@2540d97039f41bae9bf79ae337f6be6bf8f7a44d
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@2c554894d3c40a704af3babb5c5334a386b1b131
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -31,5 +31,5 @@ jobs:
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       dotnet_workloads: wasm-tools
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 2540d97039f41bae9bf79ae337f6be6bf8f7a44d
+      powerforge_ref: 2c554894d3c40a704af3babb5c5334a386b1b131
       report_artifact_name: powerforge-website-reports

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -31,12 +31,12 @@ jobs:
       actions: write
       contents: read
       packages: read
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@2c554894d3c40a704af3babb5c5334a386b1b131
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@9f2d36a18c8334d9a27587f04b38ad0dc9bd515d
     with:
       website_root: Website
       pipeline_config: Website/pipeline.maintenance.json
       engine_mode: source
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 2c554894d3c40a704af3babb5c5334a386b1b131
+      powerforge_ref: 9f2d36a18c8334d9a27587f04b38ad0dc9bd515d
       report_artifact_name: powerforge-website-maintenance-reports

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -31,12 +31,12 @@ jobs:
       actions: write
       contents: read
       packages: read
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@2540d97039f41bae9bf79ae337f6be6bf8f7a44d
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@2c554894d3c40a704af3babb5c5334a386b1b131
     with:
       website_root: Website
       pipeline_config: Website/pipeline.maintenance.json
       engine_mode: source
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 2540d97039f41bae9bf79ae337f6be6bf8f7a44d
+      powerforge_ref: 2c554894d3c40a704af3babb5c5334a386b1b131
       report_artifact_name: powerforge-website-maintenance-reports


### PR DESCRIPTION
## Summary

- pin OfficeIMO website deploy, CI, and maintenance workflows to the merged PowerForge WebMCP runtime at `9f2d36a18c8334d9a27587f04b38ad0dc9bd515d`
- consume the generated-search visibility fix from [PowerForge PR #876](https://github.com/EvotecIT/PSPublishModule/pull/876)
- keep the Office search page on the canonical bounded renderer introduced in PR #2449

## Validation

- all referenced reusable workflows exist at the immutable engine commit
- deploy and live search/converter acceptance will run after merge