### PR TITLE
Prepare OfficeIMO 3.4.1 package set

### DIFF
--- a/.agents/plugins/officeimo-document-tools/.mcp.json
+++ b/.agents/plugins/officeimo-document-tools/.mcp.json
@@ -5,7 +5,7 @@
       "command": "dotnet",
       "args": [
         "dnx",
-        "OfficeIMO.Tool@3.4.0",
+        "OfficeIMO.Tool@3.4.1",
         "mcp",
         "serve",
         "--stdio"

--- a/OfficeIMO.Adf/OfficeIMO.Adf.csproj
+++ b/OfficeIMO.Adf/OfficeIMO.Adf.csproj
@@ -4,7 +4,7 @@
     <Description>Atlas Document Format model and OfficeIMO conversion support.</Description>
     <AssemblyName>OfficeIMO.Adf</AssemblyName>
     <AssemblyTitle>OfficeIMO.Adf</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.AsciiDoc.Markdown/OfficeIMO.AsciiDoc.Markdown.csproj
+++ b/OfficeIMO.AsciiDoc.Markdown/OfficeIMO.AsciiDoc.Markdown.csproj
@@ -4,7 +4,7 @@
     <Description>Loss-aware AsciiDoc and Markdown conversion bridge for OfficeIMO.</Description>
     <AssemblyName>OfficeIMO.AsciiDoc.Markdown</AssemblyName>
     <AssemblyTitle>OfficeIMO.AsciiDoc.Markdown</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.AsciiDoc.Pdf/OfficeIMO.AsciiDoc.Pdf.csproj
+++ b/OfficeIMO.AsciiDoc.Pdf/OfficeIMO.AsciiDoc.Pdf.csproj
@@ -4,7 +4,7 @@
     <PackageId>OfficeIMO.AsciiDoc.Pdf</PackageId>
     <AssemblyName>OfficeIMO.AsciiDoc.Pdf</AssemblyName>
     <AssemblyTitle>OfficeIMO.AsciiDoc.Pdf</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.AsciiDoc/OfficeIMO.AsciiDoc.csproj
+++ b/OfficeIMO.AsciiDoc/OfficeIMO.AsciiDoc.csproj
@@ -4,7 +4,7 @@
     <Description>Source-preserving AsciiDoc parser, semantic model, and writer for .NET.</Description>
     <AssemblyName>OfficeIMO.AsciiDoc</AssemblyName>
     <AssemblyTitle>OfficeIMO.AsciiDoc</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.Bibliography/OfficeIMO.Bibliography.csproj
+++ b/OfficeIMO.Bibliography/OfficeIMO.Bibliography.csproj
@@ -4,7 +4,7 @@
     <Description>Source-preserving citation data model and deterministic bibliography codecs for .NET.</Description>
     <AssemblyName>OfficeIMO.Bibliography</AssemblyName>
     <AssemblyTitle>OfficeIMO.Bibliography</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.CSV/OfficeIMO.CSV.csproj
+++ b/OfficeIMO.CSV/OfficeIMO.CSV.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>OfficeIMO.CSV</AssemblyName>
     <AssemblyTitle>OfficeIMO.CSV</AssemblyTitle>
 
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0;net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Company>Evotec</Company>

--- a/OfficeIMO.ChartForgeX/OfficeIMO.ChartForgeX.csproj
+++ b/OfficeIMO.ChartForgeX/OfficeIMO.ChartForgeX.csproj
@@ -4,7 +4,7 @@
     <PackageId>OfficeIMO.ChartForgeX</PackageId>
     <AssemblyName>OfficeIMO.ChartForgeX</AssemblyName>
     <AssemblyTitle>OfficeIMO.ChartForgeX</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.Confluence/OfficeIMO.Confluence.csproj
+++ b/OfficeIMO.Confluence/OfficeIMO.Confluence.csproj
@@ -4,7 +4,7 @@
     <Description>Dependency-light Confluence Cloud client and OfficeIMO content conversion support.</Description>
     <AssemblyName>OfficeIMO.Confluence</AssemblyName>
     <AssemblyTitle>OfficeIMO.Confluence</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Core/OfficeIMO.Core.csproj
+++ b/OfficeIMO.Core/OfficeIMO.Core.csproj
@@ -4,7 +4,7 @@
     <Description>Shared zero-dependency document, security, drawing, color, image, and font primitives for OfficeIMO projects.</Description>
     <AssemblyName>OfficeIMO.Core</AssemblyName>
     <AssemblyTitle>OfficeIMO.Core</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Data.Arrow/OfficeIMO.Data.Arrow.csproj
+++ b/OfficeIMO.Data.Arrow/OfficeIMO.Data.Arrow.csproj
@@ -3,7 +3,7 @@
     <Description>Apache Arrow adapters for forward-only OfficeIMO and ADO.NET tabular readers.</Description>
     <AssemblyName>OfficeIMO.Data.Arrow</AssemblyName>
     <AssemblyTitle>OfficeIMO.Data.Arrow</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <IsPackable>true</IsPackable>

--- a/OfficeIMO.Data.Generators/OfficeIMO.Data.Generators.csproj
+++ b/OfficeIMO.Data.Generators/OfficeIMO.Data.Generators.csproj
@@ -3,7 +3,7 @@
     <Description>Incremental source generators for AOT-safe OfficeIMO tabular row mappings.</Description>
     <AssemblyName>OfficeIMO.Data.Generators</AssemblyName>
     <AssemblyTitle>OfficeIMO.Data.Generators</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFramework>netstandard2.0</TargetFramework>
     <EnableAotAnalyzer>false</EnableAotAnalyzer>
     <EnableTrimAnalyzer>false</EnableTrimAnalyzer>

--- a/OfficeIMO.DocBook/OfficeIMO.DocBook.csproj
+++ b/OfficeIMO.DocBook/OfficeIMO.DocBook.csproj
@@ -3,7 +3,7 @@
     <Description>Bounded, source-preserving DocBook 4.5 and 5.2 common-structure parser, editor, writer, validator, and converter.</Description>
     <AssemblyName>OfficeIMO.DocBook</AssemblyName>
     <AssemblyTitle>OfficeIMO.DocBook</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.Drawing.CodeGlyphX/OfficeIMO.Drawing.CodeGlyphX.csproj
+++ b/OfficeIMO.Drawing.CodeGlyphX/OfficeIMO.Drawing.CodeGlyphX.csproj
@@ -4,7 +4,7 @@
     <PackageId>OfficeIMO.Drawing.CodeGlyphX</PackageId>
     <AssemblyName>OfficeIMO.Drawing.CodeGlyphX</AssemblyName>
     <AssemblyTitle>OfficeIMO.Drawing.CodeGlyphX</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.Drawing.HarfBuzz/OfficeIMO.Drawing.HarfBuzz.csproj
+++ b/OfficeIMO.Drawing.HarfBuzz/OfficeIMO.Drawing.HarfBuzz.csproj
@@ -4,7 +4,7 @@
     <Description>Optional HarfBuzz text-shaping provider for OfficeIMO.Drawing and OfficeIMO.Pdf.</Description>
     <AssemblyName>OfficeIMO.Drawing.HarfBuzz</AssemblyName>
     <AssemblyTitle>OfficeIMO.Drawing.HarfBuzz</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Email.Html/OfficeIMO.Email.Html.csproj
+++ b/OfficeIMO.Email.Html/OfficeIMO.Email.Html.csproj
@@ -3,7 +3,7 @@
     <Description>Dependency-isolated safe HTML, RTF, text, and inline-resource projection for OfficeIMO email artifacts.</Description>
     <AssemblyName>OfficeIMO.Email.Html</AssemblyName>
     <AssemblyTitle>OfficeIMO.Email.Html</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Email.Image/OfficeIMO.Email.Image.csproj
+++ b/OfficeIMO.Email.Image/OfficeIMO.Email.Image.csproj
@@ -3,7 +3,7 @@
     <Description>HTML-backed image rendering for OfficeIMO email documents.</Description>
     <AssemblyName>OfficeIMO.Email.Image</AssemblyName>
     <AssemblyTitle>OfficeIMO.Email.Image</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Email/OfficeIMO.Email.csproj
+++ b/OfficeIMO.Email/OfficeIMO.Email.csproj
@@ -4,7 +4,7 @@
     <Description>Managed email and Outlook data engine for EML, MSG/OFT, TNEF, ICS, vCard, Mbox, PST/OST, OLM, EMLX, Maildir, and Offline Address Book artifacts.</Description>
     <AssemblyName>OfficeIMO.Email</AssemblyName>
     <AssemblyTitle>OfficeIMO.Email</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Epub.Image/OfficeIMO.Epub.Image.csproj
+++ b/OfficeIMO.Epub.Image/OfficeIMO.Epub.Image.csproj
@@ -3,7 +3,7 @@
     <Description>Thin EPUB-to-image adapter over OfficeIMO.Html and OfficeIMO.Drawing.</Description>
     <AssemblyName>OfficeIMO.Epub.Image</AssemblyName>
     <AssemblyTitle>OfficeIMO.Epub.Image</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Epub/OfficeIMO.Epub.csproj
+++ b/OfficeIMO.Epub/OfficeIMO.Epub.csproj
@@ -3,7 +3,7 @@
     <Description>EPUB extraction primitives for modular OfficeIMO ingestion pipelines.</Description>
     <AssemblyName>OfficeIMO.Epub</AssemblyName>
     <AssemblyTitle>OfficeIMO.Epub</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Excel.Csv/OfficeIMO.Excel.Csv.csproj
+++ b/OfficeIMO.Excel.Csv/OfficeIMO.Excel.Csv.csproj
@@ -3,7 +3,7 @@
     <Description>Bidirectional CSV and Excel conversion adapter using the native OfficeIMO.CSV and OfficeIMO.Excel engines.</Description>
     <AssemblyName>OfficeIMO.Excel.Csv</AssemblyName>
     <AssemblyTitle>OfficeIMO.Excel.Csv</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Excel.GoogleSheets/OfficeIMO.Excel.GoogleSheets.csproj
+++ b/OfficeIMO.Excel.GoogleSheets/OfficeIMO.Excel.GoogleSheets.csproj
@@ -4,7 +4,7 @@
         <Description>Create, safely replace, import, diff, and translate Google Sheets documents with OfficeIMO.Excel.</Description>
         <AssemblyName>OfficeIMO.Excel.GoogleSheets</AssemblyName>
         <AssemblyTitle>OfficeIMO.Excel.GoogleSheets</AssemblyTitle>
-        <VersionPrefix>3.4.0</VersionPrefix>
+        <VersionPrefix>3.4.1</VersionPrefix>
         <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
             $(TargetFrameworks);net472</TargetFrameworks>

--- a/OfficeIMO.Excel.Html/OfficeIMO.Excel.Html.csproj
+++ b/OfficeIMO.Excel.Html/OfficeIMO.Excel.Html.csproj
@@ -4,7 +4,7 @@
     <PackageId>OfficeIMO.Excel.Html</PackageId>
     <AssemblyName>OfficeIMO.Excel.Html</AssemblyName>
     <AssemblyTitle>OfficeIMO.Excel.Html</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.Excel.IWork/OfficeIMO.Excel.IWork.csproj
+++ b/OfficeIMO.Excel.IWork/OfficeIMO.Excel.IWork.csproj
@@ -4,7 +4,7 @@
     <PackageId>OfficeIMO.Excel.IWork</PackageId>
     <AssemblyName>OfficeIMO.Excel.IWork</AssemblyName>
     <AssemblyTitle>OfficeIMO.Excel.IWork</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.Excel.OpenDocument/OfficeIMO.Excel.OpenDocument.csproj
+++ b/OfficeIMO.Excel.OpenDocument/OfficeIMO.Excel.OpenDocument.csproj
@@ -4,7 +4,7 @@
     <PackageId>OfficeIMO.Excel.OpenDocument</PackageId>
     <AssemblyName>OfficeIMO.Excel.OpenDocument</AssemblyName>
     <AssemblyTitle>OfficeIMO.Excel.OpenDocument</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.Excel.Pdf/OfficeIMO.Excel.Pdf.csproj
+++ b/OfficeIMO.Excel.Pdf/OfficeIMO.Excel.Pdf.csproj
@@ -4,7 +4,7 @@
     <PackageId>OfficeIMO.Excel.Pdf</PackageId>
     <AssemblyName>OfficeIMO.Excel.Pdf</AssemblyName>
     <AssemblyTitle>OfficeIMO.Excel.Pdf</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.Excel/OfficeIMO.Excel.csproj
+++ b/OfficeIMO.Excel/OfficeIMO.Excel.csproj
@@ -5,7 +5,7 @@
         <AssemblyName>OfficeIMO.Excel</AssemblyName>
         <AssemblyTitle>OfficeIMO.Excel</AssemblyTitle>
 
-        <VersionPrefix>3.4.0</VersionPrefix>
+        <VersionPrefix>3.4.1</VersionPrefix>
         <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
             $(TargetFrameworks);net472</TargetFrameworks>

--- a/OfficeIMO.GoogleWorkspace.Auth.GoogleApis/OfficeIMO.GoogleWorkspace.Auth.GoogleApis.csproj
+++ b/OfficeIMO.GoogleWorkspace.Auth.GoogleApis/OfficeIMO.GoogleWorkspace.Auth.GoogleApis.csproj
@@ -4,7 +4,7 @@
     <Description>Optional Google.Apis.Auth adapters, PKCE desktop authorization, and pluggable token persistence for OfficeIMO Google Workspace libraries.</Description>
     <AssemblyName>OfficeIMO.GoogleWorkspace.Auth.GoogleApis</AssemblyName>
     <AssemblyTitle>OfficeIMO.GoogleWorkspace.Auth.GoogleApis</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.GoogleWorkspace.Drive/OfficeIMO.GoogleWorkspace.Drive.csproj
+++ b/OfficeIMO.GoogleWorkspace.Drive/OfficeIMO.GoogleWorkspace.Drive.csproj
@@ -4,7 +4,7 @@
         <Description>Typed Google Drive API client, shared-drive support, conversion, media transfer, collaboration, and change tracking for OfficeIMO.</Description>
         <AssemblyName>OfficeIMO.GoogleWorkspace.Drive</AssemblyName>
         <AssemblyTitle>OfficeIMO.GoogleWorkspace.Drive</AssemblyTitle>
-        <VersionPrefix>3.4.0</VersionPrefix>
+        <VersionPrefix>3.4.1</VersionPrefix>
         <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
         <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.GoogleWorkspace.Sync/OfficeIMO.GoogleWorkspace.Sync.csproj
+++ b/OfficeIMO.GoogleWorkspace.Sync/OfficeIMO.GoogleWorkspace.Sync.csproj
@@ -3,7 +3,7 @@
     <Description>Google Drive change tracking and explicit plan/apply synchronization workflows for OfficeIMO Google Workspace libraries.</Description>
     <AssemblyName>OfficeIMO.GoogleWorkspace.Sync</AssemblyName>
     <AssemblyTitle>OfficeIMO.GoogleWorkspace.Sync</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.GoogleWorkspace/OfficeIMO.GoogleWorkspace.csproj
+++ b/OfficeIMO.GoogleWorkspace/OfficeIMO.GoogleWorkspace.csproj
@@ -4,7 +4,7 @@
         <Description>Shared Google Workspace abstractions for OfficeIMO extension packages.</Description>
         <AssemblyName>OfficeIMO.GoogleWorkspace</AssemblyName>
         <AssemblyTitle>OfficeIMO.GoogleWorkspace</AssemblyTitle>
-        <VersionPrefix>3.4.0</VersionPrefix>
+        <VersionPrefix>3.4.1</VersionPrefix>
         <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
             $(TargetFrameworks);net472</TargetFrameworks>

--- a/OfficeIMO.Html.Pdf.Browser/OfficeIMO.Html.Pdf.Browser.csproj
+++ b/OfficeIMO.Html.Pdf.Browser/OfficeIMO.Html.Pdf.Browser.csproj
@@ -3,7 +3,7 @@
     <Description>Optional HtmlTinkerX browser-PDF bridge for OfficeIMO.</Description>
     <AssemblyName>OfficeIMO.Html.Pdf.Browser</AssemblyName>
     <AssemblyTitle>OfficeIMO.Html.Pdf.Browser</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Html.Pdf/OfficeIMO.Html.Pdf.csproj
+++ b/OfficeIMO.Html.Pdf/OfficeIMO.Html.Pdf.csproj
@@ -4,7 +4,7 @@
     <PackageId>OfficeIMO.Html.Pdf</PackageId>
     <AssemblyName>OfficeIMO.Html.Pdf</AssemblyName>
     <AssemblyTitle>OfficeIMO.Html.Pdf</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.Html.Rtf/OfficeIMO.Html.Rtf.csproj
+++ b/OfficeIMO.Html.Rtf/OfficeIMO.Html.Rtf.csproj
@@ -3,7 +3,7 @@
     <Description>Bidirectional HTML and RTF conversion for OfficeIMO.</Description>
     <AssemblyName>OfficeIMO.Html.Rtf</AssemblyName>
     <AssemblyTitle>OfficeIMO.Html.Rtf</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Html/OfficeIMO.Html.csproj
+++ b/OfficeIMO.Html/OfficeIMO.Html.csproj
@@ -4,7 +4,7 @@
     <Description>HTML parsing, resource policy, CSS layout, diagnostics, and direct rendering for OfficeIMO converters.</Description>
     <AssemblyName>OfficeIMO.Html</AssemblyName>
     <AssemblyTitle>OfficeIMO.Html</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.IWork/OfficeIMO.IWork.csproj
+++ b/OfficeIMO.IWork/OfficeIMO.IWork.csproj
@@ -3,7 +3,7 @@
     <Description>Bounded read-only Apple iWork package and IWA inspection with Pages, Numbers, and Keynote source projections.</Description>
     <AssemblyName>OfficeIMO.IWork</AssemblyName>
     <AssemblyTitle>OfficeIMO.IWork</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Latex.Markdown/OfficeIMO.Latex.Markdown.csproj
+++ b/OfficeIMO.Latex.Markdown/OfficeIMO.Latex.Markdown.csproj
@@ -4,7 +4,7 @@
     <Description>Loss-aware LaTeX and Markdown conversion bridge for OfficeIMO.</Description>
     <AssemblyName>OfficeIMO.Latex.Markdown</AssemblyName>
     <AssemblyTitle>OfficeIMO.Latex.Markdown</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.Latex.Pdf/OfficeIMO.Latex.Pdf.csproj
+++ b/OfficeIMO.Latex.Pdf/OfficeIMO.Latex.Pdf.csproj
@@ -4,7 +4,7 @@
     <PackageId>OfficeIMO.Latex.Pdf</PackageId>
     <AssemblyName>OfficeIMO.Latex.Pdf</AssemblyName>
     <AssemblyTitle>OfficeIMO.Latex.Pdf</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.Latex/OfficeIMO.Latex.csproj
+++ b/OfficeIMO.Latex/OfficeIMO.Latex.csproj
@@ -4,7 +4,7 @@
     <Description>Source-preserving LaTeX interoperability profile for .NET.</Description>
     <AssemblyName>OfficeIMO.Latex</AssemblyName>
     <AssemblyTitle>OfficeIMO.Latex</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.Markdown.Html/OfficeIMO.Markdown.Html.csproj
+++ b/OfficeIMO.Markdown.Html/OfficeIMO.Markdown.Html.csproj
@@ -4,7 +4,7 @@
         <Description>HTML converter for OfficeIMO.Markdown - Convert HTML fragments or documents into OfficeIMO.Markdown documents and Markdown text.</Description>
         <AssemblyName>OfficeIMO.Markdown.Html</AssemblyName>
         <AssemblyTitle>OfficeIMO.Markdown.Html</AssemblyTitle>
-        <VersionPrefix>3.4.0</VersionPrefix>
+        <VersionPrefix>3.4.1</VersionPrefix>
         <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
             $(TargetFrameworks);net472

--- a/OfficeIMO.Markdown.Pdf/OfficeIMO.Markdown.Pdf.csproj
+++ b/OfficeIMO.Markdown.Pdf/OfficeIMO.Markdown.Pdf.csproj
@@ -4,7 +4,7 @@
     <PackageId>OfficeIMO.Markdown.Pdf</PackageId>
     <AssemblyName>OfficeIMO.Markdown.Pdf</AssemblyName>
     <AssemblyTitle>OfficeIMO.Markdown.Pdf</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.Markdown/OfficeIMO.Markdown.csproj
+++ b/OfficeIMO.Markdown/OfficeIMO.Markdown.csproj
@@ -4,7 +4,7 @@
         <Description>Markdown builder, typed reader/AST, and HTML renderer for .NET with GitHub-like output and an optional portable reader profile.</Description>
         <AssemblyName>OfficeIMO.Markdown</AssemblyName>
         <AssemblyTitle>OfficeIMO.Markdown</AssemblyTitle>
-        <VersionPrefix>3.4.0</VersionPrefix>
+        <VersionPrefix>3.4.1</VersionPrefix>
         <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
             $(TargetFrameworks);net472</TargetFrameworks>

--- a/OfficeIMO.MarkdownRenderer.IntelligenceX/OfficeIMO.MarkdownRenderer.IntelligenceX.csproj
+++ b/OfficeIMO.MarkdownRenderer.IntelligenceX/OfficeIMO.MarkdownRenderer.IntelligenceX.csproj
@@ -4,7 +4,7 @@
     <Description>IntelligenceX renderer plugin pack for OfficeIMO.MarkdownRenderer with transcript-oriented preset helpers and IX visual aliases.</Description>
     <AssemblyName>OfficeIMO.MarkdownRenderer.IntelligenceX</AssemblyName>
     <AssemblyTitle>OfficeIMO.MarkdownRenderer.IntelligenceX</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
       $(TargetFrameworks);net472

--- a/OfficeIMO.MarkdownRenderer.Wpf/OfficeIMO.MarkdownRenderer.Wpf.csproj
+++ b/OfficeIMO.MarkdownRenderer.Wpf/OfficeIMO.MarkdownRenderer.Wpf.csproj
@@ -4,7 +4,7 @@
     <Description>Reusable WPF/WebView2 host control for OfficeIMO.MarkdownRenderer.</Description>
     <AssemblyName>OfficeIMO.MarkdownRenderer.Wpf</AssemblyName>
     <AssemblyTitle>OfficeIMO.MarkdownRenderer.Wpf</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Company>Evotec</Company>

--- a/OfficeIMO.MarkdownRenderer/OfficeIMO.MarkdownRenderer.csproj
+++ b/OfficeIMO.MarkdownRenderer/OfficeIMO.MarkdownRenderer.csproj
@@ -4,7 +4,7 @@
     <Description>WebView-friendly Markdown rendering helpers (shell + incremental updates) built on OfficeIMO.Markdown.</Description>
     <AssemblyName>OfficeIMO.MarkdownRenderer</AssemblyName>
     <AssemblyTitle>OfficeIMO.MarkdownRenderer</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
       $(TargetFrameworks);net472

--- a/OfficeIMO.Mhtml.Pdf/OfficeIMO.Mhtml.Pdf.csproj
+++ b/OfficeIMO.Mhtml.Pdf/OfficeIMO.Mhtml.Pdf.csproj
@@ -3,7 +3,7 @@
     <Description>Direct MHTML-to-PDF conversion for OfficeIMO.</Description>
     <AssemblyName>OfficeIMO.Mhtml.Pdf</AssemblyName>
     <AssemblyTitle>OfficeIMO.Mhtml.Pdf</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Mhtml/OfficeIMO.Mhtml.csproj
+++ b/OfficeIMO.Mhtml/OfficeIMO.Mhtml.csproj
@@ -3,7 +3,7 @@
     <Description>MHTML archive loading, saving, HTML projection, and embedded MIME resources for OfficeIMO.</Description>
     <AssemblyName>OfficeIMO.Mhtml</AssemblyName>
     <AssemblyTitle>OfficeIMO.Mhtml</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Ocr.Process/OfficeIMO.Ocr.Process.csproj
+++ b/OfficeIMO.Ocr.Process/OfficeIMO.Ocr.Process.csproj
@@ -3,7 +3,7 @@
     <Description>Optional process-protocol provider for the engine-neutral OfficeIMO OCR contract.</Description>
     <AssemblyName>OfficeIMO.Ocr.Process</AssemblyName>
     <AssemblyTitle>OfficeIMO.Ocr.Process</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Ocr.Tesseract/OfficeIMO.Ocr.Tesseract.csproj
+++ b/OfficeIMO.Ocr.Tesseract/OfficeIMO.Ocr.Tesseract.csproj
@@ -3,7 +3,7 @@
     <Description>Optional Tesseract CLI provider for the engine-neutral OfficeIMO OCR contract.</Description>
     <AssemblyName>OfficeIMO.Ocr.Tesseract</AssemblyName>
     <AssemblyTitle>OfficeIMO.Ocr.Tesseract</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Ocr/OfficeIMO.Ocr.csproj
+++ b/OfficeIMO.Ocr/OfficeIMO.Ocr.csproj
@@ -3,7 +3,7 @@
     <Description>Dependency-light OCR contracts shared by OfficeIMO document formats and providers.</Description>
     <AssemblyName>OfficeIMO.Ocr</AssemblyName>
     <AssemblyTitle>OfficeIMO.Ocr</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.OneNote.Html/OfficeIMO.OneNote.Html.csproj
+++ b/OfficeIMO.OneNote.Html/OfficeIMO.OneNote.Html.csproj
@@ -3,7 +3,7 @@
     <Description>First-party offline OneNote to HTML conversion for OfficeIMO.</Description>
     <AssemblyName>OfficeIMO.OneNote.Html</AssemblyName>
     <AssemblyTitle>OfficeIMO.OneNote.Html</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.OneNote.Markdown/OfficeIMO.OneNote.Markdown.csproj
+++ b/OfficeIMO.OneNote.Markdown/OfficeIMO.OneNote.Markdown.csproj
@@ -3,7 +3,7 @@
     <Description>Semantic offline OneNote to Markdown conversion for OfficeIMO.</Description>
     <AssemblyName>OfficeIMO.OneNote.Markdown</AssemblyName>
     <AssemblyTitle>OfficeIMO.OneNote.Markdown</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <IsPackable>true</IsPackable>

--- a/OfficeIMO.OneNote.Pdf/OfficeIMO.OneNote.Pdf.csproj
+++ b/OfficeIMO.OneNote.Pdf/OfficeIMO.OneNote.Pdf.csproj
@@ -3,7 +3,7 @@
     <Description>First-party offline OneNote to PDF conversion for OfficeIMO.</Description>
     <AssemblyName>OfficeIMO.OneNote.Pdf</AssemblyName>
     <AssemblyTitle>OfficeIMO.OneNote.Pdf</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.OneNote/OfficeIMO.OneNote.csproj
+++ b/OfficeIMO.OneNote/OfficeIMO.OneNote.csproj
@@ -3,7 +3,7 @@
     <Description>Managed, cross-platform Microsoft OneNote file-format engine for .one, .onetoc2, and .onepkg artifacts.</Description>
     <AssemblyName>OfficeIMO.OneNote</AssemblyName>
     <AssemblyTitle>OfficeIMO.OneNote</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.OpenDocument.Odp.Pdf/OfficeIMO.OpenDocument.Odp.Pdf.csproj
+++ b/OfficeIMO.OpenDocument.Odp.Pdf/OfficeIMO.OpenDocument.Odp.Pdf.csproj
@@ -4,7 +4,7 @@
     <PackageId>OfficeIMO.OpenDocument.Odp.Pdf</PackageId>
     <AssemblyName>OfficeIMO.OpenDocument.Odp.Pdf</AssemblyName>
     <AssemblyTitle>OfficeIMO.OpenDocument.Odp.Pdf</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.OpenDocument.Ods.Pdf/OfficeIMO.OpenDocument.Ods.Pdf.csproj
+++ b/OfficeIMO.OpenDocument.Ods.Pdf/OfficeIMO.OpenDocument.Ods.Pdf.csproj
@@ -4,7 +4,7 @@
     <PackageId>OfficeIMO.OpenDocument.Ods.Pdf</PackageId>
     <AssemblyName>OfficeIMO.OpenDocument.Ods.Pdf</AssemblyName>
     <AssemblyTitle>OfficeIMO.OpenDocument.Ods.Pdf</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.OpenDocument.Odt.Pdf/OfficeIMO.OpenDocument.Odt.Pdf.csproj
+++ b/OfficeIMO.OpenDocument.Odt.Pdf/OfficeIMO.OpenDocument.Odt.Pdf.csproj
@@ -4,7 +4,7 @@
     <PackageId>OfficeIMO.OpenDocument.Odt.Pdf</PackageId>
     <AssemblyName>OfficeIMO.OpenDocument.Odt.Pdf</AssemblyName>
     <AssemblyTitle>OfficeIMO.OpenDocument.Odt.Pdf</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.OpenDocument/OfficeIMO.OpenDocument.csproj
+++ b/OfficeIMO.OpenDocument/OfficeIMO.OpenDocument.csproj
@@ -3,7 +3,7 @@
     <Description>Native OpenDocument ODT, ODS, and ODP reader, writer, and preservation-aware document model for .NET.</Description>
     <AssemblyName>OfficeIMO.OpenDocument</AssemblyName>
     <AssemblyTitle>OfficeIMO.OpenDocument</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Opml/OfficeIMO.Opml.csproj
+++ b/OfficeIMO.Opml/OfficeIMO.Opml.csproj
@@ -3,7 +3,7 @@
     <Description>Lossless OPML 1.0 and 2.0 parser, editor, writer, validator, and conversion model for .NET.</Description>
     <AssemblyName>OfficeIMO.Opml</AssemblyName>
     <AssemblyTitle>OfficeIMO.Opml</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.Pdf.Ocr/OfficeIMO.Pdf.Ocr.csproj
+++ b/OfficeIMO.Pdf.Ocr/OfficeIMO.Pdf.Ocr.csproj
@@ -3,7 +3,7 @@
     <Description>Optional OCR rendering, native-text merge, and searchable output for OfficeIMO.Pdf.</Description>
     <AssemblyName>OfficeIMO.Pdf.Ocr</AssemblyName>
     <AssemblyTitle>OfficeIMO.Pdf.Ocr</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Pdf/OfficeIMO.Pdf.csproj
+++ b/OfficeIMO.Pdf/OfficeIMO.Pdf.csproj
@@ -4,7 +4,7 @@
     <Description>First-party PDF builder, reader, editor, renderer, and signature workflow for .NET.</Description>
     <AssemblyName>OfficeIMO.Pdf</AssemblyName>
     <AssemblyTitle>OfficeIMO.Pdf</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.PowerPoint.GoogleSlides/OfficeIMO.PowerPoint.GoogleSlides.csproj
+++ b/OfficeIMO.PowerPoint.GoogleSlides/OfficeIMO.PowerPoint.GoogleSlides.csproj
@@ -3,7 +3,7 @@
     <Description>Bidirectional OfficeIMO PowerPoint and Google Slides translation with safe replacement, template, and Drive fallback workflows.</Description>
     <AssemblyName>OfficeIMO.PowerPoint.GoogleSlides</AssemblyName>
     <AssemblyTitle>OfficeIMO.PowerPoint.GoogleSlides</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.PowerPoint.Html/OfficeIMO.PowerPoint.Html.csproj
+++ b/OfficeIMO.PowerPoint.Html/OfficeIMO.PowerPoint.Html.csproj
@@ -4,7 +4,7 @@
     <PackageId>OfficeIMO.PowerPoint.Html</PackageId>
     <AssemblyName>OfficeIMO.PowerPoint.Html</AssemblyName>
     <AssemblyTitle>OfficeIMO.PowerPoint.Html</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.PowerPoint.IWork/OfficeIMO.PowerPoint.IWork.csproj
+++ b/OfficeIMO.PowerPoint.IWork/OfficeIMO.PowerPoint.IWork.csproj
@@ -4,7 +4,7 @@
     <PackageId>OfficeIMO.PowerPoint.IWork</PackageId>
     <AssemblyName>OfficeIMO.PowerPoint.IWork</AssemblyName>
     <AssemblyTitle>OfficeIMO.PowerPoint.IWork</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.PowerPoint.OpenDocument/OfficeIMO.PowerPoint.OpenDocument.csproj
+++ b/OfficeIMO.PowerPoint.OpenDocument/OfficeIMO.PowerPoint.OpenDocument.csproj
@@ -4,7 +4,7 @@
     <PackageId>OfficeIMO.PowerPoint.OpenDocument</PackageId>
     <AssemblyName>OfficeIMO.PowerPoint.OpenDocument</AssemblyName>
     <AssemblyTitle>OfficeIMO.PowerPoint.OpenDocument</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.PowerPoint.Pdf/OfficeIMO.PowerPoint.Pdf.csproj
+++ b/OfficeIMO.PowerPoint.Pdf/OfficeIMO.PowerPoint.Pdf.csproj
@@ -4,7 +4,7 @@
     <PackageId>OfficeIMO.PowerPoint.Pdf</PackageId>
     <AssemblyName>OfficeIMO.PowerPoint.Pdf</AssemblyName>
     <AssemblyTitle>OfficeIMO.PowerPoint.Pdf</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.PowerPoint/OfficeIMO.PowerPoint.csproj
+++ b/OfficeIMO.PowerPoint/OfficeIMO.PowerPoint.csproj
@@ -5,7 +5,7 @@
         <AssemblyName>OfficeIMO.PowerPoint</AssemblyName>
         <AssemblyTitle>OfficeIMO.PowerPoint</AssemblyTitle>
 
-        <VersionPrefix>3.4.0</VersionPrefix>
+        <VersionPrefix>3.4.1</VersionPrefix>
         <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
             $(TargetFrameworks);net472

--- a/OfficeIMO.Provenance.C2pa/OfficeIMO.Provenance.C2pa.csproj
+++ b/OfficeIMO.Provenance.C2pa/OfficeIMO.Provenance.C2pa.csproj
@@ -3,7 +3,7 @@
     <Description>Optional c2patool process adapter for C2PA Content Credential signing and verification with OfficeIMO.</Description>
     <AssemblyName>OfficeIMO.Provenance.C2pa</AssemblyName>
     <AssemblyTitle>OfficeIMO.Provenance.C2pa</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.All/OfficeIMO.Reader.All.csproj
+++ b/OfficeIMO.Reader.All/OfficeIMO.Reader.All.csproj
@@ -4,7 +4,7 @@
     <Description>Composition-only preset for registering OfficeIMO.Reader's local format adapters.</Description>
     <AssemblyName>OfficeIMO.Reader.All</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.All</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.AsciiDoc/OfficeIMO.Reader.AsciiDoc.csproj
+++ b/OfficeIMO.Reader.AsciiDoc/OfficeIMO.Reader.AsciiDoc.csproj
@@ -4,7 +4,7 @@
     <Description>Modular OfficeIMO.Reader adapter for dependency-free AsciiDoc ingestion.</Description>
     <AssemblyName>OfficeIMO.Reader.AsciiDoc</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.AsciiDoc</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.Core/OfficeIMO.Reader.Core.csproj
+++ b/OfficeIMO.Reader.Core/OfficeIMO.Reader.Core.csproj
@@ -3,7 +3,7 @@
     <Description>Dependency-light contracts, routing, processing, and normalized document models for modular OfficeIMO readers.</Description>
     <AssemblyName>OfficeIMO.Reader.Core</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.Core</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.Csv/OfficeIMO.Reader.Csv.csproj
+++ b/OfficeIMO.Reader.Csv/OfficeIMO.Reader.Csv.csproj
@@ -3,7 +3,7 @@
     <Description>CSV/TSV adapter for OfficeIMO.Reader.Core.</Description>
     <AssemblyName>OfficeIMO.Reader.Csv</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.Csv</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.DocBook/OfficeIMO.Reader.DocBook.csproj
+++ b/OfficeIMO.Reader.DocBook/OfficeIMO.Reader.DocBook.csproj
@@ -3,7 +3,7 @@
     <Description>Modular OfficeIMO.Reader adapter for bounded DocBook ingestion.</Description>
     <AssemblyName>OfficeIMO.Reader.DocBook</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.DocBook</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.Email/OfficeIMO.Reader.Email.csproj
+++ b/OfficeIMO.Reader.Email/OfficeIMO.Reader.Email.csproj
@@ -3,7 +3,7 @@
     <Description>Unified email, MHTML, Outlook store, and Offline Address Book adapter for OfficeIMO.Reader.Core.</Description>
     <AssemblyName>OfficeIMO.Reader.Email</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.Email</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.Epub/OfficeIMO.Reader.Epub.csproj
+++ b/OfficeIMO.Reader.Epub/OfficeIMO.Reader.Epub.csproj
@@ -3,7 +3,7 @@
     <Description>EPUB adapter for OfficeIMO.Reader modular ingestion.</Description>
     <AssemblyName>OfficeIMO.Reader.Epub</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.Epub</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.Excel/OfficeIMO.Reader.Excel.csproj
+++ b/OfficeIMO.Reader.Excel/OfficeIMO.Reader.Excel.csproj
@@ -3,7 +3,7 @@
     <Description>Excel workbook adapter for OfficeIMO.Reader.Core.</Description>
     <AssemblyName>OfficeIMO.Reader.Excel</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.Excel</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.Html/OfficeIMO.Reader.Html.csproj
+++ b/OfficeIMO.Reader.Html/OfficeIMO.Reader.Html.csproj
@@ -3,7 +3,7 @@
     <Description>HTML adapter for OfficeIMO.Reader using OfficeIMO.Html.</Description>
     <AssemblyName>OfficeIMO.Reader.Html</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.Html</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.Image/OfficeIMO.Reader.Image.csproj
+++ b/OfficeIMO.Reader.Image/OfficeIMO.Reader.Image.csproj
@@ -3,7 +3,7 @@
     <Description>First-party image metadata and OCR-readiness adapter for OfficeIMO.Reader.</Description>
     <AssemblyName>OfficeIMO.Reader.Image</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.Image</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.Json/OfficeIMO.Reader.Json.csproj
+++ b/OfficeIMO.Reader.Json/OfficeIMO.Reader.Json.csproj
@@ -3,7 +3,7 @@
     <Description>JSON adapter extensions for OfficeIMO.Reader.</Description>
     <AssemblyName>OfficeIMO.Reader.Json</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.Json</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.Latex/OfficeIMO.Reader.Latex.csproj
+++ b/OfficeIMO.Reader.Latex/OfficeIMO.Reader.Latex.csproj
@@ -4,7 +4,7 @@
     <Description>Modular OfficeIMO.Reader adapter for bounded-profile LaTeX ingestion.</Description>
     <AssemblyName>OfficeIMO.Reader.Latex</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.Latex</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.Markdown/OfficeIMO.Reader.Markdown.csproj
+++ b/OfficeIMO.Reader.Markdown/OfficeIMO.Reader.Markdown.csproj
@@ -3,7 +3,7 @@
     <Description>Markdown document adapter for OfficeIMO.Reader.Core.</Description>
     <AssemblyName>OfficeIMO.Reader.Markdown</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.Markdown</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.Notebook/OfficeIMO.Reader.Notebook.csproj
+++ b/OfficeIMO.Reader.Notebook/OfficeIMO.Reader.Notebook.csproj
@@ -3,7 +3,7 @@
     <Description>Bounded Jupyter Notebook adapter for OfficeIMO.Reader.</Description>
     <AssemblyName>OfficeIMO.Reader.Notebook</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.Notebook</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.Ocr/OfficeIMO.Reader.Ocr.csproj
+++ b/OfficeIMO.Reader.Ocr/OfficeIMO.Reader.Ocr.csproj
@@ -3,7 +3,7 @@
     <Description>Optional OCR execution and enrichment for normalized OfficeIMO.Reader documents.</Description>
     <AssemblyName>OfficeIMO.Reader.Ocr</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.Ocr</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.OneNote/OfficeIMO.Reader.OneNote.csproj
+++ b/OfficeIMO.Reader.OneNote/OfficeIMO.Reader.OneNote.csproj
@@ -3,7 +3,7 @@
     <Description>Offline OneNote adapter for OfficeIMO.Reader using OfficeIMO.OneNote.</Description>
     <AssemblyName>OfficeIMO.Reader.OneNote</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.OneNote</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.OpenDocument/OfficeIMO.Reader.OpenDocument.csproj
+++ b/OfficeIMO.Reader.OpenDocument/OfficeIMO.Reader.OpenDocument.csproj
@@ -3,7 +3,7 @@
     <Description>Native ODT, ODS, and ODP adapter for OfficeIMO.Reader modular ingestion.</Description>
     <AssemblyName>OfficeIMO.Reader.OpenDocument</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.OpenDocument</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.Opml/OfficeIMO.Reader.Opml.csproj
+++ b/OfficeIMO.Reader.Opml/OfficeIMO.Reader.Opml.csproj
@@ -3,7 +3,7 @@
     <Description>Modular OfficeIMO.Reader adapter for bounded OPML ingestion.</Description>
     <AssemblyName>OfficeIMO.Reader.Opml</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.Opml</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.Pdf/OfficeIMO.Reader.Pdf.csproj
+++ b/OfficeIMO.Reader.Pdf/OfficeIMO.Reader.Pdf.csproj
@@ -3,7 +3,7 @@
     <Description>PDF reader and normalized PDF projection bridge for OfficeIMO.Reader.</Description>
     <AssemblyName>OfficeIMO.Reader.Pdf</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.Pdf</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.PowerPoint/OfficeIMO.Reader.PowerPoint.csproj
+++ b/OfficeIMO.Reader.PowerPoint/OfficeIMO.Reader.PowerPoint.csproj
@@ -3,7 +3,7 @@
     <Description>PowerPoint presentation adapter for OfficeIMO.Reader.Core.</Description>
     <AssemblyName>OfficeIMO.Reader.PowerPoint</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.PowerPoint</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.Rtf/OfficeIMO.Reader.Rtf.csproj
+++ b/OfficeIMO.Reader.Rtf/OfficeIMO.Reader.Rtf.csproj
@@ -3,7 +3,7 @@
     <Description>Bounded RTF chunk, table, visual, warning, and provenance adapter for OfficeIMO.Reader.</Description>
     <AssemblyName>OfficeIMO.Reader.Rtf</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.Rtf</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.Subtitles/OfficeIMO.Reader.Subtitles.csproj
+++ b/OfficeIMO.Reader.Subtitles/OfficeIMO.Reader.Subtitles.csproj
@@ -3,7 +3,7 @@
     <Description>Dependency-free SRT and WebVTT adapter for OfficeIMO.Reader.</Description>
     <AssemblyName>OfficeIMO.Reader.Subtitles</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.Subtitles</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.Visio/OfficeIMO.Reader.Visio.csproj
+++ b/OfficeIMO.Reader.Visio/OfficeIMO.Reader.Visio.csproj
@@ -3,7 +3,7 @@
     <Description>Visio adapter for OfficeIMO.Reader using OfficeIMO.Visio inspection snapshots.</Description>
     <AssemblyName>OfficeIMO.Reader.Visio</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.Visio</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.Web/OfficeIMO.Reader.Web.csproj
+++ b/OfficeIMO.Reader.Web/OfficeIMO.Reader.Web.csproj
@@ -3,7 +3,7 @@
     <Description>Bounded caller-injected HTTP transport for OfficeIMO.Reader.</Description>
     <AssemblyName>OfficeIMO.Reader.Web</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.Web</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.Word/OfficeIMO.Reader.Word.csproj
+++ b/OfficeIMO.Reader.Word/OfficeIMO.Reader.Word.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Word document adapter for OfficeIMO.Reader.Core.</Description>
     <AssemblyName>OfficeIMO.Reader.Word</AssemblyName><AssemblyTitle>OfficeIMO.Reader.Word</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild><IsPackable>true</IsPackable><IsPublishable>true</IsPublishable>

--- a/OfficeIMO.Reader.Xml/OfficeIMO.Reader.Xml.csproj
+++ b/OfficeIMO.Reader.Xml/OfficeIMO.Reader.Xml.csproj
@@ -3,7 +3,7 @@
     <Description>XML adapter extensions for OfficeIMO.Reader.</Description>
     <AssemblyName>OfficeIMO.Reader.Xml</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.Xml</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.Yaml/OfficeIMO.Reader.Yaml.csproj
+++ b/OfficeIMO.Reader.Yaml/OfficeIMO.Reader.Yaml.csproj
@@ -3,7 +3,7 @@
     <Description>YAML adapter extensions for OfficeIMO.Reader.</Description>
     <AssemblyName>OfficeIMO.Reader.Yaml</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.Yaml</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.Zip/OfficeIMO.Reader.Zip.csproj
+++ b/OfficeIMO.Reader.Zip/OfficeIMO.Reader.Zip.csproj
@@ -3,7 +3,7 @@
     <Description>ZIP adapter for OfficeIMO.Reader modular ingestion.</Description>
     <AssemblyName>OfficeIMO.Reader.Zip</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.Zip</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Rtf.Markdown/OfficeIMO.Rtf.Markdown.csproj
+++ b/OfficeIMO.Rtf.Markdown/OfficeIMO.Rtf.Markdown.csproj
@@ -10,7 +10,7 @@
     <Company>Evotec</Company>
     <Description>Semantic Rich Text Format and Markdown conversion bridge for OfficeIMO.</Description>
     <PackageTags>RTF;Markdown;OfficeIMO;document-conversion</PackageTags>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>Latest</LangVersion>

--- a/OfficeIMO.Rtf.Pdf/OfficeIMO.Rtf.Pdf.csproj
+++ b/OfficeIMO.Rtf.Pdf/OfficeIMO.Rtf.Pdf.csproj
@@ -3,7 +3,7 @@
     <Description>Bidirectional semantic RTF/PDF converter with shared fidelity diagnostics and managed image handling.</Description>
     <AssemblyName>OfficeIMO.Rtf.Pdf</AssemblyName>
     <AssemblyTitle>OfficeIMO.Rtf.Pdf</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Rtf/OfficeIMO.Rtf.csproj
+++ b/OfficeIMO.Rtf/OfficeIMO.Rtf.csproj
@@ -4,7 +4,7 @@
     <Description>Managed Rich Text Format (RTF) reader, writer, lossless syntax tree, bounded parser, and editable document model for .NET.</Description>
     <AssemblyName>OfficeIMO.Rtf</AssemblyName>
     <AssemblyTitle>OfficeIMO.Rtf</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Security/OfficeIMO.Security.csproj
+++ b/OfficeIMO.Security/OfficeIMO.Security.csproj
@@ -3,7 +3,7 @@
     <Description>Optional CMS, S/MIME, RFC 3161, X.509, and XML Digital Signature support for OfficeIMO packages.</Description>
     <AssemblyName>OfficeIMO.Security</AssemblyName>
     <AssemblyTitle>OfficeIMO.Security</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Tool/OfficeIMO.Tool.csproj
+++ b/OfficeIMO.Tool/OfficeIMO.Tool.csproj
@@ -5,7 +5,7 @@
     <Description>Unified command-line interface for OfficeIMO document conversion, extraction, markup, provenance, output, intake, and capability discovery.</Description>
     <AssemblyName>OfficeIMO.Tool</AssemblyName>
     <AssemblyTitle>OfficeIMO.Tool</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <InformationalVersion Condition="'$(PackageVersion)' != ''">$(PackageVersion)</InformationalVersion>
     <Company>Evotec</Company>
     <Authors>Przemyslaw Klys</Authors>

--- a/OfficeIMO.Visio.Pdf/OfficeIMO.Visio.Pdf.csproj
+++ b/OfficeIMO.Visio.Pdf/OfficeIMO.Visio.Pdf.csproj
@@ -3,7 +3,7 @@
     <Description>First-party loss-aware Visio to PDF conversion for OfficeIMO.</Description>
     <AssemblyName>OfficeIMO.Visio.Pdf</AssemblyName>
     <AssemblyTitle>OfficeIMO.Visio.Pdf</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.Visio/OfficeIMO.Visio.csproj
+++ b/OfficeIMO.Visio/OfficeIMO.Visio.csproj
@@ -6,7 +6,7 @@
         <AssemblyName>OfficeIMO.Visio</AssemblyName>
         <AssemblyTitle>OfficeIMO.Visio</AssemblyTitle>
 
-        <VersionPrefix>3.4.0</VersionPrefix>
+        <VersionPrefix>3.4.1</VersionPrefix>
         <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
             $(TargetFrameworks);net472</TargetFrameworks>

--- a/OfficeIMO.Word.GoogleDocs/OfficeIMO.Word.GoogleDocs.csproj
+++ b/OfficeIMO.Word.GoogleDocs/OfficeIMO.Word.GoogleDocs.csproj
@@ -4,7 +4,7 @@
         <Description>Create, safely replace, import, diff, and translate Google Docs documents with OfficeIMO.Word.</Description>
         <AssemblyName>OfficeIMO.Word.GoogleDocs</AssemblyName>
         <AssemblyTitle>OfficeIMO.Word.GoogleDocs</AssemblyTitle>
-        <VersionPrefix>3.4.0</VersionPrefix>
+        <VersionPrefix>3.4.1</VersionPrefix>
         <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
             $(TargetFrameworks);net472</TargetFrameworks>

--- a/OfficeIMO.Word.Html/OfficeIMO.Word.Html.csproj
+++ b/OfficeIMO.Word.Html/OfficeIMO.Word.Html.csproj
@@ -5,7 +5,7 @@
         <AssemblyName>OfficeIMO.Word.Html</AssemblyName>
         <AssemblyTitle>OfficeIMO.Word.Html</AssemblyTitle>
 
-        <VersionPrefix>3.4.0</VersionPrefix>
+        <VersionPrefix>3.4.1</VersionPrefix>
         <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
             $(TargetFrameworks);net472

--- a/OfficeIMO.Word.IWork/OfficeIMO.Word.IWork.csproj
+++ b/OfficeIMO.Word.IWork/OfficeIMO.Word.IWork.csproj
@@ -4,7 +4,7 @@
     <PackageId>OfficeIMO.Word.IWork</PackageId>
     <AssemblyName>OfficeIMO.Word.IWork</AssemblyName>
     <AssemblyTitle>OfficeIMO.Word.IWork</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.Word.Markdown/OfficeIMO.Word.Markdown.csproj
+++ b/OfficeIMO.Word.Markdown/OfficeIMO.Word.Markdown.csproj
@@ -3,7 +3,7 @@
     <Description>Markdown converter for OfficeIMO.Word - Convert Word documents to/from Markdown using OfficeIMO.Markdown</Description>
     <AssemblyName>OfficeIMO.Word.Markdown</AssemblyName>
     <AssemblyTitle>OfficeIMO.Word.Markdown</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Word.OpenDocument/OfficeIMO.Word.OpenDocument.csproj
+++ b/OfficeIMO.Word.OpenDocument/OfficeIMO.Word.OpenDocument.csproj
@@ -4,7 +4,7 @@
     <PackageId>OfficeIMO.Word.OpenDocument</PackageId>
     <AssemblyName>OfficeIMO.Word.OpenDocument</AssemblyName>
     <AssemblyTitle>OfficeIMO.Word.OpenDocument</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.Word.Pdf/OfficeIMO.Word.Pdf.csproj
+++ b/OfficeIMO.Word.Pdf/OfficeIMO.Word.Pdf.csproj
@@ -4,7 +4,7 @@
     <PackageId>OfficeIMO.Word.Pdf</PackageId>
     <AssemblyName>OfficeIMO.Word.Pdf</AssemblyName>
     <AssemblyTitle>OfficeIMO.Word.Pdf</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.Word.Rtf/OfficeIMO.Word.Rtf.csproj
+++ b/OfficeIMO.Word.Rtf/OfficeIMO.Word.Rtf.csproj
@@ -3,7 +3,7 @@
     <Description>Result-bearing RTF converter and document workflow bridge for OfficeIMO.Word.</Description>
     <AssemblyName>OfficeIMO.Word.Rtf</AssemblyName>
     <AssemblyTitle>OfficeIMO.Word.Rtf</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Word/OfficeIMO.Word.csproj
+++ b/OfficeIMO.Word/OfficeIMO.Word.csproj
@@ -5,7 +5,7 @@
         <AssemblyName>OfficeIMO.Word</AssemblyName>
         <AssemblyTitle>OfficeIMO.Word</AssemblyTitle>
 
-        <VersionPrefix>3.4.0</VersionPrefix>
+        <VersionPrefix>3.4.1</VersionPrefix>
         <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
             $(TargetFrameworks);net472</TargetFrameworks>

--- a/OfficeIMO.Workflows/OfficeIMO.Workflows.csproj
+++ b/OfficeIMO.Workflows/OfficeIMO.Workflows.csproj
@@ -4,7 +4,7 @@
     <PackageId>OfficeIMO.Workflows</PackageId>
     <AssemblyName>OfficeIMO.Workflows</AssemblyName>
     <AssemblyTitle>OfficeIMO.Workflows</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Company>Evotec</Company>

--- a/OfficeIMO.Zip/OfficeIMO.Zip.csproj
+++ b/OfficeIMO.Zip/OfficeIMO.Zip.csproj
@@ -3,7 +3,7 @@
     <Description>Safe ZIP traversal primitives for modular OfficeIMO ingestion pipelines.</Description>
     <AssemblyName>OfficeIMO.Zip</AssemblyName>
     <AssemblyTitle>OfficeIMO.Zip</AssemblyTitle>
-    <VersionPrefix>3.4.0</VersionPrefix>
+    <VersionPrefix>3.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>


### PR DESCRIPTION
## Summary

- align the public OfficeIMO package family from 3.4.0 to 3.4.1
- update the OfficeIMO.Tool plugin binding to the same public version
- prepare a coherent package set containing the macOS variable-font kerning fallback from #2460

## Validation

- canonical PowerForge repository build completed successfully
- 112 expected package IDs matched 112 generated 3.4.1 packages
- no missing, extra, duplicate, or wrong-version packages
- generated packages remain unpublished pending merge and final release execution