### PR TITLE
Fix kerning fallback for default variable-font instances

### DIFF
--- a/OfficeIMO.Core/OfficeOpenTypeKerning.cs
+++ b/OfficeIMO.Core/OfficeOpenTypeKerning.cs
@@ -54,18 +54,21 @@ internal sealed class OfficeOpenTypeKerning {
     private readonly int _gpos;
     private readonly bool _includeExtendedGpos;
     private readonly Func<int, int, int>? _variationDelta;
+    private readonly bool _requireVariationDelta;
 
     internal OfficeOpenTypeKerning(
         byte[] data,
         int kern,
         int gpos,
         bool includeExtendedGpos = true,
-        Func<int, int, int>? variationDelta = null) {
+        Func<int, int, int>? variationDelta = null,
+        bool requireVariationDelta = false) {
         _data = data ?? throw new ArgumentNullException(nameof(data));
         _kern = kern;
         _gpos = gpos;
         _includeExtendedGpos = includeExtendedGpos;
         _variationDelta = variationDelta;
+        _requireVariationDelta = requireVariationDelta;
     }
 
     internal static OfficeOpenTypeKerning FromReader(
@@ -80,7 +83,8 @@ internal sealed class OfficeOpenTypeKerning {
             reader.TryGetTable("kern", out int kern, out _) ? kern : -1,
             reader.TryGetTable("GPOS", out int gpos, out _) ? gpos : -1,
             includeExtendedGpos: true,
-            variationDelta);
+            variationDelta,
+            requireVariationDelta: variations?.IsVariable == true);
     }
 
     private static Func<int, int, int>? TryCreateGdefVariationEvaluator(
@@ -576,7 +580,10 @@ internal sealed class OfficeOpenTypeKerning {
         }
         if (ReadUInt16(variationIndex + 4) != 0x8000) return 0;
         if (_variationDelta == null) {
-            throw new InvalidDataException("A GPOS VariationIndex requires a GDEF ItemVariationStore.");
+            if (_requireVariationDelta) {
+                throw new InvalidDataException("A GPOS VariationIndex requires a GDEF ItemVariationStore.");
+            }
+            return 0;
         }
         return _variationDelta(ReadUInt16(variationIndex), ReadUInt16(variationIndex + 2));
     }

--- a/OfficeIMO.Drawing.Tests/Drawing.OpenTypeKerning.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.OpenTypeKerning.cs
@@ -157,6 +157,41 @@ public sealed class DrawingOpenTypeKerningTests {
     }
 
     [Fact]
+    public void GposPairPositioningTreatsVariationIndexesAsNeutralForTheDefaultFontInstance() {
+        byte[] data = CreateKerningTables(
+            legacyAdjustment: -80,
+            gposAdjustment: -30,
+            gposRightGlyph: 2);
+        WritePairVariationPositioningSubtable(data, subtable: 254, rightGlyph: 2);
+        var kerning = new OfficeOpenTypeKerning(data, kern: 0, gpos: 64);
+
+        OfficeOpenTypePairPositioning positioning = kerning.Positioning(left: 1, right: 2, scriptTag: "DFLT");
+
+        Assert.Equal(-10, positioning.FirstGlyphXPlacement);
+        Assert.Equal(-20, positioning.FirstGlyphXAdvance);
+    }
+
+    [Fact]
+    public void GposPairPositioningRequiresAVariationStoreForASelectedVariableInstance() {
+        byte[] data = CreateKerningTables(
+            legacyAdjustment: -80,
+            gposAdjustment: -30,
+            gposRightGlyph: 2);
+        WritePairVariationPositioningSubtable(data, subtable: 254, rightGlyph: 2);
+        var kerning = new OfficeOpenTypeKerning(
+            data,
+            kern: 0,
+            gpos: 64,
+            variationDelta: null,
+            requireVariationDelta: true);
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+            kerning.Positioning(left: 1, right: 2, scriptTag: "DFLT"));
+
+        Assert.Contains("GDEF ItemVariationStore", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void GposRunSkipsTheSecondGlyphWhenValueRecord2IsPresent() {
         byte[] data = CreateKerningTables(
             legacyAdjustment: 0,


### PR DESCRIPTION
## Summary

- treat GPOS VariationIndex adjustments as neutral when shaping the default/static font instance without a selected variation model
- preserve fail-closed behavior for explicitly selected variable-font instances that lack a required GDEF ItemVariationStore
- add focused regression coverage for both contracts

This fixes raster rendering with macOS system fonts and unblocks the affected rendering paths in [PSWriteOffice](https://github.com/EvotecIT/PSWriteOffice).

## Validation

- focused OpenType kerning tests on .NET Framework 4.7.2, .NET 8, and .NET 10
- full OfficeIMO.Drawing test suite on .NET 8: 1,979 passed
- macOS ARM64 focused tests on .NET 8 and .NET 10
- downstream macOS Excel and Word/HTML raster suites: 18 passed
- independent read-only code review: no actionable findings