### PR TITLE
Purge all OfficeIMO cache variants after website deploys

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -60,7 +60,7 @@ jobs:
       packages: read
       pages: write
       id-token: write
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@9f2d36a18c8334d9a27587f04b38ad0dc9bd515d
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@3fb959e848e8d05744af826b7a74ae7edcc1e41d
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -71,7 +71,7 @@ jobs:
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       dotnet_workloads: wasm-tools
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 9f2d36a18c8334d9a27587f04b38ad0dc9bd515d
+      powerforge_ref: 3fb959e848e8d05744af826b7a74ae7edcc1e41d
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}
       cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   website-build:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@9f2d36a18c8334d9a27587f04b38ad0dc9bd515d
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@3fb959e848e8d05744af826b7a74ae7edcc1e41d
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -31,5 +31,5 @@ jobs:
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       dotnet_workloads: wasm-tools
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 9f2d36a18c8334d9a27587f04b38ad0dc9bd515d
+      powerforge_ref: 3fb959e848e8d05744af826b7a74ae7edcc1e41d
       report_artifact_name: powerforge-website-reports

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -31,12 +31,12 @@ jobs:
       actions: write
       contents: read
       packages: read
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@9f2d36a18c8334d9a27587f04b38ad0dc9bd515d
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@3fb959e848e8d05744af826b7a74ae7edcc1e41d
     with:
       website_root: Website
       pipeline_config: Website/pipeline.maintenance.json
       engine_mode: source
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 9f2d36a18c8334d9a27587f04b38ad0dc9bd515d
+      powerforge_ref: 3fb959e848e8d05744af826b7a74ae7edcc1e41d
       report_artifact_name: powerforge-website-maintenance-reports

--- a/Website/site.json
+++ b/Website/site.json
@@ -315,11 +315,7 @@
     "Cache": {
       "EdgeTtlSeconds": 604800
     },
-    "PurgeMode": "incremental",
-    "AlwaysPurgePaths": [
-      "/apps/officeimo-converter/",
-      "/apps/officeimo-converter/?embedded=1"
-    ],
+    "PurgeMode": "hostname",
     "SmartTieredCache": true
   },
   "EditLinks": {


### PR DESCRIPTION
## Summary

- purge cached responses for the full `officeimo.com` hostname after each managed Pages deployment
- pin website deploy, CI, and maintenance workflows to the PowerForge commit that implements configured non-incremental purging
- remove the incremental-only converter path list

## Why

The browser-local converter uses query-driven routes that cannot be enumerated safely. A file-scoped purge can leave an older query variant cached after fingerprinted application assets change. Hostname invalidation keeps those variants consistent while retaining the site's seven-day edge cache policy.

PowerForge owns the deployment behavior in [EvotecIT/PSPublishModule#877](https://github.com/EvotecIT/PSPublishModule/pull/877), which is already merged. This PR applies that owner contract in OfficeIMO.

## Validation

- parsed `Website/site.json` successfully
- verified all three reusable workflow files at the pinned PowerForge commit
- ran the merged PowerForge CLI against the OfficeIMO profile in dry-run mode; it selected `mode=hostname` with `officeimo.com` as the single target
