### PR TITLE
Remove checkout paths from Release package metadata

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,6 +14,13 @@
     <NuGetLockFilePath Condition="!$([MSBuild]::IsOsPlatform('Windows')) and '$(OfficeIMOStudioLockedRestore)' != 'true' and Exists('$(MSBuildProjectDirectory)/packages.lock.json')">$(BaseIntermediateOutputPath)packages.restore.lock.json</NuGetLockFilePath>
   </PropertyGroup>
 
+  <!-- Keep release binaries reproducible without embedding a maintainer's checkout path
+       in their CodeView debug-directory entries. Debug builds retain local paths so
+       source breakpoints continue to work during development. -->
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <PathMap>$(MSBuildThisFileDirectory)=/_/</PathMap>
+  </PropertyGroup>
+
   <ItemGroup Condition="'$(EnableTrimmingPolyfills)' == 'true'">
     <Compile Include="$(OfficeIMOTrimmingPolyfillsFile)"
              Link="Shared\Compatibility\TrimmingAttributes.cs"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,13 +14,6 @@
     <NuGetLockFilePath Condition="!$([MSBuild]::IsOsPlatform('Windows')) and '$(OfficeIMOStudioLockedRestore)' != 'true' and Exists('$(MSBuildProjectDirectory)/packages.lock.json')">$(BaseIntermediateOutputPath)packages.restore.lock.json</NuGetLockFilePath>
   </PropertyGroup>
 
-  <!-- Keep release binaries reproducible without embedding a maintainer's checkout path
-       in their CodeView debug-directory entries. Debug builds retain local paths so
-       source breakpoints continue to work during development. -->
-  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
-    <PathMap>$(MSBuildThisFileDirectory)=/_/</PathMap>
-  </PropertyGroup>
-
   <ItemGroup Condition="'$(EnableTrimmingPolyfills)' == 'true'">
     <Compile Include="$(OfficeIMOTrimmingPolyfillsFile)"
              Link="Shared\Compatibility\TrimmingAttributes.cs"

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,10 +1,12 @@
 <Project>
-  <!-- Keep release binaries reproducible without embedding a maintainer's checkout path
-       in their CodeView debug-directory entries. Map only compiler intermediates so
-       CallerFilePath values still resolve to source files at runtime (Verify uses them
-       to locate snapshots). Debug builds retain local paths for local breakpoints. -->
-  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
-    <PathMap>$([System.IO.Path]::GetFullPath('$(BaseIntermediateOutputPath)', '$(MSBuildProjectDirectory)'))=/_/obj/</PathMap>
+  <!-- Keep shipped release binaries reproducible without embedding a maintainer's
+       checkout path in portable PDB documents or CodeView content IDs. Limit the
+       source mapping to packable production projects: non-packable test projects
+       retain physical CallerFilePath values for Verify snapshots, and Debug builds
+       retain local paths for source breakpoints. -->
+  <PropertyGroup Condition="'$(Configuration)' == 'Release' And '$(IsPackable)' != 'false' And '$(IsTestProject)' != 'true'">
+    <DeterministicSourcePaths>true</DeterministicSourcePaths>
+    <PathMap>$(MSBuildThisFileDirectory)=/_/</PathMap>
   </PropertyGroup>
 
   <!-- Production projects inherit TreatWarningsAsErrors=true from Directory.Build.props.

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,4 +1,12 @@
 <Project>
+  <!-- Keep release binaries reproducible without embedding a maintainer's checkout path
+       in their CodeView debug-directory entries. Map only compiler intermediates so
+       CallerFilePath values still resolve to source files at runtime (Verify uses them
+       to locate snapshots). Debug builds retain local paths for local breakpoints. -->
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <PathMap>$([System.IO.Path]::GetFullPath('$(BaseIntermediateOutputPath)', '$(MSBuildProjectDirectory)'))=/_/obj/</PathMap>
+  </PropertyGroup>
+
   <!-- Production projects inherit TreatWarningsAsErrors=true from Directory.Build.props.
        Tests and benchmarks still show warnings, but warnings do not block local or CI validation. -->
   <PropertyGroup Condition="


### PR DESCRIPTION
## Summary

- map packable Release source documents, compiler intermediates, and Source Link metadata to a stable `/_/` root
- keep non-packable test projects outside that mapping so Verify retains physical `CallerFilePath` values for snapshot discovery
- keep Debug builds unchanged so local source breakpoints retain their physical paths

## Package evidence

A current-base `OfficeIMO.Core` package was built for .NET Framework 4.7.2, .NET Standard 2.0, .NET 8, and .NET 10. Packaged DLL CodeView entries use portable `/_/...` paths and the package contains no PDB files.

The final candidate was also built from two different checkout roots. `OfficeIMO.Core`, `OfficeIMO.Rtf`, and `OfficeIMO.Email` produced byte-identical DLL and portable-PDB SHA-256 hashes in both roots. The generated Source Link map is rooted at `/_/*`, and the inspected `OfficeIMO.Email` PDB contains 415 portable document names with no physical checkout path.

## Runtime validation

The mapping is limited to packable production projects. Release evaluation for `OfficeIMO.VerifyTests` leaves `PathMap` and `DeterministicSourcePaths` unset, and its compiled assembly retains the physical caller source path required by Verify. The previously affected Verify suite passed in Ubuntu WSL on both .NET 8 and .NET 10 (28/28 tests per framework).

## Release relationship

This repository owns the binary path normalization. After this change ships in the next OfficeIMO package release, [Mailozaurr #669](https://github.com/EvotecIT/Mailozaurr/pull/669) can repin to that public version to eliminate OfficeIMO checkout paths from its packaged dependency binaries.
