### PR TITLE
Add reviewed scan preparation and quick text extraction

### DIFF
--- a/OfficeIMO.Core/README.md
+++ b/OfficeIMO.Core/README.md
@@ -15,7 +15,7 @@ dotnet add package OfficeIMO.Core
 
 ## Prepare document scans
 
-`OfficeScanProcessor` in `OfficeIMO.Drawing` prepares a separately owned raster for OCR. It supports explicit quarter-turns, confidence-filtered deskew, local paper-brightness normalization, grayscale or bilevel output, and proportional downsampling:
+`OfficeScanProcessor` in `OfficeIMO.Drawing` prepares a separately owned raster for OCR. It supports explicit quarter-turns, manual straightening, confidence-filtered deskew, local paper-brightness normalization, black and white levels, gamma, grayscale or bilevel output, and proportional downsampling:
 
 ```csharp
 using OfficeIMO.Drawing;
@@ -30,7 +30,9 @@ OfficeScanProcessingResult processed = OfficeScanProcessor.Process(sourceImage,
 OfficePoint sourcePoint = processed.Report.ProcessedToSource.TransformPoint(ocrPixelPoint);
 ```
 
-The source image stays unchanged. The report records transformations, skipped decisions, estimated managed buffers, and a blank-page suggestion; pages are never removed. Pixel, buffer, and analysis-work limits throw `OfficeScanProcessingLimitException`, allowing the caller to retain the original. The operation does not detect quarter-turn orientation itself; an OCR provider or the caller supplies that evidence. Perspective correction, dewarping, and cropping are outside this contract.
+The source image stays unchanged. The report records transformations, skipped decisions, estimated managed buffers, and a blank-page suggestion; pages are never removed. Pixel, buffer, and analysis-work limits throw `OfficeScanProcessingLimitException`, allowing the caller to retain the original. The operation does not detect quarter-turn orientation itself; an OCR provider or the caller supplies that evidence.
+
+`OfficeScanProcessor.CorrectPerspective(image, options)` creates a rectangular raster from four normalized source corners. `OfficeScanPerspectiveOptions` requires a convex, clockwise quadrilateral inside the source image. The result includes a projective mapping in both directions so consumers can place recognized text back on the original. Perspective correction is separate from the affine transform reported by ordinary scan cleanup. Curved-page dewarping remains unsupported.
 
 ## Quick start
 

--- a/OfficeIMO.Core/Raster/OfficeRasterResampler.Transform.cs
+++ b/OfficeIMO.Core/Raster/OfficeRasterResampler.Transform.cs
@@ -8,10 +8,15 @@ public static partial class OfficeRasterResampler {
     /// <remarks>Coordinates describe pixel edges. Source pixels are never modified. Sampling uses premultiplied alpha.</remarks>
     public static OfficeRasterImage Transform(OfficeRasterImage source, OfficeTransform sourceToDestination,
         int width, int height, OfficeColor? background = null, CancellationToken cancellationToken = default) {
+        OfficeTransform inverse = sourceToDestination.Invert();
+        return TransformMapped(source, inverse.TransformPoint, width, height, background, cancellationToken);
+    }
+
+    internal static OfficeRasterImage TransformMapped(OfficeRasterImage source, Func<OfficePoint, OfficePoint> destinationToSource,
+        int width, int height, OfficeColor? background, CancellationToken cancellationToken) {
         if (source == null) throw new ArgumentNullException(nameof(source));
         OfficeRasterGuards.EnsureOutputPixels(width, height, "Transformed raster exceeds the managed image limit.");
         EnsureSimpleWorkingSet(source, width, height, retainedManagedBytes: 0L);
-        OfficeTransform inverse = sourceToDestination.Invert();
         OfficeColor fill = background ?? OfficeColor.White;
         cancellationToken.ThrowIfCancellationRequested();
         var result = new OfficeRasterImage(width, height);
@@ -19,7 +24,7 @@ public static partial class OfficeRasterResampler {
             cancellationToken.ThrowIfCancellationRequested();
             for (int x = 0; x < width; x++) {
                 if ((x & 1023) == 0) cancellationToken.ThrowIfCancellationRequested();
-                OfficePoint point = inverse.TransformPoint(new OfficePoint(x + 0.5D, y + 0.5D));
+                OfficePoint point = destinationToSource(new OfficePoint(x + 0.5D, y + 0.5D));
                 double sx = point.X - 0.5D, sy = point.Y - 0.5D;
                 // Avoid narrowing enormous inverse coordinates before rejecting pixels outside the source.
                 if (sx < -1D || sy < -1D || sx > source.Width || sy > source.Height) {

--- a/OfficeIMO.Core/Raster/Scanning/OfficeScanPerspectiveMap.cs
+++ b/OfficeIMO.Core/Raster/Scanning/OfficeScanPerspectiveMap.cs
@@ -1,0 +1,47 @@
+using System;
+
+namespace OfficeIMO.Drawing;
+
+/// <summary>Reversible projective mapping between original and corrected image pixel-edge coordinates.</summary>
+public sealed class OfficeScanPerspectiveMap {
+    private readonly double[] _forward, _inverse;
+    internal OfficeScanPerspectiveMap(OfficeScanPerspectiveOptions options, int sourceWidth, int sourceHeight, int width, int height) {
+        SourceWidth = sourceWidth; SourceHeight = sourceHeight; Width = width; Height = height;
+        OfficePoint a = options.TopLeft, b = options.TopRight, c = options.BottomRight, d = options.BottomLeft;
+        double dx1 = b.X - c.X, dx2 = d.X - c.X, dy1 = b.Y - c.Y, dy2 = d.Y - c.Y;
+        double dx3 = a.X - b.X + c.X - d.X, dy3 = a.Y - b.Y + c.Y - d.Y;
+        double determinant = dx1 * dy2 - dx2 * dy1;
+        if (Math.Abs(determinant) < 1E-12) throw new ArgumentException("Perspective corners cannot be inverted.");
+        double g = (dx3 * dy2 - dx2 * dy3) / determinant;
+        double h = (dx1 * dy3 - dx3 * dy1) / determinant;
+        _inverse = new[] { b.X - a.X + g * b.X, d.X - a.X + h * d.X, a.X,
+            b.Y - a.Y + g * b.Y, d.Y - a.Y + h * d.Y, a.Y, g, h, 1D };
+        // A projective pole must not cross any part of the output rectangle.
+        if (Math.Min(Math.Min(1D, 1D + g), Math.Min(1D + h, 1D + g + h)) <= 1E-8)
+            throw new ArgumentException("Perspective corners produce an unstable mapping.");
+        double[] m = _inverse;
+        _forward = new[] { m[4]*m[8]-m[5]*m[7], m[2]*m[7]-m[1]*m[8], m[1]*m[5]-m[2]*m[4],
+            m[5]*m[6]-m[3]*m[8], m[0]*m[8]-m[2]*m[6], m[2]*m[3]-m[0]*m[5],
+            m[3]*m[7]-m[4]*m[6], m[1]*m[6]-m[0]*m[7], m[0]*m[4]-m[1]*m[3] };
+        double det = m[0] * _forward[0] + m[1] * _forward[3] + m[2] * _forward[6];
+        if (Math.Abs(det) < 1E-12) throw new ArgumentException("Perspective corners produce a singular mapping.");
+    }
+    /// <summary>Original image width in pixels.</summary>
+    public int SourceWidth { get; }
+    /// <summary>Original image height in pixels.</summary>
+    public int SourceHeight { get; }
+    /// <summary>Corrected image width in pixels.</summary>
+    public int Width { get; }
+    /// <summary>Corrected image height in pixels.</summary>
+    public int Height { get; }
+    /// <summary>Maps corrected pixel-edge coordinates back to the original image.</summary>
+    public OfficePoint MapProcessedToSource(OfficePoint point) => Map(_inverse, point.X / Width, point.Y / Height, SourceWidth, SourceHeight);
+    /// <summary>Maps original pixel-edge coordinates into the corrected image. Points on a projective pole are rejected.</summary>
+    public OfficePoint MapSourceToProcessed(OfficePoint point) => Map(_forward, point.X / SourceWidth, point.Y / SourceHeight, Width, Height);
+    private static OfficePoint Map(double[] m, double x, double y, int width, int height) {
+        double w = m[6] * x + m[7] * y + m[8];
+        if (double.IsNaN(w) || double.IsInfinity(w) || Math.Abs(w) < 1E-12)
+            throw new ArgumentOutOfRangeException(nameof(x), "Point lies outside the finite projective coordinate domain.");
+        return new OfficePoint((m[0] * x + m[1] * y + m[2]) / w * width, (m[3] * x + m[4] * y + m[5]) / w * height);
+    }
+}

--- a/OfficeIMO.Core/Raster/Scanning/OfficeScanPerspectiveOptions.cs
+++ b/OfficeIMO.Core/Raster/Scanning/OfficeScanPerspectiveOptions.cs
@@ -1,0 +1,36 @@
+using System;
+
+namespace OfficeIMO.Drawing;
+
+/// <summary>Four explicitly reviewed page corners for perspective correction, normalized to the source image edges.</summary>
+public sealed class OfficeScanPerspectiveOptions {
+    /// <summary>Top-left corner; both coordinates are from zero through one.</summary>
+    public OfficePoint TopLeft { get; set; } = new OfficePoint(0, 0);
+    /// <summary>Top-right corner.</summary>
+    public OfficePoint TopRight { get; set; } = new OfficePoint(1, 0);
+    /// <summary>Bottom-right corner.</summary>
+    public OfficePoint BottomRight { get; set; } = new OfficePoint(1, 1);
+    /// <summary>Bottom-left corner.</summary>
+    public OfficePoint BottomLeft { get; set; } = new OfficePoint(0, 1);
+    /// <summary>Maximum source and output pixels.</summary>
+    public long MaximumPixels { get; set; } = 20_000_000;
+    /// <summary>Maximum accounted source and output pixel-buffer bytes.</summary>
+    public long MaximumWorkingBytes { get; set; } = 256L * 1024 * 1024;
+    /// <summary>Creates an independent settings snapshot.</summary>
+    public OfficeScanPerspectiveOptions Clone() => (OfficeScanPerspectiveOptions)MemberwiseClone();
+    /// <summary>Rejects crossed, concave, reversed, degenerate, or out-of-image corners and invalid budgets.</summary>
+    public void Validate() {
+        var corners = new[] { TopLeft, TopRight, BottomRight, BottomLeft };
+        foreach (var p in corners) {
+            if (double.IsNaN(p.X) || double.IsNaN(p.Y) || p.X < 0 || p.X > 1 || p.Y < 0 || p.Y > 1)
+                throw new ArgumentException("Perspective corners must be normalized points inside the source image.");
+        }
+        for (int i = 0; i < 4; i++) {
+            OfficePoint a = corners[i], b = corners[(i + 1) % 4], c = corners[(i + 2) % 4];
+            if ((b.X - a.X) * (c.Y - b.Y) - (b.Y - a.Y) * (c.X - b.X) < 0.000001D)
+                throw new ArgumentException("Perspective corners must form a non-degenerate convex page in clockwise order.");
+        }
+        if (MaximumPixels <= 0 || MaximumPixels > OfficeRasterGuards.MaximumPixels) throw new ArgumentOutOfRangeException(nameof(MaximumPixels));
+        if (MaximumWorkingBytes <= 0 || MaximumWorkingBytes > OfficeRasterGuards.MaximumDecodedBytes) throw new ArgumentOutOfRangeException(nameof(MaximumWorkingBytes));
+    }
+}

--- a/OfficeIMO.Core/Raster/Scanning/OfficeScanProcessingOptions.cs
+++ b/OfficeIMO.Core/Raster/Scanning/OfficeScanProcessingOptions.cs
@@ -16,6 +16,14 @@ public enum OfficeScanColorMode {
 public sealed class OfficeScanProcessingOptions {
     /// <summary>Explicit clockwise quarter-turns, applied before deskew. Must be zero through three.</summary>
     public int ClockwiseQuarterTurns { get; set; }
+    /// <summary>Additional clockwise rotation, from minus fifteen through fifteen degrees, applied with any detected deskew correction.</summary>
+    public double StraightenDegrees { get; set; }
+    /// <summary>Input sample mapped to black, from zero through 254. Must be less than WhitePoint.</summary>
+    public int BlackPoint { get; set; }
+    /// <summary>Input sample mapped to white, from one through 255. Must exceed BlackPoint.</summary>
+    public int WhitePoint { get; set; } = 255;
+    /// <summary>Midtone gamma, from 0.1 through 10. Values above one lighten midtones.</summary>
+    public double Gamma { get; set; } = 1D;
     /// <summary>Detects a small text-line skew and corrects it only when the confidence threshold is met.</summary>
     public bool Deskew { get; set; } = true;
     /// <summary>Largest absolute skew considered, from one through fifteen degrees.</summary>
@@ -47,6 +55,10 @@ public sealed class OfficeScanProcessingOptions {
     /// <summary>Validates operation settings before allocating buffers or requesting provider work.</summary>
     public void Validate() {
         if (ClockwiseQuarterTurns < 0 || ClockwiseQuarterTurns > 3) throw new ArgumentOutOfRangeException(nameof(ClockwiseQuarterTurns));
+        if (!Finite(StraightenDegrees) || Math.Abs(StraightenDegrees) > 15D) throw new ArgumentOutOfRangeException(nameof(StraightenDegrees));
+        if (BlackPoint < 0 || BlackPoint > 254) throw new ArgumentOutOfRangeException(nameof(BlackPoint));
+        if (WhitePoint <= BlackPoint || WhitePoint > 255) throw new ArgumentOutOfRangeException(nameof(WhitePoint));
+        if (!Finite(Gamma) || Gamma < 0.1D || Gamma > 10D) throw new ArgumentOutOfRangeException(nameof(Gamma));
         if (!Finite(MaximumDeskewAngleDegrees) || MaximumDeskewAngleDegrees < 1D || MaximumDeskewAngleDegrees > 15D)
             throw new ArgumentOutOfRangeException(nameof(MaximumDeskewAngleDegrees));
         if (!Finite(MinimumDeskewConfidence) || MinimumDeskewConfidence < 0D || MinimumDeskewConfidence > 1D)

--- a/OfficeIMO.Core/Raster/Scanning/OfficeScanProcessor.Perspective.cs
+++ b/OfficeIMO.Core/Raster/Scanning/OfficeScanProcessor.Perspective.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Threading;
+
+namespace OfficeIMO.Drawing;
+
+/// <summary>Separately owned perspective-corrected image and its exact coordinate mapping.</summary>
+public sealed class OfficeScanPerspectiveResult {
+    internal OfficeScanPerspectiveResult(OfficeRasterImage image, OfficeScanPerspectiveMap mapping) { Image = image; Mapping = mapping; }
+    /// <summary>Corrected image; the original source remains unchanged.</summary>
+    public OfficeRasterImage Image { get; }
+    /// <summary>Projective mapping for overlays and OCR geometry.</summary>
+    public OfficeScanPerspectiveMap Mapping { get; }
+}
+
+public static partial class OfficeScanProcessor {
+    /// <summary>Rectifies an explicitly selected convex page quadrilateral before optional affine and tonal cleanup.</summary>
+    /// <remarks>Dimensions follow the longer opposing source edges. This operation does not detect page corners automatically.</remarks>
+    public static OfficeScanPerspectiveResult CorrectPerspective(OfficeRasterImage source, OfficeScanPerspectiveOptions options,
+        CancellationToken cancellationToken = default) {
+        if (source == null) throw new ArgumentNullException(nameof(source));
+        if (options == null) throw new ArgumentNullException(nameof(options));
+        var settings = options.Clone(); settings.Validate(); cancellationToken.ThrowIfCancellationRequested();
+        int width = Math.Max(1, (int)Math.Ceiling(Math.Max(Length(settings.TopLeft, settings.TopRight), Length(settings.BottomLeft, settings.BottomRight))));
+        int height = Math.Max(1, (int)Math.Ceiling(Math.Max(Length(settings.TopLeft, settings.BottomLeft), Length(settings.TopRight, settings.BottomRight))));
+        long sourcePixels = (long)source.Width * source.Height, outputPixels = (long)width * height;
+        if (sourcePixels > settings.MaximumPixels || outputPixels > settings.MaximumPixels)
+            throw new OfficeScanProcessingLimitException("Perspective correction exceeds MaximumPixels.");
+        if ((sourcePixels + outputPixels) * 4L > settings.MaximumWorkingBytes)
+            throw new OfficeScanProcessingLimitException("Perspective correction exceeds MaximumWorkingBytes.");
+        var mapping = new OfficeScanPerspectiveMap(settings, source.Width, source.Height, width, height);
+        return new OfficeScanPerspectiveResult(OfficeRasterResampler.TransformMapped(source, mapping.MapProcessedToSource,
+            width, height, OfficeColor.White, cancellationToken), mapping);
+        double Length(OfficePoint a, OfficePoint b) {
+            double x = (b.X - a.X) * source.Width, y = (b.Y - a.Y) * source.Height;
+            return Math.Sqrt(x * x + y * y);
+        }
+    }
+}

--- a/OfficeIMO.Core/Raster/Scanning/OfficeScanProcessor.Photometric.cs
+++ b/OfficeIMO.Core/Raster/Scanning/OfficeScanProcessor.Photometric.cs
@@ -9,6 +9,12 @@ public static partial class OfficeScanProcessor {
         List<OfficeScanProcessingStep> steps, CancellationToken token) {
         byte[]? background = options.NormalizeBackground ? EstimateBackground(image, options.BackgroundRadius, token) : null;
         byte[] pixels = image.PixelBuffer;
+        bool applyLevels = options.BlackPoint != 0 || options.WhitePoint != 255 || options.Gamma != 1D;
+        var levels = new byte[256];
+        for (int value = 0; value < levels.Length; value++) {
+            double normalized = Math.Max(0D, Math.Min(1D, (value - options.BlackPoint) / (double)(options.WhitePoint - options.BlackPoint)));
+            levels[value] = (byte)Math.Round(255D * Math.Pow(normalized, 1D / options.Gamma));
+        }
         for (int y = 0; y < image.Height; y++) {
             token.ThrowIfCancellationRequested();
             for (int x = 0; x < image.Width; x++) {
@@ -23,6 +29,7 @@ public static partial class OfficeScanProcessor {
                     b = Math.Min(255, (b * 255 + paper / 2) / paper);
                 }
                 if (options.ColorMode != OfficeScanColorMode.PreserveColor) r = g = b = (r * 77 + g * 150 + b * 29 + 128) >> 8;
+                if (applyLevels) { r = levels[r]; g = levels[g]; b = levels[b]; }
                 pixels[offset] = (byte)r; pixels[offset + 1] = (byte)g; pixels[offset + 2] = (byte)b; pixels[offset + 3] = 255;
             }
         }
@@ -31,6 +38,8 @@ public static partial class OfficeScanProcessor {
             options.NormalizeBackground ? "Normalized local paper brightness; composited transparency over white." : "Background normalization was disabled; transparency was composited over white."));
         steps.Add(new OfficeScanProcessingStep("color", options.ColorMode != OfficeScanColorMode.PreserveColor,
             "Output color mode: " + options.ColorMode + "."));
+        steps.Add(new OfficeScanProcessingStep("levels", applyLevels,
+            applyLevels ? "Applied black point, white point, and midtone gamma." : "Retained the input tonal range."));
     }
 
     private static byte[] EstimateBackground(OfficeRasterImage image, int radius, CancellationToken token) {

--- a/OfficeIMO.Core/Raster/Scanning/OfficeScanProcessor.cs
+++ b/OfficeIMO.Core/Raster/Scanning/OfficeScanProcessor.cs
@@ -31,7 +31,9 @@ public static partial class OfficeScanProcessor {
         steps.Add(new OfficeScanProcessingStep("deskew", correctSkew,
             !effective.Deskew ? "Deskew was disabled." : correctSkew ? "Applied the confident text-line skew correction." :
             "Retained source orientation: no confident in-range skew correction was found."));
-        OfficeTransform rotation = OfficeTransform.RotateDegrees(quarterRotation + correction);
+        steps.Add(new OfficeScanProcessingStep("straighten", effective.StraightenDegrees != 0D,
+            "Explicit clockwise straightening: " + effective.StraightenDegrees.ToString(CultureInfo.InvariantCulture) + " degrees."));
+        OfficeTransform rotation = OfficeTransform.RotateDegrees(quarterRotation + correction + effective.StraightenDegrees);
         var bounds = rotation.TransformRectangleBounds(0D, 0D, source.Width, source.Height);
         int width = checked((int)Math.Ceiling(bounds.Right - bounds.Left - 0.0000001D));
         int height = checked((int)Math.Ceiling(bounds.Bottom - bounds.Top - 0.0000001D));

--- a/OfficeIMO.Drawing.Tests/Drawing.ScanPerspective.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.ScanPerspective.cs
@@ -1,0 +1,89 @@
+using OfficeIMO.Drawing;
+using System.Threading;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class ScanPerspectiveTests {
+    [Fact]
+    public void IdentityRetainsPixelsAndOwnsItsBuffer() {
+        var source = new OfficeRasterImage(40, 30, OfficeColor.White);
+        source.SetPixel(12, 14, OfficeColor.Black);
+        var result = OfficeScanProcessor.CorrectPerspective(source, new OfficeScanPerspectiveOptions());
+        Assert.Equal(source.GetPixels(), result.Image.GetPixels());
+        result.Image.SetPixel(12, 14, OfficeColor.White);
+        Assert.Equal(OfficeColor.Black, source.GetPixel(12, 14));
+    }
+
+    [Fact]
+    public void PerspectiveCornersAndInteriorRoundTripToOriginalPixels() {
+        var options = new OfficeScanPerspectiveOptions {
+            TopLeft = new OfficePoint(.2, .1),
+            TopRight = new OfficePoint(.8, .15),
+            BottomRight = new OfficePoint(.95, .9),
+            BottomLeft = new OfficePoint(.05, .85)
+        };
+        var source = new OfficeRasterImage(200, 300, OfficeColor.White);
+        var result = OfficeScanProcessor.CorrectPerspective(source, options);
+        OfficePoint[] sourceCorners = { options.TopLeft, options.TopRight, options.BottomRight, options.BottomLeft };
+        OfficePoint[] outputCorners = { new(0, 0), new(result.Image.Width, 0), new(result.Image.Width, result.Image.Height), new(0, result.Image.Height) };
+        for (int index = 0; index < 4; index++) {
+            var mapped = result.Mapping.MapProcessedToSource(outputCorners[index]);
+            Assert.Equal(sourceCorners[index].X * 200, mapped.X, 7);
+            Assert.Equal(sourceCorners[index].Y * 300, mapped.Y, 7);
+        }
+        for (int y = 0; y <= 10; y++) for (int x = 0; x <= 10; x++) {
+                var point = new OfficePoint(x * result.Image.Width / 10D, y * result.Image.Height / 10D);
+                var mapped = result.Mapping.MapSourceToProcessed(result.Mapping.MapProcessedToSource(point));
+                Assert.Equal(point.X, mapped.X, 7); Assert.Equal(point.Y, mapped.Y, 7);
+            }
+    }
+
+    [Fact]
+    public void CropRetainsSelectedPixelsAndReportsOffset() {
+        var source = new OfficeRasterImage(100, 100, OfficeColor.White);
+        for (int y = 25; y < 75; y++) for (int x = 25; x < 75; x++) source.SetPixel(x, y, OfficeColor.Black);
+        var result = OfficeScanProcessor.CorrectPerspective(source, new OfficeScanPerspectiveOptions {
+            TopLeft = new(.25, .25),
+            TopRight = new(.75, .25),
+            BottomRight = new(.75, .75),
+            BottomLeft = new(.25, .75)
+        });
+        Assert.Equal(50, result.Image.Width); Assert.Equal(50, result.Image.Height);
+        Assert.Equal(OfficeColor.Black, result.Image.GetPixel(0, 0)); Assert.Equal(OfficeColor.Black, result.Image.GetPixel(49, 49));
+        var corner = result.Mapping.MapProcessedToSource(new(0, 0)); Assert.Equal(25, corner.X); Assert.Equal(25, corner.Y);
+    }
+
+    [Fact]
+    public void RejectsCrossedCornersBudgetsAndCancellation() {
+        var source = new OfficeRasterImage(40, 30, OfficeColor.White);
+        Assert.Throws<ArgumentException>(() => OfficeScanProcessor.CorrectPerspective(source, new() { TopRight = new(0, 1), BottomLeft = new(1, 0) }));
+        Assert.Throws<ArgumentException>(() => OfficeScanProcessor.CorrectPerspective(source, new() { TopRight = new(0, 0) }));
+        Assert.Throws<OfficeScanProcessingLimitException>(() => OfficeScanProcessor.CorrectPerspective(source, new() { MaximumPixels = 100 }));
+        Assert.Throws<OfficeScanProcessingLimitException>(() => OfficeScanProcessor.CorrectPerspective(source, new() { MaximumWorkingBytes = 100 }));
+        Assert.ThrowsAny<OperationCanceledException>(() => OfficeScanProcessor.CorrectPerspective(source, new(), new CancellationToken(true)));
+    }
+
+    [Fact]
+    public void ManualStraighteningReportsReversibleGeometryAndLevels() {
+        var source = new OfficeRasterImage(100, 80, OfficeColor.FromRgb(128, 128, 128));
+        var options = new OfficeScanProcessingOptions {
+            Deskew = false,
+            NormalizeBackground = false,
+            StraightenDegrees = 5,
+            BlackPoint = 64,
+            WhitePoint = 192,
+            Gamma = 2
+        };
+        var result = OfficeScanProcessor.Process(source, options);
+        var point = new OfficePoint(20, 30);
+        var roundTrip = result.Report.ProcessedToSource.TransformPoint(result.Report.SourceToProcessed.TransformPoint(point));
+        Assert.Equal(point.X, roundTrip.X, 8); Assert.Equal(point.Y, roundTrip.Y, 8);
+        Assert.InRange(result.Image.GetPixel(result.Image.Width / 2, result.Image.Height / 2).R, (byte)179, (byte)181);
+        Assert.Equal((byte)128, source.GetPixel(20, 30).R);
+        Assert.Contains(result.Report.Steps, step => step.Operation == "straighten" && step.Applied);
+        Assert.Contains(result.Report.Steps, step => step.Operation == "levels" && step.Applied);
+        Assert.Throws<ArgumentOutOfRangeException>(() => OfficeScanProcessor.Process(source, new() { BlackPoint = 200, WhitePoint = 100 }));
+        Assert.Throws<ArgumentOutOfRangeException>(() => OfficeScanProcessor.Process(source, new() { Gamma = double.NaN }));
+    }
+}

--- a/OfficeIMO.Pdf.Ocr/PdfOcr.Execution.cs
+++ b/OfficeIMO.Pdf.Ocr/PdfOcr.Execution.cs
@@ -83,6 +83,9 @@ internal static partial class PdfOcr {
             PdfLogicalPage nativePage, IReadOnlyList<PdfSelectionQuad> nativeBounds) {
             try {
                 PreparedPage prepared = await PreparePageAsync(request, engine, options, workCancellation.Token).ConfigureAwait(false);
+                if (prepared.HasGeometryTransform) {
+                    prepared.RecognitionWidth = request.Region!.Width; prepared.RecognitionHeight = request.Region.Height;
+                }
                 OcrResult recognized = await engine.RecognizeAsync(
                     request, options.ProviderTimeout, workCancellation.Token).ConfigureAwait(false);
                 ProjectedOcrResult projected = ProjectResult(recognized, request, engine.Id, options, workCancellation.Token, prepared);
@@ -97,7 +100,7 @@ internal static partial class PdfOcr {
                     projected = new ProjectedOcrResult(projected.Words, diagnostics.AsReadOnly(),
                         projected.Provider, projected.Model, projected.Language);
                 }
-                results[index] = MergePage(nativePage, nativeBounds, projected, options, workCancellation.Token, prepared.Report);
+                results[index] = MergePage(nativePage, nativeBounds, projected, options, workCancellation.Token, prepared);
             } catch (Exception exception) {
                 if (exception is not OperationCanceledException)
                     Interlocked.CompareExchange(ref providerFailure, ExceptionDispatchInfo.Capture(exception), null);

--- a/OfficeIMO.Pdf.Ocr/PdfOcr.RegionProcessing.cs
+++ b/OfficeIMO.Pdf.Ocr/PdfOcr.RegionProcessing.cs
@@ -1,0 +1,50 @@
+using OfficeIMO.Drawing;
+using OfficeIMO.Ocr;
+using System.Threading;
+
+namespace OfficeIMO.Pdf.Ocr;
+
+internal static partial class PdfOcr {
+    private static void PrepareRegionAndPerspective(OcrRequest request, PdfOcrMergeOptions options, PreparedPage prepared, CancellationToken token) {
+        PdfOcrPageRegion? region = options.Regions.FirstOrDefault(item => item.PageNumber == request.PageNumber);
+        if (region == null && options.Perspective == null) return;
+        long maximumPixels = Math.Min(options.MaxPixelsPerPage, options.Perspective?.MaximumPixels ?? options.ScanProcessing?.MaximumPixels ?? 20_000_000L);
+        long maximumBytes = options.Perspective?.MaximumWorkingBytes ?? options.ScanProcessing?.MaximumWorkingBytes ?? 256L * 1024 * 1024;
+        long sourcePixels = (long)request.PixelWidth!.Value * request.PixelHeight!.Value;
+        if (sourcePixels > maximumPixels || sourcePixels * 8L > maximumBytes)
+            throw new InvalidOperationException("The selected OCR preparation exceeds its raster budget. Reduce the render DPI.");
+        if (!OfficeRasterImageDecoder.TryDecode(request.Payload, new OfficeRasterDecodeOptions {
+            MaximumDecodedPixels = maximumPixels,
+            CancellationToken = token
+        }, out OfficeRasterImage? image, out _) || image == null)
+            throw new NotSupportedException("The rendered page could not be decoded for region OCR.");
+        double pointPerPixelX = request.Region!.Width / image.Width, pointPerPixelY = request.Region.Height / image.Height;
+        if (region != null) {
+            int left = (int)Math.Floor(region.X * image.Width), top = (int)Math.Floor(region.Y * image.Height);
+            int right = Math.Min(image.Width, (int)Math.Ceiling((region.X + region.Width) * image.Width));
+            int bottom = Math.Min(image.Height, (int)Math.Ceiling((region.Y + region.Height) * image.Height));
+            image = OfficeRasterResampler.Transform(image, OfficeTransform.Translate(-left, -top), right - left, bottom - top, cancellationToken: token);
+            double offsetX = left * pointPerPixelX, offsetY = top * pointPerPixelY;
+            prepared.PreparedToOriginal = point => new OfficePoint(point.X + offsetX, point.Y + offsetY);
+            prepared.Diagnostics.Add("ocr-region: Sent only the selected visual rectangle to the provider; geometry is mapped to the original page.");
+        }
+        if (options.Perspective != null) {
+            // Include the retained original decoded page while the intermediate correction allocates its output.
+            var perspective = options.Perspective.Clone();
+            perspective.MaximumWorkingBytes = Math.Min(perspective.MaximumWorkingBytes, maximumBytes - sourcePixels * 4L);
+            var corrected = OfficeScanProcessor.CorrectPerspective(image, perspective, token);
+            OfficeScanPerspectiveMap mapping = corrected.Mapping;
+            Func<OfficePoint, OfficePoint>? prior = prepared.PreparedToOriginal;
+            prepared.PreparedToOriginal = point => {
+                OfficePoint original = mapping.MapProcessedToSource(new OfficePoint(point.X / pointPerPixelX, point.Y / pointPerPixelY));
+                original = new OfficePoint(original.X * pointPerPixelX, original.Y * pointPerPixelY);
+                return prior == null ? original : prior(original);
+            };
+            image = corrected.Image;
+            prepared.Diagnostics.Add("ocr-perspective: Corrected the explicitly selected page corners for recognition; original page samples remain unchanged.");
+        }
+        request.Payload = OfficeRasterImageEncoder.Encode(image, OfficeImageExportFormat.Png, options: null, maximumEncodedBytes: options.MaxRenderedBytesPerPage, cancellationToken: token);
+        request.PixelWidth = image.Width; request.PixelHeight = image.Height;
+        request.Region = new OcrRegion { Width = image.Width * pointPerPixelX, Height = image.Height * pointPerPixelY };
+    }
+}

--- a/OfficeIMO.Pdf.Ocr/PdfOcr.ScanProcessing.cs
+++ b/OfficeIMO.Pdf.Ocr/PdfOcr.ScanProcessing.cs
@@ -11,25 +11,40 @@ internal static partial class PdfOcr {
         internal double SourceWidth { get; }
         internal double SourceHeight { get; }
         internal OfficeTransform PointsToSource { get; set; } = OfficeTransform.Identity;
+        internal Func<OfficePoint, OfficePoint>? PreparedToOriginal { get; set; }
+        internal bool HasGeometryTransform => Report != null || PreparedToOriginal != null;
+        internal double? RecognitionWidth { get; set; }
+        internal double? RecognitionHeight { get; set; }
         internal OfficeScanProcessingReport? Report { get; set; }
         internal List<string> Diagnostics { get; } = new List<string>();
     }
 
-    private static async Task<PreparedPage> PreparePageAsync(OcrRequest request, OcrEngineExecution engine,
+    private static async Task<PreparedPage> PreparePageAsync(OcrRequest request, OcrEngineExecution? engine,
         PdfOcrMergeOptions options, CancellationToken token) {
         var prepared = new PreparedPage(request.Region!.Width, request.Region.Height);
+        PrepareRegionAndPerspective(request, options, prepared, token);
         if (options.ScanProcessing == null && !options.DetectOrientation) return prepared;
         int detectedTurns = 0;
         if (options.DetectOrientation) {
-            if (!engine.Capabilities.SupportsOrientationDetection) {
+            if (engine == null || !engine.Capabilities.SupportsOrientationDetection) {
                 prepared.Diagnostics.Add("ocr-orientation-unsupported: The provider does not detect orientation; retained the source orientation.");
             } else {
                 var orientationRequest = new OcrRequest {
-                    Operation = OcrOperation.DetectOrientation, Payload = request.Payload, MediaType = request.MediaType,
-                    FileName = request.FileName, SourceId = request.SourceId, SourceName = request.SourceName,
-                    CandidateId = request.CandidateId, CandidateKind = request.CandidateKind, PageNumber = request.PageNumber,
-                    PixelWidth = request.PixelWidth, PixelHeight = request.PixelHeight, Region = request.Region,
-                    RegionCoordinateUnit = request.RegionCoordinateUnit, Language = request.Language, ProviderOptions = request.ProviderOptions
+                    Operation = OcrOperation.DetectOrientation,
+                    Payload = request.Payload,
+                    MediaType = request.MediaType,
+                    FileName = request.FileName,
+                    SourceId = request.SourceId,
+                    SourceName = request.SourceName,
+                    CandidateId = request.CandidateId,
+                    CandidateKind = request.CandidateKind,
+                    PageNumber = request.PageNumber,
+                    PixelWidth = request.PixelWidth,
+                    PixelHeight = request.PixelHeight,
+                    Region = request.Region,
+                    RegionCoordinateUnit = request.RegionCoordinateUnit,
+                    Language = request.Language,
+                    ProviderOptions = request.ProviderOptions
                 };
                 OcrResult detection = await engine.RecognizeAsync(orientationRequest, options.ProviderTimeout, token).ConfigureAwait(false);
                 // Use the same diagnostic count, length, metadata, and provider-result bounds as recognition.
@@ -47,12 +62,15 @@ internal static partial class PdfOcr {
         }
         if (options.ScanProcessing == null && detectedTurns == 0) return prepared;
         OfficeScanProcessingOptions scanOptions = options.ScanProcessing?.Clone() ?? new OfficeScanProcessingOptions {
-            Deskew = false, NormalizeBackground = false, ColorMode = OfficeScanColorMode.PreserveColor
+            Deskew = false,
+            NormalizeBackground = false,
+            ColorMode = OfficeScanColorMode.PreserveColor
         };
         if (scanOptions.ClockwiseQuarterTurns < 0 || scanOptions.ClockwiseQuarterTurns > 3)
             throw new ArgumentOutOfRangeException(nameof(scanOptions.ClockwiseQuarterTurns));
         scanOptions.ClockwiseQuarterTurns = (scanOptions.ClockwiseQuarterTurns + detectedTurns) % 4;
         int originalWidth = request.PixelWidth!.Value, originalHeight = request.PixelHeight!.Value;
+        double originalPointWidth = request.Region!.Width, originalPointHeight = request.Region.Height;
         try {
             // Reject optional cleanup before decoding when the caller's processing budget cannot hold its input.
             long sourcePixels = (long)originalWidth * originalHeight;
@@ -61,7 +79,8 @@ internal static partial class PdfOcr {
                 return prepared;
             }
             var decodeOptions = new OfficeRasterDecodeOptions {
-                MaximumDecodedPixels = scanOptions.MaximumPixels, CancellationToken = token
+                MaximumDecodedPixels = scanOptions.MaximumPixels,
+                CancellationToken = token
             };
             if (!OfficeRasterImageDecoder.TryDecode(request.Payload, decodeOptions, out OfficeRasterImage? original, out _) || original == null)
                 throw new NotSupportedException("The rendered PNG could not be decoded for scan processing.");
@@ -69,14 +88,14 @@ internal static partial class PdfOcr {
             byte[] payload = OfficeRasterImageEncoder.Encode(processed.Image, OfficeImageExportFormat.Png,
                 options: null, maximumEncodedBytes: options.MaxRenderedBytesPerPage, cancellationToken: token);
             prepared.Report = processed.Report;
-            prepared.PointsToSource = OfficeTransform.Scale(originalWidth / prepared.SourceWidth, originalHeight / prepared.SourceHeight)
+            prepared.PointsToSource = OfficeTransform.Scale(originalWidth / originalPointWidth, originalHeight / originalPointHeight)
                 .Then(processed.Report.ProcessedToSource)
-                .Then(OfficeTransform.Scale(prepared.SourceWidth / originalWidth, prepared.SourceHeight / originalHeight));
+                .Then(OfficeTransform.Scale(originalPointWidth / originalWidth, originalPointHeight / originalHeight));
             request.Payload = payload;
             request.PixelWidth = processed.Image.Width; request.PixelHeight = processed.Image.Height;
             request.Region = new OcrRegion {
-                Width = processed.Image.Width * prepared.SourceWidth / originalWidth,
-                Height = processed.Image.Height * prepared.SourceHeight / originalHeight
+                Width = processed.Image.Width * originalPointWidth / originalWidth,
+                Height = processed.Image.Height * originalPointHeight / originalHeight
             };
         } catch (OfficeScanProcessingLimitException exception) {
             prepared.Diagnostics.Add("ocr-scan-limit: Retained the original rendered image. " + exception.Message);
@@ -91,6 +110,7 @@ internal static partial class PdfOcr {
         OfficeTransform transform = prepared?.PointsToSource ?? OfficeTransform.Identity;
         PdfSelectionPoint Map(double px, double py) {
             OfficePoint point = transform.TransformPoint(new OfficePoint(px, py));
+            if (prepared?.PreparedToOriginal != null) point = prepared.PreparedToOriginal(point);
             return new PdfSelectionPoint(point.X, point.Y);
         }
         return new PdfSelectionQuad(Map(x, y), Map(x + width, y), Map(x + width, y + height), Map(x, y + height));

--- a/OfficeIMO.Pdf.Ocr/PdfOcr.cs
+++ b/OfficeIMO.Pdf.Ocr/PdfOcr.cs
@@ -24,12 +24,7 @@ internal static partial class PdfOcr {
         PdfReadDocument overlapReadDocument = readOptions?.IncludeArtifactText == true
             ? readDocument
             : PdfReadDocument.Open(pdf, PdfLoadOptions.WithArtifactText(readOptions), cancellationToken);
-        int[] selectedPages = semanticOptions.PageSelection?.ToPageNumbers(
-            readDocument.Pages.Count,
-            nameof(semanticOptions.PageSelection)) ?? Enumerable.Range(1, readDocument.Pages.Count).ToArray();
-        if (selectedPages.Length > effectiveOptions.MaxPages) {
-            throw PdfReadLimitException.Create(PdfReadLimitKind.Pages, effectiveOptions.MaxPages, selectedPages.Length);
-        }
+        int[] selectedPages = effectiveOptions.GetSelectedPages(readDocument.Pages.Count);
 
         PdfTextLayoutOptions layoutOptions = semanticOptions.LayoutOptions;
         PdfUnderstandingPipelineOptions pipelineOptions = PdfUnderstandingPipelineOptions.Resolve(semanticOptions.Pipeline);
@@ -143,7 +138,7 @@ internal static partial class PdfOcr {
                 diagnostics.Add("ocr-span-geometry: A recognized span did not contain valid page geometry.");
                 continue;
             }
-            PdfLogicalVisualBounds? recognitionBounds = prepared?.Report != null
+            PdfLogicalVisualBounds? recognitionBounds = prepared?.HasGeometryTransform == true
                 ? new PdfLogicalVisualBounds(x, y, x + width, y + height) : null;
             PdfSelectionQuad geometry = MapWordGeometry(x, y, width, height, prepared);
             if (prepared != null && (geometry.Left < -0.01D || geometry.Top < -0.01D ||
@@ -219,7 +214,7 @@ internal static partial class PdfOcr {
         ProjectedOcrResult result,
         PdfOcrMergeOptions options,
         CancellationToken cancellationToken,
-        OfficeIMO.Drawing.OfficeScanProcessingReport? scanProcessing = null) {
+        PreparedPage? prepared = null) {
         if (nativePage.TextBlocks.Count > options.MaxNativeTextBlocksPerPage) {
             throw PdfReadLimitException.Create(PdfReadLimitKind.OcrArtifacts, options.MaxNativeTextBlocksPerPage, nativePage.TextBlocks.Count);
         }
@@ -276,7 +271,7 @@ internal static partial class PdfOcr {
             result.Provider,
             result.Model,
             result.Language,
-            evidence.AsReadOnly(), scanProcessing);
+            evidence.AsReadOnly(), prepared?.Report, prepared?.RecognitionWidth, prepared?.RecognitionHeight);
     }
 
     private static bool TryConvertRegion(

--- a/OfficeIMO.Pdf.Ocr/PdfOcrExtensions.cs
+++ b/OfficeIMO.Pdf.Ocr/PdfOcrExtensions.cs
@@ -7,6 +7,15 @@ namespace OfficeIMO.Pdf.Ocr;
 
 /// <summary>Optional OCR operations for loaded PDF documents.</summary>
 public static class PdfOcrExtensions {
+    /// <summary>Previews one page using the same region, perspective, and scan preparation as OCR, without invoking a provider.
+    /// Provider orientation detection is not performed. Source bytes remain unchanged.</summary>
+    public static Task<PdfScanPreview> PreviewScanAsync(this PdfDocument document, int pageNumber,
+        PdfOcrMergeOptions? options = null, CancellationToken cancellationToken = default) {
+        if (document == null) throw new ArgumentNullException(nameof(document));
+        return PdfOcr.PreviewScanAsync(document.GetBytesForOperation(cancellationToken), pageNumber,
+            options?.Clone() ?? new PdfOcrMergeOptions(), document.ReadOptions, cancellationToken);
+    }
+
     /// <summary>
     /// Renders selected pages, invokes an engine-neutral OCR provider, and merges accepted spans into the
     /// same logical result contract returned by <see cref="PdfDocument.Read"/>.

--- a/OfficeIMO.Pdf.Ocr/PdfOcrLogicalDocumentBuilder.ReadingFrame.cs
+++ b/OfficeIMO.Pdf.Ocr/PdfOcrLogicalDocumentBuilder.ReadingFrame.cs
@@ -6,13 +6,11 @@ internal static partial class PdfOcrLogicalDocumentBuilder {
     private static long ApplyRecognitionFrameOrder(
         PdfUnderstandingPipeline pipeline, PdfReadPage sourcePage, PdfLogicalPage nativePage,
         PdfOcrPageMergeResult merge, OcrArtifacts artifacts, CancellationToken token) {
-        var report = merge.ScanProcessing;
-        if (report == null || artifacts.Lines.Count < 2 ||
+        if (!merge.RecognitionWidth.HasValue || !merge.RecognitionHeight.HasValue || artifacts.Lines.Count < 2 ||
             artifacts.Lines.All(static line => line.SourceSequence.HasValue)) return 0;
 
-        (double sourceWidth, double sourceHeight) = sourcePage.GetVisualPageSize();
-        double width = report.Width * sourceWidth / report.SourceWidth;
-        double height = report.Height * sourceHeight / report.SourceHeight;
+        double width = merge.RecognitionWidth.Value;
+        double height = merge.RecognitionHeight.Value;
         var normalizedBySequence = new Dictionary<int, PdfUnderstandingWord>(merge.Words.Count);
         foreach (PdfRecognizedWord word in merge.Words) {
             token.ThrowIfCancellationRequested();

--- a/OfficeIMO.Pdf.Ocr/PdfOcrMergeOptions.cs
+++ b/OfficeIMO.Pdf.Ocr/PdfOcrMergeOptions.cs
@@ -34,6 +34,11 @@ public sealed class PdfOcrMergeOptions {
     public OfficeIMO.Drawing.IOfficeRasterImageCodec? ImageCodec { get; set; }
     /// <summary>Optional shared scan-cleanup settings. Null preserves the rendered samples.</summary>
     public OfficeIMO.Drawing.OfficeScanProcessingOptions? ScanProcessing { get; set; }
+    /// <summary>Optional explicit perspective corners, relative to each selected region or full page. Applied before affine cleanup.</summary>
+    public OfficeIMO.Drawing.OfficeScanPerspectiveOptions? Perspective { get; set; }
+    /// <summary>Optional OCR rectangles, at most one per page. A nonempty list sends only these pages and cropped pixels to the provider.
+    /// Every region page must also belong to ReadOptions.PageSelection when it is supplied.</summary>
+    public IReadOnlyList<PdfOcrPageRegion> Regions { get; set; } = Array.Empty<PdfOcrPageRegion>();
     /// <summary>Requests provider orientation evidence before cleanup. Unsupported or inconclusive detection retains the source orientation.</summary>
     public bool DetectOrientation { get; set; }
     /// <summary>Minimum normalized provider orientation confidence required to rotate the OCR image.</summary>
@@ -89,6 +94,8 @@ public sealed class PdfOcrMergeOptions {
             Dpi = Dpi,
             ImageCodec = ImageCodec,
             ScanProcessing = ScanProcessing?.Clone(),
+            Perspective = Perspective?.Clone(),
+            Regions = (Regions ?? throw new ArgumentNullException(nameof(Regions))).ToArray(),
             DetectOrientation = DetectOrientation,
             MinimumOrientationConfidence = MinimumOrientationConfidence,
             MinimumConfidence = MinimumConfidence,
@@ -111,8 +118,29 @@ public sealed class PdfOcrMergeOptions {
         };
     }
 
+    /// <summary>Resolves the page selection and optional region restriction against an actual document page count.</summary>
+    /// <remarks>Preserves requested page order. Invalid region pages and the configured page budget are rejected before rendering.</remarks>
+    public int[] GetSelectedPages(int pageCount) {
+        Validate();
+        if (pageCount < 0) throw new ArgumentOutOfRangeException(nameof(pageCount));
+        int[] pages = ReadOptions.PageSelection?.ToPageNumbers(pageCount, nameof(ReadOptions.PageSelection))
+            ?? Enumerable.Range(1, pageCount).ToArray();
+        if (Regions.Count > 0) {
+            var regionPages = new HashSet<int>(Regions.Select(region => region.PageNumber));
+            if (regionPages.Any(page => !pages.Contains(page)))
+                throw new ArgumentException("Each OCR region must refer to an existing selected page.", nameof(Regions));
+            pages = pages.Where(regionPages.Contains).ToArray();
+        }
+        if (pages.Length > MaxPages) throw PdfReadLimitException.Create(PdfReadLimitKind.Pages, MaxPages, pages.Length);
+        return pages;
+    }
+
     internal void Validate() {
         ScanProcessing?.Validate();
+        Perspective?.Validate();
+        if (Regions == null) throw new ArgumentNullException(nameof(Regions));
+        if (Regions.Count > MaxPages || Regions.Any(region => region == null) || Regions.Select(region => region.PageNumber).Distinct().Count() != Regions.Count)
+            throw new ArgumentException("OCR regions require unique pages within MaxPages.", nameof(Regions));
         Guard.NotNull(ReadOptions, nameof(ReadOptions));
         PdfReadOptions.Resolve(ReadOptions);
         Guard.Positive(Dpi, nameof(Dpi));

--- a/OfficeIMO.Pdf.Ocr/PdfOcrMergeResult.cs
+++ b/OfficeIMO.Pdf.Ocr/PdfOcrMergeResult.cs
@@ -30,10 +30,11 @@ public sealed class PdfOcrMergeResult {
 
 /// <summary>Accepted OCR words and evidence for one page.</summary>
 public sealed class PdfOcrPageMergeResult {
-    internal PdfOcrPageMergeResult(int pageNumber, IReadOnlyList<PdfRecognizedWord> words, int rejectedLowConfidenceCount, int rejectedNativeOverlapCount, IReadOnlyList<string> diagnostics, string text, string? provider = null, string? model = null, string? language = null, IReadOnlyList<PdfOcrWordEvidence>? wordEvidence = null, OfficeIMO.Drawing.OfficeScanProcessingReport? scanProcessing = null) {
+    internal PdfOcrPageMergeResult(int pageNumber, IReadOnlyList<PdfRecognizedWord> words, int rejectedLowConfidenceCount, int rejectedNativeOverlapCount, IReadOnlyList<string> diagnostics, string text, string? provider = null, string? model = null, string? language = null, IReadOnlyList<PdfOcrWordEvidence>? wordEvidence = null, OfficeIMO.Drawing.OfficeScanProcessingReport? scanProcessing = null, double? recognitionWidth = null, double? recognitionHeight = null) {
         PageNumber = pageNumber; Words = words; RejectedLowConfidenceCount = rejectedLowConfidenceCount; RejectedNativeOverlapCount = rejectedNativeOverlapCount; Diagnostics = diagnostics; Text = text;
         Provider = provider; Model = model; Language = language;
         ScanProcessing = scanProcessing;
+        RecognitionWidth = recognitionWidth; RecognitionHeight = recognitionHeight;
         WordEvidence = wordEvidence ?? Array.AsReadOnly(words.Select(word => new PdfOcrWordEvidence(word, PdfOcrWordDisposition.Accepted)).ToArray());
     }
     /// <summary>One-based page number.</summary>
@@ -48,8 +49,11 @@ public sealed class PdfOcrPageMergeResult {
     public int RejectedNativeOverlapCount { get; }
     /// <summary>Rendering, provider, and normalization diagnostics.</summary>
     public IReadOnlyList<string> Diagnostics { get; }
-    /// <summary>Applied scan transformations and their inverse geometry. Null means cleanup was disabled or retained the original after a reported limit.</summary>
+    /// <summary>Affine scan transformations and their inverse geometry, relative to the image after optional region and perspective preparation.
+    /// Use each word's Geometry for original-page coordinates. Null means affine cleanup was disabled or retained its input after a reported limit.</summary>
     public OfficeIMO.Drawing.OfficeScanProcessingReport? ScanProcessing { get; }
+    internal double? RecognitionWidth { get; }
+    internal double? RecognitionHeight { get; }
     /// <summary>Native and accepted OCR text in approximate visual order.</summary>
     public string Text { get; }
     /// <summary>OCR provider identifier reported for this page, when available.</summary>
@@ -74,7 +78,7 @@ public sealed class PdfOcrPageMergeResult {
             Provider,
             Model,
             Language,
-            WordEvidence, ScanProcessing);
+            WordEvidence, ScanProcessing, RecognitionWidth, RecognitionHeight);
     }
 }
 

--- a/OfficeIMO.Pdf.Ocr/PdfOcrPageRegion.cs
+++ b/OfficeIMO.Pdf.Ocr/PdfOcrPageRegion.cs
@@ -1,0 +1,24 @@
+namespace OfficeIMO.Pdf.Ocr;
+
+/// <summary>One OCR rectangle in normalized top-left visual page coordinates, after the PDF crop and page rotation.</summary>
+public sealed class PdfOcrPageRegion {
+    /// <summary>Creates a nonempty rectangle inside one one-based page.</summary>
+    public PdfOcrPageRegion(int pageNumber, double x, double y, double width, double height) {
+        if (pageNumber < 1) throw new ArgumentOutOfRangeException(nameof(pageNumber));
+        if (!Finite(x) || !Finite(y) || !Finite(width) || !Finite(height) || x < 0 || y < 0 ||
+            width <= 0 || height <= 0 || x + width > 1 || y + height > 1)
+            throw new ArgumentException("OCR regions must be nonempty normalized rectangles inside the visual page.");
+        PageNumber = pageNumber; X = x; Y = y; Width = width; Height = height;
+    }
+    /// <summary>One-based source page.</summary>
+    public int PageNumber { get; }
+    /// <summary>Left edge, normalized to visual page width.</summary>
+    public double X { get; }
+    /// <summary>Top edge, normalized to visual page height.</summary>
+    public double Y { get; }
+    /// <summary>Width, normalized to visual page width.</summary>
+    public double Width { get; }
+    /// <summary>Height, normalized to visual page height.</summary>
+    public double Height { get; }
+    private static bool Finite(double value) => !double.IsNaN(value) && !double.IsInfinity(value);
+}

--- a/OfficeIMO.Pdf.Ocr/PdfScanPreview.cs
+++ b/OfficeIMO.Pdf.Ocr/PdfScanPreview.cs
@@ -1,0 +1,74 @@
+using OfficeIMO.Drawing;
+using OfficeIMO.Ocr;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OfficeIMO.Pdf.Ocr;
+
+/// <summary>Source and prepared page appearances for explicit scan review.</summary>
+public sealed class PdfScanPreview {
+    private readonly byte[] _source, _processed;
+    internal PdfScanPreview(int pageNumber, byte[] source, byte[] processed, double width, double height,
+        int pixelWidth, int pixelHeight, IReadOnlyList<string> diagnostics, OfficeScanProcessingReport? report) {
+        PageNumber = pageNumber; _source = (byte[])source.Clone(); _processed = (byte[])processed.Clone();
+        Width = width; Height = height; PixelWidth = pixelWidth; PixelHeight = pixelHeight;
+        Diagnostics = Array.AsReadOnly(diagnostics.ToArray()); ScanProcessing = report;
+    }
+    /// <summary>One-based source page.</summary>
+    public int PageNumber { get; }
+    /// <summary>Prepared width in points at the requested sampling density.</summary>
+    public double Width { get; }
+    /// <summary>Prepared height in points at the requested sampling density.</summary>
+    public double Height { get; }
+    /// <summary>Prepared width in pixels.</summary>
+    public int PixelWidth { get; }
+    /// <summary>Prepared height in pixels.</summary>
+    public int PixelHeight { get; }
+    /// <summary>Geometry and tone decisions from optional affine processing.</summary>
+    public OfficeScanProcessingReport? ScanProcessing { get; }
+    /// <summary>Rendering and preparation limits or decisions.</summary>
+    public IReadOnlyList<string> Diagnostics { get; }
+    /// <summary>Independent original page PNG.</summary>
+    public byte[] GetSourcePng() => (byte[])_source.Clone();
+    /// <summary>Independent prepared page PNG.</summary>
+    public byte[] GetPreparedPng() => (byte[])_processed.Clone();
+    /// <summary>Creates a single-page raster PDF of the reviewed appearance. Interactive content and native text are not copied.</summary>
+    public PdfDocument CreateImagePdf(CancellationToken cancellationToken = default) => PdfDocument.CreateFromImages(
+        new[] { new PdfImageDocumentSource(_processed) }, new PdfImageDocumentOptions {
+            FixedPageSize = new PageSize(Width, Height),
+            Margin = 0,
+            Fit = OfficeImageFit.Stretch
+        }, cancellationToken);
+}
+
+internal static partial class PdfOcr {
+    internal static async Task<PdfScanPreview> PreviewScanAsync(byte[] source, int pageNumber,
+        PdfOcrMergeOptions options, PdfLoadOptions? loadOptions, CancellationToken token) {
+        options.Validate(); token.ThrowIfCancellationRequested();
+        var document = PdfReadDocument.Open(source, loadOptions, token);
+        if (pageNumber < 1 || pageNumber > document.Pages.Count) throw new ArgumentOutOfRangeException(nameof(pageNumber));
+        if (!options.GetSelectedPages(document.Pages.Count).Contains(pageNumber))
+            throw new ArgumentException("The preview page does not belong to the selected OCR pages.", nameof(pageNumber));
+        var rendered = PdfPageImageRenderer.RenderPage(document, pageNumber, new PdfPageRenderOptions {
+            Dpi = options.Dpi,
+            Format = PdfPageRenderFormat.Png,
+            ImageCodec = options.ImageCodec,
+            MaxPixelsPerPage = options.MaxPixelsPerPage,
+            MaxOutputBytesPerPage = options.MaxRenderedBytesPerPage,
+            ContinueOnError = false
+        }, token);
+        (double width, double height) = document.Pages[pageNumber - 1].GetInteractionPageSize();
+        var request = new OcrRequest {
+            Payload = rendered.Bytes!,
+            MediaType = "image/png",
+            PageNumber = pageNumber,
+            PixelWidth = rendered.Width,
+            PixelHeight = rendered.Height,
+            RegionCoordinateUnit = OcrCoordinateUnit.Points,
+            Region = new OcrRegion { Width = width, Height = height }
+        };
+        PreparedPage prepared = await PreparePageAsync(request, null, options, token).ConfigureAwait(false);
+        return new PdfScanPreview(pageNumber, rendered.Bytes!, request.Payload, request.Region!.Width, request.Region.Height,
+            request.PixelWidth!.Value, request.PixelHeight!.Value, rendered.Diagnostics.Concat(prepared.Diagnostics).ToArray(), prepared.Report);
+    }
+}

--- a/OfficeIMO.Pdf.Ocr/PdfSearchableOcrReview.cs
+++ b/OfficeIMO.Pdf.Ocr/PdfSearchableOcrReview.cs
@@ -53,6 +53,24 @@ public sealed class PdfSearchableOcrReview {
         return ApplyCore(selectedWords, null, cancellationToken);
     }
 
+    /// <summary>Returns selected eligible words in logical reading order without creating or modifying a PDF.</summary>
+    /// <remarks>Selection validation matches <see cref="Apply"/>. Words are separated by spaces and pages by newlines.</remarks>
+    public string ExtractText(IEnumerable<PdfRecognizedWord> selectedWords, CancellationToken cancellationToken = default) {
+        var selected = ValidateSelection(selectedWords, cancellationToken);
+        var pages = new List<string>();
+        foreach (var page in Ocr.Pages) {
+            cancellationToken.ThrowIfCancellationRequested();
+            var canonicalPage = Ocr.Document.Pages.First(item => item.PageNumber == page.PageNumber);
+            var words = PdfOcrLogicalDocumentBuilder.OrderWordsForLogicalReading(
+                page.Words.Where(selected.Contains).ToArray(), canonicalPage,
+                _options.ReadOptions.LayoutOptions.ReadingDirection, cancellationToken);
+            string text = string.Join(" ", words.Select(word => word.Text));
+            if (text.Length > 0) pages.Add(text);
+        }
+        cancellationToken.ThrowIfCancellationRequested();
+        return string.Join(Environment.NewLine, pages);
+    }
+
     /// <summary>Creates a searchable artifact from eligible words and their reviewed replacement text.</summary>
     /// <remarks>Only dictionary entries are included. Keys must be eligible words from this review. Geometry,
     /// ordering, and original provider evidence are retained; replacements do not bypass confidence or overlap policy.</remarks>
@@ -73,6 +91,11 @@ public sealed class PdfSearchableOcrReview {
 
     private PdfSearchableOcrResult ApplyCore(IEnumerable<PdfRecognizedWord> selectedWords,
         IReadOnlyDictionary<PdfRecognizedWord, string>? corrections, CancellationToken cancellationToken) {
+        var selected = ValidateSelection(selectedWords, cancellationToken);
+        return ApplyValidated(selected, corrections, cancellationToken);
+    }
+
+    private HashSet<PdfRecognizedWord> ValidateSelection(IEnumerable<PdfRecognizedWord> selectedWords, CancellationToken cancellationToken) {
         Guard.NotNull(selectedWords, nameof(selectedWords));
         var selected = new HashSet<PdfRecognizedWord>();
         foreach (var word in selectedWords) {
@@ -82,6 +105,11 @@ public sealed class PdfSearchableOcrReview {
             if (!selected.Add(word)) throw new ArgumentException("A word cannot be selected more than once.", nameof(selectedWords));
         }
         cancellationToken.ThrowIfCancellationRequested();
+        return selected;
+    }
+
+    private PdfSearchableOcrResult ApplyValidated(HashSet<PdfRecognizedWord> selected,
+        IReadOnlyDictionary<PdfRecognizedWord, string>? corrections, CancellationToken cancellationToken) {
         var wordsByPage = Ocr.Pages.Select(page => new {
             page.PageNumber, Words = (IReadOnlyList<PdfRecognizedWord>)Array.AsReadOnly(page.Words.Where(selected.Contains).ToArray())
         }).Where(page => page.Words.Count > 0).ToDictionary(page => page.PageNumber, page => page.Words);

--- a/OfficeIMO.Pdf.Ocr/README.md
+++ b/OfficeIMO.Pdf.Ocr/README.md
@@ -165,6 +165,8 @@ PdfSearchableOcrReview review = await pdf.PrepareSearchableOcrAsync(engine);
 // Replace this confidence selection with the eligible word instances chosen in a review interface.
 var selected = review.Ocr.Pages.SelectMany(page => page.Words)
     .Where(word => word.Confidence >= 0.90).ToArray();
+// Text extraction uses logical reading order and does not create or modify a PDF.
+string recognizedText = review.ExtractText(selected);
 PdfSearchableOcrResult reviewed = review.Apply(selected);
 await reviewed.Document.SaveAsync("reviewed-searchable.pdf");
 ```

--- a/OfficeIMO.Pdf.Ocr/README.md
+++ b/OfficeIMO.Pdf.Ocr/README.md
@@ -97,9 +97,32 @@ PdfSearchableOcrResult searchable = review.ApplyAll();
 
 Orientation detection uses the provider's optional orientation capability and the same timeout, cancellation, and concurrency gate as recognition. Missing or low-confidence evidence retains the source orientation and produces a diagnostic. Tesseract needs its `osd` trained data. An explicit `ClockwiseQuarterTurns` value can supply a caller-reviewed correction; it combines with any accepted provider correction.
 
-Deskew searches a bounded range of small angles. Background normalization estimates local paper brightness, and `Bilevel` uses a measured or explicit global threshold. Downsampling never enlarges a scan. Blank-page detection reports a suggestion and keeps the page. These operations do not perform perspective correction, curved-page dewarping, or document cropping.
+Deskew searches a bounded range of small angles; `StraightenDegrees` supplies a manual correction from -15 to 15 degrees. Background normalization estimates local paper brightness. `BlackPoint`, `WhitePoint`, and `Gamma` adjust tonal levels before optional bilevel conversion. Downsampling never enlarges a scan. Blank-page detection reports a suggestion and keeps the page. Curved-page dewarping remains unsupported.
 
 `ScanProcessing` reports applied and skipped operations, buffer estimates, and forward/inverse pixel transforms. Its pixel, buffer, and analysis-work limits reject optional cleanup with an `ocr-scan-limit` diagnostic and retain the original OCR raster; cancellation still propagates. Buffer accounting covers the managed image operation, while encoded PDF/raster and provider-process limits remain separate. `PdfRecognizedWord.Geometry` retains all four corners on the original page, so the invisible text layer follows the original scan's angle after deskew or a quarter-turn. `X`, `Y`, `Width`, and `Height` remain its enclosing visual bounds.
+
+### Review a region and perspective correction
+
+`Regions` accepts one normalized rectangle per page. A nonempty list sends only those pages and pixels to the OCR provider. Region pages must also belong to `ReadOptions.PageSelection` when supplied. `Perspective` specifies four normalized corners relative to the region, or to the full page when no region is selected. Preparation crops first, corrects perspective next, and applies affine scan cleanup last.
+
+```csharp
+var options = new PdfOcrMergeOptions {
+    Regions = new[] { new PdfOcrPageRegion(1, 0.1, 0.1, 0.8, 0.7) },
+    Perspective = new OfficeScanPerspectiveOptions {
+        TopLeft = new(0.02, 0.04), TopRight = new(0.98, 0),
+        BottomRight = new(1, 1), BottomLeft = new(0, 0.96)
+    },
+    ScanProcessing = new OfficeScanProcessingOptions {
+        Deskew = false, StraightenDegrees = 2, Gamma = 1.1
+    }
+};
+PdfScanPreview preview = await document.PreviewScanAsync(1, options);
+byte[] originalPreview = preview.GetSourcePng();
+byte[] preparedPreview = preview.GetPreparedPng();
+PdfSearchableOcrReview review = await document.PrepareSearchableOcrAsync(engine, options);
+```
+
+Preview uses the same preparation code without calling an OCR provider. OCR geometry maps back through all transforms to the original visible page. `preview.CreateImagePdf()` instead creates a separate raster-only PDF of the prepared pixels: native text, forms, links, signatures, and attachments are omitted. Invalid region or perspective settings stop preparation; they do not silently select a different area. `ScanProcessing` describes the affine cleanup relative to the prepared region; its matrix alone does not describe the earlier crop and perspective mapping.
 
 ## Discover scanned redaction candidates
 

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfOcrScanProcessingTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfOcrScanProcessingTests.cs
@@ -11,13 +11,73 @@ namespace OfficeIMO.Tests.Pdf;
 
 public sealed class PdfOcrScanProcessingTests {
     [Theory]
+    [InlineData(72, 0)]
+    [InlineData(144, 0)]
+    [InlineData(144, 1)]
+    public async Task RegionRecognitionSendsCroppedPixelsAndMapsWordsToOriginalPage(double dpi, int turns) {
+        byte[] source = Source();
+        var engine = new DelegateOcrEngine("region", (request, providerToken) => {
+            int size = (int)(50 * dpi / 72);
+            Assert.Equal(size, request.PixelWidth); Assert.Equal(size, request.PixelHeight);
+            Assert.True(OfficeRasterImageDecoder.TryDecode(request.Payload, new OfficeRasterDecodeOptions(), out var cropped, out _));
+            Assert.True(cropped!.GetPixel(size / 2, size / 2).R > cropped.GetPixel(size / 2, size / 2).B);
+            return Task.FromResult(new OcrResult {
+                Spans = new[] { new OcrTextSpan {
+                Text = "Region", Level = OcrTextSpanLevel.Word, Confidence = 1, CoordinateUnit = OcrCoordinateUnit.Normalized,
+                Region = new OcrRegion { X = .2, Y = .2, Width = .2, Height = .2 }
+            } }
+            });
+        });
+        var review = await PdfDocument.Load(source).PrepareSearchableOcrAsync(engine, new PdfOcrMergeOptions {
+            Dpi = dpi,
+            Regions = new[] { new PdfOcrPageRegion(1, .125, .25, .25, .5) },
+            ScanProcessing = new() { ClockwiseQuarterTurns = turns, Deskew = false, NormalizeBackground = false, ColorMode = OfficeScanColorMode.PreserveColor }
+        });
+        var word = Assert.Single(review.Ocr.Pages[0].Words);
+        Assert.Equal(35, word.X, 5); Assert.Equal(turns == 0 ? 35 : 55, word.Y, 5);
+        Assert.Equal(10, word.Width, 5); Assert.Equal(10, word.Height, 5);
+        byte[] searchable = review.ApplyAll().Document.ToBytes();
+        Assert.Equal(PdfPageImageRenderer.RenderPageAsPng(source), PdfPageImageRenderer.RenderPageAsPng(searchable));
+        Assert.Contains("Region", PdfReadDocument.Open(searchable).ExtractText());
+    }
+
+    [Fact]
+    public async Task PerspectiveRecognitionMapsWordCornersAndKeepsSourceAppearance() {
+        byte[] source = Source();
+        var options = new OfficeScanPerspectiveOptions { TopLeft = new(.2, .1), TopRight = new(.8, .1), BottomRight = new(.95, .9), BottomLeft = new(.05, .9) };
+        var engine = new DelegateOcrEngine("perspective", (request, _) => Task.FromResult(new OcrResult {
+            Spans = new[] {
+            new OcrTextSpan { Text = "Corrected", Level = OcrTextSpanLevel.Word, Confidence = 1, CoordinateUnit = OcrCoordinateUnit.Normalized,
+                Region = new OcrRegion { X = .1, Y = .1, Width = .3, Height = .1 } }
+        }
+        }));
+        var review = await PdfDocument.Load(source).PrepareSearchableOcrAsync(engine, new PdfOcrMergeOptions { Dpi = 72, Perspective = options });
+        var expected = OfficeScanProcessor.CorrectPerspective(new OfficeRasterImage(200, 100, OfficeColor.White), options);
+        var corner = expected.Mapping.MapProcessedToSource(new OfficePoint(expected.Image.Width * .1, expected.Image.Height * .1));
+        var word = Assert.Single(review.Ocr.Pages[0].Words);
+        Assert.Equal(corner.X, word.Geometry.TopLeft.X, 5); Assert.Equal(corner.Y, word.Geometry.TopLeft.Y, 5);
+        Assert.Equal(PdfPageImageRenderer.RenderPageAsPng(source), PdfPageImageRenderer.RenderPageAsPng(review.ApplyAll().Document.ToBytes()));
+    }
+
+    [Fact]
+    public async Task InvalidRegionPageFailsBeforeProviderWork() {
+        int calls = 0;
+        var engine = new DelegateOcrEngine("regions", (_, _) => { calls++; return Task.FromResult(new OcrResult()); });
+        await Assert.ThrowsAsync<ArgumentException>(() => PdfDocument.Load(Source()).ReadWithOcrAsync(engine,
+            new PdfOcrMergeOptions { Regions = new[] { new PdfOcrPageRegion(2, 0, 0, 1, 1) } }));
+        Assert.Equal(0, calls);
+    }
+
+    [Theory]
     [InlineData(0)]
     [InlineData(1)]
     [InlineData(2)]
     [InlineData(3)]
     public async Task TransformedHierarchyFreeParagraphsRetainColumnOrder(int turns) {
         OcrTextSpan Word(string text, double x, double y) => new OcrTextSpan {
-            Text = text, Level = OcrTextSpanLevel.Word, Confidence = 1,
+            Text = text,
+            Level = OcrTextSpanLevel.Word,
+            Confidence = 1,
             CoordinateUnit = OcrCoordinateUnit.Normalized,
             Region = new OcrRegion { X = x, Y = y, Width = 0.08, Height = 0.015 }
         };
@@ -30,8 +90,11 @@ public sealed class PdfOcrScanProcessingTests {
         }
         var engine = new DelegateOcrEngine("columns", (_, _) => Task.FromResult(new OcrResult { Spans = words }));
         var result = await PdfDocument.Load(Source()).ReadWithOcrAsync(engine, new PdfOcrMergeOptions {
-            Dpi = 72, ScanProcessing = new OfficeScanProcessingOptions {
-                ClockwiseQuarterTurns = turns, Deskew = false, NormalizeBackground = false,
+            Dpi = 72,
+            ScanProcessing = new OfficeScanProcessingOptions {
+                ClockwiseQuarterTurns = turns,
+                Deskew = false,
+                NormalizeBackground = false,
                 ColorMode = OfficeScanColorMode.PreserveColor
             }
         });
@@ -50,15 +113,25 @@ public sealed class PdfOcrScanProcessingTests {
     [InlineData(2, false)]
     [InlineData(3, false)]
     public async Task RotatedWordGeometryPreservesLogicalWordSpacing(int turns, bool hierarchy) {
-        OcrTextSpan Word(string text, double x) => new OcrTextSpan { Text = text, Level = OcrTextSpanLevel.Word,
-            Confidence = 1, LineId = hierarchy ? "line" : null, CoordinateUnit = OcrCoordinateUnit.Normalized,
-            Region = new OcrRegion { X = x, Y = 0.1, Width = 0.15, Height = 0.05 } };
+        OcrTextSpan Word(string text, double x) => new OcrTextSpan {
+            Text = text,
+            Level = OcrTextSpanLevel.Word,
+            Confidence = 1,
+            LineId = hierarchy ? "line" : null,
+            CoordinateUnit = OcrCoordinateUnit.Normalized,
+            Region = new OcrRegion { X = x, Y = 0.1, Width = 0.15, Height = 0.05 }
+        };
         var engine = new DelegateOcrEngine("rotated-spacing", (_, _) => Task.FromResult(new OcrResult {
             Spans = new[] { Word("Hello", 0.1), Word("world", 0.3) }
         }));
         var review = await PdfDocument.Load(Source()).PrepareSearchableOcrAsync(engine, new PdfOcrMergeOptions {
-            Dpi = 72, ScanProcessing = new OfficeScanProcessingOptions { ClockwiseQuarterTurns = turns,
-                Deskew = false, NormalizeBackground = false, ColorMode = OfficeScanColorMode.PreserveColor }
+            Dpi = 72,
+            ScanProcessing = new OfficeScanProcessingOptions {
+                ClockwiseQuarterTurns = turns,
+                Deskew = false,
+                NormalizeBackground = false,
+                ColorMode = OfficeScanColorMode.PreserveColor
+            }
         });
         Assert.Equal("Hello world", review.Ocr.Text.Trim());
     }
@@ -69,15 +142,25 @@ public sealed class PdfOcrScanProcessingTests {
     [InlineData(2)]
     [InlineData(3)]
     public async Task TransformedHierarchyFreeLinesRetainReadingOrderAndPhraseSearch(int turns) {
-        OcrTextSpan Word(string text, double x, double y) => new OcrTextSpan { Text = text, Level = OcrTextSpanLevel.Word,
-            Confidence = 1, CoordinateUnit = OcrCoordinateUnit.Normalized,
-            Region = new OcrRegion { X = x, Y = y, Width = 0.15, Height = 0.05 } };
+        OcrTextSpan Word(string text, double x, double y) => new OcrTextSpan {
+            Text = text,
+            Level = OcrTextSpanLevel.Word,
+            Confidence = 1,
+            CoordinateUnit = OcrCoordinateUnit.Normalized,
+            Region = new OcrRegion { X = x, Y = y, Width = 0.15, Height = 0.05 }
+        };
         // A provider may return unsorted geometry without hierarchy. Infer rows in its recognized coordinate frame.
         var engine = new DelegateOcrEngine("rotated-lines", (_, _) => Task.FromResult(new OcrResult {
             Spans = new[] { Word("line", 0.3, 0.3), Word("world", 0.3, 0.1), Word("Next", 0.1, 0.3), Word("Hello", 0.1, 0.1) }
         }));
-        var options = new PdfOcrMergeOptions { Dpi = 72, ScanProcessing = new OfficeScanProcessingOptions {
-            ClockwiseQuarterTurns = turns, Deskew = false, NormalizeBackground = false, ColorMode = OfficeScanColorMode.PreserveColor }
+        var options = new PdfOcrMergeOptions {
+            Dpi = 72,
+            ScanProcessing = new OfficeScanProcessingOptions {
+                ClockwiseQuarterTurns = turns,
+                Deskew = false,
+                NormalizeBackground = false,
+                ColorMode = OfficeScanColorMode.PreserveColor
+            }
         };
         PdfDocument document = PdfDocument.Load(Source());
         var review = await document.PrepareSearchableOcrAsync(engine, options);
@@ -101,7 +184,8 @@ public sealed class PdfOcrScanProcessingTests {
                 Region = new OcrRegion { X = 0.25, Y = 0.25, Width = 0.2, Height = 0.05 } } }
         }));
         var review = await PdfDocument.Load(original).PrepareSearchableOcrAsync(engine, new PdfOcrMergeOptions {
-            Dpi = 300, ScanProcessing = new OfficeScanProcessingOptions { NormalizeBackground = false }
+            Dpi = 300,
+            ScanProcessing = new OfficeScanProcessingOptions { NormalizeBackground = false }
         });
         PdfRecognizedWord word = Assert.Single(review.Ocr.Pages[0].Words);
         Assert.InRange(review.Ocr.Pages[0].ScanProcessing!.AppliedDeskewDegrees, -3.2, -2.8);
@@ -131,9 +215,13 @@ public sealed class PdfOcrScanProcessingTests {
         });
         var source = PdfDocument.Load(original);
         var review = await source.PrepareSearchableOcrAsync(engine, new PdfOcrMergeOptions {
-            Dpi = dpi, ScanProcessing = new OfficeScanProcessingOptions {
-                ClockwiseQuarterTurns = 1, Deskew = false, NormalizeBackground = false,
-                ColorMode = OfficeScanColorMode.PreserveColor, MaximumDimension = maximumDimension
+            Dpi = dpi,
+            ScanProcessing = new OfficeScanProcessingOptions {
+                ClockwiseQuarterTurns = 1,
+                Deskew = false,
+                NormalizeBackground = false,
+                ColorMode = OfficeScanColorMode.PreserveColor,
+                MaximumDimension = maximumDimension
             }
         });
         PdfRecognizedWord word = Assert.Single(review.Ocr.Pages[0].Words);
@@ -187,7 +275,8 @@ public sealed class PdfOcrScanProcessingTests {
         });
         var source = PdfDocument.Load(Source());
         var result = await source.ReadWithOcrAsync(engine, new PdfOcrMergeOptions {
-            Dpi = 72, ScanProcessing = new OfficeScanProcessingOptions { MaximumPixels = 10 }
+            Dpi = 72,
+            ScanProcessing = new OfficeScanProcessingOptions { MaximumPixels = 10 }
         });
         Assert.Equal(1, calls);
         Assert.Contains(result.Pages[0].Diagnostics, message => message.StartsWith("ocr-scan-limit:", StringComparison.Ordinal));
@@ -223,9 +312,16 @@ public sealed class PdfOcrScanProcessingTests {
     }
 
     private static OcrTextSpan RelativeWord(OcrRequest request) => new OcrTextSpan {
-        Text = "Word", Level = OcrTextSpanLevel.Word, Confidence = 0.99D, CoordinateUnit = OcrCoordinateUnit.Pixels,
-        Region = new OcrRegion { X = request.PixelWidth!.Value * 0.1D, Y = request.PixelHeight!.Value * 0.1D,
-            Width = request.PixelWidth.Value * 0.3D, Height = request.PixelHeight.Value * 0.05D }
+        Text = "Word",
+        Level = OcrTextSpanLevel.Word,
+        Confidence = 0.99D,
+        CoordinateUnit = OcrCoordinateUnit.Pixels,
+        Region = new OcrRegion {
+            X = request.PixelWidth!.Value * 0.1D,
+            Y = request.PixelHeight!.Value * 0.1D,
+            Width = request.PixelWidth.Value * 0.3D,
+            Height = request.PixelHeight.Value * 0.05D
+        }
     };
 
     // An independent two-color scan producer; the PDF writer under test does not create this source.

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfScanPreviewTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfScanPreviewTests.cs
@@ -1,0 +1,53 @@
+using System.Threading;
+using System.Threading.Tasks;
+using OfficeIMO.Pdf;
+using OfficeIMO.Pdf.Ocr;
+using Xunit;
+
+namespace OfficeIMO.Tests.Pdf;
+
+public sealed class PdfScanPreviewTests {
+    [Fact]
+    public async Task PreviewOwnsItsPixelsAndCreatesOnlyTheReviewedRegion() {
+        var document = Source();
+        byte[] source = document.ToBytes();
+        var options = new PdfOcrMergeOptions {
+            Dpi = 72, Regions = new[] { new PdfOcrPageRegion(2, .25, .25, .5, .5) },
+            ReadOptions = new() { PageSelection = PdfPageSelection.From(1, 2) }
+        };
+        Assert.Equal(new[] { 2 }, options.GetSelectedPages(2));
+        var preview = await document.PreviewScanAsync(2, options);
+        Assert.Equal(100, preview.Width); Assert.Equal(50, preview.Height);
+        byte[] originalPixels = preview.GetSourcePng(), preparedPixels = preview.GetPreparedPng();
+        byte[] disposableSource = preview.GetSourcePng(), disposablePrepared = preview.GetPreparedPng();
+        Array.Clear(disposableSource, 0, disposableSource.Length);
+        Array.Clear(disposablePrepared, 0, disposablePrepared.Length);
+        Assert.Equal(originalPixels, preview.GetSourcePng());
+        Assert.Equal(preparedPixels, preview.GetPreparedPng());
+        var output = preview.CreateImagePdf();
+        Assert.Equal(1, output.Inspect().PageCount);
+        Assert.Equal(100, output.Render.Drawing(1).Width);
+        Assert.Equal(50, output.Render.Drawing(1).Height);
+        Assert.True(string.IsNullOrWhiteSpace(output.Reader.Text()));
+        Assert.Equal(source, document.ToBytes());
+    }
+
+    [Fact]
+    public async Task PreviewRejectsExcludedPagesInvalidRegionsBudgetsAndCancellation() {
+        var document = Source();
+        await Assert.ThrowsAsync<ArgumentException>(() => document.PreviewScanAsync(1,
+            new() { ReadOptions = new() { PageSelection = PdfPageSelection.From(2) } }));
+        await Assert.ThrowsAsync<ArgumentException>(() => document.PreviewScanAsync(1,
+            new() { Regions = new[] { new PdfOcrPageRegion(3, 0, 0, 1, 1) } }));
+        await Assert.ThrowsAsync<PdfReadLimitException>(() => document.PreviewScanAsync(1,
+            new() { Dpi = 72, MaxPixelsPerPage = 1 }));
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => document.PreviewScanAsync(1, cancellationToken: cancellation.Token));
+    }
+
+    private static PdfDocument Source() => PdfDocument.Create(compose => {
+        compose.Page(page => page.Size(200, 100).Margin(0).Content(c => c.Item(i => i.Paragraph(t => t.Text("First source page")))));
+        compose.Page(page => page.Size(200, 100).Margin(0).Content(c => c.Item(i => i.Paragraph(t => t.Text("Second source page")))));
+    });
+}

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfSearchableOcrReviewTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfSearchableOcrReviewTests.cs
@@ -8,6 +8,24 @@ using Xunit;
 namespace OfficeIMO.Tests.Pdf;
 
 public sealed class PdfSearchableOcrReviewTests {
+    [Fact]
+    public async Task TextExtractionUsesReviewPolicyAndReadingOrderWithoutChangingSource() {
+        byte[] bytes = Source();
+        var source = PdfDocument.Load(bytes);
+        var review = await source.PrepareSearchableOcrAsync(Engine());
+        var other = await source.PrepareSearchableOcrAsync(Engine());
+        var words = review.Ocr.Pages[0].Words;
+        Assert.Equal("First Second", review.ExtractText(words.Reverse()));
+        Assert.Equal("Second", review.ExtractText(new[] { words[1] }));
+        Assert.Equal(string.Empty, review.ExtractText(Array.Empty<PdfRecognizedWord>()));
+        Assert.Throws<ArgumentException>(() => review.ExtractText(new[] { words[0], words[0] }));
+        Assert.Throws<ArgumentException>(() => review.ExtractText(other.Ocr.Pages[0].Words));
+        Assert.Throws<ArgumentException>(() => review.ExtractText(new[] { review.Ocr.Pages[0].WordEvidence[2].Word }));
+        Assert.Throws<ArgumentException>(() => review.ExtractText(new PdfRecognizedWord[] { null! }));
+        Assert.ThrowsAny<OperationCanceledException>(() => review.ExtractText(words, new CancellationToken(true)));
+        Assert.Equal(bytes, source.ToBytes());
+    }
+
     [Theory]
     [InlineData("Searchable", 10)]
     [InlineData("Zażółć", 6)]

--- a/OfficeIMO.Studio.Tests/ScanPreparationVisualTests.cs
+++ b/OfficeIMO.Studio.Tests/ScanPreparationVisualTests.cs
@@ -1,0 +1,84 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Input;
+using Avalonia.VisualTree;
+using OfficeIMO.Pdf;
+using OfficeIMO.Studio.Features.Shell;
+using OfficeIMO.Studio.Features.Workflows;
+using OfficeIMO.Studio.Infrastructure.Preferences;
+
+namespace OfficeIMO.Studio.Tests;
+
+public sealed class ScanPreparationVisualTests {
+    [Theory]
+    [InlineData(960, 640)]
+    [InlineData(1280, 800)]
+    public async Task DrawRegionPreviewCorrectionsAndSaveReviewedRasterCopy(int width, int height) {
+        using var app = TestAppBuilder.StartSession();
+        await app.Dispatch(async () => {
+            var services = ((App)Application.Current!).Services;
+            services.Preferences.Update(value => value with { Theme = width >= 1000 ? StudioThemePreference.Dark : StudioThemePreference.Light });
+            string source = Path.Combine(services.Paths.Root, "scan.pdf"), output = Path.Combine(services.Paths.Root, "prepared.pdf");
+            PdfDocument.Create(c => c.Page(p => p.Size(240, 320).Content(content => content.Item(i => i.Paragraph(t => t.Text("Scanned page for review")))))).Save(source);
+            using var model = new MainWindowViewModel(_ => Task.FromResult<string?>(source), pickSavePdf: _ => Task.FromResult<string?>(output), services: services);
+            model.OcrWorkbench.UseDocument(source);
+            var scan = model.OcrWorkbench.Scan; scan.Dpi = 72;
+            var view = new SearchablePdfOcrView { DataContext = model };
+            var window = new Window { Width = width, Height = height, Content = view };
+            try {
+                window.Show(); window.UpdateLayout();
+                await scan.PreviewCommand.ExecuteAsync(null);
+                Assert.True(scan.IsCurrent, scan.Status); Assert.NotNull(scan.SourcePreview);
+                window.UpdateLayout();
+                var canvas = view.GetVisualDescendants().OfType<ScanSelectionCanvas>().Single();
+                canvas.BringIntoView(); window.UpdateLayout();
+                Capture(window, "scan-before-selection-" + width);
+                double scale = Math.Min(canvas.Bounds.Width / scan.SourcePreview.Size.Width, canvas.Bounds.Height / scan.SourcePreview.Size.Height);
+                double imageWidth = scan.SourcePreview.Size.Width * scale, imageHeight = scan.SourcePreview.Size.Height * scale;
+                Point start = canvas.TranslatePoint(new Point((canvas.Bounds.Width - imageWidth) / 2 + imageWidth * .25, (canvas.Bounds.Height - imageHeight) / 2 + imageHeight * .25), window)!.Value;
+                Point end = canvas.TranslatePoint(new Point((canvas.Bounds.Width - imageWidth) / 2 + imageWidth * .75, (canvas.Bounds.Height - imageHeight) / 2 + imageHeight * .75), window)!.Value;
+                window.MouseDown(start, MouseButton.Left); window.MouseMove(end, RawInputModifiers.LeftMouseButton); window.MouseUp(end, MouseButton.Left);
+                Assert.True(scan.UseRegion, $"Canvas {canvas.Bounds}; start {start}; end {end}; editable {scan.CanEdit}"); Assert.False(scan.IsCurrent); Assert.False(scan.SaveCommand.CanExecute(null));
+                Assert.InRange(scan.Region.Width, .1, .9); Assert.InRange(scan.Region.Height, .4, .6);
+                Capture(window, "scan-region-" + width);
+                Rect drawn = scan.Region;
+                canvas.Focus();
+                window.KeyPress(Key.Right, RawInputModifiers.None, PhysicalKey.None, null);
+                window.KeyPress(Key.Left, RawInputModifiers.Shift, PhysicalKey.None, null);
+                Assert.Equal(drawn.X + .01, scan.Region.X, 5);
+                Assert.Equal(drawn.Width - .01, scan.Region.Width, 5);
+                scan.UsePerspective = true; scan.EditCorners = true;
+                window.KeyPress(Key.D1, RawInputModifiers.None, PhysicalKey.None, null);
+                window.KeyPress(Key.Right, RawInputModifiers.None, PhysicalKey.None, null);
+                window.KeyPress(Key.Down, RawInputModifiers.None, PhysicalKey.None, null);
+                Assert.Equal(new Point(.01, .01), scan.TopLeft);
+                Point RegionPoint(double x, double y) => canvas.TranslatePoint(new Point(
+                    (canvas.Bounds.Width - imageWidth) / 2 + imageWidth * (scan.Region.X + scan.Region.Width * x),
+                    (canvas.Bounds.Height - imageHeight) / 2 + imageHeight * (scan.Region.Y + scan.Region.Height * y)), window)!.Value;
+                Point cornerStart = RegionPoint(.99, .99), cornerEnd = RegionPoint(.94, .96);
+                window.MouseDown(cornerStart, MouseButton.Left);
+                window.MouseMove(cornerEnd, RawInputModifiers.LeftMouseButton);
+                window.MouseUp(cornerEnd, MouseButton.Left);
+                Assert.InRange(scan.BottomRight.X, .93, .95);
+                Assert.InRange(scan.BottomRight.Y, .95, .97);
+                Capture(window, "scan-perspective-" + width);
+                scan.EnableCleanup = true; scan.Deskew = false; scan.NormalizeBackground = false; scan.StraightenDegrees = 3;
+                await scan.PreviewCommand.ExecuteAsync(null); Assert.True(scan.IsCurrent, scan.Status);
+                var prepared = view.GetVisualDescendants().OfType<Image>().Single(image => ReferenceEquals(image.Source, scan.PreparedPreview));
+                prepared.BringIntoView(); window.UpdateLayout(); Capture(window, "scan-prepared-" + width);
+                await scan.SaveCommand.ExecuteAsync(null);
+                Assert.True(File.Exists(output), model.OcrWorkbench.ErrorMessage ?? scan.Status);
+                Assert.Equal(1, PdfDocument.Load(File.ReadAllBytes(output)).Inspect().PageCount);
+                scan.Gamma = 1.5; Assert.False(scan.IsCurrent); Assert.False(scan.SaveCommand.CanExecute(null));
+            } finally { window.Close(); }
+            return true;
+        }, default);
+    }
+    private static void Capture(Window window, string name) {
+        using var frame = window.CaptureRenderedFrame(); Assert.NotNull(frame);
+        string? output = Environment.GetEnvironmentVariable("OFFICEIMO_STUDIO_VISUAL_OUTPUT");
+        if (string.IsNullOrWhiteSpace(output)) return; Directory.CreateDirectory(output);
+        frame.Save(Path.Combine(output, name + ".png"), Avalonia.Media.Imaging.PngBitmapEncoderOptions.Default);
+    }
+}

--- a/OfficeIMO.Studio.Tests/ScanPreparationVisualTests.cs
+++ b/OfficeIMO.Studio.Tests/ScanPreparationVisualTests.cs
@@ -11,6 +11,72 @@ using OfficeIMO.Studio.Infrastructure.Preferences;
 namespace OfficeIMO.Studio.Tests;
 
 public sealed class ScanPreparationVisualTests {
+    [Fact]
+    public async Task PageAndDocumentChangesClearVisualSelectionsAndDisabledPerspectiveStaysDisabled() {
+        using var app = TestAppBuilder.StartSession();
+        await app.Dispatch(async () => {
+            var services = ((App)Application.Current!).Services;
+            string source = Path.Combine(services.Paths.Root, "distinct-scan-pages.pdf");
+            PdfDocument.Create(c => {
+                c.Page(p => p.Size(240, 320).Content(content => content.Item(i => i.Paragraph(t => t.Text("FIRST PORTRAIT PAGE")))));
+                c.Page(p => p.Size(320, 240).Content(content => content.Item(i => i.Paragraph(t => t.Text("SECOND LANDSCAPE PAGE")))));
+            }).Save(source);
+            using var model = new MainWindowViewModel(_ => Task.FromResult<string?>(source), services: services);
+            model.OcrWorkbench.UseDocument(source);
+            var scan = model.OcrWorkbench.Scan;
+            scan.Dpi = 72;
+            var view = new SearchablePdfOcrView { DataContext = model };
+            var window = new Window { Width = 960, Height = 640, Content = view };
+            try {
+                window.Show(); window.UpdateLayout();
+                await scan.PreviewCommand.ExecuteAsync(null);
+                Assert.True(scan.IsCurrent, scan.Status);
+                Assert.Equal(240, scan.SourcePreview!.PixelSize.Width);
+                scan.Region = new Rect(.1, .1, .5, .5); scan.UseRegion = true;
+                scan.UsePerspective = true; scan.EditCorners = true;
+                scan.TopLeft = new Point(.05, .05);
+                scan.PageNumber = 2;
+                Assert.Null(scan.SourcePreview); Assert.Null(scan.PreparedPreview);
+                Assert.False(scan.CanEdit); Assert.False(scan.IsCurrent);
+                Assert.False(scan.UseRegion); Assert.False(scan.UsePerspective); Assert.False(scan.EditCorners);
+                Assert.Empty(scan.ApplyTo(new()).Regions);
+                await scan.PreviewCommand.ExecuteAsync(null);
+                Assert.True(scan.IsCurrent, scan.Status);
+                Assert.Equal(320, scan.SourcePreview!.PixelSize.Width);
+                Assert.Equal(240, scan.SourcePreview.PixelSize.Height);
+                window.UpdateLayout();
+                var canvas = view.GetVisualDescendants().OfType<ScanSelectionCanvas>().Single();
+                canvas.BringIntoView(); window.UpdateLayout();
+                Capture(window, "scan-page-two-selection-reset");
+                scan.UsePerspective = true; scan.EditCorners = true;
+                scan.UsePerspective = false;
+                Assert.False(scan.EditCorners);
+                canvas.Focus();
+                window.KeyPress(Key.Right, RawInputModifiers.None, PhysicalKey.None, null);
+                Assert.False(scan.UsePerspective); Assert.True(scan.UseRegion);
+                double scale = Math.Min(canvas.Bounds.Width / 320, canvas.Bounds.Height / 240);
+                Point At(double x, double y) => canvas.TranslatePoint(new Point(
+                    (canvas.Bounds.Width - 320 * scale) / 2 + 320 * scale * x,
+                    (canvas.Bounds.Height - 240 * scale) / 2 + 240 * scale * y), window)!.Value;
+                window.MouseDown(At(.2, .2), MouseButton.Left);
+                window.MouseMove(At(.7, .7), RawInputModifiers.LeftMouseButton);
+                window.MouseUp(At(.7, .7), MouseButton.Left);
+                Assert.False(scan.UsePerspective);
+                Assert.Equal(.5, scan.Region.Width, 4);
+                Assert.Equal(2, Assert.Single(scan.ApplyTo(new()).Regions).PageNumber);
+                Capture(window, "scan-perspective-disabled-region");
+                scan.UsePerspective = true;
+                Assert.False(scan.EditCorners);
+                scan.EditCorners = true;
+                scan.Invalidate(clearSource: true);
+                Assert.Equal(1, scan.PageNumber);
+                Assert.False(scan.EditCorners); Assert.False(scan.UsePerspective); Assert.False(scan.CanEdit);
+                Assert.Null(scan.SourcePreview);
+            } finally { window.Close(); }
+            return true;
+        }, default);
+    }
+
     [Theory]
     [InlineData(960, 640)]
     [InlineData(1280, 800)]

--- a/OfficeIMO.Studio.Tests/ScanPreparationVisualTests.cs
+++ b/OfficeIMO.Studio.Tests/ScanPreparationVisualTests.cs
@@ -29,6 +29,7 @@ public sealed class ScanPreparationVisualTests {
             var window = new Window { Width = 960, Height = 640, Content = view };
             try {
                 window.Show(); window.UpdateLayout();
+                Assert.All(view.GetVisualDescendants().OfType<NumericUpDown>(), input => Assert.True(input.IsEffectivelyEnabled));
                 await scan.PreviewCommand.ExecuteAsync(null);
                 Assert.True(scan.IsCurrent, scan.Status);
                 Assert.Equal(240, scan.SourcePreview!.PixelSize.Width);
@@ -37,7 +38,9 @@ public sealed class ScanPreparationVisualTests {
                 scan.TopLeft = new Point(.05, .05);
                 scan.PageNumber = 2;
                 Assert.Null(scan.SourcePreview); Assert.Null(scan.PreparedPreview);
-                Assert.False(scan.CanEdit); Assert.False(scan.IsCurrent);
+                Assert.False(scan.CanSelectRegion); Assert.False(scan.IsCurrent);
+                window.UpdateLayout();
+                Assert.All(view.GetVisualDescendants().OfType<NumericUpDown>(), input => Assert.True(input.IsEffectivelyEnabled));
                 Assert.False(scan.UseRegion); Assert.False(scan.UsePerspective); Assert.False(scan.EditCorners);
                 Assert.Empty(scan.ApplyTo(new()).Regions);
                 await scan.PreviewCommand.ExecuteAsync(null);
@@ -70,7 +73,8 @@ public sealed class ScanPreparationVisualTests {
                 scan.EditCorners = true;
                 scan.Invalidate(clearSource: true);
                 Assert.Equal(1, scan.PageNumber);
-                Assert.False(scan.EditCorners); Assert.False(scan.UsePerspective); Assert.False(scan.CanEdit);
+                Assert.False(scan.EditCorners); Assert.False(scan.UsePerspective); Assert.False(scan.CanSelectRegion);
+                Assert.True(scan.CanEdit);
                 Assert.Null(scan.SourcePreview);
             } finally { window.Close(); }
             return true;

--- a/OfficeIMO.Studio.Tests/ScanTextExtractionTests.cs
+++ b/OfficeIMO.Studio.Tests/ScanTextExtractionTests.cs
@@ -36,6 +36,8 @@ public sealed class ScanTextExtractionTests {
             try {
                 window.Show(); model.InputPath = source; model.OutputPath = string.Empty;
                 model.Scan.PageNumber = 2;
+                model.Scan.UseRegion = width == 960;
+                model.Scan.Region = new Rect(.1, .1, .7, .7);
                 Assert.True(model.ExtractTextCommand.CanExecute(null));
                 Assert.False(model.RunCommand.CanExecute(null));
                 var running = model.ExtractTextCommand.ExecuteAsync(null);
@@ -43,7 +45,17 @@ public sealed class ScanTextExtractionTests {
                 Assert.Equal(2, Assert.Single(review.Pages).Number);
                 Assert.Equal("Use selected text", review.CommitLabel);
                 Assert.False(model.ExtractTextCommand.CanExecute(null));
+                if (model.Scan.UseRegion) Assert.Equal(2, Assert.Single(recognition.Options!.Pdf.Regions).PageNumber);
+                else Assert.Empty(recognition.Options!.Pdf.Regions);
                 review.Words.Single(word => word.Text == "Discard").IsIncluded = false;
+                window.UpdateLayout();
+                using (var frame = window.CaptureRenderedFrame()) {
+                    string? output = Environment.GetEnvironmentVariable("OFFICEIMO_STUDIO_VISUAL_OUTPUT");
+                    if (!string.IsNullOrEmpty(output)) {
+                        Directory.CreateDirectory(output);
+                        frame!.Save(Path.Combine(output, $"quick-text-review-{width}.png"), Avalonia.Media.Imaging.PngBitmapEncoderOptions.Default);
+                    }
+                }
                 review.CommitCommand.Execute(null); await running;
                 Assert.Equal("Copy this", model.ExtractedText);
                 Assert.False(model.HasOutput);
@@ -91,8 +103,10 @@ public sealed class ScanTextExtractionTests {
 
     private sealed class RecognitionService : IScanTextRecognitionService {
         public int Calls { get; private set; }
+        public SearchablePdfOcrOptions? Options { get; private set; }
         public Task<PdfSearchableOcrReview> PrepareAsync(byte[] source, SearchablePdfOcrOptions options, CancellationToken token) {
             Calls++;
+            Options = options;
             var engine = new DelegateOcrEngine("quick-text", (_, _) => Task.FromResult(new OcrResult {
                 Provider = "fixture", Language = "eng", Spans = [Word("Copy this", 20), Word("Discard", 60)]
             }));

--- a/OfficeIMO.Studio.Tests/ScanTextExtractionTests.cs
+++ b/OfficeIMO.Studio.Tests/ScanTextExtractionTests.cs
@@ -1,0 +1,106 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Input.Platform;
+using Avalonia.Interactivity;
+using Avalonia.VisualTree;
+using OfficeIMO.Ocr;
+using OfficeIMO.Pdf;
+using OfficeIMO.Pdf.Ocr;
+using OfficeIMO.Studio.Features.Shell;
+using OfficeIMO.Studio.Features.Workflows;
+
+namespace OfficeIMO.Studio.Tests;
+
+public sealed class ScanTextExtractionTests {
+    [Theory]
+    [InlineData(960, 640)]
+    [InlineData(1440, 900)]
+    public async Task ReviewedTextCopiesWithoutOutputAndCancellationLeavesSourceUnchanged(int width, int height) {
+        using var session = TestAppBuilder.StartSession();
+        await session.Dispatch(async () => {
+            var services = ((App)Application.Current!).Services;
+            Directory.CreateDirectory(services.Paths.Root);
+            string source = Path.Combine(services.Paths.Root, "quick-text.pdf");
+            PdfDocument.Create(doc => {
+                doc.Page(page => page.Size(300, 300));
+                doc.Page(page => page.Size(300, 300));
+            }).Save(source);
+            byte[] original = File.ReadAllBytes(source);
+            var recognition = new RecognitionService();
+            using var shell = new MainWindowViewModel(_ => Task.FromResult<string?>(null), services: services,
+                scanTextRecognition: recognition, canPublishPath: _ => throw new InvalidOperationException("Text extraction must not publish."));
+            var model = shell.OcrWorkbench;
+            var view = new SearchablePdfOcrView { DataContext = shell };
+            var window = new Window { Width = width, Height = height, Content = view };
+            try {
+                window.Show(); model.InputPath = source; model.OutputPath = string.Empty;
+                model.Scan.PageNumber = 2;
+                Assert.True(model.ExtractTextCommand.CanExecute(null));
+                Assert.False(model.RunCommand.CanExecute(null));
+                var running = model.ExtractTextCommand.ExecuteAsync(null);
+                var review = await WaitForReview(model, running);
+                Assert.Equal(2, Assert.Single(review.Pages).Number);
+                Assert.Equal("Use selected text", review.CommitLabel);
+                Assert.False(model.ExtractTextCommand.CanExecute(null));
+                review.Words.Single(word => word.Text == "Discard").IsIncluded = false;
+                review.CommitCommand.Execute(null); await running;
+                Assert.Equal("Copy this", model.ExtractedText);
+                Assert.False(model.HasOutput);
+                Assert.Null(model.ErrorMessage);
+                Assert.Equal(original, File.ReadAllBytes(source));
+                window.UpdateLayout();
+                var textBox = view.FindControl<TextBox>("ExtractedTextBox")!;
+                view.FindControl<Button>("CopyExtractedTextButton")!.BringIntoView();
+                await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() => window.UpdateLayout(), Avalonia.Threading.DispatcherPriority.Background);
+                Assert.True(textBox.IsReadOnly);
+                Assert.Equal("Copy this", textBox.Text);
+                view.FindControl<Button>("CopyExtractedTextButton")!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+                for (int retry = 0; retry < 100 && model.Status != "Reviewed text copied."; retry++) await Task.Delay(10);
+                Assert.Equal("Reviewed text copied.", model.Status);
+                Assert.Equal("Copy this", await window.Clipboard!.TryGetTextAsync());
+                using (var frame = window.CaptureRenderedFrame()) {
+                    Assert.NotNull(frame);
+                    string? output = Environment.GetEnvironmentVariable("OFFICEIMO_STUDIO_VISUAL_OUTPUT");
+                    if (!string.IsNullOrEmpty(output)) {
+                        Directory.CreateDirectory(output);
+                        frame.Save(Path.Combine(output, $"quick-text-{width}.png"), Avalonia.Media.Imaging.PngBitmapEncoderOptions.Default);
+                    }
+                }
+                running = model.ExtractTextCommand.ExecuteAsync(null);
+                review = await WaitForReview(model, running);
+                review.CancelCommand.Execute(null); await running;
+                Assert.False(model.HasExtractedText);
+                Assert.False(model.HasReview);
+                Assert.False(model.IsBusy);
+                Assert.Equal(original, File.ReadAllBytes(source));
+                Assert.Equal(2, recognition.Calls);
+            } finally { window.Close(); }
+            return true;
+        }, CancellationToken.None);
+    }
+
+    private static async Task<OcrReviewViewModel> WaitForReview(SearchablePdfOcrViewModel model, Task running) {
+        var deadline = DateTime.UtcNow.AddSeconds(30);
+        while (model.Review == null && !running.IsCompleted && DateTime.UtcNow < deadline) await Task.Delay(10);
+        Assert.True(model.Review != null, model.ErrorMessage);
+        await model.Review!.PreviewTask;
+        Assert.True(model.Review.CommitCommand.CanExecute(null), model.Review.PreviewError);
+        return model.Review;
+    }
+
+    private sealed class RecognitionService : IScanTextRecognitionService {
+        public int Calls { get; private set; }
+        public Task<PdfSearchableOcrReview> PrepareAsync(byte[] source, SearchablePdfOcrOptions options, CancellationToken token) {
+            Calls++;
+            var engine = new DelegateOcrEngine("quick-text", (_, _) => Task.FromResult(new OcrResult {
+                Provider = "fixture", Language = "eng", Spans = [Word("Copy this", 20), Word("Discard", 60)]
+            }));
+            return PdfDocument.Load(source).PrepareSearchableOcrAsync(engine, options.Pdf, token);
+        }
+        private static OcrTextSpan Word(string text, double y) => new() {
+            Text = text, Confidence = .95, Level = OcrTextSpanLevel.Word, CoordinateUnit = OcrCoordinateUnit.Points,
+            Region = new OcrRegion { X = 20, Y = y, Width = 80, Height = 12 }
+        };
+    }
+}

--- a/OfficeIMO.Studio.Tests/StudioResponsiveLayoutTests.cs
+++ b/OfficeIMO.Studio.Tests/StudioResponsiveLayoutTests.cs
@@ -26,7 +26,7 @@ public sealed class StudioResponsiveLayoutTests {
                 Layout(window, width, 620);
                 var workflow = window.GetVisualDescendants().OfType<SearchablePdfOcrView>().Single();
                 var source = workflow.FindControl<Border>("SourcePanel")!;
-                var information = workflow.FindControl<ScrollViewer>("InformationPanel")!;
+                var information = workflow.FindControl<Control>("InformationPanel")!;
                 Assert.False(source.Bounds.Intersects(information.Bounds));
                 Assert.True(information.Bounds.Right <= workflow.Bounds.Width + 1);
                 if (width == 960) {

--- a/OfficeIMO.Studio/Features/Shell/MainWindowViewModel.cs
+++ b/OfficeIMO.Studio/Features/Shell/MainWindowViewModel.cs
@@ -117,7 +117,8 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable 
         Func<PdfSigningPreviewViewModel, Task<bool>>? reviewSigning = null,
         Func<PdfSigningPreviewViewModel, Task>? showSigningResult = null,
         Func<string, System.Security.Cryptography.X509Certificates.X509Certificate2>? loadSigningCertificate = null,
-        Func<CancellationToken, Task<string?>>? pickSaveRedactionReport = null) {
+        Func<CancellationToken, Task<string?>>? pickSaveRedactionReport = null,
+        IScanTextRecognitionService? scanTextRecognition = null) {
         _services = services ?? (Avalonia.Application.Current as App)?.Services ?? StudioApplicationServices.CreateDefault();
         _persistDocumentViews = services is not null;
         _localizer = _services.Localizer;
@@ -185,7 +186,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable 
             path => !_services.Storage.IsRecoveryLocation(path) && (canPublishPath ?? _canSaveAsPath)(path),
             _localizer, jobHistory: _services.Jobs, publicationGuard: publicationGuard, storage: _services.Storage,
             pickOutputPdf: _pickSavePdf, recoveryStore: _services.WorkflowRecovery,
-            confirmProviderWrite: confirmWorkflowProviderWrite ?? _confirmProviderWrite);
+            confirmProviderWrite: confirmWorkflowProviderWrite ?? _confirmProviderWrite, textRecognition: scanTextRecognition);
         Settings = new StudioSettingsViewModel(_services.Preferences, _services.Localizer, _services.Diagnostics, _services.Recovery, _services.DocumentHistory);
         OcrSession = new OcrSessionViewModel(pickOcrFiles ?? pickWorkflowFiles ?? (_ => Task.FromResult<IReadOnlyList<string>>([])),
             _pickOutputFolder, _localizer, _services.Storage, _services.Jobs, _services.WorkflowRecovery,

--- a/OfficeIMO.Studio/Features/Workflows/OcrReviewView.axaml
+++ b/OfficeIMO.Studio/Features/Workflows/OcrReviewView.axaml
@@ -71,9 +71,9 @@
         <ScrollViewer MaxHeight="120"><TextBlock Text="{Binding Diagnostics}" TextWrapping="Wrap" /></ScrollViewer>
       </Expander>
       <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="10">
-        <TextBlock Text="{loc:Loc Ocr.Review.CommitNote}" TextWrapping="Wrap" Classes="muted" VerticalAlignment="Center" />
+        <TextBlock Text="{Binding CommitNote}" TextWrapping="Wrap" Classes="muted" VerticalAlignment="Center" />
         <Button Grid.Column="1" Classes="tool" Content="{loc:Loc SearchablePdfOcr.Cancel}" Command="{Binding CancelCommand}" />
-        <Button Grid.Column="2" Classes="primary" Content="{loc:Loc SearchablePdfOcr.CreateSearchablePDF}" Command="{Binding CommitCommand}" />
+        <Button Grid.Column="2" Classes="primary" Content="{Binding CommitLabel}" Command="{Binding CommitCommand}" />
       </Grid>
     </StackPanel>
   </Grid>

--- a/OfficeIMO.Studio/Features/Workflows/OcrReviewViewModel.cs
+++ b/OfficeIMO.Studio/Features/Workflows/OcrReviewViewModel.cs
@@ -42,14 +42,20 @@ public sealed partial class OcrReviewViewModel : ObservableObject, IDisposable {
     internal Task PreviewTask { get; private set; } = Task.CompletedTask;
     internal Task<IReadOnlyList<PdfRecognizedWord>> Completion => _completion.Task;
 
-    internal OcrReviewViewModel(PdfSearchableOcrReview review, IStudioLocalizer localizer, Action cancel) {
+    internal OcrReviewViewModel(PdfSearchableOcrReview review, IStudioLocalizer localizer, Action cancel, bool textOnly = false) {
         _review = review; _localizer = localizer; _cancel = cancel;
+        CommitLabel = textOnly ? localizer.GetOrDefault("Ocr.Text.UseSelected", "Use selected text")
+            : localizer.GetOrDefault("SearchablePdfOcr.CreateSearchablePDF", "Create searchable PDF");
+        CommitNote = textOnly ? localizer.GetOrDefault("Ocr.Text.CommitNote", "Extract the selected words without creating a PDF.")
+            : localizer.GetOrDefault("Ocr.Review.CommitNote", "Only selected eligible words will be added to the searchable PDF.");
         Pages = review.Ocr.Pages.Select(page => new OcrReviewPageChoice(page.PageNumber,
             localizer.FormatOrDefault("Ocr.Review.Page", "Page {0}", page.PageNumber))).ToArray();
         SelectedPage = Pages.FirstOrDefault();
     }
 
     public IReadOnlyList<OcrReviewPageChoice> Pages { get; }
+    public string CommitLabel { get; }
+    public string CommitNote { get; }
     [ObservableProperty] private IReadOnlyList<OcrReviewWord> _words = [];
     public string Summary => _localizer.FormatOrDefault("Ocr.Review.Summary", "Selected words: {0:N0} · Reviewed pages: {1:N0}. Rejected words remain excluded.",
         _review.Ocr.AcceptedWordCount - _excluded.Count, Pages.Count);

--- a/OfficeIMO.Studio/Features/Workflows/ScanPreparationView.axaml
+++ b/OfficeIMO.Studio/Features/Workflows/ScanPreparationView.axaml
@@ -1,0 +1,43 @@
+<UserControl xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+ xmlns:workflow="using:OfficeIMO.Studio.Features.Workflows" xmlns:loc="using:OfficeIMO.Studio.Infrastructure.Localization"
+ x:Class="OfficeIMO.Studio.Features.Workflows.ScanPreparationView" x:DataType="workflow:ScanPreparationViewModel">
+ <StackPanel Spacing="10">
+  <TextBlock Text="{loc:Loc Scan.Title}" Classes="sectionTitle" />
+  <TextBlock Text="{loc:Loc Scan.Hint}" TextWrapping="Wrap" Classes="muted" />
+  <StackPanel Spacing="8" IsEnabled="{Binding CanEdit}">
+   <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
+    <StackPanel><TextBlock Text="{loc:Loc Scan.Page}" /><NumericUpDown Minimum="1" Maximum="100000" Value="{Binding PageNumber}" /></StackPanel>
+    <StackPanel Grid.Column="1"><TextBlock Text="{loc:Loc SearchablePdfOcr.RenderDPI}" /><NumericUpDown Minimum="72" Maximum="600" Value="{Binding Dpi}" /></StackPanel>
+   </Grid>
+   <CheckBox Content="{loc:Loc Scan.Cleanup}" IsChecked="{Binding EnableCleanup}" />
+   <Expander Header="{loc:Loc Scan.Adjustments}" IsVisible="{Binding EnableCleanup}">
+    <StackPanel Spacing="8">
+     <WrapPanel><CheckBox Content="{loc:Loc Scan.Deskew}" IsChecked="{Binding Deskew}" Margin="0,0,12,0" /><CheckBox Content="{loc:Loc Scan.Background}" IsChecked="{Binding NormalizeBackground}" /></WrapPanel>
+     <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto,Auto" ColumnSpacing="8" RowSpacing="8">
+      <StackPanel><TextBlock Text="{loc:Loc Scan.Turns}" TextWrapping="Wrap" /><NumericUpDown Minimum="0" Maximum="3" Value="{Binding QuarterTurns}" /></StackPanel>
+      <StackPanel Grid.Column="1"><TextBlock Text="{loc:Loc Scan.Straighten}" TextWrapping="Wrap" /><NumericUpDown Minimum="-15" Maximum="15" Increment="0.5" Value="{Binding StraightenDegrees}" /></StackPanel>
+      <StackPanel Grid.Row="1"><TextBlock Text="{loc:Loc Scan.Black}" /><NumericUpDown Minimum="0" Maximum="254" Value="{Binding BlackPoint}" /></StackPanel>
+      <StackPanel Grid.Row="1" Grid.Column="1"><TextBlock Text="{loc:Loc Scan.White}" /><NumericUpDown Minimum="1" Maximum="255" Value="{Binding WhitePoint}" /></StackPanel>
+      <StackPanel Grid.Row="2"><TextBlock Text="{loc:Loc Scan.Gamma}" /><NumericUpDown Minimum="0.1" Maximum="10" Increment="0.1" Value="{Binding Gamma}" /></StackPanel>
+      <StackPanel Grid.Row="2" Grid.Column="1"><TextBlock Text="{loc:Loc Scan.Color}" /><ComboBox ItemsSource="{Binding ColorModes}" SelectedItem="{Binding SelectedColorMode}" HorizontalAlignment="Stretch" /></StackPanel>
+     </Grid>
+    </StackPanel>
+   </Expander>
+   <WrapPanel><CheckBox Content="{loc:Loc Scan.Region}" IsChecked="{Binding UseRegion}" Margin="0,0,12,0" /><CheckBox Content="{loc:Loc Scan.Perspective}" IsChecked="{Binding UsePerspective}" /></WrapPanel>
+   <CheckBox Content="{loc:Loc Scan.MoveCorners}" IsChecked="{Binding EditCorners}" IsVisible="{Binding UsePerspective}" />
+   <Button Classes="tool" Content="{loc:Loc Scan.Reset}" Command="{Binding ResetSelectionCommand}" HorizontalAlignment="Left" />
+  </StackPanel>
+  <Button Classes="primary" Content="{loc:Loc Scan.Preview}" Command="{Binding PreviewCommand}" HorizontalAlignment="Left" />
+  <StackPanel IsVisible="{Binding HasPreview}" Spacing="8">
+   <TextBlock Text="{loc:Loc Scan.Source}" FontWeight="SemiBold" />
+   <TextBlock Text="{loc:Loc Scan.DrawHint}" TextWrapping="Wrap" Classes="muted" />
+   <TextBlock Text="{loc:Loc Scan.KeyboardHint}" TextWrapping="Wrap" Classes="muted" />
+   <Border Background="White" BorderBrush="Gray" BorderThickness="1"><workflow:ScanSelectionCanvas Height="280" AutomationProperties.Name="{loc:Loc Scan.Source}" /></Border>
+   <TextBlock Text="{loc:Loc Scan.Prepared}" FontWeight="SemiBold" />
+   <Border Background="White" BorderBrush="Gray" BorderThickness="1"><Image Source="{Binding PreparedPreview}" MaxHeight="280" Stretch="Uniform" /></Border>
+  </StackPanel>
+  <TextBlock Text="{Binding Status}" TextWrapping="Wrap" />
+  <TextBlock Text="{loc:Loc Scan.SaveHint}" TextWrapping="Wrap" Classes="muted" />
+  <Button Classes="tool" Content="{loc:Loc Scan.Save}" Command="{Binding SaveCommand}" HorizontalAlignment="Left" />
+ </StackPanel>
+</UserControl>

--- a/OfficeIMO.Studio/Features/Workflows/ScanPreparationView.axaml.cs
+++ b/OfficeIMO.Studio/Features/Workflows/ScanPreparationView.axaml.cs
@@ -1,0 +1,6 @@
+using Avalonia.Controls;
+namespace OfficeIMO.Studio.Features.Workflows;
+
+public sealed partial class ScanPreparationView : UserControl {
+    public ScanPreparationView() => InitializeComponent();
+}

--- a/OfficeIMO.Studio/Features/Workflows/ScanPreparationViewModel.cs
+++ b/OfficeIMO.Studio/Features/Workflows/ScanPreparationViewModel.cs
@@ -1,0 +1,152 @@
+using System.ComponentModel;
+using System.Security.Cryptography;
+using Avalonia;
+using Avalonia.Media.Imaging;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using OfficeIMO.Drawing;
+using OfficeIMO.Pdf;
+using OfficeIMO.Pdf.Ocr;
+using OfficeIMO.Studio.Infrastructure.Localization;
+
+namespace OfficeIMO.Studio.Features.Workflows;
+
+/// <summary>A localized scan color choice.</summary>
+public sealed record ScanColorChoice(OfficeScanColorMode Value, string Label) {
+    /// <inheritdoc />
+    public override string ToString() => Label;
+}
+
+/// <summary>Reviewed scan settings and source-coordinate selection over the shared PDF preparation owner.</summary>
+public sealed partial class ScanPreparationViewModel : ObservableObject, IDisposable {
+    private readonly Func<CancellationToken, Task<byte[]>> _readSource;
+    private readonly Func<PdfOcrMergeOptions, string, CancellationToken, Task> _save;
+    private readonly IStudioLocalizer _localizer;
+    private CancellationTokenSource? _previewCancellation;
+    private PdfOcrMergeOptions? _reviewedOptions;
+    private string? _reviewedHash;
+    private bool _disposed;
+    internal ScanPreparationViewModel(Func<CancellationToken, Task<byte[]>> readSource,
+        Func<PdfOcrMergeOptions, string, CancellationToken, Task> save, IStudioLocalizer localizer) {
+        _readSource = readSource; _save = save; _localizer = localizer;
+        ColorModes = [
+            new(OfficeScanColorMode.PreserveColor, T("Color.Keep", "Keep color")),
+            new(OfficeScanColorMode.Grayscale, T("Color.Gray", "Grayscale")),
+            new(OfficeScanColorMode.Bilevel, T("Color.BlackWhite", "Black and white"))
+        ];
+    }
+    [ObservableProperty] private int _pageNumber = 1;
+    [ObservableProperty] private double _dpi = 150;
+    [ObservableProperty] private bool _enableCleanup;
+    [ObservableProperty] private bool _deskew = true;
+    [ObservableProperty] private bool _normalizeBackground = true;
+    [ObservableProperty] private int _quarterTurns;
+    [ObservableProperty] private double _straightenDegrees;
+    [ObservableProperty] private int _blackPoint;
+    [ObservableProperty] private int _whitePoint = 255;
+    [ObservableProperty] private double _gamma = 1;
+    [ObservableProperty] private OfficeScanColorMode _colorMode = OfficeScanColorMode.Grayscale;
+    [ObservableProperty] private bool _useRegion;
+    [ObservableProperty] private Rect _region = new(0, 0, 1, 1);
+    [ObservableProperty] private bool _usePerspective;
+    [ObservableProperty] private Point _topLeft = new(0, 0);
+    [ObservableProperty] private Point _topRight = new(1, 0);
+    [ObservableProperty] private Point _bottomRight = new(1, 1);
+    [ObservableProperty] private Point _bottomLeft = new(0, 1);
+    [ObservableProperty] private bool _editCorners;
+    [ObservableProperty] private Bitmap? _sourcePreview;
+    [ObservableProperty] private Bitmap? _preparedPreview;
+    [ObservableProperty] private bool _isBusy;
+    [ObservableProperty] private bool _hostBusy;
+    [ObservableProperty] private bool _isCurrent;
+    [ObservableProperty] private string _status = string.Empty;
+    public IReadOnlyList<ScanColorChoice> ColorModes { get; }
+    public ScanColorChoice SelectedColorMode {
+        get => ColorModes.First(choice => choice.Value == ColorMode);
+        set { if (value != null) ColorMode = value.Value; }
+    }
+    partial void OnColorModeChanged(OfficeScanColorMode value) => OnPropertyChanged(nameof(SelectedColorMode));
+    public bool CanPreview => !_disposed && !IsBusy && !HostBusy;
+    public bool CanSave => CanPreview && IsCurrent;
+    public bool CanEdit => CanPreview;
+    public bool HasPreview => SourcePreview != null;
+    protected override void OnPropertyChanged(PropertyChangedEventArgs e) {
+        base.OnPropertyChanged(e);
+        if (e.PropertyName is nameof(PageNumber) or nameof(Dpi) or nameof(EnableCleanup) or nameof(Deskew) or nameof(NormalizeBackground)
+            or nameof(QuarterTurns) or nameof(StraightenDegrees) or nameof(BlackPoint) or nameof(WhitePoint) or nameof(Gamma)
+            or nameof(ColorMode) or nameof(UseRegion) or nameof(Region) or nameof(UsePerspective) or nameof(TopLeft)
+            or nameof(TopRight) or nameof(BottomRight) or nameof(BottomLeft)) Invalidate();
+        if (e.PropertyName is nameof(IsBusy) or nameof(HostBusy) or nameof(IsCurrent)) {
+            PreviewCommand.NotifyCanExecuteChanged(); SaveCommand.NotifyCanExecuteChanged();
+            OnPropertyChanged(nameof(CanEdit)); OnPropertyChanged(nameof(CanSave));
+        }
+        if (e.PropertyName == nameof(SourcePreview)) OnPropertyChanged(nameof(HasPreview));
+    }
+    internal void Invalidate(bool clearSource = false) {
+        _previewCancellation?.Cancel(); _reviewedOptions = null; _reviewedHash = null; IsCurrent = false;
+        if (clearSource) {
+            SourcePreview?.Dispose(); SourcePreview = null; PreparedPreview?.Dispose(); PreparedPreview = null;
+            Region = new(0, 0, 1, 1); UseRegion = false;
+            PageNumber = 1; UsePerspective = false;
+        }
+        Status = T("Refresh", "Preview the current settings before saving a prepared copy.");
+    }
+    internal PdfOcrMergeOptions ApplyTo(PdfOcrMergeOptions options) {
+        options.Dpi = Dpi;
+        options.ScanProcessing = EnableCleanup ? new OfficeScanProcessingOptions {
+            ClockwiseQuarterTurns = QuarterTurns,
+            StraightenDegrees = StraightenDegrees,
+            Deskew = Deskew,
+            NormalizeBackground = NormalizeBackground,
+            BlackPoint = BlackPoint,
+            WhitePoint = WhitePoint,
+            Gamma = Gamma,
+            ColorMode = ColorMode
+        } : null;
+        options.Perspective = UsePerspective ? new OfficeScanPerspectiveOptions {
+            TopLeft = new(TopLeft.X, TopLeft.Y),
+            TopRight = new(TopRight.X, TopRight.Y),
+            BottomRight = new(BottomRight.X, BottomRight.Y),
+            BottomLeft = new(BottomLeft.X, BottomLeft.Y)
+        } : null;
+        options.Regions = UseRegion ? new[] { new PdfOcrPageRegion(PageNumber, Region.X, Region.Y, Region.Width, Region.Height) } : [];
+        return options;
+    }
+    [RelayCommand(CanExecute = nameof(CanPreview))]
+    private async Task PreviewAsync(CancellationToken token) {
+        Invalidate();
+        using var operation = CancellationTokenSource.CreateLinkedTokenSource(token);
+        _previewCancellation = operation; IsBusy = true;
+        try {
+            int page = PageNumber;
+            var options = ApplyTo(new PdfOcrMergeOptions { ReadOptions = new() { PageSelection = PdfPageSelection.From(page) } });
+            byte[] source = await _readSource(operation.Token).ConfigureAwait(true);
+            var preview = await Task.Run(() => PdfDocument.Load(source).PreviewScanAsync(page, options, operation.Token), operation.Token).ConfigureAwait(true);
+            operation.Token.ThrowIfCancellationRequested();
+            if (_disposed || !ReferenceEquals(_previewCancellation, operation)) return;
+            using var original = new MemoryStream(preview.GetSourcePng());
+            using var processed = new MemoryStream(preview.GetPreparedPng());
+            Bitmap sourceBitmap = new(original);
+            Bitmap preparedBitmap;
+            try { preparedBitmap = new(processed); } catch { sourceBitmap.Dispose(); throw; }
+            SourcePreview?.Dispose(); PreparedPreview?.Dispose(); SourcePreview = sourceBitmap; PreparedPreview = preparedBitmap;
+            _reviewedOptions = options.Clone(); _reviewedHash = Convert.ToHexString(SHA256.HashData(source)); IsCurrent = true;
+            Status = T("Ready", "Prepared preview ready. Region OCR keeps the visible source page; saving a scan copy keeps only the prepared pixels.") +
+                " " + string.Join(" ", preview.Diagnostics.Concat(preview.ScanProcessing?.Steps.Where(step => step.Applied).Select(step => step.Message) ?? []));
+        } catch (OperationCanceledException) when (operation.IsCancellationRequested) { } catch (Exception error) { if (ReferenceEquals(_previewCancellation, operation)) Status = error.Message; } finally { if (ReferenceEquals(_previewCancellation, operation)) _previewCancellation = null; IsBusy = false; }
+    }
+    [RelayCommand(CanExecute = nameof(CanSave))]
+    private async Task SaveAsync(CancellationToken token) {
+        if (_reviewedOptions == null || _reviewedHash == null) return;
+        var options = _reviewedOptions.Clone(); string hash = _reviewedHash;
+        IsBusy = true;
+        try { await _save(options, hash, token).ConfigureAwait(true); } catch (Exception error) { Status = error.Message; } finally { IsBusy = false; }
+    }
+    [RelayCommand]
+    private void ResetSelection() {
+        if (!CanEdit) return;
+        Region = new(0, 0, 1, 1); TopLeft = new(0, 0); TopRight = new(1, 0); BottomRight = new(1, 1); BottomLeft = new(0, 1);
+    }
+    public void Dispose() { _disposed = true; _previewCancellation?.Cancel(); SourcePreview?.Dispose(); PreparedPreview?.Dispose(); }
+    private string T(string key, string fallback) => _localizer.GetOrDefault("Scan." + key, fallback);
+}

--- a/OfficeIMO.Studio/Features/Workflows/ScanPreparationViewModel.cs
+++ b/OfficeIMO.Studio/Features/Workflows/ScanPreparationViewModel.cs
@@ -75,7 +75,8 @@ public sealed partial class ScanPreparationViewModel : ObservableObject, IDispos
     }
     public bool CanPreview => !_disposed && !IsBusy && !HostBusy;
     public bool CanSave => CanPreview && IsCurrent;
-    public bool CanEdit => CanPreview && SourcePreview != null;
+    public bool CanEdit => CanPreview;
+    public bool CanSelectRegion => CanEdit && SourcePreview != null;
     public bool HasPreview => SourcePreview != null;
     protected override void OnPropertyChanged(PropertyChangedEventArgs e) {
         base.OnPropertyChanged(e);
@@ -86,10 +87,11 @@ public sealed partial class ScanPreparationViewModel : ObservableObject, IDispos
         if (e.PropertyName is nameof(IsBusy) or nameof(HostBusy) or nameof(IsCurrent)) {
             PreviewCommand.NotifyCanExecuteChanged(); SaveCommand.NotifyCanExecuteChanged();
             OnPropertyChanged(nameof(CanEdit)); OnPropertyChanged(nameof(CanSave));
+            OnPropertyChanged(nameof(CanSelectRegion));
         }
         if (e.PropertyName == nameof(SourcePreview)) {
             OnPropertyChanged(nameof(HasPreview));
-            OnPropertyChanged(nameof(CanEdit));
+            OnPropertyChanged(nameof(CanSelectRegion));
         }
     }
     internal void Invalidate(bool clearSource = false) {

--- a/OfficeIMO.Studio/Features/Workflows/ScanPreparationViewModel.cs
+++ b/OfficeIMO.Studio/Features/Workflows/ScanPreparationViewModel.cs
@@ -66,9 +66,16 @@ public sealed partial class ScanPreparationViewModel : ObservableObject, IDispos
         set { if (value != null) ColorMode = value.Value; }
     }
     partial void OnColorModeChanged(OfficeScanColorMode value) => OnPropertyChanged(nameof(SelectedColorMode));
+    partial void OnPageNumberChanged(int value) {
+        ClearPageSelection();
+        Invalidate();
+    }
+    partial void OnUsePerspectiveChanged(bool value) {
+        if (!value) EditCorners = false;
+    }
     public bool CanPreview => !_disposed && !IsBusy && !HostBusy;
     public bool CanSave => CanPreview && IsCurrent;
-    public bool CanEdit => CanPreview;
+    public bool CanEdit => CanPreview && SourcePreview != null;
     public bool HasPreview => SourcePreview != null;
     protected override void OnPropertyChanged(PropertyChangedEventArgs e) {
         base.OnPropertyChanged(e);
@@ -80,16 +87,26 @@ public sealed partial class ScanPreparationViewModel : ObservableObject, IDispos
             PreviewCommand.NotifyCanExecuteChanged(); SaveCommand.NotifyCanExecuteChanged();
             OnPropertyChanged(nameof(CanEdit)); OnPropertyChanged(nameof(CanSave));
         }
-        if (e.PropertyName == nameof(SourcePreview)) OnPropertyChanged(nameof(HasPreview));
+        if (e.PropertyName == nameof(SourcePreview)) {
+            OnPropertyChanged(nameof(HasPreview));
+            OnPropertyChanged(nameof(CanEdit));
+        }
     }
     internal void Invalidate(bool clearSource = false) {
         _previewCancellation?.Cancel(); _reviewedOptions = null; _reviewedHash = null; IsCurrent = false;
         if (clearSource) {
-            SourcePreview?.Dispose(); SourcePreview = null; PreparedPreview?.Dispose(); PreparedPreview = null;
-            Region = new(0, 0, 1, 1); UseRegion = false;
-            PageNumber = 1; UsePerspective = false;
+            ClearPageSelection();
+            PageNumber = 1;
         }
         Status = T("Refresh", "Preview the current settings before saving a prepared copy.");
+    }
+    private void ClearPageSelection() {
+        SourcePreview?.Dispose(); SourcePreview = null;
+        PreparedPreview?.Dispose(); PreparedPreview = null;
+        Region = new(0, 0, 1, 1); UseRegion = false;
+        UsePerspective = false; EditCorners = false;
+        TopLeft = new(0, 0); TopRight = new(1, 0);
+        BottomRight = new(1, 1); BottomLeft = new(0, 1);
     }
     internal PdfOcrMergeOptions ApplyTo(PdfOcrMergeOptions options) {
         options.Dpi = Dpi;

--- a/OfficeIMO.Studio/Features/Workflows/ScanSelectionCanvas.cs
+++ b/OfficeIMO.Studio/Features/Workflows/ScanSelectionCanvas.cs
@@ -59,7 +59,7 @@ public sealed class ScanSelectionCanvas : Control {
     }
     protected override void OnPointerPressed(PointerPressedEventArgs e) {
         base.OnPointerPressed(e);
-        if (_model?.CanEdit != true || _model.SourcePreview == null || !e.GetCurrentPoint(this).Properties.IsLeftButtonPressed) return;
+        if (_model?.CanSelectRegion != true || !e.GetCurrentPoint(this).Properties.IsLeftButtonPressed) return;
         Rect bounds = ImageBounds(); Point position = e.GetPosition(this);
         if (!bounds.Contains(position)) return;
         Focus();
@@ -75,7 +75,7 @@ public sealed class ScanSelectionCanvas : Control {
     }
     protected override void OnPointerMoved(PointerEventArgs e) {
         base.OnPointerMoved(e);
-        if (_start == null || _model?.CanEdit != true) return;
+        if (_start == null || _model?.CanSelectRegion != true) return;
         Point point = Normalize(e.GetPosition(this), ImageBounds());
         if (_corner >= 0) SetCorner(InRegion(point));
         else {
@@ -92,7 +92,7 @@ public sealed class ScanSelectionCanvas : Control {
     protected override void OnPointerCaptureLost(PointerCaptureLostEventArgs e) { _start = null; _corner = -1; base.OnPointerCaptureLost(e); }
     protected override void OnKeyDown(KeyEventArgs e) {
         base.OnKeyDown(e);
-        if (_model?.CanEdit != true || _model.SourcePreview == null) return;
+        if (_model?.CanSelectRegion != true) return;
         if (_model.UsePerspective && _model.EditCorners && e.Key is >= Key.D1 and <= Key.D4) {
             _keyboardCorner = (int)e.Key - (int)Key.D1;
             e.Handled = true;

--- a/OfficeIMO.Studio/Features/Workflows/ScanSelectionCanvas.cs
+++ b/OfficeIMO.Studio/Features/Workflows/ScanSelectionCanvas.cs
@@ -1,0 +1,125 @@
+using System.ComponentModel;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
+
+namespace OfficeIMO.Studio.Features.Workflows;
+
+/// <summary>Draws an OCR region or adjusts four perspective corners in source-image coordinates.</summary>
+public sealed class ScanSelectionCanvas : Control {
+    private ScanPreparationViewModel? _model;
+    private Point? _start;
+    private int _corner = -1;
+    private int _keyboardCorner;
+    public ScanSelectionCanvas() {
+        Focusable = true;
+        ClipToBounds = true;
+        DataContextChanged += (_, _) => {
+            if (_model != null) _model.PropertyChanged -= ModelChanged;
+            _model = DataContext as ScanPreparationViewModel;
+            if (_model != null) _model.PropertyChanged += ModelChanged;
+            InvalidateVisual();
+        };
+        DetachedFromVisualTree += (_, _) => { if (_model != null) _model.PropertyChanged -= ModelChanged; };
+        AttachedToVisualTree += (_, _) => { if (_model != null) { _model.PropertyChanged -= ModelChanged; _model.PropertyChanged += ModelChanged; } };
+    }
+    private void ModelChanged(object? sender, PropertyChangedEventArgs e) => InvalidateVisual();
+    private Rect ImageBounds() {
+        if (_model?.SourcePreview is not { } image) return default;
+        double scale = Math.Min(Bounds.Width / image.Size.Width, Bounds.Height / image.Size.Height);
+        var size = new Size(image.Size.Width * scale, image.Size.Height * scale);
+        return new Rect((Bounds.Width - size.Width) / 2, (Bounds.Height - size.Height) / 2, size.Width, size.Height);
+    }
+    public override void Render(DrawingContext context) {
+        base.Render(context);
+        if (_model?.SourcePreview is not { } image) return;
+        Rect bounds = ImageBounds();
+        context.DrawImage(image, new Rect(image.Size), bounds);
+        context.DrawRectangle(null, new Pen(Brushes.Gray, 1), bounds);
+        Rect region = _model.UseRegion ? _model.Region : new Rect(0, 0, 1, 1);
+        Rect rectangle = new(bounds.X + region.X * bounds.Width, bounds.Y + region.Y * bounds.Height, region.Width * bounds.Width, region.Height * bounds.Height);
+        var pen = new Pen(Brushes.DodgerBlue, 2);
+        if (_model.UseRegion) context.DrawRectangle(new SolidColorBrush(Color.FromArgb(28, 0, 120, 255)), pen, rectangle);
+        if (_model.UsePerspective) {
+            Point[] corners = { _model.TopLeft, _model.TopRight, _model.BottomRight, _model.BottomLeft };
+            Point Map(Point p) => new(rectangle.X + p.X * rectangle.Width, rectangle.Y + p.Y * rectangle.Height);
+            for (int i = 0; i < 4; i++) {
+                context.DrawLine(pen, Map(corners[i]), Map(corners[(i + 1) % 4]));
+                context.DrawEllipse(IsFocused && _model.EditCorners && i == _keyboardCorner ? Brushes.DodgerBlue : Brushes.White, pen, Map(corners[i]), 6, 6);
+            }
+        }
+    }
+    protected override void OnPointerPressed(PointerPressedEventArgs e) {
+        base.OnPointerPressed(e);
+        if (_model?.CanEdit != true || _model.SourcePreview == null || !e.GetCurrentPoint(this).Properties.IsLeftButtonPressed) return;
+        Rect bounds = ImageBounds(); Point position = e.GetPosition(this);
+        if (!bounds.Contains(position)) return;
+        Focus();
+        _start = Normalize(position, bounds);
+        if (_model.EditCorners) {
+            _model.UsePerspective = true;
+            Point normalized = InRegion(_start.Value);
+            Point[] corners = { _model.TopLeft, _model.TopRight, _model.BottomRight, _model.BottomLeft };
+            _corner = Enumerable.Range(0, 4).OrderBy(i => Math.Pow(corners[i].X - normalized.X, 2) + Math.Pow(corners[i].Y - normalized.Y, 2)).First();
+            _keyboardCorner = _corner;
+            SetCorner(normalized);
+        } else { _corner = -1; _model.UseRegion = true; }
+        e.Pointer.Capture(this); e.Handled = true;
+    }
+    protected override void OnPointerMoved(PointerEventArgs e) {
+        base.OnPointerMoved(e);
+        if (_start == null || _model?.CanEdit != true) return;
+        Point point = Normalize(e.GetPosition(this), ImageBounds());
+        if (_corner >= 0) SetCorner(InRegion(point));
+        else {
+            double left = Math.Min(_start.Value.X, point.X), top = Math.Min(_start.Value.Y, point.Y);
+            double width = Math.Abs(point.X - _start.Value.X), height = Math.Abs(point.Y - _start.Value.Y);
+            if (width > .002 && height > .002) _model.Region = new Rect(left, top, width, height);
+        }
+        e.Handled = true;
+    }
+    protected override void OnPointerReleased(PointerReleasedEventArgs e) {
+        base.OnPointerReleased(e); if (_start == null) return;
+        _start = null; _corner = -1; e.Pointer.Capture(null); e.Handled = true;
+    }
+    protected override void OnPointerCaptureLost(PointerCaptureLostEventArgs e) { _start = null; _corner = -1; base.OnPointerCaptureLost(e); }
+    protected override void OnKeyDown(KeyEventArgs e) {
+        base.OnKeyDown(e);
+        if (_model?.CanEdit != true || _model.SourcePreview == null) return;
+        if (_model.EditCorners && e.Key is >= Key.D1 and <= Key.D4) {
+            _keyboardCorner = (int)e.Key - (int)Key.D1;
+            e.Handled = true;
+            InvalidateVisual();
+            return;
+        }
+        double dx = e.Key == Key.Left ? -0.01 : e.Key == Key.Right ? 0.01 : 0;
+        double dy = e.Key == Key.Up ? -0.01 : e.Key == Key.Down ? 0.01 : 0;
+        if (dx == 0 && dy == 0) return;
+        if (_model.EditCorners) {
+            _model.UsePerspective = true;
+            Point[] corners = { _model.TopLeft, _model.TopRight, _model.BottomRight, _model.BottomLeft };
+            Point current = corners[_keyboardCorner];
+            _corner = _keyboardCorner;
+            SetCorner(new Point(Math.Clamp(current.X + dx, 0, 1), Math.Clamp(current.Y + dy, 0, 1)));
+            _corner = -1;
+        } else {
+            _model.UseRegion = true;
+            Rect current = _model.Region;
+            _model.Region = e.KeyModifiers.HasFlag(KeyModifiers.Shift)
+                ? new Rect(current.X, current.Y, Math.Clamp(current.Width + dx, Math.Min(0.01, 1 - current.X), 1 - current.X),
+                    Math.Clamp(current.Height + dy, Math.Min(0.01, 1 - current.Y), 1 - current.Y))
+                : new Rect(Math.Clamp(current.X + dx, 0, 1 - current.Width),
+                    Math.Clamp(current.Y + dy, 0, 1 - current.Height), current.Width, current.Height);
+        }
+        e.Handled = true;
+    }
+    private static Point Normalize(Point point, Rect bounds) => new(Math.Clamp((point.X - bounds.X) / bounds.Width, 0, 1), Math.Clamp((point.Y - bounds.Y) / bounds.Height, 0, 1));
+    private Point InRegion(Point point) {
+        Rect region = _model!.UseRegion ? _model.Region : new Rect(0, 0, 1, 1);
+        return new(Math.Clamp((point.X - region.X) / region.Width, 0, 1), Math.Clamp((point.Y - region.Y) / region.Height, 0, 1));
+    }
+    private void SetCorner(Point point) {
+        switch (_corner) { case 0: _model!.TopLeft = point; break; case 1: _model!.TopRight = point; break; case 2: _model!.BottomRight = point; break; case 3: _model!.BottomLeft = point; break; }
+    }
+}

--- a/OfficeIMO.Studio/Features/Workflows/ScanSelectionCanvas.cs
+++ b/OfficeIMO.Studio/Features/Workflows/ScanSelectionCanvas.cs
@@ -24,7 +24,14 @@ public sealed class ScanSelectionCanvas : Control {
         DetachedFromVisualTree += (_, _) => { if (_model != null) _model.PropertyChanged -= ModelChanged; };
         AttachedToVisualTree += (_, _) => { if (_model != null) { _model.PropertyChanged -= ModelChanged; _model.PropertyChanged += ModelChanged; } };
     }
-    private void ModelChanged(object? sender, PropertyChangedEventArgs e) => InvalidateVisual();
+    private void ModelChanged(object? sender, PropertyChangedEventArgs e) {
+        if (e.PropertyName is nameof(ScanPreparationViewModel.SourcePreview)
+            or nameof(ScanPreparationViewModel.EditCorners) or nameof(ScanPreparationViewModel.UsePerspective)) {
+            _start = null;
+            _corner = -1;
+        }
+        InvalidateVisual();
+    }
     private Rect ImageBounds() {
         if (_model?.SourcePreview is not { } image) return default;
         double scale = Math.Min(Bounds.Width / image.Size.Width, Bounds.Height / image.Size.Height);
@@ -57,8 +64,7 @@ public sealed class ScanSelectionCanvas : Control {
         if (!bounds.Contains(position)) return;
         Focus();
         _start = Normalize(position, bounds);
-        if (_model.EditCorners) {
-            _model.UsePerspective = true;
+        if (_model.UsePerspective && _model.EditCorners) {
             Point normalized = InRegion(_start.Value);
             Point[] corners = { _model.TopLeft, _model.TopRight, _model.BottomRight, _model.BottomLeft };
             _corner = Enumerable.Range(0, 4).OrderBy(i => Math.Pow(corners[i].X - normalized.X, 2) + Math.Pow(corners[i].Y - normalized.Y, 2)).First();
@@ -87,7 +93,7 @@ public sealed class ScanSelectionCanvas : Control {
     protected override void OnKeyDown(KeyEventArgs e) {
         base.OnKeyDown(e);
         if (_model?.CanEdit != true || _model.SourcePreview == null) return;
-        if (_model.EditCorners && e.Key is >= Key.D1 and <= Key.D4) {
+        if (_model.UsePerspective && _model.EditCorners && e.Key is >= Key.D1 and <= Key.D4) {
             _keyboardCorner = (int)e.Key - (int)Key.D1;
             e.Handled = true;
             InvalidateVisual();
@@ -96,8 +102,7 @@ public sealed class ScanSelectionCanvas : Control {
         double dx = e.Key == Key.Left ? -0.01 : e.Key == Key.Right ? 0.01 : 0;
         double dy = e.Key == Key.Up ? -0.01 : e.Key == Key.Down ? 0.01 : 0;
         if (dx == 0 && dy == 0) return;
-        if (_model.EditCorners) {
-            _model.UsePerspective = true;
+        if (_model.UsePerspective && _model.EditCorners) {
             Point[] corners = { _model.TopLeft, _model.TopRight, _model.BottomRight, _model.BottomLeft };
             Point current = corners[_keyboardCorner];
             _corner = _keyboardCorner;

--- a/OfficeIMO.Studio/Features/Workflows/ScanTextRecognitionService.cs
+++ b/OfficeIMO.Studio/Features/Workflows/ScanTextRecognitionService.cs
@@ -1,0 +1,20 @@
+using OfficeIMO.Ocr.Tesseract;
+using OfficeIMO.Pdf;
+using OfficeIMO.Pdf.Ocr;
+
+namespace OfficeIMO.Studio.Features.Workflows;
+
+internal interface IScanTextRecognitionService {
+    Task<PdfSearchableOcrReview> PrepareAsync(byte[] source, SearchablePdfOcrOptions options, CancellationToken cancellationToken);
+}
+
+internal sealed class ScanTextRecognitionService : IScanTextRecognitionService {
+    public async Task<PdfSearchableOcrReview> PrepareAsync(byte[] source, SearchablePdfOcrOptions options, CancellationToken cancellationToken) {
+        var session = await TesseractOcr.CreateSessionAsync(new TesseractOcrSessionOptions {
+            Languages = options.Languages, ProvisionMissingLanguageData = options.ProvisionMissingLanguageData
+        }, cancellationToken).ConfigureAwait(false);
+        var settings = options.Pdf.Clone();
+        settings.Language = options.Languages.ToTesseractExpression();
+        return await PdfDocument.Load(source).PrepareSearchableOcrAsync(session.Engine, settings, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/OfficeIMO.Studio/Features/Workflows/SearchablePdfOcrView.axaml
+++ b/OfficeIMO.Studio/Features/Workflows/SearchablePdfOcrView.axaml
@@ -87,7 +87,18 @@
 
       <Border x:Name="InformationPanel" Grid.Column="1" VerticalAlignment="Top">
         <StackPanel Margin="30,26" Spacing="22" MaxWidth="820" HorizontalAlignment="Stretch">
-          <Border Classes="card" Padding="16"><workflow:ScanPreparationView DataContext="{Binding OcrWorkbench.Scan}" /></Border>
+          <Border Classes="card" Padding="16">
+            <StackPanel Spacing="12">
+              <workflow:ScanPreparationView DataContext="{Binding OcrWorkbench.Scan}" />
+              <TextBlock Text="{loc:Loc Ocr.Text.Hint}" TextWrapping="Wrap" Classes="muted" />
+              <Button Classes="primary" Content="{loc:Loc Ocr.Text.Recognize}" Command="{Binding OcrWorkbench.ExtractTextCommand}" />
+              <StackPanel IsVisible="{Binding OcrWorkbench.HasExtractedText}" Spacing="8">
+                <TextBox x:Name="ExtractedTextBox" Text="{Binding OcrWorkbench.ExtractedText, Mode=OneWay}" IsReadOnly="True"
+                         AcceptsReturn="True" TextWrapping="Wrap" MinHeight="90" MaxHeight="220" />
+                <Button x:Name="CopyExtractedTextButton" Classes="tool" Content="{loc:Loc Ocr.Text.Copy}" Click="CopyExtractedText" />
+              </StackPanel>
+            </StackPanel>
+          </Border>
           <Border Classes="card" Padding="20">
             <Grid ColumnDefinitions="48,*" ColumnSpacing="14">
               <Border Width="44" Height="44" CornerRadius="10" Background="{DynamicResource StudioAccentSoftBrush}">

--- a/OfficeIMO.Studio/Features/Workflows/SearchablePdfOcrView.axaml
+++ b/OfficeIMO.Studio/Features/Workflows/SearchablePdfOcrView.axaml
@@ -18,7 +18,6 @@
     <Grid x:Name="OcrColumns" ColumnDefinitions="400,*" RowDefinitions="Auto,Auto">
       <Border x:Name="SourcePanel" Grid.Column="0" VerticalAlignment="Top" Background="{DynamicResource StudioPanelBrush}"
               BorderBrush="{DynamicResource StudioBorderBrush}" BorderThickness="0,0,1,0">
-        <ScrollViewer VerticalScrollBarVisibility="Disabled">
           <StackPanel Margin="22" Spacing="13">
             <TextBlock TextWrapping="Wrap" Text="{loc:Loc SearchablePdfOcr.SOURCE}" Classes="eyebrow" />
             <TextBlock TextWrapping="Wrap" Text="{loc:Loc SearchablePdfOcr.ScannedPDF}" FontWeight="SemiBold" />
@@ -84,11 +83,11 @@
             <Button Classes="tool" AutomationProperties.Name="{loc:Loc SearchablePdfOcr.Cancel}" Content="{loc:Loc SearchablePdfOcr.Cancel}" HorizontalAlignment="Left"
                     IsVisible="{Binding OcrWorkbench.CanCancel}" Command="{Binding OcrWorkbench.CancelCommand}" />
           </StackPanel>
-        </ScrollViewer>
       </Border>
 
-      <ScrollViewer x:Name="InformationPanel" Grid.Column="1" VerticalAlignment="Top" VerticalScrollBarVisibility="Disabled">
+      <Border x:Name="InformationPanel" Grid.Column="1" VerticalAlignment="Top">
         <StackPanel Margin="30,26" Spacing="22" MaxWidth="820" HorizontalAlignment="Stretch">
+          <Border Classes="card" Padding="16"><workflow:ScanPreparationView DataContext="{Binding OcrWorkbench.Scan}" /></Border>
           <Border Classes="card" Padding="20">
             <Grid ColumnDefinitions="48,*" ColumnSpacing="14">
               <Border Width="44" Height="44" CornerRadius="10" Background="{DynamicResource StudioAccentSoftBrush}">
@@ -131,7 +130,7 @@
             </StackPanel>
           </Border>
         </StackPanel>
-      </ScrollViewer>
+      </Border>
     </Grid>
     </ScrollViewer>
     <Border Grid.Row="1" IsVisible="{Binding OcrWorkbench.HasReview}">

--- a/OfficeIMO.Studio/Features/Workflows/SearchablePdfOcrView.axaml.cs
+++ b/OfficeIMO.Studio/Features/Workflows/SearchablePdfOcrView.axaml.cs
@@ -1,8 +1,24 @@
 using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Input.Platform;
+using Avalonia.Interactivity;
+using OfficeIMO.Studio.Features.Shell;
+using OfficeIMO.Studio.Infrastructure.Localization;
 
 namespace OfficeIMO.Studio.Features.Workflows;
 
 public sealed partial class SearchablePdfOcrView : UserControl {
+    private async void CopyExtractedText(object? sender, RoutedEventArgs args) {
+        if (DataContext is not MainWindowViewModel shell || !shell.OcrWorkbench.HasExtractedText) return;
+        var model = shell.OcrWorkbench;
+        try {
+            var clipboard = TopLevel.GetTopLevel(this)?.Clipboard
+                ?? throw new InvalidOperationException(StudioLocalization.Current.GetOrDefault("Ocr.Text.NoClipboard", "Clipboard is unavailable. Select the text to copy it manually."));
+            await clipboard.SetTextAsync(model.ExtractedText);
+            model.Status = StudioLocalization.Current.GetOrDefault("Ocr.Text.Copied", "Reviewed text copied.");
+        } catch (Exception error) { model.ErrorMessage = error.Message; }
+    }
+
     public SearchablePdfOcrView() {
         InitializeComponent();
         SizeChanged += (_, e) => {

--- a/OfficeIMO.Studio/Features/Workflows/SearchablePdfOcrViewModel.Extraction.cs
+++ b/OfficeIMO.Studio/Features/Workflows/SearchablePdfOcrViewModel.Extraction.cs
@@ -1,0 +1,60 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using OfficeIMO.Ocr.Tesseract;
+using OfficeIMO.Pdf;
+using OfficeIMO.Pdf.Ocr;
+using OfficeIMO.Workflows;
+
+namespace OfficeIMO.Studio.Features.Workflows;
+
+public sealed partial class SearchablePdfOcrViewModel {
+    private readonly IScanTextRecognitionService _textRecognition;
+    private bool _isExtractingText;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasExtractedText))]
+    private string _extractedText = string.Empty;
+
+    public bool HasExtractedText => !string.IsNullOrEmpty(ExtractedText);
+    private bool CanExtractText => !_disposed && !IsBusy && !Scan.IsBusy && !string.IsNullOrWhiteSpace(InputPath)
+        && Languages.Any(choice => choice.IsSelected);
+
+    [RelayCommand(CanExecute = nameof(CanExtractText))]
+    private async Task ExtractTextAsync() {
+        if (!CanExtractText) return;
+        using var operation = new CancellationTokenSource();
+        _cancellation = operation;
+        _isExtractingText = true;
+        IsBusy = true;
+        ExtractedText = string.Empty;
+        ErrorMessage = null;
+        Status = T("Text.Preparing", "Recognizing text on the selected scan page…");
+        try {
+            var languages = Languages.Where(choice => choice.IsSelected)
+                .Aggregate((TesseractOcrLanguage)0, (current, choice) => current | choice.Value);
+            var settings = Scan.ApplyTo(new PdfOcrMergeOptions {
+                ReadOptions = new PdfReadOptions { PageSelection = PdfPageSelection.From(Scan.PageNumber) },
+                Dpi = RenderDpi, MinimumConfidence = MinimumConfidencePercent / 100D
+            });
+            var options = new SearchablePdfOcrOptions(languages, ProvisionMissingLanguageData,
+                OfficeConversionFileConflictPolicy.FailIfExists, settings);
+            byte[] source = await ReadScanSourceAsync(operation.Token).ConfigureAwait(true);
+            using IDisposable? execution = _jobHistory == null ? null : await _jobHistory.EnterAsync(operation.Token).ConfigureAwait(true);
+            var evidence = await _textRecognition.PrepareAsync(source, options, operation.Token).ConfigureAwait(true);
+            operation.Token.ThrowIfCancellationRequested();
+            var selected = await ReviewWordsAsync(evidence, operation.Token, textOnly: true).ConfigureAwait(true);
+            ExtractedText = evidence.ExtractText(selected, operation.Token);
+            Status = HasExtractedText ? T("Text.Ready", "Reviewed text is ready to copy.") : T("Text.Empty", "No eligible words were selected.");
+        } catch (OperationCanceledException) when (operation.IsCancellationRequested) {
+            Status = T("Status.Cancelled", "OCR cancelled");
+        } catch (Exception error) {
+            Status = T("Status.Failed", "OCR could not finish");
+            ErrorMessage = error.Message;
+        } finally {
+            Review?.Dispose(); Review = null;
+            if (ReferenceEquals(_cancellation, operation)) _cancellation = null;
+            _isExtractingText = false;
+            IsBusy = false;
+        }
+    }
+}

--- a/OfficeIMO.Studio/Features/Workflows/SearchablePdfOcrViewModel.Review.cs
+++ b/OfficeIMO.Studio/Features/Workflows/SearchablePdfOcrViewModel.Review.cs
@@ -11,13 +11,17 @@ public sealed partial class SearchablePdfOcrViewModel {
 
     public bool HasReview => Review is not null;
 
-    private async Task<IReadOnlyList<PdfRecognizedWord>> ReviewWordsAsync(PdfSearchableOcrReview evidence, CancellationToken cancellationToken) {
+    private Task<IReadOnlyList<PdfRecognizedWord>> ReviewWordsAsync(PdfSearchableOcrReview evidence, CancellationToken cancellationToken) =>
+        ReviewWordsAsync(evidence, cancellationToken, false);
+
+    private async Task<IReadOnlyList<PdfRecognizedWord>> ReviewWordsAsync(PdfSearchableOcrReview evidence, CancellationToken cancellationToken, bool textOnly) {
         var model = await Dispatcher.UIThread.InvokeAsync(() => {
             cancellationToken.ThrowIfCancellationRequested();
             var operation = _cancellation;
-            var pending = new OcrReviewViewModel(evidence, _localizer, () => operation?.Cancel());
+            var pending = new OcrReviewViewModel(evidence, _localizer, () => operation?.Cancel(), textOnly);
             Review = pending;
-            Status = T("Review.Status", "Review the recognized words before creating the searchable PDF.");
+            Status = textOnly ? T("Text.Review", "Review the recognized words to extract.")
+                : T("Review.Status", "Review the recognized words before creating the searchable PDF.");
             return pending;
         });
         try { return await model.Completion.WaitAsync(cancellationToken).ConfigureAwait(false); }

--- a/OfficeIMO.Studio/Features/Workflows/SearchablePdfOcrViewModel.Scans.cs
+++ b/OfficeIMO.Studio/Features/Workflows/SearchablePdfOcrViewModel.Scans.cs
@@ -1,0 +1,62 @@
+using System.ComponentModel;
+using OfficeIMO.Pdf.Ocr;
+using OfficeIMO.Studio.Infrastructure;
+using OfficeIMO.Workflows;
+
+namespace OfficeIMO.Studio.Features.Workflows;
+
+public sealed partial class SearchablePdfOcrViewModel {
+    private void ScanChanged(object? sender, PropertyChangedEventArgs e) {
+        if (e.PropertyName == nameof(ScanPreparationViewModel.Dpi)) RenderDpi = Scan.Dpi;
+        if (e.PropertyName == nameof(ScanPreparationViewModel.IsBusy)) RunCommand.NotifyCanExecuteChanged();
+    }
+    partial void OnRenderDpiChanged(double value) { if (Scan != null) Scan.Dpi = value; }
+    private async Task<byte[]> ReadScanSourceAsync(CancellationToken token) {
+        if (string.IsNullOrWhiteSpace(InputPath)) throw new InvalidOperationException("Choose a PDF before previewing its scans.");
+        if (_storage != null) return (await _storage.ReadSnapshotAsync(InputPath, token, 128L * 1024 * 1024).ConfigureAwait(true)).Bytes;
+        using var access = new StudioStorageAccess();
+        return (await access.ReadSnapshotAsync(InputPath, token, 128L * 1024 * 1024).ConfigureAwait(true)).Bytes;
+    }
+    private async Task SaveScanCopyAsync(PdfOcrMergeOptions options, string sourceHash, CancellationToken token) {
+        if (IsBusy) return;
+        using var operation = CancellationTokenSource.CreateLinkedTokenSource(token);
+        _cancellation = operation; IsBusy = true;
+        string input = InputPath;
+        StudioJobRecord? job = null;
+        try {
+            string? output = await _pickOutputPdf(operation.Token).ConfigureAwait(true);
+            if (string.IsNullOrWhiteSpace(output)) return;
+            bool provider = _storage?.UsesProviderPublication(output) == true;
+            if (!provider && !_canPublishPath(output))
+                throw new InvalidOperationException(T("Error.OutputOpen", "That PDF is already open in another tab. Close it or choose a different output file name."));
+            if (provider && !await _confirmProviderWrite(output).ConfigureAwait(true)) return;
+            operation.Token.ThrowIfCancellationRequested();
+            PublishedPath = null; ErrorMessage = null; HasRecovery = false;
+            job = _jobHistory?.Start(_localizer.GetOrDefault("Scan.Title", "Scan preparation"), input, output, operation.Cancel);
+            using IDisposable? execution = _jobHistory == null ? null : await _jobHistory.EnterAsync(operation.Token).ConfigureAwait(true);
+            var request = new OfficeWorkflowRequest {
+                Operation = OfficeWorkflowOperation.ScanCleanup,
+                InputPath = input,
+                InputStream = _storage?.CreateWorkflowInput(input),
+                OutputPath = output,
+                PublicationGuard = _publicationGuard,
+                ConflictPolicy = provider || ReplaceExistingOutput ? OfficeWorkflowConflictPolicy.Replace : OfficeWorkflowConflictPolicy.Fail,
+                OutputStream = provider ? _storage!.CreateWorkflowOutput(output, _recoveryStore ?? throw new IOException("Workflow recovery storage is unavailable.")) : null,
+                ScanCleanup = new() { Preparation = options, ExpectedSourceSha256 = sourceHash, AcknowledgeRasterOutput = true }
+            };
+            var result = await new OfficeWorkflowRunner().RunAsync(request, cancellationToken: operation.Token).ConfigureAwait(true);
+            Status = result.Summary; Summary = result.Summary;
+            HasRecovery = result.Recovery != null;
+            job?.Complete(result.Status, result.OutputPath, result.Summary, result.Recovery);
+            if (result.Status == OfficeWorkflowStatus.Completed) PublishedPath = result.OutputPath;
+            else ErrorMessage = result.Summary;
+        } catch (OperationCanceledException) when (operation.IsCancellationRequested) {
+            job?.Complete(OfficeWorkflowStatus.Cancelled, null, T("Status.Cancelled", "OCR cancelled"));
+            throw;
+        } catch (Exception error) {
+            job?.Complete(OfficeWorkflowStatus.Failed, null, error.Message);
+            throw;
+        } finally { if (ReferenceEquals(_cancellation, operation)) _cancellation = null; IsBusy = false; }
+    }
+    partial void OnIsBusyChanged(bool value) { if (Scan != null) Scan.HostBusy = value; }
+}

--- a/OfficeIMO.Studio/Features/Workflows/SearchablePdfOcrViewModel.Scans.cs
+++ b/OfficeIMO.Studio/Features/Workflows/SearchablePdfOcrViewModel.Scans.cs
@@ -8,7 +8,10 @@ namespace OfficeIMO.Studio.Features.Workflows;
 public sealed partial class SearchablePdfOcrViewModel {
     private void ScanChanged(object? sender, PropertyChangedEventArgs e) {
         if (e.PropertyName == nameof(ScanPreparationViewModel.Dpi)) RenderDpi = Scan.Dpi;
-        if (e.PropertyName == nameof(ScanPreparationViewModel.IsBusy)) RunCommand.NotifyCanExecuteChanged();
+        if (e.PropertyName == nameof(ScanPreparationViewModel.IsBusy)) {
+            RunCommand.NotifyCanExecuteChanged(); ExtractTextCommand.NotifyCanExecuteChanged();
+        }
+        if (e.PropertyName == nameof(ScanPreparationViewModel.PageNumber)) ExtractedText = string.Empty;
     }
     partial void OnRenderDpiChanged(double value) { if (Scan != null) Scan.Dpi = value; }
     private async Task<byte[]> ReadScanSourceAsync(CancellationToken token) {

--- a/OfficeIMO.Studio/Features/Workflows/SearchablePdfOcrViewModel.cs
+++ b/OfficeIMO.Studio/Features/Workflows/SearchablePdfOcrViewModel.cs
@@ -114,6 +114,7 @@ public sealed partial class SearchablePdfOcrViewModel : ObservableObject, IDispo
     private readonly Func<string, Task<bool>> _confirmProviderWrite;
     private CancellationTokenSource? _cancellation;
     private string? _automaticOutputPath;
+    private bool _disposed;
 
     internal SearchablePdfOcrViewModel(
         Func<CancellationToken, Task<string?>> pickPdf,
@@ -127,11 +128,13 @@ public sealed partial class SearchablePdfOcrViewModel : ObservableObject, IDispo
         StudioStorageAccess? storage = null,
         Func<CancellationToken, Task<string?>>? pickOutputPdf = null,
         OfficeWorkflowOutputRecoveryStore? recoveryStore = null,
-        Func<string, Task<bool>>? confirmProviderWrite = null) {
+        Func<string, Task<bool>>? confirmProviderWrite = null,
+        IScanTextRecognitionService? textRecognition = null) {
         _pickPdf = pickPdf ?? throw new ArgumentNullException(nameof(pickPdf));
         _pickOutputFolder = pickOutputFolder ?? throw new ArgumentNullException(nameof(pickOutputFolder));
         _openDocument = openDocument;
         _service = service ?? new SearchablePdfOcrService();
+        _textRecognition = textRecognition ?? new ScanTextRecognitionService();
         _canPublishPath = canPublishPath ?? (_ => true);
         _publicationGuard = publicationGuard ?? new OfficeIMO.Studio.Features.Shell.StudioWorkflowPublicationGuard((path, _) => _canPublishPath(path));
         _localizer = localizer ?? StudioLocalization.Current;
@@ -154,6 +157,7 @@ public sealed partial class SearchablePdfOcrViewModel : ObservableObject, IDispo
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(RunCommand))]
     [NotifyPropertyChangedFor(nameof(InputName))]
+    [NotifyCanExecuteChangedFor(nameof(ExtractTextCommand))]
     private string _inputPath = string.Empty;
 
     [ObservableProperty]
@@ -186,6 +190,7 @@ public sealed partial class SearchablePdfOcrViewModel : ObservableObject, IDispo
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(CanCancel))]
+    [NotifyCanExecuteChangedFor(nameof(ExtractTextCommand))]
     [NotifyCanExecuteChangedFor(nameof(RunCommand))]
     private bool _isBusy;
 
@@ -233,6 +238,8 @@ public sealed partial class SearchablePdfOcrViewModel : ObservableObject, IDispo
     }
 
     partial void OnInputPathChanged(string value) {
+        if (_isExtractingText) _cancellation?.Cancel();
+        ExtractedText = string.Empty;
         Scan.Invalidate(clearSource: true);
         string? suggestion = TryCreateOutputPath(value);
         if (suggestion is null) {
@@ -389,6 +396,7 @@ public sealed partial class SearchablePdfOcrViewModel : ObservableObject, IDispo
     private void OnLanguagePropertyChanged(object? sender, PropertyChangedEventArgs e) {
         if (e.PropertyName != nameof(OcrLanguageChoice.IsSelected)) return;
         OnPropertyChanged(nameof(LanguageSummary));
+        ExtractTextCommand.NotifyCanExecuteChanged();
         RunCommand.NotifyCanExecuteChanged();
     }
 
@@ -420,6 +428,8 @@ public sealed partial class SearchablePdfOcrViewModel : ObservableObject, IDispo
     }
 
     public void Dispose() {
+        _disposed = true;
+        ExtractTextCommand.NotifyCanExecuteChanged();
         _cancellation?.Cancel();
         Review?.Dispose();
         Scan.PropertyChanged -= ScanChanged; Scan.Dispose();

--- a/OfficeIMO.Studio/Features/Workflows/SearchablePdfOcrViewModel.cs
+++ b/OfficeIMO.Studio/Features/Workflows/SearchablePdfOcrViewModel.cs
@@ -47,11 +47,15 @@ internal sealed class SearchablePdfOcrService : ISearchablePdfOcrService {
         pdfOptions.Language = options.Languages.ToTesseractExpression();
         pdfOptions.SourceName = options.InputStream?.Name ?? OfficeStorageIdentity.GetFileName(inputPath);
         var request = new PdfSearchableWorkflowRequest {
-            InputPath = inputPath, OutputPath = outputPath, Ocr = pdfOptions,
-            InputStream = options.InputStream, OutputStream = options.OutputStream,
+            InputPath = inputPath,
+            OutputPath = outputPath,
+            Ocr = pdfOptions,
+            InputStream = options.InputStream,
+            OutputStream = options.OutputStream,
             ConflictPolicy = options.OutputConflictPolicy == OfficeConversionFileConflictPolicy.Replace
                 ? OfficeWorkflowConflictPolicy.Replace : OfficeWorkflowConflictPolicy.Fail,
-            PublicationGuard = options.PublicationGuard, ReviewAsync = options.ReviewAsync
+            PublicationGuard = options.PublicationGuard,
+            ReviewAsync = options.ReviewAsync
         };
         TesseractOcrSession session = await TesseractOcr
             .CreateSessionAsync(new TesseractOcrSessionOptions {
@@ -136,6 +140,8 @@ public sealed partial class SearchablePdfOcrViewModel : ObservableObject, IDispo
         _pickOutputPdf = pickOutputPdf ?? (_ => Task.FromResult<string?>(null));
         _recoveryStore = recoveryStore;
         _confirmProviderWrite = confirmProviderWrite ?? (_ => Task.FromResult(false));
+        Scan = new ScanPreparationViewModel(ReadScanSourceAsync, SaveScanCopyAsync, _localizer);
+        Scan.PropertyChanged += ScanChanged;
         Languages = new ObservableCollection<OcrLanguageChoice>(OcrLanguageChoice.CreateChoices(_localizer));
         foreach (var choice in Languages) choice.PropertyChanged += OnLanguagePropertyChanged;
         Status = T("Status.Ready", "Choose a scanned PDF to make its text searchable.");
@@ -143,6 +149,7 @@ public sealed partial class SearchablePdfOcrViewModel : ObservableObject, IDispo
     }
 
     public ObservableCollection<OcrLanguageChoice> Languages { get; }
+    public ScanPreparationViewModel Scan { get; }
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(RunCommand))]
@@ -215,7 +222,7 @@ public sealed partial class SearchablePdfOcrViewModel : ObservableObject, IDispo
     }
 
     private bool CanRun =>
-        !IsBusy &&
+        !IsBusy && !Scan.IsBusy &&
         !string.IsNullOrWhiteSpace(InputPath) &&
         !string.IsNullOrWhiteSpace(OutputPath) &&
         Languages.Any(static choice => choice.IsSelected);
@@ -226,6 +233,7 @@ public sealed partial class SearchablePdfOcrViewModel : ObservableObject, IDispo
     }
 
     partial void OnInputPathChanged(string value) {
+        Scan.Invalidate(clearSource: true);
         string? suggestion = TryCreateOutputPath(value);
         if (suggestion is null) {
             if (PathsEqual(OutputPath, _automaticOutputPath)) OutputPath = string.Empty;
@@ -304,13 +312,13 @@ public sealed partial class SearchablePdfOcrViewModel : ObservableObject, IDispo
                 ReplaceExistingOutput
                     ? OfficeConversionFileConflictPolicy.Replace
                     : OfficeConversionFileConflictPolicy.FailIfExists,
-                new PdfOcrMergeOptions {
+                Scan.ApplyTo(new PdfOcrMergeOptions {
                     ReadOptions = new PdfReadOptions {
                         PageSelection = string.IsNullOrWhiteSpace(Pages) ? null : PdfPageSelection.Parse(Pages)
                     },
                     Dpi = RenderDpi,
                     MinimumConfidence = MinimumConfidencePercent / 100D
-                }) { PublicationGuard = _publicationGuard, InputStream = _storage?.CreateWorkflowInput(input), ReviewAsync = ReviewWordsAsync };
+                })) { PublicationGuard = _publicationGuard, InputStream = _storage?.CreateWorkflowInput(input), ReviewAsync = ReviewWordsAsync };
             if (providerOutput) {
                 if (!await _confirmProviderWrite(output).ConfigureAwait(true)) {
                     Status = T("Status.Cancelled", "OCR cancelled");
@@ -408,13 +416,13 @@ public sealed partial class SearchablePdfOcrViewModel : ObservableObject, IDispo
 
     private string Describe(string location) {
         if (string.IsNullOrWhiteSpace(location)) return string.Empty;
-        try { return _storage?.Describe(location).Name ?? OfficeStorageIdentity.GetFileName(location); }
-        catch (Exception error) when (error is ArgumentException or NotSupportedException or IOException) { return location; }
+        try { return _storage?.Describe(location).Name ?? OfficeStorageIdentity.GetFileName(location); } catch (Exception error) when (error is ArgumentException or NotSupportedException or IOException) { return location; }
     }
 
     public void Dispose() {
         _cancellation?.Cancel();
         Review?.Dispose();
+        Scan.PropertyChanged -= ScanChanged; Scan.Dispose();
         foreach (OcrLanguageChoice language in Languages) language.PropertyChanged -= OnLanguagePropertyChanged;
     }
 

--- a/OfficeIMO.Studio/Localization/StudioStrings.resx
+++ b/OfficeIMO.Studio/Localization/StudioStrings.resx
@@ -1804,4 +1804,15 @@
   <data name="Scan.Color.Gray" xml:space="preserve"><value>Grayscale</value></data>
   <data name="Scan.Color.BlackWhite" xml:space="preserve"><value>Black and white</value></data>
   <data name="Scan.KeyboardHint" xml:space="preserve"><value>With the source page focused, use arrow keys to move the region and Shift+arrow keys to resize it. In corner mode, choose corner 1–4 clockwise from top left, then use arrow keys.</value></data>
+  <data name="Ocr.Text.Hint" xml:space="preserve"><value>Recognize the selected scan page or region, review its words, and copy the text.</value></data>
+  <data name="Ocr.Text.Recognize" xml:space="preserve"><value>Recognize text to copy</value></data>
+  <data name="Ocr.Text.Copy" xml:space="preserve"><value>Copy reviewed text</value></data>
+  <data name="Ocr.Text.UseSelected" xml:space="preserve"><value>Use selected text</value></data>
+  <data name="Ocr.Text.CommitNote" xml:space="preserve"><value>Extract the selected words without creating a PDF.</value></data>
+  <data name="Ocr.Text.NoClipboard" xml:space="preserve"><value>Clipboard is unavailable. Select the text to copy it manually.</value></data>
+  <data name="Ocr.Text.Copied" xml:space="preserve"><value>Reviewed text copied.</value></data>
+  <data name="Ocr.Text.Preparing" xml:space="preserve"><value>Recognizing text on the selected scan page…</value></data>
+  <data name="Ocr.Text.Ready" xml:space="preserve"><value>Reviewed text is ready to copy.</value></data>
+  <data name="Ocr.Text.Empty" xml:space="preserve"><value>No eligible words were selected.</value></data>
+  <data name="Ocr.Text.Review" xml:space="preserve"><value>Review the recognized words to extract.</value></data>
 </root>

--- a/OfficeIMO.Studio/Localization/StudioStrings.resx
+++ b/OfficeIMO.Studio/Localization/StudioStrings.resx
@@ -1775,4 +1775,33 @@
   <data name="Conversion.Preview.Failed" xml:space="preserve"><value>Preview unavailable: </value></data>
   <data name="Conversion.Output.OpenFailed" xml:space="preserve"><value>The output could not be opened: </value></data>
   <data name="Conversion.Job.VisualFidelity" xml:space="preserve"><value>Visual page images · review rendering and editability limits</value></data>
+  <data name="Scan.Title" xml:space="preserve"><value>Scan preparation</value></data>
+  <data name="Scan.Hint" xml:space="preserve"><value>Preview a page, draw an OCR region, or correct a photographed page before recognition.</value></data>
+  <data name="Scan.Page" xml:space="preserve"><value>Preview page</value></data>
+  <data name="Scan.Cleanup" xml:space="preserve"><value>Apply scan cleanup</value></data>
+  <data name="Scan.Adjustments" xml:space="preserve"><value>Straightening and levels</value></data>
+  <data name="Scan.Deskew" xml:space="preserve"><value>Automatic deskew</value></data>
+  <data name="Scan.Background" xml:space="preserve"><value>Normalize paper brightness</value></data>
+  <data name="Scan.Turns" xml:space="preserve"><value>Clockwise quarter-turns</value></data>
+  <data name="Scan.Straighten" xml:space="preserve"><value>Straighten (degrees)</value></data>
+  <data name="Scan.Black" xml:space="preserve"><value>Black point</value></data>
+  <data name="Scan.White" xml:space="preserve"><value>White point</value></data>
+  <data name="Scan.Gamma" xml:space="preserve"><value>Midtone gamma</value></data>
+  <data name="Scan.Color" xml:space="preserve"><value>Color mode</value></data>
+  <data name="Scan.Region" xml:space="preserve"><value>Use drawn region (this page only)</value></data>
+  <data name="Scan.Perspective" xml:space="preserve"><value>Correct perspective</value></data>
+  <data name="Scan.MoveCorners" xml:space="preserve"><value>Move page corners instead of drawing a region</value></data>
+  <data name="Scan.Reset" xml:space="preserve"><value>Reset region and corners</value></data>
+  <data name="Scan.Preview" xml:space="preserve"><value>Preview preparation</value></data>
+  <data name="Scan.Source" xml:space="preserve"><value>Source page</value></data>
+  <data name="Scan.DrawHint" xml:space="preserve"><value>Drag to select a region. Enable perspective and move the four corners to the page edges. Preview again after adjustments.</value></data>
+  <data name="Scan.Prepared" xml:space="preserve"><value>Prepared appearance</value></data>
+  <data name="Scan.SaveHint" xml:space="preserve"><value>Save creates a separate raster PDF of this preview page. Native text, forms, links, signatures, and attachments are omitted. Recognize and review keeps the visible source unchanged.</value></data>
+  <data name="Scan.Save" xml:space="preserve"><value>Save reviewed page as raster PDF</value></data>
+  <data name="Scan.Refresh" xml:space="preserve"><value>Preview the current settings before saving a prepared copy.</value></data>
+  <data name="Scan.Ready" xml:space="preserve"><value>Prepared preview ready. Region OCR keeps the visible source page; saving a scan copy keeps only the prepared pixels.</value></data>
+  <data name="Scan.Color.Keep" xml:space="preserve"><value>Keep color</value></data>
+  <data name="Scan.Color.Gray" xml:space="preserve"><value>Grayscale</value></data>
+  <data name="Scan.Color.BlackWhite" xml:space="preserve"><value>Black and white</value></data>
+  <data name="Scan.KeyboardHint" xml:space="preserve"><value>With the source page focused, use arrow keys to move the region and Shift+arrow keys to resize it. In corner mode, choose corner 1–4 clockwise from top left, then use arrow keys.</value></data>
 </root>

--- a/OfficeIMO.Studio/README.md
+++ b/OfficeIMO.Studio/README.md
@@ -55,6 +55,8 @@ Studio does not contain a second document engine:
 
 In the single-PDF OCR workspace, **Scan preparation** previews the source and prepared page before recognition. Draw one region for the selected page, adjust perspective corners, or enable cleanup for straightening, black and white levels, gamma, and color mode. Arrow keys move the focused region; Shift+arrow keys resize it. In corner mode, keys 1–4 select a corner clockwise from top left and arrow keys move it. Changed settings invalidate the reviewed preview. OCR uses the prepared pixels and maps recognized text back to the original visible PDF. **Save reviewed page as raster PDF** instead exports a separate pixel-only copy and omits native text and interactive content. The source digest is checked before saving.
 
+For quick extraction, choose **Recognize text to copy**, review the selected page or region, exclude unwanted words, and choose **Use selected text**. The result remains selectable in the workspace; **Copy reviewed text** sends it to the clipboard without choosing an output file or creating a PDF. Confidence and native-text overlap rules still apply.
+
 Tesseract is an explicit OCR runtime prerequisite. OfficeIMO discovers an installed executable and can provision checksum-pinned language data, but the application does not silently install or bundle a native OCR executable. Scan preparation and raster-copy export do not require it.
 
 ## Language, accessibility, and local data

--- a/OfficeIMO.Studio/README.md
+++ b/OfficeIMO.Studio/README.md
@@ -53,7 +53,9 @@ Studio does not contain a second document engine:
 - `OfficeIMO.Pdf.Ocr` owns searchable text generation. `OfficeIMO.Workflows` owns source snapshots, output validation, publication, and ordered OCR sessions; Studio configures the optional Tesseract CLI provider. `OfficeIMO.Reader.Image` identifies image sources, and `OfficeIMO.Reader.Ocr` owns their recognition and normalized-document enrichment.
 - Avalonia owns only the cross-platform windowing and control layer. Studio uses OfficeIMO's retained page scene with the canonical raster renderer for content that the Avalonia adapter cannot preserve, including transformed text and embedded-font metrics. Restricted viewing also uses the raster path. Studio does not use PDFium.
 
-Tesseract is an explicit OCR runtime prerequisite. OfficeIMO discovers an installed executable and can provision checksum-pinned language data, but the application does not silently install or bundle a native OCR executable.
+In the single-PDF OCR workspace, **Scan preparation** previews the source and prepared page before recognition. Draw one region for the selected page, adjust perspective corners, or enable cleanup for straightening, black and white levels, gamma, and color mode. Arrow keys move the focused region; Shift+arrow keys resize it. In corner mode, keys 1–4 select a corner clockwise from top left and arrow keys move it. Changed settings invalidate the reviewed preview. OCR uses the prepared pixels and maps recognized text back to the original visible PDF. **Save reviewed page as raster PDF** instead exports a separate pixel-only copy and omits native text and interactive content. The source digest is checked before saving.
+
+Tesseract is an explicit OCR runtime prerequisite. OfficeIMO discovers an installed executable and can provision checksum-pinned language data, but the application does not silently install or bundle a native OCR executable. Scan preparation and raster-copy export do not require it.
 
 ## Language, accessibility, and local data
 

--- a/OfficeIMO.Workflows.Tests/ScanCleanupTests.cs
+++ b/OfficeIMO.Workflows.Tests/ScanCleanupTests.cs
@@ -1,0 +1,84 @@
+using System.Security.Cryptography;
+using OfficeIMO.Pdf;
+using OfficeIMO.Pdf.Ocr;
+
+namespace OfficeIMO.Workflows.Tests;
+
+public sealed class ScanCleanupTests {
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ProviderScanCopyNeverOpensTheSourceForWriting(bool deferred) {
+        string root = Path.Combine(Path.GetTempPath(), "officeimo-scan-provider-" + Guid.NewGuid().ToString("N"));
+        const string sourceLocation = "content://scan/source";
+        byte[] source = PdfDocument.Create(c => c.Page(p => p.Size(200, 100).Margin(0))).ToBytes();
+        int writes = 0;
+        try {
+            var recovery = new OfficeWorkflowOutputRecoveryStore(root);
+            var request = new OfficeWorkflowRequest {
+                Operation = OfficeWorkflowOperation.ScanCleanup,
+                InputPath = sourceLocation,
+                InputStream = new("source.pdf", _ => Task.FromResult<Stream>(new MemoryStream(source))),
+                OutputPath = deferred ? "content://scan/folder" : sourceLocation,
+                ConflictPolicy = OfficeWorkflowConflictPolicy.Replace,
+                OutputStream = new("copy.pdf", _ => Task.FromResult<Stream>(new MemoryStream(source)),
+                    _ => { writes++; return Task.FromResult<Stream>(new MemoryStream()); }, recovery,
+                    deferred ? _ => Task.FromResult(sourceLocation) : null),
+                ScanCleanup = new() { AcknowledgeRasterOutput = true, Preparation = new() { Dpi = 72 } }
+            };
+            OfficeWorkflowResult result = await new OfficeWorkflowRunner().RunAsync(request);
+            Assert.Equal(deferred ? OfficeWorkflowStatus.Unconfirmed : OfficeWorkflowStatus.Failed, result.Status);
+            Assert.Equal(0, writes);
+        } finally { if (Directory.Exists(root)) Directory.Delete(root, true); }
+    }
+
+    [Fact]
+    public async Task ReviewedRasterCopyKeepsSelectedPageAndRequiresMatchingSource() {
+        string root = Path.Combine(Path.GetTempPath(), "officeimo-scan-workflow-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try {
+            string input = Path.Combine(root, "source.pdf"), output = Path.Combine(root, "cleaned.pdf");
+            var document = PdfDocument.Create(compose => {
+                compose.Page(page => page.Size(200, 300).Content(c => c.Item(i => i.Paragraph(p => p.Text("First page")))));
+                compose.Page(page => page.Size(300, 200).Content(c => c.Item(i => i.Paragraph(p => p.Text("Second page")))));
+            });
+            byte[] source = document.ToBytes(); await File.WriteAllBytesAsync(input, source);
+            var settings = new OfficeScanCleanupOptions {
+                AcknowledgeRasterOutput = true,
+                ExpectedSourceSha256 = Convert.ToHexString(SHA256.HashData(source)),
+                Preparation = new() { Dpi = 72, ReadOptions = new() { PageSelection = PdfPageSelection.From(2) }, ScanProcessing = new() { Deskew = false, NormalizeBackground = false } }
+            };
+            var request = new OfficeWorkflowRequest { Operation = OfficeWorkflowOperation.ScanCleanup, InputPath = input, OutputPath = output, ScanCleanup = settings };
+            var result = await new OfficeWorkflowRunner().RunAsync(request);
+            Assert.Equal(OfficeWorkflowStatus.Completed, result.Status);
+            var cleaned = PdfDocument.Load(await File.ReadAllBytesAsync(output));
+            Assert.Equal(1, cleaned.Inspect().PageCount); Assert.Equal(300, cleaned.Render.Drawing(1).Width);
+            Assert.True(string.IsNullOrWhiteSpace(cleaned.Reader.Text())); Assert.Single(cleaned.Images.Placements());
+            Assert.Equal(source, await File.ReadAllBytesAsync(input));
+            File.Delete(output);
+            var overwrite = new OfficeWorkflowRequest {
+                Operation = OfficeWorkflowOperation.ScanCleanup,
+                InputPath = input,
+                OutputPath = input,
+                ConflictPolicy = OfficeWorkflowConflictPolicy.Replace,
+                ScanCleanup = settings
+            };
+            Assert.NotEqual(OfficeWorkflowStatus.Completed, (await new OfficeWorkflowRunner().RunAsync(overwrite)).Status);
+            Assert.Equal(source, await File.ReadAllBytesAsync(input));
+            settings.Preparation.ReadOptions = new() { PageSelection = PdfPageSelection.From(1, 2) };
+            settings.Preparation.Regions = new[] { new PdfOcrPageRegion(2, 0, 0, 0.5, 1) };
+            var cropped = await new OfficeWorkflowRunner().RunAsync(request);
+            Assert.Equal(OfficeWorkflowStatus.Completed, cropped.Status);
+            var cropDocument = PdfDocument.Load(await File.ReadAllBytesAsync(output));
+            Assert.Equal(1, cropDocument.Inspect().PageCount);
+            Assert.Equal(150, cropDocument.Render.Drawing(1).Width);
+            File.Delete(output);
+            settings.ExpectedSourceSha256 = new string('0', 64);
+            var stale = await new OfficeWorkflowRunner().RunAsync(request);
+            Assert.Equal(OfficeWorkflowStatus.Failed, stale.Status); Assert.Contains("changed since scan review", stale.Summary); Assert.False(File.Exists(output));
+            settings.AcknowledgeRasterOutput = false;
+            Assert.Equal(OfficeWorkflowStatus.Failed, (await new OfficeWorkflowRunner().RunAsync(request)).Status);
+            Assert.False(File.Exists(output));
+        } finally { Directory.Delete(root, true); }
+    }
+}

--- a/OfficeIMO.Workflows/OfficeScanCleanupOptions.cs
+++ b/OfficeIMO.Workflows/OfficeScanCleanupOptions.cs
@@ -1,0 +1,21 @@
+using OfficeIMO.Pdf.Ocr;
+
+namespace OfficeIMO.Workflows;
+
+/// <summary>Creates a separate raster-only PDF from selected, prepared scan pages.</summary>
+public sealed class OfficeScanCleanupOptions {
+    /// <summary>Page selection, sampling density, region cropping, perspective, and tonal settings.</summary>
+    public PdfOcrMergeOptions Preparation { get; set; } = new();
+    /// <summary>Must be true to acknowledge that only rendered appearances are copied; native text, forms, links, signatures, and attachments are omitted.</summary>
+    public bool AcknowledgeRasterOutput { get; set; }
+    /// <summary>Optional SHA-256 hex digest from a reviewed source snapshot; a mismatch blocks output.</summary>
+    public string? ExpectedSourceSha256 { get; set; }
+    internal OfficeScanCleanupOptions Snapshot() {
+        if (!AcknowledgeRasterOutput) throw new ArgumentException("Acknowledge the raster-only scan output before saving.");
+        if (Preparation == null) throw new ArgumentNullException(nameof(Preparation));
+        if (ExpectedSourceSha256 != null && (ExpectedSourceSha256.Length != 64 || ExpectedSourceSha256.Any(character => !Uri.IsHexDigit(character))))
+            throw new ArgumentException("The reviewed source digest must be SHA-256 hex.", nameof(ExpectedSourceSha256));
+        if (Preparation.DetectOrientation) throw new ArgumentException("Scan-copy preparation requires explicit rotation; provider orientation detection is available during OCR.");
+        return new() { Preparation = Preparation.Clone(), AcknowledgeRasterOutput = true, ExpectedSourceSha256 = ExpectedSourceSha256 };
+    }
+}

--- a/OfficeIMO.Workflows/OfficeWorkflowContracts.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowContracts.cs
@@ -25,7 +25,9 @@ public enum OfficeWorkflowOperation {
     /// <summary>Create a separate unencrypted PDF after owner authorization.</summary>
     RemovePdfProtection,
     /// <summary>Create a separate PDF with a cryptographically verified certificate signature.</summary>
-    SignPdf
+    SignPdf,
+    /// <summary>Create an explicitly reviewed raster PDF from prepared scan pages.</summary>
+    ScanCleanup
 }
 
 /// <summary>Controls how an existing output path is handled.</summary>
@@ -188,6 +190,8 @@ public sealed class OfficeWorkflowRequest {
 
     /// <summary>Optional route-specific settings, independently copied and validated before asynchronous execution.</summary>
     public OfficeWorkflowConversionOptions? ConversionOptions { get; set; }
+    /// <summary>Explicit scan preparation and raster-output acknowledgement for ScanCleanup.</summary>
+    public OfficeScanCleanupOptions? ScanCleanup { get; set; }
 
     /// <summary>Requested output file. Inspect does not require one; compare emits HTML when one is supplied.</summary>
     public string? OutputPath { get; set; }

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.Inputs.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.Inputs.cs
@@ -79,7 +79,7 @@ public sealed partial class OfficeWorkflowRunner {
                     "Lossless PDF optimization does not support the TextOnly output profile.",
                     nameof(request));
             }
-            if (request.Operation is OfficeWorkflowOperation.Optimize or OfficeWorkflowOperation.Repair or OfficeWorkflowOperation.Sanitize or OfficeWorkflowOperation.ExtractPages or OfficeWorkflowOperation.ProtectPdf or OfficeWorkflowOperation.RemovePdfProtection or OfficeWorkflowOperation.SignPdf) {
+            if (request.Operation is OfficeWorkflowOperation.Optimize or OfficeWorkflowOperation.Repair or OfficeWorkflowOperation.Sanitize or OfficeWorkflowOperation.ExtractPages or OfficeWorkflowOperation.ProtectPdf or OfficeWorkflowOperation.RemovePdfProtection or OfficeWorkflowOperation.SignPdf or OfficeWorkflowOperation.ScanCleanup) {
                 outputPath ??= Path.Combine(
                     Path.GetDirectoryName(inputPath)!,
                     Path.GetFileNameWithoutExtension(inputPath) + "." + request.Operation.ToString().ToLowerInvariant() + ".pdf");
@@ -92,6 +92,11 @@ public sealed partial class OfficeWorkflowRunner {
         if (request.ConversionOptions is not null && route is null)
             throw new ArgumentException("Conversion settings are valid only for conversion operations.", nameof(request));
         OfficeWorkflowConversionOptions? conversionOptions = request.ConversionOptions?.Snapshot(route!);
+        OfficeScanCleanupOptions? scanCleanup = request.ScanCleanup?.Snapshot();
+        if ((request.Operation == OfficeWorkflowOperation.ScanCleanup) != (scanCleanup != null))
+            throw new ArgumentException("ScanCleanup requires scan settings; other operations cannot accept them.", nameof(request));
+        if (scanCleanup != null && request.OutputProfile != OfficeWorkflowOutputProfile.Faithful)
+            throw new ArgumentException("Scan preparation does not support conversion output profiles.", nameof(request));
 
         if (request.PageNumbers is { Length: > 100000 })
             throw new ArgumentException("Page extraction is limited to 100,000 selected pages.", nameof(request));
@@ -128,7 +133,7 @@ public sealed partial class OfficeWorkflowRunner {
         var outputOptions = CreatePdfLoadOptions(outputPassword, limits.MaximumOutputBytes);
         if (encryption?.AesCryptographyProvider is not null) outputOptions = OfficeIMO.Pdf.PdfLoadOptions.WithAesCryptographyProvider(outputOptions, encryption.AesCryptographyProvider);
         OfficeWorkflowStreamInput? inputStream = request.InputStream;
-        if ((request.Operation == OfficeWorkflowOperation.ExtractPages || securityOutput || signing) && inputStream is null) {
+        if ((request.Operation is OfficeWorkflowOperation.ExtractPages or OfficeWorkflowOperation.ScanCleanup || securityOutput || signing) && inputStream is null) {
             inputStream = new OfficeWorkflowStreamInput(Path.GetFileName(inputPath), token => {
                 token.ThrowIfCancellationRequested();
                 return Task.FromResult<Stream>(new FileStream(inputPath, FileMode.Open, FileAccess.Read, FileShare.Read));
@@ -150,7 +155,7 @@ public sealed partial class OfficeWorkflowRunner {
             outputOptions,
             request.PublicationGuard,
             inputStream, request.ComparisonStream, request.OutputStream, pages, encryption, request.PdfOwnerPassword ?? request.PdfPassword,
-            request.OutputSigner, signatureOptions, request.OutputSignatureValidator, conversionOptions);
+            request.OutputSigner, signatureOptions, request.OutputSignatureValidator, conversionOptions, scanCleanup);
     }
 
     private static string ValidateInputLocation(string location, OfficeWorkflowStreamInput? stream) {
@@ -186,8 +191,11 @@ public sealed partial class OfficeWorkflowRunner {
                 : await CaptureOneAsync(request.ComparisonPath, request.ComparisonStream, request.Limits.MaximumInputBytes, token).ConfigureAwait(false);
             string[]? protectedSources = request.InputStream is null && request.ComparisonStream is null && request.OutputStream is null
                 ? null : new[] { request.InputPath, request.ComparisonPath }.OfType<string>().ToArray();
-            return request with { InputPath = inputPath, ComparisonPath = comparisonPath,
-                PublicationGuard = Guard(request.PublicationGuard, request.Limits.MaximumInputBytes, protectedSources, request.OutputStream) };
+            return request with {
+                InputPath = inputPath,
+                ComparisonPath = comparisonPath,
+                PublicationGuard = Guard(request.PublicationGuard, request.Limits.MaximumInputBytes, protectedSources, request.OutputStream)
+            };
         }
 
         internal async Task<ValidatedAssemblyRequest> CaptureAsync(ValidatedAssemblyRequest request, CancellationToken token) {
@@ -216,10 +224,14 @@ public sealed partial class OfficeWorkflowRunner {
                 }
                 sources.Add(path);
             }
-            return request with { Sources = sources, SourceStreams = stagedStreams, SourceLocations = sourceLocations,
+            return request with {
+                Sources = sources,
+                SourceStreams = stagedStreams,
+                SourceLocations = sourceLocations,
                 PublicationGuard = Guard(request.PublicationGuard, request.Limits.MaximumInputBytes,
                     request.Sources.Where(source => request.SourceDirectories?.ContainsKey(source) != true)
-                        .Concat(_directoryFiles.Select(item => item.Access.Location)).ToArray(), request.OutputStream) };
+                        .Concat(_directoryFiles.Select(item => item.Access.Location)).ToArray(), request.OutputStream)
+            };
         }
 
         internal IOfficeWorkflowPublicationGuard? Guard(IOfficeWorkflowPublicationGuard? host, long maximumBytes,
@@ -247,8 +259,7 @@ public sealed partial class OfficeWorkflowRunner {
         }
 
         internal void Cleanup(List<OfficeWorkflowDiagnostic> diagnostics) {
-            try { Dispose(); }
-            catch (IOException error) {
+            try { Dispose(); } catch (IOException error) {
                 diagnostics.Add(new OfficeWorkflowDiagnostic("InputStagingCleanupFailed", error.Message,
                     OfficeWorkflowDiagnosticSeverity.Warning, "cleanup"));
             }
@@ -258,8 +269,7 @@ public sealed partial class OfficeWorkflowRunner {
             List<Exception>? failures = null;
             CleanupDirectories(ref failures);
             foreach (var item in _snapshots) {
-                try { item.Snapshot.Dispose(); }
-                catch (Exception error) when (error is IOException or UnauthorizedAccessException) {
+                try { item.Snapshot.Dispose(); } catch (Exception error) when (error is IOException or UnauthorizedAccessException) {
                     (failures ??= new()).Add(error);
                 }
             }

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.Scans.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.Scans.cs
@@ -1,0 +1,38 @@
+using System.Security.Cryptography;
+using OfficeIMO.Pdf;
+using OfficeIMO.Pdf.Ocr;
+
+namespace OfficeIMO.Workflows;
+
+public sealed partial class OfficeWorkflowRunner {
+    private static OperationArtifact CleanScan(ValidatedRequest request, List<OfficeWorkflowDiagnostic> diagnostics, CancellationToken token) {
+        var settings = request.ScanCleanup ?? throw new InvalidOperationException("Scan settings are missing.");
+        byte[] input = ReadInput(request.InputPath, request.Limits, token);
+        if (settings.ExpectedSourceSha256 != null && !string.Equals(settings.ExpectedSourceSha256,
+            System.Convert.ToHexString(SHA256.HashData(input)), StringComparison.OrdinalIgnoreCase))
+            throw new IOException("The source changed since scan review. Preview the current source before saving.");
+        PdfDocument source = PdfDocument.Load(input, request.PdfLoadOptions);
+        int pageCount = source.Inspect(request.PdfLoadOptions, token).PageCount;
+        var preparation = settings.Preparation;
+        int[] pages = preparation.GetSelectedPages(pageCount);
+        if (pages.Length == 0 || pages.Length > preparation.MaxPages) throw new InvalidOperationException("Scan page selection exceeds its page limit.");
+        var documents = new List<PdfDocument>();
+        long retainedBytes = 0;
+        foreach (int page in pages) {
+            token.ThrowIfCancellationRequested();
+            PdfScanPreview preview = source.PreviewScanAsync(page, preparation, token).GetAwaiter().GetResult();
+            PdfDocument output = preview.CreateImagePdf(token);
+            retainedBytes = checked(retainedBytes + output.ToBytes().LongLength);
+            if (retainedBytes > request.Limits.MaximumOutputBytes) throw new IOException("Prepared scan pages exceed the output byte budget.");
+            documents.Add(output);
+            foreach (string message in preview.Diagnostics)
+                diagnostics.Add(new OfficeWorkflowDiagnostic("ScanPreparation", $"Page {page}: {message}", OfficeWorkflowDiagnosticSeverity.Warning, "scan"));
+        }
+        PdfDocument result = documents.Count == 1 ? documents[0] : PdfDocument.Merge(documents, token);
+        byte[] bytes = result.ToBytes();
+        if (PdfDocument.Load(bytes).Inspect(options: null, cancellationToken: token).PageCount != pages.Length)
+            throw new IOException("The prepared scan page count could not be verified.");
+        diagnostics.Add(new OfficeWorkflowDiagnostic("RasterScanCopy", "Saved rendered page appearances only; native text and interactive content are omitted.", OfficeWorkflowDiagnosticSeverity.Warning, "scan"));
+        return new OperationArtifact(bytes, $"Created a prepared raster copy containing {pages.Length} page(s).", null);
+    }
+}

--- a/OfficeIMO.Workflows/OfficeWorkflowRunner.cs
+++ b/OfficeIMO.Workflows/OfficeWorkflowRunner.cs
@@ -202,6 +202,7 @@ public sealed partial class OfficeWorkflowRunner : IOfficeWorkflowRunner {
         CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
         return request.Operation switch {
+            OfficeWorkflowOperation.ScanCleanup => CleanScan(request, diagnostics, cancellationToken),
             OfficeWorkflowOperation.SignPdf => SignPdf(request, cancellationToken),
             OfficeWorkflowOperation.ProtectPdf or OfficeWorkflowOperation.RemovePdfProtection => ChangeProtection(request, cancellationToken),
             OfficeWorkflowOperation.ExtractPages => ExtractPages(request, cancellationToken),
@@ -523,13 +524,13 @@ public sealed partial class OfficeWorkflowRunner : IOfficeWorkflowRunner {
         string extension = Path.GetExtension(outputPath).ToLowerInvariant();
         switch (extension) {
             case ".pdf": {
-                PdfDocument document = await PdfDocument
-                    .LoadAsync(stagingPath, loadOptions, cancellationToken)
-                    .ConfigureAwait(false);
-                PdfDocumentInfo info = document.Inspect(loadOptions, cancellationToken);
-                if (info.PageCount == 0) throw new InvalidOperationException("Generated PDF has no pages.");
-                break;
-            }
+                    PdfDocument document = await PdfDocument
+                        .LoadAsync(stagingPath, loadOptions, cancellationToken)
+                        .ConfigureAwait(false);
+                    PdfDocumentInfo info = document.Inspect(loadOptions, cancellationToken);
+                    if (info.PageCount == 0) throw new InvalidOperationException("Generated PDF has no pages.");
+                    break;
+                }
             case ".docx":
                 await using (FileStream stream = OpenStagedArtifact(stagingPath))
                 using (WordDocument document = await WordDocument.LoadAsync(
@@ -694,6 +695,7 @@ public sealed partial class OfficeWorkflowRunner : IOfficeWorkflowRunner {
     private static string NormalizeExtension(string extension) => extension.StartsWith('.') ? extension : "." + extension;
 
     private static string DescribeOperation(OfficeWorkflowOperation operation) => operation switch {
+        OfficeWorkflowOperation.ScanCleanup => "Preparing reviewed scan page appearances",
         OfficeWorkflowOperation.SignPdf => "Signing and verifying a separate PDF copy",
         OfficeWorkflowOperation.ProtectPdf => "Creating and verifying a protected PDF copy",
         OfficeWorkflowOperation.RemovePdfProtection => "Creating and verifying an unencrypted PDF copy",
@@ -753,5 +755,6 @@ public sealed partial class OfficeWorkflowRunner : IOfficeWorkflowRunner {
         IPdfExternalSigner? OutputSigner = null,
         PdfExternalSignatureOptions? OutputSignatureOptions = null,
         IPdfSignatureCryptographyProvider? OutputSignatureValidator = null,
-        OfficeWorkflowConversionOptions? ConversionOptions = null);
+        OfficeWorkflowConversionOptions? ConversionOptions = null,
+        OfficeScanCleanupOptions? ScanCleanup = null);
 }

--- a/OfficeIMO.Workflows/README.md
+++ b/OfficeIMO.Workflows/README.md
@@ -12,6 +12,32 @@ When working from an OfficeIMO source checkout, reference the workflow project d
 <ProjectReference Include="..\OfficeIMO.Workflows\OfficeIMO.Workflows.csproj" />
 ```
 
+## Save a prepared scan copy
+
+`ScanCleanup` creates a separate PDF containing the prepared page pixels. It uses the same page selection, region crop, perspective correction, and tonal settings as `OfficeIMO.Pdf.Ocr` preview. The source is protected from replacement. Native text, forms, links, signatures, and attachments are omitted from the raster copy, so callers must acknowledge that output contract.
+
+```csharp
+using OfficeIMO.Pdf;
+using OfficeIMO.Pdf.Ocr;
+using OfficeIMO.Workflows;
+
+OfficeWorkflowResult result = await new OfficeWorkflowRunner().RunAsync(new() {
+    Operation = OfficeWorkflowOperation.ScanCleanup,
+    InputPath = "scan.pdf",
+    OutputPath = "prepared-scan.pdf",
+    ScanCleanup = new() {
+        AcknowledgeRasterOutput = true,
+        Preparation = new() {
+            Dpi = 200,
+            ReadOptions = new() { PageSelection = PdfPageSelection.From(1) },
+            ScanProcessing = new() { Deskew = false, StraightenDegrees = 2, Gamma = 1.1 }
+        }
+    }
+});
+```
+
+Set `ExpectedSourceSha256` to the SHA-256 hex digest of a reviewed snapshot to reject a source that changed before export. Provider inputs and destinations use the same snapshot, confirmation, recovery, and publication guards as other workflows. To retain the visible source and add searchable text, use the searchable OCR workflow instead.
+
 ## Convert a document
 
 ```csharp


### PR DESCRIPTION
## Changes

Studio's scan preparation workbench previews the selected page, supports deskew and tonal cleanup, and lets users define a crop or four perspective corners with the mouse or keyboard. Users can export a cleaned raster PDF copy, add reviewed searchable text, or recognize a page or region and copy its selected words without creating another PDF. Page changes clear stale previews and selections, while ordinary settings remain editable before a preview is available or after rendering fails.

Perspective correction belongs to OfficeIMO.Drawing; PDF scan preview, OCR coordinate mapping, and eligible-word text extraction belong to OfficeIMO.Pdf.Ocr. OfficeIMO.Workflows handles source snapshots, ownership checks, and publication of the reviewed result. Existing searchable text is preserved when adding recognized regional text. The copy path uses the same confidence and native-text overlap policy without publishing an output file.

## Validation

Validated perspective and OCR mapping, source preservation, cancellation and provider behavior, plus runnable Studio interactions at compact and wide sizes. The full Studio suite passed with 484 tests; OCR review and text extraction checks passed on .NET 8, .NET 10, and .NET Framework 4.7.2. Independent local review is complete. Clipboard interaction was exercised in the headless Studio runtime; native clipboard and Tesseract installation remain platform validation boundaries.

Depends on [#2480](https://github.com/EvotecIT/OfficeIMO/pull/2480). Review against `feature/studio-conversion-review`; merge the base first.
