### PR TITLE
Repin shared maintenance workflow source

### DIFF
--- a/.github/workflows/github-housekeeping.yml
+++ b/.github/workflows/github-housekeeping.yml
@@ -24,7 +24,7 @@ jobs:
     with:
       config_path: ./.powerforge/github-housekeeping.json
       apply: ${{ (github.event_name == 'workflow_dispatch' && inputs.apply == 'true') || (github.event_name != 'workflow_dispatch' && vars.POWERFORGE_GITHUB_HOUSEKEEPING_APPLY == 'true') }}
-      powerforge_ref: c6451c9d264a81c7f179b38f6e4d2b62f0784037
+      powerforge_ref: 1a38d9e53c1908a0caaa0e2c6162cc5ec87ed08f
       report_artifact_name: github-housekeeping-reports
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -38,5 +38,5 @@ jobs:
       engine_mode: source
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: d8abd2ec6375c2bbfa4d1eddf3bdbdb553855160
+      powerforge_ref: 1a38d9e53c1908a0caaa0e2c6162cc5ec87ed08f
       report_artifact_name: powerforge-website-maintenance-reports


### PR DESCRIPTION
OfficeIMO scheduled website maintenance and GitHub housekeeping now resolve the shared PowerForge source at the exact commit from [PSPublishModule PR #917](https://github.com/EvotecIT/PSPublishModule/pull/917). This keeps both callers on the shared SDK-context fix while preserving their existing workflow contracts. Merge PSPublishModule PR #917 before this downstream PR.